### PR TITLE
grpcio: split outputs to remove build protobuf from closure

### DIFF
--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage rec {
     sha256 = "af40774c0275f5465f49fd92bfcd9831b19b013de4cc77b8fb38aea76fa6dce3";
   };
 
+  outputs = [ "out" "dev" ];
+
   enableParallelBuilding = true;
 
   propagatedBuildInputs = [ protobuf grpcio setuptools ];

--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -6,6 +6,8 @@ buildPythonPackage rec {
   inherit (grpc) src version;
   pname = "grpcio";
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cython pkgconfig ]
                     ++ stdenv.lib.optional stdenv.isDarwin darwin.cctools;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The Python protobuf library has C++ protobuf in `propagatedNativeBuildInputs`. When cross-compiling this causes a build arch package to end up in grpcio's runtime closure, which can be be prevented by splitting outputs.

cc @marsam @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
