### PR TITLE
libmtp, libgphoto2, gphoto2: Switch to Github, allow building from repo

### DIFF
--- a/pkgs/applications/misc/gphoto2/default.nix
+++ b/pkgs/applications/misc/gphoto2/default.nix
@@ -1,17 +1,38 @@
-{ stdenv, fetchurl, pkgconfig, libgphoto2, libexif, popt, gettext
-, libjpeg, readline, libtool
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, gettext
+, libexif
+, libgphoto2
+, libjpeg
+, libtool
+, popt
+, readline
 }:
 
 stdenv.mkDerivation rec {
-  name = "gphoto2-2.5.26";
+  pname = "gphoto2";
+  version = "2.5.26";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/gphoto/${name}.tar.bz2";
-    sha256 = "0bxbcn31xalsvjp8fra324hf2105y3ps7zlyfz11v71j0lxj2lvn";
+  src = fetchFromGitHub {
+    owner = "gphoto";
+    repo = "gphoto2";
+    rev = "v${version}";
+    sha256 = "1w01j3qvjl2nlfs38rnsmjvn3r0r2xf7prxz1i6yarbpj3fzwqqc";
   };
 
-  nativeBuildInputs = [ pkgconfig gettext libtool ];
-  buildInputs = [ libgphoto2 libexif popt libjpeg readline ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    gettext
+    libtool
+  ];
+
+  buildInputs = [
+    libexif
+    libgphoto2
+    libjpeg
+    popt
+    readline
+  ];
 
   meta = with stdenv.lib; {
     description = "A ready to use set of digital camera software applications";

--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -1,19 +1,34 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libusb1, libtool, libexif, libjpeg, gettext, autoreconfHook }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gettext
+, libusb1
+, libtool
+, libexif
+, libjpeg
+}:
 
 stdenv.mkDerivation rec {
-  name = "libgphoto2-${meta.version}";
+  pname = "libgphoto2";
+  version = "2.5.23";
 
   src = fetchFromGitHub {
     owner = "gphoto";
     repo = "libgphoto2";
-    rev = meta.tag;
+    rev = "libgphoto2-${builtins.replaceStrings [ "." ] [ "_" ] version}-release";
     sha256 = "1sc2ycx11khf0qzp1cqxxx1qymv6bjfbkx3vvbwz6wnbyvsigxz2";
   };
 
   patches = [];
 
-  nativeBuildInputs = [ pkgconfig gettext autoreconfHook ];
-  buildInputs = [ libtool libjpeg libusb1  ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    gettext
+    libtool
+  ];
+
+  buildInputs = [
+    libjpeg
+    libusb1
+  ];
 
   # These are mentioned in the Requires line of libgphoto's pkg-config file.
   propagatedBuildInputs = [ libexif ];
@@ -33,8 +48,6 @@ stdenv.mkDerivation rec {
       MTP, and other vendor specific protocols for controlling and transferring data
       from digital cameras.
     '';
-    version = "2.5.23";
-    tag = "libgphoto2-2_5_23-release";
     # XXX: the homepage claims LGPL, but several src files are lgpl21Plus
     license = stdenv.lib.licenses.lgpl21Plus;
     platforms = with stdenv.lib.platforms; unix;

--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -1,18 +1,40 @@
-{ stdenv, fetchurl, pkgconfig, libusb1, libiconv }:
+{ stdenv, fetchFromGitHub, autoconf, automake, gettext, libtool, pkgconfig
+, libusb1
+, libiconv
+}:
 
 stdenv.mkDerivation rec {
-  name = "libmtp-1.1.18";
+  pname = "libmtp";
+  version = "1.1.18";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libmtp/${name}.tar.gz";
-    sha256 = "1w41l93yi0dmw218daiw36rylkc8rammxx37csh1ij24q18gx03j";
+  src = fetchFromGitHub {
+    owner = "libmtp";
+    repo = "libmtp";
+    rev = "libmtp-${builtins.replaceStrings [ "." ] [ "-" ] version}";
+    sha256 = "0lniy0xq397zddlhsv6n4qjn0wwakli5p3ydzxmbzn0z0jgngjja";
   };
 
   outputs = [ "bin" "dev" "out" ];
 
-  buildInputs = [ libiconv ];
-  propagatedBuildInputs = [ libusb1 ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gettext
+    libtool
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libiconv
+  ];
+
+  propagatedBuildInputs = [
+    libusb1
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   # tried to install files to /lib/udev, hopefully OK
   configureFlags = [ "--with-udev=$$bin/lib/udev" ];


### PR DESCRIPTION
###### Motivation for this change

Github is where upstream's development happens now,
and building from repo makes adding patches and overriding the commit easier.

Also use pname+version, see #103997, and reformat for reduced merge conflicts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).