### PR TITLE
staticjinja: enable tests; lift to top level

### DIFF
--- a/pkgs/development/python-modules/staticjinja/default.nix
+++ b/pkgs/development/python-modules/staticjinja/default.nix
@@ -1,24 +1,45 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
+, isPy27
 , docopt
 , easywatch
 , jinja2
+, pytestCheckHook
+, markdown
 }:
 
 buildPythonPackage rec {
   pname = "staticjinja";
   version = "0.4.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "597837899008409359680ee9cd04779639b9c0eb3380b6545025d26a702ba36c";
+  disabled = isPy27; # 0.4.0 drops python2 support
+
+  # For some reason, in pypi the tests get disabled when using
+  # PY_IGNORE_IMPORTMISMATCH, so we just fetch from GitHub
+  src = fetchFromGitHub {
+    owner = "staticjinja";
+    repo = pname;
+    rev = version;
+    sha256 = "0pysk8pzmcg1nfxz8m4i6bvww71w2zg6xp33zgg5vrf8yd2dfx9i";
   };
 
-  propagatedBuildInputs = [ jinja2 docopt easywatch ];
+  propagatedBuildInputs = [
+    jinja2
+    docopt
+    easywatch
+  ];
 
-  # There are no tests on pypi
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    markdown
+  ];
+
+  # Import paths differ by a "build/lib" subdirectory, but the files are
+  # the same, so we ignore import mismatches.
+  preCheck = ''
+    export PY_IGNORE_IMPORTMISMATCH=1
+  '';
 
   meta = with lib; {
     description = "A library and cli tool that makes it easy to build static sites using Jinja2";
@@ -27,4 +48,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ fgaz ];
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7621,6 +7621,8 @@ in
 
   stabber = callPackage ../misc/stabber { };
 
+  staticjinja = with python3.pkgs; toPythonApplication staticjinja;
+
   stress = callPackage ../tools/system/stress { };
 
   stress-ng = callPackage ../tools/system/stress-ng { };


### PR DESCRIPTION

###### Motivation for this change

Lifted to the top level because most users will probably use the cli tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
