### PR TITLE
pythonPackage.python-crontab: init at 2.5.1

### DIFF
--- a/pkgs/development/python-modules/python-crontab/default.nix
+++ b/pkgs/development/python-modules/python-crontab/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, python-dateutil, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "python-crontab";
+  version = "2.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4bbe7e720753a132ca4ca9d4094915f40e9d9dc8a807a4564007651018ce8c31";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [ "test_07_non_posix_shell"];
+
+  propagatedBuildInputs = [ python-dateutil ];
+
+  meta = with lib; {
+    description = "Python API for crontab";
+    longDescription = ''
+      Crontab module for reading and writing crontab files
+      and accessing the system cron automatically and simply using a direct API.
+    '';
+    homepage = "https://pypi.org/project/python-crontab/";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ kfollesdal ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5788,6 +5788,8 @@ in {
 
   python-constraint = callPackage ../development/python-modules/python-constraint { };
 
+  python-crontab = callPackage ../development/python-modules/python-crontab { };
+
   python-ctags3 = callPackage ../development/python-modules/python-ctags3 { };
 
   python-daemon = callPackage ../development/python-modules/python-daemon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add pythonPackage.python-crontab to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
