### PR TITLE
runLaTeX: fixed empty table of contents + refactor

### DIFF
--- a/pkgs/tools/typesetting/tex/nix/run-latex.sh
+++ b/pkgs/tools/typesetting/tex/nix/run-latex.sh
@@ -41,7 +41,10 @@ showError() {
     exit 1
 }
 
+pass=1
+
 runLaTeX() {
+    echo "PASS $pass..."
     if ! $latex $latexFlags $rootName >$tmpFile 2>&1; then showError; fi
     runNeeded=
     if fgrep -q \
@@ -51,6 +54,8 @@ runLaTeX() {
         "$tmpFile"; then
         runNeeded=1
     fi
+    echo
+    ((pass=pass+1))
 }
 
 echo
@@ -61,10 +66,7 @@ if test -n "$copySources"; then
 fi
 
 
-echo "PASS 1..."
 runLaTeX
-echo
-
 
 for auxFile in $(find . -name "*.aux"); do
     # Run bibtex to process all bibliographies.  There may be several
@@ -89,11 +91,8 @@ for auxFile in $(find . -name "*.aux"); do
     fi
 done
 
-
 if test "$runNeeded"; then
-    echo "PASS 2..."
     runLaTeX
-    echo
 fi
 
 
@@ -105,20 +104,14 @@ if test -f $rootNameBase.idx; then
     makeindex $makeindexFlags $rootNameBase.idx
     runNeeded=1
     echo
-fi    
-
-
-if test "$runNeeded"; then
-    echo "PASS 3..."
-    runLaTeX
-    echo
 fi
 
 
+runLaTeX
+
+
 if test "$runNeeded"; then
-    echo "PASS 4..."
     runLaTeX
-    echo
 fi
 
 

--- a/pkgs/tools/typesetting/tex/nix/run-latex.sh
+++ b/pkgs/tools/typesetting/tex/nix/run-latex.sh
@@ -41,9 +41,10 @@ showError() {
     exit 1
 }
 
-pass=1
+pass=0
 
 runLaTeX() {
+    ((pass=pass+1))
     echo "PASS $pass..."
     if ! $latex $latexFlags $rootName >$tmpFile 2>&1; then showError; fi
     runNeeded=
@@ -55,7 +56,6 @@ runLaTeX() {
         runNeeded=1
     fi
     echo
-    ((pass=pass+1))
 }
 
 echo
@@ -106,9 +106,13 @@ if test -f $rootNameBase.idx; then
     echo
 fi
 
-
-runLaTeX
-
+# We check that pass is less than 2 to catch situations where the document is
+# simple enough (no bibtex, etc.) so that it would otherwise require only one
+# pass but also contains a ToC.
+# In essence this check ensures that we do at least two passes on all documents.
+if test "$runNeeded" = 1 -o "$pass" -lt 2 ; then
+    runLaTeX
+fi
 
 if test "$runNeeded"; then
     runLaTeX


### PR DESCRIPTION
###### Motivation for this change

The current behavior of `nixpkgs.texFunctions.runLaTeX` does not always yield a valid document. More precisely, the builder determines whether LaTeX should be run additional times based on the files written during the previous run and whether the logs mention the need for a rerun. However, there are situations when the document needs to be rebuilt but there is no indication of it. An example of such a situation is the presence of a table of contents in the document. If the document is built once, the table of contents will be empty. LaTeX needs to be run twice to get a proper table of contents.

The current versions of nixpkgs yields a document with an empty table of contents:

```bash
cat <<EOF > default.nix
(import (builtins.fetchGit {
  url = "https://github.com/NixOS/nixpkgs";
  rev = "f2e4de720d80775eb198b252f0f31af6cbcce99e";
}) {}).texFunctions.runLaTeX {rootFile = ./doc.tex;}
EOF

cat <<EOF > doc.tex
\documentclass[12pt]{article}
\begin{document}
\tableofcontents
\section{Hello}
\end{document}
EOF

nix-build
```

[doc.pdf](https://github.com/NixOS/nixpkgs/files/5561341/doc.pdf)

![Screenshot 2020-11-18 at 19 28 27](https://user-images.githubusercontent.com/6209627/99557914-3d1c4300-29d4-11eb-9d88-7c4de760c5bb.png)


My branch yields a non-empty table of contents which seems to clearly be more desireable:

```bash
cat <<EOF > default.nix
(import (builtins.fetchGit {
  url = "https://github.com/ilyakooo0/nixpkgs";
  ref = "fix-latex-empty-contents";
}) {}).texFunctions.runLaTeX {rootFile = ./doc.tex;}
EOF

cat <<EOF > doc.tex
\documentclass[12pt]{article}
\begin{document}
\tableofcontents
\section{Hello}
\end{document}
EOF

nix-build
```

[doc.pdf](https://github.com/NixOS/nixpkgs/files/5561349/doc.pdf)
![Screenshot 2020-11-18 at 19 29 47](https://user-images.githubusercontent.com/6209627/99558092-6ccb4b00-29d4-11eb-9769-92f1627f4054.png)


###### Perofmance considerations

The only situation where the additional `runLaTeX` would not have been needed is when there is no table of contents and `runLaTeX` would have been run once (when bibTeX was not used). If building the document called `runLaTeX` multiple times before this PR, then the number `runLaTeX` calls will not be changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
