### PR TITLE
haskellPackages.binary-search: unbreak and patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -261,7 +261,7 @@ self: super: {
         });
   aws-kinesis = dontCheck super.aws-kinesis;            # needs aws credentials for testing
   binary-protocol = dontCheck super.binary-protocol;    # http://hydra.cryp.to/build/499749/log/raw
-  binary-search = dontCheck super.binary-search;
+  binary-search = dontCheck (appendPatch super.binary-search ./patches/binary-search-fix-for-ghc-8.patch);
   bits = dontCheck super.bits;                          # http://hydra.cryp.to/build/500239/log/raw
   bloodhound = dontCheck super.bloodhound;
   buildwrapper = dontCheck super.buildwrapper;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3409,7 +3409,6 @@ broken-packages:
   - binary-indexed-tree
   - binary-protocol
   - binary-protocol-zmq
-  - binary-search
   - binary-streams
   - binary-tagged
   - binary-typed

--- a/pkgs/development/haskell-modules/patches/binary-search-fix-for-ghc-8.patch
+++ b/pkgs/development/haskell-modules/patches/binary-search-fix-for-ghc-8.patch
@@ -1,0 +1,8 @@
+diff --git a/Setup.hs b/Setup.hs
+index 362b40c..9a994af 100644
+--- a/Setup.hs
++++ b/Setup.hs
+@@ -1,2 +1,2 @@
+ import Distribution.Simple
+-main = defaultMainWithHooks defaultUserHooks
++main = defaultMain


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix broken haskell package `binary-search`

This was wrongly managed in another PR i closed for being badly formatted and merging wrong updates: https://github.com/NixOS/nixpkgs/pull/98196

I rebased from NixOS/nixpkgs#haskell-updates and created a new/clean branch for better organization

I just have one question, is this the right branch to merge? It is a haskell package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
