### PR TITLE
Revert "python3Packages.greenlet: 0.4.16 -> 0.4.17"

### DIFF
--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "greenlet";
-  version = "0.4.17";
+  version = "0.4.16";
   disabled = isPyPy;  # builtin for pypy
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "41d8835c69a78de718e466dd0e6bfd4b46125f21a67c3ff6d76d8d8059868d6b";
+    sha256 = "6e06eac722676797e8fce4adb8ad3dc57a1bb3adfb0dd3fdf8306c055a38456c";
   };
 
   propagatedBuildInputs = [ six ];


### PR DESCRIPTION
###### Motivation for this change
This reverts commit 4bfbcbeb383e442bb9b60d82fc401340bc38536a.

0.4.17 can cause segfaults, and some packages such as `dulwich`
will fail during tests

made an upstream issue here: https://github.com/python-greenlet/greenlet/issues/217

closes: #104275

did `git bisect` to locate this offending commit:
```
4bfbcbeb383e442bb9b60d82fc401340bc38536a is the first bad commit
commit 4bfbcbeb383e442bb9b60d82fc401340bc38536a
Author: Frederik Rietdijk <fridh@fridh.nl>
Date:   Sun Oct 25 10:06:52 2020 +0100

    python3Packages.greenlet: 0.4.16 -> 0.4.17

 pkgs/development/python-modules/greenlet/default.nix | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
bisect run success
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
