### PR TITLE
cc65: init at 2.18

### DIFF
--- a/pkgs/development/compilers/cc65/default.nix
+++ b/pkgs/development/compilers/cc65/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cc65";
+  version = "2.18";
+
+  src = fetchFromGitHub {
+    owner = "cc65";
+    repo = pname;
+    rev = "V${version}";
+    sha256 = "sha256-XRGhukYite1GtPkO9clmkwvvU62OnYphO8V1Rrr7yMg=";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}"];
+
+  meta = with stdenv.lib; {
+    homepage = "https://cc65.github.io/";
+    description = "C compiler for processors of 6502 family";
+    longDescription = ''
+      cc65 is a complete cross development package for 65(C)02 systems,
+      including a powerful macro assembler, a C compiler, linker, librarian and
+      several other tools.
+
+      cc65 has C and runtime library support for many of the old 6502 machines,
+      including the following Commodore machines:
+
+      - VIC20
+      - C16/C116 and Plus/4
+      - C64
+      - C128
+      - CBM 510 (aka P500)
+      - the 600/700 family
+      - newer PET machines (not 2001).
+      - the Apple ][+ and successors.
+      - the Atari 8-bit machines.
+      - the Atari 2600 console.
+      - the Atari 5200 console.
+      - GEOS for the C64, C128 and Apple //e.
+      - the Bit Corporation Gamate console.
+      - the NEC PC-Engine (aka TurboGrafx-16) console.
+      - the Nintendo Entertainment System (NES) console.
+      - the Watara Supervision console.
+      - the VTech Creativision console.
+      - the Oric Atmos.
+      - the Oric Telestrat.
+      - the Lynx console.
+      - the Ohio Scientific Challenger 1P.
+
+      The libraries are fairly portable, so creating a version for other 6502s
+      shouldn't be too much work.
+    '';
+    license = licenses.zlib;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8707,6 +8707,8 @@ in
     chicken
     egg2nix;
 
+  cc65 = callPackage ../development/compilers/cc65 { };
+
   ccl = callPackage ../development/compilers/ccl {
     inherit (buildPackages.darwin) bootstrap_cmds;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
