### PR TITLE
bat: Add update script

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -29,6 +29,7 @@ in
   avahi = handleTest ./avahi.nix {};
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };
   babeld = handleTest ./babeld.nix {};
+  bat = handleTest ./bat.nix {};
   bazarr = handleTest ./bazarr.nix {};
   bcachefs = handleTestOn ["x86_64-linux"] ./bcachefs.nix {}; # linux-4.18.2018.10.12 is unsupported on aarch64
   beanstalkd = handleTest ./beanstalkd.nix {};

--- a/nixos/tests/bat.nix
+++ b/nixos/tests/bat.nix
@@ -1,0 +1,18 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "bat";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ nequissimus ];
+  };
+
+  machine = { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.bat ];
+    };
+
+  testScript =
+    ''
+      machine.succeed("echo 'Foobar\n\n\n42' > /tmp/foo")
+      assert "Foobar" in machine.succeed("bat -p /tmp/foo")
+      assert "42" in machine.succeed("bat -p /tmp/foo -r 4:4")
+    '';
+})

--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -1,13 +1,6 @@
-{ stdenv
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, less
-, Security
-, libiconv
-, installShellFiles
-, makeWrapper
-}:
+{ stdenv, rustPlatform, fetchFromGitHub, pkg-config, less, Security, libiconv
+, installShellFiles, makeWrapper, writeScript, common-updater-scripts, git
+, nixfmt, nix, coreutils, gnused, gnugrep, gawk }:
 
 rustPlatform.buildRustPackage rec {
   pname = "bat";
@@ -38,10 +31,49 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : "${stdenv.lib.makeBinPath [ less ]}"
   '';
 
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!${stdenv.shell}
+      set -o errexit
+      PATH=${
+        stdenv.lib.makeBinPath [
+          common-updater-scripts
+          git
+          nixfmt
+          nix
+          coreutils
+          gnused
+          gnugrep
+          gawk
+        ]
+      }
+
+      oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
+      latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags git@github.com:sharkdp/bat.git '*' | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's|^v||g')"
+
+      if [ ! "$oldVersion" = "$latestTag" ]; then
+        update-source-version ${pname} "$latestTag" --version-key=version --print-changes
+        nixpkgs="$(git rev-parse --show-toplevel)"
+        default_nix="$nixpkgs/pkgs/tools/misc/bat/default.nix"
+        dummy_cargo="19vhhxfyx3nrngcs6dvwldnk9h4lvs7xjkb31aj1y0pyawz882h9"
+        old_cargo=$(grep '^\s*cargoSha256 = ' pkgs/tools/misc/bat/default.nix | awk -F= '{print $2}' | tr -d '" ;')
+        sed -i "s|$old_cargo|$dummy_cargo|g" "$default_nix"
+        new_cargo=$(nix-build -A bat 2>&1 | grep sha256 | grep got | awk -F: '{print $3}')
+        sed -i "s|$dummy_cargo|$new_cargo|g" "$default_nix"
+        nixfmt "$default_nix"
+      else
+        echo "${pname} is already up-to-date"
+      fi
+    '';
+  };
+
   meta = with stdenv.lib; {
     description = "A cat(1) clone with syntax highlighting and Git integration";
     homepage = "https://github.com/sharkdp/bat";
-    license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ dywedir lilyball zowoq ];
+    license = with licenses; [
+      asl20 # or
+      mit
+    ];
+    maintainers = with maintainers; [ dywedir lilyball nequissimus zowoq ];
   };
 }

--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -1,6 +1,6 @@
 { stdenv, rustPlatform, fetchFromGitHub, pkg-config, less, Security, libiconv
 , installShellFiles, makeWrapper, writeScript, common-updater-scripts, git
-, nixfmt, nix, coreutils, gnused, gnugrep, gawk }:
+, nixfmt, nix, coreutils, gnused, gnugrep, gawk, nixosTests }:
 
 rustPlatform.buildRustPackage rec {
   pname = "bat";
@@ -32,6 +32,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru = {
+    tests = { inherit (nixosTests) bat; };
+
     updateScript = writeScript "update.sh" ''
       #!${stdenv.shell}
       set -o errexit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Add update script
  - There is no good way to get `cargoSha256`, so the update script is a little complex.
- Add test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
