### PR TITLE
urlwatch: 2.19 -> 2.21

### DIFF
--- a/pkgs/development/python-modules/pyee/default.nix
+++ b/pkgs/development/python-modules/pyee/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage, fetchPypi, lib, vcversioner, pytestrunner, mock, pytest, pytest-asyncio, pytest-trio, twisted, zipp, pyparsing, pyhamcrest, futures, attrs, stdenv, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "pyee";
+  version = "7.0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "105n8jzw8vy6cm8mm5sm86mwyaqqr8zjh8w9xvcb7hp29p0vrihm";
+  };
+
+  buildInputs = [
+    vcversioner
+  ];
+
+  checkInputs = [
+    mock
+    pyhamcrest
+    pytest
+    pytest-asyncio
+    pytest-trio
+    pytestrunner
+    twisted
+  ] ++ stdenv.lib.optional isPy27 [
+    attrs
+    futures
+    pyparsing
+    zipp
+  ];
+
+  meta = {
+    description = "A port of Node.js's EventEmitter to python";
+    homepage = "https://github.com/jfhbrook/pyee";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kmein ];
+  };
+}

--- a/pkgs/development/python-modules/pyppeteer/default.nix
+++ b/pkgs/development/python-modules/pyppeteer/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, fetchPypi, lib, urllib3, pyee, tqdm, websockets, appdirs }:
+
+buildPythonPackage rec {
+  pname = "pyppeteer";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1s92izan7s3iffc85wpwi1qv9brcq0rlfqyi84wmpmg1dxk64g0m";
+  };
+
+  # tests want to write to /homeless-shelter
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    appdirs
+    websockets
+    tqdm
+    pyee
+    urllib3
+  ];
+
+  meta = {
+    description = "Headless chrome/chromium automation library (unofficial port of puppeteer)";
+    homepage = "https://github.com/pyppeteer/pyppeteer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kmein ];
+  };
+}

--- a/pkgs/tools/networking/urlwatch/default.nix
+++ b/pkgs/tools/networking/urlwatch/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   name = "urlwatch-${version}";
-  version = "2.19";
+  version = "2.21";
 
   src = fetchFromGitHub {
     owner  = "thp";
     repo   = "urlwatch";
     rev    = version;
-    sha256 = "05vxs0x8gnsv2r9cy0brqny1y5jnj2mw11lqc8lqahx84xcs2m00";
+    sha256 = "1s6bigkwymxdp9bkgvwg3lbf465i6k8kmak2w7czf4mhwavcfq63";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -20,12 +20,13 @@ python3Packages.buildPythonApplication rec {
     pycodestyle
     pyyaml
     requests
+    pyppeteer
   ];
 
   meta = with stdenv.lib; {
     description = "A tool for monitoring webpages for updates";
     homepage = "https://thp.io/2008/urlwatch/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ tv ];
+    maintainers = with maintainers; [ kmein tv ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4984,6 +4984,8 @@ in {
 
   pyechonest = callPackage ../development/python-modules/pyechonest { };
 
+  pyee = callPackage ../development/python-modules/pyee { };
+
   pyelftools = callPackage ../development/python-modules/pyelftools { };
 
   pyemd = callPackage ../development/python-modules/pyemd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5346,6 +5346,8 @@ in {
 
   pypoppler = callPackage ../development/python-modules/pypoppler { };
 
+  pyppeteer = callPackage ../development/python-modules/pyppeteer { };
+
   pyprind = callPackage ../development/python-modules/pyprind { };
 
   pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };


### PR DESCRIPTION
###### Motivation for this change
The `urlwatch` package was out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
