### PR TITLE
cudnn_cudatoolkit_10: 10.1 -> 10.2

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -79,7 +79,7 @@ in rec {
     sha256 = "084c13vzjdkb5s1996yilybg6dgav1lscjr1xdcgvlmfrbr6f0k0";
   };
 
-  cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_1;
+  cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_2;
 
   cudnn_cudatoolkit_11_0 = generic rec {
     version = "8.0.2";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`cudatoolkit_10` is currently CUDA 10.2, whereas `cudnn_cudatoolkit_10`
was using CuDNN with CUDA 10.1. This change rectifies that
discrepancy.

Tested PyTorch with CUDA build.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
