### PR TITLE
python3Packages.black: 19.10b0 -> 20.8b1

### DIFF
--- a/pkgs/development/python-modules/black/tests.patch
+++ b/pkgs/development/python-modules/black/tests.patch
@@ -1,0 +1,27 @@
+--- a/tests/test_primer.py
++++ b/tests/test_primer.py
+@@ -150,13 +150,13 @@ def test_gen_check_output(self) -> None:
+         if lib.WINDOWS:
+             return
+
+-        false_bin = "/usr/bin/false" if system() == "Darwin" else "/bin/false"
++        false_bin = "false"
+         with self.assertRaises(CalledProcessError):
+             loop.run_until_complete(lib._gen_check_output([false_bin]))
+
+         with self.assertRaises(asyncio.TimeoutError):
+             loop.run_until_complete(
+-                lib._gen_check_output(["/bin/sleep", "2"], timeout=0.1)
++                lib._gen_check_output(["sleep", "2"], timeout=0.1)
+             )
+
+     @event_loop()
+@@ -176,7 +176,7 @@ def test_git_checkout_or_rebase(self) -> None:
+     @event_loop()
+     def test_process_queue(self, mock_stdout: Mock) -> None:
+         loop = asyncio.get_event_loop()
+-        config_path = Path(lib.__file__).parent / "primer.json"
++        config_path = Path(__file__).parent / "data/primer.json"
+         with patch("black_primer.lib.git_checkout_or_rebase", return_false):
+             with TemporaryDirectory() as td:
+                 return_val = loop.run_until_complete(


### PR DESCRIPTION
###### Motivation for this change

Upgrade python3Packages.black to its latest version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
