### PR TITLE
autogen: make man output reproducible

### DIFF
--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "lib" "out" "man" "info" ];
 
+  # Setting the man page date to make the man output binary
+  # reproducible. If we do not set that env variable, we'll end up
+  # with the build datetime in the man output.
+  MAN_PAGE_DATE = "1970-01-01";
+
   nativeBuildInputs = [
     which pkgconfig perl autoreconfHook/*patches applied*/
   ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [


### PR DESCRIPTION
###### Motivation for this change

```
The man page output embeds the build datetime, injecting some
indeterminism to this otherwise binary reproducible build.

Hardcoding this datetime to timestamp 0 via the MAN_PAGE_DATE env variable.

----

Before:

cat columns.1 | grep "User Commands"
.TH columns 1 "16 Nov 2020" "GNU AutoGen (1.2)" "User Commands"

After:

cat columns.1 | grep "User Commands"
.TH columns 1 "1970-01-01" "GNU AutoGen (1.2)" "User Commands"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
