### PR TITLE
vulkan-extension-layer: 2020-08-25 -> 2020-11-20

### DIFF
--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "2020-08-25";
+  version = "2020-11-20";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ExtensionLayer";
-    rev = "352f8e3e269ff2c650da50ce36313547c2a1fbb6";
-    sha256 = "1503z1zj1xvjpry2h7fpg1frx7lcm54zs3azcgiv5i3ar4wqfkz9";
+    rev = "7474cb8e1f70e9f4a8bf382708a7f15465453af5";
+    sha256 = "1lxkgcnv32wqk4hlckv13xy84g38jzgc4qxp9vsbkrgz87hkdvwj";
   };
 
   nativeBuildInputs = [ cmake jq ];


### PR DESCRIPTION
###### Motivation for this change

Includes a couple of important fixes:

https://github.com/KhronosGroup/Vulkan-ExtensionLayer/pull/41
https://github.com/KhronosGroup/Vulkan-ExtensionLayer/pull/38


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).