### PR TITLE
pypy, pypy3: 7.3.1 → 7.3.2

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -160,9 +160,9 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "1";
+      patch = "2";
     };
-    sha256 = "08ckkhd0ix6j9873a7gr507c72d4cmnv5lwvprlljdca9i8p2dzs";
+    sha256 = "1l98b7s9sf16a5w8y0fdn7a489l3gpykjasws1j67bahhc6li2c1";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
     python = python27;
@@ -176,9 +176,9 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "1";
+      patch = "2";
     };
-    sha256 = "10zsk8jby8j6visk5mzikpb1cidvz27qq4pfpa26jv53klic6b0c";
+    sha256 = "03f1fdw6yk2mypa9pbmgk26r8y1hhmw801l6g36zry9zsvz7aqgx";
     pythonVersion = "3.6";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
     python = python27;
@@ -193,9 +193,9 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "1";
+      patch = "2";
     };
-    sha256 = "18xc5kwidj5hjwbr0w8v1nfpg5l4lk01z8cn804zfyyz8xjqhx5y"; # linux64
+    sha256 = "0fx1kp13cgx3rijd0zf8rdjbai6mfhc9is4xfc7kl5cpd88hhkwd"; # linux64
     pythonVersion = "2.7";
     inherit passthruFun;
   };
@@ -206,9 +206,9 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "1";
+      patch = "2";
     };
-    sha256 = "04nv0mkalaliphbjw7y0pmb372bxwjzwmcsqkf9kwsik99kg2z7n"; # linux64
+    sha256 = "10xdx7q04fzy4v4rbj9bbdw8g9y68qgaih7z2n0s5aknj0bizafp"; # linux64
     pythonVersion = "3.6";
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -34,7 +34,7 @@ in with passthru; stdenv.mkDerivation rec {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://bitbucket.org/pypy/pypy/downloads/pypy${pythonVersion}-v${version}-src.tar.bz2";
+    url = "https://downloads.python.org/pypy/pypy${pythonVersion}-v${version}-src.tar.bz2";
     inherit sha256;
   };
 

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -54,7 +54,7 @@ in with passthru; stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://bitbucket.org/pypy/pypy/downloads/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
+    url = "https://downloads.python.org/pypy/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
     inherit sha256;
   };
 

--- a/pkgs/development/interpreters/python/pypy/tk_tcl_paths.patch
+++ b/pkgs/development/interpreters/python/pypy/tk_tcl_paths.patch
@@ -1,13 +1,14 @@
---- pypy-pypy-84a2f3e6a7f8.org/lib_pypy/_tkinter/tklib_build.py	2017-10-03 11:49:20.000000000 +0100
-+++ pypy-pypy-84a2f3e6a7f8/lib_pypy/_tkinter/tklib_build.py	2017-11-21 13:20:51.398607530 +0000
-@@ -17,18 +17,14 @@
+--- a/lib_pypy/_tkinter/tklib_build.py
++++ b/lib_pypy/_tkinter/tklib_build.py
+@@ -17,19 +17,14 @@ elif sys.platform == 'win32':
      incdirs = []
      linklibs = ['tcl85', 'tk85']
      libdirs = []
 -elif sys.platform == 'darwin':
--    incdirs = ['/System/Library/Frameworks/Tk.framework/Versions/Current/Headers/']
--    linklibs = ['tcl', 'tk']
--    libdirs = []
+-    # homebrew
+-    incdirs = ['/usr/local/opt/tcl-tk/include']
+-    linklibs = ['tcl8.6', 'tk8.6']
+-    libdirs = ['/usr/local/opt/tcl-tk/lib']
  else:
      # On some Linux distributions, the tcl and tk libraries are
      # stored in /usr/include, so we must check this case also


### PR DESCRIPTION
###### Motivation for this change

Upgrade pypy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
