### PR TITLE
nix: add static nix via `pkgs.nixStatic`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29338,6 +29338,8 @@ in
     nixUnstable
     nixFlakes;
 
+  nixStatic = pkgsStatic.nix;
+
   nixops = callPackage ../tools/package-management/nixops { };
 
   nixopsUnstable = lowPrio (callPackage ../applications/networking/cluster/nixops { });

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -93,32 +93,36 @@ in {
   clangStdenv = foldl (flip id) super.clangStdenv staticAdapters;
   libcxxStdenv = foldl (flip id) super.libcxxStdenv staticAdapters;
 
-  zlib = super.zlib.override {
-    # Don’t use new stdenv zlib because
-    # it doesn’t like the --disable-shared flag
-    stdenv = super.stdenv;
-  };
-  openssl = super.openssl_1_1.overrideAttrs (o: {
-    # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
-    configureFlags = (removeUnknownConfigureFlags o.configureFlags);
-  });
   boost = super.boost.override {
     # Don’t use new stdenv for boost because it doesn’t like the
     # --disable-shared flag
     stdenv = super.stdenv;
   };
+
   curl = super.curl.override {
     brotliSupport = false;
     # disable gss becuase of: undefined reference to `k5_bcmp'
     gssSupport = false;
   };
+
+  ocaml-ng = self.lib.mapAttrs (_: set:
+    if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
+  ) super.ocaml-ng;
+
+  openssl = super.openssl_1_1.overrideAttrs (o: {
+    # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
+    configureFlags = (removeUnknownConfigureFlags o.configureFlags);
+  });
+
   perl = super.perl.override {
     # Don’t use new stdenv zlib because
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
   };
 
-  ocaml-ng = self.lib.mapAttrs (_: set:
-    if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
-  ) super.ocaml-ng;
+  zlib = super.zlib.override {
+    # Don’t use new stdenv zlib because
+    # it doesn’t like the --disable-shared flag
+    stdenv = super.stdenv;
+  };
 }

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -107,6 +107,11 @@ in {
     # --disable-shared flag
     stdenv = super.stdenv;
   };
+  curl = super.curl.override {
+    brotliSupport = false;
+    # disable gss becuase of: undefined reference to `k5_bcmp'
+    gssSupport = false;
+  };
   perl = super.perl.override {
     # Don’t use new stdenv zlib because
     # it doesn’t like the --disable-shared flag

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -100,6 +100,7 @@ in {
   };
 
   curl = super.curl.override {
+    # brotli doesn't build static (Mar. 2021)
     brotliSupport = false;
     # disable gss becuase of: undefined reference to `k5_bcmp'
     gssSupport = false;


### PR DESCRIPTION
###### Motivation for this change
Having a static nix build will open up more possibilities to create alternative and simpler installation mechanisms for nix.

Also I believe this is very useful for other restricted scenarios where a proper installation is just not feasible.

My personal motivation behind this is to create a portable nix distribution to distribute via pypi and conda.

###### Things done
added attribute `pkgs.nixStatic`

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
