### PR TITLE
pdfpc: 4.4.0 → 4.4.1

### DIFF
--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "pdfpc";
-  version = "4.4.0";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     repo = product;
     owner = product;
     rev = "v${version}";
-    sha256 = "0vh2r32akvasdrghkaq7ard24r2qncp34jfiyshi3zxabm9bhfaa";
+    sha256 = "11n925c5jj3yfwnqkgxzqrmsrpqh8ls1g4idmqqzpsanpam1xvna";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Bug fixes: https://github.com/pdfpc/pdfpc/blob/v4.4.1/CHANGELOG.txt

cc maintainer @pSub 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
