### PR TITLE
firefox: 82.0.3 -> 83.0, firefox-esr: 78.4.1esr -> 78.5.0esr, nss: 3.56 -> 3.58, cacert refactor

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -4,7 +4,7 @@
 
 { lib, stdenv, pkgconfig, pango, perl, python2, python3, zip
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
-, freetype, fontconfig, file, nspr, nss, libnotify
+, freetype, fontconfig, file, nspr, nss, nss_3_53, libnotify
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libXdamage, libevent, libstartup_notification
 , libvpx_1_8
@@ -106,6 +106,8 @@ let
   # 78 ESR won't build with rustc 1.47
   inherit (if lib.versionAtLeast ffversion "82" then rustPackages else rustPackages_1_45)
     rustc cargo;
+
+  nss_pkg = if lib.versionOlder ffversion "83" then nss_3_53 else nss;
 in
 
 buildStdenv.mkDerivation ({
@@ -169,7 +171,7 @@ buildStdenv.mkDerivation ({
     # yasm can potentially be removed in future versions
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1501796
     # https://groups.google.com/forum/#!msg/mozilla.dev.platform/o-8levmLU80/SM_zQvfzCQAJ
-    nspr nss
+    nspr nss_pkg
   ]
   ++ lib.optional  alsaSupport alsaLib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
@@ -190,7 +192,7 @@ buildStdenv.mkDerivation ({
 
   NIX_CFLAGS_COMPILE = toString [
     "-I${glib.dev}/include/gio-unix-2.0"
-    "-I${nss.dev}/include/nss"
+    "-I${nss_pkg.dev}/include/nss"
   ];
 
   MACH_USE_SYSTEM_PYTHON = "1";

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -116,12 +116,37 @@ buildStdenv.mkDerivation ({
 
   patches = [
     ./env_var_for_system_dir.patch
-  ] ++ lib.optional pipewireSupport
+  ] ++
+
+  # there are two flavors of pipewire support
+  # The patches for the ESR release and the patches for the current stable
+  # release.
+  # Until firefox upstream stabilizes pipewire support we will have to continue
+  # tracking multiple versions here.
+  lib.optional (pipewireSupport && lib.versionOlder ffversion "83")
     (fetchpatch {
       # https://src.fedoraproject.org/rpms/firefox/blob/master/f/firefox-pipewire-0-3.patch
       url = "https://src.fedoraproject.org/rpms/firefox/raw/e99b683a352cf5b2c9ff198756859bae408b5d9d/f/firefox-pipewire-0-3.patch";
       sha256 = "0qc62di5823r7ly2lxkclzj9rhg2z7ms81igz44nv0fzv3dszdab";
     })
+    ++
+    # This picks pipewire patches from fedora that are part of https://bugzilla.mozilla.org/show_bug.cgi?id=1672944
+    lib.optionals (pipewireSupport && lib.versionAtLeast ffversion "83") (let
+      fedora_revision = "d6756537dd8cf4d9816dc63ada66ea026e0fd128";
+      mkPWPatch = spec: fetchpatch {
+        inherit (spec) name sha256;
+        url = "https://src.fedoraproject.org/rpms/firefox/raw/${fedora_revision}/f/${spec.name}";
+      };
+    in map mkPWPatch [
+        { name = "pw1.patch"; sha256 = "1a7zvngn3k7dg886zmi38kmrsdzh2rrr46aw59bhr1gfmq8wlwn0"; }
+        { name = "pw2.patch"; sha256 = "17irg3yb2mchcy0z0nr4k65mwvkps467cvvczr10fnm06lhkhw1l"; }
+        { name = "pw3.patch"; sha256 = "12p6ql5ff2lfzlni6xkpz63h2xr6n2a9zf8hhjl99fj56rif6706"; }
+        { name = "pw4.patch"; sha256 = "0rvysc92rdm98s47w5lvbnrklrf7d299k3918qnldniyb4b9p4mg"; }
+        { name = "pw5.patch"; sha256 = "0kk2yxq4qkfwc4px6m08jrn18a7a7dhrngfiaw84r9ga6sgn0z00"; }
+        { name = "pw6.patch"; sha256 = "12lhx9wjpw0ahbfmw07wsx76bb223mr453q9cg8cq951vyskch3s"; }
+        { name = "pw7.patch"; sha256 = "0afw7cfd48vn62zb9y5kd2l26fg44s3aq1kyg3gm4q3rj34xidf6"; }
+    ])
+
   ++ patches;
 
 
@@ -172,7 +197,7 @@ buildStdenv.mkDerivation ({
 
   postPatch = ''
     rm -rf obj-x86_64-pc-linux-gnu
-  '' + lib.optionalString pipewireSupport ''
+  '' + lib.optionalString (pipewireSupport && lib.versionOlder ffversion "83") ''
     # substitute the /usr/include/ lines for the libraries that pipewire provides.
     # The patch we pick from fedora only contains the generated moz.build files
     # which hardcode the dependency paths instead of running pkg_config.

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -35,10 +35,10 @@ rec {
 
   firefox-esr-78 = common rec {
     pname = "firefox-esr";
-    ffversion = "78.4.1esr";
+    ffversion = "78.5.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3gfhipbihyznnh822lxams6rm0bcslh31b58lzibjx8a9dn99hy3p04h07slygcqazbz1rrs7b2b8q321fknp27aisk0sz8cynrcw18";
+      sha512 = "20h53cn7p4dds1yfm166iwbjdmw4fkv5pfk4z0pni6x8ddjvg19imzs6ggmpnfhaji8mnlknm7xp5j7x9vi24awvdxdds5n88rh25hd";
     };
 
     patches = [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "82.0.3";
+    ffversion = "83.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "0j5s5fkph9bm87lv53d4xvfj02qjfqzj5graxcc8air49iqswfmqjdzghna6bj9m8fbn6f5klgm6jbrmavdsycbps0y88x23b6kab5i";
+      sha512 = "3va5a9471677jfzkhqp8xkba45n0bcpphbabhqbcbnps6p85m3y98pl5jy9q7cpq3a6gxc4ax7bp90yz2nfvfq7i64iz397xpprri2a";
     };
 
     patches = [

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -13,12 +13,17 @@ let
     sha256 = "1d4q27j1gss0186a5m8bs5dk786w07ccyq0qi6xmd2zr1a8q16wy";
   };
 
+  version = "3.57";
+  underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 in
 
 stdenv.mkDerivation {
-  name = "nss-cacert-${nss.version}";
+  name = "nss-cacert-${version}";
 
-  src = nss.src;
+  src = fetchurl {
+    url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/nss-${version}.tar.gz";
+    sha256 = "55a86c01be860381d64bb4e5b94eb198df9b0f098a8af0e58c014df398bdc382";
+  };
 
   outputs = [ "out" "unbundled" ];
 
@@ -59,6 +64,8 @@ stdenv.mkDerivation {
   '';
 
   setupHook = ./setup-hook.sh;
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     homepage = "https://curl.haxx.se/docs/caextract.html";

--- a/pkgs/data/misc/cacert/update.sh
+++ b/pkgs/data/misc/cacert/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix common-updater-scripts jq
+
+# Build both the cacert package and an overriden version where we use the source attribute of NSS.
+# Cacert and NSS are both from the same upstream sources. They are decoupled as
+# the cacert output only cares about a few infrequently changing files in the
+# sources while the NSS source code changes frequently.
+#
+# By having cacert on a older source revision that produces the same
+# certificate output as a newer version we can avoid large amounts of
+# unnecessary rebuilds.
+#
+# As of this writing there are a few magnitudes more packages depending on
+# cacert than on nss.
+
+
+set -ex
+
+BASEDIR="$(dirname "$0")/../../../.."
+
+
+CURRENT_PATH=$(nix-build --no-out-link -A cacert.out)
+PATCHED_PATH=$(nix-build --no-out-link -E "with import $BASEDIR {}; (cacert.overrideAttrs (_: { inherit (nss) src version; })).out")
+
+# Check the hash of the etc subfolder
+# We can't check the entire output as that contains the nix-support folder
+# which contains the output path itself.
+CURRENT_HASH=$(nix-hash "$CURRENT_PATH/etc")
+PATCHED_HASH=$(nix-hash "$PATCHED_PATH/etc")
+
+if [[ "$CURRENT_HASH" !=  "$PATCHED_HASH" ]]; then
+    NSS_VERSION=$(nix-instantiate --json --eval -E "with import $BASEDIR {}; nss.version" | jq -r .)
+    update-source-version cacert "$NSS_VERSION"
+fi

--- a/pkgs/development/libraries/nss/3.53.nix
+++ b/pkgs/development/libraries/nss/3.53.nix
@@ -1,0 +1,169 @@
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, darwin, fixDarwinDylibNames, buildPackages, ninja
+, # allow FIPS mode. Note that this makes the output non-reproducible.
+  # https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Tech_Notes/nss_tech_note6
+  enableFIPS ? false
+}:
+
+let
+  nssPEM = fetchurl {
+    url = "http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz";
+    sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
+  };
+  version = "3.53.1";
+  underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
+
+in stdenv.mkDerivation rec {
+  pname = "nss";
+  inherit version;
+
+  src = fetchurl {
+    url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
+    sha256 = "05jk65x3zy6q8lx2djj8ik7kg741n88iy4n3bblw89cv0xkxxk1d";
+  };
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [ perl ninja (buildPackages.python3.withPackages (ps: with ps; [ gyp ])) ]
+    ++ stdenv.lib.optionals stdenv.hostPlatform.isDarwin [ darwin.cctools fixDarwinDylibNames ];
+
+  buildInputs = [ zlib sqlite ];
+
+  propagatedBuildInputs = [ nspr ];
+
+  prePatch = ''
+    # strip the trailing whitespace from the patch line and the renamed CKO_NETSCAPE_ enum to CKO_NSS_
+    xz -d < ${nssPEM} | sed \
+       -e 's/-DIRS = builtins $/-DIRS = . builtins/g' \
+       -e 's/CKO_NETSCAPE_/CKO_NSS_/g' \
+       -e 's/CKT_NETSCAPE_/CKT_NSS_/g' \
+       | patch -p1
+
+    patchShebangs nss
+
+    for f in nss/coreconf/config.gypi nss/build.sh nss/coreconf/config.gypi; do
+      substituteInPlace "$f" --replace "/usr/bin/env" "${buildPackages.coreutils}/bin/env"
+    done
+
+    substituteInPlace nss/coreconf/config.gypi --replace "/usr/bin/grep" "${buildPackages.coreutils}/bin/env grep"
+  '';
+
+  patches =
+    [
+      # Based on http://patch-tracker.debian.org/patch/series/dl/nss/2:3.15.4-1/85_security_load.patch
+      ./85_security_load.patch
+      ./ckpem.patch
+      ./fix-cross-compilation.patch
+    ];
+
+  patchFlags = [ "-p0" ];
+
+  postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
+     substituteInPlace nss/coreconf/Darwin.mk --replace '@executable_path/$(notdir $@)' "$out/lib/\$(notdir \$@)"
+     substituteInPlace nss/coreconf/config.gypi --replace "'DYLIB_INSTALL_NAME_BASE': '@executable_path'" "'DYLIB_INSTALL_NAME_BASE': '$out/lib'"
+   '';
+
+  outputs = [ "out" "dev" "tools" ];
+
+  preConfigure = "cd nss";
+
+  buildPhase = let
+    getArch = platform: if platform.isx86_64 then "x64"
+          else if platform.isx86_32 then "ia32"
+          else if platform.isAarch32 then "arm"
+          else if platform.isAarch64 then "arm64"
+          else if platform.isPower && platform.is64bit then (
+            if platform.isLittleEndian then "ppc64le" else "ppc64"
+          )
+          else platform.parsed.cpu.name;
+    # yes, this is correct. nixpkgs uses "host" for the platform the binary will run on whereas nss uses "host" for the platform that the build is running on
+    target = getArch stdenv.hostPlatform;
+    host = getArch stdenv.buildPlatform;
+  in ''
+    runHook preBuild
+
+    sed -i 's|nss_dist_dir="$dist_dir"|nss_dist_dir="'$out'"|;s|nss_dist_obj_dir="$obj_dir"|nss_dist_obj_dir="'$out'"|' build.sh
+    ./build.sh -v --opt \
+      --with-nspr=${nspr.dev}/include:${nspr.out}/lib \
+      --system-sqlite \
+      --enable-legacy-db \
+      --target ${target} \
+      -Dhost_arch=${host} \
+      -Duse_system_zlib=1 \
+      --enable-libpkix \
+      ${stdenv.lib.optionalString enableFIPS "--enable-fips"} \
+      ${stdenv.lib.optionalString stdenv.isDarwin "--clang"} \
+      ${stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-tests"}
+
+    runHook postBuild
+  '';
+
+  NIX_CFLAGS_COMPILE = "-Wno-error -DNIX_NSS_LIBDIR=\"${placeholder "out"}/lib/\"";
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf $out/private
+    find $out -name "*.TOC" -delete
+    mv $out/public $out/include
+
+    ln -s lib $out/lib64
+
+    # Upstream issue: https://bugzilla.mozilla.org/show_bug.cgi?id=530672
+    # https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/nss/files/nss-3.32-gentoo-fixups.patch?id=af1acce6c6d2c3adb17689261dfe2c2b6771ab8a
+    NSS_MAJOR_VERSION=`grep "NSS_VMAJOR" lib/nss/nss.h | awk '{print $3}'`
+    NSS_MINOR_VERSION=`grep "NSS_VMINOR" lib/nss/nss.h | awk '{print $3}'`
+    NSS_PATCH_VERSION=`grep "NSS_VPATCH" lib/nss/nss.h | awk '{print $3}'`
+    PREFIX="$out"
+
+    mkdir -p $out/lib/pkgconfig
+    sed -e "s,%prefix%,$PREFIX," \
+        -e "s,%exec_prefix%,$PREFIX," \
+        -e "s,%libdir%,$PREFIX/lib64," \
+        -e "s,%includedir%,$dev/include/nss," \
+        -e "s,%NSS_VERSION%,$NSS_MAJOR_VERSION.$NSS_MINOR_VERSION.$NSS_PATCH_VERSION,g" \
+        -e "s,%NSPR_VERSION%,4.16,g" \
+        pkg/pkg-config/nss.pc.in > $out/lib/pkgconfig/nss.pc
+    chmod 0644 $out/lib/pkgconfig/nss.pc
+
+    sed -e "s,@prefix@,$PREFIX," \
+        -e "s,@MOD_MAJOR_VERSION@,$NSS_MAJOR_VERSION," \
+        -e "s,@MOD_MINOR_VERSION@,$NSS_MINOR_VERSION," \
+        -e "s,@MOD_PATCH_VERSION@,$NSS_PATCH_VERSION," \
+        pkg/pkg-config/nss-config.in > $out/bin/nss-config
+    chmod 0755 $out/bin/nss-config
+  '';
+
+  postFixup = let
+    isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+    nss = if isCross then buildPackages.nss.tools else "$out";
+  in
+  (stdenv.lib.optionalString enableFIPS (''
+    for libname in freebl3 nssdbm3 softokn3
+    do '' +
+    (if stdenv.isDarwin
+     then ''
+       libfile="$out/lib/lib$libname.dylib"
+       DYLD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
+     '' else ''
+       libfile="$out/lib/lib$libname.so"
+       LD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
+     '') + ''
+        ${nss}/bin/shlibsign -v -i "$libfile"
+    done
+  '')) +
+  ''
+    moveToOutput bin "$tools"
+    moveToOutput bin/nss-config "$dev"
+    moveToOutput lib/libcrmf.a "$dev" # needed by firefox, for example
+    rm -f "$out"/lib/*.a
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://developer.mozilla.org/en-US/docs/NSS";
+    description = "A set of libraries for development of security-enabled client and server applications";
+    license = licenses.mpl20;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -15,7 +15,7 @@ let
   #       It will rebuild itself using the version of this package (NSS) and if
   #       an update is required do the required changes to the expression.
   #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.57";
+  version = "3.58";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "55a86c01be860381d64bb4e5b94eb198df9b0f098a8af0e58c014df398bdc382";
+    sha256 = "1h2kjdicnxprwf6brw0qinlay34vc0dmafajisbrn42zkdwcywwz";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -15,7 +15,7 @@ let
   #       It will rebuild itself using the version of this package (NSS) and if
   #       an update is required do the required changes to the expression.
   #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.58";
+  version = "3.59";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "1h2kjdicnxprwf6brw0qinlay34vc0dmafajisbrn42zkdwcywwz";
+    sha256 = "096fs3z21r171q24ca3rq53p1389xmvqz1f2rpm7nlm8r9s82ag6";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -9,6 +9,12 @@ let
     url = "http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz";
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
+
+  # NOTE: Whenever you updated this version check if the `cacert` package also
+  #       needs an update. You can run the regular updater script for cacerts.
+  #       It will rebuild itself using the version of this package (NSS) and if
+  #       an update is required do the required changes to the expression.
+  #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
   version = "3.57";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14896,6 +14896,9 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
   nss_3_44 = lowPrio (callPackage ../development/libraries/nss/3.44.nix { });
   nssTools = nss.tools;
 
+  # required for stable thunderbird and firefox-esr-78
+  nss_3_53 = lowPrio (callPackage ../development/libraries/nss/3.53.nix { });
+
   nss_wrapper = callPackage ../development/libraries/nss_wrapper { };
 
   nsss = skawarePackages.nsss;


### PR DESCRIPTION
###### Motivation for this change

This updates the firefox source packages to the latest upstream version.

This is the continued work of #104051 & #100765.

In #100765 @vcunat pointed out that we could decouple cacert from the NSS package to make it more rebuild friendly. Just rebuilding packages that depend on NSS seems to be about ~100. Rebuilding all the packages that depend on cacert is >9k as of this writing.This makes it much more feasible to upgrade high-profile packages that are (rightfully) pedantic on their NSS version like firefox and thunderbird.



###### Things done

- [x] firefox NixOS test executed
- [x] firefox-esr NixOS test executed
- [ ] thunderbird pinned to older NSS version (FIXME!)
- [ ] verified that pipewire still works

Paging @vcunat and @ajs124 for the NSS & cacert changes, @worldofpeace & @mweinelt for the pipewire functionality and finally @stigtsp and @taku0 for the actual firefox change. :)