### PR TITLE
mitmproxy: 5.2 -> 5.3.0

### DIFF
--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -37,32 +37,25 @@
 , parver
 , pytest-asyncio
 , hypothesis
+, asgiref
+, msgpack
 }:
 
 buildPythonPackage rec {
   pname = "mitmproxy";
-  version = "5.2";
+  version = "5.3.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0ja0aqnfmkvns5qmd51hmrvbw8dnccaks30gxgzgcjgy30rj4brq";
+    sha256 = "04y7fxxssrs14i7zl7fwlwrpnms39i7a6m18481sg8vlrkbagxjr";
   };
-
-  patches = [
-    # Apply patch from upstream to make mitmproxy v5.2 compatible with urwid >v2.1.0
-    (fetchpatch {
-      name = "urwid-lt-2.1.0.patch";
-      url = "https://github.com/mitmproxy/mitmproxy/commit/ea9177217208fdf642ffc54f6b1f6507a199350c.patch";
-      sha256 = "1z5r8izg5nvay01ywl3xc6in1vjfi9f144j057p3k5rzfliv49gg";
-    })
-  ];
 
   postPatch = ''
     # remove dependency constraints
-    sed 's/>=\([0-9]\.\?\)\+\( \?, \?<\([0-9]\.\?\)\+\)\?//' -i setup.py
+    sed 's/>=\([0-9]\.\?\)\+\( \?, \?<\([0-9]\.\?\)\+\)\?\( \?, \?!=\([0-9]\.\?\)\+\)\?//' -i setup.py
   '';
 
   doCheck = (!stdenv.isDarwin);
@@ -75,6 +68,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     setuptools
     # setup.py
+    asgiref
     blinker
     brotli
     certifi
@@ -85,6 +79,7 @@ buildPythonPackage rec {
     hyperframe
     kaitaistruct
     ldap3
+    msgpack
     passlib
     protobuf
     publicsuffix2


### PR DESCRIPTION
Resolves #103992 where test phase was failing due to
openssl 1.1.1g -> 1.1.1h causing test certificate rejection.
Which was fixed in 5.3.0 release.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
