### PR TITLE
nixos/sane: bump the MaxConnections to a reasonable amount

### DIFF
--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -148,7 +148,7 @@ in
           # saned needs to distinguish between IPv4 and IPv6 to open matching data sockets.
           BindIPv6Only = "ipv6-only";
           Accept = true;
-          MaxConnections = 1;
+          MaxConnections = 64;
         };
       };
 


### PR DESCRIPTION
###### Motivation for this change
Whenever I try to scan from another computer it has to establish >2
connections in order to succeed. With the connections being limited to 1
I can not scan any document.

This is also what other distributions ([Debian], [ArchLinux], …) have
done in one way or another.

[Debian]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850649#5
[ArchLinux]: no limit: https://github.com/archlinux/svntogit-packages/blob/99cba454bb0b69034bc45e97cde4a460bccfef4b/trunk/saned.socket#L4



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS - I have been using this change since 18.09 on my machines.
