### PR TITLE
directx-shader-compiler: init at 1.5.2010

### DIFF
--- a/pkgs/tools/graphics/directx-shader-compiler/default.nix
+++ b/pkgs/tools/graphics/directx-shader-compiler/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, cmake, python3, git }:
+
+stdenv.mkDerivation rec {
+  pname = "directx-shader-compiler";
+  version = "1.5.2010";
+
+  # Put headers in dev, there are lot of them which aren't necessary for
+  # using the compiler binary.
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "DirectXShaderCompiler";
+    rev = "v${version}";
+    sha256 = "0ccfy1bfp0cm0pq63ri4yl1sr3fdn1a526bsnakg4bl6z4fwrnnj";
+    # We rely on the side effect of leaving the .git directory here for the
+    # version-grabbing functionality of the build system.
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake git python3 ];
+
+  configurePhase = ''
+    # Requires some additional flags to cmake from a file in the repo
+    additionalCMakeFlags=$(< utils/cmake-predefined-config-params)
+    cmakeFlags="$additionalCMakeFlags''${cmakeFlags:+ $cmakeFlags}"
+    cmakeConfigurePhase
+  '';
+
+  # The default install target installs heaps of LLVM stuff.
+  #
+  # Upstream issue: https://github.com/microsoft/DirectXShaderCompiler/issues/3276
+  #
+  # The following is based on the CI script:
+  # https://github.com/microsoft/DirectXShaderCompiler/blob/master/appveyor.yml#L63-L66
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $dev/include
+    mv bin/dxc* $out/bin/
+    mv lib/libdxcompiler.so* $out/lib/
+    cp -r $src/include/dxc $dev/include/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A compiler to compile HLSL programs into DXIL and SPIR-V";
+    homepage = "https://github.com/microsoft/DirectXShaderCompiler";
+    platforms = platforms.linux;
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16982,6 +16982,8 @@ in
 
   diod = callPackage ../servers/diod { lua = lua5_1; };
 
+  directx-shader-compiler = callPackage ../tools/graphics/directx-shader-compiler {};
+
   dkimproxy = callPackage ../servers/mail/dkimproxy { };
 
   do-agent = callPackage ../servers/monitoring/do-agent { };


### PR DESCRIPTION
I've tested the compiler with some basic shaders and they seem to work
fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).