### PR TITLE
ceph: Fix CVE-2020-25660

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -1,4 +1,5 @@
 { stdenv, runCommand, fetchurl
+, fetchpatch
 , ensureNewerSourcesHook
 , cmake, pkgconfig
 , which, git
@@ -134,6 +135,11 @@ in rec {
     patches = [
       ./0000-fix-SPDK-build-env.patch
       ./ceph-glibc-2-32-sigdescr_np.patch
+      (fetchpatch {
+        name = "CVE-2020-25660";
+        url = "https://github.com/ceph/ceph/compare/2c93eff00150f0cc5f106a559557a58d3d7b6f1f...6c14c2fb5650426285428dfe6ca1597e5ea1d07d.patch";
+        sha256 = "032hl15q34gq7y6bnljmklpsbd3bpkzmg7r3w0x0ly786iz7zwhm";
+      })
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1890354

Test in progress.

Note that ceph itself is broken (#104047) in master for other reasons, but this is still a useful path for a clean backport.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
