### PR TITLE
[20.09] mutt: 1.14.7 -> 2.0.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -27,11 +27,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "1.14.7";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    sha256 = "0r58xnjgkw0kmnnzhb32mk5gkkani5kbi5krybpbag156fqhgxg4";
+    sha256 = "1bxf8976mrl3vbn3s5i32i1lf908yag5rsf84n76dllmly61794k";
   };
 
   patches = optional smimeSupport (fetchpatch {

--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -27,11 +27,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    sha256 = "1nr1n0lshif6lrn4c5ym473jrg0jaka5wfyy06qmbxhnavmgvx8c";
+    sha256 = "1j0i2jmlk5sc78af9flj3ynj0iiwa8biw7jgf12qm5lppsx1h4j7";
   };
 
   patches = optional smimeSupport (fetchpatch {

--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -27,11 +27,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "mutt";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchurl {
     url = "http://ftp.mutt.org/pub/mutt/${pname}-${version}.tar.gz";
-    sha256 = "1bxf8976mrl3vbn3s5i32i1lf908yag5rsf84n76dllmly61794k";
+    sha256 = "1nr1n0lshif6lrn4c5ym473jrg0jaka5wfyy06qmbxhnavmgvx8c";
   };
 
   patches = optional smimeSupport (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change

Backport of #104399, fixes CVE-2020-28896

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Cc: @matthiasbeyer 
