### PR TITLE
amoeba: fix build

### DIFF
--- a/pkgs/games/amoeba/default.nix
+++ b/pkgs/games/amoeba/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, amoeba-data, alsaLib, expat, freetype, gtk2, libvorbis, libGLU, pkgconfig }:
+{ stdenv, fetchurl, amoeba-data, alsaLib, expat, freetype, gtk2, libvorbis, libGLU, xlibs, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "amoeba-${version}-${debver}";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ alsaLib expat freetype gtk2 libvorbis libGLU ];
+  buildInputs = [ alsaLib expat freetype gtk2 libvorbis libGLU xlibs.libXxf86vm ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1/


### PR DESCRIPTION

###### Motivation for this change
fixes
```
  In file included from ./main/piprecalc.h:5,
                   from ./main/mainloop.h:12,
                   from main/mainloop.cpp:17:
  ./opengl/glwindow.h:10:10: fatal error: X11/extensions/xf86vmode.h: No such file or directory
     10 | #include <X11/extensions/xf86vmode.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  make: *** [<builtin>: main/mainloop.o] Error 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
