### PR TITLE
m/x32edit: 3.2 -> 4.1

### DIFF
--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, lib, libX11, libXext, alsaLib, freetype, brand, type, version, homepage, sha256, ... }:
+{ stdenv, fetchurl, lib, libX11, libXext, alsaLib, freetype, brand, type, version, homepage, url, sha256, ... }:
 stdenv.mkDerivation rec {
   inherit type;
   baseName = "${type}-Edit";
   name = "${lib.toLower baseName}-${version}";
 
   src = fetchurl {
-    url = "http://downloads.music-group.com/software/behringer/${type}/${type}-Edit_LINUX_64bit_${version}.tar.gz";
+    inherit url;
     inherit sha256;
   };
 

--- a/pkgs/applications/audio/midas/m32edit.nix
+++ b/pkgs/applications/audio/midas/m32edit.nix
@@ -1,9 +1,10 @@
 { callPackage, ... } @ args:
 
-callPackage ./generic.nix (args // {
+callPackage ./generic.nix (args // rec {
   brand = "Midas";
   type = "M32";
-  version = "3.2";
-  sha256 = "1cds6qinz37086l6pmmgrzrxadygjr2z96sjjyznnai2wz4z2nrd";
-  homepage = "http://www.musictri.be/Categories/Midas/Mixers/Digital/M32/p/P0B3I/downloads";
+  version = "4.1";
+  url = "https://mediadl.musictribe.com/download/software/midas_${type}/${type}-Edit_LINUX_64-Bit_${version}.tar.gz";
+  sha256 = "0aqhdrxqa49liyvbbw5x32kwk0h1spzvmizmdxklrfs64vvr9bvh";
+  homepage = "https://midasconsoles.com/midas/product?modelCode=P0B3I";
 })

--- a/pkgs/applications/audio/midas/x32edit.nix
+++ b/pkgs/applications/audio/midas/x32edit.nix
@@ -1,9 +1,10 @@
 { callPackage, ... } @ args:
 
-callPackage ./generic.nix (args // {
+callPackage ./generic.nix (args // rec {
   brand = "Behringer";
   type = "X32";
-  version = "3.2";
-  sha256 = "1lzmhd0sqnlzc0khpwm82sfi48qhv7rg153a57qjih7hhhy41mzk";
-  homepage = "http://www.musictri.be/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/downloads";
+  version = "4.1";
+  url = "https://mediadl.musictribe.com/download/software/behringer/${type}/${type}-Edit_LINUX_64-Bit_${version}.tar.gz";
+  sha256 = "0zsw7qfmcci87skkpq8vx5zxk35phn8y4byispvki9ascifnnb33";
+  homepage = "https://www.behringer.com/behringer/product?modelCode=P0ASF";
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Partially fixes https://github.com/NixOS/nixpkgs/issues/104048

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
