### PR TITLE
doc/builders: Remove out-of-date example

### DIFF
--- a/doc/builders/packages/shell-helpers.xml
+++ b/doc/builders/packages/shell-helpers.xml
@@ -8,18 +8,14 @@
   <itemizedlist>
    <listitem>
     <para>
-     <literal>autojump</literal>: <command>autojump-share</command>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      <literal>fzf</literal>: <command>fzf-share</command>
     </para>
    </listitem>
   </itemizedlist>
-  E.g. <literal>autojump</literal> can then used in the .bashrc like this:
+  E.g. <literal>fzf</literal> can then used in the .bashrc like this:
 <screen>
-  source "$(autojump-share)/autojump.bash"
+  source "$(fzf-share)/completion.bash"
+  source "$(fzf-share)/key-bindings.bash"
 </screen>
  </para>
 </section>


### PR DESCRIPTION
Signed-off-by: Pamplemousse <xav.maso@gmail.com>

###### Motivation for this change

There is no `autojump-share` script!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
