### PR TITLE
pythonPackages.psycopg2cffi: init at 2.8.1

### DIFF
--- a/pkgs/development/python-modules/psycopg2cffi/default.nix
+++ b/pkgs/development/python-modules/psycopg2cffi/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage, cffi, fetchFromGitHub, lib, postgresql, pytestCheckHook, six }:
+
+buildPythonPackage rec {
+  pname = "psycopg2cffi";
+  version = "2.8.1";
+
+  # NB: This is a fork.
+  # The original repo exists at https://github.com/chtd/psycopg2cffi, however
+  # this is mostly unmaintained and does not build for PyPy. Given that the
+  # whole point of this cffi alternative to psycopg2 is to use it with PyPy, I
+  # chose to use a working fork instead, which was linked in the relevant issue:
+  # https://github.com/chtd/psycopg2cffi/issues/113#issuecomment-730548574
+  #
+  # If/when these changes get merged back upstream we should revert to using the
+  # original source as opposed to the fork.
+  src = fetchFromGitHub {
+    owner = "Omegapol";
+    repo = pname;
+    rev = "c202b25cd861d5e8f0f55c329764ff1da9f020c0";
+    sha256 = "09hsnjkix1c0vlhmfvrp8pchpnz2ya4xrchyq15czj527nx2dmy2";
+  };
+
+  nativeBuildInputs = [ postgresql ];
+  propagatedBuildInputs = [ six cffi ];
+  checkInputs = [ pytestCheckHook ];
+
+  # NB: The tests need a postgres instance running to test against, and so we
+  # disable them.
+  doCheck = false;
+
+  pythonImportsCheck = [ "psycopg2cffi" ];
+
+  meta = with lib; {
+    description = "An implementation of the psycopg2 module using cffi";
+    homepage = "https://pypi.org/project/psycopg2cffi/";
+    license = with licenses; [ lgpl3Plus ];
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4773,6 +4773,8 @@ in {
 
   psycopg2 = callPackage ../development/python-modules/psycopg2 { };
 
+  psycopg2cffi = callPackage ../development/python-modules/psycopg2cffi { };
+
   ptable = callPackage ../development/python-modules/ptable { };
 
   ptest = callPackage ../development/python-modules/ptest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a pypy-compat alternative to psycopg2.

c.c. @FRidh @jonringer
c.f. #104151

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
