### PR TITLE
[staging] python3.pkgs.pipInstallHook: don't warn on script installation

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -11,7 +11,7 @@ pipInstallPhase() {
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
     pushd dist || return 1
-    @pythonInterpreter@ -m pip install ./*.whl --no-index --prefix="$out" --no-cache $pipInstallFlags --build tmpbuild
+    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags --build tmpbuild
     popd || return 1
 
     runHook postInstall


### PR DESCRIPTION
###### Motivation for this change
we don't have `$out/bin` on the PATH when installing scripts, so pip will issue a warning:

master:
```
Installing collected packages: pip
  WARNING: The scripts pip, pip3 and pip3.8 are installed in '/nix/store/kv23pa2s08mljd4fyl6gl8hdhgfpkgjg-python3.8-pip-20.2.4/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
Successfully installed pip-20.2.4
```
this PR:
```
Installing collected packages: pip
Successfully installed pip-20.2.4
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
