### PR TITLE
lgogdownloader: 3.5 -> 3.7

### DIFF
--- a/pkgs/games/lgogdownloader/default.nix
+++ b/pkgs/games/lgogdownloader/default.nix
@@ -1,33 +1,36 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, curl, boost, liboauth, jsoncpp
-, htmlcxx, rhash, tinyxml-2, help2man, fetchpatch }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, curl
+, boost
+, liboauth
+, jsoncpp
+, htmlcxx
+, rhash
+, tinyxml-2
+, help2man
+}:
 
 stdenv.mkDerivation rec {
   pname = "lgogdownloader";
-  version = "3.5";
+  version = "3.7";
 
   src = fetchFromGitHub {
     owner = "Sude-";
     repo = "lgogdownloader";
     rev = "v${version}";
-    sha256 = "0a3rrkgqwdqxx3ghzw182jx88gzzw6ldp3jasmgnr4l7gpxkmwws";
+    sha256 = "sha256-3xFlFokqdD1Nstu7TSUCaHUxvSodIb12QNVjmNgn9gs=";
   };
 
   nativeBuildInputs = [ cmake pkgconfig help2man ];
 
-  buildInputs = [ curl boost liboauth jsoncpp htmlcxx rhash tinyxml-2 ];
+  buildInputs = [ boost curl htmlcxx jsoncpp liboauth rhash tinyxml-2 ];
 
-  patches = [
-    # Fix find_path for newer jsoncpp. Remove with the next release
-    (fetchpatch {
-      url = "https://github.com/Sude-/lgogdownloader/commit/ff353126ecda61824cf866d3807c9ebada96282e.patch";
-      sha256 = "1xr1lwxlrncrj662s9l1is1x1mhs1jbwlj8qafixz5hw2kx22w19";
-    })
-  ];
-
-  meta = {
-    homepage = "https://github.com/Sude-/lgogdownloader";
+  meta = with stdenv.lib; {
     description = "Unofficial downloader to GOG.com for Linux users. It uses the same API as the official GOGDownloader";
-    license = stdenv.lib.licenses.wtfpl;
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://github.com/Sude-/lgogdownloader";
+    license = licenses.wtfpl;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The GOG API changed so we need this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).