### PR TITLE
curaLulzbot: Move from Python 3.8 back to 3.6 to avoid showstopper bugs

### DIFF
--- a/pkgs/applications/misc/cura/lulzbot/curaengine.nix
+++ b/pkgs/applications/misc/cura/lulzbot/curaengine.nix
@@ -1,12 +1,14 @@
-{ lib, gcc8Stdenv, callPackage, fetchgit, fetchpatch, cmake, libarcusLulzbot, stb, protobuf }:
+{ lib, gcc8Stdenv, callPackage, fetchFromGitLab, fetchpatch, cmake, libarcusLulzbot, stb, protobuf }:
 
 gcc8Stdenv.mkDerivation rec {
   pname = "curaengine-lulzBot";
   version = "3.6.21";
 
-  src = fetchgit {
-    url = "https://code.alephobjects.com/source/curaengine-lulzbot.git";
-    rev = "ec6a1a0f0aa387ef97e5c106633cf8d7fb9cd00d";
+  src = fetchFromGitLab {
+    group = "lulzbot3d";
+    owner = "cura-le";
+    repo = "cura-engine-le";
+    rev = "v${version}";
     sha256 = "0wdkvg1hmqp1gaym804lw09x4ngf5ffasd861jhflpy7djbmkfn8";
   };
 
@@ -19,7 +21,7 @@ gcc8Stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A powerful, fast and robust engine for processing 3D models into 3D printing instruction";
-    homepage = "https://code.alephobjects.com/source/curaengine-lulzbot/";
+    homepage = "https://gitlab.com/lulzbot3d/cura-le/cura-engine-le";
     license = licenses.agpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ chaduffy ];

--- a/pkgs/applications/misc/cura/lulzbot/default.nix
+++ b/pkgs/applications/misc/cura/lulzbot/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, wrapQtAppsHook, callPackage, fetchgit, cmake, jq, python3, qtbase, qtquickcontrols2 }:
+{ lib, mkDerivation, wrapQtAppsHook, callPackage, fetchgit, cmake, jq, python36, qtbase, qtquickcontrols2 }:
 
 let
   # admittedly, we're using (printer firmware) blobs when we could compile them ourselves.
@@ -10,19 +10,19 @@ let
   };
 
   libarcusLulzbot = callPackage ./libarcus.nix {
-    inherit (python3.pkgs) buildPythonPackage sip pythonOlder;
+    inherit (python36.pkgs) buildPythonPackage sip pythonOlder;
   };
   libsavitarLulzbot = callPackage ./libsavitar.nix {
-    inherit (python3.pkgs) buildPythonPackage sip pythonOlder;
+    inherit (python36.pkgs) buildPythonPackage sip pythonOlder;
   };
 
