### PR TITLE
aws-sam-cli: 1.6.2 -> 1.11.0

### DIFF
--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "aws-sam-translator";
-  version = "1.27.0";
+  version = "1.30.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0m24cdiry8p74s5ysyriy6wks4ic8782sf21q4yvlwfn9hpi4n1j";
+    sha256 = "0d9ppd94x2kw404m49ajswmmxgdngbs4p5ajyrdvnlivfzqbv7dx";
   };
 
   # Tests are not included in the PyPI package

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -8,18 +8,18 @@ let
   py = python.override {
     packageOverrides = self: super: {
       flask = super.flask.overridePythonAttrs (oldAttrs: rec {
-        version = "1.0.2";
+        version = "1.1.2";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "0j6f4a9rpfh25k1gp7azqhnni4mb4fgy50jammgjgddw1l3w0w92";
+          sha256 = "0q3h295izcil7lswkzfnyg3k5gq4hpmqmpl6i7s5m1n9szi1myjf";
         };
       });
 
       cookiecutter = super.cookiecutter.overridePythonAttrs (oldAttrs: rec {
-        version = "1.6.0";
+        version = "1.7.2";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "0glsvaz8igi2wy1hsnhm9fkn6560vdvdixzvkq6dn20z3hpaa5hk";
+          sha256 = "1b2xa5dypk1vf8aq599fd8zw4y0pwvq3hgl7ia8aiv8gg3ab5dpg";
         };
       });
     };
@@ -31,11 +31,11 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "1.6.2";
+  version = "1.11.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0scnymhhiiqrs2j0jaypxgq2wg1qf1w8f55qfay0b3nf51y6mh8y";
+    sha256 = "1drb8qcn30r44m0jy0y1nvhzxphn3qari5qwmsdb6wlkdppwxg3f";
   };
 
   # Tests are not included in the PyPI package
@@ -67,7 +67,7 @@ buildPythonApplication rec {
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \
-      --replace "boto3~=1.14.0, >=1.14.23" "boto3~=1.14" \
+      --replace "boto3~=1.14.23" "boto3~=1.14" \
       --replace "docker~=4.2.0" "docker~=4.3.1" \
       --replace "jmespath~=0.9.5" "jmespath~=0.10.0" \
       --replace "python-dateutil~=2.6, <2.8.1" "python-dateutil~=2.6" \


### PR DESCRIPTION
Motivation of change: current version is really outdated, many features
missed. In my case there was lack of HttpApi support for
`sam local-run-api`.

Also aws-sam-translator: 1.27.0 -> 1.30.1 as dependency.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
