### PR TITLE
kernel config: explicitly enable CONFIG_IPV6

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1062,7 +1062,6 @@ in
       ];
 
     boot.kernelModules = [ ]
-      ++ optional cfg.enableIPv6 "ipv6"
       ++ optional hasVirtuals "tun"
       ++ optional hasSits "sit"
       ++ optional hasBonds "bonding";

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -132,6 +132,7 @@ let
       IP_MROUTE_MULTIPLE_TABLES   = yes;
       IP_MULTICAST                = yes;
       IP_MULTIPLE_TABLES          = yes;
+      IPV6                        = yes;
       IPV6_ROUTER_PREF            = yes;
       IPV6_ROUTE_INFO             = yes;
       IPV6_OPTIMISTIC_DAD         = yes;


### PR DESCRIPTION
We currently build CONFIG_IPV6=m.

This seems to be not really well-supported in mainline kernels - see
https://lore.kernel.org/netdev/20201115224509.2020651-1-flokli@flokli.de/T/#u

Compiling it as a module doesn't give too much benefit - even for people
who did explicitly set `enableIPv6` to false, the `ipv6` module was
still loaded, as soon as another module was loaded that requires it
(bridge,br_netfilter,wireguard,ip6table_mangle,sctp,…).

By compiling it in, we only loose the possibility to not add it to
`boot.kernelModules` anymore (as it's part of the kernel directly). The
space savings are negligible.

People wanting to disable IPv6 still get the appropriate sysctls and
options set (while having the kernel code loaded), nothing is really
changing here.

###### Motivation for this change
```
ip route add 1.2.3.4/32 via inet6 fe80::1 dev eth0
```
fails with the message "Error: IPv6 support not enabled in kernel." if
CONFIG_IPV6 is `m`.

###### Things done

I poked one of the existing networking tests, and tried to program the route manually.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
