### PR TITLE
rspamd: fix builds on non-x86_64-linux platforms

### DIFF
--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -33,7 +33,8 @@ stdenv.mkDerivation rec {
     "-DLOGDIR=/var/log/rspamd"
     "-DLOCAL_CONFDIR=/etc/rspamd"
     "-DENABLE_JEMALLOC=ON"
-  ] ++ lib.optional withHyperscan "-DENABLE_HYPERSCAN=ON";
+  ] ++ lib.optional withHyperscan "-DENABLE_HYPERSCAN=ON"
+  ++ lib.optional (!withLuaJIT) "-DENABLE_LUAJIT=OFF";
 
   passthru.tests.rspamd = nixosTests.rspamd;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #102751 - architectures other than `x86_64` need some love too! (also, it's a package I use on my production machine and I finally figured out how to fix it)

LuaJIT is built in rspamd only on x86_64-linux, and LuaJIT support became enabled by default in 2.6, breaking builds without it. This commit explicitly disables LuaJIT support on non-x86_64 architectures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (i686-linux, x86_64-linux, aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - `nixpkgs#legacyPackages.x86_64-linux.rspamd.tests.rspamd.simple`
  - `nixpkgs#legacyPackages.i686-linux.rspamd.tests.rspamd.simple`
  - `nixpkgs#legacyPackages.aarch64-linux.rspamd.tests.rspamd.simple`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @avnik @fpletz @globin