### PR TITLE
Update Haskell package set to Stackage Nightly 2020-11-23 (plus other fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -295,6 +295,9 @@ self: super: {
   github-rest = dontCheck super.github-rest;  # test suite needs the network
   gitlib-cmdline = dontCheck super.gitlib-cmdline;
   GLFW-b = dontCheck super.GLFW-b;                      # https://github.com/bsl/GLFW-b/issues/50
+  #next release supports random 1.1; jailbroken because i didn't know about vty when glguy was updating the bounds
+  #should be fixed soon. maybe even before this is merged. currently glirc is 2.37
+  glirc = doJailbreak (super.glirc.override { random = self.random_1_2_0; });
   hackport = dontCheck super.hackport;
   hadoop-formats = dontCheck super.hadoop-formats;
   haeredes = dontCheck super.haeredes;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -366,6 +366,9 @@ self: super: {
   punycode = dontCheck super.punycode;
   pwstore-cli = dontCheck super.pwstore-cli;
   quantities = dontCheck super.quantities;
+  QuickCheck_2_14_2 = super.QuickCheck_2_14_2.override( {
+    splitmix = self.splitmix_0_1_0_3;
+  });
   redis-io = dontCheck super.redis-io;
   rethinkdb = dontCheck super.rethinkdb;
   Rlang-QQ = dontCheck super.Rlang-QQ;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -69,7 +69,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "13s6czv4p6n6s16kr5r255vldrn9038qjd5yl5xrh91xk6z410cd";
+      sha256 = "1l2syrslba4mrxjzj0iblflz72siw3ibqri6p5hf59fk7rmm30a8";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1505,4 +1505,7 @@ self: super: {
   # 2020-11-23: Jailbreaking until: https://github.com/michaelt/text-pipes/pull/29
   pipes-text = doJailbreak super.pipes-text;
 
+  # 2020-11-23: https://github.com/Rufflewind/blas-hs/issues/8
+  blas-hs = dontCheck super.blas-hs;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -338,7 +338,8 @@ self: super: {
     then dontCheck super.math-functions # "erf table" test fails on Darwin https://github.com/bos/math-functions/issues/63
     else super.math-functions;
   matplotlib = dontCheck super.matplotlib;
-
+  # https://github.com/matterhorn-chat/matterhorn/issues/679 they do not want to be on stackage
+  matterhorn = doJailbreak super.matterhorn; # this is needed until the end of time :')
   memcache = dontCheck super.memcache;
   metrics = dontCheck super.metrics;
   milena = dontCheck super.milena;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -394,9 +394,7 @@ self: super: {
   tickle = dontCheck super.tickle;
   tpdb = dontCheck super.tpdb;
   translatable-intset = dontCheck super.translatable-intset;
-  # Aarch64 affected by this bug https://gitlab.haskell.org/ghc/ghc/-/issues/15275#note_295461
-  # Darwin https://hydra.nixos.org/build/129070963/nixlog/1
-  trifecta = if (pkgs.stdenv.hostPlatform.isAarch64 || pkgs.stdenv.isDarwin) then dontCheck super.trifecta else super.trifecta;
+  trifecta = if pkgs.stdenv.hostPlatform.isAarch64 then dontCheck super.trifecta else super.trifecta; # affected by this bug https://gitlab.haskell.org/ghc/ghc/-/issues/15275#note_295461
   ua-parser = dontCheck super.ua-parser;
   unagi-chan = dontCheck super.unagi-chan;
   wai-logger = dontCheck super.wai-logger;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -85,11 +85,6 @@ self: super: {
     url = "https://github.com/hercules-ci/optparse-applicative/compare/0.15.1...hercules-ci:0.15.1-nixpkgs-compgen.diff";
     sha256 = "1bcp6b7gvc8pqbn1n1ybhizkkl5if7hk9ipgl746vk08v0d3xxql";
   });
-  optparse-applicative_0_16_0_0 = appendPatch super.optparse-applicative_0_16_0_0 (pkgs.fetchpatch {
-    name = "optparse-applicative-0.15.1-hercules-ci-compgen.diff";
-    url = "https://github.com/hercules-ci/optparse-applicative/compare/0.15.1...hercules-ci:0.15.1-nixpkgs-compgen.diff";
-    sha256 = "1bcp6b7gvc8pqbn1n1ybhizkkl5if7hk9ipgl746vk08v0d3xxql";
-  });
 
   # Fix test trying to access /home directory
   shell-conduit = overrideCabal super.shell-conduit (drv: {
@@ -1378,7 +1373,7 @@ self: super: {
   in generateOptparseApplicativeCompletion "update-nix-fetchgit" (overrideCabal
     (addTestToolDepends (super.update-nix-fetchgit.overrideScope (self: super: {
       optparse-generic = self.optparse-generic_1_4_4;
-      optparse-applicative = self.optparse-applicative_0_16_0_0;
+      optparse-applicative = self.optparse-applicative_0_16_1_0;
     })) deps) (drv: {
       buildTools = drv.buildTools or [ ] ++ [ pkgs.makeWrapper ];
       postInstall = drv.postInstall or "" + ''
@@ -1387,10 +1382,6 @@ self: super: {
         }"
       '';
     }));
-
-  optparse-generic_1_4_4 = super.optparse-generic_1_4_4.override {
-    optparse-applicative = self.optparse-applicative_0_16_0_0;
-  };
 
   # Our quickcheck-instances is too old for the newer binary-instances, but
   # quickcheck-instances is only used in the tests of binary-instances.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1508,4 +1508,7 @@ self: super: {
   # 2020-11-23: https://github.com/Rufflewind/blas-hs/issues/8
   blas-hs = dontCheck super.blas-hs;
 
+  # 2020-11-23: https://github.com/cdornan/fmt/issues/30
+  fmt = dontCheck super.fmt;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1502,4 +1502,7 @@ self: super: {
     excludes = [ "stack.yaml" "sources.json" "src/Cachix/Types/Session.hs" "src/Cachix/API/Signing.hs" "cachix-api.cabal" "workflows/test.yml" ];
   });
 
+  # 2020-11-23: Jailbreaking until: https://github.com/michaelt/text-pipes/pull/29
+  pipes-text = doJailbreak super.pipes-text;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -399,6 +399,7 @@ self: super: {
   xsd = dontCheck super.xsd;
   zip-archive = dontCheck super.zip-archive;  # https://github.com/jgm/zip-archive/issues/57
 
+  random_1_2_0 = super.random_1_2_0.override ({ splitmix = self.splitmix_0_1_0_3; });
   # These test suites run for ages, even on a fast machine. This is nuts.
   Random123 = dontCheck super.Random123;
   systemd = dontCheck super.systemd;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1519,4 +1519,12 @@ self: super: {
   # 2020-11-23: https://github.com/cdornan/fmt/issues/30
   fmt = dontCheck super.fmt;
 
+
+  # 2020-11-27: Tests broken
+  # Upstream issue: https://github.com/haskell-servant/servant-swagger/issues/129
+  servant-swagger = dontCheck super.servant-swagger;
+
+  # 2020-11-27: cxx-options is broken in Cabal 3.2.0.0
+  hercules-ci-agent = addSetupDepend super.hercules-ci-agent self.Cabal_3_2_1_0;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1483,10 +1483,6 @@ self: super: {
   # Due to tests restricting base in 0.8.0.0 release
   http-media = doJailbreak super.http-media;
 
-  # 2020-11-19: Disabling tests with this issue: https://github.com/cchalmers/pcg-random/issues/10
-  # Issue has been fixed in 0.1.3.7, we can enable tests again, once stackage bumps the version
-  pcg-random = assert super.pcg-random.version == "0.1.3.6"; dontCheck super.pcg-random;
-
   # Use an already merged upstream patch fixing the build with primitive >= 0.7.2
   # The version bounds were correctly specified before, so we need to jailbreak as well
   streamly = appendPatch (doJailbreak super.streamly) (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -73,9 +73,6 @@ self: super: {
   shellmet = doJailbreak super.shellmet;
   shower = doJailbreak super.shower;
 
-  # Broken test compile
-  servant-swagger = dontCheck super.servant-swagger;
-
   # The shipped Setup.hs file is broken.
   csv = overrideCabal super.csv (drv: { preCompileBuildDriver = "rm Setup.hs"; });
 
@@ -95,8 +92,4 @@ self: super: {
 
   # Break out of "Cabal < 3.2" constraint.
   stylish-haskell = doJailbreak super.stylish-haskell;
-
-  # cxx-options is broken in Cabal 3.2.0.0
-  hercules-ci-agent = addSetupDepend super.hercules-ci-agent self.Cabal_3_2_1_0;
-
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -96,4 +96,7 @@ self: super: {
   # Break out of "Cabal < 3.2" constraint.
   stylish-haskell = doJailbreak super.stylish-haskell;
 
+  # cxx-options is broken in Cabal 3.2.0.0
+  hercules-ci-agent = addSetupDepend super.hercules-ci-agent self.Cabal_3_2_1_0;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -73,6 +73,9 @@ self: super: {
   shellmet = doJailbreak super.shellmet;
   shower = doJailbreak super.shower;
 
+  # Broken test compile
+  servant-swagger = dontCheck super.servant-swagger;
+
   # The shipped Setup.hs file is broken.
   csv = overrideCabal super.csv (drv: { preCompileBuildDriver = "rm Setup.hs"; });
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10306,7 +10306,6 @@ broken-packages:
   - Tape
   - tapioca
   - target
-  - tart
   - task
   - task-distribution
   - taskell

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2694,6 +2694,8 @@ package-maintainers:
     # - pipes-mongodb
     - streaming-wai
   kiwi:
+    - config-schema
+    - config-value
     - irc-core
     - QuickCheck_2_14_2
     - random_1_2_0
@@ -4142,9 +4144,7 @@ broken-packages:
   - conffmt
   - confide
   - config-parser
-  - config-schema
   - config-select
-  - config-value
   - config-value-getopt
   - ConfigFileTH
   - Configger

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2701,8 +2701,6 @@ package-maintainers:
     - matterhorn
     - mattermost-api
     - mattermost-api-qc
-    - QuickCheck_2_14_2
-    - random_1_2_0
     - Unique
   psibi:
     - path-pieces

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -76,7 +76,7 @@ default-package-overrides:
   # haskell-language-server 0.5.0.0 doesn't accept newer versions
   - fourmolu ==0.2.*
   - refinery ==0.2.*
-  # Stackage Nightly 2020-11-11
+  # Stackage Nightly 2020-11-23
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -91,6 +91,7 @@ default-package-overrides:
   - aeson-better-errors ==0.9.1.0
   - aeson-casing ==0.2.0.0
   - aeson-combinators ==0.0.4.0
+  - aeson-commit ==1.3
   - aeson-compat ==0.3.9
   - aeson-default ==0.9.1.0
   - aeson-diff ==1.1.0.9
@@ -273,7 +274,7 @@ default-package-overrides:
   - avro ==0.5.2.0
   - aws-cloudfront-signed-cookies ==0.2.0.6
   - backtracking ==0.1.0
-  - bank-holidays-england ==0.2.0.5
+  - bank-holidays-england ==0.2.0.6
   - barbies ==2.0.2.0
   - base-compat ==0.11.2
   - base-compat-batteries ==0.11.2
@@ -359,7 +360,7 @@ default-package-overrides:
   - boundingboxes ==0.2.3
   - bower-json ==1.0.0.1
   - boxes ==0.1.5
-  - brick ==0.57
+  - brick ==0.57.1
   - broadcast-chan ==0.2.1.1
   - bsb-http-chunked ==0.0.0.4
   - bson ==0.4.0.1
@@ -368,10 +369,11 @@ default-package-overrides:
   - buffer-pipe ==0.0
   - bugsnag-hs ==0.2.0.3
   - bugzilla-redhat ==0.3.0
-  - burrito ==1.1.0.2
+  - burrito ==1.2.0.0
   - butcher ==1.3.3.2
   - bv ==0.5
   - bv-little ==1.1.1
+  - byte-count-reader ==0.10.1.2
   - byte-order ==0.1.2.0
   - byteable ==0.1.1
   - bytedump ==1.0
@@ -393,7 +395,7 @@ default-package-overrides:
   - ca-province-codes ==1.0.0.0
   - cabal-debian ==5.1
   - cabal-doctest ==1.0.8
-  - cabal-file ==0.1.0
+  - cabal-file ==0.1.1
   - cabal-flatpak ==0.1.0.2
   - cabal-plan ==0.7.2.0
   - cabal-rpm ==2.0.7
@@ -549,7 +551,7 @@ default-package-overrides:
   - crackNum ==2.4
   - crc32c ==0.0.0
   - credential-store ==0.1.2
-  - criterion ==1.5.7.0
+  - criterion ==1.5.9.0
   - criterion-measurement ==0.1.2.0
   - cron ==0.7.0
   - crypto-api ==0.13.3
@@ -725,7 +727,7 @@ default-package-overrides:
   - elm-bridge ==0.6.1
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
-  - elm2nix ==0.2
+  - elm2nix ==0.2.1
   - elynx ==0.5.0
   - elynx-markov ==0.5.0
   - elynx-nexus ==0.5.0
@@ -787,6 +789,8 @@ default-package-overrides:
   - failable ==1.2.4.0
   - fakedata ==0.8.0
   - fakedata-parser ==0.1.0.0
+  - fakefs ==0.3.0.2
+  - fakepull ==0.3.0.2
   - fast-digits ==0.3.0.0
   - fast-logger ==3.0.2
   - fast-math ==1.0.2
@@ -873,6 +877,7 @@ default-package-overrides:
   - gd ==3000.7.3
   - gdp ==0.0.3.0
   - general-games ==1.1.1
+  - generic-aeson ==0.2.0.11
   - generic-arbitrary ==0.1.0
   - generic-constraints ==1.1.1.1
   - generic-data ==0.9.2.0
@@ -913,10 +918,10 @@ default-package-overrides:
   - geojson ==4.0.2
   - getopt-generics ==0.13.0.4
   - ghc-byteorder ==4.11.0.0.10
-  - ghc-check ==0.5.0.2
+  - ghc-check ==0.5.0.3
   - ghc-core ==0.5.6
-  - ghc-events ==0.13.0
-  - ghc-exactprint ==0.6.3.2
+  - ghc-events ==0.14.0
+  - ghc-exactprint ==0.6.3.3
   - ghc-lib ==8.10.2.20200916
   - ghc-lib-parser ==8.10.2.20200916
   - ghc-lib-parser-ex ==8.10.0.16
@@ -956,7 +961,8 @@ default-package-overrides:
   - ginger ==0.10.1.0
   - gingersnap ==0.3.1.0
   - githash ==0.1.5.0
-  - github-release ==1.3.3
+  - github ==0.26
+  - github-release ==1.3.5
   - github-rest ==1.0.3
   - github-types ==0.2.1
   - github-webhooks ==0.15.0
@@ -992,6 +998,7 @@ default-package-overrides:
   - hackage-security ==0.6.0.1
   - haddock-library ==1.9.0
   - hadoop-streaming ==0.2.0.3
+  - hakyll-convert ==0.3.0.3
   - half ==0.3
   - hall-symbols ==0.1.0.6
   - hamtsolo ==1.0.3
@@ -1044,6 +1051,7 @@ default-package-overrides:
   - hedgehog-fn ==1.0
   - hedgehog-quickcheck ==0.1.1
   - hedis ==0.12.15
+  - hedn ==0.3.0.2
   - here ==1.2.13
   - heredoc ==0.2.0.0
   - heterocephalus ==1.0.5.4
@@ -1070,7 +1078,7 @@ default-package-overrides:
   - hlibcpuid ==0.2.0
   - hlibgit2 ==0.18.0.16
   - hlibsass ==0.1.10.1
-  - hmatrix ==0.20.0.0
+  - hmatrix ==0.20.1
   - hmatrix-gsl ==0.19.0.1
   - hmatrix-gsl-stats ==0.4.1.8
   - hmatrix-morpheus ==0.1.1.2
@@ -1215,7 +1223,7 @@ default-package-overrides:
   - hxt-tagsoup ==9.1.4
   - hxt-unicode ==9.0.2.4
   - hybrid-vectors ==0.2.2
-  - hyper ==0.1.0.3
+  - hyper ==0.2.1.0
   - hyperloglog ==0.4.3
   - hyphenation ==0.8
   - iconv ==0.4.1.3
@@ -1272,7 +1280,7 @@ default-package-overrides:
   - io-streams ==1.5.2.0
   - io-streams-haproxy ==1.0.1.0
   - ip6addr ==1.0.1
-  - iproute ==1.7.9
+  - iproute ==1.7.10
   - IPv6Addr ==1.1.5
   - ipynb ==0.1.0.1
   - ipython-kernel ==0.10.2.1
@@ -1280,7 +1288,7 @@ default-package-overrides:
   - irc-client ==1.1.2.0
   - irc-conduit ==0.3.0.4
   - irc-ctcp ==0.1.3.0
-  - isbn ==1.1.0.1
+  - isbn ==1.1.0.2
   - islink ==0.1.0.0
   - iso3166-country-codes ==0.20140203.8
   - iso639 ==0.1.0.3
@@ -1293,9 +1301,11 @@ default-package-overrides:
   - ixset-typed-conversions ==0.1.2.0
   - ixset-typed-hashable-instance ==0.1.0.2
   - jack ==0.7.1.4
+  - jalaali ==1.0.0.0
   - jira-wiki-markup ==1.3.2
   - jose ==0.8.4
   - jose-jwt ==0.8.0
+  - js-chart ==2.9.4.1
   - js-dgtable ==0.5.2
   - js-flot ==0.8.3
   - js-jquery ==3.3.1
@@ -1433,9 +1443,9 @@ default-package-overrides:
   - markdown ==0.1.17.4
   - markdown-unlit ==0.5.0
   - markov-chain ==0.0.3.4
-  - massiv ==0.5.5.0
+  - massiv ==0.5.6.0
   - massiv-io ==0.4.0.0
-  - massiv-test ==0.1.4
+  - massiv-test ==0.1.5
   - math-extras ==0.1.1.0
   - math-functions ==0.3.4.1
   - mathexpr ==0.3.0.0
@@ -1472,7 +1482,7 @@ default-package-overrides:
   - microlens-mtl ==0.2.0.1
   - microlens-platform ==0.4.1
   - microlens-process ==0.2.0.2
-  - microlens-th ==0.4.3.6
+  - microlens-th ==0.4.3.8
   - microspec ==0.2.1.3
   - microstache ==1.0.1.1
   - midair ==0.2.0.1
@@ -1519,6 +1529,7 @@ default-package-overrides:
   - monad-par-extras ==0.3.3
   - monad-parallel ==0.7.2.3
   - monad-peel ==0.2.1.2
+  - monad-primitive ==0.1
   - monad-products ==4.0.1
   - monad-resumption ==0.1.4.0
   - monad-skeleton ==0.1.5
@@ -1542,6 +1553,7 @@ default-package-overrides:
   - morpheus-graphql-client ==0.16.0
   - morpheus-graphql-core ==0.16.0
   - morpheus-graphql-subscriptions ==0.16.0
+  - moss ==0.2.0.0
   - mountpoints ==1.0.2
   - mpi-hs ==0.7.2.0
   - mpi-hs-binary ==0.1.1.0
@@ -1561,6 +1573,7 @@ default-package-overrides:
   - mutable-containers ==0.3.4
   - mwc-probability ==2.3.1
   - mwc-random ==0.14.0.0
+  - mwc-random-monad ==0.7.3.1
   - mx-state-codes ==1.0.0.0
   - mysql ==0.1.7.2
   - mysql-simple ==0.4.5
@@ -1609,7 +1622,7 @@ default-package-overrides:
   - nonce ==1.0.7
   - nondeterminism ==1.4
   - nonempty-containers ==0.3.4.1
-  - nonempty-vector ==0.2.0.2
+  - nonempty-vector ==0.2.1.0
   - nonemptymap ==0.0.6.0
   - not-gloss ==0.7.7.0
   - nowdoc ==0.1.1.0
@@ -1669,7 +1682,7 @@ default-package-overrides:
   - optparse-simple ==0.1.1.3
   - optparse-text ==0.1.1.0
   - ordered-containers ==0.2.2
-  - ormolu ==0.1.3.1
+  - ormolu ==0.1.4.1
   - overhang ==1.0.0
   - packcheck ==0.5.1
   - packdeps ==0.6.0.0
@@ -1677,9 +1690,10 @@ default-package-overrides:
   - pagination ==0.2.1
   - pagure-cli ==0.2
   - pandoc-types ==1.22
-  - pantry ==0.5.1.3
+  - pantry ==0.5.1.4
   - parallel ==3.2.2.0
   - parallel-io ==0.3.3
+  - parameterized ==0.5.0.0
   - paripari ==0.7.0.0
   - parseargs ==0.2.0.9
   - parsec-class ==1.0.0.0
@@ -1706,7 +1720,7 @@ default-package-overrides:
   - pathwalk ==0.3.1.2
   - pattern-arrows ==0.0.2
   - pava ==0.1.0.0
-  - pcg-random ==0.1.3.6
+  - pcg-random ==0.1.3.7
   - pcre-heavy ==1.0.0.2
   - pcre-light ==0.4.1.0
   - pcre-utils ==0.1.8.1.1
@@ -1774,7 +1788,7 @@ default-package-overrides:
   - postgresql-libpq ==0.9.4.3
   - postgresql-libpq-notify ==0.2.0.0
   - postgresql-orm ==0.5.1
-  - postgresql-simple ==0.6.2
+  - postgresql-simple ==0.6.3
   - postgresql-typed ==0.6.1.2
   - postgrest ==7.0.1
   - pptable ==0.3.0.0
@@ -1801,7 +1815,9 @@ default-package-overrides:
   - primes ==0.2.1.0
   - primitive ==0.7.1.0
   - primitive-addr ==0.1.0.2
+  - primitive-extras ==0.8
   - primitive-unaligned ==0.1.1.1
+  - primitive-unlifted ==0.1.3.0
   - print-console-colors ==0.1.0.0
   - probability ==0.2.7
   - process-extras ==0.7.4
@@ -1879,7 +1895,7 @@ default-package-overrides:
   - range-set-list ==0.1.3.1
   - Ranged-sets ==0.4.0
   - rank1dynamic ==0.4.1
-  - rank2classes ==1.4.0.1
+  - rank2classes ==1.4.1
   - Rasterific ==0.7.5.3
   - rasterific-svg ==0.3.3.2
   - rate-limit ==1.4.2
@@ -2028,20 +2044,22 @@ default-package-overrides:
   - sequenceTools ==1.4.0.5
   - serf ==0.1.1.0
   - serialise ==0.2.3.0
-  - servant ==0.18.1
+  - servant ==0.18.2
   - servant-blaze ==0.9.1
-  - servant-client ==0.18.1
-  - servant-client-core ==0.18.1
+  - servant-client ==0.18.2
+  - servant-client-core ==0.18.2
   - servant-conduit ==0.15.1
-  - servant-docs ==0.11.7
-  - servant-foreign ==0.15.2
-  - servant-http-streams ==0.18.1
+  - servant-docs ==0.11.8
+  - servant-errors ==0.1.6.0
+  - servant-foreign ==0.15.3
+  - servant-github-webhook ==0.4.2.0
+  - servant-http-streams ==0.18.2
   - servant-machines ==0.15.1
   - servant-multipart ==0.12
   - servant-openapi3 ==2.0.1.0
   - servant-pipes ==0.15.2
   - servant-rawm ==1.0.0.0
-  - servant-server ==0.18.1
+  - servant-server ==0.18.2
   - servant-swagger ==1.1.10
   - servant-swagger-ui ==0.3.4.3.36.1
   - servant-swagger-ui-core ==0.3.3
@@ -2151,8 +2169,11 @@ default-package-overrides:
   - step-function ==0.2
   - stm-chans ==3.0.0.4
   - stm-conduit ==4.0.1
+  - stm-containers ==1.2
   - stm-delay ==0.1.1.1
   - stm-extras ==0.1.0.3
+  - stm-hamt ==1.2.0.4
+  - stm-lifted ==2.5.0.0
   - stm-split ==0.0.2.1
   - STMonadTrans ==0.4.4
   - stopwatch ==0.1.0.6
@@ -2173,7 +2194,7 @@ default-package-overrides:
   - strict ==0.4
   - strict-concurrency ==0.2.4.3
   - strict-list ==0.1.5
-  - strict-tuple ==0.1.3
+  - strict-tuple ==0.1.4
   - strict-tuple-lens ==0.1.0.1
   - string-class ==0.1.7.0
   - string-combinators ==0.6.0.5
@@ -2233,7 +2254,7 @@ default-package-overrides:
   - tasty-expected-failure ==0.11.1.2
   - tasty-golden ==2.3.3.2
   - tasty-hedgehog ==1.0.0.2
-  - tasty-hspec ==1.1.5.1
+  - tasty-hspec ==1.1.6
   - tasty-hunit ==0.10.0.2
   - tasty-kat ==0.0.3
   - tasty-leancheck ==0.0.1
@@ -2282,7 +2303,7 @@ default-package-overrides:
   - text-regex-replace ==0.1.1.3
   - text-region ==0.3.1.0
   - text-short ==0.1.3
-  - text-show ==3.8.5
+  - text-show ==3.9
   - text-show-instances ==3.8.4
   - text-zipper ==0.10.1
   - textlocal ==0.1.0.5
@@ -2298,7 +2319,7 @@ default-package-overrides:
   - th-expand-syns ==0.4.6.0
   - th-extras ==0.0.0.4
   - th-lift ==0.8.2
-  - th-lift-instances ==0.1.17
+  - th-lift-instances ==0.1.18
   - th-nowq ==0.1.0.5
   - th-orphans ==0.13.11
   - th-printf ==0.7
@@ -2332,7 +2353,7 @@ default-package-overrides:
   - timeit ==2.0
   - timelens ==0.2.0.2
   - timer-wheel ==0.3.0
-  - timerep ==2.0.0.2
+  - timerep ==2.0.1.0
   - timezone-olson ==0.2.0
   - timezone-series ==0.1.9
   - tinylog ==0.15.0
@@ -2350,7 +2371,8 @@ default-package-overrides:
   - topograph ==1.0.0.1
   - torsor ==0.1
   - tostring ==0.2.1.1
-  - tracing ==0.0.5.1
+  - tracing ==0.0.5.2
+  - tracing-control ==0.0.6
   - transaction ==0.1.1.3
   - transformers-base ==0.4.5.2
   - transformers-bifunctors ==0.1
@@ -2381,6 +2403,7 @@ default-package-overrides:
   - type-map ==0.1.6.0
   - type-natural ==0.9.0.0
   - type-of-html ==1.6.1.2
+  - type-of-html-static ==0.1.0.2
   - type-operators ==0.2.0.0
   - type-spec ==0.4.0.0
   - TypeCompose ==0.9.14
@@ -2496,6 +2519,8 @@ default-package-overrides:
   - wai-middleware-caching ==0.1.0.2
   - wai-middleware-clacks ==0.1.0.1
   - wai-middleware-static ==0.9.0
+  - wai-rate-limit ==0.1.0.0
+  - wai-rate-limit-redis ==0.1.0.0
   - wai-saml2 ==0.2.1.2
   - wai-session ==0.3.3
   - wai-slack-middleware ==0.2.0
@@ -2521,6 +2546,7 @@ default-package-overrides:
   - Win32 ==2.6.1.0
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
+  - witch ==0.0.0.3
   - with-location ==0.1.0
   - with-utf8 ==1.0.2.1
   - witherable-class ==0
@@ -2581,7 +2607,7 @@ default-package-overrides:
   - yesod-auth ==1.6.10.1
   - yesod-auth-hashdb ==1.7.1.5
   - yesod-bin ==1.6.0.6
-  - yesod-core ==1.6.18.6
+  - yesod-core ==1.6.18.7
   - yesod-fb ==0.6.1
   - yesod-form ==1.6.7
   - yesod-gitrev ==0.2.1
@@ -2602,7 +2628,7 @@ default-package-overrides:
   - zeromq4-haskell ==0.8.0
   - zeromq4-patterns ==0.3.1.0
   - zim-parser ==0.2.1.0
-  - zio ==0.1.0.0
+  - zio ==0.1.0.2
   - zip ==1.6.0
   - zip-archive ==0.4.1
   - zip-stream ==0.2.0.1
@@ -2614,6 +2640,7 @@ default-package-overrides:
   - zot ==0.0.3
   - zstd ==0.1.2.0
   - ztail ==1.2.0.2
+  - zydiskell ==0.2.0.0
 
 extra-packages:
   - Cabal == 2.2.*                      # required for jailbreak-cabal etc.

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8703,7 +8703,6 @@ broken-packages:
   - pipes-s3
   - pipes-shell
   - pipes-sqlite-simple
-  - pipes-text
   - pipes-transduce
   - pipes-vector
   - pipes-zeromq4

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5170,7 +5170,6 @@ broken-packages:
   - FM-SBLEX
   - fmark
   - FModExRaw
-  - fmt
   - fmt-for-rio
   - fmt-terminal-colors
   - fn-extra

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2712,6 +2712,9 @@ package-maintainers:
     - Agda
   roberth:
     - arion-compose
+    - hercules-ci-agent
+    - hercules-ci-api-agent
+    - hercules-ci-api-core
   cdepillabout:
     - pretty-simple
     - spago
@@ -6208,9 +6211,6 @@ broken-packages:
   - HERA
   - herbalizer
   - HerbiePlugin
-  - hercules-ci-agent
-  - hercules-ci-api-agent
-  - hercules-ci-api-core
   - heredocs
   - Hermes
   - hermit

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2695,6 +2695,7 @@ package-maintainers:
     - streaming-wai
   kiwi:
     - irc-core
+    - QuickCheck_2_14_2
     - random_1_2_0
     - Unique
   psibi:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3545,7 +3545,6 @@ broken-packages:
   - blakesum
   - blakesum-demo
   - blas
-  - blas-hs
   - BlastHTTP
   - blastxml
   - blatex

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2694,6 +2694,7 @@ package-maintainers:
     # - pipes-mongodb
     - streaming-wai
   kiwi:
+    - irc-core
     - Unique
   psibi:
     - path-pieces
@@ -6994,7 +6995,6 @@ broken-packages:
   - iptadmin
   - IPv6DB
   - Irc
-  - irc-core
   - irc-dcc
   - irc-fun-bot
   - irc-fun-client

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2695,6 +2695,7 @@ package-maintainers:
     - streaming-wai
   kiwi:
     - irc-core
+    - random_1_2_0
     - Unique
   psibi:
     - path-pieces

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8032,6 +8032,7 @@ broken-packages:
   - mu-protobuf
   - mu-rpc
   - mu-schema
+  - mu-servant-server
   - mu-tracing
   - MuCheck
   - MuCheck-Hspec
@@ -9150,6 +9151,7 @@ broken-packages:
   - rclient
   - rdioh
   - react-flux
+  - react-flux-servant
   - react-haskell
   - react-tutorial-haskell-server
   - reaction-logic
@@ -9359,6 +9361,7 @@ broken-packages:
   - rfc-prelude
   - rfc-psql
   - rfc-redis
+  - rfc-servant
   - rg
   - rhythm-game-tutorial
   - rib
@@ -9623,6 +9626,23 @@ broken-packages:
   - serpentine
   - serv
   - serv-wai
+  - servant-auth-cookie
+  - servant-auth-token
+  - servant-auth-token-acid
+  - servant-auth-token-api
+  - servant-auth-token-leveldb
+  - servant-auth-token-persistent
+  - servant-auth-token-rocksdb
+  - servant-cli
+  - servant-csharp
+  - servant-db-postgresql
+  - servant-examples
+  - servant-iCalendar
+  - servant-jquery
+  - servant-js
+  - servant-openapi3
+  - servant-snap
+  - servant-waargonaut
   - server-generic
   - serversession-backend-acid-state
   - serversession-backend-persistent
@@ -10893,6 +10913,7 @@ broken-packages:
   - verilog
   - verismith
   - versioning
+  - versioning-servant
   - vflow-types
   - vfr-waypoints
   - vgrep

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2698,6 +2698,9 @@ package-maintainers:
     - config-value
     - glirc
     - irc-core
+    - matterhorn
+    - mattermost-api
+    - mattermost-api-qc
     - QuickCheck_2_14_2
     - random_1_2_0
     - Unique
@@ -7739,9 +7742,6 @@ broken-packages:
   - matrix-market
   - matrix-sized
   - matsuri
-  - matterhorn
-  - mattermost-api
-  - mattermost-api-qc
   - maude
   - maxent
   - maxent-learner-hw

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2696,6 +2696,7 @@ package-maintainers:
   kiwi:
     - config-schema
     - config-value
+    - glirc
     - irc-core
     - QuickCheck_2_14_2
     - random_1_2_0
@@ -5533,7 +5534,6 @@ broken-packages:
   - gli
   - glicko
   - glider-nlp
-  - glirc
   - GLMatrix
   - glob-posix
   - global

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3177,6 +3177,7 @@ broken-packages:
   - arbor-monad-metric-datadog
   - arbtt
   - arch-hs
+  - archive-libarchive
   - archiver
   - archlinux
   - archlinux-web
@@ -3459,6 +3460,7 @@ broken-packages:
   - bindings-apr-util
   - bindings-bfd
   - bindings-cctools
+  - bindings-common
   - bindings-dc1394
   - bindings-eskit
   - bindings-EsounD
@@ -3780,6 +3782,7 @@ broken-packages:
   - call-haskell-from-anything
   - camfort
   - campfire
+  - candid
   - canon
   - canonical-filepath
   - canonical-json
@@ -3936,6 +3939,9 @@ broken-packages:
   - citeproc-hs-pandoc-filter
   - cj-token
   - cjk
+  - cl3
+  - cl3-hmatrix-interface
+  - cl3-linear-interface
   - clac
   - clafer
   - claferIG
@@ -4226,6 +4232,7 @@ broken-packages:
   - CoreDump
   - CoreErlang
   - CoreFoundation
+  - corenlp-parser
   - Coroutine
   - coroutine-enumerator
   - coroutine-iteratee
@@ -4243,6 +4250,7 @@ broken-packages:
   - cparsing
   - CPBrainfuck
   - cpio-conduit
+  - cpkg
   - CPL
   - cplusplus-th
   - cprng-aes-effect
@@ -4332,6 +4340,7 @@ broken-packages:
   - curry-frontend
   - CurryDB
   - cursedcsv
+  - cursor-fuzzy-time-gen
   - curves
   - custom-prelude
   - CV
@@ -5022,6 +5031,7 @@ broken-packages:
   - fastirc
   - fastly
   - FastPush
+  - fastsum
   - FastxPipe
   - fathead-util
   - fault-tree
@@ -5206,6 +5216,7 @@ broken-packages:
   - FormalGrammars
   - format
   - format-status
+  - formatn
   - formattable
   - forml
   - formlets
@@ -5323,6 +5334,7 @@ broken-packages:
   - fusion
   - futun
   - future
+  - fuzzy-time-gen
   - fuzzy-timings
   - fwgl
   - fwgl-glfw
@@ -6082,6 +6094,7 @@ broken-packages:
   - hasql-postgres-options
   - hasql-queue
   - hasql-simple
+  - hasql-th
   - hastache
   - hastache-aeson
   - haste
@@ -6163,6 +6176,7 @@ broken-packages:
   - hdr-histogram
   - HDRUtils
   - headergen
+  - heap-console
   - heapsort
   - heart-app
   - heart-core
@@ -6181,6 +6195,7 @@ broken-packages:
   - hedgehog-gen-json
   - hedgehog-generic
   - hedgehog-golden
+  - hedgehog-servant
   - Hedi
   - hedis-config
   - hedis-pile
@@ -6779,6 +6794,7 @@ broken-packages:
   - hw-json-simd
   - hw-json-simple-cursor
   - hw-json-standard-cursor
+  - hw-prim-bits
   - hw-simd
   - hw-uri
   - hwall-auth-iitk
@@ -7418,6 +7434,7 @@ broken-packages:
   - lhe
   - lhs2TeX-hl
   - lhslatex
+  - libarchive
   - LibClang
   - libconfig
   - libcspm
@@ -7835,6 +7852,10 @@ broken-packages:
   - midimory
   - midisurface
   - mighttpd
+  - migrant-core
+  - migrant-hdbc
+  - migrant-postgresql-simple
+  - migrant-sqlite-simple
   - mikmod
   - mikrokosmos
   - miku
@@ -7908,6 +7929,7 @@ broken-packages:
   - monad-log
   - monad-lrs
   - monad-mersenne-random
+  - monad-metrics-extensible
   - monad-mock
   - monad-open
   - monad-parallel-progressbar
@@ -8114,6 +8136,9 @@ broken-packages:
   - nagios-plugin-ekg
   - nakadi-client
   - named-lock
+  - named-servant
+  - named-servant-client
+  - named-servant-server
   - named-sop
   - namelist
   - namespace
@@ -8190,6 +8215,7 @@ broken-packages:
   - network-hans
   - network-house
   - network-interfacerequest
+  - network-messagepack-rpc-websocket
   - network-minihttp
   - network-msgpack-rpc
   - network-netpacket
@@ -8815,6 +8841,7 @@ broken-packages:
   - postgresql-simple-queue
   - postgresql-simple-sop
   - postgresql-simple-typed
+  - postgresql-syntax
   - postgresql-tx-query
   - postgresql-tx-squeal
   - postgresql-typed-lifted
@@ -9220,6 +9247,8 @@ broken-packages:
   - reflex-gloss
   - reflex-gloss-scene
   - reflex-libtelnet
+  - reflex-localize
+  - reflex-localize-dom
   - reflex-orphans
   - reflex-process
   - reflex-sdl2
@@ -9400,6 +9429,7 @@ broken-packages:
   - roc-cluster
   - roc-cluster-demo
   - rock
+  - rocksdb-haskell
   - roku-api
   - rollbar
   - rollbar-hs
@@ -9571,6 +9601,7 @@ broken-packages:
   - sdl2-cairo-image
   - sdl2-compositor
   - sdl2-fps
+  - sdr
   - seakale
   - seakale-postgresql
   - seakale-tests
@@ -9623,23 +9654,78 @@ broken-packages:
   - serpentine
   - serv
   - serv-wai
+  - servant-aeson-specs
   - servant-auth-cookie
+  - servant-auth-hmac
   - servant-auth-token
   - servant-auth-token-acid
   - servant-auth-token-api
   - servant-auth-token-leveldb
   - servant-auth-token-persistent
   - servant-auth-token-rocksdb
+  - servant-auth-wordpress
+  - servant-avro
+  - servant-cassava
   - servant-cli
+  - servant-client-js
+  - servant-client-namedargs
   - servant-csharp
+  - servant-db
   - servant-db-postgresql
+  - servant-dhall
+  - servant-docs-simple
+  - servant-ede
+  - servant-ekg
+  - servant-elm
   - servant-examples
+  - servant-fiat-content
+  - servant-generate
+  - servant-generic
+  - servant-github
+  - servant-haxl-client
+  - servant-hmac-auth
+  - servant-http2-client
   - servant-iCalendar
   - servant-jquery
   - servant-js
+  - servant-JuicyPixels
+  - servant-kotlin
+  - servant-matrix-param
+  - servant-mock
+  - servant-namedargs
+  - servant-nix
   - servant-openapi3
+  - servant-pagination
+  - servant-pandoc
+  - servant-pool
+  - servant-postgresql
+  - servant-proto-lens
+  - servant-purescript
+  - servant-pushbullet-client
+  - servant-py
+  - servant-quickcheck
+  - servant-rawm-client
+  - servant-reason
+  - servant-reflex
+  - servant-router
+  - servant-scotty
+  - servant-seo
+  - servant-serf
+  - servant-server-namedargs
+  - servant-smsc-ru
   - servant-snap
+  - servant-streaming
+  - servant-streaming-client
+  - servant-streaming-docs
+  - servant-streaming-server
+  - servant-swagger-tags
+  - servant-to-elm
   - servant-waargonaut
+  - servant-yaml
+  - servant-zeppelin
+  - servant-zeppelin-client
+  - servant-zeppelin-server
+  - servant-zeppelin-swagger
   - server-generic
   - serversession-backend-acid-state
   - serversession-backend-persistent
@@ -9795,6 +9881,7 @@ broken-packages:
   - skeletons
   - skell
   - skemmtun
+  - skews
   - skulk
   - skylark-client
   - skylighting-lucid
@@ -10538,6 +10625,7 @@ broken-packages:
   - tomato-rubato-openal
   - toml
   - tonatona-google-server-api
+  - tonatona-servant
   - too-many-cells
   - toodles
   - top
@@ -10720,6 +10808,9 @@ broken-packages:
   - typesafe-precure
   - typescript-docs
   - typograffiti
+  - typson-beam
+  - typson-esqueleto
+  - typson-selda
   - tyro
   - u2f
   - uber
@@ -11135,6 +11226,7 @@ broken-packages:
   - wsedit
   - wshterm
   - wsjtx-udp
+  - wss-client
   - wstunnel
   - wtk
   - wtk-gtk
@@ -11405,6 +11497,7 @@ broken-packages:
   - zeromq3-haskell
   - zeromq4-clone-pattern
   - zeromq4-conduit
+  - zeromq4-patterns
   - zeroth
   - zettelkast
   - ZFS


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-11-27 20:00 +01:00. You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.