### PR TITLE
Unbreak xhtml2pdf

### DIFF
--- a/pkgs/development/python-modules/arabic-reshaper/default.nix
+++ b/pkgs/development/python-modules/arabic-reshaper/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, future, configparser, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "arabic_reshaper";
+  version = "2.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "zzGPpdUdLSJPpJv2vbu0aE9r0sBot1z84OYH+JrBmdw=";
+  };
+
+  propagatedBuildInputs = [ future ]
+    ++ lib.optionals isPy27 [ configparser ];
+
+  # Tests are not published on pypi
+  doCheck = false;
+
+  pythonImportsCheck = [ "arabic_reshaper" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mpcabd/python-arabic-reshaper";
+    description = "Reconstruct Arabic sentences to be used in applications that don't support Arabic";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/development/python-modules/python-bidi/default.nix
+++ b/pkgs/development/python-modules/python-bidi/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "python-bidi";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "U0f3HoKz6Zdtxlfwne0r/jm6jWd3yoGlssVsMBIcSW4=";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with lib; {
+    homepage = "https://github.com/MeirKriheli/python-bidi";
+    description = "Pure python implementation of the BiDi layout algorithm";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ freezeboy ];
+  };
+}

--- a/pkgs/development/python-modules/xhtml2pdf/default.nix
+++ b/pkgs/development/python-modules/xhtml2pdf/default.nix
@@ -6,13 +6,19 @@
 , pypdf2
 , reportlab
 , six
+, python-bidi
+, arabic-reshaper
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "xhtml2pdf";
   version = "0.2.5";
 
-  propagatedBuildInputs = [pillow html5lib pypdf2 reportlab six];
+  propagatedBuildInputs = [
+    pillow html5lib pypdf2 reportlab six
+    setuptools python-bidi arabic-reshaper
+  ];
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5770,6 +5770,8 @@ in {
 
   python-baseconv = callPackage ../development/python-modules/python-baseconv { };
 
+  python-bidi = callPackage ../development/python-modules/python-bidi { };
+
   python-binance = callPackage ../development/python-modules/python-binance { };
 
   python-constraint = callPackage ../development/python-modules/python-constraint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -358,6 +358,8 @@ in {
 
   apsw = callPackage ../development/python-modules/apsw { };
 
+  arabic-reshaper = callPackage ../development/python-modules/arabic-reshaper { };
+
   area = callPackage ../development/python-modules/area { };
 
   arelle = callPackage ../development/python-modules/arelle { gui = true; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding `setuptools` `python-bidi` and `arabic-reshaper` to unbreak xhtml2pdf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
