### PR TITLE
lambda-delta: init at 0.98.3

### DIFF
--- a/pkgs/misc/emulators/lambda-delta/default.nix
+++ b/pkgs/misc/emulators/lambda-delta/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkg-config, SDL2 }:
+
+stdenv.mkDerivation rec {
+  pname = "lambda-delta";
+  version = "0.98.3";
+
+  src = fetchFromGitHub {
+    owner = "dseagrav";
+    repo = "ld";
+    rev = version;
+    sha256 = "02m43fj9dzc1i1jl01qwnhjiq1rh03jw1xq59sx2h3bhn7dk941x";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ SDL2 ];
+
+  configureFlags = [ "--without-SDL1" ];
+
+  meta = with stdenv.lib; {
+    description = "LMI (Lambda Lisp Machine) emulator";
+    homepage = "https://github.com/dseagrav/ld";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22028,6 +22028,8 @@ julia_15 = callPackage ../development/compilers/julia/1.5.nix {
 
   kvirc = libsForQt514.callPackage ../applications/networking/irc/kvirc { };
 
+  lambda-delta = callPackage ../misc/emulators/lambda-delta { };
+
   lame = callPackage ../development/libraries/lame { };
 
   larswm = callPackage ../applications/window-managers/larswm { };


### PR DESCRIPTION
I don't know how to use the software, but it builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
