### PR TITLE
neomutt: 20200925 -> 20201120

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -6,32 +6,20 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "20200925";
+  version = "20201120";
   pname = "neomutt";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
     rev    = version;
-    sha256 = "1q931n9sijq1iin3swzk57rz7qmy485hvr1fahy5i2wd1xx9yhb2";
+    sha256 = "0z6xavgd0zv9pqvfsdyvhhi1q3y7zxhgg24isbnn9r6mldafqwna";
   };
 
   buildInputs = [
     cyrus_sasl gss gpgme kerberos libidn ncurses
     notmuch openssl perl lmdb
     mailcap sqlite
-  ];
-
-  patches = [
-    # To be removed on next release. Fixes two bugs in the sidebar behavior.
-    (fetchpatch {
-      url = "https://github.com/neomutt/neomutt/commit/96753674e70edb695c1dc7af73e3317956c1b259.patch";
-      sha256 = "0yjmgdfhn8ra7bc3d40c3c29imgpgbhzphjxp6575llh9kw5h53s";
-    })
-    (fetchpatch {
-      url = "https://github.com/neomutt/neomutt/commit/6078653c9233644ca76c24bdb64e49bd443dd714.patch";
-      sha256 = "1s1p86bqpc9xq9z5qfh0mxxh6syps8shq0dm7bbkg1bz7qya5phy";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
