### PR TITLE
pythonPackages: add new 'seccomp' library

### DIFF
--- a/pkgs/development/libraries/libseccomp/default.nix
+++ b/pkgs/development/libraries/libseccomp/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wql62cg8f95cwpy057cl764nni9g4sdn5lqj68x22kjs8w71yhz";
   };
 
-  outputs = [ "out" "lib" "dev" "man" ];
+  outputs = [ "out" "lib" "dev" "man" "pythonsrc" ];
 
   nativeBuildInputs = [ gperf ];
   buildInputs = [ getopt ];
@@ -23,6 +23,13 @@ stdenv.mkDerivation rec {
 
   # Hack to ensure that patchelf --shrink-rpath get rids of a $TMPDIR reference.
   preFixup = "rm -rfv src";
+
+  # Copy the python module code into a tarball that we can export and use as the
+  # src input for buildPythonPackage calls
+  postInstall = ''
+    cp -R ./src/python/ tmp-pythonsrc/
+    tar -zcf $pythonsrc --transform s/tmp-pythonsrc/python-foundationdb/ ./tmp-pythonsrc/
+  '';
 
   meta = with stdenv.lib; {
     description = "High level library for the Linux Kernel seccomp filter";

--- a/pkgs/development/python-modules/seccomp/default.nix
+++ b/pkgs/development/python-modules/seccomp/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, lib
+, cython, libseccomp
+}:
+
+buildPythonPackage rec {
+  pname   = "libseccomp";
+  version = libseccomp.version;
+  src     = libseccomp.pythonsrc;
+
+  VERSION_RELEASE = version; # used by build system
+
+  nativeBuildInputs = [ cython ];
+  buildInputs = [ libseccomp ];
+
+  unpackCmd = "tar xf $curSrc";
+  doInstallCheck = true;
+
+  postPatch = ''
+    substituteInPlace ./setup.py \
+      --replace 'extra_objects=["../.libs/libseccomp.a"]' \
+                'libraries=["seccomp"]'
+  '';
+
+  meta = with lib; {
+    description = "Python bindings for libseccomp";
+    license     = with licenses; [ lgpl21 ];
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6503,6 +6503,8 @@ in {
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };
 
+  seccomp = callPackage ../development/python-modules/seccomp { };
+
   secp256k1 = callPackage ../development/python-modules/secp256k1 { inherit (pkgs) secp256k1 pkgconfig; };
 
   secretstorage = if isPy3k then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

See #99553. This implementation ensures we don't build a copy of `libseccomp` for every version of python, but only build the cython extension for every version of python. See the commit message (or patch) for details.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
(https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
