### PR TITLE
php80: init at 8.0.0

### DIFF
--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -1,0 +1,17 @@
+{ callPackage, lib, stdenv, nixosTests, ... }@_args:
+
+let
+  generic = (import ./generic.nix) _args;
+
+  base = callPackage generic (_args // {
+    version = "8.0.0";
+    sha256 = "02cx3gvxqvkllp54jfvs83kl8bmpcqyzp9jf1d0l9x5bgv1jv0sy";
+  });
+
+in base.withExtensions ({ all, ... }: with all; ([
+  bcmath calendar curl ctype dom exif fileinfo filter ftp gd
+  gettext gmp iconv intl ldap mbstring mysqli mysqlnd opcache
+  openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
+  posix readline session simplexml sockets soap sodium sqlite3
+  tokenizer xmlreader xmlwriter zip zlib
+] ++ lib.optionals (!stdenv.isDarwin) [ imap ]))

--- a/pkgs/development/interpreters/php/fix-opcache-configure.patch
+++ b/pkgs/development/interpreters/php/fix-opcache-configure.patch
@@ -1,0 +1,81 @@
+diff --git a/Zend/Zend.m4 b/Zend/Zend.m4
+index 726188597496..781e51d3e44c 100644
+--- a/Zend/Zend.m4
++++ b/Zend/Zend.m4
+@@ -190,12 +190,6 @@ dnl LIBZEND_OTHER_CHECKS
+ dnl
+ AC_DEFUN([LIBZEND_OTHER_CHECKS],[
+ 
+-AC_ARG_ENABLE([zts],
+-  [AS_HELP_STRING([--enable-zts],
+-    [Enable thread safety])],
+-  [ZEND_ZTS=$enableval],
+-  [ZEND_ZTS=no])
+-
+ AC_MSG_CHECKING(whether to enable thread-safety)
+ AC_MSG_RESULT($ZEND_ZTS)
+ 
+diff --git a/configure.ac b/configure.ac
+index 8d6e922fa9bf..e07a75d19ac7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -797,6 +797,19 @@ if test "$PHP_DEBUG_ASSERTIONS" = "yes"; then
+   ZEND_DEBUG=yes
+ fi
+ 
++AC_ARG_ENABLE([zts],
++  [AS_HELP_STRING([--enable-zts],
++    [Enable thread safety])],
++  [ZEND_ZTS=$enableval],
++  [ZEND_ZTS=no])
++
++if test "$ZEND_ZTS" = "yes"; then
++  AC_DEFINE(ZTS, 1,[ ])
++  PHP_THREAD_SAFETY=yes
++else
++  PHP_THREAD_SAFETY=no
++fi
++
+ PHP_ARG_ENABLE([rtld-now],
+   [whether to dlopen extensions with RTLD_NOW instead of RTLD_LAZY],
+   [AS_HELP_STRING([--enable-rtld-now],
+@@ -1136,13 +1149,6 @@ LIBZEND_BASIC_CHECKS
+ LIBZEND_DLSYM_CHECK
+ LIBZEND_OTHER_CHECKS
+ 
+-if test "$ZEND_ZTS" = "yes"; then
+-  AC_DEFINE(ZTS,1,[ ])
+-  PHP_THREAD_SAFETY=yes
+-else
+-  PHP_THREAD_SAFETY=no
+-fi
+-
+ INCLUDES="$INCLUDES -I\$(top_builddir)/TSRM"
+ INCLUDES="$INCLUDES -I\$(top_builddir)/Zend"
+ 
+diff --git a/ext/opcache/config.m4 b/ext/opcache/config.m4
+index 054cd28c0247..93d72fb73d19 100644
+--- a/ext/opcache/config.m4
++++ b/ext/opcache/config.m4
+@@ -66,7 +66,7 @@ if test "$PHP_OPCACHE" != "no"; then
+       esac
+     fi
+ 
+-    if test "$enable_zts" = "yes"; then
++    if test "$PHP_THREAD_SAFETY" = "yes"; then
+       DASM_FLAGS="$DASM_FLAGS -D ZTS=1"
+     fi
+ 
+diff --git a/ext/session/config.m4 b/ext/session/config.m4
+index 7abc8813b72a..da31bbde86cc 100644
+--- a/ext/session/config.m4
++++ b/ext/session/config.m4
+@@ -31,7 +31,7 @@ if test "$PHP_MM" != "no"; then
+     AC_MSG_ERROR(cannot find mm library)
+   fi
+ 
+-  if test "$enable_zts" = "yes"; then
++  if test "$PHP_THREAD_SAFETY" = "yes"; then
+     dnl The mm library is not thread-safe, and mod_mm.c refuses to compile.
+     AC_MSG_ERROR(--with-mm cannot be combined with --enable-zts)
+   fi

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -198,7 +198,8 @@ let
             ++ lib.optional (!ipv6Support) "--disable-ipv6"
             ++ lib.optional systemdSupport "--with-fpm-systemd"
             ++ lib.optional valgrindSupport "--with-valgrind=${valgrind.dev}"
-            ++ lib.optional ztsSupport "--enable-maintainer-zts"
+            ++ lib.optional (ztsSupport && (lib.versionOlder version "8.0")) "--enable-maintainer-zts"
+            ++ lib.optional (ztsSupport && (lib.versionAtLeast version "8.0")) "--enable-zts"
 
 
             # Sendmail

--- a/pkgs/development/php-packages/couchbase/default.nix
+++ b/pkgs/development/php-packages/couchbase/default.nix
@@ -14,9 +14,10 @@ buildPecl {
   };
 
   configureFlags = [ "--with-couchbase" ];
+  broken = lib.versionAtLeast php.version "8.0";
 
   buildInputs = with pkgs; [ libcouchbase zlib ];
-  internalDeps = [ php.extensions.json ];
+  internalDeps = [] ++ lib.optionals (lib.versionOlder php.version "8.0") [ php.extensions.json ];
   peclDeps = [ php.extensions.igbinary ];
 
   patches = [

--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -1,10 +1,18 @@
-{ buildPecl, lib, pkgs, pcre' }:
+{ buildPecl, fetchpatch, lib, pkgs, pcre' }:
 
 buildPecl {
   pname = "imagick";
 
   version = "3.4.4";
   sha256 = "0xvhaqny1v796ywx83w7jyjyd0nrxkxf34w9zi8qc8aw8qbammcd";
+
+  patches = [
+    # Fix compatibility with PHP 8.
+    (fetchpatch {
+      url = "https://github.com/Imagick/imagick/pull/336.patch";
+      sha256 = "nuRdh02qaMx0s/5OzlfWjyYgZG1zgrYnAjsZ/UVIrUM=";
+    })
+  ];
 
   configureFlags = [ "--with-imagick=${pkgs.imagemagick.dev}" ];
   nativeBuildInputs = [ pkgs.pkgconfig ];

--- a/pkgs/development/php-packages/redis/default.nix
+++ b/pkgs/development/php-packages/redis/default.nix
@@ -7,8 +7,9 @@ buildPecl {
   sha256 = "1cfsbxf3q3im0cmalgk76jpz581zr92z03c1viy93jxb53k2vsgl";
 
   internalDeps = with php.extensions; [
-    json
     session
+  ] ++ lib.optionals (lib.versionOlder php.version "8.0") [
+    json
   ] ++ lib.optionals (lib.versionOlder php.version "7.4") [
     hash
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10492,6 +10492,12 @@ in
   phpExtensions = php74Extensions;
   phpPackages = php74Packages;
 
+  php80 = callPackage ../development/interpreters/php/8.0.nix {
+    stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
+  };
+  php80Extensions = recurseIntoAttrs php80.extensions;
+  php80Packages = recurseIntoAttrs php80.packages;
+
   # Import PHP74 interpreter, extensions and packages
   php74 = callPackage ../development/interpreters/php/7.4.nix {
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;


### PR DESCRIPTION
###### Motivation for this change

Amazing new major version of PHP

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).