### PR TITLE
[20.09] elixir_1_6: remove

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -39,27 +39,22 @@ let
         elixir = elixir_1_10;
 
         elixir_1_10 = lib.callElixir ../interpreters/elixir/1.10.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 
         elixir_1_9 = lib.callElixir ../interpreters/elixir/1.9.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 
         elixir_1_8 = lib.callElixir ../interpreters/elixir/1.8.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 
         elixir_1_7 = lib.callElixir ../interpreters/elixir/1.7.nix {
-          inherit rebar erlang;
-          debugInfo = true;
-        };
-
-        elixir_1_6 = lib.callElixir ../interpreters/elixir/1.6.nix {
-          inherit rebar erlang;
+          inherit erlang;
           debugInfo = true;
         };
 

--- a/pkgs/development/interpreters/elixir/1.6.nix
+++ b/pkgs/development/interpreters/elixir/1.6.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "1.6.6";
-  sha256 = "1wl8rfpw0dxacq4f7xf6wjr8v2ww5691d0cfw9pzw7phd19vazgl";
-  minimumOTPVersion = "19";
-}

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, fetchFromGitHub, erlang, rebar, makeWrapper,
+{ pkgs, stdenv, fetchFromGitHub, erlang, makeWrapper,
   coreutils, curl, bash, debugInfo ? false }:
 
 { baseName ? "elixir"
@@ -20,7 +20,7 @@ in
 
     inherit src version;
 
-    buildInputs = [ erlang rebar makeWrapper ];
+    buildInputs = [ erlang makeWrapper ];
 
     LANG = "C.UTF-8";
     LC_TYPE = "C.UTF-8";
@@ -32,10 +32,6 @@ in
     buildFlags = optional debugInfo "ERL_COMPILER_OPTIONS=debug_info";
 
     preBuild = ''
-      # The build process uses ./rebar. Link it to the nixpkgs rebar
-      rm -vf rebar
-      ln -s ${rebar}/bin/rebar rebar
-
       patchShebangs lib/elixir/generate_app.escript || true
 
       substituteInPlace Makefile \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9896,7 +9896,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR23 erlangR22 erlangR21 erlangR20 erlangR19 erlangR18
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
+    elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
 
   inherit (beam.packages.erlang)
     rebar rebar3

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -97,7 +97,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR22.elixir`.
-    inherit (packages.erlang) elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6;
+    inherit (packages.erlang) elixir elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
 
     inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };


### PR DESCRIPTION
Additionally removed the now obsolete rebar build dependency for elixir.

###### Motivation for this change

As noted by @cw789 in his original PR https://github.com/NixOS/nixpkgs/pull/98649, rebar does not compile anymore on otp 23.

We allowed otp 23 in nixos 20.09, which means that all compilation of elixir are broken sometimes, because they depend on rebar, which does not compile on otp 23. On top of that, rebar has problems with openssl in general.

I know this drop elixir 1.6, which technically could break people using it. Elixir should be fully backward compatible, so they should be able to update to a newer one. On top of this, 1.6 was the last one depending on rebar and cannot be compiled on otp23 in the current state anyway.

So or we break anyone using otp 23 with elixir, or we break people using elixir 1.6.

I understand if the decision is to keep the current (broken) situation. @ankhers what do you think ?

###### Things done

Remove elixir 1.6. remove elixir dependency on rebar