### PR TITLE
obs-move-transition: init at 2.0.2

### DIFF
--- a/pkgs/applications/video/obs-studio/obs-move-transition.nix
+++ b/pkgs/applications/video/obs-studio/obs-move-transition.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, fetchurl
+, cmake
+, obs-studio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-move-transition";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "exeldro";
+    repo = "obs-move-transition";
+    rev = version;
+    sha256 = "0kr868lxlanq0y98f2hb70y92ac2nla8khsj879kjf3z6dqdpd66";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio ];
+
+  cmakeFlags = with lib; [
+    "-DLIBOBS_INCLUDE_DIR=${obs-studio.src}/libobs"
+    "-Wno-dev"
+  ];
+
+  preConfigure = ''
+    cp ${obs-studio.src}/cmake/external/FindLibobs.cmake FindLibobs.cmake
+  '';
+
+  patches = [ ./rename-obs-move-transition-cmake.patch ];
+
+  postPatch = ''
+    substituteInPlace move-source-filter.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
+    substituteInPlace move-value-filter.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
+    substituteInPlace move-transition.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
+  '';
+
+  # obs-studio expects the shared object to be located in bin/32bit or bin/64bit
+  # https://github.com/obsproject/obs-studio/blob/d60c736cb0ec0491013293c8a483d3a6573165cb/libobs/obs-nix.c#L48
+  postInstall = let
+    pluginPath = {
+      i686-linux = "bin/32bit";
+      x86_64-linux = "bin/64bit";
+    }.${stdenv.targetPlatform.system} or (throw "Unsupported system: ${stdenv.targetPlatform.system}");
+  in ''
+    mkdir -p $out/share/obs/obs-plugins/move-transition/${pluginPath}
+    ln -s $out/lib/obs-plugins/move-transition.so $out/share/obs/obs-plugins/move-transition/${pluginPath}
+  '';
+
+  meta = with lib; {
+    description = "Plugin for OBS Studio to move source to a new position during scene transition";
+    homepage = "https://github.com/exeldro/obs-move-transition";
+    maintainers = with maintainers; [ starcraft66 ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/applications/video/obs-studio/rename-obs-move-transition-cmake.patch
+++ b/pkgs/applications/video/obs-studio/rename-obs-move-transition-cmake.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d116619..a1366ce 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,17 @@
++if (POLICY CMP0048)
++	cmake_policy(SET CMP0048 NEW)
++endif (POLICY CMP0048)
++
+ project(move-transition VERSION 2.0.2)
+ set(PROJECT_FULL_NAME "Move Transition")
+ 
++include(FindLibobs.cmake)
++find_package(LibObs REQUIRED)
++
++include_directories(
++	"${LIBOBS_INCLUDE_DIR}/../plugins/obs-transitions"
++	"${LIBOBS_INCLUDE_DIR}/../UI/obs-frontend-api")
++
+ set(move-transition_HEADERS
+ 	move-transition.h
+ 	easing.h)
+@@ -34,4 +45,10 @@ target_link_libraries(move-transition
+ 	libobs)
+ 
+ set_target_properties(move-transition PROPERTIES FOLDER "plugins/exeldro")
+-install_obs_plugin_with_data(move-transition data)
++set_target_properties(move-transition PROPERTIES PREFIX "")
++
++install(TARGETS move-transition
++	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/obs-plugins)
++
++install(DIRECTORY data/locale/
++	DESTINATION "${CMAKE_INSTALL_PREFIX}/share/obs/obs-plugins/move-transition/locale")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22845,6 +22845,8 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
 
   obs-wlrobs = callPackage ../applications/video/obs-studio/wlrobs.nix { };
 
+  obs-move-transition = callPackage ../applications/video/obs-studio/obs-move-transition.nix { };
+
   obs-v4l2sink = libsForQt514.callPackage ../applications/video/obs-studio/v4l2sink.nix { };
 
   obs-ndi = libsForQt514.callPackage ../applications/video/obs-studio/obs-ndi.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There aren't a lot of OBS plugins packaged for NixOS so I thought I'd pitch in. It can either be installed manually with a symlink or declaratively using home-manager. Tested fully working on OBS 25.0.8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
