### PR TITLE
sourceInputCompletionHook: init

### DIFF
--- a/pkgs/shells/hooks/sourceInputCompletionHook/default.nix
+++ b/pkgs/shells/hooks/sourceInputCompletionHook/default.nix
@@ -1,0 +1,8 @@
+{ makeSetupHook, findutils, substituteAll }:
+
+# See the header comment in ./source-input-completion-hook.sh for example usage.
+makeSetupHook { name = "source-input-completion-hook"; } (
+  substituteAll {
+    src = ./source-input-completion-hook.sh;
+    inherit findutils;
+  })

--- a/pkgs/shells/hooks/sourceInputCompletionHook/source-input-completion-hook.sh
+++ b/pkgs/shells/hooks/sourceInputCompletionHook/source-input-completion-hook.sh
@@ -1,0 +1,40 @@
+
+# This function is meant to inspect the inputs to a derivation and source the shell completion.
+# This is intended to be only used with nix-shell to provide a better user experience, and is not
+# intended to be used within nixpkgs as shell completion is only useful in an interactive shell.
+sourceInputCompletion() {
+    local completionPath=
+
+    case $(basename $SHELL) in
+        bash)
+            completionPath=share/bash-completion/completions/
+            ;;
+        fish)
+            completionPath=share/fish/vendor_completions.d/
+            ;;
+        zsh)
+            completionPath=share/zsh/site-functions/
+            ;;
+        *)
+            echo "$(basename $SHELL) is not supported for shell completion. Skipping."
+            exit 0
+    esac
+
+    declare -A inputsSourced
+    for input in $nativeBuildInputs $buildInputs $propagatedNativeBuildInputs $propagatedBuildInputs; do
+        local completionDir=$input/$completionPath
+        if [ -d $completionDir ]; then
+            for script in $(@findutils@/bin/find $completionDir -type f); do
+                . $script
+                # grab derivation pname. E.g. /nix/store/...-kubectl-1.19.4 -> kubectl
+                inputsSourced[$(echo $input | sed -e 's/[^-]*-//' | sed -e 's/-.*$//')]=1
+            done
+        fi
+    done
+
+    echo "Completions added for: ${!inputsSourced[@]}"
+}
+
+if [ -z "$dontUseSourceInputCompletion" ]; then
+  sourceInputCompletion
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -161,6 +161,8 @@ in
     deps = [ innoextract file-rename ]; }
     ../build-support/setup-hooks/gog-unpack.sh;
 
+  sourceInputCompletionHook = callPackage ../shells/hooks/sourceInputCompletionHook { };
+
   buildEnv = callPackage ../build-support/buildenv { }; # not actually a package
 
   # TODO: eventually migrate everything to buildFHSUserEnvBubblewrap


### PR DESCRIPTION
###### Motivation for this change
It's been a recurrent theme that there's some pain with `nix-shell` and bringing in some tools, only to have shell completion not work without adding additional code to `shellHook`. This solves that! (at least for bash)

This hasn't been tested with zsh or fish, as running `nix-shell` even with those shells will drop me into a bash shell.

If this does get added, may have it added to `mkShell` by default, as that's likely intended user behavior.

Also, I don't feel strongly about the name, if anyone can come up with a better name, I'll gladly change it.

example scenario:
```
$ kubectl
The program ‘kubectl’ is currently not installed. It is provided by
several packages. You can install it by typing one of the following:
  nix-env -iA nixos.kubectl
  nix-env -iA nixos.kubernetes
  nix-env -iA nixos.openshift
$ cat shell.nix
with import ./. { };

mkShell rec {
  buildInputs = [
    exa
    kubectl
    hyperfine
    sourceInputCompletionHook
  ];
}

$ nix-shell
Completions added for: kubectl hyperfine exa

[nix-shell:/home/jon/projects/nixpkgs]$ kubectl <tab><tab>
alpha          auth           convert        diff           get            plugin         scale          wait
annotate       autoscale      cordon         drain          kustomize      port-forward   set
api-resources  certificate    cp             edit           label          proxy          taint
api-versions   cluster-info   create         exec           logs           replace        top
apply          completion     delete         explain        options        rollout        uncordon
attach         config         describe       expose         patch          run            version
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
