### PR TITLE
vector: include the "unix" cargo feature if targetPlatform isUnix

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -8,6 +8,8 @@
      then [ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ]
      else [ "leveldb" "leveldb/leveldb-sys-2" "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ])
      ++
+     (lib.optional stdenv.targetPlatform.isUnix "unix")
+     ++
      [ "sinks" "sources" "transforms" ])
 , coreutils
 , CoreServices


### PR DESCRIPTION

###### Motivation for this change

Fixes the issue that @happysalada is facing here: https://github.com/NixOS/nixpkgs/pull/103393#issuecomment-726434830

The journald source is apparently guarded by the "unix" cargo feature flag:
https://github.com/timberio/vector/blob/v0.10.0/src/sources/mod.rs#L14-L15

Don't know why the Vector folks made the choice that unix is a "feature". There might be a good reason why it's not just: `#[cfg(unix)]`, but never mind. Including "unix" in the default features when targetPlatform is unix should be sufficient for nixpkgs.

cc @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
