### PR TITLE
iannix: 2016-01-31 -> 0.9.20-b

### DIFF
--- a/pkgs/applications/audio/iannix/default.nix
+++ b/pkgs/applications/audio/iannix/default.nix
@@ -26,6 +26,6 @@ mkDerivation rec {
     homepage = "https://www.iannix.org/";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nico202 ];
+    maintainers = with maintainers; [ freezeboy ];
   };
 }

--- a/pkgs/applications/audio/iannix/default.nix
+++ b/pkgs/applications/audio/iannix/default.nix
@@ -1,14 +1,15 @@
-{ mkDerivation, stdenv, fetchFromGitHub, alsaLib, pkgconfig, qtbase, qtscript, qmake
+{ mkDerivation, lib, fetchFromGitHub, alsaLib, pkgconfig, qtbase, qtscript, qmake
 }:
 
-mkDerivation {
+mkDerivation rec {
   pname = "iannix";
-  version = "2016-01-31";
+  version = "0.9.20-b";
+
   src = fetchFromGitHub {
     owner = "iannix";
     repo = "IanniX";
-    rev = "f84becdcbe154b20a53aa2622068cb8f6fda0755";
-    sha256 = "184ydb9f1303v332k5k3f1ki7cb6nkxhh6ij0yn72v7dp7figrgj";
+    rev = "v${version}";
+    sha256 = "6jjgMvD2VkR3ztU5LguqhtNd+4/ZqRy5pVW5xQ6K20Q=";
   };
 
   nativeBuildInputs = [ pkgconfig qmake ];
@@ -20,11 +21,11 @@ mkDerivation {
 
   enableParallelBuilding = true;
 
-  meta = {
-    description = "Graphical open-source sequencer,";
+  meta = with lib; {
+    description = "Graphical open-source sequencer";
     homepage = "https://www.iannix.org/";
-    license = stdenv.lib.licenses.lgpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.nico202 ];
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nico202 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Use an official release. This version still doesn't allow yet to migrate to Qt5.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
