### PR TITLE
dockerTools: Always cross compile for another arch in the cross example

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -237,14 +237,14 @@ import ./make-test-python.nix ({ pkgs, ... }: {
 
     with subtest("Ensure cross compiled image can be loaded and has correct arch."):
         docker.succeed(
-            "docker load --input='${pkgs.dockerTools.examples.cross-aarch64}'",
+            "docker load --input='${pkgs.dockerTools.examples.cross}'",
         )
         assert (
             docker.succeed(
-                "docker inspect ${pkgs.dockerTools.examples.cross-aarch64.imageName} "
+                "docker inspect ${pkgs.dockerTools.examples.cross.imageName} "
                 + "| ${pkgs.jq}/bin/jq -r .[].Architecture"
             ).strip()
-            == "arm64v8"
+            == "${if pkgs.system == "aarch64-linux" then "amd64" else "arm64v8"}"
         )
   '';
 })

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -408,10 +408,15 @@ rec {
     };
 
   # basic example, with cross compilation
-  cross-aarch64 = pkgsCross.aarch64-multiplatform.dockerTools.buildImage {
+  cross = let
+    # Cross compile for x86_64 if on aarch64
+    crossPkgs =
+      if pkgs.system == "aarch64-linux" then pkgsCross.gnu64
+      else pkgsCross.aarch64-multiplatform;
+  in crossPkgs.dockerTools.buildImage {
     name = "hello-cross";
     tag = "latest";
-    contents = pkgsCross.aarch64-multiplatform.hello;
+    contents = crossPkgs.hello;
   };
 
 }


### PR DESCRIPTION
The example fails to build on aarch64, so lets cross build for gnu64.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
