### PR TITLE
[20.09] Backport Unbreak qt512 apps: elisa, kwave, minuet

### DIFF
--- a/pkgs/applications/kde/elisa.nix
+++ b/pkgs/applications/kde/elisa.nix
@@ -3,6 +3,7 @@
 , lib
 , extra-cmake-modules
 , kdoctools
+, qtbase
 , qtmultimedia
 , qtquickcontrols2
 , qtwebsockets
@@ -42,5 +43,6 @@ mkDerivation rec {
     description = "A simple media player for KDE";
     license = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
+    broken = lib.versionOlder qtbase.version "5.14";
   };
 }

--- a/pkgs/applications/kde/kwave.nix
+++ b/pkgs/applications/kde/kwave.nix
@@ -1,14 +1,17 @@
-{ mkDerivation, lib, extra-cmake-modules, kdoctools, qtmultimedia, kcompletion, kconfig, kcrash, kiconthemes, kio, audiofile, libsamplerate
-, alsaLib, libpulseaudio, flac, id3lib, libogg, libmad, libopus, libvorbis, fftw, librsvg }:
+{ mkDerivation, lib, extra-cmake-modules, kdoctools, qtmultimedia, kcompletion, kconfig
+, kcrash, kiconthemes, kio, audiofile, libsamplerate, alsaLib, libpulseaudio, flac, id3lib
+, libogg, libmad, libopus, libvorbis, fftw, librsvg, qtbase }:
 
 mkDerivation {
   name = "kwave";
+
   meta = with lib; {
     homepage = "https://kde.org/applications/en/multimedia/org.kde.kwave";
     description = "KWave is a simple media player";
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+    broken = lib.versionOlder qtbase.version "5.14";
   };
   nativeBuildInputs = [
     extra-cmake-modules

--- a/pkgs/applications/kde/minuet.nix
+++ b/pkgs/applications/kde/minuet.nix
@@ -1,4 +1,4 @@
-{ mkDerivation
+{ mkDerivation, qtbase
 , lib, extra-cmake-modules, gettext, python
 , drumstick, fluidsynth
 , kcoreaddons, kcrash, kdoctools
@@ -10,6 +10,7 @@ mkDerivation {
   meta = with lib; {
     license = with licenses; [ lgpl21 gpl3 ];
     maintainers = with maintainers; [ peterhoeg HaoZeke ];
+    broken = lib.versionOlder qtbase.version "5.14";
   };
 
   nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python qtdeclarative ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Original PR #102761

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
