### PR TITLE
python3Packages.xmlschema: 1.2.5 -> 1.3.1

### DIFF
--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -5,14 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.2.5";
+  version = "1.3.1";
   pname = "xmlschema";
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "xmlschema";
     rev = "v${version}";
-    sha256 = "0rsa75x86gdjalvy4riq7613szb616hff80crx006chyppzdkxmq";
+    sha256 = "08p6fm15600h40r5h7f3gfv34cys481f89pf57dv3y8gf6y2if56";
   };
 
   propagatedBuildInputs = [ elementpath ];


### PR DESCRIPTION
###### Motivation for this change
simple version 

https://github.com/sissaschool/xmlschema/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
