### PR TITLE
nixUnstable: pre20201102_550e11f -> pre20201118_79aa7d9

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -199,13 +199,13 @@ in rec {
 
   nixUnstable = lib.lowPrio (callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20201102_550e11f";
+    suffix = "pre20201118_79aa7d9";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "550e11f077ae508abde5a33998a9d4029880e7b2";
-      sha256 = "186grfxsfqg7r92wgwbma66xc7p3iywn43ff7s59m4g6bvb0qgcl";
+      rev = "79aa7d95183cbe6c0d786965f0dbff414fd1aa67";
+      sha256 = "0aa0xggrczylwp3da3q9m4ad9j6gzi7wpa3ph4i8a1ng36kl91c7";
     };
 
     inherit storeDir stateDir confDir boehmgc;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update `nixUnstable` to a version that doesn't crash as much.

Replaces, closes #102932. To quote it:
Fix a memory corruption and deadlock caused by new constant-memory source filtering implementation (+ fix implementation error)
Fix nix-copy-closure with drvs
Fix a varargs error in an error message (also a crash?)

Since then, more fixes have landed. Hopefully not much has broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
