### PR TITLE
snallygaster: init at 0.0.9

### DIFF
--- a/pkgs/tools/security/snallygaster/default.nix
+++ b/pkgs/tools/security/snallygaster/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "snallygaster";
+  version = "0.0.9";
+
+  src = fetchFromGitHub {
+    owner = "hannob";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gan5asgrxdgfi9lalhxzj3vs7nkazi8nqia36bpz1qb5fz7jrx3";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    urllib3
+    beautifulsoup4
+    dnspython
+  ];
+
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # we are not interested in linting the project
+    "--ignore=tests/test_codingstyle.py"
+  ];
+
+  meta = with lib; {
+    description = "Tool to scan for secret files on HTTP servers";
+    homepage = "https://github.com/hannob/snallygaster";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7237,7 +7237,9 @@ in
 
   sn0int = callPackage ../tools/security/sn0int { };
 
-  snabb = callPackage ../tools/networking/snabb { } ;
+  snabb = callPackage ../tools/networking/snabb { };
+
+  snallygaster = callPackage ../tools/security/snallygaster { };
 
   snapcast = callPackage ../applications/audio/snapcast { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://blog.hboeck.de/archives/892-Introducing-Snallygaster-a-Tool-to-Scan-for-Secrets-on-Web-Servers.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
