### PR TITLE
[20.09] crate2nix: init at 0.8.0

### DIFF
--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, makeWrapper
+
+, cargo
+, nix
+, nix-prefetch-git
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "crate2nix";
+  version = "0.8.0";
+
+  src = fetchFromGitHub
+    {
+      owner = "kolloch";
+      repo = pname;
+      rev = version;
+      sha256 = "sha256-pqg1BsEq3kGmUzt1zpQvXgdnRcIsiuIyvtUBi3VxtZ4=";
+    } + "/crate2nix";
+
+  cargoSha256 = "sha256-dAMWrGNMleQ3lDbG46Hr4qvCyxR+QcPOUZw9r2/CxV4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Tests use nix(1), which tries (and fails) to set up /nix/var inside the
+  # sandbox
+  doCheck = false;
+
+  postFixup = ''
+    wrapProgram $out/bin/crate2nix \
+        --suffix PATH ":" ${lib.makeBinPath [ cargo nix nix-prefetch-git ]}
+  '';
+
+  meta = with lib; {
+    description = "A Nix build file generator for Rust crates.";
+    longDescription = ''
+      Crate2nix generates Nix files from Cargo.toml/lock files
+      so that you can build every crate individually in a Nix sandbox.
+    '';
+    homepage = "https://github.com/kolloch/crate2nix";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kolloch andir cole-h ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9650,6 +9650,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  crate2nix = callPackage ../development/tools/rust/crate2nix { };
+
   maturin = callPackage ../development/tools/rust/maturin { };
   inherit (rustPackages) rls;
   rustfmt = rustPackages.rustfmt;


### PR DESCRIPTION
crate2nix is a tool that "generates nix build files for rust crates
using cargo".

(cherry picked from commit 011ecb8f904daf95f238cc594f016f15a97cd7f3)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

pijul uses nixos-20.09 in its flake, and we would like to use crate2nix from Nixpkgs -- thus, please merge the crate2nix init into the 20.09 branch ❤️

(There have  been "init" backports in the past, so I'm hoping there is enough precedent for this to be non-controversial.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

EDIT: Backport of https://github.com/NixOS/nixpkgs/pull/104027.