### PR TITLE
lib.licenses: add Parity-7.0.0 license

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -613,6 +613,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Open Software License 3.0";
   };
 
+  parity70 = spdx {
+    spdxId = "Parity-7.0.0";
+    fullName = "Parity Public License 7.0.0";
+    url = "https://paritylicense.com/versions/7.0.0.html";
+  };
+
   php301 = spdx {
     spdxId = "PHP-3.01";
     fullName = "PHP License v3.01";


### PR DESCRIPTION
###### Motivation for this change

Adds Parity-7.0.0 which was recently added to SPDX over at [spdx/license-list-XML#949](https://github.com/spdx/license-list-XML/pull/949).

See https://paritylicense.com for more information.

###### Things done

  * [ ]  Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
  * Built on platform(s)
     * [ ]  NixOS
     * [ ]  macOS
     * [ ]  other Linux distributions
  * [ ]  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * [ ]  Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  * [ ]  Tested execution of all binary files (usually in `./result/bin/`)
  * [ ]  Determined the impact on package closure size (by running `nix path-info -S` before and after)
  * [x]  Ensured that relevant documentation is up to date
  * [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).