### PR TITLE
remove genesis maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3193,12 +3193,6 @@
     githubId = 313929;
     name = "Gabriel Ebner";
   };
-  genesis = {
-    email = "ronan@aimao.org";
-    github = "bignaux";
-    githubId = 149484;
-    name = "Ronan Bignaux";
-  };
   georgewhewell = {
     email = "georgerw@gmail.com";
     github = "georgewhewell";

--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -94,7 +94,7 @@ mkDerivation rec {
     homepage = "https://github.com/falkTX/Cadence/";
     description = "Collection of tools useful for audio production";
     license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ genesis worldofpeace ];
+    maintainers = with stdenv.lib.maintainers; [ worldofpeace ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/kde/kmahjongg.nix
+++ b/pkgs/applications/kde/kmahjongg.nix
@@ -14,6 +14,6 @@ mkDerivation {
   buildInputs = [ kdeclarative libkmahjongg knewstuff libkdegames ];
   meta = {
     license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ genesis ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/kde/ksudoku.nix
+++ b/pkgs/applications/kde/ksudoku.nix
@@ -13,6 +13,6 @@ mkDerivation {
   buildInputs = [ libGLU kdeclarative libkdegames ];
   meta = {
     license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ genesis ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/kde/libkmahjongg.nix
+++ b/pkgs/applications/kde/libkmahjongg.nix
@@ -9,7 +9,7 @@ mkDerivation {
   name = "libkmahjongg";
   meta = {
     license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ genesis ];
+    maintainers = with lib.maintainers; [ ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kcompletion kconfig kconfigwidgets kcoreaddons ki18n

--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.navit-project.org";
     description = "Car navigation system with routing engine using OSM maps";
     license = licenses.gpl2;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/xkbd/default.nix
+++ b/pkgs/applications/misc/xkbd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mahatma-kaganovich/xkbd";
     description = "onscreen soft keyboard for X11";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -53,7 +53,7 @@ mkDerivation rec {
     description = "Official Qt SoulSeek client";
     homepage = "https://www.slsknet.org";
     license = licenses.unfree;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -23,7 +23,7 @@ mkDerivation rec {
 
   dontBuild = true;
   dontConfigure = true;
-  
+
   nativeBuildInputs = [ imagemagick autoPatchelfHook desktop-file-utils ];
   buildInputs = [ qtmultimedia stdenv.cc.cc ];
 

--- a/pkgs/applications/networking/ps2client/default.nix
+++ b/pkgs/applications/networking/ps2client/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     description = "Desktop clients to interact with ps2link and ps2netfs";
     homepage = "https://github.com/ps2dev/ps2client";
     license = licenses.bsd3;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/ps2client/default.nix
+++ b/pkgs/applications/networking/ps2client/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   patchPhase = ''
    sed -i -e "s|-I/usr/include||g" -e "s|-I/usr/local/include||g" Makefile
   '';
-  
+
   installPhase = ''
     make PREFIX=$out install
   '';

--- a/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
+++ b/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.astrolabeproject.com";
     description = "A Java-based tool for generating EPS files for constructing astrolabes and related tools";
     license = licenses.gpl3;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/rasm/default.nix
+++ b/pkgs/development/compilers/rasm/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Z80 assembler";
     # use -n option to display all licenses
     license = licenses.mit; # expat version
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     homepage    = "https://www.z88dk.org";
     description = "z80 Development Kit";
     license     = licenses.clArtistic;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/tld/default.nix
+++ b/pkgs/development/python-modules/tld/default.nix
@@ -33,7 +33,7 @@ python.pkgs.buildPythonPackage rec {
     homepage = "https://github.com/barseghyanartur/tld";
     description = "Extracts the top level domain (TLD) from the URL given";
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ genesis ];
+    maintainers = with maintainers; [ ];
   };
 
 }

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Fast and fun first-person-shooter based on the Cube fps";
     homepage = "https://assault.cubers.net";
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux; # should work on darwin with a little effort.
     license = stdenv.lib.licenses.zlib;
   };

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       cp ${desktop}/share/applications/* $out/share/applications
       install -Dpm644 packages/misc/icon.png $out/share/icons/assaultcube.png
       install -Dpm644 packages/misc/icon.png $out/share/pixmaps/assaultcube.png
-      
+
       makeWrapper $out/bin/ac_client $out/bin/${pname} \
         --run "cd $out/$gamedatadir" --add-flags "--home=\$HOME/.assaultcube/v1.2next --init"
     fi

--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -35,6 +35,6 @@ buildPythonApplication {
     homepage = "https://github.com/RaaH/gscrabble/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/games/gweled/default.nix
+++ b/pkgs/games/gweled/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gweled.org";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/games/lugaru/default.nix
+++ b/pkgs/games/lugaru/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Third person ninja rabbit fighting game";
     homepage = "https://osslugaru.gitlab.io";
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
     license = stdenv.lib.licenses.gpl2Plus;
   };

--- a/pkgs/games/pentobi/default.nix
+++ b/pkgs/games/pentobi/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "A computer opponent for the board game Blokus";
     homepage = "https://pentobi.sourceforge.io";
     license = licenses.gpl3;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/games/pysolfc/default.nix
+++ b/pkgs/games/pysolfc/default.nix
@@ -43,6 +43,6 @@ buildPythonApplication rec {
     description = "A collection of more than 1000 solitaire card games";
     homepage = "https://pysolfc.sourceforge.io";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ kierdavis genesis ];
+    maintainers = with maintainers; [ kierdavis ];
   };
 }

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Simon Tatham's portable puzzle collection";
     license = licenses.mit;
-    maintainers = [ maintainers.raskin maintainers.genesis ];
+    maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/";
   };

--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "A complete emulation of CPC464, CPC664 and CPC6128";
     homepage = "https://github.com/ColinPitrat/caprice32";
     license = licenses.gpl2;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/emulators/libdsk/default.nix
+++ b/pkgs/misc/emulators/libdsk/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     description = "A library for accessing discs and disc image files";
     homepage = "http://www.seasip.info/Unix/LibDsk/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/emulators/qmc2/default.nix
+++ b/pkgs/misc/emulators/qmc2/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "A Qt frontend for MAME/MESS";
     homepage = "https://qmc2.batcom-it.net";
     license = licenses.gpl2;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
     broken = true;
   };

--- a/pkgs/misc/emulators/qmc2/default.nix
+++ b/pkgs/misc/emulators/qmc2/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
       url = "mirror://sourceforge/project/qmc2/qmc2/${version}/${pname}-${version}.tar.gz";
       sha256 = "1dzmjlfk8pdspns6zg1jmd5fqzg8igd4q38cz4a1vf39lx74svns";
   };
-  
+
   preBuild = ''
     patchShebangs scripts
   '';

--- a/pkgs/misc/emulators/xcpc/default.nix
+++ b/pkgs/misc/emulators/xcpc/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "A portable Amstrad CPC 464/664/6128 emulator written in C";
     homepage = "https://www.xcpc-emulator.net";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/cpcfs/default.nix
+++ b/pkgs/tools/filesystems/cpcfs/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "Manipulating CPC dsk images and files";
     homepage = "https://github.com/derikz/cpcfs/" ;
     license = licenses.bsd2;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/cpcfs/default.nix
+++ b/pkgs/tools/filesystems/cpcfs/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
 
   pname = "cpcfs";
   version = "0.85.4";
-  
+
   src = fetchFromGitHub {
     owner = "derikz";
     repo = "cpcfs";

--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "Manipulating CPC dsk images and files";
     homepage = "https://github.com/cpcsdk/idsk" ;
     license = licenses.mit;
-    maintainers = [ maintainers.genesis ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/romdirfs/default.nix
+++ b/pkgs/tools/filesystems/romdirfs/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mlafeldt/romdirfs";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ genesis ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -8,14 +8,6 @@ stdenv.mkDerivation rec {
   pname = "squashfuse";
   version = "0.1.103";
 
-  meta = {
-    description = "FUSE filesystem to mount squashfs archives";
-    homepage = "https://github.com/vasi/squashfuse";
-    maintainers = [ maintainers.genesis ];
-    platforms = platforms.linux;
-    license = "BSD-2-Clause";
-  };
-
   # platforms.darwin should be supported : see PLATFORMS file in src.
   # we could use a nix fuseProvider, and let the derivation choose the OS
   # specific implementation.
@@ -29,4 +21,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
   buildInputs = [ lz4 xz zlib lzo zstd fuse ];
+
+  meta = {
+    description = "FUSE filesystem to mount squashfs archives";
+    homepage = "https://github.com/vasi/squashfuse";
+    maintainers = [  ];
+    platforms = platforms.linux;
+    license = "BSD-2-Clause";
+  };
 }

--- a/pkgs/tools/networking/photon/default.nix
+++ b/pkgs/tools/networking/photon/default.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
   installPhase = ''
     mkdir -p "$out"/{bin,share/photon}
     cp -R photon.py core plugins $out/share/photon
- 
+
     makeWrapper ${python3Packages.python.interpreter} $out/bin/photon \
       --set PYTHONPATH "$PYTHONPATH:$out/share/photon" \
       --add-flags "-O $out/share/photon/photon.py"

--- a/pkgs/tools/networking/photon/default.nix
+++ b/pkgs/tools/networking/photon/default.nix
@@ -29,6 +29,6 @@ python3Packages.buildPythonApplication rec {
     description = "a lightning fast web crawler which extracts URLs, files, intel & endpoints from a target";
     homepage = "https://github.com/s0md3v/Photon";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ genesis ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/text/poedit/default.nix
+++ b/pkgs/tools/text/poedit/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.poedit.net/";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ domenkozar genesis ];
+    maintainers = with maintainers; [ domenkozar ];
   };
 }

--- a/pkgs/tools/text/poedit/default.nix
+++ b/pkgs/tools/text/poedit/default.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "0pvd903j2x3h9wh38fhlcn23d0jkjlqnfbdpbvnbhy6al1ngx72w";
   };
 
-  nativeBuildInputs = [ autoconf automake asciidoc wrapGAppsHook 
+  nativeBuildInputs = [ autoconf automake asciidoc wrapGAppsHook
     libxslt xmlto boost libtool pkgconfig ];
 
   buildInputs = [ lucenepp nlohmann_json wxGTK30 icu pugixml gtk2 gtkspell2 hicolor-icon-theme ];
 
   propagatedBuildInputs = [ gettext ];
-  
+
   preConfigure = "
     patchShebangs bootstrap
     ./bootstrap
@@ -29,11 +29,11 @@ stdenv.mkDerivation rec {
     "--with-boost-libdir=${boost.out}/lib"
     "CPPFLAGS=-I${nlohmann_json}/include/nlohmann/"
   ];
- 
+
   preFixup = ''
     gappsWrapperArgs+=(--prefix PATH : "${stdenv.lib.makeBinPath [ gettext ]}")
   '';
- 
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
genesis has no longer access to github

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
