### PR TITLE
crate2nix: init at 0.8.0

### DIFF
--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, makeWrapper
+
+, cargo
+, nix
+, nix-prefetch-git
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "crate2nix";
+  version = "0.8.0";
+
+  src = fetchFromGitHub
+    {
+      owner = "kolloch";
+      repo = pname;
+      rev = version;
+      sha256 = "sha256-pqg1BsEq3kGmUzt1zpQvXgdnRcIsiuIyvtUBi3VxtZ4=";
+    } + "/crate2nix";
+
+  cargoSha256 = "sha256-dAMWrGNMleQ3lDbG46Hr4qvCyxR+QcPOUZw9r2/CxV4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Tests use nix(1), which tries (and fails) to set up /nix/var inside the
+  # sandbox
+  doCheck = false;
+
+  postFixup = ''
+    wrapProgram $out/bin/crate2nix \
+        --suffix PATH ":" ${lib.makeBinPath [ cargo nix nix-prefetch-git ]}
+  '';
+
+  meta = with lib; {
+    description = "A Nix build file generator for Rust crates.";
+    longDescription = ''
+      Crate2nix generates Nix files from Cargo.toml/lock files
+      so that you can build every crate individually in a Nix sandbox.
+    '';
+    homepage = "https://github.com/kolloch/crate2nix";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kolloch andir cole-h ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9969,6 +9969,8 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  crate2nix = callPackage ../development/tools/rust/crate2nix { };
+
   maturin = callPackage ../development/tools/rust/maturin { };
   inherit (rustPackages) rls;
   rustfmt = rustPackages.rustfmt;


### PR DESCRIPTION
crate2nix is a tool that "generates nix build files for rust crates
using cargo".

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

For flakes-enabled Rust projects, it would be very nice to rely on crate2nix through Nixpkgs, rather than having to add a non-flake input. If it's in Nixpkgs, it's built by Hydra, and the result will be uploaded to the cache, meaning users don't have to rebuild it every time (themselves, at least).

Closes https://github.com/kolloch/crate2nix/issues/137.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @andir @kolloch: I added you two as maintainers for obvious reasons -- if, for whatever reason, you'd rather not be added, let me know and I'll remove your name.