### PR TITLE
vulkan-tools-lunarg: init at 1.2.141.0

### DIFF
--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -51,6 +51,11 @@ stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
   version = "1.2.141.0";
 
+  # If we were to use "dev" here instead of headers, the setupHook would be
+  # placed in that output instead of "out".
+  outputs = ["out" "headers"];
+  outputInclude = "headers";
+
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
@@ -78,6 +83,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DGLSLANG_INSTALL_DIR=${localGlslang}"
+    "-DBUILD_LAYER_SUPPORT_FILES=ON"
   ];
 
   # Help vulkan-loader find the validation layers

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -1,0 +1,86 @@
+{ stdenv, cmake, expat, fetchFromGitHub, jq, lib, libXdmcp, libXrandr, libffi
+, libxcb, pkgconfig, python3, symlinkJoin, vulkan-headers, vulkan-loader
+, vulkan-validation-layers, wayland, writeText, xcbutilkeysyms, xcbutilwm
+, xlibsWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "vulkan-tools-lunarg";
+  # The version must match that in vulkan-headers
+  version = "1.2.141.0";
+
+  src = (assert version == vulkan-headers.version; fetchFromGitHub {
+    owner = "LunarG";
+    repo = "VulkanTools";
+    rev = "sdk-${version}";
+    sha256 = "1zsgc1hdmivdahzrarx7a5byhgnmm5ahz366l92fmdb8pffgq42g";
+    fetchSubmodules = true;
+  });
+
+  nativeBuildInputs = [ cmake pkgconfig python3 jq ];
+
+  buildInputs = [
+    expat
+    libXdmcp
+    libXrandr
+    libffi
+    libxcb
+    wayland
+    xcbutilkeysyms
+    xcbutilwm
+    xlibsWrapper
+  ];
+
+  cmakeFlags = [
+    "-DVULKAN_HEADERS_INSTALL_DIR=${vulkan-headers}"
+    "-DVULKAN_LOADER_INSTALL_DIR=${vulkan-loader}"
+    "-DVULKAN_VALIDATIONLAYERS_INSTALL_DIR=${
+      symlinkJoin {
+        name = "vulkan-validation-layers-merged";
+        paths = [ vulkan-validation-layers.headers vulkan-validation-layers ];
+      }
+    }"
+  ];
+
+  preConfigure = ''
+    # We need to run this update script which generates some source files,
+    # Remove the line in it which calls 'git submodule update' though.
+    # Also patch the scripts in ./scripts
+    update=update_external_sources.sh
+    patchShebangs $update
+    patchShebangs scripts/*
+    sed -i '/^git /d' $update
+    ./$update
+  '';
+
+  # Include absolute paths to layer libraries in their associated
+  # layer definition json files.
+  preFixup = ''
+    for f in "$out"/etc/vulkan/explicit_layer.d/*.json "$out"/etc/vulkan/implicit_layer.d/*.json; do
+      jq <"$f" >tmp.json ".layer.library_path = \"$out/lib/\" + .layer.library_path"
+      mv tmp.json "$f"
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  # Same as vulkan-validation-layers
+  libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
+  dontPatchELF = true;
+
+  # Help vulkan-loader find the validation layers
+  setupHook = writeText "setup-hook" ''
+    export XDG_CONFIG_DIRS=@out@/etc''${XDG_CONFIG_DIRS:+:''${XDG_CONFIG_DIRS}}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "LunarG Vulkan Tools and Utilities";
+    longDescription = ''
+      Tools to aid in Vulkan development including useful layers, trace and
+      replay, and tests.
+    '';
+    homepage = "https://github.com/LunarG/VulkanTools";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    maintainers = [ maintainers.expipiplus1 ];
+  };
+}

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -30,8 +30,13 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "LunarG Vulkan loader";
-    homepage    = "https://www.lunarg.com";
+    description = "Khronos official Vulkan Tools and Utilities";
+    longDescription = ''
+      This project provides Vulkan tools and utilities that can assist
+      development by enabling developers to verify their applications correct
+      use of the Vulkan API.
+    '';
+    homepage    = "https://github.com/KhronosGroup/Vulkan-Tools";
     platforms   = platforms.linux;
     license     = licenses.asl20;
     maintainers = [ maintainers.ralith ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16159,6 +16159,7 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { };
   vulkan-tools = callPackage ../tools/graphics/vulkan-tools { };
+  vulkan-tools-lunarg = callPackage ../tools/graphics/vulkan-tools-lunarg { };
   vulkan-validation-layers = callPackage ../development/tools/vulkan-validation-layers { };
 
   vtkWithQt5 = vtk.override { qtLib = qt514; };


### PR DESCRIPTION
Requires some small changes to vulkan-validation-layers on which it
depends.

I chose the name vulkan-tools-lunarg to keep it alphabetically near its
sister packages, and to distinguish it from the other vulkan-tools.

###### Things done

I've tested that the binaries don't crash on start

The setup hook exposes the layers correctly to the vulkan loader and I've tested a couple of the layers with a vulkan program.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).