### PR TITLE
davix: fix src

### DIFF
--- a/pkgs/tools/networking/davix/default.nix
+++ b/pkgs/tools/networking/davix/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig python3 ];
   buildInputs = [ openssl libxml2 boost libuuid ];
 
-  # using the url below since the 0.7.6 release did carry a broken CMake file,
-  # supposedly fixed in the next release
-  # https://github.com/cern-fts/davix/issues/40
+  # using the url below since the github release page states
+  # "please ignore the GitHub-generated tarballs, as they are incomplete"
+  # https://github.com/cern-fts/davix/releases/tag/R_0_7_6
   src = fetchurl {
-    url = "http://grid-deployment.web.cern.ch/grid-deployment/dms/lcgutil/tar/davix/${version}/davix-${version}.tar.gz";
+    url = "https://github.com/cern-fts/${pname}/releases/download/R_${stdenv.lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.gz";
     sha256 = "0wq66spnr616cns72f9dvr2xfvkdvfqqmc6d7dx29fpp57zzvrx2";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#104048

The previously used CERN url no longer exist, and the upstream GitHub requests that we download the provided tarball instead of the auto generated one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
