### PR TITLE
treewide: enable security hardening flags

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -5,7 +5,6 @@ stdenv.mkDerivation {
   name = "security-wrapper";
   buildInputs = [ linuxHeaders ];
   dontUnpack = true;
-  hardeningEnable = [ "pie" ];
   CFLAGS = [
     ''-DWRAPPER_DIR="${parentWrapperDir}"''
   ] ++ (if debug then [

--- a/nixos/tests/boot-stage1.nix
+++ b/nixos/tests/boot-stage1.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         kdev = config.boot.kernelPackages.kernel.dev;
         kver = config.boot.kernelPackages.kernel.modDirVersion;
         ksrc = "${kdev}/lib/modules/${kver}/build";
-        hardeningDisable = [ "pic" ];
+        hardeningDisable = [ "pic" "pie" ];
         nativeBuildInputs = kdev.moduleBuildDependencies;
       } ''
         echo "obj-m += $name.o" > Makefile

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
     sha256 = "0qsfbyrrpb3bbdyq68k28mjql7kglxh8nqcw9jvja28x6x9ik5a0";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [
     gettext
     hicolor-icon-theme

--- a/pkgs/applications/audio/gxmatcheq-lv2/default.nix
+++ b/pkgs/applications/audio/gxmatcheq-lv2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   # error: format not a string literal and no format arguments [-Werror=format-security]
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   installFlags = [ "INSTALL_DIR=$(out)/lib/lv2" ];
 

--- a/pkgs/applications/audio/gxplugins-lv2/default.nix
+++ b/pkgs/applications/audio/gxplugins-lv2/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     xorg.libX11 xorgproto cairo lv2

--- a/pkgs/applications/audio/lsp-plugins/default.nix
+++ b/pkgs/applications/audio/lsp-plugins/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1apw8zh3a3il4smkjji6bih4vbsymj0hjs10fgkrd4nazqkjvgyd";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config php makeWrapper ];
   buildInputs = [ jack2 libsndfile libGLU libGL lv2 cairo ladspaH ];
 

--- a/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1h0bhjhx023476gbijq842b6f8z71zcyn4c9mddwyb18w9cdamp5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0yhj680zgk4dn4fi8j3apm72f3z2mjk12amf2a7p0lwn9iyh4a2z";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sipmc25fr7w7xqx1r0y6i2zwfkgszzwvhk1v15mnsb3cqvk8ybn";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "10xdydwmsnkx8hzsm74pa546yahp29wifydbc48yywv3sfj5anm7";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0mdzaqmxzgspfgx9w1hdip18y17hwpdcgjyq1rrfm843vkascwip";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     (fetchpatch {
       url = "https://github.com/magnetophon/MBdistortion/commit/10e35084b88c559f1b63760cf40fd5ef5a6745a5.patch";

--- a/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1j0bjl9agz43dcrcrbiqd7fv7xsxgd65s4ahhv5pvcr729y0fxg4";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "144f6g17q4m50kxzdncsfzdyycdfprnpwdaxcwgxj4jky1xsha1d";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1hnr5sp7k6ypf4ks61lnyqx44dkv35yllf3a3xcbrw7yqzagwr1c";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1b1h4z5fs2xm7wvw11p9wnd0bxs3m88124f5phh0gwvpsdrd0im5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/mamba/default.nix
+++ b/pkgs/applications/audio/mamba/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ cairo fluidsynth libX11 libjack2 alsaLib liblo libsigcxx libsmf ];
 

--- a/pkgs/applications/audio/mooSpace/default.nix
+++ b/pkgs/applications/audio/mooSpace/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "10vsbddf6d7i06040850v8xkmqh3bqawczs29kfgakair809wqxl";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   patchPhase = "mv ${pname}_faust.dsp ${pname}.dsp";

--- a/pkgs/applications/audio/orca-c/default.nix
+++ b/pkgs/applications/audio/orca-c/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
     sha256 = "101y617a295hzwr98ykvza1sycxlk29kzxn2ybjwc718r0alkbzz";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ncurses portmidi ];
 
   patchPhase = ''

--- a/pkgs/applications/audio/tambura/default.nix
+++ b/pkgs/applications/audio/tambura/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1w80cmiyzca1wirf5gypg3hcix1ky777id8wnd3k92mn1jf4a24y";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ faust2jaqt faust2lv2 ];
 
   buildPhase = ''

--- a/pkgs/applications/audio/xtuner/default.nix
+++ b/pkgs/applications/audio/xtuner/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ cairo libX11 libjack2 liblo libsigcxx zita-resampler fftwFloat ];
 

--- a/pkgs/applications/blockchains/aeon/default.nix
+++ b/pkgs/applications/blockchains/aeon/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     "-DReadline_ROOT_DIR=${readline.dev}"
   ];
 
-  hardeningDisable = [ "fortify" ];
+  hardeningDisable = [ "fortify" "pie" ];
 
   meta = with lib; {
     description = "Private, secure, untraceable currency";

--- a/pkgs/applications/blockchains/quorum.nix
+++ b/pkgs/applications/blockchains/quorum.nix
@@ -13,6 +13,8 @@ buildGoPackage rec {
     sha256 = "0xfdaqp9bj5dkw12gy19lxj73zh7w80j051xclsvnd41sfah86ll";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ git which ];
 
   buildPhase = ''

--- a/pkgs/applications/blockchains/sumokoin.nix
+++ b/pkgs/applications/blockchains/sumokoin.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ndgcawhxh3qb3llrrilrwzhs36qpxv7f53rxgcansbff9b3za6n";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ unbound openssl boost libunwind lmdb miniupnpc ];
 

--- a/pkgs/applications/editors/code-browser/default.nix
+++ b/pkgs/applications/editors/code-browser/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     url = "https://tibleiz.net/download/code-browser-${version}-src.tar.gz";
     sha256 = "1svi0v3h42h2lrb8c7pjvqc8019v1p20ibsnl48pfhl8d96mmdnz";
   };
+  hardeningDisable = [ "pie" ];
   postPatch = ''
     substituteInPlace Makefile --replace "LFLAGS=-no-pie" "LFLAGS=-no-pie -L."
     substituteInPlace libs/copper-ui/Makefile --replace "moc -o" "${qtbase.dev}/bin/moc -o"

