### PR TITLE
awscli: 1.18.150 -> 1.18.181

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname =  "boto3";
-  version = "1.15.18"; # N.B: if you change this, change botocore too
+  version = "1.16.21"; # N.B: if you change this, change botocore too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f56148e2c6b9a2d704218da42f07d72f00270bfddb13bc1bdea20d3327daa51e";
+    sha256 = "04qb86i7z6m9h3kpyxp343p0m0x45biw7hbvx270ls8iim0n703s";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.18.18"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.19.21"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e224754230e7e015836ba20037cac6321e8e2ce9b8627c14d579fcb37249decd";
+    sha256 = "18785n40mz97qqn51dm12z4za49bywv33hliwxvfqw92rasmy1lg";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyspark/default.nix
+++ b/pkgs/development/python-modules/pyspark/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sed -i "s/'pypandoc'//" setup.py
 
     # Current release works fine with py4j 0.10.8.1
-    substituteInPlace setup.py --replace py4j==0.10.7 'py4j>=0.10.7,<0.11'
+    substituteInPlace setup.py --replace py4j==0.10.9 'py4j>=0.10.7,<0.11'
   '';
 
   propagatedBuildInputs = [ py4j ];

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -19,15 +19,16 @@ let
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.18.150"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.18.181"; # N.B: if you change this, change botocore to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0jrxzr4dx2s6ychmrz19yz8i4kqcwj7f8ly82ydwvrr0ff62374g";
+    sha256 = "0l1zkhzq76bxm5b2m41arpppalq0w4m5fwqaidfq451jz9f32f62";
   };
 
   postPatch = ''
     substituteInPlace setup.py --replace "docutils>=0.10,<0.16" "docutils>=0.10"
+    substituteInPlace setup.py --replace "colorama>=0.2.5,<0.4.4" "colorama>=0.2.5"
   '';
 
   # No tests included


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, awscli & botocore & boto3 have incompatible versions, so they won't build. This syncs and updates the versions.

Also, pyspark is fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
