### PR TITLE
ocamlPackages.ca-certs: 0.1.2 → 0.1.3

### DIFF
--- a/pkgs/development/ocaml-modules/ca-certs/default.nix
+++ b/pkgs/development/ocaml-modules/ca-certs/default.nix
@@ -1,21 +1,21 @@
 { lib, buildDunePackage, fetchurl
-, bos, fpath, rresult, ptime, mirage-crypto, x509
+, bos, fpath, rresult, ptime, mirage-crypto, x509, astring, logs
 }:
 
 buildDunePackage rec {
   pname = "ca-certs";
-  version = "0.1.2";
+  version = "0.1.3";
 
   minimumOCamlVersion = "4.07";
 
   src = fetchurl {
     url = "https://github.com/mirage/ca-certs/releases/download/v${version}/ca-certs-v${version}.tbz";
-    sha256 = "10bbqbrsqcmslz56zc5407knalh3kqypbm7lblnzzbidbapa9wpz";
+    sha256 = "0jpghxjp2n8wx6ig0d2x87ycaql6mb92w8ai3xh3jb288m7g02zn";
   };
 
   useDune2 = true;
 
-  propagatedBuildInputs = [ bos fpath rresult ptime mirage-crypto x509 ];
+  propagatedBuildInputs = [ bos fpath rresult ptime mirage-crypto x509 astring logs ];
 
   # tests need access to network and systemwide ca cert chain
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bugfix release: <https://github.com/mirage/ca-certs/releases/tag/v0.1.3>

Seems like I had bad timing with the initial PR…

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
