### PR TITLE
pythonPackages.pyro-ppl: fix build, unmark as broken

### DIFF
--- a/pkgs/development/python-modules/pyro-api/default.nix
+++ b/pkgs/development/python-modules/pyro-api/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage, fetchPypi, lib }:
+
+buildPythonPackage rec {
+  version = "0.1.1";
+  pname = "pyro-api";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0rhd7p61pf2vvflbdixp7sygblvvl9qbqavxj27910lr79vl4fdz";
+  };
+
+  pythonImportsCheck = [ "pyroapi" ];
+
+  # tests require pyro-ppl which depends on this package
+  doCheck = false;
+
+  meta = {
+    description = "Generic API for dispatch to Pyro backends.";
+    homepage = "http://pyro.ai";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ georgewhewell ];
+  };
+}

--- a/pkgs/development/python-modules/pyro-ppl/default.nix
+++ b/pkgs/development/python-modules/pyro-ppl/default.nix
@@ -1,15 +1,17 @@
 { buildPythonPackage, fetchPypi, lib, pytorch, contextlib2
-, graphviz, networkx, six, opt-einsum, tqdm }:
+, graphviz, networkx, six, opt-einsum, tqdm, pyro-api }:
+
 buildPythonPackage rec {
-  version = "1.4.0";
+  version = "1.5.1";
   pname = "pyro-ppl";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "e863321bee141fb8d20d621aedc5925c472e06c08988447490115f54a31487ad";
+    sha256 = "00mprgf8pf9jq3kanxjldj00cg3nbfkb5yg0mdfbdi0b1rx3vnsa";
   };
 
   propagatedBuildInputs = [
+    pyro-api
     pytorch
     contextlib2
     # TODO(tom): graphviz pulls in a lot of dependencies - make
@@ -22,18 +24,19 @@ buildPythonPackage rec {
   ];
 
   # pyro not shipping tests do simple smoke test instead
-  checkPhase = ''
-    python -c "import pyro"
-    python -c "import pyro.distributions"
-    python -c "import pyro.infer"
-    python -c "import pyro.optim"
-  '';
+  pythonImportsCheck = [
+    "pyro"
+    "pyro.distributions"
+    "pyro.infer"
+    "pyro.optim"
+  ];
+
+  doCheck = false;
 
   meta = {
     description = "A Python library for probabilistic modeling and inference";
     homepage = "http://pyro.ai";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ teh ];
-    broken = true;
+    maintainers = with lib.maintainers; [ teh georgewhewell ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5450,6 +5450,8 @@ in {
 
   pyroma = callPackage ../development/python-modules/pyroma { };
 
+  pyro-api = callPackage ../development/python-modules/pyro-api { };
+
   pyro-ppl = callPackage ../development/python-modules/pyro-ppl { };
 
   pyroute2 = callPackage ../development/python-modules/pyroute2 { };


### PR DESCRIPTION
###### Motivation for this change
pythonPackages.pyro-ppl is broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
