### PR TITLE
Update btcpayserver, nbxplorer

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/deps.nix
+++ b/pkgs/applications/blockchains/btcpayserver/deps.nix
@@ -21,8 +21,8 @@
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.All";
-    version = "1.2.3";
-    sha256 = "1vx47rb505904pz30n5jzc9x42pcfln695l31q4dv5p4fbf10g4q";
+    version = "1.2.4";
+    sha256 = "1f4wgs8ijk1wmppz5lmas7l6m83szz57jyk6ak0dxhccdld9rdaj";
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.Charge";
@@ -31,8 +31,8 @@
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.CLightning";
-    version = "1.2.0";
-    sha256 = "0a47fz20ngcz90h2y01isi2h940jljcmnfy6wyknj029sii7i1zs";
+    version = "1.2.1";
+    sha256 = "14km69jzmnyqg19w27g6znml4z0xkm8l4j7rj0x36bw67cjmgahv";
   })
   (fetchNuGet {
     name = "BTCPayServer.Lightning.Common";
@@ -706,8 +706,8 @@
   })
   (fetchNuGet {
     name = "NBitcoin.Altcoins";
-    version = "2.0.16";
-    sha256 = "0fsdb96k5lwyq4d7h7yg91qghima08yk0bsw5cvr4h2jsfphk423";
+    version = "2.0.21";
+    sha256 = "0xmygiwjlia7fbxy63893jb15g6fxggxxr9bbm8znd9bs3jzp2g1";
   })
   (fetchNuGet {
     name = "NBitcoin";
@@ -726,13 +726,8 @@
   })
   (fetchNuGet {
     name = "NBitcoin";
-    version = "5.0.45";
-    sha256 = "102vwxwkg367yxv26hycnc7hjxlv2zvsgr8g6adw8dmzsxck5fwk";
-  })
-  (fetchNuGet {
-    name = "NBitcoin";
-    version = "5.0.51";
-    sha256 = "0rg014sl7rqscnranwyfk41xfr5ccjqyx7aidfl5mh0znz44db2g";
+    version = "5.0.60";
+    sha256 = "0pin4ldfz5lfxyd47mj1ypyp8lmj0v5nq5zvygdjna956vphd39v";
   })
   (fetchNuGet {
     name = "NBitpayClient";
@@ -741,8 +736,8 @@
   })
   (fetchNuGet {
     name = "NBXplorer.Client";
-    version = "3.0.17";
-    sha256 = "0xx2xshgpci9l9883zpqnmgchpizygy0hcq2wp2ch6yf3hbrj9qq";
+    version = "3.0.19";
+    sha256 = "0nahfxdsryf5snjy87770m51v2jcry02lmb10ilsg4h2ig4pjdk4";
   })
   (fetchNuGet {
     name = "NETStandard.Library";
@@ -956,8 +951,8 @@
   })
   (fetchNuGet {
     name = "Selenium.WebDriver.ChromeDriver";
-    version = "83.0.4103.3900";
-    sha256 = "17j9b637209nm5cs5sgr3vflphkhaxpm8bcjizhgj65r52gn17as";
+    version = "85.0.4183.8700";
+    sha256 = "0klyqmwa6yc0ibbmci51mzb2vl6n13qlk06chc9w78i0a43fs382";
   })
   (fetchNuGet {
     name = "Selenium.WebDriver";

--- a/pkgs/applications/blockchains/nbxplorer/default.nix
+++ b/pkgs/applications/blockchains/nbxplorer/default.nix
@@ -15,13 +15,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "nbxplorer";
-  version = "2.1.42";
+  version = "2.1.46";
 
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
     rev = "v${version}";
-    sha256 = "01q6n7095rrha00xs3l7igzfb9rd743z8crxa2dcz4q5srapfzpi";
+    sha256 = "1aph7yiwmch7s7x1qkzqv1shs3v6kg8i2s7266la0yp9ksf3w35p";
   };
 
   nativeBuildInputs = [ dotnetSdk dotnetPackages.Nuget makeWrapper ];

--- a/pkgs/applications/blockchains/nbxplorer/deps.nix
+++ b/pkgs/applications/blockchains/nbxplorer/deps.nix
@@ -31,8 +31,8 @@
   })
   (fetchNuGet {
     name = "Microsoft.CodeCoverage";
-    version = "16.6.1";
-    sha256 = "01ffm4nflqdb93vq4xl0j3377x360fgx6c6h12mpkcy85ixbv3rl";
+    version = "16.7.1";
+    sha256 = "1farw63445cdyciplfs6l9j1gayxw16rkzmrwsiswfyjhqz70xd4";
   })
   (fetchNuGet {
     name = "Microsoft.CSharp";
@@ -126,8 +126,8 @@
   })
   (fetchNuGet {
     name = "Microsoft.NET.Test.Sdk";
-    version = "16.6.1";
-    sha256 = "0jjdg468jc6pv2z764f3xc19lcr772nzjm9cjfqq3bqw8vkpzmhv";
+    version = "16.7.1";
+    sha256 = "0yqxipj74ax2n76w9ccydppx78ym8m5fda88qnvj4670qjvl0kf8";
   })
   (fetchNuGet {
     name = "Microsoft.NETCore.Platforms";
@@ -156,13 +156,13 @@
   })
   (fetchNuGet {
     name = "Microsoft.TestPlatform.ObjectModel";
-    version = "16.6.1";
-    sha256 = "0q98q1nw6jl4bajm66z4a9vvh928w8ffsd3k6fpsps23ykpsky7h";
+    version = "16.7.1";
+    sha256 = "0s9dyh99gzdpk1i5v468i2r9m6i3jrr41r394pwdwiajsz99kay0";
   })
   (fetchNuGet {
     name = "Microsoft.TestPlatform.TestHost";
-    version = "16.6.1";
-    sha256 = "0anzvb2mda548swb2ll1hv65knb8gwjm01hwbl0pzzr607my3lix";
+    version = "16.7.1";
+    sha256 = "1xik06rxn9ps83in0zn9vcl2ibv3acmdqvrx07qq89lxj1sgqlhs";
   })
   (fetchNuGet {
     name = "Microsoft.Win32.Primitives";
@@ -181,18 +181,23 @@
   })
   (fetchNuGet {
     name = "NBitcoin.Altcoins";
-    version = "2.0.19";
-    sha256 = "12a3bf1pi6sq78z6h3clyczvycx7cjry8fby4fyi748wjwljjizz";
+    version = "2.0.21";
+    sha256 = "0xmygiwjlia7fbxy63893jb15g6fxggxxr9bbm8znd9bs3jzp2g1";
   })
   (fetchNuGet {
     name = "NBitcoin.TestFramework";
-    version = "2.0.11";
-    sha256 = "09jrbq9p5k67kdic2038s7q299y2nc8ij6m55m3m8hys7jdrrv05";
+    version = "2.0.12";
+    sha256 = "1d6lmymc9x3p74c8hc2x3m61ncnkqqgrddw9cw2m0zkvilkncsns";
   })
   (fetchNuGet {
     name = "NBitcoin";
-    version = "5.0.54";
-    sha256 = "0mx2gr8j8bc4mf1vi1fvqj3672qalxvzvincc61if79p46cik24b";
+    version = "5.0.58";
+    sha256 = "0qim9xbbj380254iyi1jsh2gnr90ddwd2593jw9a8bjwnlk7qr2c";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.60";
+    sha256 = "0pin4ldfz5lfxyd47mj1ypyp8lmj0v5nq5zvygdjna956vphd39v";
   })
   (fetchNuGet {
     name = "NETStandard.Library";
@@ -1061,8 +1066,8 @@
   })
   (fetchNuGet {
     name = "xunit.runner.visualstudio";
-    version = "2.4.2";
-    sha256 = "0fi85h43nyrhfc5jzg07znh01r7cpb7bpjdc6mzb9z1pm14ppfm6";
+    version = "2.4.3";
+    sha256 = "0j1d0rbcm7pp6dypi61sjxp8l22sv261252z55b243l39jgv2rp3";
   })
   (fetchNuGet {
     name = "xunit";


### PR DESCRIPTION
The `btcpayserver` pkg is now built in the same way as the `nbxplorer` pkg:
Use `dotnet publish` instead of `dotnet build` and wrap the executable.

Both packages pass [nix-bitcoin](https://github.com/fort-nix/nix-bitcoin)'s NixOS VM test suite.

To run the test, use the following script.
It leaves no traces (outside of `/nix/store`) on the host system.

```bash
#!/usr/bin/env bash

mkdir -p /tmp/btcpayserver-test/{nixpkgs,nix-bitcoin}
trap "rm -rf /tmp/btcpayserver-test" EXIT
cd /tmp/btcpayserver-test

fetchRepo() { curl -SL https://github.com/$1.tar.gz | tar xz --strip-components=1 -C $2; }
# this PR
fetchRepo erikarvstedt/nixpkgs/archive/ae1716cb7e731f3bf5fb677d1709b9cdbca1d480 nixpkgs
# master as of 2020-11-19
fetchRepo fort-nix/nix-bitcoin/archive/7e81071d0bb2a4cc814660dd4926359c55bdff1a nix-bitcoin

cat > scenarios.nix <<EOF
{ testEnv, ... }:
let
  pkgs = import $(pwd)/nixpkgs {};
in rec {
  btcpayserverUpdate = {
    services.btcpayserver.enable = true;
    services.nbxplorer.package = pkgs.nbxplorer;
    services.btcpayserver.package = pkgs.btcpayserver;
  };
  btcpayserverUpdateRegtest.imports = [
    btcpayserverUpdate
    testEnv.scenarios.regtestBase
  ];
}
EOF
scenarioOverridesFile=$(realpath scenarios.nix) nix-bitcoin/test/run-tests.sh -s btcpayserverUpdate
scenarioOverridesFile=$(realpath scenarios.nix) nix-bitcoin/test/run-tests.sh -s btcpayserverUpdateRegtest
```