### PR TITLE
opendungeons: unbreak

### DIFF
--- a/pkgs/games/opendungeons/cmakepaths.patch
+++ b/pkgs/games/opendungeons/cmakepaths.patch
@@ -1,6 +1,6 @@
---- ../CMakeLists.txt	
-+++ ../CMakeLists.txt	
-@@ -31,12 +31,12 @@
+--- a/CMakeLists.txt	
++++ b/CMakeLists.txt	
+@@ -30,12 +30,12 @@
      set(OD_PLUGINS_CFG_PATH ".")
  else()
      # Set binary and data install locations if we want to use the installer

--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./cmakepaths.patch ];
 
+  postPatch = ''
+    sed -i "s|<OIS/|<ois/|" \
+      source/modes/AbstractApplicationMode.h \
+      source/modes/InputManager.cpp
+  '';
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake ogre cegui boost sfml openal ois ];
   NIX_LDFLAGS = "-lpthread";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some header were included from `OIS` folder but, they are located in a `ois` folder

also some fixes in the patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
