### PR TITLE
pythonPackages.sqlite-utils: depend on sqlite-fts4

### DIFF
--- a/pkgs/development/python-modules/sqlite-fts4/default.nix
+++ b/pkgs/development/python-modules/sqlite-fts4/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "sqlite-fts4";
+  version = "1.0.1";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = pname;
+    rev = version;
+    sha256 = "15r1mijk306fpm61viry5wjhqyxlbqqdk4nfcd901qarx7vqypgy";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Custom Python functions for working with SQLite FTS4";
+    homepage = "https://github.com/simonw/sqlite-fts4";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ meatcar ];
+  };
+
+}

--- a/pkgs/development/python-modules/sqlite-utils/default.nix
+++ b/pkgs/development/python-modules/sqlite-utils/default.nix
@@ -1,19 +1,22 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy3k
+, pythonOlder
 , click
 , click-default-group
+, sqlite-fts4
 , tabulate
 , pytestCheckHook
 , pytestrunner
 , black
+, hypothesis
+, sqlite
 }:
 
 buildPythonPackage rec {
   pname = "sqlite-utils";
   version = "3.0";
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -23,6 +26,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     click
     click-default-group
+    sqlite-fts4
     tabulate
   ];
 
@@ -30,13 +34,19 @@ buildPythonPackage rec {
     pytestCheckHook
     pytestrunner
     black
+    hypothesis
+  ];
+
+  # disabled until upstream updates tests
+  disabledTests = lib.optionals (lib.versionAtLeast sqlite.version "3.34.0") [
+    "test_optimize"
   ];
 
   meta = with lib; {
     description = "Python CLI utility and library for manipulating SQLite databases";
     homepage = "https://github.com/simonw/sqlite-utils";
     license = licenses.asl20;
-    maintainers = [ maintainers.meatcar ];
+    maintainers = with maintainers; [ meatcar ];
   };
 
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7030,6 +7030,7 @@ in {
 
   sqlitedict = callPackage ../development/python-modules/sqlitedict { };
 
+  sqlite-fts4 = callPackage ../development/python-modules/sqlite-fts4 { };
   sqlite-utils = callPackage ../development/python-modules/sqlite-utils { };
 
   sqlmap = callPackage ../development/python-modules/sqlmap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding `sqlite-fts4` as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
