### PR TITLE
inboxer: 1.2.1 -> 1.3.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -1,88 +1,38 @@
-{ stdenv, fetchurl, binutils, patchelf, makeWrapper
-, expat, xorg, gdk-pixbuf, glib, gnome2, gnome3, cairo, atk, freetype, pango
-, fontconfig, dbus, nss, nspr, gtk2-x11, alsaLib, cups, libpulseaudio, udev }:
+{ stdenv, fetchurl, appimageTools }:
 
-stdenv.mkDerivation rec {
+let
   pname = "inboxer";
   version = "1.3.2";
+  name = "${pname}-${version}";
 
-  meta = with stdenv.lib; {
+  src = fetchurl {
+    url = "https://github.com/denysdovhan/inboxer/releases/download/v${version}/inboxer-${version}-x86_64.AppImage";
+    sha256 = "110c4g4c18j9hlp31acr9nardr2isrq3lbi2a10l2kf1ngxh7cc6";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    # fix the path in the desktop file
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/inboxer.desktop $out/share/applications/inboxer.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/inboxer.png \
+      $out/share/icons/hicolor/512x512/apps/inboxer.png
+    substituteInPlace \
+      $out/share/applications/inboxer.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+   meta = with stdenv.lib; {
     description = "Unofficial, free and open-source Google Inbox Desktop App";
     homepage    = "https://denysdovhan.com/inboxer";
     maintainers = [ maintainers.mgttlinger ];
     license     = licenses.mit;
     platforms   = [ "x86_64-linux" ];
   };
-
-  src = fetchurl {
-    url = "https://github.com/denysdovhan/inboxer/releases/download/v${version}/inboxer_${version}_amd64.deb";
-    sha256 = "0nyxas07d6ckgjazxapmc6iyakd2cddla6wflr5rhfp78d7kax3a";
-  };
-
-  unpackPhase = ''
-    ar p $src data.tar.xz | tar xJ
-  '';
-  nativeBuildInputs = [ patchelf makeWrapper ];
-  buildInputs = [ binutils ];
-
-  preFixup = with stdenv.lib; let
-    lpath = makeLibraryPath [
-      alsaLib
-      atk
-      cairo
-      cups
-      dbus
-      nss
-      nspr
-      freetype
-      fontconfig
-      gtk2-x11
-      xorg.libX11
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXi
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXcomposite
-      xorg.libXtst
-      xorg.libXScrnSaver
-      xorg.libxcb
-      gdk-pixbuf
-      glib
-      pango
-      gnome2.GConf
-      gnome3.gtk
-      expat
-      stdenv.cc.cc.lib
-      libpulseaudio
-      udev
-    ];
-  in ''
-    patchelf \
-      --set-rpath "$out/opt/Inboxer:${lpath}" \
-      $out/opt/Inboxer/libnode.so
-    patchelf \
-      --set-rpath "$out/opt/Inboxer:${lpath}" \
-      $out/opt/Inboxer/libffmpeg.so
-
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/opt/Inboxer:${lpath}" \
-      $out/opt/Inboxer/inboxer
-
-    wrapProgram $out/opt/Inboxer/inboxer --set LD_LIBRARY_PATH "${xorg.libxkbfile}/lib:${lpath}"
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -R usr/share opt $out/
-    # fix the path in the desktop file
-    substituteInPlace \
-      $out/share/applications/inboxer.desktop \
-      --replace /opt/ $out/opt/
-    # symlink the binary to bin/
-    ln -s $out/opt/Inboxer/inboxer $out/bin/inboxer
-  '';
 }

--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, binutils, patchelf, makeWrapper
-, expat, xorg, gdk-pixbuf, glib, gnome2, cairo, atk, freetype, pango
+, expat, xorg, gdk-pixbuf, glib, gnome2, gnome3, cairo, atk, freetype, pango
 , fontconfig, dbus, nss, nspr, gtk2-x11, alsaLib, cups, libpulseaudio, udev }:
 
 stdenv.mkDerivation rec {
   pname = "inboxer";
-  version = "1.2.1";
+  version = "1.3.2";
 
   meta = with stdenv.lib; {
     description = "Unofficial, free and open-source Google Inbox Desktop App";
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
       glib
       pango
       gnome2.GConf
+      gnome3.gtk
       expat
       stdenv.cc.cc.lib
       libpulseaudio


### PR DESCRIPTION
Fixes missing gtk3 dependency and closes #103878 because this updates
directly to the last version.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Dependency on gtk3 was missing even from previous versions of the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
