### PR TITLE
anarchism: fix src

### DIFF
--- a/pkgs/data/documentation/anarchism/default.nix
+++ b/pkgs/data/documentation/anarchism/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = pname;
-    rev = "debian%2F${version}"; # %2F = urlquote("/")
+    rev = "debian/${version}";
     sha256 = "04ylk0y5b3jml2awmyz7m1hnymni8y1n83m0k6ychdh0px8frhm5";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/share/doc/anarchism $out/share/applications $out/share/icons/hicolor/scalable/apps 
+    mkdir -p $out/share/doc/anarchism $out/share/applications $out/share/icons/hicolor/scalable/apps
     cp -r {html,markdown} $out/share/doc/anarchism
     cp debian/anarchism.svg $out/share/icons/hicolor/scalable/apps
     cp debian/anarchism.desktop $out/share/applications


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#104048

The pre-escaped URL was producing:

https://salsa.debian.org/api/v4/projects/debian%2Fanarchism/repository/archive.tar.gz?sha=debian%252F15.3-1

instead of:

https://salsa.debian.org/api/v4/projects/debian%2Fanarchism/repository/archive.tar.gz?sha=debian%2F15.3-1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
