### PR TITLE
texmacs: 1.99.14 -> 1.99.15

### DIFF
--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, callPackage, fetchurl, fetchpatch,
+{ lib, mkDerivation, callPackage, fetchFromGitHub,
   guile_1_8, qtbase, xmodmap, which, freetype,
   libjpeg,
   sqlite,
@@ -16,7 +16,7 @@
 
 let
   pname = "TeXmacs";
-  version = "1.99.14";
+  version = "1.99.15";
   common = callPackage ./common.nix {
     inherit tex extraFonts chineseFonts japaneseFonts koreanFonts;
   };
@@ -24,9 +24,11 @@ in
 mkDerivation {
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://www.texmacs.org/Download/ftp/tmftp/source/TeXmacs-${version}-src.tar.gz";
-    sha256 = "1zbl1ddhppgnn3j213jl1b9mn8zmwnknxiqswm25p4llj0mqcgna";
+  src = fetchFromGitHub {
+    owner = "texmacs";
+    repo = "texmacs";
+    rev = "v${version}";
+    sha256 = "04585hdh98fvyhj4wsxf69xal2wvfa6lg76gad8pr6ww9abi5105";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Switched to GitHub mirror, because it has the most reliable tags. (Upstream savannah repo does not tag at all, official download regularly forgets to bump version).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).