### PR TITLE
ocamlPackages.ca-certs: init at 0.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/ca-certs/default.nix
+++ b/pkgs/development/ocaml-modules/ca-certs/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildDunePackage, fetchurl
+, bos, fpath, rresult, ptime, mirage-crypto, x509
+}:
+
+buildDunePackage rec {
+  pname = "ca-certs";
+  version = "0.1.2";
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ca-certs/releases/download/v${version}/ca-certs-v${version}.tbz";
+    sha256 = "10bbqbrsqcmslz56zc5407knalh3kqypbm7lblnzzbidbapa9wpz";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [ bos fpath rresult ptime mirage-crypto x509 ];
+
+  # tests need access to network and systemwide ca cert chain
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Detect root CA certificates from the operating system";
+    maintainers = [ maintainers.sternenseemann ];
+    license = licenses.isc;
+    homepage = "https://github.com/mirage/ca-certs";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -70,6 +70,8 @@ let
 
     bos = callPackage ../development/ocaml-modules/bos { };
 
+    ca-certs = callPackage ../development/ocaml-modules/ca-certs { };
+
     camlidl = callPackage ../development/tools/ocaml/camlidl { };
 
     camlp4 =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`ca-certs` is used in a few unix implementations from the mirage ocaml universe, like in cohttp 3.0.0, so it's probably good to have in nixpkgs in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
