### PR TITLE
python3Packages.breezy: remove dulwich optional dependency

### DIFF
--- a/pkgs/development/python-modules/breezy/default.nix
+++ b/pkgs/development/python-modules/breezy/default.nix
@@ -4,7 +4,6 @@
 , configobj
 , six
 , fastimport
-, dulwich
 , launchpadlib
 , testtools
 }:
@@ -18,9 +17,14 @@ buildPythonPackage rec {
     sha256 = "50f16bc7faf299f98fe58573da55b0664078f94b1a0e7f0ce9e1e6a0d47e68e0";
   };
 
-  propagatedBuildInputs = [ configobj six fastimport dulwich launchpadlib ];
+  propagatedBuildInputs = [ configobj six fastimport launchpadlib ];
 
   checkInputs = [ testtools ];
+
+  # breezy works without dulwich, and it's failing to build
+  patches = [
+    ./remove-dulwich.patch
+  ];
 
   # There is a conflict with their `lazy_import` and plugin tests
   doCheck = false;

--- a/pkgs/development/python-modules/breezy/remove-dulwich.patch
+++ b/pkgs/development/python-modules/breezy/remove-dulwich.patch
@@ -1,0 +1,21 @@
+diff --git a/setup.py b/setup.py
+index 2662fc7..5909207 100755
+--- a/setup.py
++++ b/setup.py
+@@ -68,7 +68,6 @@ META_INFO = {
+         # Technically, Breezy works without these two dependencies too. But there's
+         # no way to enable them by default and let users opt out.
+         'fastimport>=0.9.8',
+-        'dulwich>=0.19.11',
+         ],
+     'extras_require': {
+         'fastimport': [],
+@@ -481,7 +480,7 @@ def get_svn_py2exe_info(includes, excludes, packages):
+ 
+ 
+ def get_git_py2exe_info(includes, excludes, packages):
+-    packages.append('dulwich')
++    return
+ 
+ 
+ def get_fastimport_py2exe_info(includes, excludes, packages):


### PR DESCRIPTION
###### Motivation for this change
related: https://github.com/NixOS/nixpkgs/issues/104275

they mention:
>         # Technically, Breezy works without these two dependencies too. But there's
>         # no way to enable them by default and let users opt out.

So, I just removed it for them since dulwich likes to fall on the segfault sword.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
