### PR TITLE
linuxPackages.xpadneo: 0.8.4 -> 0.8.5

### DIFF
--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xpadneo";
-  version = "0.8.4";
+  version = "0.8.5";
 
   src = fetchFromGitHub {
     owner = "atar-axis";
     repo = pname;
     rev = "v${version}";
-    sha256 = "113xa2mxs2hc4fpjdk3jhhchy81kli6jxdd6vib7zz61n10cjb85";
+    sha256 = "1icgqwh3z0bkijla0kai95xxmy8igy7awx2hqf9lww3fg4v9bx5a";
   };
 
   setSourceRoot = ''


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest release: https://github.com/atar-axis/xpadneo/releases/tag/v0.8.5

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  ```
  17 packages built:
  linuxPackages-libre.xpadneo linuxPackages.xpadneo linuxPackages_4_14.xpadneo linuxPackages_4_19.xpadneo linuxPackages_4_4.xpadneo linuxPackages_4_9.xpadneo linuxPackages_5_8.xpadneo linuxPackages_5_9.xpadneo linuxPackages_hardened.xpadneo linuxPackages_latest-libre.xpadneo linuxPackages_latest_hardened.xpadneo linuxPackages_latest_xen_dom0.xpadneo linuxPackages_latest_xen_dom0_hardened.xpadneo linuxPackages_testing_bcachefs.xpadneo linuxPackages_xen_dom0.xpadneo linuxPackages_xen_dom0_hardened.xpadneo linuxPackages_zen.xpadneo
  ```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files. Enabled with `hardware.xpadneo.enable = true` & tested through use of Xbox One controller.

  Tested:
  - Bluetooth connectivity
  - All buttons
  - Rumble support
  <br/>

  ```
  > modinfo hid_xpadneo
  filename:       /run/current-system/kernel-modules/lib/modules/5.9.8/extra/hid-xpadneo.ko.xz
  version:        0.8.5
  description:    Linux kernel driver for Xbox ONE S+ gamepads (BT), incl. FF
  author:         Florian Dollinger <dollinger.florian@gmx.de>
  license:        GPL
  srcversion:     CDD5A9474F72B8692509403
  alias:          hid:b0005g*v0000045Ep00000B05
  alias:          hid:b0005g*v0000045Ep000002E0
  alias:          hid:b0005g*v0000045Ep000002FD
  depends:        hid,ff-memless
  retpoline:      Y
  name:           hid_xpadneo
  vermagic:       5.9.8 SMP mod_unload
  parm:           debug_level:(u8) Debug information level: 0 (none) to 3+ (most verbose). (byte)
  parm:           combined_z_axis:(bool) Combine the triggers to form a single axis. 1: combine, 0: do not combine. (bool)
  parm:           trigger_rumble_mode:(u8) Trigger rumble mode. 0: pressure, 1: directional, 2: disable. (byte)
  parm:           rumble_attenuation:(u8) Attenuate the rumble strength: all[,triggers] 0 (none, full rumble) to 100 (max, no rumble). (array of byte)
  parm:           ff_connect_notify:(bool) Connection notification using force feedback. 1: enable, 0: disable. (bool)
  parm:           gamepad_compliance:(bool) Adhere to Linux Gamepad Specification by using signed axis values. 1: enable, 0: disable. (bool)
  parm:           disable_deadzones:(bool) Disable dead zone handling for raw processing by Wine/Proton, confuses joydev. 0: disable, 1: enable. (bool)
  parm:           quirks:(string) Override device quirks, specify as: "MAC1:quirks1[,...16]", MAC format = 11:22:33:44:55:66, no pulse parameters = 1, no trigger rumble = 2, no motor masking = 4, use Linux button mappings = 16, use Nintendo mappings = 32 (array of charp)
  ```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).