### PR TITLE
unit: 1.20.0 -> 1.21.0

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub, nixosTests, which
+, pcre2
 , withPython2 ? false, python2
 , withPython3 ? true, python3, ncurses
 , withPHP73 ? false, php73
@@ -30,19 +31,19 @@ let
   php74-unit = php74.override phpConfig;
 
 in stdenv.mkDerivation rec {
-  version = "1.20.0";
+  version = "1.21.0";
   pname = "unit";
 
   src = fetchFromGitHub {
     owner = "nginx";
-    repo = "unit";
+    repo = pname;
     rev = version;
-    sha256 = "1qmcz01ifmd80qgpvf1y8nhad6yk56772xdhqvwfxn3mdjfqvcs8";
+    sha256 = "1jczdxixxyj16w10pkcplchbqvx3m32nkmcl0hqap5ffqj08mmf7";
   };
 
   nativeBuildInputs = [ which ];
 
-  buildInputs = [ ]
+  buildInputs = [ pcre2.dev ]
     ++ optional withPython2 python2
     ++ optionals withPython3 [ python3 ncurses ]
     ++ optional withPHP73 php73-unit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update unit to 1.21.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
