### PR TITLE
python3Packages.astropy: fix build

### DIFF
--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -2,6 +2,8 @@
 , fetchPypi
 , buildPythonPackage
 , isPy3k
+, cython
+, jinja2
 , numpy
 , pytest
 , pytest-astropy
@@ -19,7 +21,7 @@ buildPythonPackage rec {
     sha256 = "cf69d1a3f140ca8fe1664202072201395495a73c334a69fc965fab6a6e1d281a";
   };
 
-  nativeBuildInputs = [ astropy-helpers ];
+  nativeBuildInputs = [ astropy-helpers cython jinja2 ];
 
   propagatedBuildInputs = [ numpy pytest ]; # yes it really has pytest in install_requires
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing reviewing another PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
