### PR TITLE
release: disable darwin bootstrapped stdenv test

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -173,8 +173,13 @@ let
             in {
               # Lightweight distribution and test
               inherit (bootstrap) dist test;
+
               # Test a full stdenv bootstrap from the bootstrap tools definition
-              inherit (bootstrap.test-pkgs) stdenv;
+              # Temporarily disabled. The darwin bootstrap is transitioning the
+              # structure of bootstrap tools. The tools that are generated as
+              # part of the current package set cannot be unpacked in the same
+              # way as the tools used by the current package set.
+              # inherit (bootstrap.test-pkgs) stdenv;
             };
           };
 


### PR DESCRIPTION
###### Motivation for this change

This targets a failing job that will block the channel.

The bootstrap tools are internally consistent, but as expressed in the comment, the generated tools and used tools are different enough that the unpack script doesn't handle them both. We can either disable the test, or try to make unpack handle both. There's still some work to be done in making a new unpack script, and it may require changes to the bootstrap tarball itself. For now I'd prefer to disable this test, and re-enable it when we're ready to merge the new bootstrap tools.

cc @LnL7 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
