### PR TITLE
python3Packages.gevent: 20.5.2 -> 20.9.0

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -42,5 +42,6 @@ buildPythonPackage rec {
     description = "A Python client driver for Apache Cassandra";
     homepage = "http://datastax.github.io/python-driver";
     license = licenses.asl20;
+    broken = true; # geomet doesn't exist
   };
 }

--- a/pkgs/development/python-modules/gevent/default.nix
+++ b/pkgs/development/python-modules/gevent/default.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "gevent";
-  version = "20.5.2";
+  version = "20.9.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2756de36f56b33c46f6cc7146a74ba65afcd1471922c95b6771ce87b279d689c";
+    sha256 = "13aw9x6imsy3b369kfjblqiwfni69pp32m4r13n62r9k3l2lhvaz";
   };
 
   buildInputs = [ libev ];

--- a/pkgs/development/python-modules/gipc/default.nix
+++ b/pkgs/development/python-modules/gipc/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
     '';
     homepage = "http://gehrcke.de/gipc";
     license = licenses.mit;
+    # gipc only has support for older versions of gevent
+    broken = versionOlder "1.6" gevent.version;
   };
 
 }

--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "greenlet";
-  version = "0.4.16";
+  version = "0.4.17";
   disabled = isPyPy;  # builtin for pypy
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6e06eac722676797e8fce4adb8ad3dc57a1bb3adfb0dd3fdf8306c055a38456c";
+    sha256 = "0swdhrcq13bdszv3yz5645gi4ijbzmmhxpb6whcfg3d7d5f87n21";
   };
 
   propagatedBuildInputs = [ six ];


### PR DESCRIPTION
###### Motivation for this change
I guess there was an abi change, which his why  #104275 occured with the latest `python3Packages.greenlet` sometimes segfaulted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

failures are broken on master
```
ttps://github.com/NixOS/nixpkgs/pull/104338
13 packages marked as broken and skipped:
python27Packages.cassandra-driver python27Packages.gipc python27Packages.sipsimple python27Packages.zake python37Packages.cassandra-driver python37Packages.gipc python37Packages.qasm2image python37Packages.zake python38Packages.cassandra-driver python38Packages.gipc python38Packages.qasm2image python38Packages.zake rabbitvcs

8 packages failed to build:
graalvm8 jvmci8 python27Packages.locustio python37Packages.locustio python37Packages.pyalgotrade python37Packages.ws4py python38Packages.pyalgotrade python38Packages.ws4py

150 packages built:
appdaemon azure-cli breezy buku cabal2nix dep2nix devpi-client eolie errbot flatpak-builder gdbgui gitAndTools.git-fast-export gnvim http-prompt httpie hydra-unstable klaus klipper lexicon mercurial_4 mx neovim neovim-qt neovim-remote nix-prefetch-bzr nix-prefetch-scripts nix-update-source nvchecker papis patroni python27Packages.aioeventlet python27Packages.dulwich python27Packages.eventlet python27Packages.eventlib python27Packages.flask-sockets python27Packages.gevent python27Packages.gevent-socketio python27Packages.gevent-websocket python27Packages.geventhttpclient python27Packages.greenlet python27Packages.grequests python27Packages.hg-git python27Packages.kazoo python27Packages.meinheld python27Packages.msrplib python27Packages.mwlib python27Packages.mwlib-rl python27Packages.opentracing python27Packages.pyfxa python27Packages.pynvim python27Packages.pytest-twisted python27Packages.ruffus python27Packages.xcaplib python27Packages.zerorpc python37Packages.bpython python37Packages.breezy python37Packages.check-manifest python37Packages.debugpy python37Packages.duecredit python37Packages.dulwich python37Packages.eventlet python37Packages.flask-common python37Packages.flask-socketio python37Packages.flask-sockets python37Packages.gevent python37Packages.gevent-socketio python37Packages.gevent-websocket python37Packages.geventhttpclient python37Packages.graphql-core python37Packages.graphql-server-core python37Packages.greenlet python37Packages.grequests python37Packages.habanero python37Packages.httpbin python37Packages.kazoo python37Packages.klaus python37Packages.knack python37Packages.meinheld python37Packages.nvchecker python37Packages.opentracing python37Packages.papis python37Packages.promise python37Packages.pyfxa python37Packages.pynvim python37Packages.pytest-httpbin python37Packages.pytest-twisted python37Packages.python-engineio python37Packages.python-socketio python37Packages.qiskit python37Packages.qiskit-ibmq-provider python37Packages.ruffus python37Packages.runway-python python37Packages.scrapy python37Packages.scrapy-deltafetch python37Packages.scrapy-fake-useragent python37Packages.scrapy-splash python37Packages.vcrpy python37Packages.yappi python37Packages.zerorpc python38Packages.bpython python38Packages.check-manifest python38Packages.debugpy python38Packages.duecredit python38Packages.dulwich python38Packages.eventlet python38Packages.flask-common python38Packages.flask-socketio python38Packages.flask-sockets python38Packages.gevent python38Packages.gevent-socketio python38Packages.gevent-websocket python38Packages.geventhttpclient python38Packages.graphql-core python38Packages.graphql-server-core python38Packages.greenlet python38Packages.grequests python38Packages.habanero python38Packages.httpbin python38Packages.kazoo python38Packages.knack python38Packages.meinheld python38Packages.opentracing python38Packages.promise python38Packages.pyfxa python38Packages.pynvim python38Packages.pytest-httpbin python38Packages.pytest-twisted python38Packages.python-engineio python38Packages.python-socketio python38Packages.qiskit python38Packages.qiskit-ibmq-provider python38Packages.ruffus python38Packages.runway-python python38Packages.scrapy python38Packages.scrapy-deltafetch python38Packages.scrapy-fake-useragent python38Packages.scrapy-splash python38Packages.vcrpy python38Packages.yappi python38Packages.zerorpc reno searx termpdfpy theharvester vcstool vimPlugins.sved wal_e xandikos zeronet zk-shell
```