### PR TITLE
amdvlk: 2020.Q4.4 -> 2020.Q4.5

### DIFF
--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -21,13 +21,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "amdvlk";
-  version = "2020.Q4.4";
+  version = "2020.Q4.5";
 
   src = fetchRepoProject {
     name = "${pname}-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${version}";
-    sha256 = "vlTmJlBHRZOiQFsziefh9VIomFPv8oUr9paagC+q6+8=";
+    sha256 = "1CcupEm19ZGEma0TIkGxOa0doKhlPbfXFX2S44EBNp0=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
2020.Q4.4 didn’t age well, here goes 2020.Q4.5 with RX 6800 support: https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2020.Q4.5

Closure size compared to 2020.Q4.3 (which I still have installed):
/nix/store/nbvkmav524q20z0j1gm49xkda3yzl54d-amdvlk-2020.Q4.3      103230952 (~98.4 MiB)
/nix/store/da87cbkih1r856b96x3il2mgq9kkgym7-amdvlk-2020.Q4.5      104152552 (~99.3 MiB)

i686 version
/nix/store/64xxlxvy64fm59x96s6nka1xslxidp62-amdvlk-2020.Q4.3      108721400 (~103.7 MiB)
/nix/store/ziiyvi9xvl06yxdyh3xjh02fvqq4yvyr-amdvlk-2020.Q4.5      109737208 (~104.7 MiB)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested vkcube and Dota 2
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
