### PR TITLE
creddump: fix src

### DIFF
--- a/pkgs/tools/security/creddump/default.nix
+++ b/pkgs/tools/security/creddump/default.nix
@@ -7,8 +7,7 @@ python2Packages.buildPythonApplication rec {
   src = fetchFromGitLab {
     owner = "kalilinux";
     repo = "packages/creddump";
-    # url-encoding workaround: https://github.com/NixOS/nixpkgs/issues/65796#issuecomment-517829019
-    rev = "debian%2F${version}-1kali2"; # %2F = urlquote("/")
+    rev = "debian/${version}-1kali2";
     sha256 = "0r3rs2hggsvv619l3fh3c0jli6d3ryyj30ni3hz0nz670z5smzcf";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#104048

Similar issue to #104059

The original issue seems to have been #65796, but looks like either `fetchFromGitLab` is already escaping things properly, or GitLab has updated their system to deal with it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