--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
     sha256 = "1zq17yi5zn4hdgrrn3c3cdk6s38fv36r66dl0dqz2z8jjd6vy4p3";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     substituteInPlace app/proc_globdata.pas \
       --replace "/usr/share/cudatext" "$out/share/cudatext" \

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -121,7 +121,7 @@ let emacs = stdenv.mkDerivation (lib.optionalAttrs nativeComp {
     ++ lib.optionals nativeComp [ libgccjit ]
     ;
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" ] ++ lib.optionals (lib.versionOlder version "27") [ "pie" ];
 
   configureFlags = [
     "--disable-build-details" # for a (more) reproducible build

--- a/pkgs/applications/graphics/deskew/default.nix
+++ b/pkgs/applications/graphics/deskew/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0zjjj66qhgqkmfxl3q7p78dv4xl4ci918pgl4d5259pqdj1bfgc8";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ fpc ];
   buildInputs = [ libtiff ];
 

--- a/pkgs/applications/graphics/lazpaint/default.nix
+++ b/pkgs/applications/graphics/lazpaint/default.nix
@@ -27,6 +27,8 @@ in stdenv.mkDerivation rec {
     sha256 = "0bpk3rlqzbxvgrxmrzs0hcrgwhsqnpjqv1kdd9cp09knimmksvy5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ lazarus fpc makeWrapper ];
 
   buildInputs = [ pango cairo glib atk gtk2 libX11 gdk-pixbuf ];

--- a/pkgs/applications/misc/cpu-x/default.nix
+++ b/pkgs/applications/misc/cpu-x/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LWIcE86o+uU8G9DtumiH6iTqHhvq4y/QyQX7J3FhKEc=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook nasm makeWrapper ];
   buildInputs = [
     gtk3 ncurses libcpuid pciutils procps

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     sha256 = "0rljl44y8p8hgaqializlyrgpij1wbnrzyp0ll5kcg7w05nylq48";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = lib.optional stdenv.isDarwin ./darwin.patch ++ [
     (fetchpatch {
       name = "pdfocr.patch";

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -7,6 +7,11 @@ mkChromiumDerivation (base: rec {
   packageName = "chromium";
   buildTargets = [ "mksnapshot" "chrome_sandbox" "chrome" ];
 
+  hardeningDisable = [
+    "cfprotection"
+    "pie" # clang++: warning: argument unused during compilation: '-pie'
+  ];
+
   outputs = ["out" "sandbox"];
 
   sandboxExecutableName = "__chromium-suid-sandbox";

--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LxJJ0yBlw9hJ/agyL9dbVe4STKdXE8rtk1mMFqe1fFI=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [
     ncurses xlibsWrapper bzip2 zlib brotli zstd xz
     openssl libidn tre expat libev

--- a/pkgs/applications/networking/browsers/lynx/default.nix
+++ b/pkgs/applications/networking/browsers/lynx/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = [ "pie" ];
-
   configureFlags = [
     "--enable-default-colors"
     "--enable-widec"

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -31,6 +31,8 @@ in buildGoPackage rec {
     sha256 = "16bc6ljm418kxz92gz8ldm82491mvlqamrvigyr6ff72rf7ml7ba";
   };
 
+  hardeningDisable = [ "pie" ]; # clang-7: error: argument unused during compilation: '-pie'
+
   goPackagePath = "github.com/openshift/origin";
 
   buildInputs = [ libkrb5 ncurses ];

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0zhhcbcr59sx9h4maf8zamzv2waya7sbsl7w74gbyilvy93dw5cz";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ] ++ optional doCheck check;
 
   buildInputs = [ gnutls libotr python2 ]

--- a/pkgs/applications/networking/instant-messengers/utox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/utox/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [
     libtoxcore dbus libvpx libX11 openal freetype
     libv4l libXrender fontconfig libXext libXft filter-audio

--- a/pkgs/applications/networking/p2p/transgui/default.nix
+++ b/pkgs/applications/networking/p2p/transgui/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1dyx778756zhvz5sxgdvy49p2c0x44w4nmcfd90wqrmgfknncnf5";
   };
 
+  hardeningDisable = [ "glibcxxassertions" "pie" ];
+
   nativeBuildInputs = [ pkg-config unzip ];
   buildInputs = [
     fpc lazarus stdenv.cc

--- a/pkgs/applications/radio/cqrlog/default.nix
+++ b/pkgs/applications/radio/cqrlog/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     sha256 = "0zzcg0bl6mq4wfifj998x9x09w8sigbh46synpqx034fpr0swyhb";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # Adds the possiblity to change the lazarus directory,
   # otherwise, we would get error : "directory lcl not found"
   patches = [ ./fix-makefile-lazarusdir.patch ];

--- a/pkgs/applications/radio/gnuradio/3.7.nix
+++ b/pkgs/applications/radio/gnuradio/3.7.nix
@@ -234,7 +234,7 @@ stdenv.mkDerivation rec {
     dontWrapPythonPrograms
     meta
   ;
-
+  hardeningDisable = [ "glibcxxassertions" ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must
     inherit boost volk;

--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -230,6 +230,7 @@ stdenv.mkDerivation rec {
     dontWrapQtApps
     meta
   ;
+  hardeningDisable = [ "glibcxxassertions" ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must
     inherit boost volk;

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -240,6 +240,7 @@ stdenv.mkDerivation rec {
     dontWrapQtApps
     meta
   ;
+  hardeningDisable = [ "glibcxxassertions" ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must
     inherit boost volk;

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
     sha256 = "Xfx0bsHUQ5+Dp+xk0sVWWP83oyXQcUH5AX4PNEE7fY4=";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   cmakeFlags = [
     "-DENABLE_LIBUHD=ON"
     "-DENABLE_USB=ON"

--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1zfhv2zg9v1icdlq4p9ssc8k01mca5d1bd87w71py2swfi74s6yy";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ zlib ];
 
   # Avoid hardcoding gcc to allow environments with a different

--- a/pkgs/applications/science/biology/freebayes/default.nix
+++ b/pkgs/applications/science/biology/freebayes/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ zlib bzip2 xz ];
 
   installPhase = ''

--- a/pkgs/applications/science/biology/whisper/default.nix
+++ b/pkgs/applications/science/biology/whisper/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0wpx1w1mar2d6zq2v14vy6nn896ds1n3zshxhhrrj5d528504iyw";
   };
 
+  hardeningDisable = [ "pie" ];
+
   preConfigure = ''
     cd src
 

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     sha256 = "0nzcyi6l2zv9wxzsv9i963p3igyjds0n55x0ph561mc3pfbc7aqp";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ autoconf bison flex gperf ];
 
   buildInputs = [ bzip2 ncurses readline zlib ];

--- a/pkgs/applications/science/logic/cadical/default.nix
+++ b/pkgs/applications/science/logic/cadical/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "05lvnvapjawgkky38xknb9lgaliiwan4kggmb9yggl4ifpjrh8qf";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   doCheck = true;
   dontAddPrefix = true;
 

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     ./Fix-to-string.agda-to-compile-with-Agda-2.6.1.patch
   ];

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -73,6 +73,8 @@ self = stdenv.mkDerivation {
   pname = "coq";
   inherit (fetched) version src;
 
+  hardeningDisable = [ "pie" ];
+
   passthru = {
     inherit coq-version;
     inherit ocamlPackages ocamlBuildInputs;

--- a/pkgs/applications/science/logic/iprover/default.nix
+++ b/pkgs/applications/science/logic/iprover/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lik8p7ayhjwpkln1iwf0ri84ramhch74j5nj6z7ph6wfi92pgg8";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ocaml eprover zlib ];
 
   preConfigure = "patchShebangs .";

--- a/pkgs/applications/science/logic/lingeling/default.nix
+++ b/pkgs/applications/science/logic/lingeling/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation {
     sha256 = "1lw1yfy219p7rrk88sbq4zl24b70040zapbjdrpv5a6i0jsblksx";
   };
 
+  hardeningDisable = [ "pie" ];
+
   configurePhase = ''
     ./configure.sh
 

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -31,6 +31,7 @@ let
   core = stdenv.mkDerivation {
     name = "${pname}-${version}";
     inherit src patches;
+    hardeningDisable = [ "glibcxxassertions" ];
     nativeBuildInputs = [ cmake ];
     buildInputs = [ zlib gmp jdk8 ];
 

--- a/pkgs/applications/science/logic/ott/default.nix
+++ b/pkgs/applications/science/logic/ott/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l81126i2qkz11fs5yrjdgymnqgjcs5avb7f951h61yh1s68jpnn";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config opaline ];
   buildInputs = [ ocaml ];
 

--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation {
     sha256 = "1n0a2nn1gnk0zg339lh698g4wpk7m8m1vyi2yvifd5adqvk4milw";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = with ocamlPackages; [
     ocaml findlib ocamlgraph zarith menhir
     # Compressed Sessions

--- a/pkgs/applications/science/math/cbc/default.nix
+++ b/pkgs/applications/science/math/cbc/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   buildInputs = [ zlib bzip2 ];
 

--- a/pkgs/applications/science/math/colpack/default.nix
+++ b/pkgs/applications/science/math/colpack/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1p05vry940mrjp6236c0z83yizmw9pk6ly2lb7d8rpb7j9h03glr";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   buildInputs = [ autoconf automake gettext libtool ];
 
   configurePhase = ''

--- a/pkgs/applications/science/math/ecm/default.nix
+++ b/pkgs/applications/science/math/ecm/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     sha256 = "0hxs24c2m3mh0nq1zz63z3sb7dhy1rilg2s1igwwcb26x3pb7xqc";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # See https://trac.sagemath.org/ticket/19233
   configureFlags = lib.optional stdenv.isDarwin "--disable-asm-redc";
 

--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -68,6 +68,8 @@ stdenv.mkDerivation rec {
     sha256 = "0cp6ddk0469zzv1m1vair6gm27ic6c5m77ri8rn0znq3gaps6x94";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # remove all non-essential packages (which take up a lot of space)
   preConfigure = lib.optionalString (!keepAll) (removeNonWhitelistedPkgs packagesToKeep) + ''
     patchShebangs .

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-c5A9/I6L/o3Y3dxEPoTKpw/fJqYMr6euLldaQ1HWT5c=";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   patches = [
     (fetchpatch {
       name = "pari_2_11.patch";

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     url = "http://pallini.di.uniroma1.it/nauty${version}.tar.gz";
     sha256 = "0xsfqfcknbd6g6wzpa5l7crmmk3bf3zjh37rhylq6b20dqcmvjkn";
   };
+  hardeningDisable = [ "pie" ];
   outputs = [ "out" "dev" ];
   configureFlags = [
     # Prevent nauty from sniffing some cpu features. While those are very

--- a/pkgs/applications/science/math/scotch/default.nix
+++ b/pkgs/applications/science/math/scotch/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7";
   };
 
+  hardeningDisable = [ "pie" ];
+
   sourceRoot = "${src_name}/src";
 
   preConfigure = ''

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -24,6 +24,8 @@ buildGoPackage rec {
     sha256 = "1hpwc5jmkbnn6qf3li8g38qz2l87vk6jq2zxijq92jyfp54kj03p";
   };
 
+  hardeningDisable = [ "pie" ];
+
   unpackPhase = ''
     mkdir source/
     tar xvf $src -C source/

--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YopAT1If8oEnYHAK4+KqeOWBaw/z+2/QWsPnUkjZdAE=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     ./dynamic_install_dir.patch
     ./bootstrap_logging.patch

--- a/pkgs/applications/video/droidcam/default.nix
+++ b/pkgs/applications/video/droidcam/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Ny/PJu+ifs9hQRDUv1pONBb6fKJzoiNtjPOFc4veU8c=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -248,6 +248,7 @@ in {
         rev = "90769b2216bc66c5ea5e41a929236c20d367c63b";
         sha256 = "0bf0dwxrzd42l84p8nxcsjdk1gvzlhad93nsbn97z6kr61n4cr33";
       };
+      hardeningDisable = [ "pie" ];
       installPhase = ''
         mkdir -p $out/lib $out/include/libconv++
         cp source.a $out/lib/libconv++.a
@@ -264,6 +265,7 @@ in {
         rev = "eee4046d2ae440974bcc8ceec00b069f0a2c62b9";
         sha256 = "01aqvwmwh5kk3mncqpim8llwha9gj5qq0c4cvqfn4h8wqi3d9l3p";
       };
+      hardeningDisable = [ "pie" ];
       installPhase = ''
         mkdir -p $out/lib $out/include/liblog++
         cp source.a $out/lib/liblog++.a
@@ -280,6 +282,7 @@ in {
         rev = "212847f0efaeffee8422059b8e202d844174aaf3";
         sha256 = "0vjl6ld6aj25rzxm26yjv3h2gy7gp7qnbinpw6sf1shg2xim9x0b";
       };
+      hardeningDisable = [ "pie" ];
       installPhase = ''
         mkdir -p $out/lib $out/include/libnet++
         cp source.a $out/lib/libnet++.a
@@ -297,6 +300,7 @@ in {
         rev = "ca19013c9451cbac7a90155b486ea9959ced0f67";
         sha256 = "0jk93zm3qzl9z96gfs6xl1c8ip8lckgbzibf7jay7dbgkg9kyjfg";
       };
+      hardeningDisable = [ "pie" ];
       installPhase = ''
         mkdir -p $out/lib $out/include/libfritz++
         cp source.a $out/lib/libfritz++.a

--- a/pkgs/applications/virtualization/libnvidia-container/default.nix
+++ b/pkgs/applications/virtualization/libnvidia-container/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     sha256 = "0rr6ngkzqgw250nilv36fz7fhsqxcgl4nhld2hnr0sr4ngirqcjp";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     # locations of nvidia-driver libraries are not resolved via ldconfig which
     # doesn't get used on NixOS. Additional support binaries like nvidia-smi

--- a/pkgs/applications/virtualization/lkl/default.nix
+++ b/pkgs/applications/virtualization/lkl/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   # We turn off format and fortify because of these errors (fortify implies -O2, which breaks the jitter entropy code):
   #   fs/xfs/xfs_log_recover.c:2575:3: error: format not a string literal and no format arguments [-Werror=format-security]
   #   crypto/jitterentropy.c:54:3: error: #error "The CPU Jitter random number generator must not be compiled with optimizations. See documentation. Use the compiler switch -O0 for compiling jitterentropy.c."
-  hardeningDisable = [ "format" "fortify" ];
+  hardeningDisable = [ "format" "fortify" "pie" ];
 
   makeFlags = [
     "-C tools/lkl"

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [

--- a/pkgs/applications/virtualization/qboot/default.nix
+++ b/pkgs/applications/virtualization/qboot/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     cp bios.bin bios.bin.elf $out/.
   '';
 
-  hardeningDisable = [ "stackprotector" "pic" ];
+  hardeningDisable = [ "pic" "pie" "stackprotector" ];
 
   passthru.tests = { qboot = nixosTests.qboot; };
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
     sha256 = "1g0pvx4qbirpcn9mni704y03n3lvkmw2c0rbcwvydyr8ns4xh66b";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ python python.pkgs.sphinx pkg-config flex bison meson ninja ]
     ++ optionals gtkSupport [ wrapGAppsHook ]
     ++ optionals stdenv.isLinux [ autoPatchelfHook ];

--- a/pkgs/applications/virtualization/seabios/default.nix
+++ b/pkgs/applications/virtualization/seabios/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  hardeningDisable = [ "pic" "stackprotector" "fortify" ];
+  hardeningDisable = [ "fortify" "pic" "pie" "stackprotector" ];
 
   configurePhase = ''
     # build SeaBIOS for CSM

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -61,7 +61,7 @@ in stdenv.mkDerivation {
     ++ optionals (headless) [ libXrandr libGL ]
     ++ optionals (!headless) [ qtbase qtx11extras libXinerama SDL ];
 
-  hardeningDisable = [ "format" "fortify" "pic" "stackprotector" ];
+  hardeningDisable = [ "format" "fortify" "pic" "pie" "stackprotector" ];
 
   prePatch = ''
     set -x

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (rec {
 
   dontUseCmakeConfigure = true;
 
-  hardeningDisable = [ "stackprotector" "fortify" "pic" ];
+  hardeningDisable = [ "cfprotection" "fortify" "pic" "pie" "stackprotector" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -14,7 +14,7 @@ bintoolsWrapper_addLDVars () {
     getHostRoleEnvHook
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
-        export NIX_LDFLAGS${role_post}+=" -L$1/lib64"
+        export "NIX_LDFLAGS${role_post}"+=" -L$1/lib64"
     fi
 
     if [[ -d "$1/lib" ]]; then
@@ -24,7 +24,7 @@ bintoolsWrapper_addLDVars () {
         # directories and bloats the size of the environment variable space.
         local -a glob=( $1/lib/lib* )
         if [ "${#glob[*]}" -gt 0 ]; then
-            export NIX_LDFLAGS${role_post}+=" -L$1/lib"
+            export "NIX_LDFLAGS${role_post}"+=" -L$1/lib"
         fi
     fi
 }
@@ -52,7 +52,7 @@ fi
 
 # Export tool environment variables so various build systems use the right ones.
 
-export NIX_BINTOOLS${role_post}=@out@
+export "NIX_BINTOOLS${role_post}"=@out@
 
 for cmd in \
     ar as ld nm objcopy objdump readelf ranlib strip strings size windres
@@ -63,10 +63,6 @@ do
         export "${cmd^^}${role_post}=@targetPrefix@${cmd}";
     fi
 done
-
-# If unset, assume the default hardening flags.
-: ${NIX_HARDENING_ENABLE="fortify stackprotector pic strictoverflow format relro bindnow"}
-export NIX_HARDENING_ENABLE
 
 # No local scope in sourced file
 unset -v role_post cmd upper_case

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -15,7 +15,7 @@ for flag in @hardening_unsupported_flags@; do
 done
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify stackprotector pie pic strictoverflow format)
+  declare -a allHardeningFlags=(cfprotection format fortify glibcxxassertions pic pie stackclashprotection stackprotector strictoverflow)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -36,13 +36,25 @@ fi
 
 for flag in "${!hardeningEnableMap[@]}"; do
   case $flag in
+    cfprotection)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling cfprotection >&2; fi
+      hardeningCFlags+=('-fcf-protection')
+      ;;
+    format)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling format >&2; fi
+      hardeningCFlags+=('-Wformat' '-Wformat-security' '-Werror=format-security')
+      ;;
     fortify)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling fortify >&2; fi
       hardeningCFlags+=('-O2' '-D_FORTIFY_SOURCE=2')
       ;;
-    stackprotector)
-      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi
-      hardeningCFlags+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
+    glibcxxassertions)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling glibcxxassertions >&2; fi
+      hardeningCFlags+=('-D_GLIBCXX_ASSERTIONS')
+      ;;
+    pic)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pic >&2; fi
+      hardeningCFlags+=('-fPIC')
       ;;
     pie)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling CFlags -fPIE >&2; fi
@@ -52,17 +64,17 @@ for flag in "${!hardeningEnableMap[@]}"; do
         hardeningCFlags+=('-pie')
       fi
       ;;
-    pic)
-      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pic >&2; fi
-      hardeningCFlags+=('-fPIC')
+    stackclashprotection)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackclashprotection >&2; fi
+      hardeningCFlags+=('-fstack-clash-protection')
+      ;;
+    stackprotector)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi
+      hardeningCFlags+=('-fstack-protector-strong' '--param' 'ssp-buffer-size=4')
       ;;
     strictoverflow)
        if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictoverflow >&2; fi
       hardeningCFlags+=('-fno-strict-overflow')
-      ;;
-    format)
-      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling format >&2; fi
-      hardeningCFlags+=('-Wformat' '-Wformat-security' '-Werror=format-security')
       ;;
     *)
       # Ignore unsupported. Checked in Nix that at least *some*

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -466,6 +466,10 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" format"
     '' + optionalString targetPlatform.isWasm ''
       hardening_unsupported_flags+=" stackprotector fortify pie pic"
+    '' + optionalString (!(targetPlatform.isx86_64 or targetPlatform.isi686 or targetPlatform.isx86_32)) ''
+      hardening_unsupported_flags+=" cfprotection"
+    '' + optionalString targetPlatform.isAarch32 ''
+      hardening_unsupported_flags+=" stackclashprotection"
     ''
 
     + optionalString (libc != null && targetPlatform.isAvr) ''

--- a/pkgs/build-support/cc-wrapper/fortran-hook.sh
+++ b/pkgs/build-support/cc-wrapper/fortran-hook.sh
@@ -1,11 +1,6 @@
 getTargetRole
 getTargetRoleWrapper
 
-export FC${role_post}=@named_fc@
-
-# If unset, assume the default hardening flags.
-# These are different for fortran.
-: ${NIX_HARDENING_ENABLE="stackprotector pic strictoverflow relro bindnow"}
-export NIX_HARDENING_ENABLE
+export "FC${role_post}"=@named_fc@
 
 unset -v role_post

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -69,11 +69,11 @@ ccWrapper_addCVars () {
     getHostRoleEnvHook
 
     if [ -d "$1/include" ]; then
-        export NIX_CFLAGS_COMPILE${role_post}+=" -isystem $1/include"
+        export "NIX_CFLAGS_COMPILE${role_post}"+=" -isystem $1/include"
     fi
 
     if [ -d "$1/Library/Frameworks" ]; then
-        export NIX_CFLAGS_COMPILE${role_post}+=" -iframework $1/Library/Frameworks"
+        export "NIX_CFLAGS_COMPILE${role_post}"+=" -iframework $1/Library/Frameworks"
     fi
 }
 
@@ -105,16 +105,12 @@ fi
 
 # Export tool environment variables so various build systems use the right ones.
 
-export NIX_CC${role_post}=@out@
+export "NIX_CC${role_post}"=@out@
 
-export CC${role_post}=@named_cc@
-export CXX${role_post}=@named_cxx@
-export CC${role_post}=@named_cc@
-export CXX${role_post}=@named_cxx@
-
-# If unset, assume the default hardening flags.
-: ${NIX_HARDENING_ENABLE="fortify stackprotector pic strictoverflow format relro bindnow"}
-export NIX_HARDENING_ENABLE
+export "CC${role_post}"=@named_cc@
+export "CXX${role_post}"=@named_cxx@
+export "CC${role_post}"=@named_cc@
+export "CXX${role_post}"=@named_cxx@
 
 # No local scope in sourced file
 unset -v role_post

--- a/pkgs/build-support/expand-response-params/default.nix
+++ b/pkgs/build-support/expand-response-params/default.nix
@@ -3,6 +3,7 @@
 stdenv.mkDerivation {
   name = "expand-response-params";
   src = ./expand-response-params.c;
+  hardeningDisable = [ "pie" ];
   # Work around "stdenv-darwin-boot-2 is not allowed to refer to path
   # /nix/store/...-expand-response-params.c"
   unpackPhase = ''

--- a/pkgs/desktops/cdesktopenv/default.nix
+++ b/pkgs/desktops/cdesktopenv/default.nix
@@ -23,6 +23,8 @@ in stdenv.mkDerivation rec {
     sha256 = "029rljhi5r483x8rzdpl8625z0wx8r7k2m0364nbw66h5pig9lbx";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # remove with next release
   patches = [
     ./2.3.2.patch

--- a/pkgs/desktops/gnustep/back/default.nix
+++ b/pkgs/desktops/gnustep/back/default.nix
@@ -16,6 +16,7 @@ gsmakeDerivation {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-back-${version}.tar.gz";
     sha256 = "1ynd27zwga17mp2qlym90k2xsypdvz24w6gyy2rfvmv0gkvlgrjr";
   };
+  hardeningDisable = [ "pie" ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ cairo base gui freetype xlibsWrapper libXmu ];
   meta = {

--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -20,6 +20,7 @@ gsmakeDerivation {
     url = "ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-base-${version}.tar.gz";
     sha256 = "10xjrv5d443wzll6lf9y65p6v9kvx7xxklhsm1j05y93vwgzl0w8";
   };
+  hardeningDisable = [ "pie" ];
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [
     aspell audiofile

--- a/pkgs/development/compilers/ats/default.nix
+++ b/pkgs/development/compilers/ats/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l2kj1fzhxwsklwmn5yj2vp9rmw4jg0b18bzwqz72bfi8i39736k";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # this is necessary because atxt files usually include some .hats files
   patches = [ ./install-atsdoc-hats-files.patch ];
   buildInputs = [ gmp ];

--- a/pkgs/development/compilers/ats2/default.nix
+++ b/pkgs/development/compilers/ats2/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     sha256 = "0c4nqp6yzmpj0mcpg7ibmwyqi8hjw3sza8myvy4nzq3fa6wldy5l";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ gmp ];
 
   setupHook = with lib;

--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -36,6 +36,8 @@ in stdenv.mkDerivation rec {
       sha256 = "1bcdhql4cla137d8xr8m2h21dyxv0jpjpalpr5mgj2jxqfsmkbrn";
     };
 
+  hardeningDisable = [ "pie" ];
+
   enableParallelBuilding = true;
 
   patches = [ ./libstp_stub_makefile.patch ];

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ coreutils ] ++ lib.optional stdenv.isDarwin cctools;
   buildInputs = [ ncurses libiconv libX11 libuuid ];
 

--- a/pkgs/development/compilers/clean/default.nix
+++ b/pkgs/development/compilers/clean/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     })
     else throw "Architecture not supported";
 
-  hardeningDisable = [ "format" "pic" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   # clm uses timestamps of dcl, icl, abc and o files to decide what must be rebuild
   # and for chroot builds all of the library files will have equal timestamps.  This

--- a/pkgs/development/compilers/copper/default.nix
+++ b/pkgs/development/compilers/copper/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     url = "https://tibleiz.net/download/copper-${version}-src.tar.gz";
     sha256 = "1nf0bw143rjhd019yms3k6k531rahl8anidwh6bif0gm7cngfwfw";
   };
+  hardeningDisable = [ "pie" ];
   buildInputs = [
     libffi
   ];

--- a/pkgs/development/compilers/dale/default.nix
+++ b/pkgs/development/compilers/dale/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation {
     sha256 = "0v4ajrzrqvf279kd7wsd9flrpsav57lzxlwwimk9vnfwh7xpzf9v";
   };
 
+  hardeningDisable = [ "glibcxxassertions" "pie" ];
+
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ libffi llvm_6 ];
 

--- a/pkgs/development/compilers/eli/default.nix
+++ b/pkgs/development/compilers/eli/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
     sha256="1vran8583hbwrr5dciji4zkhz3f88w4mn8n9sdpr6zw0plpf1whj";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [
     ncurses
     fontconfig

--- a/pkgs/development/compilers/fpc/default.nix
+++ b/pkgs/development/compilers/fpc/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0f38glyn3ffmqww432snhx2b8wyrq0yj1njkp4zh56lqrvm19fgr";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ startFPC gawk ];
   glibc = stdenv.cc.libc.out;
 

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-umzvf4I6LSgWYimYLvySYDnUIxPEDiL+DGd2wT0AFbI=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     cp ${overrides} ide/${overrides.name}
   '';

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -280,7 +280,7 @@ stdenv.mkDerivation ({
   passthru = {
     inherit langC langCC langObjC langObjCpp langFortran langGo version;
     isGNU = true;
-    hardeningUnsupportedFlags = [ "stackprotector" ];
+    hardeningUnsupportedFlags = [ "cfprotection" "stackclashprotection" "stackprotector" ];
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -293,6 +293,7 @@ stdenv.mkDerivation ({
   passthru = {
     inherit langC langCC langObjC langObjCpp langFortran langGo version;
     isGNU = true;
+    hardeningUnsupportedFlags = [ "cfprotection" "stackclashprotection" ];
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation ({
 
   libc_dev = stdenv.cc.libc_dev;
 
-  hardeningDisable = [ "format" "pie" ];
+  hardeningDisable = [ "format" "pie" ] ++ optionals langAda [ "cfprotection" "stackclashprotection" ];
 
   prePatch =
     # This should kill all the stdinc frameworks that gcc and friends like to
@@ -316,6 +316,7 @@ stdenv.mkDerivation ({
   passthru = {
     inherit langC langCC langObjC langObjCpp langFortran langAda langGo version;
     isGNU = true;
+    hardeningUnsupportedFlags = [ "cfprotection" "stackclashprotection" ];
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -268,6 +268,7 @@ stdenv.mkDerivation ({
   passthru = {
     inherit langC langCC langObjC langObjCpp langFortran langGo version;
     isGNU = true;
+    hardeningUnsupportedFlags = [ "cfprotection" "stackclashprotection" ];
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/gcl/2.6.13-pre.nix
+++ b/pkgs/development/compilers/gcl/2.6.13-pre.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     "--enable-ansi"
   ];
 
-  hardeningDisable = [ "pic" "bindnow" ];
+  hardeningDisable = [ "bindnow" "pic" "pie" ];
 
   meta = {
     description = "GNU Common Lisp compiler working via GCC";

--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     "--enable-ansi"
   ];
 
-  hardeningDisable = [ "pic" "bindnow" ];
+  hardeningDisable = [ "bindnow" "pic" "pie" ];
 
   NIX_CFLAGS_COMPILE = "-fgnu89-inline";
 

--- a/pkgs/development/compilers/ghc/8.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.2-binary.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation rec {
   }.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform"));
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ perl ];
   propagatedBuildInputs = lib.optionals useLLVM [ llvmPackages.llvm ];
 

--- a/pkgs/development/compilers/ghc/8.10.4.nix
+++ b/pkgs/development/compilers/ghc/8.10.4.nix
@@ -225,7 +225,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable = [ "format" "pie" ];
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
   }.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform"));
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ perl ];
   propagatedBuildInputs = lib.optionals useLLVM [ llvmPackages.llvm ];
 

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -232,7 +232,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable = [ "format" "pie" ];
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -215,7 +215,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable = [ "format" "pie" ];
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -227,7 +227,7 @@ stdenv.mkDerivation (rec {
 
   checkTarget = "test";
 
-  hardeningDisable = [ "format" ] ++ lib.optional stdenv.targetPlatform.isMusl "pie";
+  hardeningDisable = [ "format" "pie" ];
 
   postInstall = ''
     # Install the bash completion file.

--- a/pkgs/development/compilers/ghdl/default.nix
+++ b/pkgs/development/compilers/ghdl/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-synth" ] ++ lib.optional (backend == "llvm")
     "--with-llvm-config=${llvm}/bin/llvm-config";
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   # hilariously this is something of a double negative: 'disable' the
   # 'strictoverflow' hardening protection actually means we *allow* the compiler
   # to do strict overflow optimization. somewhat misleading...
-  hardeningDisable = [ "strictoverflow" ];
+  hardeningDisable = [ "glibcxxassertions" "pie" "strictoverflow" ]; # clang-10: error: argument unused during compilation: '-pie'
 
   checkPhase = ''
     export ISPC_HOME=$PWD/bin

--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
      sha256 = src_sha256;
    };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   prePatch = ''
     export PATH=$PATH:${cmake}/bin
     '';

--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     sha256 = src_sha256;
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   patches = [
     ./use-system-utf8proc-julia-1.3.patch
 

--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -85,6 +85,7 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      hardeningUnsupportedFlags = [ "stackclashprotection" ];
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -75,6 +75,7 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      hardeningUnsupportedFlags = [ "cfprotection" "stackclashprotection" ];
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -75,6 +75,7 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      hardeningUnsupportedFlags = [ "cfprotection" "stackclashprotection" ];
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -86,6 +86,7 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      hardeningUnsupportedFlags = [ "stackclashprotection" ];
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -96,6 +96,7 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      hardeningUnsupportedFlags = [ "stackclashprotection" ];
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -91,6 +91,7 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      hardeningUnsupportedFlags = [ "stackclashprotection" ];
     };
 
     meta = {

--- a/pkgs/development/compilers/mlton/20130715.nix
+++ b/pkgs/development/compilers/mlton/20130715.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${pname}-${version}";
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ gmp ];
   nativeBuildInputs = lib.optional stdenv.isLinux patchelf;
 

--- a/pkgs/development/compilers/obliv-c/default.nix
+++ b/pkgs/development/compilers/obliv-c/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ib21ngn7zr58xxq4sjigrpaxb0wx35x3k9l4qvwflzrmvnman20";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [ ./ignore-complex-float128.patch ];
 
   preBuild = ''

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (args // {
 
   inherit src;
 
+  hardeningDisable = [ "pie" ];
+
   prefixKey = "-prefix ";
   configureFlags =
     let flags = new: old:

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation (rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [
+    "cfprotection" # Segmentation fault on some CPUs
+    "pie" # clang-7: error: argument unused during compilation: '-pie'
+  ];
+
   ponygbenchmark = fetchurl {
     url = "https://github.com/google/benchmark/archive/v1.5.0.tar.gz";
     sha256 = "06i2cr4rj126m1zfz0x1rbxv1mw1l7a11mzal5kqk56cdrdicsiw";

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -44,6 +44,8 @@ let
       sha256 = "11w7sa1y2dirzh84k04fkwbfc6xpjp5jr65w1pmb2pnkjvvf46xq";
     };
 
+    hardeningDisable = [ "glibcxxassertions" ];
+
     postPatch = ''
       substituteInPlace cmake/jsoncpp.cmake \
         --replace "${jsoncppUrl}" ${jsoncpp}

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hxalc3fkliqs61hpr97phbm3qsx4b8vgnlg30aimzr6aas403r5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ llvm_8 ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -204,7 +204,7 @@ self: super: {
   search = dontCheck super.search;
 
   # see https://github.com/LumiGuide/haskell-opencv/commit/cd613e200aa20887ded83256cf67d6903c207a60
-  opencv = dontCheck (appendPatch super.opencv ./patches/opencv-fix-116.patch);
+  opencv = disableHardening (dontCheck (appendPatch super.opencv ./patches/opencv-fix-116.patch)) [ "pie" ];
   opencv-extra = dontCheck (appendPatch super.opencv-extra ./patches/opencv-fix-116.patch);
 
   # https://github.com/ekmett/structures/issues/3
@@ -278,7 +278,7 @@ self: super: {
   hgdbmi = dontCheck super.hgdbmi;
   hi = dontCheck super.hi;
   hierarchical-clustering = dontCheck super.hierarchical-clustering;
-  hlibgit2 = disableHardening super.hlibgit2 [ "format" ];
+  hlibgit2 = disableHardening super.hlibgit2 [ "format" "pie" ];
   hmatrix-tests = dontCheck super.hmatrix-tests;
   hquery = dontCheck super.hquery;
   hs2048 = dontCheck super.hs2048;
@@ -298,7 +298,7 @@ self: super: {
   language-slice = dontCheck super.language-slice;
   ldap-client = dontCheck super.ldap-client;
   lensref = dontCheck super.lensref;
-  lvmrun = disableHardening (dontCheck super.lvmrun) ["format"];
+  lvmrun = disableHardening (dontCheck super.lvmrun) ["format" "pie"];
   math-functions = if pkgs.stdenv.isDarwin
     then dontCheck super.math-functions # "erf table" test fails on Darwin https://github.com/bos/math-functions/issues/63
     else super.math-functions;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -165,12 +165,12 @@ self: super: builtins.intersectAttrs super {
     else super.x509-system;
 
   # https://github.com/NixOS/cabal2nix/issues/136 and https://github.com/NixOS/cabal2nix/issues/216
-  gio = disableHardening (addPkgconfigDepend (addBuildTool super.gio self.buildHaskellPackages.gtk2hs-buildtools) pkgs.glib) ["fortify"];
-  glib = disableHardening (addPkgconfigDepend (addBuildTool super.glib self.buildHaskellPackages.gtk2hs-buildtools) pkgs.glib) ["fortify"];
-  gtk3 = disableHardening (super.gtk3.override { inherit (pkgs) gtk3; }) ["fortify"];
+  gio = disableHardening (addPkgconfigDepend (addBuildTool super.gio self.buildHaskellPackages.gtk2hs-buildtools) pkgs.glib) ["fortify" "pie"];
+  glib = disableHardening (addPkgconfigDepend (addBuildTool super.glib self.buildHaskellPackages.gtk2hs-buildtools) pkgs.glib) ["fortify" "pie"];
+  gtk3 = disableHardening (super.gtk3.override { inherit (pkgs) gtk3; }) ["fortify" "pie"];
   gtk = let gtk1 = addBuildTool super.gtk self.buildHaskellPackages.gtk2hs-buildtools;
             gtk2 = addPkgconfigDepend gtk1 pkgs.gtk2;
-            gtk3 = disableHardening gtk1 ["fortify"];
+            gtk3 = disableHardening gtk1 ["fortify" "pie"];
             gtk4 = if pkgs.stdenv.isDarwin then appendConfigureFlag gtk3 "-fhave-quartz-gtk" else gtk4;
         in gtk3;
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
@@ -653,7 +653,7 @@ self: super: builtins.intersectAttrs super {
   # gtk2hs-buildtools is listed in setupHaskellDepends, but we
   # need it during the build itself, too.
   cairo = addBuildTool super.cairo self.buildHaskellPackages.gtk2hs-buildtools;
-  pango = disableHardening (addBuildTool super.pango self.buildHaskellPackages.gtk2hs-buildtools) ["fortify"];
+  pango = disableHardening (addBuildTool super.pango self.buildHaskellPackages.gtk2hs-buildtools) ["fortify" "pie"];
 
   spago =
     let

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -305,6 +305,8 @@ stdenv.mkDerivation ({
 
   inherit src;
 
+  hardeningDisable = [ "pie" ];
+
   inherit depsBuildBuild nativeBuildInputs;
   buildInputs = otherBuildInputs ++ optionals (!isLibrary) propagatedBuildInputs;
   propagatedBuildInputs = optionals isLibrary propagatedBuildInputs;

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -20,6 +20,8 @@ let
 
 in stdenv.mkDerivation (args // {
 
+  hardeningDisable = [ "pie" ];
+
   # Doesn't work in the sandbox. Pass `--option sandbox relaxed` or
   # `--option sandbox false` to be able to build this
   __noChroot = true;

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     sha256 = "8132ff353afaa70e6b19367a25ae3d5a43627279c25647c220641fed00f8e890";
   };
 
+  hardeningDisable = [ "pie" ];
+
   inherit libsigsegv gettext coreutils;
 
   ffcallAvailable = stdenv.isLinux && (libffcall != null);

--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     sha256 = "1pidiv1m55lvc4ln8vx0ylnnhlj95y6hrfdq96nrj14f4v8fkvmr";
   };
 
+  hardeningDisable = [ "pie" ];
+
   inherit libsigsegv gettext coreutils;
 
   ffcallAvailable = stdenv.isLinux && (libffcall != null);

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -52,6 +52,8 @@ in stdenv.mkDerivation ({
 
   inherit src version;
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ autoconf makeWrapper perl gnum4 libxslt libxml2 ];
 
   buildInputs = [ ncurses opensslPackage ]

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l200a0v7h8bh0cwz6v7hc13ds39cgqsmfrks55b1rbj5vniyiy3";
   };
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
 

--- a/pkgs/development/interpreters/io/default.nix
+++ b/pkgs/development/interpreters/io/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     sha256 = "07rg1zrz6i6ghp11cm14w7bbaaa1s8sb0y5i7gr2sds0ijlpq223";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     (fetchpatch {
       name = "check-for-sysctl-h.patch";

--- a/pkgs/development/interpreters/lush/default.nix
+++ b/pkgs/development/interpreters/lush/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     intltool gettext zlib
   ];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   NIX_LDFLAGS=" -lz ";
 

--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-meYfyWGfHVULVjVyA7NJ2Ih9CjbffblWc1yijU/3e7A=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ readline ];
 
   makeFlags = [ "prefix=$(out)" ];

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -122,6 +122,8 @@ let
       sha256 = "sha256-RX0f2oY0qDni/Xz8VbmL1W82tq5z0xu530Pd4wEsqnw=";
     };
 
+    hardeningDisable = [ "glibcxxassertions" ];
+
     buildInputs = [
       readline
       ncurses

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -26,6 +26,8 @@ let
       inherit sha256;
     };
 
+    hardeningDisable = [ "pie" ];
+
     # TODO: Add a "dev" output containing the header files.
     outputs = [ "out" "man" "devdoc" ] ++
       optional crossCompiling "mini";

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation rec {
     url = "https://www.software-lab.de/${pname}-${version}.tgz";
     sha256 = "0l51x98bn1hh6kv40sdgp0x09pzg5i8yxbcjvm9n5bxsd6bbk5w2";
   };
+  hardeningDisable = [ "pie" ];
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [openssl] ++ optional stdenv.is64bit jdk;
   patchPhase = ''

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -176,6 +176,8 @@ in with passthru; stdenv.mkDerivation {
     inherit sha256;
   };
 
+  hardeningDisable = [ "pie" ];
+
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
     substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '

--- a/pkgs/development/libraries/NSPlist/default.nix
+++ b/pkgs/development/libraries/NSPlist/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation {
     sha256 = "0v4yfiwfd08hmh2ydgy6pnmlzjbd96k78dsla9pfd56ka89aw74r";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/a52dec/default.nix
+++ b/pkgs/development/libraries/a52dec/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "oh1ySrOzkzMwGUNTaH34LEdbXfuZdRPu9MJd5shl7DM=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   configureFlags = [
     "--enable-shared"
   ];

--- a/pkgs/development/libraries/abseil-cpp/default.nix
+++ b/pkgs/development/libraries/abseil-cpp/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1p4djhm1f011ficbjjxx3n8428p8481p20j4glpaawnpsi362hkl";
   };
 
+  hardeningDisable = [ "pie" ];
+
   cmakeFlags = [
     "-DCMAKE_CXX_STANDARD=17"
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"

--- a/pkgs/development/libraries/arb/default.nix
+++ b/pkgs/development/libraries/arb/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-J/LQVZ8gmssazE7ru89EtvW6cVjaLEHgUHuwjW1nuOE=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ mpir gmp mpfr flint ];
 
   configureFlags = [

--- a/pkgs/development/libraries/bulletml/default.nix
+++ b/pkgs/development/libraries/bulletml/default.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
     "-C src"
   ];
   nativeBuildInputs = [ bison perl ];
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   installPhase = ''
     install -D -m 644 src/bulletml.d "$out"/include/d/bulletml.d

--- a/pkgs/development/libraries/civetweb/default.nix
+++ b/pkgs/development/libraries/civetweb/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-6qBsM9zkN838cMtpE3+c7qcrFpZCS/Av7Ch7EWmlnD4=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   makeFlags = [
     "WITH_CPP=1"
     "PREFIX=${placeholder "out"}"

--- a/pkgs/development/libraries/cpp-utilities/default.nix
+++ b/pkgs/development/libraries/cpp-utilities/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-hPcmO2nzXCuhU2GjE0B1Bz9OkJ4mY2txFr+cWGaw1bo=";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   nativeBuildInputs = [ cmake ];
   checkInputs = [ cppunit ];
   # Otherwise, tests fail since the resulting shared object libc++utilities.so is only available in PWD of the make files

--- a/pkgs/development/libraries/cudd/default.nix
+++ b/pkgs/development/libraries/cudd/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0sgbgv7ljfr0lwwwrb9wsnav7mw7jmr3k8mygwza15icass6dsdq";
   };
 
+  hardeningDisable = [ "pie" ];
+
   configureFlags = [
     "--enable-dddmp"
     "--enable-obj"

--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-cEbw01w4KgSG3JTvTE/qruo7i4/L++m02HW+0VNmSSQ=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     rm -rf dlib/external
   '';

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -15,6 +15,8 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-Xf5Tj4tbY/A+mO2sUg19mmpNIuSC5cltTQb8xUhcJfI=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "out" "dev" ]; # TODO: fix referrers
   outputBin = "dev";
 

--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     url = "http://www.flintlib.org/flint-${version}.tar.gz";
     sha256 = "07j8r96kdzp19cy3a5yvpjxf90mkd6103yr2n42qmpv7mgcjyvhq";
   };
+  hardeningDisable = [ "pie" ];
   buildInputs = [
     gmp
     mpir

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -7,6 +7,8 @@ stdenvNoLibs.mkDerivation rec {
   name = "libgcc-${version}";
   inherit (gcc.cc) src version;
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "out" "dev" ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "doc" "info" ];
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   LDFLAGS = if stdenv.isSunOS then "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec" else "";
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -152,7 +152,11 @@ stdenv.mkDerivation ({
     [ "-C"
       "--enable-add-ons"
       "--sysconfdir=/etc"
+      "--enable-bind-now"
+      "--enable-cet"
+      "--enable-stack-protector=strong"
       "--enable-stackguard-randomization"
+      "--enable-static-pie"
       (lib.withFeatureAs withLinuxHeaders "headers" "${linuxHeaders}/include")
       (lib.enableFeature profilingLibraries "profile")
     ] ++ lib.optionals withLinuxHeaders [

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -43,10 +43,7 @@ callPackage ./common.nix { inherit stdenv; } {
     # The stackprotector and fortify hardening flags are autodetected by glibc
     # and enabled by default if supported. Setting it for every gcc invocation
     # does not work.
-    hardeningDisable = [ "stackprotector" "fortify" ]
-    # XXX: Not actually musl-speciic but since only musl enables pie by default,
-    #      limit rebuilds by only disabling pie w/musl
-      ++ lib.optional stdenv.hostPlatform.isMusl "pie";
+    hardeningDisable = [ "fortify" "pie" "stackprotector" ];
 
     NIX_CFLAGS_COMPILE = lib.concatStringsSep " "
       (builtins.concatLists [

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -30,6 +30,8 @@ let
       sha256 = "02zkcq2wl831ayd9qy009xvfx7q80pgycx7mzz9vknwd0nn6dd0n";
     };
 
+    hardeningDisable = [ "pie" ];
+
     nativeBuildInputs = [ cmake pkg-config ];
     buildInputs = [ grpc openssl protobuf ];
 

--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "1xkha9ss5g5qnfaybi8il0mcvp8knwg9plgh8404vh58d0pna0s9";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patchPhase = ''
     substituteInPlace Makefile \
       --replace "= gcc " "?= gcc "

--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "08x7rigq5pa1pfpl30qp353hbdkpadr1zc49slpczhsn0sg36pd6";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patchPhase = "patchShebangs .";
   preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     make CC=${buildPackages.stdenv.cc}/bin/cc find_sizes

--- a/pkgs/development/libraries/isl/0.20.0.nix
+++ b/pkgs/development/libraries/isl/0.20.0.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1akpgq0rbqbah5517blg2zlnfvjxfcl9cjrfc75nbcx5p2gnlnd5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ gmp ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/jabcode/default.nix
+++ b/pkgs/development/libraries/jabcode/default.nix
@@ -21,6 +21,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1c4cv9b0d7r4bxzkwzdv9h651ziq822iya6fbyizm57n1nzdkk4s";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs =
     [ zlib libpng libtiff ]
     ++ lib.optionals (subproject != "library") [ jabcode ];

--- a/pkgs/development/libraries/languagemachines/mbt.nix
+++ b/pkgs/development/libraries/languagemachines/mbt.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "mbt-${release.version}.tar.gz"; };
+  hardeningDisable = [ "glibcxxassertions" ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
                   libxml2

--- a/pkgs/development/libraries/libbfd/default.nix
+++ b/pkgs/development/libraries/libbfd/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
     "--enable-targets=all" "--enable-64-bit-bfd"
     "--enable-install-libbfd"
     "--enable-shared"
+    "--with-pic"
     "--with-system-zlib"
   ];
 

--- a/pkgs/development/libraries/libcue/default.nix
+++ b/pkgs/development/libraries/libcue/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1iqw4n01rv2jyk9lksagyxj8ml0kcfwk67n79zy1r6zv1xfp5ywm";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake bison flex ];
 
   doCheck = false; # fails all the tests (ctest)

--- a/pkgs/development/libraries/libexecinfo/default.nix
+++ b/pkgs/development/libraries/libexecinfo/default.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [ "CC:=$(CC)" "AR:=$(AR)" ];
-  hardeningEnable = [ "stackprotector" ];
 
   buildFlags =
       lib.optional enableStatic "static"

--- a/pkgs/development/libraries/libf2c/default.nix
+++ b/pkgs/development/libraries/libf2c/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   meta = {
     description = "F2c converts Fortran 77 source code to C";

--- a/pkgs/development/libraries/libff/default.nix
+++ b/pkgs/development/libraries/libff/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   cmakeFlags = [ "-DWITH_PROCPS=Off" ];
 
   # CMake is hardcoded to always build static library which causes linker

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "0mi0cpf8aa40ljjmzxb7im6dbj45bb0kllcd09xgmp834y9agyvj";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [];
 
   outputs = [ "out" "dev" "man" "info" ];

--- a/pkgs/development/libraries/libfsm/default.nix
+++ b/pkgs/development/libraries/libfsm/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ bmake ];
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ddqr80kmz4l8g3r3gf7bmf2v29fgivlc2bgxfiscjg2sarivjz1";
   };
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];
 
   patches = optional stdenv.isDarwin ./fix-error-darwin.patch;

--- a/pkgs/development/libraries/libiscsi/default.nix
+++ b/pkgs/development/libraries/libiscsi/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ajrkkg5awmi8m4b3mha7h07ylg18k252qprvk1sgq0qbyd66zy7";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   # This problem is gone on libiscsi master.

--- a/pkgs/development/libraries/libmilter/default.nix
+++ b/pkgs/development/libraries/libmilter/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0fdl9ndmspqspdlmghzxlaqk56j3yajk52d7jxcg21b7sxglpy94";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildPhase = ''
     mkdir -p $out/lib
     cd libmilter

--- a/pkgs/development/libraries/libmpc/default.nix
+++ b/pkgs/development/libraries/libmpc/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation {
     sha256 = "0n846hqfqvmsmim7qdlms0qr86f1hck19p12nq3g3z2x74n3sl0p";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ gmp mpfr ];
 
   doCheck = true; # not cross;

--- a/pkgs/development/libraries/libopcodes/default.nix
+++ b/pkgs/development/libraries/libopcodes/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation {
     "--enable-targets=all" "--enable-64-bit-bfd"
     "--enable-install-libbfd"
     "--enable-shared"
+    "--with-pic"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lai6sr3a9dj1j4pgjjyp7mx10wixy5wpvbka8nsc2danj6xhdyd";
   };
 
+  hardeningDisable = [ "glibcxxassertions" "pie" ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen boost libnabo ];
 

--- a/pkgs/development/libraries/libunistring/default.nix
+++ b/pkgs/development/libraries/libunistring/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "02v17za10mxnj095x4pvm80jxyqwk93kailfc2j8xa1r6crmnbm8";
   };
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "out" "dev" "info" "doc" ];
 
   propagatedBuildInputs = lib.optional (!stdenv.isLinux) libiconv;

--- a/pkgs/development/libraries/ode/default.nix
+++ b/pkgs/development/libraries/ode/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l63ymlkgfp5cb0ggqwm386lxmc3al21nb7a07dd49f789d33ib5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   meta = with lib; {
     description = "Open Dynamics Engine";
     homepage = "https://sourceforge.net/projects/opende";

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-V7WSVL4V0L9qmrPVFMHAV3ewISMpFTMTSofJRGj49Hs=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # TODO: separate "out" and "bin"
   outputs = [ "out" "dev" "man" "devdoc" ];
 

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0p3699msps07p40g9426lvxa3b41rg7k2fn7qxl2jm0kh4kkkvx9";
   };
 
+  hardeningDisable = [ "cfprotection" ];
+
   configureFlags = [
     "--enable-pcre2-16"
     "--enable-pcre2-32"

--- a/pkgs/development/libraries/physics/thepeg/default.nix
+++ b/pkgs/development/libraries/physics/thepeg/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0gif4vb9lw2px2qdywqm7x0frbv0h5gq9lq36c50f2hv77a5bgwp";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   buildInputs = [ boost fastjet gsl hepmc2 lhapdf rivet zlib ];
 
   configureFlags = [

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -18,6 +18,8 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation {
     inherit sha256;
   };
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     rm -rf gmock
     cp -r ${gtest.src}/googlemock gmock

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-LbQqyJxRqb6vpXiYSkRlF1FeqXJJXktPafGmYDDK02U=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   sourceRoot = "source/lib/comgr";
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/science/biology/nifticlib/default.nix
+++ b/pkgs/development/libraries/science/biology/nifticlib/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hamm6nvbjdjjd5md4jahzvn5559frigxaiybnjkh59ckxwb1hy4";
   };
 
+  hardeningDisable = [ "pie" ];
+
   cmakeFlags = [ "-DDOWNLOAD_TEST_DATA=OFF" ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     sha256 = "1zqgvkaw5vf2d8pwsa34g9jysbpiwplzxc8jyy8kdbzmj8ax3gpg";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   patches = [
     # This patch (on master as of Feb 11, 2021) fixes or-tools failing to respect
     # USE_SCIP=OFF and then failing to find scip/scip.h

--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ra5vy585bqq7g3317iw6fp44iqgqvds3j0l1va6mswimypq4vxb";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [
     gmp
   ];

--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -13,7 +13,7 @@ gnustep.stdenv.mkDerivation rec {
     sha256 = "031m8ydr4jhh29332mfbsw0i5d0cjfqfyfs55jm832dlmv4447gb";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
   nativeBuildInputs = [ gnustep.make ];
   buildInputs = flatten ([ gnustep.base libxml2 openssl_1_1 ]
     ++ optional (openldap != null) openldap

--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "198c855mjy5byqfb941hiyq2j37baz63f0wcfy4vp8y8v4f5xnhk";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # Workaround to make the python wrapper not drop this package:
   # pythonFull.buildEnv.override { extraLibs = [ thrift ]; }
   pythonPath = [];

--- a/pkgs/development/libraries/v8/default.nix
+++ b/pkgs/development/libraries/v8/default.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation rec {
     sha256 = "07ymw4kqbz7kv311gpk5bs5q90wj73n2q7jkyfhqk4hvhs1q5bw7";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   postUnpack = ''
     ${lib.concatStringsSep "\n" (
       lib.mapAttrsToList (n: v: ''

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation (rec {
     sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = lib.optional stdenv.hostPlatform.isCygwin ./disable-cygwin-widechar.patch;
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "14ymjahqdxj26da8wik9d5dzlxn81b3z1iggdl7rn2nn06jy7lvy";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ perl gmp mpfr ppl ocaml findlib camlidl ];
   propagatedBuildInputs = [ mlgmpidl ];
 

--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ocaml findlib ];
 
   installTargets = [ "ocamlfind-install" ];

--- a/pkgs/development/ocaml-modules/menhir/generic.nix
+++ b/pkgs/development/ocaml-modules/menhir/generic.nix
@@ -6,6 +6,8 @@ stdenv.mkDerivation {
 
   inherit src;
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ocaml findlib ocamlbuild ];
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0m9g16wrrr86gw4fz2fazrh8nkqms0n863w7ndcvrmyafgxvxsnr";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ocaml findlib ]
   ++ lib.optional gtkSupport lablgtk
   ;

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1kp72yv4k176i94np0m09g10cviqp2pnpm7jmiq6ik7fmmbknk7c";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ocaml findlib ocamlbuild ];
 
   makeFlags = [ "-C" "interpreter" ];

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -13,6 +13,8 @@ toPerlModule(stdenv.mkDerivation (
   (
   lib.recursiveUpdate
   {
+    hardeningDisable = [ "pie" ];
+
     outputs = [ "out" "devdoc" ];
 
     doCheck = true;

--- a/pkgs/development/pharo/vm/build-vm.nix
+++ b/pkgs/development/pharo/vm/build-vm.nix
@@ -42,17 +42,13 @@ stdenv.mkDerivation rec {
   pharo-share = import ./share.nix { inherit lib stdenv fetchurl unzip; };
 
   # Note: -fPIC causes the VM to segfault.
-  hardeningDisable = [ "format" "pic"
-                       # while the VM depends on <= gcc48:
-                       "stackprotector" ];
+  hardeningDisable = [ "format" "pic" ];
 
   # gcc 4.8 used for the build:
   #
   # gcc5 crashes during compilation; gcc >= 4.9 produces a
   # binary that crashes when forking a child process. See:
   # http://forum.world.st/OSProcess-fork-issue-with-Debian-built-VM-td4947326.html
-  #
-  # (stack protection is disabled above for gcc 4.8 compatibility.)
   nativeBuildInputs = [ autoreconfHook unzip ];
   buildInputs = [
     bash

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
     sha256 = "3e477db76c22929e4c6876c44f88d790aacdf3c3f8f3a90cb1975c0bf37825b0";
   };
 
+  hardeningDisable = [ "pie" ];
+
   XDG_RUNTIME_DIR = "/tmp";
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/tools/analysis/eresi/default.nix
+++ b/pkgs/development/tools/analysis/eresi/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0a5a7mh2zw9lcdrl8n1mqccrc0xcgj7743l7l4kslkh722fxv625";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     (fetchpatch {
       url = "https://github.com/thorkill/eresi/commit/a79406344cc21d594d27fa5ec5922abe9f7475e7.patch";

--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     sha256 = "1mq1fijka95ydrla486yr4w6wdl9l7vmp512s1q00b0p6lmfwmkh";
   };
 
+  hardeningDisable = [ "pie" ];
+
   preConfigure = lib.optionalString stdenv.cc.isClang "configureFlagsArray=(\"--with-cpp=clang -E -C\")";
 
   nativeBuildInputs = [ autoconf wrapGAppsHook ];

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     sha256 = "0n3k190qjhdlj10fjqijx6ismz0g7fk28i83j0480cxdqgmmlbxc";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postInstall = ''
     install -D -m755 $src/binr/r2pm/r2pm $out/bin/r2pm
   '';

--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -34,6 +34,7 @@ in stdenv.mkDerivation rec {
     url = "https://github.com/ohwgiles/laminar/archive/${version}.tar.gz";
     sha256 = "11m6h3rdmj2rsmsryy7r40gqccj4gg1cnqwy6blscs87gx4s423g";
   };
+  hardeningDisable = [ "pie" ];
   patches = [ ./patches/no-network.patch ];
   nativeBuildInputs = [ cmake pandoc ];
   buildInputs = [ capnproto sqlite boost zlib rapidjson ];

--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "17chvi3i80rj4750smpizf562xjzd2xcv5rfyh997pyvc1zbq5rh";
   };
 
+  hardeningDisable = [ "glibcxxassertions" ];
+
   nativeBuildInputs = [
     cmake
     python3

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "14sd8xqph4kb109g073daiavpadb20fcz7ch1ipn0waz7nlly4sw";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libzip glib libusb1 libftdi1 check libserialport
     librevisa doxygen glibmm python

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation {
     then "-Wno-string-plus-int -Wno-deprecated-declarations"
     else "-static-libgcc";
 
-  hardeningDisable = [ "format" "pie" ];
+  hardeningDisable = [ "pie" ];
 
   # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
   configurePlatforms = [ "build" "host" ] ++ lib.optional (stdenv.targetPlatform != stdenv.hostPlatform) "target";
@@ -115,12 +115,13 @@ stdenv.mkDerivation {
                      else [ "--disable-shared" "--enable-static" ])
   ++ lib.optional withAllTargets "--enable-targets=all"
   ++ [
-    "--enable-64-bit-bfd"
-    "--with-system-zlib"
-
-    "--enable-deterministic-archives"
     "--disable-werror"
+    "--enable-64-bit-bfd"
+    "--enable-cet"
+    "--enable-deterministic-archives"
     "--enable-fix-loongson2f-nop"
+    "--with-pic"
+    "--with-system-zlib"
 
     # Turn on --enable-new-dtags by default to make the linker set
     # RUNPATH instead of RPATH on binaries.  This is important because

--- a/pkgs/development/tools/misc/gengetopt/default.nix
+++ b/pkgs/development/tools/misc/gengetopt/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1b44fn0apsgawyqa4alx2qj5hls334mhbszxsy6rfr0q074swhdr";
   };
 
+  hardeningDisable = [ "pie" ];
+
   doCheck = true;
   # attempts to open non-existent file
   preCheck = ''

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation {
     sha256 = "1xkwwq0sgv05cla0g0a01yzhk0wpsn9y40w9kh9miiiv0imxfh36";
   };
 
+  hardeningDisable = [ "pie" ];
+
   doCheck = false;
 
   configureFlags = [ "--with-syscmd-shell=${stdenv.shell}" ];

--- a/pkgs/development/tools/misc/help2man/default.nix
+++ b/pkgs/development/tools/misc/help2man/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3op0dAvQWGRlZ7kqtOzeudqfGgfMfE9gejwU3TjRB5k=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ gettext perlPackages.LocaleGettext ];
   buildInputs = [ perlPackages.perl perlPackages.LocaleGettext ];
 

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qq61k6lp1fp75xs398yzi6wvbx232l7xbyn3p13cnh27mflvgg3";
   };
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "out" "lib" ];
 
   nativeBuildInputs = [ perl help2man m4 ];

--- a/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
+++ b/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "1s3wlz4yb2p8by5p66vr0z72n84mxkrmda63x9yr6pinqinsyrvv";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [ bzip2 libusb1 libzip openssl ];

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "14npmdxppmh0ci140w8i8cy7zg1pnqg81a1mdsnza711ab7k36k9";
   };
 
+  hardeningDisable = [ "pie" ];
+
   setupHook = [ ./setup-hook.sh ];
 
   # fails 8 out of 24 tests, problems when loading libc.so.6

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = optional crossBuildTools ./cross-tools-flags.patch;
 
   # ncurses is required to build `makedoc'

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     inherit (param) sha256;
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ which ocaml ocamlbuild ];
 
   dontAddPrefix = true;

--- a/pkgs/development/tools/ocaml/obuild/default.nix
+++ b/pkgs/development/tools/ocaml/obuild/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
     sha256 = "15arsgbhk1c39vd8qhpa3pag94m44bwvzggdvkibx6hnpkv8z9bn";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ ocaml ];
 
   buildPhase = ''

--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation {
     sha256 = "1hb5mcdz4wv7sh1pj7dq9q4fgz5h3zg7frpiya6s8zd3ypwzq0kh";
   };
 
+  hardeningDisable = [ "pie" ];
+
   createFindlibDestdir = true;
 
   buildInputs = [ ocaml findlib ];

--- a/pkgs/development/tools/ocaml/opam/1.2.2.nix
+++ b/pkgs/development/tools/ocaml/opam/1.2.2.nix
@@ -52,6 +52,8 @@ in stdenv.mkDerivation {
 
   src = srcs.opam;
 
+  hardeningDisable = [ "pie" ];
+
   postUnpack = ''
     ln -sv ${srcs.cudf} $sourceRoot/src_ext/${srcs.cudf.name}
     ln -sv ${srcs.extlib} $sourceRoot/src_ext/${srcs.extlib.name}

--- a/pkgs/development/tools/parsing/antlr/2.7.7.nix
+++ b/pkgs/development/tools/parsing/antlr/2.7.7.nix
@@ -6,6 +6,7 @@ stdenv.mkDerivation {
     url = "https://www.antlr2.org/download/antlr-2.7.7.tar.gz";
     sha256 = "1ffvcwdw73id0dk6pj2mlxjvbg0662qacx4ylayqcxgg381fnfl5";
   };
+  hardeningDisable = [ "pie" ];
   patches = [ ./2.7.7-fixes.patch ];
   buildInputs = [ jdk ];
   nativeBuildInputs = [ python2 ];

--- a/pkgs/development/tools/parsing/bison/default.nix
+++ b/pkgs/development/tools/parsing/bison/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-adwLtG6o/DB9TKHgthyMNV6yB9Cwxp9PhGIyjnTXueo=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ m4 perl ] ++ lib.optional stdenv.isSunOS help2man;
   propagatedBuildInputs = [ m4 ];
 

--- a/pkgs/development/tools/rucksack/default.nix
+++ b/pkgs/development/tools/rucksack/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0bcm20hqxqnq1j0zghb9i7z9frri6bbf7rmrv5g8dd626sq07vyv";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ liblaxjson freeimage ];
 

--- a/pkgs/development/tools/uftrace/default.nix
+++ b/pkgs/development/tools/uftrace/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "09zj4lgsbx0yp4i8ij9nh7wzylfcj421jzf1kkc2zpnn5hgynsb5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postUnpack = ''
         patchShebangs .
   '';

--- a/pkgs/games/angband/default.nix
+++ b/pkgs/games/angband/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-z1HTt3+lWIr2F9YZFdw47lkYVgYl17qbb/OJ9YyYQa8=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ ncurses5 ];
   installFlags = [ "bindir=$(out)/bin" ];

--- a/pkgs/games/azimuth/default.nix
+++ b/pkgs/games/azimuth/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1znfvpmqiixd977jv748glk5zc4cmhw5813zp81waj07r9b0828r";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ which ];
   buildInputs = [ SDL ];
 

--- a/pkgs/games/gav/default.nix
+++ b/pkgs/games/gav/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation {
     sha256 = "8f0deb8b2cd775b339229054f4f282583a4cfbcba9d27a6213cf910bab944f3e";
   };
 
+  hardeningDisable = [ "pie" ];
+
   prePatch = ''
     mkdir -p $out/bin
     sed -e "s@/usr@$out@" -i Makefile

--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -23,6 +23,8 @@ mkDerivation rec {
     sha256 = "0nqm9w02m0xkndlsj6ys3wr0ik8zc14zgilq7k6fwjrf3zk385i1";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake pkg-config qttools ];
 
   buildInputs = [

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -29,6 +29,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1liyckjp34j354qnxc1zn9730lh1p2dabrg1hap24z6xnqx0rpng";
   };
 
+  hardeningDisable = lib.optionals qtMode [ "pie" ];
+
   buildInputs = [ ncurses ]
                 ++ lib.optionals x11Mode [ libXaw libXext libXpm ]
                 ++ lib.optionals qtMode [ gzip qt5.qtbase.bin qt5.qtmultimedia.bin ];

--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation rec {
     sha256 = "17i3nlhxm4x4zx00i00aivhxmagbnyizxnpwiqzg57bf23hrvdj3";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook ];
 
   buildInputs = [ SDL2 freetype physfs openal gamenetworkingsockets ];

--- a/pkgs/games/ultrastardx/default.nix
+++ b/pkgs/games/ultrastardx/default.nix
@@ -39,6 +39,8 @@ in stdenv.mkDerivation rec {
     sha256 = "0vmfv8zpyf8ymx3rjydpd7iqis080lni94vb316vfxkgvjmqbhym";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ fpc libpng ] ++ sharedLibs;
 

--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     sha256 = "013g1zngxffavqrk5jy934q3bdhsv6z05ilfixdn8dj0zy26lwv5";
   };
 
+  hardeningDisable = [ "pie" ];
+
   makeFlags = [
     "BUILD=RELEASE"
     "VERSION=${version}"

--- a/pkgs/misc/emulators/cdemu/vhba.nix
+++ b/pkgs/misc/emulators/cdemu/vhba.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" "INSTALL_MOD_PATH=$(out)" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   meta = with lib; {
     description = "Provides a Virtual (SCSI) HBA";

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     sha256 = "07mlfnh0hwvk6xarcg315x7z2j0qbg9g7cm040df9c8psiahc3g6";
   };
 
+  hardeningDisable = [ "pie" ];
+
   patches = [
     # Fix build with soundtouch 2.1.2
     (fetchpatch {

--- a/pkgs/misc/emulators/firebird-emu/default.nix
+++ b/pkgs/misc/emulators/firebird-emu/default.nix
@@ -12,6 +12,8 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  hardeningDisable = [ "pie" ];
+
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ qmake ];

--- a/pkgs/misc/emulators/fs-uae/default.nix
+++ b/pkgs/misc/emulators/fs-uae/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qwzhp34wy7bnd3c0plv11rg9fs5m92rh3ffnr9pn6ng0cpc8vpj";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ gettext gtk2 SDL2 zlib glib openal libGLU libGL lua freetype libmpeg2 zip ];
 

--- a/pkgs/misc/emulators/mednafen/default.nix
+++ b/pkgs/misc/emulators/mednafen/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   postInstall = ''
     mkdir -p $out/share/doc

--- a/pkgs/misc/emulators/mupen64plus/default.nix
+++ b/pkgs/misc/emulators/mupen64plus/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1a21n4gqdvag6krwcjm5bnyw5phrlxw6m0mk73jy53iq03f3s96m";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config nasm ];
   buildInputs = [ boost dash freetype libpng SDL which zlib ];
 

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -20,6 +20,8 @@ mkDerivation {
     sha256 = "182rkmbnnlcfzam4bwas7lwv10vqiqvvaw3299a3hariacd7rq8x";
   };
 
+  hardeningDisable = [ "pie" ];
+
   preConfigure = ''
     cat > ./rpcs3/git-version.h <<EOF
     #define RPCS3_GIT_VERSION "${gitVersion}"

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530
   # https://github.com/NixOS/nixpkgs/issues/31989
-  hardeningDisable = [ "bindnow" ]
+  hardeningDisable = [ "bindnow" "pie" "stackclashprotection" ]
     ++ lib.optional (stdenv.hostPlatform.isDarwin) "fortify"
     ++ lib.optional (supportFlags.mingwSupport) "format";
 

--- a/pkgs/misc/emulators/yabause/default.nix
+++ b/pkgs/misc/emulators/yabause/default.nix
@@ -10,6 +10,8 @@ mkDerivation rec {
     sha256 = "1cn2rjjb7d9pkr4g5bqz55vd4pzyb7hg94cfmixjkzzkw0zw8d23";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ qtbase qt5.qtmultimedia libGLU libGL freeglut openal SDL2 ];
 

--- a/pkgs/os-specific/linux/acpi-call/default.nix
+++ b/pkgs/os-specific/linux/acpi-call/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mr4rjbv6fj4phf038addrgv32940bphghw2v9n1z4awvw7wzkbg";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0r5xg7pz0wl6pq5029rpzm9fn978vq0md31xjkp2amny7rrgxw72";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ qmake ];
   dontWrapQtApps = true;
 

--- a/pkgs/os-specific/linux/amdgpu-pro/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-pro/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     curlOpts = "--referer http://support.amd.com/en-us/kb-articles/Pages/AMD-Radeon-GPU-PRO-Linux-Beta-Driver%e2%80%93Release-Notes.aspx";
   };
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   inherit libsOnly;
 

--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1km1nslp4f5znwskh4bb1b61r1inw1dlbwiyyq3rrh0f0agf8d0v";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   KERNEL_SRC="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
+++ b/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0kc0xlrsmf783ln5bqyj6qxzmrhdxdfdd2b9ygf2lbl2153i04vc";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/ati-drivers/default.nix
+++ b/pkgs/os-specific/linux/ati-drivers/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     curlOpts = "--referer https://www.amd.com/en/support";
   };
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   patchPhaseSamples = "patch -p2 < ${./patches/patch-samples.patch}";
   patches = [

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   preBuild = ''
     makeFlags="KERNELPATH=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   preBuild = ''
     substituteInPlace Makefile \

--- a/pkgs/os-specific/linux/bpftool/default.nix
+++ b/pkgs/os-specific/linux/bpftool/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation {
   pname = "bpftool";
   inherit (linuxPackages_latest.kernel) version src;
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ python3 ];
   buildInputs = [ libopcodes libbfd libelf zlib ];
 

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     sha256 = hashes.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/can-isotp/default.nix
+++ b/pkgs/os-specific/linux/can-isotp/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   pname = "can-isotp";
   version = "20200910";
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   src = fetchFromGitHub {
     owner = "hartkopp";

--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     export SHELL=""
   '';
 
-  hardeningDisable = [ "stackprotector" "fortify" ];
+  hardeningDisable = [ "fortify" "pie" "stackprotector" ];
   # dropping fortify here as well as package uses it by default:
   # command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
 

--- a/pkgs/os-specific/linux/cryptodev/default.nix
+++ b/pkgs/os-specific/linux/cryptodev/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ky850qiyacq8p3lng7n3w6h3x2clqrz4lkv2cv3psy92mg9pvc9";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   KERNEL_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   INSTALL_MOD_PATH = "\${out}";

--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vkkja3ykjil783zjpwp0vz7jy2fp9ccazzi3afd4fjk8gldin7f";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1l54j85540386a8aypqka7p5hy1b63cwmpsscv9rmmf10f78v8mm";
   };
 
+  hardeningDisable = [ "pie" ];
+
   INSTALL_MOD_PATH = "\${out}";
 
   postPatch = ''

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -18,6 +18,8 @@ in stdenv.mkDerivation rec {
     sha256 = "0h0xv2zwb91b9n29afg5ihn06a8q28in64hag2f112kc19f79jj8";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [
     doxygen
     meson

--- a/pkgs/os-specific/linux/e1000e/default.nix
+++ b/pkgs/os-specific/linux/e1000e/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1q8dbqh14c7r15q6k6iv5k0d6xpi74i71d5r54py60gr099m2ha4";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   configurePhase = ''
     cd src

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0f3i878g11yfw6n68p3qf125jsnggy706jhc8sc0z1xgap6qgh09";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 
-  hardeningDisable = [ "format" "pic" "fortify" ];
+  hardeningDisable = [ "format" "fortify" "pic" "pie" ];
 
   installPhase = ''
     install -Dm755 module/evdi.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gpu/drm/evdi/evdi.ko

--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "14jahy7n6pr482fjfrlf9ck3f2rkr5ds0n5r85xdfsla37ria26d";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     export INSTALL_MOD_PATH="$out"
   '';
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/fwts/module.nix
+++ b/pkgs/os-specific/linux/fwts/module.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   makeFlags = [
     "INSTALL_MOD_PATH=${placeholder "out"}"

--- a/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
+++ b/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
@@ -17,6 +17,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1nqhj3vqq9rnj37cnm2c4867mnxkr8di3i036shcz44h9qmy9d40";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = [

--- a/pkgs/os-specific/linux/hyperv-daemons/default.nix
+++ b/pkgs/os-specific/linux/hyperv-daemons/default.nix
@@ -11,7 +11,7 @@ let
     nativeBuildInputs = [ makeWrapper ];
 
     # as of 4.9 compilation will fail due to -Werror=format-security
-    hardeningDisable = [ "format" ];
+    hardeningDisable = [ "format" "pie" ];
 
     postPatch = ''
       cd tools/hv

--- a/pkgs/os-specific/linux/intel-speed-select/default.nix
+++ b/pkgs/os-specific/linux/intel-speed-select/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation {
   pname = "intel-speed-select";
   inherit (kernel) src version;
 
+  hardeningDisable = [ "pie" ];
+
   makeFlags = [ "bindir=${placeholder "out"}/bin" ];
 
   postPatch = ''

--- a/pkgs/os-specific/linux/isgx/default.nix
+++ b/pkgs/os-specific/linux/isgx/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ygi4mwds4q7byhg8gqnh3syamdj5rpjy3jj012k7vl54gdgrmgm";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/ixgbevf/default.nix
+++ b/pkgs/os-specific/linux/ixgbevf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   configurePhase = ''
     cd src

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   src = sourceAttrs.src;
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   prePatch = ''
     sed -e 's@/lib/modules/\$(.*)@${kernel.dev}/lib/modules/${kernel.modDirVersion}@' -i src/mod/*/Makefile

--- a/pkgs/os-specific/linux/kernel/gpio-utils.nix
+++ b/pkgs/os-specific/linux/kernel/gpio-utils.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
 
   inherit (linux) src makeFlags;
 
+  hardeningDisable = [ "pie" ];
+
   preConfigure = ''
     cd tools/gpio
   '';

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   makeFlags = ["prefix=$(out)" "WERROR=0"] ++ kernel.makeFlags;
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   # perf refers both to newt and slang
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl ];
   strictDeps = true;
 
-  hardeningDisable = [ "format" "stackprotector" ];
+  hardeningDisable = [ "cfprotection" "format" "pie" "stackprotector" ];
 
   makeFlags = commonMakeFlags ++ [
     "KLIBCARCH=${stdenv.hostPlatform.linuxArch}"

--- a/pkgs/os-specific/linux/kmscon/default.nix
+++ b/pkgs/os-specific/linux/kmscon/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
     sha256 = "0q62kjsvy2iwy8adfiygx2bfwlh83rphgxbis95ycspqidg9py87";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [
     libGLU libGL
     libdrm

--- a/pkgs/os-specific/linux/lockdep/default.nix
+++ b/pkgs/os-specific/linux/lockdep/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1my2m9hvnvdrvzcg0fgqgaga59y2cd5zlpv7xrfj2nn98sjhglwq";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # ensure *this* kernel's userspace-headers are picked up before we
   # fall back to those in glibc, as they will be from a mismatched
   # kernel version

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 

--- a/pkgs/os-specific/linux/mba6x_bl/default.nix
+++ b/pkgs/os-specific/linux/mba6x_bl/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   };
 
   enableParallelBuilding = true;
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     export INSTALL_MOD_PATH="$out"
   '';
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   makeFlags = [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   meta = with lib; {
     description = "MOXA UPort 11x0 USB to Serial Hub driver";

--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   name = "ndiswrapper-${version}-${kernel.version}";
   inherit version;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   patches = [ ./no-sbin.patch ];
 

--- a/pkgs/os-specific/linux/netatop/default.nix
+++ b/pkgs/os-specific/linux/netatop/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib ];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   preConfigure = ''
     patchShebangs mkversion

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -75,7 +75,7 @@ let
     kernel = if libsOnly then null else kernel.dev;
     kernelVersion = if libsOnly then null else kernel.modDirVersion;
 
-    hardeningDisable = [ "pic" "format" ];
+    hardeningDisable = [ "format" "pic" "pie" ];
 
     dontStrip = true;
     dontPatchELF = true;

--- a/pkgs/os-specific/linux/nvidiabl/default.nix
+++ b/pkgs/os-specific/linux/nvidiabl/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1z57gbnayjid2jv782rpfpp13qdchmbr1vr35g995jfnj624nlgy";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/openrazer/driver.nix
+++ b/pkgs/os-specific/linux/openrazer/driver.nix
@@ -12,6 +12,8 @@ in
 stdenv.mkDerivation (common // {
   name = "openrazer-${common.version}-${kernel.version}";
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildFlags = [

--- a/pkgs/os-specific/linux/paxtest/default.nix
+++ b/pkgs/os-specific/linux/paxtest/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0zv6vlaszlik98gj9200sv0irvfzrvjn46rnr2v2m37x66288lym";
   };
 
+  hardeningDisable = [ "pie" ];
+
   enableParallelBuilding = true;
 
   makefile     = "Makefile.psm";

--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which ] ++ kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   makeFlags = with kernel; [
     "DESTDIR=$(out)"

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "1jwzwif69qlhmfky9kigjaxpxfj0lyrl1iyrpqy4iwqvajdgbbym";
   };
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   # also maybe python2 to generate xorg.conf
   nativeBuildInputs = [ p7zip undmg ] ++ lib.optionals (!libsOnly) [ makeWrapper ] ++ kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "0h2y4mzydhc7var5281bk2jj1knig6i64k11ii4b94az3g9dbq24";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1l8llpcnapcaafxp7wlyny2ywh7k6q5zygwwjl9h0l6p04cghss4";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
     sha256 = "159vg0scq47wnn600karpgzx3naaiyl1rg8608c8d28nhm62gvjz";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pxqya14a61vv2v5ky1ldybc0mjfin9mpvmajlmv0lls904rph7g";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   buildInputs = [ nukeReferences ];
 

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ bc nukeReferences ];
   buildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   prePatch = ''
     substituteInPlace ./Makefile --replace /lib/modules/ "${kernel.dev}/lib/modules/"

--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
 

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ bc nukeReferences ];
   buildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" "format" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
 

--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0935dzz0njxh78wfd17yqah1dxn6b3kaszvzclwwrwwhwcrdp80j";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = [ bc ];
   buildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ccl94727yq7gzn37ky91k0736cambgnkaa37r2f2hinpl9qdd8q";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = [ bc ];
   buildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0nw2kgblpq6qlr43gbfxqvq0c83664f4czfwzsyfjr47rj00iyq7";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = [ bc ];
   buildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   NIX_CFLAGS_COMPILE="-Wno-error=incompatible-pointer-types";
 

--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     hash = "sha256-PRzWXC1lre8gt1GfVdnaG836f5YK57P9a8tG20yef0w=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   makeFlags = [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/sch_cake/default.nix
+++ b/pkgs/os-specific/linux/sch_cake/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "08582jy01j32b3mj8hf6m8687qrcz64zv2m236j24inlkmd94q21";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   makeFlags = [
     "KERNEL_VERSION=${kernel.version}"

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     luajit ncurses jsoncpp libb64 openssl curl jq gcc elfutils tbb protobuf grpc
   ] ++ optionals (kernel != null) kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   cmakeFlags = [
     "-DUSE_BUNDLED_DEPS=OFF"

--- a/pkgs/os-specific/linux/syslinux/default.nix
+++ b/pkgs/os-specific/linux/syslinux/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation {
   buildInputs = [ libuuid ];
 
   enableParallelBuilding = false; # Fails very rarely with 'No rule to make target: ...'
-  hardeningDisable = [ "pic" "stackprotector" "fortify" ];
+  hardeningDisable = [ "fortify" "pic" "pie" "stackprotector" ];
 
   stripDebugList = [ "bin" "sbin" "share/syslinux/com32" ];
 

--- a/pkgs/os-specific/linux/system76-acpi/default.nix
+++ b/pkgs/os-specific/linux/system76-acpi/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/system76-io/default.nix
+++ b/pkgs/os-specific/linux/system76-io/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/system76/default.nix
+++ b/pkgs/os-specific/linux/system76/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/tp_smapi/default.nix
+++ b/pkgs/os-specific/linux/tp_smapi/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   makeFlags = [
     "KBASE=${kernel.dev}/lib/modules/${kernel.modDirVersion}"

--- a/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-keyboard/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1s48qpwybwh5pwqas2d1v2a7x4r97sm4hr9i4902r1d7h384bv17";
   };
 
+  hardeningDisable = [ "pie" ];
+
   makeFlags = [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   installPhase = ''

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qi4l6yam8nrlmc3zwkrz9vph0xsj1cgmkqci4652mbpbzigg7vn";
   };
 
-  hardeningDisable = [ "format" "pic" ];
+  hardeningDisable = [ "format" "pic" "pie" ];
 
   preBuild = ''
     substituteInPlace Makefile --replace "modules_install" "INSTALL_MOD_PATH=$out modules_install"

--- a/pkgs/os-specific/linux/v86d/default.nix
+++ b/pkgs/os-specific/linux/v86d/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-klibc" "--with-x86emu" ];
 
-  hardeningDisable = [ "stackprotector" ];
+  hardeningDisable = [ "pie" "stackprotector" ];
 
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"

--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   makeFlags = [
     "KVER=${kernel.modDirVersion}"

--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -3,9 +3,7 @@
 stdenv.mkDerivation {
   name = "virtualbox-modules-${virtualbox.version}-${kernel.version}";
   src = virtualbox.modsrc;
-  hardeningDisable = [
-    "fortify" "pic" "stackprotector"
-  ];
+  hardeningDisable = [ "fortify" "pic" "pie" "stackprotector" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ZYZBnfX8DP0IV3VEBSzg7wnFCnlCzOT6Ql3kFZ0klfQ=";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-VUcS4OzvPj0o627ZWIOBqEAQJ4JuMCMjgaZoMkL/IHc=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   setSourceRoot = ''
     export sourceRoot=$(pwd)/source/hid-xpadneo/src
   '';

--- a/pkgs/os-specific/linux/zenmonitor/default.nix
+++ b/pkgs/os-specific/linux/zenmonitor/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0smv94vi36hziw42gasivyw25h5n1sgwwk1cv78id5g85w0kw246";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ gtk3 ];
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
 

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "116yrw4ygh3fqwhniaqq0nps29pq87mi2q1375f1ylkfiak8n63a";
   };
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -95,7 +95,7 @@ let
       # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
       NIX_CFLAGS_LINK = "-lgcc_s";
 
-      hardeningDisable = [ "fortify" "stackprotector" "pic" ];
+      hardeningDisable = [ "fortify" "pic" "pie" "stackprotector" ];
 
       configureFlags = [
         "--with-config=${configFile}"

--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -24,8 +24,6 @@ in stdenv.mkDerivation {
     sha256 = "sha256-zrxNCXJIuEbtE3YNRK8Bxu2koHsQkcF+xItoIyhj9Uc=";
   };
 
-  hardeningEnable = [ "pie" ];
-
   configurePhase = ''
     runHook preConfigure
     sh configure.sh

--- a/pkgs/os-specific/windows/mcfgthreads/default.nix
+++ b/pkgs/os-specific/windows/mcfgthreads/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1ib90lrd4dz8irq4yvzwhxqa86i5vxl2q2z3z04sf1i8hw427p2f";
   };
 
+  hardeningDisable = [ "stackclashprotection" ];
+
   outputs = [ "out" "dev" ];
 
   # Don't want prebuilt binaries sneaking in.

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [ windows.mingw_w64_headers ];
   dontStrip = true;
-  hardeningDisable = [ "stackprotector" "fortify" ];
+  hardeningDisable = [ "fortify" "stackclashprotection" "stackprotector" ];
 
   meta = {
     platforms = lib.platforms.windows;

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -14,6 +14,8 @@ let
         url = "ftp://bird.network.cz/pub/bird/${pname}-${version}.tar.gz";
       };
 
+      hardeningDisable = [ "pie" ];
+
       nativeBuildInputs = [ flex bison ];
       buildInputs = [ readline libssh ];
 

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   # nixos test fails to start slurmd with 'undefined symbol: slurm_job_preempt_mode'
   # https://groups.google.com/forum/#!topic/slurm-devel/QHOajQ84_Es
   # this doesn't fix tests completely at least makes slurmd to launch
-  hardeningDisable = [ "bindnow" ];
+  hardeningDisable = [ "bindnow" "pie" ];
 
   nativeBuildInputs = [ pkg-config libtool python3 ];
   buildInputs = [

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "18wcqxrv2bz88xadkqpqznprrxmcmwr0g6k895xrm8rbp9mpdzlg";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ erlang icu openssl spidermonkey_68 (python3.withPackages(ps: with ps; [ requests ]))];
   postPatch = ''
     substituteInPlace src/couch/rebar.config.script --replace '/usr/include/mozjs-68' "${spidermonkey_68.dev}/include/mozjs-68"

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -132,8 +132,6 @@ stdenv.mkDerivation {
     })
   ] ++ mapModules "patches");
 
-  hardeningEnable = optional (!stdenv.isDarwin) "pie";
-
   enableParallelBuilding = true;
 
   postInstall = if postInstall != null then postInstall else ''

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -103,8 +103,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
 
-  hardeningEnable = optional (!stdenv.isDarwin) "pie";
-
   enableParallelBuilding = true;
 
   postInstall = ''

--- a/pkgs/servers/icecast/default.nix
+++ b/pkgs/servers/icecast/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libxml2 libxslt curl libvorbis libtheora speex libkate libopus ];
 
-  hardeningEnable = [ "pie" ];
-
   meta = {
     description = "Server software for streaming multimedia";
 

--- a/pkgs/servers/mail/postfix/default.nix
+++ b/pkgs/servers/mail/postfix/default.nix
@@ -41,7 +41,6 @@ in stdenv.mkDerivation rec {
                 ++ lib.optional withLDAP openldap;
 
   hardeningDisable = [ "format" ];
-  hardeningEnable = [ "pie" ];
 
   patches = [
     ./postfix-script-shell.patch

--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [cyrus_sasl libevent];
 
-  hardeningEnable = [ "pie" ];
-
   NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ]
     ++ lib.optional stdenv.isDarwin "-Wno-error";
 

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -124,8 +124,6 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = [ "pie" ];
-
   meta = {
     description = "A scalable, high-performance, open source NoSQL database";
     homepage = "http://www.mongodb.org";

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -51,7 +51,7 @@ in stdenv.mkDerivation {
     })
   ];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   configureFlags = [
     "--with-linux-kernel-build=${kernelBuildDir}"

--- a/pkgs/servers/openafs/1.9/module.nix
+++ b/pkgs/servers/openafs/1.9/module.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
 
   patches = [];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   configureFlags = [
     "--with-linux-kernel-build=${kernelBuildDir}"

--- a/pkgs/servers/xmpp/ejabberd/default.nix
+++ b/pkgs/servers/xmpp/ejabberd/default.nix
@@ -32,6 +32,8 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-nZxdYXRyv4UejPLHNT/p6CrvW22Koo7rZSi96KRjqFQ=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ fakegit makeWrapper ];
 
   buildInputs = [ erlang openssl expat libyaml gd ]

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     sha256 = "1jyz6snd63xjn6skk7za6psgidsd53k05cr3lksqybi0q6936syq";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   outputs = [ "out" "dev" "man" "doc" "info" ];
 

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
       ocamlPackages.srt ocamlPackages.sedlex_2 ocamlPackages.menhir
     ];
 
-  hardeningDisable = [ "format" "fortify" ];
+  hardeningDisable = [ "format" "fortify" "pie" ];
 
   meta = with lib; {
     description = "Swiss-army knife for multimedia streaming";

--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -66,6 +66,8 @@ in stdenv.mkDerivation rec {
     hash = "sha256-xvKjb+ql3WxnGHqcn3WnxunY5+s9f8Gt/n6EFSBrNdI=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # Unpack subproject sources
   postUnpack = ''(
     cd "$sourceRoot/subprojects"

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-FnhwNy4OHe8d5M6iYCClkxzcB/EHXg0veXwv43ZlxbA=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ autoreconfHook ];
 
   patches = [

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ps2i8i212n0f4xpq6clp7h13q7m1y8slqvxha9i8d0bj0qgj5si";
   };
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   configureFlags = lib.optional enableStatic "--disable-shared";

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -25,6 +25,8 @@ in rec {
       fetchSubmodules = true;
     };
 
+    hardeningDisable = [ "pie" ]; # clang-7: error: argument unused during compilation: '-pie'
+
     # Patches:
     # irods_root_path.patch : the root path is obtained by stripping 3 items of the path,
     #                         but we don't use /usr with nix, so remove only 2 items.
@@ -71,6 +73,8 @@ in rec {
        rev = version;
        sha256 = "08hqrc9iaw0y9rrrcknnl5mzbcrsvqc39pwvm62fipl3vnfqryli";
      };
+
+     hardeningDisable = [ "pie" ]; # clang-7: error: argument unused during compilation: '-pie'
 
      patches = [ ./zmqcpp-deprecated-send_recv.patch ];
 

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation {
     sha256 = "09fpy4n4f867j23pr3b719wpvp8hjrr4drxp0r1csw74p8j6vfy3";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [
     pkg-config
     flex

--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation rec {
     sha256 = "0j5vaf930lb21gx4h7z6mksh1fazqw32gajjjkyir94wbmml9n3s";
   };
 
+  hardeningDisable = [ "pie" ];
+
   # put data at the correct locations else cmake tries to fetch them,
   # which fails in sandboxed mode
   prePatch = ''

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0nk54chr7z2w579vyiak9xk2avhnvrx7x2l5sk8nyw2zplchkx9q";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config python3.pkgs.cython ];
   buildInputs = [ bluez ]
     ++ lib.optional alsaSupport alsaLib

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ texinfo ];
 
-  hardeningDisable = [ "format" "stackprotector" ];
+  hardeningDisable = [ "format" "pie" "stackprotector" ];
 
   passthru.grubTarget = "";
 

--- a/pkgs/tools/misc/grub4dos/default.nix
+++ b/pkgs/tools/misc/grub4dos/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ nasm ];
 
-  hardeningDisable = [ "stackprotector" ];
+  hardeningDisable = [ "cfprotection" "pie" "stackprotector" ];
 
   configureFlags = [ "--host=${arch}-pc-linux-gnu" ];
 

--- a/pkgs/tools/misc/pipelight/default.nix
+++ b/pkgs/tools/misc/pipelight/default.nix
@@ -17,6 +17,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1kyy6knkr42k34rs661r0f5sf6l1s2jdbphdg89n73ynijqmzjhk";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ wine_custom libX11 libGLU libGL curl ];
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];

--- a/pkgs/tools/misc/pv/default.nix
+++ b/pkgs/tools/misc/pv/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1wbk14xh9rfypiwyy68ssl8dliyji30ly70qki1y2xx3ywszk3k0";
   };
 
+  hardeningDisable = [ "pie" ];
+
   meta = {
     homepage = "http://www.ivarch.com/programs/pv";
     description = "Tool for monitoring the progress of data through a pipeline";

--- a/pkgs/tools/misc/wimboot/default.nix
+++ b/pkgs/tools/misc/wimboot/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     cd src
   '';
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "pie" ];
 
   buildInputs = [ libbfd zlib libiberty ];
   makeFlags = [ "wimboot.x86_64.efi" ];

--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isLinux [ libcap libseccomp pps-tools ];
   nativeBuildInputs = [ pkg-config ];
 
-  hardeningEnable = [ "pie" ];
-
   configureFlags = [ "--chronyvardir=$(out)/var/lib/chrony" ]
     ++ lib.optional stdenv.isLinux "--enable-scfilter";
 

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
     "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
   ];
 
-  hardeningEnable = [ "pie" ];
-
   postBuild = optionalString stdenv.isLinux ''
     make -C contrib/lease-tools
   '';

--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
     ++ lib.optional withSeccomp libseccomp
     ++ lib.optional stdenv.isLinux pps-tools;
 
-  hardeningEnable = [ "pie" ];
-
   postInstall = ''
     rm -rf $out/share/doc
   '';

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -97,8 +97,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = [ "pie" ];
-
   postInstall = ''
     # Install ssh-copy-id, it's very useful.
     cp contrib/ssh-copy-id $out/bin/

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xh3kAIxiRF7Bjx8nBAfL8jcuq6k76szcnjI4uy3v7tc=";
   };
 
-  hardeningEnable = [ "pie" ];
-
   nativeBuildInputs = [ autoreconfHook w3m man ];
   buildInputs = [ zlib pcre mbedtls brotli ];
 

--- a/pkgs/tools/networking/shncpd/default.nix
+++ b/pkgs/tools/networking/shncpd/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation {
     sha256 = "1sj7a77isc2jmh7gw2naw9l9366kjx6jb909h7spj7daxdwvji8f";
   };
 
-  hardeningEnable = [ "pie" ];
-
   preConfigure = ''
     makeFlags=( "PREFIX=$out" )
   '';

--- a/pkgs/tools/networking/snabb/default.nix
+++ b/pkgs/tools/networking/snabb/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1sas9d9kk92mc2wrwgmm0xxz7ycmh388dwvyxf1hy183yvin1nac";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];

--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl readline ];
 
-  hardeningEnable = [ "pie" ];
-
   checkInputs = [ which nettools ];
   doCheck = false; # fails a bunch, hangs
 

--- a/pkgs/tools/nix/nix-script/default.nix
+++ b/pkgs/tools/nix/nix-script/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation {
     sha256 = "0yiqljamcj9x8z801bwj7r30sskrwv4rm6sdf39j83jqql1fyq7y";
   };
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs  = [
     (haskellPackages.ghcWithPackages (hs: with hs; [ posix-escape ]))
   ];

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -36,6 +36,8 @@ common =
 
       VERSION_SUFFIX = suffix;
 
+      hardeningDisable = lib.optionals is24 [ "glibcxxassertions" ];
+
       outputs = [ "out" "dev" "man" "doc" ];
 
       nativeBuildInputs =

--- a/pkgs/tools/security/aespipe/default.nix
+++ b/pkgs/tools/security/aespipe/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "15pg9j27mjzl78mpzkdqd84kdafj0g6j72f8wgjrpp2qkxjy2ddi";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   configureFlags = [ "--enable-padlock" "--enable-intelaes" ];

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -20,6 +20,8 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "01sp24z63r3nqxx57zc4873b8i5dqipy7yrxzrwjns531vznhiy2";
   };
 
+  hardeningDisable = lib.optionals withDriver [ "pie" ];
+
   patches = lib.optionals withDriver [ ./ko-path.diff ./compile-ko.diff ];
 
   KSRC = lib.optionalString withDriver "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/tools/security/kwalletcli/default.nix
+++ b/pkgs/tools/security/kwalletcli/default.nix
@@ -12,6 +12,8 @@ mkDerivation rec {
     sha256 = "sha256-DUtaQITzHhQrqA9QJd0U/5EDjH0IzY9/kal/7SYQ/Ck=";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     substituteInPlace GNUmakefile \
       --replace -I/usr/include/KF5/KCoreAddons -I${kcoreaddons.dev}/include/KF5/KCoreAddons \

--- a/pkgs/tools/security/mkp224o/default.nix
+++ b/pkgs/tools/security/mkp224o/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
           stdenv.mkDerivation {
             name = "mkp224o-${suffix}-${version}";
             inherit version src configureFlags;
+            hardeningDisable = [ "pie" ];
             nativeBuildInputs = [ autoreconfHook ];
             buildInputs = [ libsodium ];
             installPhase = "install -D mkp224o $out";

--- a/pkgs/tools/security/nsjail/default.nix
+++ b/pkgs/tools/security/nsjail/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256          = "1w6x8xcrs0i1y3q41gyq8z3cq9x24qablklc4jiydf855lhqn4dh";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ autoconf bison flex libtool pkg-config which ];
   buildInputs = [ libnl protobuf protobufc ];
   enableParallelBuilding = true;

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation {
 
   unpackCmd = "(mkdir cron && cd cron && sh $curSrc)";
 
-  hardeningEnable = [ "pie" ];
-
   preBuild = ''
     # do not set sticky bit in /nix/store
     substituteInPlace Makefile --replace ' -o root' ' ' --replace 111 755 --replace 4755 0755

--- a/pkgs/tools/system/ddrescueview/default.nix
+++ b/pkgs/tools/system/ddrescueview/default.nix
@@ -15,6 +15,8 @@ in stdenv.mkDerivation rec {
   };
   sourceRoot = "ddrescueview-source-${versionBase}~${versionSuffix}/source";
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ fpc lazarus ];
 
   buildInputs = [ atk cairo gdk-pixbuf glib gtk2 libX11 pango ];

--- a/pkgs/tools/system/efivar/default.nix
+++ b/pkgs/tools/system/efivar/default.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
   postPatch = "sed '/^OPTIMIZE /s/-flto//' -i Make.defaults";
   NIX_CFLAGS_COMPILE = "-Wno-error=stringop-truncation";
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ popt ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation {
     sha256 = "0gwzqm5wpscj3fchlv3qggf3zzn0v00s4crb5ciwljan1zrqadhy";
   };
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     substituteInPlace src/GNUmakefile \
       --replace /bin/echo ${coreutils}/bin/echo

--- a/pkgs/tools/text/dirdiff/default.nix
+++ b/pkgs/tools/text/dirdiff/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lljd8av68j70733yshzzhxjr1lm0vgmbqsm8f02g03qsma3cdyb";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ copyDesktopItems ];
   buildInputs = [ tcl tk ];
 

--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha512 = "1rbsngfw36lyc8s6qxl8hgb1pzj0gdzlb7yqkfblb8fpgs2z0ggyhnfszrqfir8s569i7a9yk9bdx2ggwqhjj56hmi2i4inlnb3rmni";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ which ]
     ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 

--- a/pkgs/tools/video/harvid/default.nix
+++ b/pkgs/tools/video/harvid/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l1plfsfh2ixhlzg3hqqvjj42z7g422718a9kgbh7b4p882n71x7";
   };
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ ffmpeg libjpeg libpng ];

--- a/pkgs/tools/video/mjpegtools/default.nix
+++ b/pkgs/tools/video/mjpegtools/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "01y4xpfdvd4zgv6fmcjny9mr1gbfd4y2i4adp657ydw6fqyi8kw6";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [ "format" "pie" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libdv libjpeg libpng ]


### PR DESCRIPTION
###### Motivation for this change
https://blog.fpmurphy.com/2008/06/position-independent-executables.html
>PIE is an address space randomization technique that compiles & links executables to be position independent, i.e. machine instruction code that executes properly regardless of where in memory it actually resides. When combined with a kernel that can recognize it is loading a PIE binary, the kernel loads it into a random address instead of the traditional fixed address locations.

https://fedoraproject.org/wiki/Security_Features_Matrix#Address_Space_Layout_Randomization_.28ASLR.29
>This makes memory addresses harder to predict when an attacker is attempting a memory-corruption exploit.
>To make ASLR effective all segments must be randomized. Leaving the text segment loading address non-randomized reduces the protection provided by the ASLR since the attackers can use ret2text attacks. The loading address of the text segment in a binary can be randomized by building the binary as PIE (Position Independent Executable).

https://fedoraproject.org/wiki/Changes/Harden_All_Packages#Detailed_Harden_Flags_Description
>Copy relocations support in GCC 5 and binutils 2.26 makes the performance [decrease] on x86_64 of PIE literally zero for many programs.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).