### PR TITLE
spago: get building again with ghc8102

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -664,9 +664,26 @@ self: super: builtins.intersectAttrs super {
     let
       # Spago needs a small patch to work with the latest versions of rio.
       # https://github.com/purescript/spago/pull/647
-      spagoWithPatches = appendPatch super.spago (pkgs.fetchpatch {
-        url = "https://github.com/purescript/spago/pull/647/commits/917ee541a966db74f0f5d11f2f86df0030c35dd7.patch";
-        sha256 = "1nspqgcjk6z90cl9zhard0rn2q979kplcqz72x8xv5mh57zabk0w";
+      spagoWithPatches = overrideCabal (appendPatch super.spago (
+        # Spago-0.17 needs a small patch to work with the latest version of dhall.
+        # This can probably be removed with Spago-0.18.
+        # https://github.com/purescript/spago/pull/695
+        pkgs.fetchpatch {
+          url = "https://github.com/purescript/spago/commit/6258ac601480e776c215c989cc5faae46d5ca9f7.patch";
+          sha256 = "02zy4jf24qlqz9fkcs2rqg64ijd8smncmra8s5yp2mln4dmmii1k";
+        }
+      )) (old: {
+        # The above patch contains a completely new spago.cabal file, but our
+        # source tree from Hackage already contains a cabal file.  Delete the
+        # local cabal file and just take the one from the patch.
+        #
+        # WARNING: The empty line above the `rm` needs to be kept.
+        prePatch = old.prePatch or "" + ''
+
+          rm spago.cabal
+        '';
+        # The above patch also adds a dependency on the stringsearch package.
+        libraryHaskellDepends = old.libraryHaskellDepends or [] ++ [ self.stringsearch ];
       });
 
       # spago requires an older version of megaparsec, but it appears to work


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The Haskell package set here in nixpkgs recently updated to tracking Stackage Nightly instead of LTS-16.  This means that the latest compiler is now to GHC-8.10.2 (not GHC-8.8.4).

I have fixed up the Spago derivation here in nixpkgs to compile with GHC-8.10.2.

cc @f-f because this is based on work he did on https://github.com/purescript/spago/pull/695. Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
