### PR TITLE
firefox-bin: 82.0.2 -> 82.0.3

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "82.0.2";
+  version = "82.0.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ach/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ach/firefox-82.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "7850a7cdf7f842d8ebac2d7d24f0823b1743b7fe139987554bc3f54af47c31f9";
+      sha256 = "cebf34988221418454b7674778aeb165cfa5d455c93a7b1ff8461c1460f28913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/af/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/af/firefox-82.0.3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "c43b0e976a553840da783139ecf2c8a59823da6a31a1d3b5588c496c270260e6";
+      sha256 = "cffc807143433dc414415843eb14b34ca3d3f18d5fa26e6ccec090032bb98965";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/an/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/an/firefox-82.0.3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "4f9103c6043e2fa7ceb0021e09e8616a4e4484d19641e6fc67cde0b60136d8aa";
+      sha256 = "1c7b084e089ed4d938f30ecb338f6a20001fc5c92b7ddd7d54dfebabcee67549";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ar/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ar/firefox-82.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "7f8bddc573ca33cd48b6e29709c80d8dd617a46f1435303fa0931ecc413b69e2";
+      sha256 = "10930a02e0a902d67b2e3eab8d9cd45dc93611bb77834f6ac7b7ef109d592cb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ast/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ast/firefox-82.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "d0bac8231fd4e9e777754378ff5b2e697379666b682c512d4d4d17a3bd82ad10";
+      sha256 = "91191ea0d52b33f2815b02be6af05ed462f394d112218638c427fccd7aef56e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/az/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/az/firefox-82.0.3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "3d0a5facfdce39e798ef72d22e737860327a669f1752deee7192877a2635ce97";
+      sha256 = "47dc248859683863c2907867e3c411c4d3620c2ae3001c5a0c693b485a0e5b87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/be/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/be/firefox-82.0.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "70606a5e490c3a0dcd1bf9b291c5d16525e044eca667166abbf1d75b58f3922b";
+      sha256 = "2e4ddfdbb28d7444b30f58235f634f9f16f88989fd61e7ef8dbf238c0a8455de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/bg/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/bg/firefox-82.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "501ba77092a68b32ba6048360f8695f52756593241f4a8d210a072260792cde2";
+      sha256 = "4c19e9af25e58bbc70d913f5cbaf8551443beee81c854ff8af2f81019b516534";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/bn/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/bn/firefox-82.0.3.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "f465d794e887b6867bae0e9f768e468876ae7f31a78e91725ccc8f7d965ebfd2";
+      sha256 = "40628ea1443ef7c8840ee65767d684f90ddb8ee547ec62367c6bb2e0833e7d8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/br/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/br/firefox-82.0.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "977beb4edf63e823087ce9e62ebb1c1d122991de4a350cfcfc93427b3f381608";
+      sha256 = "7a44ab9c67ec58f098cc8ca210ec2e37f922587aaf7495bb0dea60f1b0330e72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/bs/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/bs/firefox-82.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "3951d25f3f1eeadde330e0a68fd581595fa56fc5e98bb4baa3fa707879377674";
+      sha256 = "017d91858f3df6744eaf2b6764f4f2a303712cb23eaa8ab8ccf58f9b8b215a27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ca-valencia/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ca-valencia/firefox-82.0.3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "466fe1080eac737ed87cd83580f585fe5e685090b0d5b6a4c2c5a01ca33175bc";
+      sha256 = "f97c9f63139c23167c90b0cb91eddc1e887a827e2f839a7ab9d7a8cb1ec971ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ca/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ca/firefox-82.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6e13af5bdbbe50b8101e60a15d22f9f561d1846e67689a23a933f6fffa73b9ce";
+      sha256 = "631ae73074f22c446899ac82713c1f5404fbf63efbdde7aa93612f828d64a5af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/cak/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/cak/firefox-82.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a96ca82a2723e90595b76279b3b2a902cf4f121afa448784bf684cf26c514c8c";
+      sha256 = "72085e68e7f8cccbe4bf4244e11ddbbfa94f6a16c3dfa582fab94ca7ef191e68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/cs/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/cs/firefox-82.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "bfeac431918060b210d35ac74e7333b0c0f851435275c81f2ae76af34e3a05e8";
+      sha256 = "41da43aa44eaa092aa6481269d7100792a675764be92af7375e3bbbb21663ae2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/cy/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/cy/firefox-82.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "7f81dd91072ff34551394ef969c62baae625c648f5d880f5754862855f71dc74";
+      sha256 = "b61d03510d351c0c00f7a2e8cc459e736f72cec01e596cb0b95ef53d32e0ce26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/da/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/da/firefox-82.0.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "b21dcd0ecd9f0010852a143a38d5d0a77dc9240a49d959b00f101491d3a01e10";
+      sha256 = "5c495d632ae0ce2e3f990b41473c12551e66269b612b32ca0a2bf0f9ebddb268";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/de/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/de/firefox-82.0.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "56429f714fc1bb06efded1c601741ba3cc98788ed54ae345518328f9dcdf7f5d";
+      sha256 = "c9c7c2d8f5dea3639d213185718f64266fce8e267d2bc2b6afa9313e1452fd83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/dsb/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/dsb/firefox-82.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "bafc42263929851718a7cf38163aa3c020b0631b0a0e5ce8fe238849f7cd76e2";
+      sha256 = "f8c563b71e221e6ced9ecf927e37d9a351ab83303b252e52fc4aae51d6db0703";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/el/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/el/firefox-82.0.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "e1e8bb8cf866ea69465250a3f760a3cf9e9b06fe15ad03737c6739da5a5df2be";
+      sha256 = "dc0c4e503cab7913cba4186f22c96ebe3f80af59fdb5c9ef1373c799c0f6fc8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/en-CA/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/en-CA/firefox-82.0.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f3a252002ceae09c56334010167861abb84840466c939fc87f0ce39aa1537566";
+      sha256 = "735a3a4eddc0f660029020ec694d06e5dcf62b95b6b18dc90453a5a2262d18f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/en-GB/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/en-GB/firefox-82.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "2f384fdadb06254d12aa1c39b7cff6c26be4b7617d0b845a0efef2c92515cbf0";
+      sha256 = "985ee60c7d017569db4f455cd1fdaf252432057ed153d6449594d72139833d0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/en-US/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/en-US/firefox-82.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "d95758297ac2db1a050e6431b637855c4a58222db7d9014c3a8322448083a4d2";
+      sha256 = "54e1f9516aee97ef2858e04a67d691956a461591fdcfecc9bdf9c34c3f026472";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/eo/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/eo/firefox-82.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "0591aa9225572cdce7036eff924dd3337b85625bdeb6d59aacdc7a06c5af1f71";
+      sha256 = "b07fc960e9204d1995e040ca3e70a61aa531e34bf0dfe6e09cfc35583559f988";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/es-AR/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-AR/firefox-82.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "455b211bf85363089721803255829e4e7891cb43b2b6f35f85bf8a7242c360b3";
+      sha256 = "b8c5d160a92bfe94b66fc9554e3343b3385d39e2551bc6b9b0a917135f4f0407";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/es-CL/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-CL/firefox-82.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "b5d22bbd082eb5b6df2ab8002b465f64afdfb2c06b352a90c72e491aeab81336";
+      sha256 = "c89601e6a8dbd91723d8d9174cbba25f43a2729da5bfdf92919abd8972dfa3fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/es-ES/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-ES/firefox-82.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "678c9ecf360ad9231f31a8f761a48e793b6438b598d200619e5fd54a3296e1d5";
+      sha256 = "4643c154924c5153123796dbef8f759070b7446a31e056259be1f246fdf91ec3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/es-MX/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-MX/firefox-82.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "daf28e88dacd3202c759caec279244aa9bf418420df9ea11896658e53c966061";
+      sha256 = "026c72bcc1e22092a605145952fed6697a1de4945e81ee9f02b95f6654bc2f2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/et/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/et/firefox-82.0.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c42572576da4d6fd4cfbe5cc518b2c7dc68353141f952eaeadbd9b8679b98d95";
+      sha256 = "e69266e61365d94fb32b3d4f6560a66b94e5e793fe0e36d6cf075ac6ddb31b1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/eu/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/eu/firefox-82.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "5945c782ae8d23473ec1d4682d7fc5a0c524e494393e96c98e3202061fa6551a";
+      sha256 = "3107f667f558c443ae1925d77b3c2a4b2b2b9257da16af3a3a0f5f03a28d9bf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/fa/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fa/firefox-82.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8b5f607d7726333fa9f012d5d9e74170350e205717f7ad0bd7aceec60620ab16";
+      sha256 = "bcdc8928b712bd988ef21065207bd8ce40ec7b40958094aaa15261457954f6d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ff/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ff/firefox-82.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "996f0efe4c3eab9152a254077a53e994888fb20345302ed1718f8edba67a9bf0";
+      sha256 = "1bd27b188cd1527512d3de37af6b6e0d49064f8e1688a1257c17c16c1cd632f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/fi/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fi/firefox-82.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "2830c7775e54f3adbda827b5fae13fdde7fb4b3c8b37644273a88da33db78f2a";
+      sha256 = "2072f0847eb952e937de66bc0dc2a3b5e2cfa267909232b43b19c5f2e0a16622";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/fr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fr/firefox-82.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "bec556a28a30c478e36c3ea1463950039458d1a7442bd7a9807f31cc4ca003fb";
+      sha256 = "d858bffb885d64aefc589835f783bd8ff22cc962ff718bc142aa2fbb9f728795";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/fy-NL/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fy-NL/firefox-82.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "b549eb7900d15f8606face90c521aac596230b25705f7dc459c039e8ef559698";
+      sha256 = "7eb1301dfc9266093232c5dc8fe4da7b5139d1312b67266b2e3073e6a29d346b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ga-IE/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ga-IE/firefox-82.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "5a69d9bd67dbae5e8659bf3980d373c485bc67d5719c3b37948d2054f92ecdfe";
+      sha256 = "d08167164f083ddcff337da35d289dad0b83097243d9fe8bd77186d75b9dc8fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/gd/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gd/firefox-82.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6d76b0659f3d0b0793cbc963dfbd6d20c7c91aa46aec1ab9cf9192d003eda3dc";
+      sha256 = "d8a6fa4815c170661b132256274250c2e5fa238d89156f17ce95eeb938ab142b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/gl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gl/firefox-82.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "4cdfa36bd0d880135ff959a04eed53b958684253f99469c45aea39cb4a25d1ec";
+      sha256 = "b0ebff09180e34dffacd325465b0fb1a54dd2b59c757c8e1fe8425c86fcd44fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/gn/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gn/firefox-82.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "3cd0ffe9756155181cf68d2fdbc858a93be41104cfbac408adc98b72bcbb215d";
+      sha256 = "f0f514ed9bba07b1cf72846a452bc74e1d2e13b8bf5ee664382e613ddf351a72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/gu-IN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gu-IN/firefox-82.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "083ee03240b7b1f4238a464844bfad31334a21a8dd025f1d12a252c2cca1049a";
+      sha256 = "9c61f223ea072bcbe97e247f7e8cce8f0350366078dd2da276e5fc581b94f919";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/he/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/he/firefox-82.0.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "36f8951cb387fb733d689ff2a77b563e8315f76b434c283867aaedc264b227c5";
+      sha256 = "c19534b8c5e0af42c09f4afc091dedba6f15d9498183692d0a5e0285a0f743ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/hi-IN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hi-IN/firefox-82.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "6d041154437f97a0dc4b3ec3125f2cbebc10dd2089ed0f98df1c1a6a85b7a536";
+      sha256 = "3f25c2b8a33984a085622494b19d22005e6fe5694ff7e277f02b638848d473f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/hr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hr/firefox-82.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4c5b7921cba2d915240d6d9b0bf515f9299827e75a84eb089626561cc9042db3";
+      sha256 = "33bf5520c090f078daa53dbb3a2cdbdacafea8cae8ded68f7b0da30233f41916";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/hsb/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hsb/firefox-82.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "4123ec9fda1e94d4433107999905d7cca0dc2b6cfa5c5c78d3a1d29983a5960b";
+      sha256 = "11628732d6da9db696f95d6fcc0df2faa756e9782d77bc00b633f99be5921d1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/hu/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hu/firefox-82.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4c0afb928ad0b87a3efb26f09da8c5ef1ac415e14ac47b30463663ddb1955376";
+      sha256 = "e33f6bfae267454b3f541b4193ef2634ae66dfc7387c7bfbf7a8609f803cc131";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/hy-AM/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hy-AM/firefox-82.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "a2676e1450d88ab97b41cb4ee012da2a6240b739eca68e53d9607bbe0f7a313b";
+      sha256 = "0d9ea1d3adb92be4c6e40be915ab3d692eeee9e3c593b977b893e003fc7ddcbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ia/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ia/firefox-82.0.3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "8494561d37a9d41d0c8683e793419d51ba3780b8229fe98a819ce675f8dc6aa3";
+      sha256 = "bf3ad1ba8f77920ed6cb5574bb836f9780e7f19d5c34feb2d562a175ca9e7552";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/id/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/id/firefox-82.0.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "3bbc1f1acba6fe029ef1a526e3e16f6000cac1ff226be21850e9e52348b5fe49";
+      sha256 = "ffba9aefa174ff86bf963daa569796a39a3fbacb295b1932dd00a4d72f12cf86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/is/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/is/firefox-82.0.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "16fa5428d2a467bbe458c82544a3859386cfd8051de266d7af5656430a408535";
+      sha256 = "182c827998a8bead2b5f76477b01e91b66fa0b0b6ad9c20bb71684c951758728";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/it/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/it/firefox-82.0.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "5b891f5a9bd4362c6b00cbcd846d724926f2862887c3db2d6fa55f968c7e0d3f";
+      sha256 = "3ef3bfcc25ed9e1c9883bd890c60a32acefd243db37bd13eaec71a0c556c2b70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ja/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ja/firefox-82.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a3469c0b8fa55dd271768ddd491ddf1730d732d9abd697dbf779fa820f4b6d4b";
+      sha256 = "67858f54408487c9d4414dd4f072790b686379cd02aaedea165aa2f42ad9f638";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ka/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ka/firefox-82.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "8115d086a7330139f03a25209384651209b0e998a3b754ba1f79f26beddd28ce";
+      sha256 = "da27168c3eeb9d0836df349e5e258b9f5936cd715374b1614c90fbb4292776a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/kab/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/kab/firefox-82.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "c2a7cf201875831fad0eec3b558a4be41c847279f7a66fb8e1006084a385c5d8";
+      sha256 = "4f523312e1ff88ed06ead886ad8957be6b655063ecd451fcf502b387d4144e82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/kk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/kk/firefox-82.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "33aecd099402158a1fd6dc47ccdddc1476f21e31a1f25c6cd8518226de7f5d23";
+      sha256 = "b2cff1f5f94e94091d2f0d174ae5a979db34c554f4432891c9b894f0c07a7fd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/km/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/km/firefox-82.0.3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "060686475df4e47104229d02d42760e5762fc1a9d8d785a8116670a24b7cb897";
+      sha256 = "0c7b18f57c87d6d94c273b6678ce0dc891afabf9cb9bff3c03a347214bb52cc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/kn/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/kn/firefox-82.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "3b86716fd6da73f439593a3915d24710176d9be1aa3d19313c2554962e55dc51";
+      sha256 = "bf0c5dfcf7c23c033b6180cc4916a014e5c7b44464377f8e1c400db7bd7ddcc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ko/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ko/firefox-82.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "5fd1b0b428c57886552aabdaea3f691227f40cc19d18f851a2c880b1a1c8141f";
+      sha256 = "a1b30b45cce0d3bd1a4acb3a9f335592a819bc740455e56626968f2d66a07839";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/lij/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/lij/firefox-82.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "227f8dfd5b861f9e8edf1037c8f374dcae3aceefc61effab0e51907603fc21d8";
+      sha256 = "8802eef13ecf4b61adbb6f3350893ef7e4fead3395aebd290df95c7d5dc2bfe7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/lt/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/lt/firefox-82.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9ef7177b9fa3965a394dde8a39503fd8975829faca86e281d046f8fed50bdf27";
+      sha256 = "3fb34783d2768452aebfc20ff59b84a83139f2dcb04b1e11369b4984560f94d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/lv/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/lv/firefox-82.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "ac98c34657aca401de5943724a7f8607d1370b78f80c211547010911a11be498";
+      sha256 = "ad3a91899e2a1e2d22f0f15d15956c9c569b8ec0af50b7f194369d969fe9a339";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/mk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/mk/firefox-82.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "457fd0ccb4d43e99f39c89db76dc5d4cd79c560a578d1ff3229cd1d49493356d";
+      sha256 = "b98a27b50ae6c21e20f0bdc43cdf176b0d434a85ace230474bef86cb0411e925";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/mr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/mr/firefox-82.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "3bad6fb96f29a3fac72eef3f53b48e9ff10a273da069eda050fa24bdf3ee8ec1";
+      sha256 = "6f32b1ed9fe14162366d11ece5b53c185afa314131ba56105ff3aaf9c61cb621";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ms/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ms/firefox-82.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "20573511691d2615c9095988cea73d7fbb522a0b4ae958da1749ae8ee1ff31d8";
+      sha256 = "4c7ca7b1e504a9a4c14b7954987f4a2fc3843f341e26f088113aad09c2ed1727";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/my/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/my/firefox-82.0.3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "4f4a7abd9a1409ab49ad956cc1cad0adb9254b3203d9d19b7fc967284d051554";
+      sha256 = "52b234e2c32f52197d38e618b2d542c584012253d5da9b46dbb47c4198e1319a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/nb-NO/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/nb-NO/firefox-82.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "c0480f74895deecbad2f58b1b4876fdfc2c920269f4c91143c9cac41d67162f1";
+      sha256 = "63baeaf173b4c83c65b160bc12102038be1729f7ab4e535e01726c83d6af4751";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ne-NP/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ne-NP/firefox-82.0.3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "11fff99c2bf87ce9b5c315ffab4a305bed0d5170ffc4f65d00d5b5b380687214";
+      sha256 = "c95567889ad498059516e5c4c38e74fae0d937ad85b91813135cb4205b4be527";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/nl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/nl/firefox-82.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a19b8a18022f9317303e7aba19415f45133b19849fae440ec41ec5e9016a532c";
+      sha256 = "6ab74c0caa49412b41e9c26af51c18b4b23c9a2990868bb76ee640f77cf7ec81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/nn-NO/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/nn-NO/firefox-82.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "cc68e10b523681110a597c7583ede6ae08d20529bc001fa5059c9056287f3587";
+      sha256 = "8ab6be8b9883cd41a0b5ee84fed125b0592c526bd60b57658e3949e675b10909";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/oc/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/oc/firefox-82.0.3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a54056be66f78421a7f70cd5860ad5e804abd35017b02ca600c459c86c82ef50";
+      sha256 = "ffa788bf89e7d0533e14c706830e3e5a7995cf0d8827dd6f56e7a02eda85ba63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/pa-IN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pa-IN/firefox-82.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6a64174c90146c52b462a2e8b921880927774b6d9b6478df26ea194735c6eb6c";
+      sha256 = "300caec712dfd4c2a0d615671468ad6ff249b5300d94a1bf18552ec205fc96fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/pl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pl/firefox-82.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "558f08956b019d8046ac6c0e3a9922f79176d9997129e795901f40ce04651e55";
+      sha256 = "61cefb394f5490950de3a86312bf13864490c7b77f400881ba67c4e6e04c4585";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/pt-BR/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pt-BR/firefox-82.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "bcc8c4d9a55c8669cd378b2f89cfa61da82e54be360fb754be78289c2ab8434f";
+      sha256 = "d22845a258c133004216d692071f64c8e639caab6475b09de8e880dd26a808fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/pt-PT/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pt-PT/firefox-82.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "29ef81f9675b589122d311dd0f3075d48c99fb34aee9f9906d490585bd407468";
+      sha256 = "390270b8a04f3e7e7185ebe895741c6d3b82de55bd8a88384f58a2412b1156db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/rm/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/rm/firefox-82.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "390bd332f1fae6f5a48cc7b8bdd285b282689446977d859e37d8a097920dec9e";
+      sha256 = "c9f916a4bd9d01dbfa7c07988f25db6fc754e98fdf8fb0c6d28c7cf23799fd6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ro/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ro/firefox-82.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "1398529679e4220844a0b1880c0ff174fe2faa8b1c30c6041c1cd790d16a83fd";
+      sha256 = "3079e818963ce30e63f984ef3d24a321bccde52021f68abf7c38e166b63dd3df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ru/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ru/firefox-82.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "a9ba4ded0a67ae842896aa75de3dda2b427d0748244649aa9c2db17dd35a9d02";
+      sha256 = "5d5f1d4cf24e1f41f4f49edd2918790f3395bc45656bc385ff863ae996a2e964";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/si/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/si/firefox-82.0.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "a95b03c4085c096207a895d3ad193be7823da4e894793c0378391da5faaf01e5";
+      sha256 = "182d4f9f65d923aa4c190eadb2822813a0153d46a7dd789bd03e2c87deaaeee4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/sk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sk/firefox-82.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ce09728fc05f18a549c9083d383c58d4a62371d69a01d30f5aba782a60ec70b6";
+      sha256 = "9f38a513c7a35aa403bc570c50d1269fab04f3e0e78a2ee729bd306513b34655";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/sl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sl/firefox-82.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c344aa40296d249f2c6c85718fd6a9b30be0407b7df7eb73f1810cc873f03477";
+      sha256 = "916cb70157af7c6f44558954ab38b22c0e35472ae449b2cd1b3355e24f69d8ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/son/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/son/firefox-82.0.3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "3356b16e9174c90cc8e1deee262b8381fbfc34e9cd03e6f7bd48072861de5be5";
+      sha256 = "4790b6f7fad51191663549d6c06a9a27d2a6edf153caf66c8cbaefc6a2e33547";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/sq/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sq/firefox-82.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a90e1dada0ef38114f1a8ba7236d8bc97285dc46f81334c86ee7a9a03c8d2b0d";
+      sha256 = "3265c849c77d482145bdd6e67078ec82e1ba339a807ec15692431a4c43358e2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/sr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sr/firefox-82.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "d44891e53c9a41770dffb2fa744e3cea0a655194e218b70881e1f070aef07d69";
+      sha256 = "3d5616ad78372ad3e64e0bd81046680f075de53641c3c1f73edb2aed66f54d96";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/sv-SE/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sv-SE/firefox-82.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e53a4ca8a04d7858c30260999b6acc09b8146ae8a8f4e558d62cca1ce18e7689";
+      sha256 = "bf1122a7ba4cbb5525d35d7245a68bc2534d191639955a6c9810f57dc6b41efc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ta/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ta/firefox-82.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "a89ab7047cbbabde8a03e301f8067b130d37eb0ad7ddaf750051175dd721b6d0";
+      sha256 = "8ad3ac098bec9283218e0e33dc106457b8f2f21b15aa7b821a5f061566d058fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/te/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/te/firefox-82.0.3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "6f80b934ff3bf696b4753f2cbf146d9151f40def404d6d749cf8de022be194ff";
+      sha256 = "a366052f680073f1d0c300a5a8e45d6cbd1be7651463067db268626d2fe1a5ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/th/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/th/firefox-82.0.3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c37a9708768ddf723a2423ba0999e88b09a51028d7736234ffcaf8a32f56df8b";
+      sha256 = "509dcd38435c2923a5bac14bb5b2dc4838606f139c29138a0bd5d090fdcb0142";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/tl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/tl/firefox-82.0.3.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "5ab670b24e2ee1c4b4c7fe518e9d3967c85f0e27ea2c7a4ba82bbdaabc6c4fd9";
+      sha256 = "37f39b2df1209fdfa9005e6213d31aa50a8b62c55ed269625ed90f5fefcd5169";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/tr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/tr/firefox-82.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "7e51ae3fca81e691675196b298a9b03de9e798f4fc032da8e5da295820a7d2c6";
+      sha256 = "6417ff882cd86cbb7238414fd8100769ed6dea0a3532af09ed9d7e05ea322f22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/trs/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/trs/firefox-82.0.3.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "60263ac369cdc9aa9a8ab0dcb60219f3e14563fed709b99d8352c1b0469e9433";
+      sha256 = "2fa044fcba5f6155ed55501938df4646dcf83f7d67f53ea8ca945e319db54c29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/uk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/uk/firefox-82.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "38f8e0ed748427991ee9c45694460d3eee28a5f94ee1ff59eafcf9eb93fab9c3";
+      sha256 = "345be40eeaa42900bf7091fc8098a92d16369ecea3992974e4a2ad8856f58f3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/ur/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ur/firefox-82.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "65e19c2395ff45bff79beb1aa4d9c18faaceb5a7000c6de672f6c1d6964571e0";
+      sha256 = "47679117a1295b74a4b06b1407ce0dd38fc45326af970f4a20caa4ed8343e739";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/uz/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/uz/firefox-82.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d3967c3bbbd0ddd880a7cab3a359b946a7b99515c9b82bba044a33138822d864";
+      sha256 = "85dc93248a9db047cd9c97a87e0f36ccd25456c167390bff19e0e84dc93b6756";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/vi/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/vi/firefox-82.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a142d7ddc06c688666811ace6a9c32f28e74006f29eff4aa4aaae105f64a34ac";
+      sha256 = "7882f5c1e3330a567967444fde09e0bca8e2259e4f836603bac61d7fc4de47ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/xh/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/xh/firefox-82.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a696daecebfb59e8a798dcc6eb241ce10562438a013f243dd60ac8671091f585";
+      sha256 = "fcb914c24f93751ea1ba760818bee0323e5220c14ef95f3d6f302f80d58a0271";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/zh-CN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/zh-CN/firefox-82.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "d1167e254dc6c16d5d4e38cd8b98bbc065e369d7bd7414e6871b028c601118a2";
+      sha256 = "0e3635c27c594395f2364d6f4c140eac66173130afa0130bc4043e500fd91481";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-x86_64/zh-TW/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/zh-TW/firefox-82.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "453ebd33173b2ae4a5120d73e3e0fdde57b480e3f66ef2fffaba27390ae945ae";
+      sha256 = "7c3588bdac4147a43d5a40e376f359823a3503c3ae491e3d98b66b285c924e25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ach/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ach/firefox-82.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "c7840623cb65c9c28285d41694a85990e0bda181697e229ad4b71478dec8bf2c";
+      sha256 = "ed00c332dc5069a5b4755a759c4096112aa07b5fabaf0827fe63dcc8f96c70f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/af/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/af/firefox-82.0.3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "24915613ccc58840ccb1564ebacc906b96c7f171822f722265e02b8ee41b0dca";
+      sha256 = "41b4929336370eacd9fcf61bf56adc26377305f253ef8beacae8a3528949a2d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/an/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/an/firefox-82.0.3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d7acf25c0fce89775827a1e8198fccd117b94dafe5fd9820f557cee88379da8b";
+      sha256 = "d8138aebfe43f67f634f4a70142b5463497799396cd4e5ac6fcdd91a1c370d12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ar/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ar/firefox-82.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d24c74365c1b9384e8954f9b6ce4f2742bea269de7a20f448971a957f096ecf2";
+      sha256 = "f58e993bde013b674863586dd016d4ac9f8a245a4dfffcca36ea8044afec20a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ast/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ast/firefox-82.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "0b858a243143f6afa68bb14f836fbf4a7245cb2856432004222422ceeb4c4d57";
+      sha256 = "7fa1d61e805f7f3f94abafd6dd73c5ec3ac518c3192c6fdb7e31f155cfb2d8a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/az/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/az/firefox-82.0.3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "80ef7662e88c0fc1711bf385443917b325dfa46252b837f043f41fab0139967b";
+      sha256 = "354db7168cec8c18431e33d5d13efec2b2e1de6b38e462338935ec4157521f46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/be/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/be/firefox-82.0.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "93c087192c67e074ab3b00fdf55d485f39c7b86cba4fd801e61d2f61e511a191";
+      sha256 = "bfc5689bfcd37bc6afd6438130fac2486670616ebcf3f40e40dbff85f2323ed8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/bg/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/bg/firefox-82.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "19afb87d93e3a01305c24b725b8ed764f8ae2e31e72a8ce4132f1d6451589321";
+      sha256 = "18bc052d5ba75cd4406aa726648609bc95d869a633ad99f3dcb24dd2621b81c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/bn/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/bn/firefox-82.0.3.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e607dd2195d4a19d366de1f084bcdc91d4832287752c4a449d445eb7aaaff463";
+      sha256 = "896eaf0144040b5eb7281f46280b918bca93ab8ebcd3d8a9176d6468a7f82850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/br/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/br/firefox-82.0.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "dbd5fa26f0b9b20933820005022af238a5f72c8688dc10a4aafa0318af67b342";
+      sha256 = "7af967b1fa2aeb7d9e97cc883bd118b4d04a98c8cf56ea2f4f435ee13d1a087b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/bs/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/bs/firefox-82.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "7d3d4e3bc630e69b655f4668365359996266d15864b776fbe2e6a8773e212410";
+      sha256 = "990778d72c382920590a92ff0c861f8d64274d09da56fa989b5ca124731eb1e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ca-valencia/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ca-valencia/firefox-82.0.3.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "a14d58cd78c72c29307887a91b534a7553ad2b4e81da5615bfb8a918d4abce60";
+      sha256 = "ec0594197bea5db1058fe3dca4a5e3bdbda53797e87a2fb0af070664b7a7fe3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ca/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ca/firefox-82.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "2aac2aa56702b1269b5b5755da2663621da1603e6ad956afe07d86ff54d3e64e";
+      sha256 = "42a25d4006fe6e4f8e7f685304f13f715654d79df775cc6e740a49bf72e691d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/cak/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/cak/firefox-82.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "333cf7d04c22f644f0286102b498727dc448339de26fa1a1cfd353ad1b05a1ae";
+      sha256 = "452438f73a0da6bc5922de9178c66ab95a0ddc94420a97b771d44d76053d1e71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/cs/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/cs/firefox-82.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "3d3756f69b0acfc95abd5ab21b9b77cd2272afdcb7056fa4b961c1528e467447";
+      sha256 = "fa827fd11c25b37f2e93938be3461061b8c0bd3ca1391c0b50657981cd0e2ba6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/cy/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/cy/firefox-82.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "97d16b2b8def95897751397a8f5293931e1620d2b17b6a6f036d47abc79ae822";
+      sha256 = "12708a5c0f3559d8557f5eb11a5a654b999b2e758d075fa723d78434f1f0fbc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/da/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/da/firefox-82.0.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "f97a2ded9c529e992df15b797afe0622a1d02cdf3e01fa46794b4ddddcfed0ac";
+      sha256 = "660f0af8ecfbb07df68d5e28eb63b69065eec5ae1e31acbe8f89a7aac66596c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/de/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/de/firefox-82.0.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "4d9aba854f86075d29772957d7f31804ecdc1bc465315afbf0bd807a40f39bc5";
+      sha256 = "16492891efe70c69774e10a83465a5b7ada5a25a1057de0a744c347126667a1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/dsb/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/dsb/firefox-82.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "bdf18303c3e67f6bda97c709460214bcad60dc11c35fb996bb628f79bb7d0a9b";
+      sha256 = "7c830c85f67d2d54b63ddfb94765f5fe1270df06d72e05cc5e0a1dc745e3dbbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/el/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/el/firefox-82.0.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "29e9a29e97fea8cb4eb03c8ad67c8fb37e534199073202f381c6a9c50a9d6572";
+      sha256 = "f4c42a7b3b7c8faea5a54affeb47083f7070a37e3e05a85bd26d53eb2571182a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/en-CA/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/en-CA/firefox-82.0.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "7fd41cc61c01491048cd37db223007a568a8470eea693e76e3f3394901b1af5b";
+      sha256 = "fb55f47dd07ba7b8e1d4637d0cf693db8de3bae5b729bced9f22e6a3a7136e37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/en-GB/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/en-GB/firefox-82.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "818d44931c9ed4b4c258de26b33040409ebfe9a4856eb1f80715d15687ea9fdb";
+      sha256 = "98fcf28312060007364b6ae7e73b4e5ec5f78d5cf6b92c68deef49b8aac39e66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/en-US/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/en-US/firefox-82.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "54a64c8fbb263df7e05b8532f0d6f50bd34f6b3cf3080ffc99c123b6b7009210";
+      sha256 = "53e1cd6dd28b764fc0e824174de5cb1d70a2b795f7f7e6d1ed400a84d996295b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/eo/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/eo/firefox-82.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "87e497515f1a90d315e58f592d9360baef382bb986cc17a1a20e9ea9013550fc";
+      sha256 = "0277e0d4f5296fcb5d360e3949991783808362014220eebdab8fd031203d03a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/es-AR/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-AR/firefox-82.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3306113b2e5249c9bef8cbe3ee30a76855402f39385ef730725fe19c650248fe";
+      sha256 = "db90a491dde00c0625bfb91f12820235ed4b23ace245520bcea8129bc0fe99ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/es-CL/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-CL/firefox-82.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "72fc2f9c4269255c5c9b6c65f11ce8613dd68a1b382c53cab159c56af91d4f12";
+      sha256 = "da7ab44cfe8fef8a89be8180f503477d632e1b0d0e13b410e005971f1eab65cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/es-ES/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-ES/firefox-82.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "720687e90a863bc08a79e7b98f52439efbf655cc170397095dcf2212839eeb77";
+      sha256 = "b774a59300369f9aa5e695eecf2923036ac28b790a2b265bff39fa004221351d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/es-MX/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-MX/firefox-82.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "32db50431886cf3e181a440eb40e4d9e93ebb0dd6c7e9eb3f6bb4cb203530d37";
+      sha256 = "f227f0904d927a9b7696dbd42c33e247b93a517ac465e63658297d266636dd63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/et/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/et/firefox-82.0.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "21c2de424dad554b4e74509df0b40a49c23b77c406d44c611ea0e08eb98d1886";
+      sha256 = "40c66a997e4a244775c4e094b313d8de66fdd8ca9b59b14b1858e331f0c1760e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/eu/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/eu/firefox-82.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "96e3609f488fc8bdf899f07333121893dc5f74f520856536facb1a5b376773f0";
+      sha256 = "cc346925123d138c8f39f8feaaa830c87b31ec9f3e6d66d62f3c4201389528b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/fa/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fa/firefox-82.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "572a6fe2bc5c0751077344e327ff11d434eeb26eade478dd79578822bc8ea167";
+      sha256 = "74ef4fb696e3a551e920d95341e6b24ebed1abc0f50c3753b5719e649ee6569b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ff/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ff/firefox-82.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "08daf54db1c3927ff10c38ae462c806b0968abe89509e2a7251b39e2f3e3e43d";
+      sha256 = "300bd1d7ad740efdf7e783a19bbfbab32d699ded795857005e3d836086414ecf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/fi/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fi/firefox-82.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "c2bfa5646d0f39262c79dbae82f2a443e145b0b318d4213e42f265dd378a0a73";
+      sha256 = "be9e639888e7fe25508d1fecce9dff0d25fb8f4cc1df9485c06fd34dd1964341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/fr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fr/firefox-82.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "3e8ae367878e625b796e68fdc413ed4fa32a06260db7ecb000f3c089f7755a6d";
+      sha256 = "a722540cedb2694bdd8cd347cce80f0e7bd6092227a0d69d64e35cd644f9eb77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/fy-NL/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fy-NL/firefox-82.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "29dcf0040b32d2a183cc79f220ff37c6b8059a399fd111b9c4ab8f851b638acc";
+      sha256 = "d8292b69187d3b69d3e6d38076e9e448cc1851ae560432d524c9ceb25b980302";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ga-IE/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ga-IE/firefox-82.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d2f0c91780ef7dd353d58e41e539b917e6c957231579517d1d75cef89769a5b8";
+      sha256 = "3d72fde2daf9dee7d7521dbdcc257aac3e5a3090f07a02aaa4eb1247e4dae774";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/gd/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gd/firefox-82.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "1c305c577072a792aee284559202b4ca8108df8f96b1ef17c20d6918498b3599";
+      sha256 = "b599939ac3927e3da21a8b85dfcfb2bbbfbc5ca9833543b7df3e8937184fcb0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/gl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gl/firefox-82.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "86c829c97c30e5c49081283cc8ff5073d357ab09520194c56df63ab56858b083";
+      sha256 = "f7d8f6915d9867e740aeeb06614ac3c2a9c29ad914937fef99490c37c329e822";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/gn/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gn/firefox-82.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "11a41052cb779cd11fa2e9c1f2f4367a190e78e36dce900f2fd84c451a6001be";
+      sha256 = "940c94891a5bf80b12c24b49276e87c50f6edc601c1876a75ddfb36853f94c02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/gu-IN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gu-IN/firefox-82.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "6dfb8e60f2225a8db6a2b1ce31b23b51803d5fe9642cb85ff9f440e53c887616";
+      sha256 = "8961e66ea0bab00b29ccd365351517d932c75af5fceb9381a0670e225bb9a20e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/he/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/he/firefox-82.0.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "8d2f9ed875b38e6d19776c0bfb3a66fe030215d43ee247c9f1a5b85c7dcf0105";
+      sha256 = "a253c246e6a2820a6552a81291f9887007174120e13f3becd3e3f06d55e12457";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/hi-IN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hi-IN/firefox-82.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "cf160dc3ff74855a206882e045395dc1ddd69d545184d7f02acb20289465842a";
+      sha256 = "39f7bd90f28ce92b83c46580e8297367d02042eb274809a0c94f58f6fbd2d0f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/hr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hr/firefox-82.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e62b04dba13d6d8dfada3976f23715cd221d5a9f0c9d2ea9a0b828c87222b8db";
+      sha256 = "37237b7a1b28028c31118b3f6012f6122b428ed81cd0289b224aff910700c92e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/hsb/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hsb/firefox-82.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "fbf8420109b4b7470bf8e5b889cbb51b5a9d827b9cedb2aeb5089f31e74b0211";
+      sha256 = "e4c1d598ebd277309e1d9bec979373162cb34ec7874637a7140184c07e590653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/hu/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hu/firefox-82.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "161c7f91df6806310a10631f6d338cf86138f5056d265e4dfcc2823634a1cc79";
+      sha256 = "a273f90e185fea5e02fa7be0e859d6569d5a18690dca2485db39719f04f96821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/hy-AM/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hy-AM/firefox-82.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "a35885c431f6b160716355766c5e8f60ac94dc86675e91905c4781071de6c2a4";
+      sha256 = "0da0b1db8a5632776a38d8ca53fc59bb2922b9caeecb779e4fd69086330eb153";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ia/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ia/firefox-82.0.3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "e162f166587a94aaaf9a6419fdd9da21f949c7db0d1ad223016d470841e124cc";
+      sha256 = "53fc34e4f99ace2f287a39dc8ce1d13546574da940dc85703fd81f7bfa7c4483";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/id/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/id/firefox-82.0.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "bee0a6a4a0a9fa3c13650bcb4fefaaa07cce21211d2d4fc0030f4f9133781eab";
+      sha256 = "33088caa35f9939e24e1686a97762c86e6bfde246467544383b4dd20a477ce01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/is/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/is/firefox-82.0.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "8994bc2da81e1b17ac112e7ca7a43be9f578c049e879651a4014730937c83283";
+      sha256 = "e8651697dd1c6507e950dab2a7c1a3e61c7a1fff5507fa6967577c076aca43d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/it/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/it/firefox-82.0.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "7fa77ed489b07954543ba117dc3cf67fc70341a5e486d35596cc8f80f630482f";
+      sha256 = "faed37a9099007b2a06a66f0d2baf19f743a5370d354d9295d3c04d283a840c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ja/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ja/firefox-82.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "76d299e4d71a82e72bc2e446bcafcc1b1d63b54c57e9aeb7ff11e7bff8611811";
+      sha256 = "cc403028cdfecfab642f99e4fbf6920cb036f71da9ca05343b41990c01e3974a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ka/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ka/firefox-82.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6c027f7dbdff43c097a73ecad83aec6c7d623cfc8cdd77049d4dcab70984b403";
+      sha256 = "279655a3c1a9151af171066bf164c71a4541344d5bddc02e208faae5af61052b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/kab/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/kab/firefox-82.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "ebd32284e83a0df7228f34263ea03b5b3f418fa5db193e01d20ef15f7ccc393d";
+      sha256 = "febad3151c3b6dbd0e3747a4814d2451e7703d8907407255810cd87383a5d665";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/kk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/kk/firefox-82.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "39dcaefc6135f51157802878702debd14950a82a32b57862c9428236425de620";
+      sha256 = "25135a1305e6c4269ef9beec7353669d403023fd552ae43cb7a4b8042eaa9a40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/km/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/km/firefox-82.0.3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "30b0fc4885498d9453dd3179a82d7fd12bcdb5a2b1f3d6227d7a7a68123544eb";
+      sha256 = "80daab49e0fd64640fc1b0a7ecaf3b764a0a7b38020aa4a758f1e5e8ee639b9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/kn/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/kn/firefox-82.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "ab0f33c172a47fd5fe1e3caa014938647dc870a97e9db0d1ed7e9b09a3fc920b";
+      sha256 = "dd911926a98835fe4a0a97ad0ee88867bc637a673743b9c6ee75aefea1cf60b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ko/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ko/firefox-82.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "7e20d1d2c16e6278e1e8290c18b39833e23b12cc9bbcfcf3135e52d3c155118d";
+      sha256 = "975f10dc01c190604cac28705f98b0abb352adf21aa1adb031a11c8061fdb4d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/lij/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/lij/firefox-82.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "5da50a6a54b1ce15af8ca26bdb2756449622f6d441593bae4f558c079ef732ce";
+      sha256 = "9f6183b484eeabfbd4440d644d3da60c1068af430638b1bf9e4e5a4fe47e123a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/lt/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/lt/firefox-82.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a4bf43fd06f915720f3050750f226629a602aed690b74df728cfd616f8d1d063";
+      sha256 = "e95b0760385490b65c774943f72835423c3339030a9b347eeaa7a3cd172065bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/lv/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/lv/firefox-82.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "8f8eaf80606a140616cfa17fb69bc611ac631a8ec1e4d204fb0de1c073b767aa";
+      sha256 = "6a2387d24680d541e12547f6fe38c56e9960beb317e450a39cfdd481b56485d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/mk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/mk/firefox-82.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "869715dd3d72c48db3007557aabc96fee78b73ecdc747ec0f361365eb1072111";
+      sha256 = "c95e5e94680ce2dd06adb6cc6ab7cb2545e2283b34f9f6702db9c4ee48635d7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/mr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/mr/firefox-82.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "ae921995425812eb2b70a479dc1d6bc319d397c7c16e020460d2d1f65cdc9305";
+      sha256 = "6e2ac911d8b4ff89fa5719593b390ffb68f31ea9c53ca075ae91c47907ed67bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ms/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ms/firefox-82.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "55fc6ca427864cd885fa8da786f50f4e88ef2d9adf331e55a6f8e781fe5f7838";
+      sha256 = "4c573fc813f878c9baf9ebd2aee71f5459160a2449c424e1bcfbb8035b3b7c50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/my/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/my/firefox-82.0.3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "26377b5108cd1208d111792dad61cf521fda0f4c4206d17e4907b06e4ab5e7d8";
+      sha256 = "a42129e772ecef6e437aff59390da05595f55872c990122bfa07509aae204757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/nb-NO/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/nb-NO/firefox-82.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "19bcb61803f6d6bbecfd94eb769b3d302a951ac5d7f337b6937f9282cbb8222a";
+      sha256 = "3d72dd2b24c1c99fc1257a9eecf91fd694e67a161b511b991a7294c6dade77c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ne-NP/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ne-NP/firefox-82.0.3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "4575f7730e5964fa5be7ec351907d97794c06bf101bea5a98785238304d1fea9";
+      sha256 = "a85fa695c3c7a221ee54bee11b5eb88dab9d087d3535f63c143fc8fea759a83e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/nl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/nl/firefox-82.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "f22f33b1a1127a4dc91781031c0112b05e8cd5fbbb8c732a6e18b5beeb5627ec";
+      sha256 = "48aa468f774d67526e41488882f3796a399ef1789b70793570407e14bf112251";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/nn-NO/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/nn-NO/firefox-82.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "d59e605d47601c18d12e6a2a57cfb8c8752fea2711e8cb0d822b18a4f7a2c049";
+      sha256 = "857abf782407625492859630cd47be120e5daf8843dbdcb61535fafaa0d5d3cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/oc/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/oc/firefox-82.0.3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "859b0b3b7317a4b94292edcb8f159d4c42404efcf67a170f435131b0b2331422";
+      sha256 = "b8606e264be062dcafc162b5d69191d2962b547fa906e76e68345395378ea471";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/pa-IN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pa-IN/firefox-82.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "b8553bcc65ce5a075875849508876f34478a0d8166b048b4b8d0b37aacad359e";
+      sha256 = "7279685c4da5b614f6ae0832636676b06ec3384667e1cc1e25379d61b52ebe5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/pl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pl/firefox-82.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "8428f5438edadd7f3e531aeb905bd46f52a3a624e1a36706b3e0e79d29366b94";
+      sha256 = "436d60ea9bb7b84bb20973ac39ebaf1fbd6c7966b5fe5677fa829935d76f4932";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/pt-BR/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pt-BR/firefox-82.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "021cb4431781ef19cf7be1f987b6859c2c8b7db67f1428cec475d4de82d38118";
+      sha256 = "47e972cd908b61b1ffb3a194ef12bb1b9e0033a3b30804e0201a94a5dc4c9d42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/pt-PT/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pt-PT/firefox-82.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "e55fe5ebb512e184e2c67dc6b866a0f727fa89bda6fb2ed763195761b67bc79c";
+      sha256 = "cab8ffd436e69f7102519bc9ef73d7473336a0a45452f1e85cb0b0ce7c50d197";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/rm/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/rm/firefox-82.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "30bc0d66c940ddaeaff516e900f85c652a3dee07d2ede81710efd31c5858e72e";
+      sha256 = "26e71bcc89580f7a2510f7018481b86c7674b0534070a85f675a2f576de2d9c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ro/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ro/firefox-82.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "e467c27dafce634f4e507ba5520ea4dfc3d3fca2f751a8ae55fb3fb26a073b3f";
+      sha256 = "2c9838ca56e808cbcc0f08987c1b21615119d94dc93cf94dba915491130a0706";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ru/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ru/firefox-82.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "d0ea589f932e1dd4a1f6d12a758210e22213794f5d45ec5bb85621aa1ba206d2";
+      sha256 = "4f9b41754a1dd74d8979940eb17be6578c6907b0deea700697eb340fe607a586";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/si/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/si/firefox-82.0.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "6a22d47d1c193a2a048c7535ec49f2198bd2616e123353af0391272db9decd3b";
+      sha256 = "203b50ef0d0d76ab3db56bed03a1b78f3f20819cc804cb5ce470470bd6b6148b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/sk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sk/firefox-82.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "c38f8f2f172c0de6d526be926c874a765116f14af5f50cb65cd7771a46cdcfe0";
+      sha256 = "650cf2fe9ad5628b927f655fe1e88e9260c98543b7fdf6dd5faf9a1cbdf50f08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/sl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sl/firefox-82.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "f39c27bb7d334f20e09fed97c3589db6aae988d3e538d7e2dbae690ab4b4e521";
+      sha256 = "7c0aadbc5d6dfff44906eca393acc08388238fb502d183653a094f4ef7095d02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/son/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/son/firefox-82.0.3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "7edcdcb248e6cb9a78fd4061a2ab54e03692834f87c6d565ed9b777c952ba5fa";
+      sha256 = "7e60dd64c8ac8052cbc6efb8cba46713ebefd17e66626a6fa2896a3bf88e9553";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/sq/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sq/firefox-82.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "db3a6edc2a4008c09ba931e965e9853404dd272455ec8d6b20bf86e14a095bea";
+      sha256 = "d8fa2f61a2fdace3374effb32484504afb78651406216c1dc900f6958ed52561";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/sr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sr/firefox-82.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "aa6bf3ed3402813f56b6d6c53a70da8c7decad3f9d3c3af66336aadc632e334c";
+      sha256 = "f58146fd202221fec3980ed9fbe7bf84d26465fb63c334826b3271c705e5bc61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/sv-SE/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sv-SE/firefox-82.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "8ffe039f7ed159150c6ad804e980c597741439dcc339841e464589ebd535eb38";
+      sha256 = "23f71c61978bcf531790a3894e86c7bcd7c930464f9276e4d4464de3d199db53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ta/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ta/firefox-82.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "a46c944cc5b22fefe8503cf079be32cc5aeb2cd1b78e5642f5ec55f8baf28586";
+      sha256 = "78fda229fc9583bcfb3b1ee12d494d04955845a703a594e836e9bf3ae67531a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/te/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/te/firefox-82.0.3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "a7ce32a838d4add3123116628301fb6642311fd3f6fffe0ca4ed6cb314c162fe";
+      sha256 = "86aef155c9b1db83727d8e2df9cf73148ef7146aa6ec77f751f7e548e1ff3e72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/th/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/th/firefox-82.0.3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "3ed82ac4d015d397cb53149f30e2842614092413d84dd6add365428b80c40cdd";
+      sha256 = "ae647ba530f60dfad84c95d0b70ee8dba7ef183f1b76c9861b2ef3da6d95779d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/tl/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/tl/firefox-82.0.3.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "cdd9b16ad2fefdccbdea8bad3863e3177bd166fb595609f74b1afb7d279c4390";
+      sha256 = "137722d3de0ae236bb17dfc940b8eccd5ac7ed291d22a59486c2e79505d3b34d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/tr/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/tr/firefox-82.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "4b75d68d159ee4463854b53d0f68364648c2b36e6c0fc8937573cf2a1262ad0b";
+      sha256 = "0a2c8be857398f202cafeb97db2a8ac963695e285137c8e7e7df40a9673f0c2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/trs/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/trs/firefox-82.0.3.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b0947e9e8f45d848093805ff34a59d6c74a5559df91da5bf2255e2a24d386f95";
+      sha256 = "6c2d08829057be94edc1923b176fd52ee8cac5cc40e2484c38577865d179cde1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/uk/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/uk/firefox-82.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "a4ff8ded991f00825e10ebe69be7183899d8bca0692eae4e2c60049e80d6710d";
+      sha256 = "b2b9b997a9bcbe12d3378cf18928ce8cb842a4c3962a0629f6abdd41340f36e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/ur/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ur/firefox-82.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ee50b6ac2818824211c5fb871f19eb0582a5f50c3873139d6aed613d9a853197";
+      sha256 = "b91073657e73985254dde8542ca420087111de7297d7efa368204a45cd8c0932";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/uz/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/uz/firefox-82.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "6c530bd3bb2d1a3072513b203afd44affadd4cd3e8f9136f2b7e4e942d7cbd27";
+      sha256 = "6e966992653870494fc3f44a44c8e3a4863b477c506e21c384905ecf7d79077e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/vi/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/vi/firefox-82.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ebfba78fe1778b0e724822adf1f448f005f4575c4c47eaf4d7347c808d2fe5a2";
+      sha256 = "8b1d1fdac04d9fd18a52497bdd2351c511fdd7480914b142e9e83a67b8c2d352";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/xh/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/xh/firefox-82.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "e9e9b4b5cf377ab18c857242d1915ec0198393d35fd93c4ead4ac1d790db4d97";
+      sha256 = "74156e07e1a42d2cdcf8dd533f191673bb7acd6c14fffde0a2ca557cd15bb05e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/zh-CN/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/zh-CN/firefox-82.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "c7d8459ff0eaaac129f168c54454af90f9618c8515f9df2a35de578611700372";
+      sha256 = "4ff34ab97154152f0c1ae67640a7bfd51bf40fdcaa55635573cf9dd315566d5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.2/linux-i686/zh-TW/firefox-82.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/zh-TW/firefox-82.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "b9a3074700de458cd43721b683597f95f2ad81834a15d5ebde22dfc324d92fb3";
+      sha256 = "3c6e1b67a2e4132be1a506bbb1ff25c61519be5a1daa962ef629e0d1f8b670c9";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change

https://www.mozilla.org/en-US/firefox/82.0.3/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2020-49/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>dropbox</li>
    <li>dropbox-cli</li>
    <li>firefox-bin</li>
    <li>firefox-bin-unwrapped</li>
    <li>mate.caja-dropbox</li>
  </ul>
</details>