-  inherit (python3.pkgs) buildPythonPackage pyqt5 numpy scipy shapely pythonOlder;
+  inherit (python36.pkgs) buildPythonPackage pyqt5 numpy scipy_1_4 shapely pythonOlder;
   curaengine = callPackage ./curaengine.nix {
     inherit libarcusLulzbot;
   };
   uraniumLulzbot = callPackage ./uranium.nix {
     inherit callPackage libarcusLulzbot;
-    inherit (python3.pkgs) buildPythonPackage pyqt5 numpy scipy shapely pythonOlder;
+    inherit (python36.pkgs) buildPythonPackage pyqt5 numpy scipy_1_4 shapely pythonOlder;
   };
 in
 mkDerivation rec {
@@ -37,8 +37,8 @@ mkDerivation rec {
 
   buildInputs = [ qtbase qtquickcontrols2 ];
   # numpy-stl temporarily disabled due to https://code.alephobjects.com/T8415
-  propagatedBuildInputs = with python3.pkgs; [ pyserial requests zeroconf ] ++ [ libsavitarLulzbot uraniumLulzbot libarcusLulzbot ]; # numpy-stl
-  nativeBuildInputs = [ cmake python3.pkgs.wrapPython ];
+  propagatedBuildInputs = with python36.pkgs; [ pyserial requests zeroconf ] ++ [ libsavitarLulzbot uraniumLulzbot libarcusLulzbot ]; # numpy-stl
+  nativeBuildInputs = [ cmake python36.pkgs.wrapPython ];
 
   cmakeFlags = [
     "-DURANIUM_DIR=${uraniumLulzbot.src}"

--- a/pkgs/applications/misc/cura/lulzbot/default.nix
+++ b/pkgs/applications/misc/cura/lulzbot/default.nix
@@ -1,12 +1,14 @@
-{ lib, mkDerivation, wrapQtAppsHook, callPackage, fetchgit, cmake, jq, python36, qtbase, qtquickcontrols2 }:
+{ lib, mkDerivation, wrapQtAppsHook, callPackage, fetchFromGitLab, cmake, jq, python36, qtbase, qtquickcontrols2 }:
 
 let
   # admittedly, we're using (printer firmware) blobs when we could compile them ourselves.
-  curaBinaryDataVersion = "3.6.21"; # Marlin v2.0.0.174 for Bio, v2.0.0.144 for others.
-  curaBinaryData = fetchgit {
-    url = "https://code.alephobjects.com/diffusion/CBD/cura-binary-data.git";
-    rev = "5c75d0f6c10d8b7a903e2072a48cd1f08059509e";
-    sha256 = "1qdsj6rczwzdwzyr7nz7fnypbphckjrnwl8c9dr6izsxyzs465c4";
+  curaBinaryDataVersion = "3.6.23";
+  curaBinaryData = fetchFromGitLab {
+    group = "lulzbot3d";
+    owner = "cura-le";
+    repo = "cura-binary-data";
+    rev = "${curaBinaryDataVersion}";
+    sha256 = "188976fmzsvpvqfhriyws0g986zym9r7m2ismswiw2q6acj8r2nf";
   };
 
   libarcusLulzbot = callPackage ./libarcus.nix {
@@ -27,12 +29,14 @@ let
 in
 mkDerivation rec {
   pname = "cura-lulzbot";
-  version = "3.6.21";
+  version = "3.6.23";
 
-  src = fetchgit {
-    url = "https://code.alephobjects.com/source/cura-lulzbot.git";
-    rev = "7faeb18604c83004846a02c60cb240708db0034f";
-    sha256 = "10q38s8c8x6xkh1vns4p3iqa5y267vrjh5vq8h55mg1q5001scyq";
+  src = fetchFromGitLab {
+    group = "lulzbot3d";
+    owner = "cura-le";
+    repo = "cura-lulzbot";
+    rev = version;
+    sha256 = "1nq2jjjky5l5r16vcb1l49zsvqhkaq23dh4ghwdss88cpay8c9fk";
   };
 
   buildInputs = [ qtbase qtquickcontrols2 ];
@@ -74,7 +78,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "3D printer / slicing GUI built on top of the Uranium framework";
-    homepage = "https://code.alephobjects.com/diffusion/CURA/";
+    homepage = "https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot";
     license = licenses.agpl3;  # a partial relicense to LGPL has happened, but not certain that all AGPL bits are expunged
     platforms = platforms.linux;
     maintainers = with maintainers; [ chaduffy ];

--- a/pkgs/applications/misc/cura/lulzbot/default.nix
+++ b/pkgs/applications/misc/cura/lulzbot/default.nix
@@ -49,6 +49,11 @@ mkDerivation rec {
     "-DCURA_VERSION=${version}"
   ];
 
+  makeWrapperArgs = [
+    # hacky workaround for https://github.com/NixOS/nixpkgs/issues/59901
+    "--set OMP_NUM_THREADS 1"
+  ];
+
   postPatch = ''
     sed -i 's,/python''${PYTHON_VERSION_MAJOR}/dist-packages,/python''${PYTHON_VERSION_MAJOR}.''${PYTHON_VERSION_MINOR}/site-packages,g' CMakeLists.txt
     sed -i 's, executable_name = .*, executable_name = "${curaengine}/bin/CuraEngine",' plugins/CuraEngineBackend/CuraEngineBackend.py

--- a/pkgs/applications/misc/cura/lulzbot/libarcus.nix
+++ b/pkgs/applications/misc/cura/lulzbot/libarcus.nix
@@ -1,13 +1,15 @@
-{ lib, buildPythonPackage, fetchgit, fetchurl, cmake, sip, protobuf, pythonOlder }:
+{ lib, buildPythonPackage, fetchFromGitLab, fetchurl, cmake, sip, protobuf, pythonOlder }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "libarcus";
   version = "3.6.21";
   format = "other";
 
-  src = fetchgit {
-    url = "https://code.alephobjects.com/source/arcus.git";
-    rev = "aeda02d7727f45b657afb72cef203283fbf09325";
+  src = fetchFromGitLab {
+    group = "lulzbot3d";
+    owner = "cura-le";
+    repo = "libarcus";
+    rev = "v${version}";
     sha256 = "1ak0d4k745sx7paic27was3s4987z9h3czscjs21hxbi6qy83g99";
   };
 
@@ -24,7 +26,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "Communication library between internal components for Ultimaker software";
-    homepage = "https://code.alephobjects.com/source/arcus/";
+    homepage = "https://gitlab.com/lulzbot3d/cura-le/libarcus";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ chaduffy ];

--- a/pkgs/applications/misc/cura/lulzbot/libsavitar.nix
+++ b/pkgs/applications/misc/cura/lulzbot/libsavitar.nix
@@ -1,14 +1,16 @@
-{ lib, buildPythonPackage, pythonOlder, fetchgit, cmake, sip }:
+{ lib, buildPythonPackage, pythonOlder, fetchFromGitLab, cmake, sip }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "libsavitar-lulzbot";
   name = "libsavitar-lulzbot";
   version = "3.6.21";
   format = "other";
 
-  src = fetchgit {
-    url = "https://code.alephobjects.com/source/savitar.git";
-    rev = "ee8ada42c55f54727ce4d275c294ba426d3d8234";
+  src = fetchFromGitLab {
+    group = "lulzbot3d";
+    owner = "cura-le";
+    repo = "libsavitar";
+    rev = "v${version}";
     sha256 = "1wm5ii3cmni8dk3c65kw4wglpypkdsfpgd480d3hc1r5bqpq0d6j";
   };
 
@@ -25,7 +27,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "C++ implementation of 3mf loading with SIP python bindings";
-    homepage = "https://github.com/Ultimaker/libSavitar";
+    homepage = "https://gitlab.com/lulzbot3d/cura-le/libsavitar";
     license = licenses.lgpl3Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ chaduffy ];

--- a/pkgs/applications/misc/cura/lulzbot/uranium.nix
+++ b/pkgs/applications/misc/cura/lulzbot/uranium.nix
@@ -1,5 +1,5 @@
-{ lib, callPackage, fetchurl, fetchgit, buildPythonPackage, fetchFromGitHub, python, cmake
-, pyqt5, numpy, scipy, shapely, libarcusLulzbot, doxygen, gettext, pythonOlder }:
+{ lib, callPackage, fetchurl, fetchgit, buildPythonPackage, fetchFromGitHub, python36, cmake
+, pyqt5, numpy, scipy_1_4, shapely, libarcusLulzbot, doxygen, gettext, pythonOlder }:
 
 buildPythonPackage {
   version = "3.6.21";
@@ -15,8 +15,8 @@ buildPythonPackage {
 
   disabled = pythonOlder "3.5.0";
 
-  buildInputs = [ python gettext ];
-  propagatedBuildInputs = [ pyqt5 numpy scipy shapely libarcusLulzbot ];
+  buildInputs = [ python36 gettext ];
+  propagatedBuildInputs = [ pyqt5 numpy scipy_1_4 shapely libarcusLulzbot ];
   nativeBuildInputs = [ cmake doxygen ];
 
   postPatch = ''

--- a/pkgs/applications/misc/cura/lulzbot/uranium.nix
+++ b/pkgs/applications/misc/cura/lulzbot/uranium.nix
@@ -1,15 +1,17 @@
-{ lib, callPackage, fetchurl, fetchgit, buildPythonPackage, fetchFromGitHub, python36, cmake
+{ lib, callPackage, fetchurl, fetchFromGitLab, buildPythonPackage, fetchFromGitHub, python36, cmake
 , pyqt5, numpy, scipy_1_4, shapely, libarcusLulzbot, doxygen, gettext, pythonOlder }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   version = "3.6.21";
   pname = "uranium";
   name = "uraniumLulzbot";
   format = "other";
 
-  src = fetchgit {
-    url = "https://code.alephobjects.com/diffusion/U/uranium.git";
-    rev = "54d911edd2551c5875c554928896122835a0dd6c";
+  src = fetchFromGitLab {
+    group = "lulzbot3d";
+    owner = "cura-le";
+    repo = "Uranium";
+    rev = "v${version}";
     sha256 = "04bym3vwikaxw8ab0mymv9sc9n8i7yw5kfsv99ic811g9lzz3j1i";
   };
 
@@ -29,7 +31,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "A Python framework for building Desktop applications";
-    homepage = "https://code.alephobjects.com/diffusion/U/";
+    homepage = "https://gitlab.com/lulzbot3d/cura-le/uranium";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ chaduffy ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4716,7 +4716,7 @@ in {
 
   numpydoc = callPackage ../development/python-modules/numpydoc { };
 
-  numpy = if pythonOlder "3.5" then
+  numpy = if pythonOlder "3.7" then
     callPackage ../development/python-modules/numpy/1.16.nix { }
   else
     callPackage ../development/python-modules/numpy { };


### PR DESCRIPTION
See https://gitlab.com/lulzbot3d/cura-le/cura-lulzbot/-/issues/72

###### Motivation for this change

cura-lulzbot does not work at all in NixSO 20.09, as `cura_app.py` refers to `platform.linux_distribution()`, which was deprecated in Python 3.6 and removed as of (or possibly before?) 3.8.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
