### PR TITLE
fetchCargoTarball: support vendoring extra manifests

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -170,6 +170,24 @@ rustPlatform.buildRustPackage rec {
 }
 ```
 
+### Vendoring dependencies for nested crates that aren't referenced in a workspace
+The following example shows how to pass a list of additional manifest paths for vendoring.
+This list translates to several `--sync=$path` arguments passed to `cargo-vendor`.
+
+```nix
+{ rustPlatform, ... }:
+
+rustPlatform.buildRustPackage  {
+    (...)
+
+    depsExtraArgs = {
+      cargoExtraManifests = [ "path/to/nested/Cargo.toml" ];
+    };
+
+    (...)
+}
+```
+
 ## Compiling Rust crates using Nix instead of Cargo
 
 ### Simple operation

--- a/pkgs/build-support/rust/fetchCargoTarball.nix
+++ b/pkgs/build-support/rust/fetchCargoTarball.nix
@@ -24,8 +24,12 @@ in
 , sourceRoot
 , sha256
 , cargoUpdateHook ? ""
+, cargoExtraManifests ? []
 , ...
 } @ args:
+let
+  cargoSyncArgs = builtins.concatStringsSep " " (builtins.map (manifest: "--sync=" + manifest) cargoExtraManifests);
+in
 stdenv.mkDerivation ({
   name = "${name}-vendor.tar.gz";
   nativeBuildInputs = [ cacert git cargo-vendor-normalise cargo ];
@@ -55,7 +59,7 @@ stdenv.mkDerivation ({
 
     ${cargoUpdateHook}
 
-    cargo vendor $name | cargo-vendor-normalise > $CARGO_CONFIG
+    cargo vendor ${cargoSyncArgs} $name | cargo-vendor-normalise > $CARGO_CONFIG
 
     # Add the Cargo.lock to allow hash invalidation
     cp Cargo.lock.orig $name/Cargo.lock


### PR DESCRIPTION
###### Motivation for this change
This is helpful in a situation where not all crates in the given
repository are listed in the toplevel Cargo.toml but are required during
the build-process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
