### PR TITLE
ocaml-ng.ocamlPackages_4_12.ocaml: init at 4.12.0-α1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.12.nix
+++ b/pkgs/development/compilers/ocaml/4.12.nix
@@ -1,0 +1,9 @@
+import ./generic.nix {
+  major_version = "4";
+  minor_version = "12";
+  patch_version = "0-alpha1";
+  src = fetchTarball {
+    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~alpha1.tar.xz";
+    sha256 = "1p9nnj7l43b697b6bm767znbf1h0s2lyc1qb8izr1vfpsmnm11ws";
+  };
+}

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -1,12 +1,8 @@
 { minor_version, major_version, patch_version
-, url ? null
-, sha256, ...}@args:
+, ...}@args:
 let
   versionNoPatch = "${toString major_version}.${toString minor_version}";
   version = "${versionNoPatch}.${toString patch_version}";
-  real_url = if url == null then
-    "http://caml.inria.fr/pub/distrib/ocaml-${versionNoPatch}/ocaml-${version}.tar.xz"
-  else url;
   safeX11 = stdenv: !(stdenv.isAarch32 || stdenv.isMips);
 in
 
@@ -21,6 +17,13 @@ assert useX11 -> !stdenv.isAarch32 && !stdenv.isMips;
 assert aflSupport -> stdenv.lib.versionAtLeast version "4.05";
 assert flambdaSupport -> stdenv.lib.versionAtLeast version "4.03";
 assert spaceTimeSupport -> stdenv.lib.versionAtLeast version "4.04";
+
+let
+  src = args.src or (fetchurl {
+    url = args.url or "http://caml.inria.fr/pub/distrib/ocaml-${versionNoPatch}/ocaml-${version}.tar.xz";
+    inherit (args) sha256;
+  });
+in
 
 let
    useNativeCompilers = !stdenv.isMips;
@@ -39,10 +42,7 @@ stdenv.mkDerivation (args // {
   inherit name;
   inherit version;
 
-  src = fetchurl {
-    url = real_url;
-    inherit sha256;
-  };
+  inherit src;
 
   prefixKey = "-prefix ";
   configureFlags =

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1253,6 +1253,8 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_11 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.11.nix { });
 
+  ocamlPackages_4_12 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.12.nix { });
+
   ocamlPackages_latest = ocamlPackages_4_11;
 
   ocamlPackages = ocamlPackages_4_10;


### PR DESCRIPTION
###### Motivation for this change

Prepare for next version: https://inbox.ocaml.org/caml-list/21bbad4a-a932-0213-3bb4-6ab7e92b054a@inria.fr/T/#u

The `~` in the version confuses both `mkDerivation` and `fetchurl`; this motivated the minor refactoring.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
