### PR TITLE
Why is pam_unix required, even if unixAuth = false

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -372,7 +372,8 @@ let
       text = mkDefault
         (''
           # Account management.
-          account required pam_unix.so
+          ${optionalString unixAuth
+            "account required pam_unix.so"}
           ${optionalString use_ldap
               "account sufficient ${pam_ldap}/lib/security/pam_ldap.so"}
           ${optionalString (config.services.sssd.enable && cfg.sssdStrictAccess==false)
@@ -424,7 +425,8 @@ let
             || cfg.googleAuthenticator.enable
             || cfg.gnupg.enable
             || cfg.duoSecurity.enable)) ''
-              auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} ${optionalString cfg.nodelay "nodelay"} likeauth
+              ${optionalString unixAuth
+                  "auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} ${optionalString cfg.nodelay "nodelay"} likeauth"}
               ${optionalString config.security.pam.enableEcryptfs
                 "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}
               ${optionalString cfg.pamMount
@@ -477,7 +479,8 @@ let
           ${optionalString cfg.setEnvironment ''
             session required pam_env.so conffile=${config.system.build.pamEnvironment} readenv=0
           ''}
-          session required pam_unix.so
+          ${optionalString unixAuth 
+            "session required pam_unix.so"}
           ${optionalString cfg.setLoginUid
               "session ${
                 if config.boot.isContainer then "optional" else "required"


### PR DESCRIPTION
This is more of a proposal/question than an actual pull request. Not sure how to actually test it!

###### Motivation for this change
I was unable to set security.pam.services.sshd.unixAuth to false, and was having issues with SDDM/SSSD previously #94744 then I noticed no matter what, pam_unix.so was marked as required. Even if unixAuth = false.

###### Things done
Wrapped all * required pam_unix.so in optionalString's based on other lines I saw in this file. Not sure if that would fix my problem or not, hoping someone who knows more about NixOS could weigh in. I'd also like to note that SSSD worked with SSH/Console log in out of the box when I opened #94744 and are now both borked for some reason.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
