### PR TITLE
kakounePlugins.openscad-kak: init at unstable-2020-11-16

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -12,4 +12,5 @@
   kak-powerline = pkgs.callPackage ./kak-powerline.nix { };
   kak-prelude = pkgs.callPackage ./kak-prelude.nix { };
   kak-vertical-selection = pkgs.callPackage ./kak-vertical-selection.nix { };
+  openscad-kak = pkgs.callPackage ./openscad.kak.nix { };
 }

--- a/pkgs/applications/editors/kakoune/plugins/openscad.kak.nix
+++ b/pkgs/applications/editors/kakoune/plugins/openscad.kak.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "openscad.kak";
+  version = "unstable-2019-11-08";
+
+  src = fetchFromGitHub {
+    owner = "mayjs";
+    repo = "openscad.kak";
+    rev = "d9143d5e7834e3356b49720664d5647cab9db7cc";
+    sha256 = "0j4dqhrn56z77hdalfdxagwz8h6nwr8s9i4w0bs2644k72lsm2ix";
+  };
+
+  installPhase = ''
+    install -Dm644 rc/openscad.kak -t $out/share/kak/autoload/plugins/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Syntax highlighting for OpenSCAD files";
+    homepage = "https://github.com/mayjs/openscad.kak";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ eraserhd ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

New Kakoune plugin in Nix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).