### PR TITLE
thinkfan: 1.1 -> 1.2.1

### DIFF
--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "thinkfan";
-  version = "1.1";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "vmatare";
     repo = "thinkfan";
     rev = version;
-    sha256 = "1fxd1w3z65glw6y04myn7ihgswkx6sqnkky159mik4n96pfrsvr5";
+    sha256 = "18vgm5w5pjnpipa34j4x87q10695w2jnqwvc2f027afy7mnzw7kz";
   };
 
   cmakeFlags = [
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     install -Dm755 {.,$out/bin}/thinkfan
 
     cd "$NIX_BUILD_TOP"; cd "$sourceRoot" # attempt to be a bit robust
-    install -Dm644 {.,$out/share/doc/thinkfan}/README
+    install -Dm644 {.,$out/share/doc/thinkfan}/README.md
     cp -R examples $out/share/doc/thinkfan
     install -Dm644 {src,$out/share/man/man1}/thinkfan.1
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
