### PR TITLE
cpuminer-multi: fix src

### DIFF
--- a/pkgs/tools/misc/cpuminer-multi/default.nix
+++ b/pkgs/tools/misc/cpuminer-multi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, curl, jansson, autoconf, automake
+{ stdenv, fetchFromGitHub, curl, jansson, autoconf, automake
 , aesni ? stdenv.hostPlatform.aesSupport }:
 
 let
@@ -8,9 +8,10 @@ in
 stdenv.mkDerivation {
   name = "cpuminer-multi-${date}-${stdenv.lib.strings.substring 0 7 rev}";
 
-  src = fetchgit {
+  src = fetchFromGitHub {
+    owner = "hyc";
+    repo = "cpuminer-multi";
     inherit rev;
-    url = "https://github.com/wolf9466/cpuminer-multi.git";
     sha256 = "11dg4rra4dgfb9x6q85irn0hrkx2lkwyrdpgdh10pag09s3vhy4v";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#104048

The original repository has been deleted.

hyc is a collaborator on the Monero project, and I would consider him a trustworthy source. In any case, since we are picking up the same version of the package, the source is also verified via the hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
