### PR TITLE
gdk-pixbuf: 2.40.0 → 2.42.0

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -20,31 +20,23 @@
 , gobject-introspection
 , doCheck ? false
 , makeWrapper
-, fetchpatch
 , lib
 }:
 
 stdenv.mkDerivation rec {
   pname = "gdk-pixbuf";
-  version = "2.40.0";
+  version = "2.42.0";
 
   outputs = [ "out" "dev" "man" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1rnlx9yfw970maxi2x6niaxmih5la11q1ilr7gzshz2kk585k0hm";
+    sha256 = "1ixfmmamgv67is7snzighfr7c9y2maq3q4a075xdq0d9s4w16i3k";
   };
 
   patches = [
     # Move installed tests to a separate output
     ./installed-tests-path.patch
-
-    # Temporary until the fix is released.
-    (fetchpatch {
-      name = "tests-circular-table.patch";
-      url = "https://gitlab.gnome.org/GNOME/gdk-pixbuf/merge_requests/59.diff";
-      sha256 = "0kaflac3mrh6031hwxk7j9fhli775hc503818h8zfl6b28zyn93f";
-    })
   ];
 
   nativeBuildInputs = [
@@ -71,9 +63,8 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Ddocs=true"
-    "-Dx11=false" # use gdk-pixbuf-xlib
-    "-Dgir=${lib.boolToString (gobject-introspection != null)}"
+    "-Dgtk_doc=true"
+    "-Dintrospection=${if gobject-introspection != null then "enabled" else "disabled"}"
     "-Dgio_sniffing=false"
   ];
 
@@ -135,7 +126,7 @@ stdenv.mkDerivation rec {
     description = "A library for image loading and manipulation";
     homepage = "https://gitlab.gnome.org/GNOME/gdk-pixbuf";
     maintainers = [ maintainers.eelco ] ++ teams.gnome.members;
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://ftp.gnome.org/pub/GNOME/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.0.news

xlib has been dropped, some build flags [changed](https://mail.gnome.org/archives/distributor-list/2020-November/msg00000.html)
Also corrected license.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
     - the world depends on gdk-pixbuf so installed tests cannot be run without rebuilding it
- [x] ran with doCheck = true and it succeeded basically immediately, maybe we could enable it by default
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
