### PR TITLE
dsview: 0.99 -> 1.12

### DIFF
--- a/pkgs/applications/science/electronics/dsview/default.nix
+++ b/pkgs/applications/science/electronics/dsview/default.nix
@@ -1,42 +1,46 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake,
-libzip, boost, fftw, qtbase,
-libusb1, wrapQtAppsHook, libsigrok4dsl, libsigrokdecode4dsl
+{ lib, mkDerivation, fetchFromGitHub, pkgconfig, cmake
+, libzip, boost, fftw, qtbase, libusb1, libsigrok4dsl
+, libsigrokdecode4dsl, python3, fetchpatch
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "dsview";
 
-  version = "0.99";
+  version = "1.12";
 
   src = fetchFromGitHub {
       owner = "DreamSourceLab";
       repo = "DSView";
-      rev = version;
-      sha256 = "189i3baqgn8k3aypalayss0g489xi0an9hmvyggvxmgg1cvcwka2";
+      rev = "v${version}";
+      sha256 = "q7F4FuK/moKkouXTNPZDVon/W/ZmgtNHJka4MiTxA0U=";
   };
 
-  postUnpack = ''
-    export sourceRoot=$sourceRoot/DSView
-  '';
+  sourceRoot = "source/DSView";
 
   patches = [
     # Fix absolute install paths
     ./install.patch
+
+    # Fix buld with Qt5.15 already merged upstream for future release
+    # Using local file instead of content of commit #33e3d896a47 because
+    # sourceRoot make it unappliable
+    ./qt515.patch
   ];
 
-  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-   boost fftw qtbase libusb1 libzip libsigrokdecode4dsl libsigrok4dsl
+    boost fftw qtbase libusb1 libzip libsigrokdecode4dsl libsigrok4dsl
+    python3
   ];
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A GUI program for supporting various instruments from DreamSourceLab, including logic analyzer, oscilloscope, etc";
     homepage = "https://www.dreamsourcelab.com/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.bachp ];
+    maintainers = with maintainers; [ bachp ];
   };
 }

--- a/pkgs/applications/science/electronics/dsview/install.patch
+++ b/pkgs/applications/science/electronics/dsview/install.patch
@@ -2,10 +2,10 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index c1c33e1..208a184 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -403,8 +403,8 @@ install(DIRECTORY res DESTINATION share/${PROJECT_NAME})
- install(FILES icons/logo.png DESTINATION share/${PROJECT_NAME} RENAME logo.png)
- install(FILES ../NEWS DESTINATION share/${PROJECT_NAME} RENAME NEWS)
- install(FILES ../ug.pdf DESTINATION share/${PROJECT_NAME} RENAME ug.pdf)
+@@ -427,8 +427,8 @@
+ install(FILES ../NEWS31 DESTINATION share/${PROJECT_NAME} RENAME NEWS31)
+ install(FILES ../ug25.pdf DESTINATION share/${PROJECT_NAME} RENAME ug25.pdf)
+ install(FILES ../ug31.pdf DESTINATION share/${PROJECT_NAME} RENAME ug31.pdf)
 -install(FILES DreamSourceLab.rules DESTINATION /etc/udev/rules.d/)
 -install(FILES DSView.desktop DESTINATION /usr/share/applications/)
 +install(FILES DreamSourceLab.rules DESTINATION etc/udev/rules.d/)

--- a/pkgs/applications/science/electronics/dsview/qt515.patch
+++ b/pkgs/applications/science/electronics/dsview/qt515.patch
@@ -1,0 +1,13 @@
+diff --git a/pv/view/viewport.cpp b/pv/view/viewport.cpp
+index 921d3db..16cdce9 100755
+--- a/pv/view/viewport.cpp
++++ b/pv/view/viewport.cpp
+@@ -37,7 +37,7 @@
+ 
+ #include <QMouseEvent>
+ #include <QStyleOption>
+-
++#include <QPainterPath>
+ 
+ #include <math.h>
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3414,7 +3414,7 @@ in
 
   dropbear = callPackage ../tools/networking/dropbear { };
 
-  dsview = libsForQt514.callPackage ../applications/science/electronics/dsview { };
+  dsview = libsForQt5.callPackage ../applications/science/electronics/dsview { };
 
   dtach = callPackage ../tools/misc/dtach { };
 


### PR DESCRIPTION
Adapted the patches and took a commit from upstream master branch to
allow the migration to Qt5.15.

Had to copy the patch because of the custom sourceRoot.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated to latest version + specific patch to allow Qt 5.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
