### PR TITLE
clojure: Mimic upstream install script

### DIFF
--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -14,22 +14,28 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
+  # See https://github.com/clojure/brew-install/blob/1.10.1/src/main/resources/clojure/install/linux-install.sh
   installPhase =
     let
       binPath = stdenv.lib.makeBinPath [ rlwrap jdk ];
     in
     ''
-      mkdir -p $out/libexec
-      cp clojure-tools-${version}.jar $out/libexec
-      cp example-deps.edn $out
-      cp deps.edn $out
-      cp exec.jar $out
+      clojure_lib_dir=$out
+      bin_dir=$out/bin
 
+      echo "Installing libs into $clojure_lib_dir"
+      install -Dm644 deps.edn "$clojure_lib_dir/deps.edn"
+      install -Dm644 example-deps.edn "$clojure_lib_dir/example-deps.edn"
+      install -Dm644 exec.jar "$clojure_lib_dir/libexec/exec.jar"
+      install -Dm644 clojure-tools-${version}.jar "$clojure_lib_dir/libexec/clojure-tools-${version}.jar"
+
+      echo "Installing clojure and clj into $bin_dir"
       substituteInPlace clojure --replace PREFIX $out
+      install -Dm755 clojure "$bin_dir/clojure"
+      install -Dm755 clj "$bin_dir/clj"
 
-      install -Dt $out/bin clj clojure
-      wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}
-      wrapProgram $out/bin/clojure --prefix PATH : $out/bin:${binPath}
+      wrapProgram $bin_dir/clojure --prefix PATH : $out/bin:${binPath}
+      wrapProgram $bin_dir/clj --prefix PATH : $out/bin:${binPath}
 
       installManPage clj.1 clojure.1
     '';


### PR DESCRIPTION
Also installs exec.jar in the expected location

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #103972
Closes #103982

I think is better to keep as close as possible to 
https://github.com/clojure/brew-install/blob/1.10.1/src/main/resources/clojure/install/linux-install.sh

ping @bennyandresen 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
