### PR TITLE
octant: 0.16.0 -> 0.16.2 -> 0.16.3

### DIFF
--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl }:
 let
-  version = "0.16.0";
+  version = "0.16.2";
 
   system = stdenv.hostPlatform.system;
   suffix = {
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchsrc {
-    x86_64-linux = "1i6i42hwxaczkfv8ldxn3wp6bslgwfkycvh88khfmapw2f5f9mhr";
-    aarch64-linux = "1ka5vscyqxckxnhnymp06yi0r2ljw42q0g62yq7qv4safljd452p";
-    x86_64-darwin = "1c50c2r2hq2fi8jcijq6vn336w96ar7b6qccv5w2240i0szsxxql";
+    x86_64-linux = "1jg4268vm3hv2jh4p5cnn6lc0p2sv6fg2gc88kxxbnigncdv53gz";
+    aarch64-linux = "0indvix9x2f0izqz21lgahlq60lq5xj5kvn8c9dss0hqnfvfxzz2";
+    x86_64-darwin = "0awhl8fkqmgzavmx7qw9w97grfqkwmjsk5nra24vdm91w8vx0m53";
   };
 
   doBuild = false;

--- a/pkgs/applications/networking/cluster/octant/default.nix
+++ b/pkgs/applications/networking/cluster/octant/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl }:
 let
-  version = "0.16.2";
+  version = "0.16.3";
 
   system = stdenv.hostPlatform.system;
   suffix = {
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchsrc {
-    x86_64-linux = "1jg4268vm3hv2jh4p5cnn6lc0p2sv6fg2gc88kxxbnigncdv53gz";
-    aarch64-linux = "0indvix9x2f0izqz21lgahlq60lq5xj5kvn8c9dss0hqnfvfxzz2";
-    x86_64-darwin = "0awhl8fkqmgzavmx7qw9w97grfqkwmjsk5nra24vdm91w8vx0m53";
+    x86_64-linux = "1c6v7d8i494k32b0zrjn4fn1idza95r6h99c33c5za4hi7gqvy0x";
+    aarch64-linux = "153jd4wsq8qc598w7y4d30dy20ljyhrl68cc3pig1p712l5258zs";
+    x86_64-darwin = "0y2qjdlyvhrzwg0fmxsr3jl39kd13276a7wg0ndhdjfwxvdwpxkz";
   };
 
   doBuild = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump octant to ~`0.16.2`~ `0.16.3`

Still trying to get a source build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
