### PR TITLE
vulkan-extension-layer: init at 2020-08-25

### DIFF
--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, cmake, writeText, vulkan-headers, jq }:
+
+stdenv.mkDerivation rec {
+  pname = "vulkan-extension-layer";
+  version = "2020-08-25";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "Vulkan-ExtensionLayer";
+    rev = "352f8e3e269ff2c650da50ce36313547c2a1fbb6";
+    sha256 = "1503z1zj1xvjpry2h7fpg1frx7lcm54zs3azcgiv5i3ar4wqfkz9";
+  };
+
+  nativeBuildInputs = [ cmake jq ];
+
+  buildInputs = [ vulkan-headers ];
+
+  # Help vulkan-loader find the validation layers
+  setupHook = writeText "setup-hook" ''
+    export XDG_DATA_DIRS=@out@/share:$XDG_DATA_DIRS
+  '';
+
+  # Include absolute paths to layer libraries in their associated
+  # layer definition json files.
+  preFixup = ''
+    for f in "$out"/share/vulkan/explicit_layer.d/*.json "$out"/share/vulkan/implicit_layer.d/*.json; do
+      jq <"$f" >tmp.json ".layer.library_path = \"$out/lib/\" + .layer.library_path"
+      mv tmp.json "$f"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Layers providing Vulkan features when native support is unavailable";
+    homepage = "https://github.com/KhronosGroup/Vulkan-ExtensionLayer/";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16160,6 +16160,7 @@ in
                                           CoreText IOSurface ImageIO OpenGL GLUT;
   };
 
+  vulkan-extension-layer = callPackage ../tools/graphics/vulkan-extension-layer { };
   vulkan-headers = callPackage ../development/libraries/vulkan-headers { };
   vulkan-loader = callPackage ../development/libraries/vulkan-loader { };
   vulkan-tools = callPackage ../tools/graphics/vulkan-tools { };


### PR DESCRIPTION
There are no tags or releases on the repo, so just use the date as version.

Khronos strikes again with weird naming here.

I've tested this and it works well apart from a couple of
(non-nix-specific) issues which have been reported upstream, so expect a
version bump when these are fixed :D

- https://github.com/KhronosGroup/Vulkan-ExtensionLayer/pull/38
- https://github.com/KhronosGroup/Vulkan-ExtensionLayer/issues/39

CC @Ralith @doronbehar

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).