### PR TITLE
[20.09] firefox-bin: 82.0.3 -> 83.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "82.0.3";
+  version = "83.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ach/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ach/firefox-83.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "cebf34988221418454b7674778aeb165cfa5d455c93a7b1ff8461c1460f28913";
+      sha256 = "cea6ad61bd402e6c84a81a3f504f1b9292079c9d48d2353b51db4f03a8837fb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/af/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/af/firefox-83.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "cffc807143433dc414415843eb14b34ca3d3f18d5fa26e6ccec090032bb98965";
+      sha256 = "d4bd0a9579f38d53f559412cc3cc04f11871ba22c81eee54dd9ab16c56303513";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/an/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/an/firefox-83.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "1c7b084e089ed4d938f30ecb338f6a20001fc5c92b7ddd7d54dfebabcee67549";
+      sha256 = "10741a6921210643250013c45e9e21bc295da8e41f2bb5c5fadcd86c0e828c80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ar/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ar/firefox-83.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "10930a02e0a902d67b2e3eab8d9cd45dc93611bb77834f6ac7b7ef109d592cb3";
+      sha256 = "3fd4aeef281e5aafdda572d4814e70295c018b7fae6d214c40dabcac367ace69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ast/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ast/firefox-83.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "91191ea0d52b33f2815b02be6af05ed462f394d112218638c427fccd7aef56e2";
+      sha256 = "237e8ff5b3fbc9d7c4095951ca014a5c26cc076305aee705ca943d81e72541dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/az/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/az/firefox-83.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "47dc248859683863c2907867e3c411c4d3620c2ae3001c5a0c693b485a0e5b87";
+      sha256 = "79ca0c798243841cc34281f917aad06c2f546a5e11b443a96e5030aefb8de9b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/be/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/be/firefox-83.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "2e4ddfdbb28d7444b30f58235f634f9f16f88989fd61e7ef8dbf238c0a8455de";
+      sha256 = "c15b0f929b3e3c6ad5618ccf6f9f6b143f893b6f77e176b52ecc608ca3157ab8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/bg/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/bg/firefox-83.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "4c19e9af25e58bbc70d913f5cbaf8551443beee81c854ff8af2f81019b516534";
+      sha256 = "fd2094c59a057e8c35054f7d09c31699aeef927cf9688a87559a8ba69a93f600";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/bn/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/bn/firefox-83.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "40628ea1443ef7c8840ee65767d684f90ddb8ee547ec62367c6bb2e0833e7d8f";
+      sha256 = "c9755c408ca1a4f426f1432339020ef3d7c675d426fae9d8697cded4c7d493f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/br/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/br/firefox-83.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "7a44ab9c67ec58f098cc8ca210ec2e37f922587aaf7495bb0dea60f1b0330e72";
+      sha256 = "d47b889d31b945a5b768b3bbb336fdc43d62c9cc86f13916225cbfe68a560972";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/bs/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/bs/firefox-83.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "017d91858f3df6744eaf2b6764f4f2a303712cb23eaa8ab8ccf58f9b8b215a27";
+      sha256 = "c36da445560b989ae9cf16a1ec72cd2cae82db670f90d27abe0499f8cc025eee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ca-valencia/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ca-valencia/firefox-83.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "f97c9f63139c23167c90b0cb91eddc1e887a827e2f839a7ab9d7a8cb1ec971ea";
+      sha256 = "ef5ee80cc0d6b1b299bc8bb6577b8e26f5de8b541530ddda231e2fafa863e6a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ca/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ca/firefox-83.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "631ae73074f22c446899ac82713c1f5404fbf63efbdde7aa93612f828d64a5af";
+      sha256 = "7c349aa7406899835bc9e70893f28c8109e17ee9ef018e7a723085117f8dd32f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/cak/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/cak/firefox-83.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "72085e68e7f8cccbe4bf4244e11ddbbfa94f6a16c3dfa582fab94ca7ef191e68";
+      sha256 = "3e7aabe665ce423bd47e7d0474039d7bfeb9958849c18e98c37f28def5fae1aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/cs/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/cs/firefox-83.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "41da43aa44eaa092aa6481269d7100792a675764be92af7375e3bbbb21663ae2";
+      sha256 = "97d5e4c255fc87430751c81edc62186e1b4ec901ccf17bfdad7a8ef918077bc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/cy/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/cy/firefox-83.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "b61d03510d351c0c00f7a2e8cc459e736f72cec01e596cb0b95ef53d32e0ce26";
+      sha256 = "c1856b51dedc5788b40671faee8f8cb996108eb514d1263de998043377f2f7c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/da/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/da/firefox-83.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "5c495d632ae0ce2e3f990b41473c12551e66269b612b32ca0a2bf0f9ebddb268";
+      sha256 = "990da1f47d04ec9200d41fa401b23d9607a8e4c11d7cc78989e81785b9633cb0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/de/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/de/firefox-83.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c9c7c2d8f5dea3639d213185718f64266fce8e267d2bc2b6afa9313e1452fd83";
+      sha256 = "94ad875d88a18f24ae38f20b324d074a367969368e660ea2b4b0645e31300c94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/dsb/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/dsb/firefox-83.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "f8c563b71e221e6ced9ecf927e37d9a351ab83303b252e52fc4aae51d6db0703";
+      sha256 = "c3edd46c44bae1b00803e587e6f52560b28ddc2fc935c1fe62714bf16fa72d80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/el/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/el/firefox-83.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "dc0c4e503cab7913cba4186f22c96ebe3f80af59fdb5c9ef1373c799c0f6fc8b";
+      sha256 = "3572a260ec17f76631ca627747ed53d1911ee1180d3e574051b3baf0afd9dcd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/en-CA/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/en-CA/firefox-83.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "735a3a4eddc0f660029020ec694d06e5dcf62b95b6b18dc90453a5a2262d18f9";
+      sha256 = "e3c9363e8b93c625234624ac5c3ab0274055c5b8f4f854da955409b9bdf28d52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/en-GB/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/en-GB/firefox-83.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "985ee60c7d017569db4f455cd1fdaf252432057ed153d6449594d72139833d0c";
+      sha256 = "240a732c034bf2ac286cefc33b02b56df205c4e175457cd84adb7666418e0be4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/en-US/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/en-US/firefox-83.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "54e1f9516aee97ef2858e04a67d691956a461591fdcfecc9bdf9c34c3f026472";
+      sha256 = "93ff827fdcba92ddb71851c46ac8192a727ed61402e896c6262943e382f92412";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/eo/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/eo/firefox-83.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "b07fc960e9204d1995e040ca3e70a61aa531e34bf0dfe6e09cfc35583559f988";
+      sha256 = "456933a6c1fb1e6ad5b2217a7e3730bd54ff037d3d718414b2c92557fea3659d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-AR/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-AR/firefox-83.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "b8c5d160a92bfe94b66fc9554e3343b3385d39e2551bc6b9b0a917135f4f0407";
+      sha256 = "040e8a4a74b8bc77e1d485c3376690f4c5ba85015b360f679ceacd848b0ca574";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-CL/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-CL/firefox-83.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "c89601e6a8dbd91723d8d9174cbba25f43a2729da5bfdf92919abd8972dfa3fa";
+      sha256 = "80e8189ce09c736af1d9927d4943e08e30bc70e9aa7e116f150f14c0dab3fb15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-ES/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-ES/firefox-83.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "4643c154924c5153123796dbef8f759070b7446a31e056259be1f246fdf91ec3";
+      sha256 = "f48489abac5358a10d8ed36b77398493b6a9189a8327bf61bec6ceaca51ab696";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/es-MX/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-MX/firefox-83.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "026c72bcc1e22092a605145952fed6697a1de4945e81ee9f02b95f6654bc2f2b";
+      sha256 = "0d4805b30f05fb8a65b81a42337a8a3732c7664b322557e844929d2b049d0111";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/et/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/et/firefox-83.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e69266e61365d94fb32b3d4f6560a66b94e5e793fe0e36d6cf075ac6ddb31b1f";
+      sha256 = "eb4a463b9271fdde45bddad28ce871953739b55126ae5613963a69a319908fb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/eu/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/eu/firefox-83.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3107f667f558c443ae1925d77b3c2a4b2b2b9257da16af3a3a0f5f03a28d9bf7";
+      sha256 = "3a662c575554d3a542e65950352c527cc51e82ae7a8f9d7ca1b69e30a683731e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fa/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fa/firefox-83.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "bcdc8928b712bd988ef21065207bd8ce40ec7b40958094aaa15261457954f6d0";
+      sha256 = "b5ad3a5d39674d60b6e97cd656c77d7d2fb90943a66a590a29e4d42ec1e18c42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ff/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ff/firefox-83.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "1bd27b188cd1527512d3de37af6b6e0d49064f8e1688a1257c17c16c1cd632f7";
+      sha256 = "2db83d638474186f52fde5fe1ee25201e84b198e44397074203d7ce50e23e74c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fi/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fi/firefox-83.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "2072f0847eb952e937de66bc0dc2a3b5e2cfa267909232b43b19c5f2e0a16622";
+      sha256 = "98bd9c50b5db43bf5fcdc829aa295975d3ec106bbc598fda3d7f26679c0ba08c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fr/firefox-83.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d858bffb885d64aefc589835f783bd8ff22cc962ff718bc142aa2fbb9f728795";
+      sha256 = "ab3427f5cf7cc88d5108b8be21806197420bd775f33d3f2dc983f0f4dec44d5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/fy-NL/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fy-NL/firefox-83.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "7eb1301dfc9266093232c5dc8fe4da7b5139d1312b67266b2e3073e6a29d346b";
+      sha256 = "9f21d91d1529a05a2da7ba29cc8e875b23ffb4b453077b5e899133cf31813397";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ga-IE/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ga-IE/firefox-83.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "d08167164f083ddcff337da35d289dad0b83097243d9fe8bd77186d75b9dc8fa";
+      sha256 = "4c22b166cccede0bcea4e75f826e100dfa4f2def01f904fbffcef789d2d61695";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gd/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gd/firefox-83.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d8a6fa4815c170661b132256274250c2e5fa238d89156f17ce95eeb938ab142b";
+      sha256 = "6ca04d381205121dc695dff78ff646499a21976ae64c110763845eda0598b414";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gl/firefox-83.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b0ebff09180e34dffacd325465b0fb1a54dd2b59c757c8e1fe8425c86fcd44fb";
+      sha256 = "d08f4ea821af5e38c21364037c17b8c97c775d60f0697eb0817dcfc7c6d4c7dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gn/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gn/firefox-83.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "f0f514ed9bba07b1cf72846a452bc74e1d2e13b8bf5ee664382e613ddf351a72";
+      sha256 = "90a8b2fdf1d3471311671761e81637d6771a61744eb480c0788cf03d295c30ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/gu-IN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gu-IN/firefox-83.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "9c61f223ea072bcbe97e247f7e8cce8f0350366078dd2da276e5fc581b94f919";
+      sha256 = "bfe65e5c9795ecdff4dc947d2e2e84d01da894b0ae55c08d73f9397c5730ce17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/he/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/he/firefox-83.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c19534b8c5e0af42c09f4afc091dedba6f15d9498183692d0a5e0285a0f743ae";
+      sha256 = "2dc01c5a929aa79056a66feb522d50cbbb567bc85589f8106e553c9ddfc02a7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hi-IN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hi-IN/firefox-83.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3f25c2b8a33984a085622494b19d22005e6fe5694ff7e277f02b638848d473f8";
+      sha256 = "ef2a61dce3ee713a4be3cee5a9dda8498095a7db69304a7d6585ac674970958a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hr/firefox-83.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "33bf5520c090f078daa53dbb3a2cdbdacafea8cae8ded68f7b0da30233f41916";
+      sha256 = "ab8357cc1f36965ccbd6f4298ffdbb3d77b09cc4b789a3be708d2c51468402bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hsb/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hsb/firefox-83.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "11628732d6da9db696f95d6fcc0df2faa756e9782d77bc00b633f99be5921d1e";
+      sha256 = "6a34074a96be7911672b7e83151244f1f963a8cc8930c8d1d113afe8a49c9529";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hu/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hu/firefox-83.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "e33f6bfae267454b3f541b4193ef2634ae66dfc7387c7bfbf7a8609f803cc131";
+      sha256 = "ffec1646df872a757b771a03c00e3e6df3397e7f4af46bd1d6c0fcab242b1721";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/hy-AM/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hy-AM/firefox-83.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "0d9ea1d3adb92be4c6e40be915ab3d692eeee9e3c593b977b893e003fc7ddcbe";
+      sha256 = "1b9da538ced466302584fef4ecf415aeae5bee51a87d38bd0a6bb3ea155af66d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ia/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ia/firefox-83.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "bf3ad1ba8f77920ed6cb5574bb836f9780e7f19d5c34feb2d562a175ca9e7552";
+      sha256 = "5f8582508155f858c7e52e623579daa7da1aa77bb4e41c2c46d3e6ae8ace6b1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/id/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/id/firefox-83.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "ffba9aefa174ff86bf963daa569796a39a3fbacb295b1932dd00a4d72f12cf86";
+      sha256 = "e5690dcc6b933ddbd27fcfb22f8ab9fc4e4c999d935b6088da38c87af2c567d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/is/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/is/firefox-83.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "182c827998a8bead2b5f76477b01e91b66fa0b0b6ad9c20bb71684c951758728";
+      sha256 = "3776fe6aad623e9b74807a48e105d1619143e78e122906360c4efbc73c2891ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/it/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/it/firefox-83.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3ef3bfcc25ed9e1c9883bd890c60a32acefd243db37bd13eaec71a0c556c2b70";
+      sha256 = "eb54c4596602150c619db6d0d5572a59f7d9c4def68a34cb874cbc6535939e2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ja/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ja/firefox-83.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "67858f54408487c9d4414dd4f072790b686379cd02aaedea165aa2f42ad9f638";
+      sha256 = "54b70bef0507611ad1ea7560668b46385661b5275c7a0ecaad723db44fd8af88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ka/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ka/firefox-83.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "da27168c3eeb9d0836df349e5e258b9f5936cd715374b1614c90fbb4292776a7";
+      sha256 = "56e72349133297d61dfdec4933a01c2cd8fa3d0da3d784e0598506c2db05938c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/kab/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/kab/firefox-83.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "4f523312e1ff88ed06ead886ad8957be6b655063ecd451fcf502b387d4144e82";
+      sha256 = "45f554342449405990c84e910dc6436489046acd00fdc4a0ddabb4b28d7c1284";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/kk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/kk/firefox-83.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b2cff1f5f94e94091d2f0d174ae5a979db34c554f4432891c9b894f0c07a7fd2";
+      sha256 = "3463c4ea5df4e072dfca22e8983fdc016adbe2326bf186a0168ea9ee2c36b3bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/km/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/km/firefox-83.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "0c7b18f57c87d6d94c273b6678ce0dc891afabf9cb9bff3c03a347214bb52cc6";
+      sha256 = "3bb7d2c3e5278d9c51b87d8140096ae01532e99160b866164d1920fb012c085c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/kn/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/kn/firefox-83.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "bf0c5dfcf7c23c033b6180cc4916a014e5c7b44464377f8e1c400db7bd7ddcc0";
+      sha256 = "c9086912382dbff66045c79130403385b9f075bf782220aeb84f03f62a563638";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ko/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ko/firefox-83.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "a1b30b45cce0d3bd1a4acb3a9f335592a819bc740455e56626968f2d66a07839";
+      sha256 = "6f70169cd58ee1559ab224c3ea6f5309bf75267d9f315e389b7971e8e1feed09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/lij/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/lij/firefox-83.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8802eef13ecf4b61adbb6f3350893ef7e4fead3395aebd290df95c7d5dc2bfe7";
+      sha256 = "0b089e6f7954f4d99e9e59bd25148c4be620f9486f8d36c3db68fec5ea700d94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/lt/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/lt/firefox-83.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "3fb34783d2768452aebfc20ff59b84a83139f2dcb04b1e11369b4984560f94d2";
+      sha256 = "b76c545aad6e5b66bd8ab34bf02f7d4f69ecee348381b16c271f4de0243c660d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/lv/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/lv/firefox-83.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "ad3a91899e2a1e2d22f0f15d15956c9c569b8ec0af50b7f194369d969fe9a339";
+      sha256 = "8504d5c00c5569f008b2e308a9193cf62130e89a6e61b33fc842081e4d504322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/mk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/mk/firefox-83.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "b98a27b50ae6c21e20f0bdc43cdf176b0d434a85ace230474bef86cb0411e925";
+      sha256 = "636a421f6238de1fee37014c3af147220af6a1f3c04e2ce6ec9dd17898bc7c20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/mr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/mr/firefox-83.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "6f32b1ed9fe14162366d11ece5b53c185afa314131ba56105ff3aaf9c61cb621";
+      sha256 = "1e00d369be11ad8bfb2dda0ceeb3b7b516fd66427d9e85bff4cc1d699ff3659f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ms/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ms/firefox-83.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "4c7ca7b1e504a9a4c14b7954987f4a2fc3843f341e26f088113aad09c2ed1727";
+      sha256 = "0590f2bff7e43b9f6c081d57276299f8327df73415a8e2a2243e3c4ec9154200";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/my/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/my/firefox-83.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "52b234e2c32f52197d38e618b2d542c584012253d5da9b46dbb47c4198e1319a";
+      sha256 = "ae43f0e8d4ff32274b25a1b78e0af44446ea6989edc4eb3c0d9fae36fcf80908";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/nb-NO/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/nb-NO/firefox-83.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "63baeaf173b4c83c65b160bc12102038be1729f7ab4e535e01726c83d6af4751";
+      sha256 = "9c3a74fc7670e2202be1f4f75208f0113c115169ef70614af631cf16879e081f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ne-NP/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ne-NP/firefox-83.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "c95567889ad498059516e5c4c38e74fae0d937ad85b91813135cb4205b4be527";
+      sha256 = "d830f802cccc7351a447fc59ed64562cac1521d281ddf218c84d1c9af8a65cb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/nl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/nl/firefox-83.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "6ab74c0caa49412b41e9c26af51c18b4b23c9a2990868bb76ee640f77cf7ec81";
+      sha256 = "ecfd03850a48ebf7c3ec9400838100514826b8f35744b0167f61c9086893ae66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/nn-NO/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/nn-NO/firefox-83.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "8ab6be8b9883cd41a0b5ee84fed125b0592c526bd60b57658e3949e675b10909";
+      sha256 = "ad0e4a89afabf1929d441129066dfcbf532d37da31c76bc79108d123cf5cc649";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/oc/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/oc/firefox-83.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "ffa788bf89e7d0533e14c706830e3e5a7995cf0d8827dd6f56e7a02eda85ba63";
+      sha256 = "9b9bbba334c4d7d3907f55a6647cecdf0bb2cd6294569a0008d866cd6eb70a35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pa-IN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pa-IN/firefox-83.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "300caec712dfd4c2a0d615671468ad6ff249b5300d94a1bf18552ec205fc96fd";
+      sha256 = "083266958874618042ee8f2a6162184cd71bc725a994aeb68158d59edb0cafaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pl/firefox-83.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "61cefb394f5490950de3a86312bf13864490c7b77f400881ba67c4e6e04c4585";
+      sha256 = "cb7c72fdc91cd9269a2e53725a26ee94db0e2e608a60ff1120fbe5c1627814bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pt-BR/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pt-BR/firefox-83.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d22845a258c133004216d692071f64c8e639caab6475b09de8e880dd26a808fd";
+      sha256 = "a2a188a222fc6054ca59d24370528e8c8d4d7dc8e4ab18f71510b415dde73d05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/pt-PT/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pt-PT/firefox-83.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "390270b8a04f3e7e7185ebe895741c6d3b82de55bd8a88384f58a2412b1156db";
+      sha256 = "528e1893438ead94afd4013d3c4f4f51107a5d0c4b6d6e018a0687f0d25f9e53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/rm/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/rm/firefox-83.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "c9f916a4bd9d01dbfa7c07988f25db6fc754e98fdf8fb0c6d28c7cf23799fd6c";
+      sha256 = "e4d6e53b642da4de5c7f30297c6fec22b37921a55cb744962dc0d60e26812549";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ro/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ro/firefox-83.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "3079e818963ce30e63f984ef3d24a321bccde52021f68abf7c38e166b63dd3df";
+      sha256 = "04ffa3eda69ea0dfc6251564c4c6bc742d5f8e5dbaf6184b4ee9461226ce5c86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ru/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ru/firefox-83.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "5d5f1d4cf24e1f41f4f49edd2918790f3395bc45656bc385ff863ae996a2e964";
+      sha256 = "697ddeb8ec024b5459492ebd652a612cfa1911267071b230f5ea6ac78a1e3075";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/si/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/si/firefox-83.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "182d4f9f65d923aa4c190eadb2822813a0153d46a7dd789bd03e2c87deaaeee4";
+      sha256 = "a3256c648ea75ce36009306a3c039af228e645ea2e54361fe239ad0cf0869ead";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sk/firefox-83.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "9f38a513c7a35aa403bc570c50d1269fab04f3e0e78a2ee729bd306513b34655";
+      sha256 = "1ae0f898d34c74ea427228d93646ae47990834d14bc4f5563427409dba066f8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sl/firefox-83.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "916cb70157af7c6f44558954ab38b22c0e35472ae449b2cd1b3355e24f69d8ac";
+      sha256 = "9e14b4ad7bd9a8026074e0a3da3d3ba74dbb1be31a2e9cae787802d090c7a965";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/son/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/son/firefox-83.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "4790b6f7fad51191663549d6c06a9a27d2a6edf153caf66c8cbaefc6a2e33547";
+      sha256 = "1b928ca974133a346950ffc663fbed9d1876a4c0bca53fd807d8077d031531d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sq/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sq/firefox-83.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "3265c849c77d482145bdd6e67078ec82e1ba339a807ec15692431a4c43358e2f";
+      sha256 = "7bb9bcfe490bf5d577e55e9b612c932c93ac58252cef592b2af39c17987e700b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sr/firefox-83.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "3d5616ad78372ad3e64e0bd81046680f075de53641c3c1f73edb2aed66f54d96";
+      sha256 = "90e496a5fe9c5d8c38dfcf5a1a07ea04be983fe78c68cb13a2b99067b0f02e7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/sv-SE/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sv-SE/firefox-83.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "bf1122a7ba4cbb5525d35d7245a68bc2534d191639955a6c9810f57dc6b41efc";
+      sha256 = "eab8a1e51a90d36b58901db6175e724f38afb91270b05c51a93c03f8c51fe432";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ta/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ta/firefox-83.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "8ad3ac098bec9283218e0e33dc106457b8f2f21b15aa7b821a5f061566d058fb";
+      sha256 = "bb6d49500393d20134a6f749a77de1fc4cae2feba4e49261862f8a634b4b9276";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/te/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/te/firefox-83.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a366052f680073f1d0c300a5a8e45d6cbd1be7651463067db268626d2fe1a5ea";
+      sha256 = "a1104e292f949976e423b587fe9728fc741b7a11e276e7d747afd3a93abe3eb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/th/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/th/firefox-83.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "509dcd38435c2923a5bac14bb5b2dc4838606f139c29138a0bd5d090fdcb0142";
+      sha256 = "403e4a86b5f95cb22cdb2100372c55d92fcb4708e3f719da72b643637c711458";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/tl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/tl/firefox-83.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "37f39b2df1209fdfa9005e6213d31aa50a8b62c55ed269625ed90f5fefcd5169";
+      sha256 = "993cf86a1b045a477fd4c683e503314fc2aea5a0a52f1faaacd18a0fdc5c7def";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/tr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/tr/firefox-83.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "6417ff882cd86cbb7238414fd8100769ed6dea0a3532af09ed9d7e05ea322f22";
+      sha256 = "8e9e96d0b1a2014dc7374ea893fe72bc72f3840742d305a6e73417468dd6245b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/trs/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/trs/firefox-83.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2fa044fcba5f6155ed55501938df4646dcf83f7d67f53ea8ca945e319db54c29";
+      sha256 = "3590ebb4c888cf92ebd615df9eda2413fd0a3031293d68809fef74fc92fa759b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/uk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/uk/firefox-83.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "345be40eeaa42900bf7091fc8098a92d16369ecea3992974e4a2ad8856f58f3f";
+      sha256 = "7a3a2bae67ddd2afd2d6953f5f045a831595ea29e5cc6ad7083b8ac89e55917b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/ur/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ur/firefox-83.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "47679117a1295b74a4b06b1407ce0dd38fc45326af970f4a20caa4ed8343e739";
+      sha256 = "445a599ba623d8673d71f6ebde70c64a93e28e57b6859e325b0151240f1d49e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/uz/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/uz/firefox-83.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "85dc93248a9db047cd9c97a87e0f36ccd25456c167390bff19e0e84dc93b6756";
+      sha256 = "b63e6c1c6afdc3694ee1d2b21175f4a5603c4454e43f0a08e87ccf800862b6bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/vi/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/vi/firefox-83.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "7882f5c1e3330a567967444fde09e0bca8e2259e4f836603bac61d7fc4de47ed";
+      sha256 = "7127340d189ff601f96ba6f5e6a6175d850e822599e10762908d406b2174a256";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/xh/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/xh/firefox-83.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "fcb914c24f93751ea1ba760818bee0323e5220c14ef95f3d6f302f80d58a0271";
+      sha256 = "41772e457eaf385230086a461033854ad214b4160c6f99f7eb6c4df8dd137dc5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/zh-CN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/zh-CN/firefox-83.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0e3635c27c594395f2364d6f4c140eac66173130afa0130bc4043e500fd91481";
+      sha256 = "013fe88aea216fbc4de9fdaaf559d65678ba389049bcff896540dae8d0a9564d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-x86_64/zh-TW/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/zh-TW/firefox-83.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7c3588bdac4147a43d5a40e376f359823a3503c3ae491e3d98b66b285c924e25";
+      sha256 = "7e9eea2a326842f652aad4995f796af9550d03c034587d171e4b2a33da934645";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ach/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ach/firefox-83.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "ed00c332dc5069a5b4755a759c4096112aa07b5fabaf0827fe63dcc8f96c70f9";
+      sha256 = "9974b19f4f15d9aa33b5432cceea05efe44f31c4123596aca9fb5cd3dd734152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/af/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/af/firefox-83.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "41b4929336370eacd9fcf61bf56adc26377305f253ef8beacae8a3528949a2d9";
+      sha256 = "5600ad5fad398648d2e7a2d7bdf7901769fa428f9ef9f79046917133e12a7eb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/an/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/an/firefox-83.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d8138aebfe43f67f634f4a70142b5463497799396cd4e5ac6fcdd91a1c370d12";
+      sha256 = "d8e0843dafcaf1b010773b83a665fd593741858b60aaba61d4c308a86f765146";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ar/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ar/firefox-83.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "f58e993bde013b674863586dd016d4ac9f8a245a4dfffcca36ea8044afec20a6";
+      sha256 = "952b2ad360662341b9281cfdd93a141fe2efd16f73baa4fc4be1de7b8f12c8c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ast/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ast/firefox-83.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "7fa1d61e805f7f3f94abafd6dd73c5ec3ac518c3192c6fdb7e31f155cfb2d8a9";
+      sha256 = "a7728b09f7e96983a031a32b1b938fa362e1a1e58722b37ec03a4048a152f0b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/az/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/az/firefox-83.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "354db7168cec8c18431e33d5d13efec2b2e1de6b38e462338935ec4157521f46";
+      sha256 = "c6019a3f7ef56583445acc5ab310770c937b44182a1bb3ed54ac452e6e19f8fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/be/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/be/firefox-83.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bfc5689bfcd37bc6afd6438130fac2486670616ebcf3f40e40dbff85f2323ed8";
+      sha256 = "12ead04878e308682f04afb6ac9ce9ab134a5a542af328e029cd973c14fe7444";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/bg/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/bg/firefox-83.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "18bc052d5ba75cd4406aa726648609bc95d869a633ad99f3dcb24dd2621b81c3";
+      sha256 = "7134539d5c259cdf6dd316205b857acae87730ca01bd6ef2efcca75f9d06d027";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/bn/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/bn/firefox-83.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "896eaf0144040b5eb7281f46280b918bca93ab8ebcd3d8a9176d6468a7f82850";
+      sha256 = "a97524e0d6f6f61045b2573ac2fe98e31fa372429f5f53c25fb4cb4d32a31940";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/br/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/br/firefox-83.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "7af967b1fa2aeb7d9e97cc883bd118b4d04a98c8cf56ea2f4f435ee13d1a087b";
+      sha256 = "4619705703a6878fba4de4227d90143abb92237ba556a8c5f4a51c9701671821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/bs/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/bs/firefox-83.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "990778d72c382920590a92ff0c861f8d64274d09da56fa989b5ca124731eb1e4";
+      sha256 = "2131babd061761fa1119a536ae354145315875c5d8cd300405a35924bbbfcc34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ca-valencia/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ca-valencia/firefox-83.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "ec0594197bea5db1058fe3dca4a5e3bdbda53797e87a2fb0af070664b7a7fe3d";
+      sha256 = "73238eb95ac828f4bc2ac220e4b953b950a75b88600b457bf3bd528245574cd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ca/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ca/firefox-83.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "42a25d4006fe6e4f8e7f685304f13f715654d79df775cc6e740a49bf72e691d5";
+      sha256 = "73e65093a587c89c9a392e3b65375ad2158c88e2905ab116eaf8da7cc5841cda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/cak/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/cak/firefox-83.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "452438f73a0da6bc5922de9178c66ab95a0ddc94420a97b771d44d76053d1e71";
+      sha256 = "7f2dd3fdf1e0cae21a1517286b60bbbabd310dfc0dc18588fbe21ba671e97dd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/cs/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/cs/firefox-83.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "fa827fd11c25b37f2e93938be3461061b8c0bd3ca1391c0b50657981cd0e2ba6";
+      sha256 = "5f639cc6d14b06ae62f73fc01b909182efea32710dfd817be60499f4da3eafd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/cy/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/cy/firefox-83.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "12708a5c0f3559d8557f5eb11a5a654b999b2e758d075fa723d78434f1f0fbc9";
+      sha256 = "7a3e9921b2e6e407ebeeb22f1ac4b529222a1f5fbdc84c44fc902b8db6aeb1ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/da/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/da/firefox-83.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "660f0af8ecfbb07df68d5e28eb63b69065eec5ae1e31acbe8f89a7aac66596c6";
+      sha256 = "05dc3274927f692ec3c60f8353a30e2bcb1a36b54f4ddff90407e2818a497a38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/de/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/de/firefox-83.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "16492891efe70c69774e10a83465a5b7ada5a25a1057de0a744c347126667a1a";
+      sha256 = "c95affb4655b7a0ad6959651cf10090970035c74601ea141366cbb5d44f8a526";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/dsb/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/dsb/firefox-83.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "7c830c85f67d2d54b63ddfb94765f5fe1270df06d72e05cc5e0a1dc745e3dbbe";
+      sha256 = "c9baf7df51fdebbb2521dd10830f759110a9c92dcdb579fad99d0c4112126e66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/el/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/el/firefox-83.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "f4c42a7b3b7c8faea5a54affeb47083f7070a37e3e05a85bd26d53eb2571182a";
+      sha256 = "52afcd2037b9cda2c66975dd184276bcccca27833cd7a6da989e32c591a06060";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/en-CA/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/en-CA/firefox-83.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "fb55f47dd07ba7b8e1d4637d0cf693db8de3bae5b729bced9f22e6a3a7136e37";
+      sha256 = "375d3a11f236560f06397f157209b1ce476197a0e7b327cf187dc2002d053c90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/en-GB/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/en-GB/firefox-83.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "98fcf28312060007364b6ae7e73b4e5ec5f78d5cf6b92c68deef49b8aac39e66";
+      sha256 = "610657a623b5680c2ea350a5f3d1ec676e9dac8720e0e67b3e627e37a58b0ad6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/en-US/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/en-US/firefox-83.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "53e1cd6dd28b764fc0e824174de5cb1d70a2b795f7f7e6d1ed400a84d996295b";
+      sha256 = "ac4df9d78ac0321f6be266e7fbf6b79d80bee7cfdf1b00c433072d2283c5fdf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/eo/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/eo/firefox-83.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "0277e0d4f5296fcb5d360e3949991783808362014220eebdab8fd031203d03a5";
+      sha256 = "f23479cb30cf27fa368e9e04591aad2051eedde5e69d105bfc9ba6168792b44b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-AR/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-AR/firefox-83.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "db90a491dde00c0625bfb91f12820235ed4b23ace245520bcea8129bc0fe99ad";
+      sha256 = "5657636c105d301474cf5d2707733a35ac5f5687790002d5778dffb32a727adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-CL/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-CL/firefox-83.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "da7ab44cfe8fef8a89be8180f503477d632e1b0d0e13b410e005971f1eab65cb";
+      sha256 = "896f2ac45b98eccd487de64b6c5aa98733d97bd4422dd1a16d02883e3a06c132";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-ES/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-ES/firefox-83.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "b774a59300369f9aa5e695eecf2923036ac28b790a2b265bff39fa004221351d";
+      sha256 = "9d337fc821dae150c4f3ce26c427ad0efa22c53f3b311b4ce7693b33c9ea4d7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/es-MX/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-MX/firefox-83.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f227f0904d927a9b7696dbd42c33e247b93a517ac465e63658297d266636dd63";
+      sha256 = "f9cbd03f9813157835ef7faf9fa2374e488144930ffdec765c370a95a9c72120";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/et/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/et/firefox-83.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "40c66a997e4a244775c4e094b313d8de66fdd8ca9b59b14b1858e331f0c1760e";
+      sha256 = "4f33cbb67003da1b4db4dc12ee2e7b9fe942bc6e6d770608361355ce7fcf8214";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/eu/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/eu/firefox-83.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "cc346925123d138c8f39f8feaaa830c87b31ec9f3e6d66d62f3c4201389528b8";
+      sha256 = "31970c98d028a83a6198dcee9c5f8191343cd84ec6a7fa032a31730db2cc7b00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fa/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fa/firefox-83.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "74ef4fb696e3a551e920d95341e6b24ebed1abc0f50c3753b5719e649ee6569b";
+      sha256 = "1125c534f2067e57701fab7ae3df55c52dc10693b069817021072c74b8b9bdcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ff/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ff/firefox-83.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "300bd1d7ad740efdf7e783a19bbfbab32d699ded795857005e3d836086414ecf";
+      sha256 = "ef6c66b0d8a6edce0c982eaee55cd14a4ac4d365478976a0c4f1cd48a6c10c6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fi/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fi/firefox-83.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "be9e639888e7fe25508d1fecce9dff0d25fb8f4cc1df9485c06fd34dd1964341";
+      sha256 = "bcd529c0227bd64403dc023ef91459556fbb186e072c12075b705d50293d86c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fr/firefox-83.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "a722540cedb2694bdd8cd347cce80f0e7bd6092227a0d69d64e35cd644f9eb77";
+      sha256 = "47c56fe2b88054d97622e9c0ff2043323b7a916da1e11541e96cf7b05c3e7d52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/fy-NL/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fy-NL/firefox-83.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "d8292b69187d3b69d3e6d38076e9e448cc1851ae560432d524c9ceb25b980302";
+      sha256 = "b0ed17e5022b0817d6b4f58ef990ce22774bde875151c60be1f7251ec90cb189";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ga-IE/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ga-IE/firefox-83.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "3d72fde2daf9dee7d7521dbdcc257aac3e5a3090f07a02aaa4eb1247e4dae774";
+      sha256 = "380aad276cadff8221e4f675751278ba994e08ddb46a0ebde12d87b741c23263";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gd/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gd/firefox-83.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "b599939ac3927e3da21a8b85dfcfb2bbbfbc5ca9833543b7df3e8937184fcb0f";
+      sha256 = "0489ed6e1e9150a0facb4e6fb59bea7673e89669d167806d5651224b939fada5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gl/firefox-83.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "f7d8f6915d9867e740aeeb06614ac3c2a9c29ad914937fef99490c37c329e822";
+      sha256 = "bc41c2b611ecb4ccdedbbf480138a3bc6326106d6c1641d6a06e40f502427af0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gn/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gn/firefox-83.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "940c94891a5bf80b12c24b49276e87c50f6edc601c1876a75ddfb36853f94c02";
+      sha256 = "ade8fe9ab75b0a5f75ce80ba0f8065c4b4cbf54d7772f4c3be96886ca166b373";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/gu-IN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gu-IN/firefox-83.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "8961e66ea0bab00b29ccd365351517d932c75af5fceb9381a0670e225bb9a20e";
+      sha256 = "bc20ad60eee0e6a3d532e436d9b62175872fcb27dab4c9a5083ed6f4bda5f036";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/he/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/he/firefox-83.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "a253c246e6a2820a6552a81291f9887007174120e13f3becd3e3f06d55e12457";
+      sha256 = "a08862d8ebdfa2d6c4f038b91f264c9abe873537d1a7cd2997a1eb4d73bf6f4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hi-IN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hi-IN/firefox-83.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "39f7bd90f28ce92b83c46580e8297367d02042eb274809a0c94f58f6fbd2d0f4";
+      sha256 = "8ed5b454bdc38f07c79924a1dc08e76e65a48bd671991744a441693185683916";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hr/firefox-83.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "37237b7a1b28028c31118b3f6012f6122b428ed81cd0289b224aff910700c92e";
+      sha256 = "97356a661d56d51a9210109db8ad75d61e3e00e4c7570d4e824712b52337af27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hsb/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hsb/firefox-83.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e4c1d598ebd277309e1d9bec979373162cb34ec7874637a7140184c07e590653";
+      sha256 = "5706aa76b23161baf24b79d2b45dd706006fb73aeedd06f41f3273f8078f371b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hu/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hu/firefox-83.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a273f90e185fea5e02fa7be0e859d6569d5a18690dca2485db39719f04f96821";
+      sha256 = "3b894beaef35012df54ba4c7509a06ece1a0cdf741308b3510ddc702c4eb3656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/hy-AM/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hy-AM/firefox-83.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "0da0b1db8a5632776a38d8ca53fc59bb2922b9caeecb779e4fd69086330eb153";
+      sha256 = "b2894092de59b7d6bd6dcd2111fa4591b1a4ed054fd107e2093bd0962edb4405";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ia/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ia/firefox-83.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "53fc34e4f99ace2f287a39dc8ce1d13546574da940dc85703fd81f7bfa7c4483";
+      sha256 = "9d9ee7e05a02078b7d4041c3b63e79f91f0a888b919cf726e2e69090ff05f71d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/id/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/id/firefox-83.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "33088caa35f9939e24e1686a97762c86e6bfde246467544383b4dd20a477ce01";
+      sha256 = "13e54589a23323e9043d4dac5586a31e5d43bdde0356b1a00a86f91ee5813eb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/is/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/is/firefox-83.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "e8651697dd1c6507e950dab2a7c1a3e61c7a1fff5507fa6967577c076aca43d6";
+      sha256 = "955a8a4ff1c5ba7124593b3c8537201ffb1fe33ea5c3edd6ab30e80e6b28f60a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/it/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/it/firefox-83.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "faed37a9099007b2a06a66f0d2baf19f743a5370d354d9295d3c04d283a840c2";
+      sha256 = "23927419191d7aee8b29da29d213ee9c7ff39363f3fc9171c70d801158cb895b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ja/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ja/firefox-83.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "cc403028cdfecfab642f99e4fbf6920cb036f71da9ca05343b41990c01e3974a";
+      sha256 = "4ffaf6df345922bcd82942956a0f344c4b52ac49ec64879fef7307a0c34eb8e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ka/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ka/firefox-83.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "279655a3c1a9151af171066bf164c71a4541344d5bddc02e208faae5af61052b";
+      sha256 = "df1027754efd054bae379b35228067799e75820b08ca7e6aff5a527fdaf046a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/kab/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/kab/firefox-83.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "febad3151c3b6dbd0e3747a4814d2451e7703d8907407255810cd87383a5d665";
+      sha256 = "6fc1e5d662ce742a48c003145b1b4b58cb296b43a20f718bdcffdc05e386078f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/kk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/kk/firefox-83.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "25135a1305e6c4269ef9beec7353669d403023fd552ae43cb7a4b8042eaa9a40";
+      sha256 = "52cb3ac3a33da1227c3aa5e47e04620be2cc020bc520fcf013fe11ad74ad6378";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/km/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/km/firefox-83.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "80daab49e0fd64640fc1b0a7ecaf3b764a0a7b38020aa4a758f1e5e8ee639b9a";
+      sha256 = "c598fa97bb79f56d01afb30caeff29a2c7dd1f162d2fb49c0632ee259d0fe860";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/kn/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/kn/firefox-83.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "dd911926a98835fe4a0a97ad0ee88867bc637a673743b9c6ee75aefea1cf60b9";
+      sha256 = "d6795f3f3c0978dbc399768fd824cceb6a3c1c883c153f65102ef476f74d6408";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ko/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ko/firefox-83.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "975f10dc01c190604cac28705f98b0abb352adf21aa1adb031a11c8061fdb4d5";
+      sha256 = "b4d0b62cdfd332d8e9878b75918a0362a7b68db0b62e4e4508dfa176e79b8ed7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/lij/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/lij/firefox-83.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "9f6183b484eeabfbd4440d644d3da60c1068af430638b1bf9e4e5a4fe47e123a";
+      sha256 = "257eec8bead076119b0c3679feb4f3de34c9cf66bd05215e7d76936e6d3ce052";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/lt/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/lt/firefox-83.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "e95b0760385490b65c774943f72835423c3339030a9b347eeaa7a3cd172065bb";
+      sha256 = "326925d68306ec6e5b7334eb413cff395ce6a27abf5b0981dee25a7888c64079";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/lv/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/lv/firefox-83.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "6a2387d24680d541e12547f6fe38c56e9960beb317e450a39cfdd481b56485d8";
+      sha256 = "036264de51a7a81b3d636b8217db571db70631231d485f353e64e9f43f0192f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/mk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/mk/firefox-83.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "c95e5e94680ce2dd06adb6cc6ab7cb2545e2283b34f9f6702db9c4ee48635d7d";
+      sha256 = "6d4966ae49ba7746395b17b98c158c07d33293b68a6c648d0238107812ccfc03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/mr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/mr/firefox-83.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "6e2ac911d8b4ff89fa5719593b390ffb68f31ea9c53ca075ae91c47907ed67bf";
+      sha256 = "88a90205bfd157fbcb0697efbd4884772a463f776f5110aae9903dbc1151fcbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ms/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ms/firefox-83.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "4c573fc813f878c9baf9ebd2aee71f5459160a2449c424e1bcfbb8035b3b7c50";
+      sha256 = "67d3651739404a73f263251896c129dc121808d4859169b3469b640345433e9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/my/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/my/firefox-83.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a42129e772ecef6e437aff59390da05595f55872c990122bfa07509aae204757";
+      sha256 = "d7e9a1fe6d2e0e32c2ab9a773d198de241ac2a7d330d9eddce4f3afb9a67671b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/nb-NO/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/nb-NO/firefox-83.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "3d72dd2b24c1c99fc1257a9eecf91fd694e67a161b511b991a7294c6dade77c6";
+      sha256 = "66c165884d4397db3e420151d2b6fa3d7bb7c6de790e6d284815cdcc323da3fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ne-NP/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ne-NP/firefox-83.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "a85fa695c3c7a221ee54bee11b5eb88dab9d087d3535f63c143fc8fea759a83e";
+      sha256 = "f75832bd74f5ce8db3765201eee058f0386f196f407223e186c0be3d2a665fcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/nl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/nl/firefox-83.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "48aa468f774d67526e41488882f3796a399ef1789b70793570407e14bf112251";
+      sha256 = "beb68fb193dfcccbe22369f9adcbebe701fd4c9ab5943ec685d5d20398a1ea5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/nn-NO/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/nn-NO/firefox-83.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "857abf782407625492859630cd47be120e5daf8843dbdcb61535fafaa0d5d3cd";
+      sha256 = "de2716b8f4c13c6ef76537ef52f1d0529016302ce220a90d9b5062af9becb5b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/oc/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/oc/firefox-83.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "b8606e264be062dcafc162b5d69191d2962b547fa906e76e68345395378ea471";
+      sha256 = "af2a788560a65cb9f3d2ce98acce4ecd3b3105b6c924c6a4de1a9deb6f2a4d42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pa-IN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pa-IN/firefox-83.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "7279685c4da5b614f6ae0832636676b06ec3384667e1cc1e25379d61b52ebe5c";
+      sha256 = "a3575371b20bab63a8bccc110343e0cd0736cffbc5c72dd7aa371c646a057060";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pl/firefox-83.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "436d60ea9bb7b84bb20973ac39ebaf1fbd6c7966b5fe5677fa829935d76f4932";
+      sha256 = "daa554b493ce1efa90a1b040e78d2f2e7ad8ca70c16ee19312c69ed4a12f00e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pt-BR/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pt-BR/firefox-83.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "47e972cd908b61b1ffb3a194ef12bb1b9e0033a3b30804e0201a94a5dc4c9d42";
+      sha256 = "4f3fe4a1ce0e12383b37832f44b59fbb40b8fb6e95786edc57ea67ea3d5530bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/pt-PT/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pt-PT/firefox-83.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "cab8ffd436e69f7102519bc9ef73d7473336a0a45452f1e85cb0b0ce7c50d197";
+      sha256 = "c16bcb116b845a6b28b72096ae43d50f19c7b9868c8bbb833db60eaaa70b001d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/rm/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/rm/firefox-83.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "26e71bcc89580f7a2510f7018481b86c7674b0534070a85f675a2f576de2d9c1";
+      sha256 = "334d3dcf333a66f4bd169536f7f3b56ba4b257793dfd0837badff2a77b3668f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ro/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ro/firefox-83.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "2c9838ca56e808cbcc0f08987c1b21615119d94dc93cf94dba915491130a0706";
+      sha256 = "1e6ad9735fe0046beaf80ac35d0a1831aade14f388d08991b9bc583135ebd94c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ru/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ru/firefox-83.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "4f9b41754a1dd74d8979940eb17be6578c6907b0deea700697eb340fe607a586";
+      sha256 = "a252bcd66f01375fbc4ce040b89c853c34745e8dede116d200303c56d6307f15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/si/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/si/firefox-83.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "203b50ef0d0d76ab3db56bed03a1b78f3f20819cc804cb5ce470470bd6b6148b";
+      sha256 = "ebc5ce83b456f75b671694ac954258ca480caee563e0cb395786692aedf24d88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sk/firefox-83.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "650cf2fe9ad5628b927f655fe1e88e9260c98543b7fdf6dd5faf9a1cbdf50f08";
+      sha256 = "28aac94a71298c459f14949c9c82b379762d3192a16d92e90605ab8925cb31ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sl/firefox-83.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "7c0aadbc5d6dfff44906eca393acc08388238fb502d183653a094f4ef7095d02";
+      sha256 = "7fe0eb68a898488bcb697120542fbdcfd1d972c658b4c361bba351a8f5eb76e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/son/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/son/firefox-83.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "7e60dd64c8ac8052cbc6efb8cba46713ebefd17e66626a6fa2896a3bf88e9553";
+      sha256 = "f9cb1327834b6a6e41d4abf531410391a40f33a8d168d562dc367faf31d9e042";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sq/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sq/firefox-83.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d8fa2f61a2fdace3374effb32484504afb78651406216c1dc900f6958ed52561";
+      sha256 = "15370cc0527797f451a5a1f47637c6663437c8f49fc5c056ccbc2e7510cd6c94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sr/firefox-83.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "f58146fd202221fec3980ed9fbe7bf84d26465fb63c334826b3271c705e5bc61";
+      sha256 = "c44773c36eb39067e429fb4a4b57676abc7eb9fcf45bd6654d96761f64747c6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/sv-SE/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sv-SE/firefox-83.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "23f71c61978bcf531790a3894e86c7bcd7c930464f9276e4d4464de3d199db53";
+      sha256 = "aa8d2dc50dce8a53a926c71a4a7a57023a017d5fbd54cd1e446ef74b5eef7dea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ta/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ta/firefox-83.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "78fda229fc9583bcfb3b1ee12d494d04955845a703a594e836e9bf3ae67531a7";
+      sha256 = "5fc3e8a048ec24e49c4c4a0e36712b378687e927c30dc8ecb3ec63bcf983062a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/te/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/te/firefox-83.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "86aef155c9b1db83727d8e2df9cf73148ef7146aa6ec77f751f7e548e1ff3e72";
+      sha256 = "ff123410cec64c47d239a432d32eaefa494e7cd7fb0157cc45917fe04b2916ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/th/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/th/firefox-83.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "ae647ba530f60dfad84c95d0b70ee8dba7ef183f1b76c9861b2ef3da6d95779d";
+      sha256 = "cb7cbf97884a5b4f62c4e0932ead0e5de018c9623590ac3798a86986916258dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/tl/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/tl/firefox-83.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "137722d3de0ae236bb17dfc940b8eccd5ac7ed291d22a59486c2e79505d3b34d";
+      sha256 = "0d55a23e2c0b7da80a6c042e50fc3c9364c3f24309cf255bfbe55a320ec2cf00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/tr/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/tr/firefox-83.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "0a2c8be857398f202cafeb97db2a8ac963695e285137c8e7e7df40a9673f0c2f";
+      sha256 = "bfc1adb570f79b4f095bc87ab5a54c6b5179579840ded61319a10ad5ff39d52f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/trs/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/trs/firefox-83.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "6c2d08829057be94edc1923b176fd52ee8cac5cc40e2484c38577865d179cde1";
+      sha256 = "05b5a2252380147ec47561e29514e3f994414b46aae3dd168909f03e7dec16ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/uk/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/uk/firefox-83.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b2b9b997a9bcbe12d3378cf18928ce8cb842a4c3962a0629f6abdd41340f36e1";
+      sha256 = "7e34b52f4d46a735e36f549295d0f9704113024058a7d8d69a8ee6a023d03755";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/ur/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ur/firefox-83.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "b91073657e73985254dde8542ca420087111de7297d7efa368204a45cd8c0932";
+      sha256 = "1d48e536c09f862bc00fcaf9a175eaeffac1e0aaff66d71ca49123c00cc885bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/uz/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/uz/firefox-83.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "6e966992653870494fc3f44a44c8e3a4863b477c506e21c384905ecf7d79077e";
+      sha256 = "1f1cf131b3196886aa0f923c5dbaa279b86c3473dc048ce23d58fe811ca1266c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/vi/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/vi/firefox-83.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "8b1d1fdac04d9fd18a52497bdd2351c511fdd7480914b142e9e83a67b8c2d352";
+      sha256 = "b98507cd809abd28c51514448bf995661dede7c727808ab8c2db46da8da0a164";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/xh/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/xh/firefox-83.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "74156e07e1a42d2cdcf8dd533f191673bb7acd6c14fffde0a2ca557cd15bb05e";
+      sha256 = "73de4ec29cd09610359909ada39820a119a15c3ae0cc1658c2e9b874801a9015";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/zh-CN/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/zh-CN/firefox-83.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "4ff34ab97154152f0c1ae67640a7bfd51bf40fdcaa55635573cf9dd315566d5e";
+      sha256 = "fea085476f4456133c1f0973121319f1c3efadcc50134cbf5ccde351bbe2ff06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/82.0.3/linux-i686/zh-TW/firefox-82.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/zh-TW/firefox-83.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "3c6e1b67a2e4132be1a506bbb1ff25c61519be5a1daa962ef629e0d1f8b670c9";
+      sha256 = "5aebd374f2e73f83bec4c14239555d9f2771d3379280fc55f90f1ae0909be009";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change

Backport of #104049

(cherry picked from commit 668f3772d274541508f9cfac71da1e55e6cc18b6)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
