### PR TITLE
ccache: 3.7.12 -> 4.0

### DIFF
--- a/pkgs/applications/networking/browsers/webbrowser/default.nix
+++ b/pkgs/applications/networking/browsers/webbrowser/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchgit, makeDesktopItem, pkgconfig, makeWrapper
 # Build
-, python2, autoconf213, yasm, perl, ccache
+, python2, autoconf213, yasm, perl
 , unzip, gnome2, gnum4
 
 # Runtime
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    gnum4 makeWrapper perl pkgconfig python2 ccache
+    gnum4 makeWrapper perl pkgconfig python2
   ];
 
   buildInputs = [
@@ -54,7 +54,6 @@ in stdenv.mkDerivation rec {
   configurePhase = ''
     export MOZCONFIG=$PWD/.mozconfig
     export MOZ_NOSPAM=1
-    export HOME=$PWD # Needed by ccache
 
     cp $src/doc/mozconfig.example $MOZCONFIG
     # Need to modify it
@@ -65,7 +64,8 @@ in stdenv.mkDerivation rec {
       --replace "mk_add_options AUTOCONF=/usr/bin/autoconf-2.13" "mk_add_options AUTOCONF=${autoconf213}/bin/autoconf" \
       --replace 'mk_add_options MOZ_OBJDIR=$HOME/build/wbobjects/' "" \
       --replace "ac_add_options --x-libraries=/usr/lib64" "ac_add_options --x-libraries=${lib.makeLibraryPath [ xorg.libX11 ]}" \
-      --replace "_BUILD_64=1" "_BUILD_64=${lib.optionalString stdenv.hostPlatform.is64bit "1"}"
+      --replace "_BUILD_64=1" "_BUILD_64=${lib.optionalString stdenv.hostPlatform.is64bit "1"}" \
+      --replace "--enable-ccache" "--disable-ccache"
 
     echo >> $MOZCONFIG '
     #

--- a/pkgs/applications/networking/instant-messengers/baresip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/baresip/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, zlib, openssl, libre, librem, pkgconfig, gst_all_1
 , cairo, mpg123, alsaLib, SDL, libv4l, celt, libsndfile, srtp, ffmpeg_3
-, gsm, speex, portaudio, spandsp, libuuid, ccache, libvpx
+, gsm, speex, portaudio, spandsp, libuuid, libvpx
 }:
 stdenv.mkDerivation rec {
   version = "0.6.5";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [zlib openssl libre librem cairo mpg123
     alsaLib SDL libv4l celt libsndfile srtp ffmpeg_3 gsm speex portaudio spandsp libuuid
-    ccache libvpx
+    libvpx
   ] ++ (with gst_all_1; [ gstreamer gst-libav gst-plugins-base gst-plugins-bad gst-plugins-good ]);
   makeFlags = [
     "LIBRE_MK=${libre}/share/re/re.mk"

--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -1,23 +1,64 @@
-{ stdenv, fetchFromGitHub, asciidoc-full, gperf, perl, autoreconfHook, zlib, makeWrapper }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, substituteAll
+, binutils
+, asciidoc
+, cmake
+, perl
+, zstd
+, xcodebuild
+, makeWrapper
+}:
 
 let ccache = stdenv.mkDerivation rec {
   pname = "ccache";
-  version = "3.7.12";
+  version = "4.0";
 
   src = fetchFromGitHub {
-    owner = "ccache";
-    repo = "ccache";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1xnv4g4n1jk1i98sa53k8w6q7hbwbw62svs30lssppysbrv8x3gz";
+    sha256 = "1frcplrv61m2iwc6jwycpbcz1101xl6s4sh8p87prdj98l60lyrx";
   };
 
-  nativeBuildInputs = [ asciidoc-full autoreconfHook gperf perl ];
+  # TODO: Remove patches from upstream in next release
+  patches = [
+    # Fix badly named man page filename
+    (fetchpatch {
+      url = "https://github.com/ccache/ccache/commit/223e706fb24ce86eb0ad86079a97e6f345b9ef40.patch";
+      sha256 = "1h7amp3ka45a79zwlxh8qnzx6n371gnfpfgijcqljps7skhl5gjg";
+    })
+    # Build and install man page by default
+    (fetchpatch {
+      url = "https://github.com/ccache/ccache/commit/294ff2face26448afa68e3ef7b68bf4898d6dc77.patch";
+      sha256 = "0rx69qn41bgksc4m3p59nk5d6rz72rwnfska9mh5j62pzfm8axja";
+    })
+    # Fixes use of undeclared identifier 'CLONE_NOOWNERCOPY' on darwin
+    (fetchpatch {
+      url = "https://github.com/ccache/ccache/commit/411c010c3a5ee690cd42b23ffcf026ae009e2897.patch";
+      sha256 = "062s424d0d0psp6wjhmfnfn1s5dsrz403hdid5drm6l2san0jhq0";
+    })
+  ] ++ lib.optional stdenv.isDarwin (substituteAll {
+    src = ./force-objdump-on-darwin.patch;
+    objdump = "${binutils.bintools}/bin/objdump";
+  });
 
-  buildInputs = [ zlib ];
+  nativeBuildInputs = [ asciidoc cmake perl ];
+
+  buildInputs = [ zstd ];
 
   outputs = [ "out" "man" ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
+  checkInputs = lib.optional stdenv.isDarwin xcodebuild;
+  checkPhase = ''
+    export HOME=$(mktemp -d)
+    ctest --output-on-failure ${lib.optionalString stdenv.isDarwin ''
+      -E '^(test.nocpp2|test.modules)$'
+    ''}
+  '';
 
   passthru = {
     # A derivation that provides gcc and g++ commands, but that
@@ -63,9 +104,10 @@ let ccache = stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Compiler cache for fast recompilation of C/C++ code";
-    homepage = "https://ccache.dev/";
+    homepage = "https://ccache.dev";
     downloadPage = "https://ccache.dev/download.html";
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ metadark r-burns ];
     platforms = platforms.unix;
   };
 };

--- a/pkgs/development/tools/misc/ccache/force-objdump-on-darwin.patch
+++ b/pkgs/development/tools/misc/ccache/force-objdump-on-darwin.patch
@@ -1,0 +1,31 @@
+diff --git a/test/run b/test/run
+index 9623e49d..3df1c5a8 100755
+--- a/test/run
++++ b/test/run
+@@ -126,23 +126,17 @@ file_size() {
+ objdump_cmd() {
+     local file="$1"
+ 
+-    if $HOST_OS_APPLE; then
+-        xcrun dwarfdump -r 0 "$file"
+-    elif $HOST_OS_WINDOWS || $HOST_OS_CYGWIN; then
++    if $HOST_OS_WINDOWS || $HOST_OS_CYGWIN; then
+         # For some reason objdump only shows the basename of the file, so fall
+         # back to brute force and ignorance.
+         strings "$1"
+     else
+-        objdump -W "$file"
++        @objdump@ -W "$file"
+     fi
+ }
+ 
+ objdump_grep_cmd() {
+-    if $HOST_OS_APPLE; then
+-        fgrep -q "\"$1\""
+-    else
+-        fgrep -q ": $1"
+-    fi
++    fgrep -q ": $1"
+ }
+ 
+ expect_stat() {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10972,7 +10972,9 @@ in
 
   cc-tool = callPackage ../development/tools/misc/cc-tool { };
 
-  ccache = callPackage ../development/tools/misc/ccache { };
+  ccache = callPackage ../development/tools/misc/ccache {
+    asciidoc = asciidoc-full;
+  };
 
   # Wrapper that works as gcc or g++
   # It can be used by setting in nixpkgs config like this, for example:
@@ -10994,12 +10996,25 @@ in
   #     };
   # You can use a different directory, but whichever directory you choose
   # should be owned by user root, group nixbld with permissions 0770.
-  ccacheWrapper = makeOverridable ({ extraConfig ? "", cc ? stdenv.cc }:
-    cc.override { cc = ccache.links {
+  ccacheWrapper = makeOverridable ({ extraConfig, cc }:
+    cc.override {
+      cc = ccache.links {
+        inherit extraConfig;
+        unwrappedCC = cc.cc;
+      };
+    }) {
+      extraConfig = "";
+      inherit (stdenv) cc;
+    };
+
+  ccacheStdenv = lowPrio (makeOverridable ({ extraConfig, stdenv }:
+    overrideCC stdenv (buildPackages.ccacheWrapper.override {
       inherit extraConfig;
-      unwrappedCC = cc.cc;
-    }; }) {};
-  ccacheStdenv = lowPrio (overrideCC stdenv buildPackages.ccacheWrapper);
+      inherit (stdenv) cc;
+    })) {
+      extraConfig = "";
+      inherit stdenv;
+    });
 
   cccc = callPackage ../development/tools/analysis/cccc { };
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/ccache/ccache/releases/tag/v4.0

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  Removed as a build dependency of baresip & webbrowser:
  ```
  5 packages built:
  baresip ccache ccacheStdenv ccacheWrapper webbrowser
  ```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).