### PR TITLE
ocamlPackages.ocaml-protoc: 1.2.0 → 2.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
@@ -1,35 +1,27 @@
-{ stdenv, ocaml, fetchFromGitHub, ocamlbuild, findlib, ppx_deriving_protobuf }:
+{ lib, fetchFromGitHub, buildDunePackage
+, stdlib-shims
+}:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ocaml-protoc-${version}";
-  version = "1.2.0";
+buildDunePackage rec {
+  pname = "ocaml-protoc";
+  version = "2.0.2";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "mransan";
     repo = "ocaml-protoc";
-    rev = "60d2d4dd55f73830e1bed603cc44d3420430632c";
-    sha256 = "1d1p8ch723z2qa9azmmnhbcpwxbpzk3imh1cgkjjq4p5jwzj8amj";
+    rev = version;
+    sha256 = "1vlnjqqpypmjhlyrxfzla79y4ilmc9ggz311giy6vmh4cyzl29h3";
   };
 
-  installPhase = ''
-    mkdir -p tmp/bin
-    export PREFIX=`pwd`/tmp
-    make all.install.build
-    make check_install
-    make lib.install
-    make bin.install
-  '';
-
-  buildInputs = [ ocaml findlib ocamlbuild ];
-  propagatedBuildInputs = [ ppx_deriving_protobuf ];
-
-  createFindlibDestdir = true;
+  buildInputs = [ stdlib-shims ];
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/mransan/ocaml-protoc";
     description = "A Protobuf Compiler for OCaml";
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, cppo, ppx_tools, ppx_deriving
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, cppo, ppx_tools, ppx_deriving
 , ppxfind }:
+
+if lib.versionAtLeast ocaml.version "4.11"
+then throw "ppx_deriving_protobuf is not available for OCaml ${ocaml.version}"
+else
 
 buildDunePackage rec {
   pname = "ppx_deriving_protobuf";
@@ -14,7 +18,7 @@ buildDunePackage rec {
 
   buildInputs = [ cppo ppx_tools ppxfind ppx_deriving ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/ocaml-ppx/ppx_deriving_protobuf";
     description = "A Protocol Buffers codec generator for OCaml";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.11

cc maintainer @vyorkin 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
