### PR TITLE
all-packages.nix: Use GCC 8 as default for MIPS targets

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8856,11 +8856,19 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then ../development/compilers/gcc/6
-    else ../development/compilers/gcc/9);
-  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then gcc6 else gcc9;
+  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then
+      ../development/compilers/gcc/6
+    else if (with stdenv.targetPlatform; isMips) then
+      ../development/compilers/gcc/8
+    else
+      ../development/compilers/gcc/9);
+
+  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then
+          gcc6
+        else if (with stdenv.targetPlatform; isMips) then
+          gcc8
+        else
+          gcc9;
 
   gcc-unwrapped = gcc.cc;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8861,11 +8861,19 @@ in
   gerbil-support = callPackage ../development/compilers/gerbil/gerbil-support.nix { };
   gerbilPackages-unstable = gerbil-support.gerbilPackages-unstable; # NB: don't recurseIntoAttrs for (unstable!) libraries
 
-  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then ../development/compilers/gcc/6
-    else ../development/compilers/gcc/9);
-  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
-    then gcc6 else gcc9;
+  gccFun = callPackage (if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then
+      ../development/compilers/gcc/6
+    else if (with stdenv.targetPlatform; isMips) then
+      ../development/compilers/gcc/8
+    else
+      ../development/compilers/gcc/9);
+
+  gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then
+          gcc6
+        else if (with stdenv.targetPlatform; isMips) then
+          gcc8
+        else
+          gcc9;
 
   gcc-unwrapped = gcc.cc;
 


### PR DESCRIPTION
> GCC 9 of nixpkgs doesn't build as MIPS cross-compiler.
> Partially reverts 8f729c0070ec3f78edadeaebcbd110257fe4577e .

###### Motivation for this change

As described in #103959 and #77732 it's currently not possible to create a cross-compiling environment for MIPS because the compilation of GCC 9 fails. Even updating to the latest stable version of `binutils` didn't solve the problems (please see #103959 for details).

This PR sets GCC 8 as default compiler of `stdenv`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
