### PR TITLE
bitwig-studio3: add libjack2 at runtime

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -1,4 +1,4 @@
-{ fetchurl, bitwig-studio1, pulseaudio, xorg }:
+{ fetchurl, bitwig-studio1, pulseaudio, libjack2, xorg }:
 
 bitwig-studio1.overrideAttrs (oldAttrs: rec {
   name = "bitwig-studio-${version}";
@@ -11,7 +11,7 @@ bitwig-studio1.overrideAttrs (oldAttrs: rec {
 
   buildInputs = oldAttrs.buildInputs ++ [ xorg.libXtst ];
 
-  runtimeDependencies = [ pulseaudio ];
+  runtimeDependencies = [ libjack2 pulseaudio ];
 
   installPhase = ''
     ${oldAttrs.installPhase}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Bitwig needs JACK to be able to play any sound. It'll try to link to it only after you've opened a project, which might be why this slipped through. Either way, I've added `libjack2` as a runtime dependency, so now it works fine.

###### Motivation for this change
The current `bitwig-studio3` runs, but cannot dynamically link at runtime to `libjack2`, so it can't use any sound.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
