### PR TITLE
svkbd: init at 0.3

### DIFF
--- a/pkgs/tools/X11/svkbd/default.nix
+++ b/pkgs/tools/X11/svkbd/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, lib
+, fetchurl
+, pkg-config
+, libX11
+, libXft
+, libXtst
+, libXi
+, libXinerama
+, layout ? "mobile-intl"
+}:
+
+assert lib.assertOneOf "layout" layout [ "mobile-intl" "mobile-plain" "de" "en" "ru" "sh" "arrows" ];
+
+stdenv.mkDerivation rec {
+  pname = "svkbd";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "https://dl.suckless.org/tools/svkbd-${version}.tar.gz";
+    sha256 = "108khx665d7dlzs04iy4g1nw3fyqpy6kd0afrwiapaibgv4xhfsk";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libX11 libXft libXtst libXi libXinerama ];
+
+  makeFlags = [ "LAYOUT=${layout}" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Simple Virtual Keyboard";
+    homepage = "https://tools.suckless.org/x/svkbd/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13197,6 +13197,8 @@ in
 
   sselp = callPackage ../tools/X11/sselp{ };
 
+  svkbd = callPackage ../tools/X11/svkbd { };
+
   stm32cubemx = callPackage ../development/tools/misc/stm32cubemx { };
 
   stm32flash = callPackage ../development/tools/misc/stm32flash { };


### PR DESCRIPTION
###### Motivation for this change
**[svkbd](https://tools.suckless.org/x/svkbd/)** - Simple Virtual Keyboard.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
