### PR TITLE
ocamlPackages.cstruct: 4.0.0 → 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -6,6 +6,7 @@
 buildDunePackage rec {
   pname = "conduit";
   version = "2.2.2";
+  useDune2 = true;
 
   minimumOCamlVersion = "4.07";
 

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
 	pname = "conduit-lwt";
-	inherit (conduit) version src minimumOCamlVersion;
+	inherit (conduit) version src useDune2 minimumOCamlVersion;
 
 	buildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,13 +1,19 @@
-{ lib, fetchurl, buildDunePackage }:
+{ lib, fetchurl, buildDunePackage, bigarray-compat }:
 
 buildDunePackage rec {
   pname = "cstruct";
-  version = "4.0.0";
+  version = "5.0.0";
+
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.03";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-v${version}.tbz";
-    sha256 = "1q4fsc2m6d96yf42g3wb3gcnhpnxw800df5mh3yr25pprj8y4m1a";
+    sha256 = "1z403q2nkgz5x07j0ypy6q0mk2yxgqbp1jlqkngbajna7124x2pb";
   };
+
+  propagatedBuildInputs = [ bigarray-compat ];
 
   meta = {
     description = "Access C-like structures directly from OCaml";

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -6,7 +6,7 @@ else
 
 buildDunePackage {
 	pname = "cstruct-lwt";
-	inherit (cstruct) version src meta;
+	inherit (cstruct) version src useDune2 meta;
 
   minimumOCamlVersion = "4.02";
 

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, cstruct, sexplib, ppx_tools_versioned }:
+{ lib, buildDunePackage, cstruct, sexplib, ppx_tools_versioned, ppxlib }:
 
 if !lib.versionAtLeast (cstruct.version or "1") "3"
 then cstruct
@@ -6,9 +6,9 @@ else
 
 buildDunePackage {
 	pname = "ppx_cstruct";
-	inherit (cstruct) version src meta;
+	inherit (cstruct) version src useDune2 meta;
 
 	minimumOCamlVersion = "4.03";
 
-	propagatedBuildInputs = [ cstruct ppx_tools_versioned sexplib ];
+	propagatedBuildInputs = [ cstruct ppx_tools_versioned ppxlib sexplib ];
 }

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -6,7 +6,7 @@ else
 
 buildDunePackage rec {
 	pname = "cstruct-sexp";
-	inherit (cstruct) version src meta;
+	inherit (cstruct) version src useDune2 meta;
 
 	doCheck = lib.versionAtLeast ocaml.version "4.03";
 	checkInputs = lib.optional doCheck alcotest;

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -6,7 +6,7 @@ else
 
 buildDunePackage {
 	pname = "cstruct-unix";
-	inherit (cstruct) version src meta;
+	inherit (cstruct) version src useDune2 meta;
 
 	minimumOCamlVersion = "4.06";
 

--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -7,6 +7,9 @@
 buildDunePackage rec {
   pname = "duff";
   version = "0.2";
+
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/duff/releases/download/v${version}/duff-v${version}.tbz";
     sha256 = "0bi081w4349cqc1n9jsjh1lrcqlnv3nycmvh9fniscv8lz1c0gjq";

--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -4,6 +4,7 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.03";
   pname = "eqaf";
   version = "0.7";
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -4,6 +4,7 @@ buildDunePackage rec {
   pname = "io-page";
   version = "2.3.0";
 
+  useDune2 = true;
   minimumOCamlVersion = "4.02.3";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/io-page/unix.nix
+++ b/pkgs/development/ocaml-modules/io-page/unix.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "io-page-unix";
 
-  inherit (io-page) version src minimumOCamlVersion;
+  inherit (io-page) version src useDune2 minimumOCamlVersion;
 
   propagatedBuildInputs = [ cstruct io-page ];
   checkInputs = [ ounit ];

--- a/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
@@ -5,7 +5,7 @@
 buildDunePackage rec {
   pname = "ipaddr-cstruct";
 
-  inherit (ipaddr) version src minimumOCamlVersion;
+  inherit (ipaddr) version src useDune2 minimumOCamlVersion;
 
   propagatedBuildInputs = [ ipaddr cstruct ];
 

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -6,7 +6,7 @@
 buildDunePackage rec {
   pname = "ipaddr";
 
-  inherit (macaddr) version src minimumOCamlVersion;
+  inherit (macaddr) version src useDune2 minimumOCamlVersion;
 
   propagatedBuildInputs = [ macaddr domain-name stdlib-shims ];
 

--- a/pkgs/development/ocaml-modules/ipaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/sexp.nix
@@ -5,7 +5,7 @@
 buildDunePackage rec {
   pname = "ipaddr-sexp";
 
-  inherit (ipaddr) version src minimumOCamlVersion;
+  inherit (ipaddr) version src useDune2 minimumOCamlVersion;
 
   propagatedBuildInputs = [ ipaddr ];
 

--- a/pkgs/development/ocaml-modules/macaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/macaddr/cstruct.nix
@@ -7,6 +7,8 @@ buildDunePackage {
 
   inherit (macaddr) version src minimumOCamlVersion;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ macaddr cstruct ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "macaddr";
   version = "5.0.1";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/macaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/macaddr/sexp.nix
@@ -7,6 +7,8 @@ buildDunePackage {
 
   inherit (macaddr) version src minimumOCamlVersion;
 
+  useDune2 = true;
+
   propagatedBuildInputs = [ ppx_sexp_conv ];
 
   checkInputs = [ macaddr-cstruct ounit ];

--- a/pkgs/development/ocaml-modules/mirage-flow/combinators.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/combinators.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "mirage-flow-combinators";
 
-  inherit (mirage-flow) version src;
+  inherit (mirage-flow) version useDune2 src;
 
   propagatedBuildInputs = [ ocaml_lwt logs cstruct mirage-clock mirage-flow ];
 

--- a/pkgs/development/ocaml-modules/mirage-flow/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/default.nix
@@ -4,6 +4,7 @@ buildDunePackage rec {
   pname = "mirage-flow";
   version = "2.0.1";
 
+  useDune2 = true;
   minimumOCamlVersion = "4.05";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/mirage-flow/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-flow/unix.nix
@@ -4,7 +4,7 @@
 buildDunePackage {
   pname = "mirage-flow-unix";
 
-  inherit (mirage-flow) version src;
+  inherit (mirage-flow) version useDune2 src;
 
   propagatedBuildInputs = [ fmt logs mirage-flow ocaml_lwt cstruct ];
 

--- a/pkgs/development/ocaml-modules/mirage-protocols/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-protocols/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "mirage-protocols";
   version = "4.0.1";
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-protocols/releases/download/v${version}/mirage-protocols-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/mirage-random/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-random/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "mirage-random";
   version = "2.0.0";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/mirage-random/releases/download/v${version}/mirage-random-v${version}.tbz";
     sha256 = "0qj41d5smkkkbjwsnz71bhhj94d2cwv53rf3j4rhky0pqbkidnv1";

--- a/pkgs/development/ocaml-modules/mirage-stack/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-stack/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "mirage-stack";
   version = "2.2.0";
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-stack/releases/download/v${version}/mirage-stack-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/randomconv/default.nix
+++ b/pkgs/development/ocaml-modules/randomconv/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "randomconv";
   version = "0.1.3";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/hannesm/randomconv/releases/download/v${version}/randomconv-v${version}.tbz";
     sha256 = "1iv3r0s5kqxs893b0d55f0r62k777haiahfkkvvfbqwgqsm6la4v";

--- a/pkgs/development/ocaml-modules/tuntap/default.nix
+++ b/pkgs/development/ocaml-modules/tuntap/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "tuntap";
   version = "2.0.0";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.04.2";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
