### PR TITLE
pythonPackages.debugpy: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "debugpy";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1f6a62hg82fn9ddrl6g11x2h27zng8jmrlfbnnra6q590i5v1ixr";
+    sha256 = "1r5w5ngipj5fgjylrmlw3jrh5y2n67n68l91sj9329549x4ww8dh";
   };
 
   patches = [
@@ -32,6 +32,11 @@ buildPythonPackage rec {
     (substituteAll {
       src = ./hardcode-gdb.patch;
       inherit gdb;
+    })
+
+    (substituteAll {
+      src = ./hardcode-version.patch;
+      inherit version;
     })
 
     # Fix importing debugpy in:
@@ -44,13 +49,6 @@ buildPythonPackage rec {
     # python.withPackages (ps: with ps; [ debugpy ])
     ./fix-test-pythonpath.patch
   ];
-
-  postPatch = ''
-    # Use nixpkgs version instead of versioneer
-    substituteInPlace setup.py \
-      --replace "cmds = versioneer.get_cmdclass()" "cmds = {}" \
-      --replace "version=versioneer.get_version()" "version='${version}'"
-  '';
 
   # Remove pre-compiled "attach" libraries and recompile for host platform
   # Compile flags taken from linux_and_mac/compile_linux.sh & linux_and_mac/compile_mac.sh

--- a/pkgs/development/python-modules/debugpy/hardcode-version.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-version.patch
@@ -1,0 +1,51 @@
+diff --git a/setup.py b/setup.py
+index cfec60d..32ca206 100644
+--- a/setup.py
++++ b/setup.py
+@@ -24,7 +24,6 @@ elif "--abi" in sys.argv:
+ from setuptools import setup  # noqa
+ 
+ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+-import versioneer  # noqa
+ 
+ del sys.path[0]
+ 
+@@ -86,7 +85,7 @@ if __name__ == "__main__":
+     if not os.getenv("SKIP_CYTHON_BUILD"):
+         cython_build()
+ 
+-    cmds = versioneer.get_cmdclass()
++    cmds = {}
+     cmds["bdist_wheel"] = bdist_wheel
+ 
+     extras = {}
+@@ -96,7 +95,7 @@ if __name__ == "__main__":
+ 
+     setup(
+         name="debugpy",
+-        version=versioneer.get_version(),
++        version="@version@",
+         description="An implementation of the Debug Adapter Protocol for Python",  # noqa
+         long_description=long_description,
+         long_description_content_type="text/markdown",
+diff --git a/src/debugpy/__init__.py b/src/debugpy/__init__.py
+index baa5a7c..5355327 100644
+--- a/src/debugpy/__init__.py
++++ b/src/debugpy/__init__.py
+@@ -27,7 +27,6 @@ __all__ = [
+ import codecs
+ import os
+ 
+-from debugpy import _version
+ from debugpy.common import compat
+ 
+ 
+@@ -204,7 +203,7 @@ def trace_this_thread(should_trace):
+     return api.trace_this_thread(should_trace)
+ 
+ 
+-__version__ = _version.get_versions()["version"]
++__version__ = "@version@"
+ 
+ # Force absolute path on Python 2.
+ __file__ = os.path.abspath(__file__)


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/microsoft/debugpy/releases/tag/v1.2.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, only a Python library.
  Tested through dap-mode in Emacs.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).