### PR TITLE
selinux: 2.9 -> 3.0

### DIFF
--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -1,26 +1,26 @@
 { stdenv, fetchurl, pcre, pkgconfig, libsepol
-, enablePython ? true, swig ? null, python ? null
+, enablePython ? true, swig ? null, python3 ? null
 , fts
 }:
 
-assert enablePython -> swig != null && python != null;
+assert enablePython -> swig != null && python3 != null;
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "libselinux";
-  version = "2.9";
+  version = "3.0";
   inherit (libsepol) se_release se_url;
 
   outputs = [ "bin" "out" "dev" "man" ] ++ optional enablePython "py";
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libselinux-${version}.tar.gz";
-    sha256 = "14r69mgmz7najf9wbizvp68q56mqx4yjbkxjlbcqg5a47s3wik0v";
+    sha256 = "0cr4p0qkr4qd5z1x677vwhz6mlz55kxyijwi2dmrvbhxcw7v78if";
   };
 
-  nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python ];
-  buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ python ];
+  nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python3 ];
+  buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ python3 ];
 
   # drop fortify here since package uses it by default, leading to compile error:
   # command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
@@ -35,13 +35,17 @@ stdenv.mkDerivation rec {
     "MAN3DIR=$(man)/share/man/man3"
     "MAN5DIR=$(man)/share/man/man5"
     "MAN8DIR=$(man)/share/man/man8"
-    "PYTHON=${python.pythonForBuild}/bin/python"
-    "PYTHONLIBDIR=$(py)/${python.sitePackages}"
+    "PYTHON=${python3.pythonForBuild}/bin/python"
+    "PYTHONLIBDIR=$(py)/${python3.sitePackages}"
     "SBINDIR=$(bin)/sbin"
     "SHLIBDIR=$(out)/lib"
 
     "LIBSEPOLA=${stdenv.lib.getLib libsepol}/lib/libsepol.a"
   ];
+
+  preInstall = ''
+    mkdir -p $py/${python3.sitePackages}/selinux
+  '';
 
   installTargets = [ "install" ] ++ optional enablePython "install-pywrap";
 

--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "libsepol";
-  version = "2.9";
-  se_release = "20190315";
+  version = "3.0";
+  se_release = "20191204";
   se_url = "https://github.com/SELinuxProject/selinux/releases/download";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libsepol-${version}.tar.gz";
-    sha256 = "0p8x7w73jn1nysx1d7416wqrhbi0r6isrjxib7jf68fi72q14jx3";
+    sha256 = "0ygb6dh5lng91xs6xiqf5v0nxa68qmjc787p0s5h9w89364f2yjv";
   };
 
   nativeBuildInputs = [ flex ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18443,9 +18443,7 @@ in
 
   keyutils = callPackage ../os-specific/linux/keyutils { };
 
-  libselinux = callPackage ../os-specific/linux/libselinux {
-    python = python37;
-  };
+  libselinux = callPackage ../os-specific/linux/libselinux { };
 
   libsemanage = callPackage ../os-specific/linux/libsemanage {
     python = python3;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3434,13 +3434,13 @@ in {
       p.overrideAttrs (super: {
         meta = super.meta // {
           outputsToInstall = [ "py" ];
-          broken = (super.meta.broken or false) || pythonAtLeast "3.8";
+          broken = super.meta.broken or isPy27;
         };
       }))
     (p:
       p.override {
         enablePython = true;
-        inherit python;
+        python3 = python;
       })
     (p: p.py)
   ];


### PR DESCRIPTION
###### Motivation for this change

Notably, Python 2 code is not be supported in this project anymore and
new Python code should be written only for Python 3, which is no longer
restricted to Python 3.7 (see 780fb563c74171aafc2fb802cfdebd56a68d0705,
5dfd3c497540bb172ff0d04cc8eb5ecbeb59b938)

https://github.com/SELinuxProject/selinux/releases/tag/20191204


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).