### PR TITLE
nixos/syncoid: fix permissions without --no-sync-snap

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -197,14 +197,14 @@ in {
                ])) (attrValues cfg.commands);
         after = [ "zfs.target" ];
         serviceConfig = {
-          ExecStartPre = (map (pool: lib.escapeShellArgs [
-            "+/run/booted-system/sw/bin/zfs" "allow"
-            cfg.user "hold,send" pool
-          ]) (getPools "source")) ++
-          (map (pool: lib.escapeShellArgs [
-            "+/run/booted-system/sw/bin/zfs" "allow"
-            cfg.user "create,mount,receive,rollback" pool
-          ]) (getPools "target"));
+          ExecStartPre = let
+            allowCmd = permissions: pool: lib.escapeShellArgs [
+              "+/run/booted-system/sw/bin/zfs" "allow"
+              cfg.user (concatStringsSep "," permissions) pool
+            ];
+          in
+            (map (allowCmd [ "hold" "send" "snapshot" "destroy" ]) (getPools "source")) ++
+            (map (allowCmd [ "create" "mount" "receive" "rollback" ]) (getPools "target"));
           User = cfg.user;
           Group = cfg.group;
         };

--- a/nixos/tests/sanoid.nix
+++ b/nixos/tests/sanoid.nix
@@ -33,13 +33,22 @@ in {
 
           autosnap = true;
         };
-        datasets."pool/test".useTemplate = [ "test" ];
+        datasets."pool/sanoid".useTemplate = [ "test" ];
+        extraArgs = [ "--verbose" ];
       };
 
       services.syncoid = {
         enable = true;
         sshKey = "/var/lib/syncoid/id_ecdsa";
-        commands."pool/test".target = "root@target:pool/test";
+        commands = {
+          # Sync snapshot taken by sanoid
+          "pool/sanoid" = {
+            target = "root@target:pool/sanoid";
+            extraArgs = [ "--no-sync-snap" ];
+          };
+          # Take snapshot and sync
+          "pool/syncoid".target = "root@target:pool/syncoid";
+        };
       };
     };
     target = { ... }: {
@@ -53,18 +62,19 @@ in {
 
   testScript = ''
     source.succeed(
-        "mkdir /tmp/mnt",
+        "mkdir /mnt",
         "parted --script /dev/vdb -- mklabel msdos mkpart primary 1024M -1s",
         "udevadm settle",
-        "zpool create pool /dev/vdb1",
-        "zfs create -o mountpoint=legacy pool/test",
-        "mount -t zfs pool/test /tmp/mnt",
+        "zpool create pool -R /mnt /dev/vdb1",
+        "zfs create pool/sanoid",
+        "zfs create pool/syncoid",
         "udevadm settle",
     )
     target.succeed(
+        "mkdir /mnt",
         "parted --script /dev/vdb -- mklabel msdos mkpart primary 1024M -1s",
         "udevadm settle",
-        "zpool create pool /dev/vdb1",
+        "zpool create pool -R /mnt /dev/vdb1",
         "udevadm settle",
     )
 
@@ -75,16 +85,15 @@ in {
         "chown -R syncoid:syncoid /var/lib/syncoid/",
     )
 
-    source.succeed("touch /tmp/mnt/test.txt")
+    # Take snapshot with sanoid
+    source.succeed("touch /mnt/pool/sanoid/test.txt")
     source.systemctl("start --wait sanoid.service")
 
+    # Sync snapshots
     target.wait_for_open_port(22)
+    source.succeed("touch /mnt/pool/syncoid/test.txt")
     source.systemctl("start --wait syncoid.service")
-    target.succeed(
-        "mkdir /tmp/mnt",
-        "zfs set mountpoint=legacy pool/test",
-        "mount -t zfs pool/test /tmp/mnt",
-    )
-    target.succeed("cat /tmp/mnt/test.txt")
+    target.succeed("cat /mnt/pool/sanoid/test.txt")
+    target.succeed("cat /mnt/pool/syncoid/test.txt")
   '';
 })

--- a/nixos/tests/sanoid.nix
+++ b/nixos/tests/sanoid.nix
@@ -39,7 +39,6 @@ in {
       services.syncoid = {
         enable = true;
         sshKey = "/var/lib/syncoid/id_ecdsa";
-        commonArgs = [ "--no-sync-snap" ];
         commands."pool/test".target = "root@target:pool/test";
       };
     };


### PR DESCRIPTION
After 733acfa140d5b73bc69c53c4ebd90ccc5f281f0e, syncoid would fail to
run if `commonArgs` did not include `[ "--no-sync-snap" ]`, since it would
not have permissions to create or destroy snapshots.

CC @lopsided98 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
