### PR TITLE
python3Packages.tubeup: unbreak 

### DIFF
--- a/pkgs/development/python-modules/tubeup/default.nix
+++ b/pkgs/development/python-modules/tubeup/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , internetarchive
 , fetchPypi
-, youtube-dl
+, youtube-dlc
 , docopt
 , isPy27
 }:
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace "docopt==0.6.2" "docopt"
   '';
 
-  propagatedBuildInputs = [ internetarchive docopt youtube-dl ];
+  propagatedBuildInputs = [ internetarchive docopt youtube-dlc ];
 
   pythonImportsCheck = [ "tubeup" ];
 

--- a/pkgs/development/python-modules/youtube-dlc/default.nix
+++ b/pkgs/development/python-modules/youtube-dlc/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "youtube_dlc";
+  version = "2020.11.11.post3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "WqoKpfvVPZrN+pW6s8JoApJusn5CXyPcg9VcsY8R0FM=";
+  };
+
+  # They are broken
+  doCheck = false;
+
+  pythonImportsCheck = [ "youtube_dlc" ];
+
+  meta = with lib; {
+    homepage = "Media downloader supporting various sites such as youtube";
+    description = "https://github.com/blackjack4494/yt-dlc";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7839,6 +7839,8 @@ in {
     phantomjsSupport = false;
   };
 
+  youtube-dlc = callPackage ../development/python-modules/youtube-dlc { };
+
   yowsup = callPackage ../development/python-modules/yowsup { };
 
   yq = callPackage ../development/python-modules/yq { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unbreak tubeup python module. It seems there are two different youtube-dl(c) packages.
The selected one was not the correct one

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
