### PR TITLE
[20.03] openldap: apply security patches

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, cyrus_sasl, db, groff, libtool }:
+{ stdenv, fetchurl, fetchpatch, openssl, cyrus_sasl, db, groff, libtool }:
 
 stdenv.mkDerivation rec {
   name = "openldap-2.4.50";
@@ -9,12 +9,20 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (fetchurl {
-      # Fix a null-ptr dereference for unauthenticated packet in slapd
-      # NO CVE yet
-      # https://bugs.openldap.org/show_bug.cgi?id=9370
+    (fetchpatch {
+      name = "CVE-2020-25692.patch";
       url = "https://git.openldap.org/openldap/openldap/-/commit/4c774220a752bf8e3284984890dc0931fe73165d.patch";
-      sha256 = "1vkbb6szscnhch5zzf6iq104l3dkwd50rih8jk9y0s2vgyz76mil";
+      sha256 = "0mpmf2wqn1wsn94qrarahqff9600lb852zpvyh0g8bwr4cmi4bx7";
+    })
+    (fetchpatch {
+      name = "CVE-2020-25709.patch";
+      url = "https://git.openldap.org/openldap/openldap/-/commit/67670f4544e28fb09eb7319c39f404e1d3229e65.patch";
+      sha256 = "12rks96gzk80892mfjm93rvyda1rv2sh9zqdnz5j885l9wkksfaf";
+    })
+    (fetchpatch {
+      name = "CVE-2020-25710.patch";
+      url = "https://git.openldap.org/openldap/openldap/-/commit/bdb0d459187522a6063df13871b82ba8dcc6efe2.patch";
+      sha256 = "1v72zcz8dk8mr259ig1xrqqb4rjffzfsbmmzn9jgmi3qnf6cilyk";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: CVE-2020-25692, CVE-2020-25709, CVE-2020-25710

Not sure if staging for 20.03 is still a thing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
