### PR TITLE
home-assistant: Respect nixpkgs Python package overrides instead of replacing them

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -45,10 +45,14 @@ let
       });
     };
 
-  py = python3.override {
-    # Put packageOverrides at the start so they are applied after defaultOverrides
-    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([ packageOverrides ] ++ defaultOverrides);
-  };
+  py = python3.override(oa: {
+    # Put packageOverrides at the start so they are applied after
+    # defaultOverrides and upstream overrides
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) (
+      [ packageOverrides ]
+      ++ defaultOverrides
+      ++ (lib.optional (oa ? packageOverrides) oa.packageOverrides));
+  });
 
   componentPackages = import ./component-packages.nix;
 


### PR DESCRIPTION
###### Motivation for this change
Currently, home-assistant's definition *replaces* any existing Python package overrides instead of just layering on top of them, preventing HA from using any packages in existing overrides. This changes that.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
