### PR TITLE
matrix-dl: (unstable-)2019-09-22 -> unstable-2020-07-14

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-dl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-dl/default.nix
@@ -1,14 +1,14 @@
 { lib, python3Packages, fetchFromGitHub }:
 
 python3Packages.buildPythonApplication rec {
-  pname = "matrix-dl-unstable";
-  version = "2019-09-22";
+  pname = "matrix-dl";
+  version = "unstable-2020-07-14";
 
   src = fetchFromGitHub {
     owner = "rubo77";
-    repo = "matrix-dl";
-    rev = "e91610f45b7b3b0aca34923309fc83ba377f8a69";
-    sha256 = "036xfdd21pcfjlilknc67z5jqpk0vz07853wwcsiac32iypc6f2q";
+    repo = pname;
+    rev = "b1a86d1421f39ee327284e1023f09dc165e3c8a5";
+    sha256 = "1l8nh8z7kz24v0wcy3ll3w6in2yxwa1yz8lyc3x0blz37d8ss4ql";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
Update, also change from

  pname = "package-unstable";
  version = "YYYY-MM-DD";

to

  pname = "package";
  version = "unstable-YYYY-MM-DD";

This allows $pname as $repo in fetchFromGitHub and also seems to be the
more common way in nixpkgs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
