### PR TITLE
notmuch: add vim plugin

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -93,6 +93,16 @@ stdenv.mkDerivation rec {
     moveToOutput bin/notmuch-emacs-mua $emacs
   '' + optionalString withVim ''
     make -C vim DESTDIR="$out/share/vim" prefix="" install
+  '' + optionalString (!isNull ruby) ''
+    make -C bindings/ruby install DESTDIR="" prefix="$out" install
+    # This is very specific, see pkgs/development/interpreters/ruby/default.nix
+    mkdir -p $out/nix-support
+    cat > $out/nix-support/setup-hook <<EOF
+    notmuchRubyBindingLibPath() {
+      addToSearchPath RUBYLIB \$1/lib/ruby/vendor_ruby/${ruby.version.libDir}/${stdenv.targetPlatform.system}
+    }
+    addEnvHooks "$hostOffset" notmuchRubyBindingLibPath
+    EOF
   '';
 
   dontGzipMan = true; # already compressed

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -7,6 +7,7 @@
 , ruby
 , which, dtach, openssl, bash, gdb, man
 , withEmacs ? true
+, withVim ? true
 }:
 
 with stdenv.lib;
@@ -90,6 +91,8 @@ stdenv.mkDerivation rec {
 
   postInstall = stdenv.lib.optionalString withEmacs ''
     moveToOutput bin/notmuch-emacs-mua $emacs
+  '' + optionalString withVim ''
+    make -C vim DESTDIR="$out/share/vim" prefix="" install
   '';
 
   dontGzipMan = true; # already compressed

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -83,8 +83,8 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
   checkInputs = [
     which dtach openssl bash
-    gdb man emacs
-  ];
+    gdb man
+  ] ++ optional (withEmacs) [ emacs ];
 
   installTargets = [ "install" "install-man" "install-info" ];
 

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -95,13 +95,10 @@ stdenv.mkDerivation rec {
     make -C vim DESTDIR="$out/share/vim" prefix="" install
   '' + optionalString (!isNull ruby) ''
     make -C bindings/ruby install DESTDIR="" prefix="$out" install
-    # This is very specific, see pkgs/development/interpreters/ruby/default.nix
+    # This is very hacky, see pkgs/development/interpreters/ruby/default.nix
     mkdir -p $out/nix-support
     cat > $out/nix-support/setup-hook <<EOF
-    notmuchRubyBindingLibPath() {
-      addToSearchPath RUBYLIB \$1/lib/ruby/vendor_ruby/${ruby.version.libDir}/${stdenv.targetPlatform.system}
-    }
-    addEnvHooks "$hostOffset" notmuchRubyBindingLibPath
+    addToSearchPath RUBYLIB $out/lib/ruby/vendor_ruby/${ruby.version.libDir}/${stdenv.targetPlatform.system}
     EOF
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Hi !

This PR adds notmuch's Vim plugin and Ruby bindings. The Ruby bindings are required by the Vim plugin.
The first commit is a bit unrelated, it removes `emacs` from the build dependencies when `withEmacs` is `false`. I don't even want this on my computer ! (kidding, it was just an easy fix)

The Vim plugin is enabled by default because it consists only of small static files. The ruby bindings are not big either and ruby is already added as a dependency. Also emacs is enabled by default, so it's fair.

The way I hook the ruby bindings doesn't seem right. I couldn't find examples in nixpkgs and I think `bundlerEnv` cannot be used here. Is here a better way ?

The ruby bindings have a dependency on the gem `mail` but it is optional and loaded at runtime, so I haven't included it.

There is a related issue: https://github.com/NixOS/nixpkgs/issues/43965

###### Motivation for this change

Make the Vim plugin available from nixpkgs and to use it like this:

```nix
let
  notmuch = (pkgs.notmuch.override {
    withEmacs = false;
  }).overrideAttrs (o: {
    doCheck = false; # Too slow
  });

  # Shadows vim, loading the notmuch plugin and a local vimrc
  notmuch_vim = { vimrc }:
    pkgs.runCommand "notmuch-wrapped-vim" {
      buildInputs = [ notmuch ];
    } ''
      # No absolute path to vim on purpose
      mkdir -p "$out/bin"
      cat <<EOF > "$out/bin/vim"
      #!/usr/bin/env bash
      this="$out"
      PATH=\''${PATH//\$this/} # Remove this package from the PATH
      exec vim -c "set packpath+=\$this/vim" -c "packadd notmuch" -c "source ${vimrc}" "\$@"
      EOF
      chmod +x "$out/bin/vim"
      plugin_out="$out/vim/pack/plugins/opt" # Vim plugins directory structure
      mkdir -p "$plugin_out"
      ln -sf "${notmuch}/share/vim" "$plugin_out/notmuch"
    '';
```

I got a bit creative here, I'll probably use something saner :D

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

