### PR TITLE
chromium: 86.0.4240.198 -> 87.0.4280.66

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -152,9 +152,6 @@ let
       ./patches/no-build-timestamps.patch # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed)
       ./patches/widevine-79.patch # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags
       # ++ optional (versionRange "68" "72") ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" )
-    ] ++ optionals (useVaapi && versionRange "86" "87") [
-      # Check for enable-accelerated-video-decode on Linux:
-      (githubPatch "54deb9811ca9bd2327def5c05ba6987b8c7a0897" "11jvxjlkzz1hm0pvfyr88j7z3zbwzplyl5idkx92l2lzv4459c8d")
     ];
 
     postPatch = ''

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -15,7 +15,7 @@
 , enablePepperFlash ? false
 , enableWideVine ? false
 , enableVaapi ? false # Disabled by default due to unofficial support
-, useOzone ? false
+, useOzone ? true
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
@@ -41,8 +41,7 @@ let
           inherit (upstream-info.deps.gn) url rev sha256;
         };
       });
-    } // lib.optionalAttrs (lib.versionAtLeast upstream-info.version "87") {
-      useOzone = true; # YAY: https://chromium-review.googlesource.com/c/chromium/src/+/2382834 \o/
+      # TODO: Cleanup useOzone and useVaapi in common.nix:
       useVaapi = !stdenv.isAarch64; # TODO: Might be best to not set use_vaapi anymore (default is fine)
     });
 

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,21 +1,21 @@
 {
   "stable": {
-    "version": "86.0.4240.198",
-    "sha256": "0i3s1il0x5yi3528gdsg3bhnyhs2x24zh7p1nd5apv3va9g85ax0",
-    "sha256bin64": "0qfhs73r6j0r3nyqbnscnf7h1rs1s68lfl5ndsyd32dmip7ma01x",
+    "version": "87.0.4280.66",
+    "sha256": "0hgpg31gkksqgyvycsan7l7vjypc7cr6ikjfygf2zv7dhbmf9a19",
+    "sha256bin64": "09hjhxjihhxq5i2wadpa0g72a6iis0igarr8arrcah4122icdr77",
     "deps": {
       "gn": {
-        "version": "2020-08-07",
+        "version": "2020-09-09",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "e327ffdc503815916db2543ec000226a8df45163",
-        "sha256": "0kvlfj3www84zp1vmxh76x8fdjm9hyk8lkh2vdsidafpmm75fphr"
+        "rev": "e002e68a48d1c82648eadde2f6aafa20d08c36f2",
+        "sha256": "0x4c7amxwzxs39grqs3dnnz0531mpf1p75niq7zhinyfqm86i4dk"
       }
     }
   },
   "beta": {
-    "version": "87.0.4280.47",
-    "sha256": "0a3c4kz85857wrbcxqknbqmai250d36nq332l66a83r8sidhbxfq",
-    "sha256bin64": "0bjls2airr4p448rx7im1a7gff68yfnfb5vymr4bin4kz0s38mpw",
+    "version": "87.0.4280.66",
+    "sha256": "0hgpg31gkksqgyvycsan7l7vjypc7cr6ikjfygf2zv7dhbmf9a19",
+    "sha256bin64": "15n01jia8sxv3a7vfbla40rq45x54pyksg0kg14bm0br6m3n65pz",
     "deps": {
       "gn": {
         "version": "2020-09-09",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2020/11/stable-channel-update-for-desktop_17.html

This update includes 33 security fixes.

CVEs:
CVE-2020-16018 CVE-2020-16019 CVE-2020-16020 CVE-2020-16021
CVE-2020-16022 CVE-2020-16015 CVE-2020-16014 CVE-2020-16023
CVE-2020-16024 CVE-2020-16025 CVE-2020-16026 CVE-2020-16027
CVE-2020-16028 CVE-2020-16029 CVE-2020-16030 CVE-2019-8075
CVE-2020-16031 CVE-2020-16032 CVE-2020-16033 CVE-2020-16034
CVE-2020-16035 CVE-2020-16012 CVE-2020-16036

Note: We'll finally build with use_ozone=true on Hydra now :) \o/

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

cc @danielfullmer (x86_64), @thefloweringash (aarch64), and @primeos (Chrome) for testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
