### PR TITLE
cura: 4.7.1 -> 4.8.0

### DIFF
--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -1,26 +1,27 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, python3, qtbase, qtquickcontrols2, qtgraphicaleffects, curaengine, plugins ? [] }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, python3, qtbase,
+ qtquickcontrols2, qtgraphicaleffects, curaengine, plugins ? [] }:
 
 mkDerivation rec {
   pname = "cura";
-  version = "4.7.1";
+  version = "4.8.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "Cura";
     rev = version;
-    sha256 = "19an168iad3cb5w8i71c0wbr79qnz5qnpxqx1j6dgh64qz6ffn2r";
+    sha256 = "060fqzspipm93ks0inrj7yrj5wmvkdfv8xaxrv22590yb9f95s9m";
   };
 
   materials = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "fdm_materials";
     rev = version;
-    sha256 = "1w6i0dlff8b30q987x3y0zv8847fc8ppfcr9vi982msmv284c89z";
+    sha256 = "0hi9w1fsnazlr0vvxdr3alsdb8m1vjjfp5zhmlz4kyyxhsy3bc33";
   };
 
   buildInputs = [ qtbase qtquickcontrols2 qtgraphicaleffects ];
   propagatedBuildInputs = with python3.pkgs; [
-    libsavitar numpy-stl pyserial requests uranium zeroconf
+    libsavitar numpy-stl pyserial requests uranium zeroconf pynest2d
     sentry-sdk trimesh
   ] ++ plugins;
   nativeBuildInputs = [ cmake python3.pkgs.wrapPython ];

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "curaengine";
-  version = "4.7.1";
+  version = "4.8.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "CuraEngine";
     rev = version;
-    sha256 = "177fk6j4gn3ssi8j1qxj8p4486f7jkz328vc75agxnh7vhd4mwsm";
+    sha256 = "083l327ry6hv3yaa1p8dx1hx7fm12b0lh5nlbshxjyym0vi15rw2";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/libnest2d/default.nix
+++ b/pkgs/development/libraries/libnest2d/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, clipper, nlopt, boost, python3 }:
+
+stdenv.mkDerivation rec {
+  version = "2020-10-09-unstable";
+  pname = "libnest2d";
+
+  # This revision is waiting to be merged upstream
+  # Once it has been merged, this should be switched to it
+  # Upstream PR: https://github.com/tamasmeszaros/libnest2d/pull/18
+  src = fetchFromGitHub {
+    owner = "Ultimaker";
+    repo = "libnest2d";
+    rev = "31391fd173249ad9b906390058e13b09238fadc8";
+    sha256 = "1hzqi4z55x76rss3xk7hfqhy9hcaq2jaav5jqxa1aqmbvarr2gla";
+  };
+
+  propagatedBuildInputs = [ clipper nlopt boost ];
+  nativeBuildInputs = [ cmake ];
+
+  CLIPPER_PATH = "${clipper.out}";
+  cmakeFlags = [ "-DLIBNEST2D_HEADER_ONLY=OFF" ];
+
+  meta = with stdenv.lib; {
+    description =
+      "2D irregular bin packaging and nesting library written in modern C++";
+    homepage = "https://github.com/Ultimaker/libnest2d";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "libarcus";
-  version = "4.7.1";
+  version = "4.8.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libArcus";
     rev = version;
-    sha256 = "0wmrcvw7k34ib93shhmjzh6kpndgqr37kyr377sril5clmac0z1f";
+    sha256 = "1dvz1rkvm4309yzvj7vy49v1vskr5yfq4nzqdiydp1jb7zpvhqqm";
   };
 
   disabled = pythonOlder "3.4.0";

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "libsavitar";
-  version = "4.7.1";
+  version = "4.8.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libSavitar";
     rev = version;
-    sha256 = "0mzr3ynfap51bcn6kshyi2h6iny2gpavn6g3b1xcsgzzlxqgfixf";
+    sha256 = "1mxkvnhn8k1a86jlnjnlpf0b8dvrcg3n7pslf60s13cgb7w3sfzh";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pynest2d/default.nix
+++ b/pkgs/development/python-modules/pynest2d/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python3, cmake
+, pythonOlder, libnest2d, sip, clipper }:
+
+buildPythonPackage rec {
+  version = "4.8.0";
+  pname = "pynest2d";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "Ultimaker";
+    repo = "pynest2d";
+    rev = version;
+    sha256 = "18dn92vgr4gvf9scfh93yg9bwrhdjvq62di08rpi7pqjrrvq2nvp";
+  };
+
+  propagatedBuildInputs = [ libnest2d sip clipper ];
+  nativeBuildInputs = [ cmake ];
+
+  CLIPPER_PATH = "${clipper.out}";
+
+  postPatch = ''
+     sed -i 's#''${Python3_SITEARCH}#${placeholder "out"}/${python3.sitePackages}#' cmake/SIPMacros.cmake
+   '';
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for libnest2d";
+    homepage = "https://github.com/Ultimaker/pynest2d";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14250,6 +14250,8 @@ in
 
   libndctl = callPackage ../development/libraries/libndctl { };
 
+  libnest2d = callPackage ../development/libraries/libnest2d { };
+
   libnet = callPackage ../development/libraries/libnet { };
 
   libnetfilter_acct = callPackage ../development/libraries/libnetfilter_acct { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5279,6 +5279,8 @@ in {
 
   pync = callPackage ../development/python-modules/pync { };
 
+  pynest2d = callPackage ../development/python-modules/pynest2d { };
+
   pynisher = callPackage ../development/python-modules/pynisher { };
 
   pynmea2 = callPackage ../development/python-modules/pynmea2 { };


### PR DESCRIPTION
~~I've added the new dependencies (pynest2d & libnest2d) but pynest2d won't build because its build target also installs it into python's site_packages folder and I have no idea how to handle that.~~

~~However, I also wanted to discuss whether switching to an AppImage wrapper might be more appropriate, as that's what Ultimaker's official release is. Ultimaker seem to be a bit lax in their release tagging convention, too, which makes maintaining the package a bit more painful (libnest2d doesn't even have a release tag on the latest version, which is used by pynest2d).
Currently I use appimage-run to run Cura 4.8.0 and it runs flawlessly.~~

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Ultimaker released a new version of Cura

Closes #103657

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
