### PR TITLE
[staging] openssh: Fix 'EOF: command not found' in ssh-copy-id

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -53,6 +53,9 @@ stdenv.mkDerivation rec {
       ./dont_create_privsep_path.patch
 
       ./ssh-keysign.patch
+
+      # See https://github.com/openssh/openssh-portable/pull/206
+      ./ssh-copy-id-fix-eof.patch
     ]
     ++ optional withGssapiPatches (assert withKerberos; gssapiPatch);
 

--- a/pkgs/tools/networking/openssh/ssh-copy-id-fix-eof.patch
+++ b/pkgs/tools/networking/openssh/ssh-copy-id-fix-eof.patch
@@ -1,0 +1,21 @@
+diff --git a/contrib/ssh-copy-id b/contrib/ssh-copy-id
+index 392f64f..a769077 100644
+--- a/contrib/ssh-copy-id
++++ b/contrib/ssh-copy-id
+@@ -247,7 +247,7 @@ installkeys_sh() {
+   #    the -z `tail ...` checks for a trailing newline. The echo adds one if was missing
+   #    the cat adds the keys we're getting via STDIN
+   #    and if available restorecon is used to restore the SELinux context
+-  INSTALLKEYS_SH=$(tr '\t\n' ' ' <<-EOF)
++  INSTALLKEYS_SH=$(tr '\t\n' ' ' <<-EOF
+ 	cd;
+ 	umask 077;
+ 	mkdir -p $(dirname "${AUTH_KEY_FILE}") &&
+@@ -258,6 +258,7 @@ installkeys_sh() {
+ 	  restorecon -F .ssh ${AUTH_KEY_FILE};
+ 	fi
+ EOF
++  )
+ 
+   # to defend against quirky remote shells: use 'exec sh -c' to get POSIX;
+   printf "exec sh -c '%s'" "${INSTALLKEYS_SH}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add patch to fix  #104223. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
