### PR TITLE
emacs: Add nativeComp packaging infrastructure

### DIFF
--- a/pkgs/applications/editors/emacs/site-start.el
+++ b/pkgs/applications/editors/emacs/site-start.el
@@ -34,6 +34,25 @@ least specific (the system profile)"
       (setenv "EMACSLOADPATH" (when new-env-list
                                 (mapconcat 'identity new-env-list ":"))))))
 
+(let ((wrapper-site-lisp (getenv "emacsWithPackages_siteLispNative"))
+      (env-load-path (getenv "EMACSNATIVELOADPATH")))
+  (when wrapper-site-lisp
+    (setenv "emacsWithPackages_siteLispNative" nil))
+  (when (and wrapper-site-lisp env-load-path)
+    (let* ((env-list (split-string env-load-path ":"))
+           (new-env-list (delete wrapper-site-lisp env-list)))
+      (setenv "EMACSNATIVELOADPATH" (when new-env-list
+                                (mapconcat 'identity new-env-list ":"))))))
+
+;;; Set up native-comp load path.
+(when (featurep 'comp)
+  ;; Append native-comp subdirectories from `NIX_PROFILES'.
+  (setq comp-eln-load-path
+        (append (mapcar (lambda (profile-dir)
+                          (concat profile-dir "/share/emacs/native-lisp/"))
+                        (nix--profile-paths))
+                comp-eln-load-path)))
+
 ;;; Make `woman' find the man pages
 (defvar woman-manpath)
 (eval-after-load 'woman

--- a/pkgs/build-support/emacs/generic.nix
+++ b/pkgs/build-support/emacs/generic.nix
@@ -60,10 +60,13 @@ stdenv.mkDerivation ({
 
   LIBRARY_PATH = "${lib.getLib stdenv.cc.libc}/lib";
 
-  postInstall = ''
-    find $out/share/emacs -type f -name '*.el' -print0 | xargs -0 -n 1 -I {} -P $NIX_BUILD_CORES sh -c "emacs --batch -f batch-native-compile {} || true"
-  '';
+  addEmacsNativeLoadPath = true;
 
+  postInstall = ''
+    find $out/share/emacs -type f -name '*.el' -print0 \
+      | xargs -0 -n 1 -I {} -P $NIX_BUILD_CORES sh -c \
+          "emacs --batch --eval=\"(add-to-list 'comp-eln-load-path \\\"$out/share/emacs/native-lisp/\\\")\" -f batch-native-compile {} || true"
+  '';
 }
 
 // removeAttrs args [ "buildInputs" "packageRequires"

--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -7,8 +7,19 @@ addToEmacsLoadPath() {
   fi
 }
 
+addToEmacsNativeLoadPath() {
+  local nativeDir="$1"
+  if [[ -d $nativeDir && ${EMACSNATIVELOADPATH-} != *"$nativeDir":* ]]; then
+    export EMACSNATIVELOADPATH="$nativeDir:${EMACSNATIVELOADPATH-}"
+  fi
+}
+
 addEmacsVars () {
   addToEmacsLoadPath "$1/share/emacs/site-lisp"
+
+  if [ -n "${addEmacsNativeLoadPath:-}" ]; then
+    addToEmacsNativeLoadPath "$1/share/emacs/native-lisp"
+  fi
 
   # Add sub paths to the Emacs load path if it is a directory
   # containing .el files. This is necessary to build some packages,

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -34,7 +34,15 @@ in customEmacsPackages.emacsWithPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 { lib, lndir, makeWrapper, runCommand }: self:
 
-with lib; let inherit (self) emacs; in
+with lib;
+
+let
+
+  inherit (self) emacs;
+
+  nativeComp = emacs.nativeComp or false;
+
+in
 
 packagesFun: # packages explicitly requested by the user
 
@@ -95,6 +103,9 @@ runCommand
         }
         mkdir -p $out/bin
         mkdir -p $out/share/emacs/site-lisp
+        ${optionalString emacs.nativeComp ''
+          mkdir -p $out/share/emacs/native-lisp
+        ''}
 
         local requires
         for pkg in $explicitRequires; do
@@ -116,6 +127,9 @@ runCommand
         linkEmacsPackage() {
           linkPath "$1" "bin" "bin"
           linkPath "$1" "share/emacs/site-lisp" "share/emacs/site-lisp"
+          ${optionalString nativeComp ''
+            linkPath "$1" "share/emacs/native-lisp" "share/emacs/native-lisp"
+          ''}
         }
 
         # Iterate over the array of inputs (avoiding nix's own interpolation)
@@ -138,12 +152,21 @@ runCommand
         (load-file "$emacs/share/emacs/site-lisp/site-start.el")
         (add-to-list 'load-path "$out/share/emacs/site-lisp")
         (add-to-list 'exec-path "$out/bin")
+        ${optionalString nativeComp ''
+          (add-to-list 'comp-eln-load-path "$out/share/emacs/native-lisp/")
+        ''}
         EOF
         # Link subdirs.el from the emacs distribution
         ln -s $emacs/share/emacs/site-lisp/subdirs.el -T $subdirs
 
         # Byte-compiling improves start-up time only slightly, but costs nothing.
         $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart" "$subdirs"
+
+        ${optionalString nativeComp ''
+          $emacs/bin/emacs --batch \
+            --eval "(add-to-list 'comp-eln-load-path \"$out/share/emacs/native-lisp/\")" \
+            -f batch-native-compile "$siteStart" "$subdirs"
+        ''}
       '';
 
     inherit (emacs) meta;
@@ -159,8 +182,14 @@ runCommand
       substitute ${./wrapper.sh} $out/bin/$progname \
         --subst-var-by bash ${emacs.stdenv.shell} \
         --subst-var-by wrapperSiteLisp "$deps/share/emacs/site-lisp" \
+        --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp:" \
         --subst-var prog
       chmod +x $out/bin/$progname
+
+      makeWrapper "$prog" "$out/bin/$progname" \
+        --suffix EMACSLOADPATH ":" "$deps/share/emacs/site-lisp:" \
+        --suffix EMACSNATIVELOADPATH ":" "$deps/share/emacs/native-lisp:"
+
     done
 
     # Wrap MacOS app
@@ -173,11 +202,16 @@ runCommand
             $emacs/Applications/Emacs.app/Contents/Resources \
             $out/Applications/Emacs.app/Contents
 
+
       substitute ${./wrapper.sh} $out/Applications/Emacs.app/Contents/MacOS/Emacs \
         --subst-var-by bash ${emacs.stdenv.shell} \
         --subst-var-by wrapperSiteLisp "$deps/share/emacs/site-lisp" \
         --subst-var-by prog "$emacs/Applications/Emacs.app/Contents/MacOS/Emacs"
       chmod +x $out/Applications/Emacs.app/Contents/MacOS/Emacs
+
+      makeWrapper $emacs/Applications/Emacs.app/Contents/MacOS/Emacs $out/Applications/Emacs.app/Contents/MacOS/Emacs \
+        --suffix EMACSLOADPATH ":" "$deps/share/emacs/site-lisp:" \
+        --suffix EMACSNATIVELOADPATH ":" "$deps/share/emacs/native-lisp:"
     fi
 
     mkdir -p $out/share

--- a/pkgs/build-support/emacs/wrapper.sh
+++ b/pkgs/build-support/emacs/wrapper.sh
@@ -3,6 +3,7 @@
 IFS=:
 
 newLoadPath=()
+newNativeLoadPath=()
 added=
 
 if [[ -n $EMACSLOADPATH ]]
@@ -21,7 +22,26 @@ else
     newLoadPath+=("")
 fi
 
+if [[ -n $EMACSNATIVELOADPATH ]]
+then
+    while read -rd: entry
+    do
+        if [[ -z $entry && -z $added ]]
+        then
+            newNativeLoadPath+=(@wrapperSiteLispNative@)
+            added=1
+        fi
+        newNativeLoadPath+=("$entry")
+    done <<< "$EMACSNATIVELOADPATH:"
+else
+    newNativeLoadPath+=(@wrapperSiteLispNative@)
+    newNativeLoadPath+=("")
+fi
+
 export EMACSLOADPATH="${newLoadPath[*]}"
 export emacsWithPackages_siteLisp=@wrapperSiteLisp@
+
+export EMACSNATIVELOADPATH="${newNativeLoadPath[*]}"
+export emacsWithPackages_siteLispNative=@wrapperSiteLispNative@
 
 exec @prog@ "$@"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Ref: https://github.com/nix-community/emacs-overlay/issues/74

This is the start of some infrastructure to package native-compilation outputs for Emacs with `nativeComp` enabled.

I've tried to mimic the existing `site-lisp` pattern as much as possible:
- Packages build to `$out/share/emacs/native-lisp`.
- Populate `comp-eln-load-path` from `$profileDir/share/emacs/native-lisp` in `site-start.el`.
- Add an `EMACSNATIVELOADPATH` env variable to mimic `EMACSLOADPATH`. As upstream does not support a variable like this, add some code to `site-start.el` to populate `comp-eln-load-path` from it.
- Add support to `emacsWithPackages` to link `native-lisp` along with `site-lisp` for included elisp packages.

This is a draft because:
- [x] The packaged ELN files are not loaded by `comp` because they are hashed by both their content *and* their absolute file path. There is some code in `comp.c` that ignores the path part of the hash if it's located in `lispdirrel`, so perhaps there's a way to rename these files correctly to match what `comp` expects for a "system" load path.
  - _Update_: Commit https://github.com/emacs-mirror/emacs/commit/3ae309bd59c608b4262209e225b963a8f73450e6 fixes this by following symlinks before computing the hash, so `.eln` files are loaded from the Nix store now when using `emacsWithPackages`.
- [x] Upstream should probably support `EMACSNATIVELOADPATH` so we don't have to have the workaround in `site-start.el`. I've filed [#44726](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44726) to request this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
