### PR TITLE
haskellPackages.hakyll: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -140,11 +140,15 @@ self: super: {
   barbly = addBuildDepend super.barbly pkgs.darwin.apple_sdk.frameworks.AppKit;
 
   # Hakyll's tests are broken on Darwin (3 failures); and they require util-linux
-  hakyll = if pkgs.stdenv.isDarwin
-    then dontCheck (overrideCabal super.hakyll (drv: {
+  hakyll = let
+    patched-hakyll = overrideCabal super.hakyll (drv: {
+      patches = [ ./patches/hakyll.patch ];
+    });
+  in if pkgs.stdenv.isDarwin
+    then dontCheck (overrideCabal patched-hakyll (drv: {
       testToolDepends = [];
     }))
-    else super.hakyll;
+    else patched-hakyll;
 
   double-conversion = if !pkgs.stdenv.isDarwin
     then super.double-conversion

--- a/pkgs/development/haskell-modules/patches/hakyll.patch
+++ b/pkgs/development/haskell-modules/patches/hakyll.patch
@@ -1,0 +1,64 @@
+diff --git a/hakyll.cabal b/hakyll.cabal
+index c80c392..e7af07d 100644
+--- a/hakyll.cabal
++++ b/hakyll.cabal
+@@ -188,7 +188,7 @@ Library
+     resourcet            >= 1.1      && < 1.3,
+     scientific           >= 0.3.4    && < 0.4,
+     tagsoup              >= 0.13.1   && < 0.15,
+-    template-haskell     >= 2.14     && < 2.16,
++    template-haskell     >= 2.14     && < 2.17,
+     text                 >= 0.11     && < 1.3,
+     time                 >= 1.8      && < 1.10,
+     time-locale-compat   >= 0.1      && < 0.2,
+@@ -232,7 +232,7 @@ Library
+     Other-Modules:
+       Hakyll.Web.Pandoc.Binary
+     Build-Depends:
+-      pandoc          >= 2.0.5    && < 2.10,
++      pandoc          >= 2.10     && < 2.11,
+       pandoc-citeproc >= 0.14     && < 0.18
+     Cpp-options:
+       -DUSE_PANDOC
+@@ -265,7 +265,7 @@ Test-suite hakyll-tests
+ 
+   Build-Depends:
+     hakyll,
+-    QuickCheck                 >= 2.8  && < 2.14,
++    QuickCheck                 >= 2.8  && < 2.15,
+     tasty                      >= 0.11 && < 1.4,
+     tasty-hunit                >= 0.9  && < 0.11,
+     tasty-quickcheck           >= 0.8  && < 0.11,
+@@ -327,4 +327,4 @@ Executable hakyll-website
+     base      >= 4     && < 5,
+     directory >= 1.0   && < 1.4,
+     filepath  >= 1.0   && < 1.5,
+-    pandoc    >= 2.0.5 && < 2.10
++    pandoc    >= 2.10  && < 2.11
+diff --git a/lib/Hakyll/Web/Pandoc/Binary.hs b/lib/Hakyll/Web/Pandoc/Binary.hs
+index deeaf08..5d3efea 100644
+--- a/lib/Hakyll/Web/Pandoc/Binary.hs
++++ b/lib/Hakyll/Web/Pandoc/Binary.hs
+@@ -14,6 +14,10 @@ import           Text.Pandoc
+ 
+ instance Binary Alignment
+ instance Binary Block
++instance Binary Caption
++instance Binary Cell
++instance Binary ColSpan
++instance Binary ColWidth
+ instance Binary CSL.Reference
+ instance Binary Citation
+ instance Binary CitationMode
+@@ -29,5 +33,11 @@ instance Binary REF.Literal
+ instance Binary REF.RefDate
+ instance Binary REF.RefType
+ instance Binary REF.Season
++instance Binary Row
++instance Binary RowHeadColumns
++instance Binary RowSpan
+ instance Binary STY.Agent
+ instance Binary STY.Formatted
++instance Binary TableBody
++instance Binary TableFoot
++instance Binary TableHead


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Hakyll is currently broken on 20.09. I fixed it by massaging https://github.com/jaspervdj/hakyll/commit/f24c5873ed5bb091f0ce5ebdf4df7ab160e87c75 and adding it in as a patch.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
