### PR TITLE
unicon-lang: unbreak adding libnsl

### DIFF
--- a/pkgs/development/interpreters/unicon-lang/default.nix
+++ b/pkgs/development/interpreters/unicon-lang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, libX11, libXt }:
+{ stdenv, fetchurl, unzip, libX11, libXt, libnsl }:
 
 stdenv.mkDerivation {
   pname = "unicon-lang";
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     url = "http://unicon.org/dist/uni-2-4-2010.zip";
     sha256 = "1g9l2dfp99dqih2ir2limqfjgagh3v9aqly6x0l3qavx3qkkwf61";
   };
-  buildInputs = [ libX11 libXt unzip ];
+  buildInputs = [ libnsl libX11 libXt unzip ];
 
   hardeningDisable = [ "fortify" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

libnsl was missing in the buildInputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
