### PR TITLE
qt5: 5.15.0 -> 5.15.2

### DIFF
--- a/doc/builders/packages/firefox.section.md
+++ b/doc/builders/packages/firefox.section.md
@@ -1,4 +1,4 @@
-# Firefox
+# Firefox {#sec-firefox}
 
 ## Build wrapped Firefox with extensions and policies
 
@@ -44,6 +44,6 @@ To view available enterprise policies visit [enterprise policies](https://github
 or type into the Firefox url bar: `about:policies#documentation`.
 Nix installed addons do not have a valid signature, which is why signature verification is disabled. This does not compromise security because downloaded addons are checksumed and manual addons can't be installed.
 
-# Troubleshooting
+## Troubleshooting {#sec-firefox-troubleshooting}
 If addons do not appear installed although they have been defined in your nix configuration file reset the local addon state of your Firefox profile by clicking `help -> restart with addons disabled -> restart -> refresh firefox`. This can happen if you switch from manual addon mode to nix addon mode and then back to manual mode and then again to nix addon mode.
 

--- a/pkgs/development/libraries/qt-5/5.15/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.15/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.15/5.15.0/submodules/ )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.15/5.15.2/submodules/ )

--- a/pkgs/development/libraries/qt-5/5.15/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.15/srcs.nix
@@ -4,339 +4,339 @@
 
 {
   qt3d = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qt3d-everywhere-src-5.15.0.tar.xz";
-      sha256 = "61856f0c453b79e98b7a1e65ea8f59976fa78230ffa8dec959b5f4b45383dffd";
-      name = "qt3d-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qt3d-everywhere-src-5.15.2.tar.xz";
+      sha256 = "03ed6a48c813c75296c19f5d721184ab168280b69d2656cf16f877d3d4c55c1d";
+      name = "qt3d-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtactiveqt-everywhere-src-5.15.0.tar.xz";
-      sha256 = "1b455eacfb9ef49912d7a79040ea409a6ab88dfa192d313e6b5e02a79d741b51";
-      name = "qtactiveqt-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtactiveqt-everywhere-src-5.15.2.tar.xz";
+      sha256 = "868161fee0876d17079cd5bed58d1667bf19ffd0018cbe515129f11510ad2a5c";
+      name = "qtactiveqt-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtandroidextras-everywhere-src-5.15.0.tar.xz";
-      sha256 = "c9019185221e94e37e250c84acaebfb7b2f5342e8ad60cdcff052ac2b85ec671";
-      name = "qtandroidextras-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtandroidextras-everywhere-src-5.15.2.tar.xz";
+      sha256 = "5813278690d89a9c232eccf697fc280034de6f9f02a7c40d95ad5fcf8ac8dabd";
+      name = "qtandroidextras-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtbase = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtbase-everywhere-src-5.15.0.tar.xz";
-      sha256 = "9e7af10aece15fa9500369efde69cb220eee8ec3a6818afe01ce1e7d484824c5";
-      name = "qtbase-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtbase-everywhere-src-5.15.2.tar.xz";
+      sha256 = "909fad2591ee367993a75d7e2ea50ad4db332f05e1c38dd7a5a274e156a4e0f8";
+      name = "qtbase-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtcharts-everywhere-src-5.15.0.tar.xz";
-      sha256 = "44a24fc16abcaf9ae97ecf3215f6f3b44ebdb3b73bcb4ed3549a51519e4883a7";
-      name = "qtcharts-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtcharts-everywhere-src-5.15.2.tar.xz";
+      sha256 = "e0750e4195bd8a8b9758ab4d98d437edbe273cd3d289dd6a8f325df6d13f3d11";
+      name = "qtcharts-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtconnectivity-everywhere-src-5.15.0.tar.xz";
-      sha256 = "f911fb8f8bf3a9958785d0378d25ced8989047938b7138d619854a94fa0b27dd";
-      name = "qtconnectivity-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtconnectivity-everywhere-src-5.15.2.tar.xz";
+      sha256 = "0380327871f76103e5b8c2a305988d76d352b6a982b3e7b3bc3cdc184c64bfa0";
+      name = "qtconnectivity-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtdatavis3d-everywhere-src-5.15.0.tar.xz";
-      sha256 = "8f07747f371f7c515c667240a795105c89aa83c08d88ee92fa1ef7efccea10a3";
-      name = "qtdatavis3d-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtdatavis3d-everywhere-src-5.15.2.tar.xz";
+      sha256 = "226a6575d573ad78aca459709722c496c23aee526aa0c38eb7c93b0bea1eb6fd";
+      name = "qtdatavis3d-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtdeclarative-everywhere-src-5.15.0.tar.xz";
-      sha256 = "9c3c93fb7d340b2f7d738d12408c047318c78973cb45bfc5ff6b3a57e1fef699";
-      name = "qtdeclarative-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtdeclarative-everywhere-src-5.15.2.tar.xz";
+      sha256 = "c600d09716940f75d684f61c5bdaced797f623a86db1627da599027f6c635651";
+      name = "qtdeclarative-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtdoc-everywhere-src-5.15.0.tar.xz";
-      sha256 = "07ca8db98c317f25cc9a041c48a6824baf63893bf5b535d6f8d266dea8c7659f";
-      name = "qtdoc-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtdoc-everywhere-src-5.15.2.tar.xz";
+      sha256 = "a47809f00f1bd690ca4e699cb32ffe7717d43da84e0167d1f562210da7714ce4";
+      name = "qtdoc-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtgamepad-everywhere-src-5.15.0.tar.xz";
-      sha256 = "dda54d9f90897944bed5e6af48a904a677fd97eb6f57ab08a2b232c431caf31a";
-      name = "qtgamepad-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtgamepad-everywhere-src-5.15.2.tar.xz";
+      sha256 = "c77611f7898326d69176ad67a9b886f617cdedc368ec29f223d63537d25b075c";
+      name = "qtgamepad-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtgraphicaleffects-everywhere-src-5.15.0.tar.xz";
-      sha256 = "0d2ea4bc73b9df13a4b739dcbc1e3c7b298c7e682f7f9252b232e3bde7b63eda";
-      name = "qtgraphicaleffects-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtgraphicaleffects-everywhere-src-5.15.2.tar.xz";
+      sha256 = "ec8d67f64967d5046410490b549c576f9b9e8b47ec68594ae84aa8870173dfe4";
+      name = "qtgraphicaleffects-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtimageformats-everywhere-src-5.15.0.tar.xz";
-      sha256 = "83f32101b1a898fcb8ed6f11a657d1125484ac0c2223014b61849d9010efebc8";
-      name = "qtimageformats-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtimageformats-everywhere-src-5.15.2.tar.xz";
+      sha256 = "bf8285c7ce04284527ab823ddc7cf48a1bb79131db3a7127342167f4814253d7";
+      name = "qtimageformats-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtlocation-everywhere-src-5.15.0.tar.xz";
-      sha256 = "c68b0778a521e5522641c41b1778999dd408ebfda1e0de166a83743268be5f3f";
-      name = "qtlocation-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtlocation-everywhere-src-5.15.2.tar.xz";
+      sha256 = "984fcb09e108df49a8dac35d5ce6dffc49caafd2acb1c2f8a5173a6a21f392a0";
+      name = "qtlocation-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtlottie = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtlottie-everywhere-src-5.15.0.tar.xz";
-      sha256 = "2053f474dcd7184fdcae2507f47af6527f6ca25b4424483f9265853c3626c833";
-      name = "qtlottie-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtlottie-everywhere-src-5.15.2.tar.xz";
+      sha256 = "cec6095ab8f714e609d2ad3ea8c4fd819461ce8793adc42abe37d0f6dc432517";
+      name = "qtlottie-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtmacextras-everywhere-src-5.15.0.tar.xz";
-      sha256 = "95a8c35b30373224cdd6d1ca0bdda1a314b20e91551a4824e8ca7e50ce8ff439";
-      name = "qtmacextras-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtmacextras-everywhere-src-5.15.2.tar.xz";
+      sha256 = "6959b0f2cec71cd66800f36cab797430860e55fa33c9c23698d6a08fc2b8776e";
+      name = "qtmacextras-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtmultimedia-everywhere-src-5.15.0.tar.xz";
-      sha256 = "0708d867697f392dd3600c5c1c88f5c61b772a5250a4d059dca67b844af0fbd7";
-      name = "qtmultimedia-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtmultimedia-everywhere-src-5.15.2.tar.xz";
+      sha256 = "0c3758810e5131aabcf76e4965e4c18b8911af54d9edd9305d2a8278d8346df5";
+      name = "qtmultimedia-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtnetworkauth-everywhere-src-5.15.0.tar.xz";
-      sha256 = "96c6107f6e85662a05f114c5b9bd3503a3100bd940e1494c73a99e77f9e7cf85";
-      name = "qtnetworkauth-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtnetworkauth-everywhere-src-5.15.2.tar.xz";
+      sha256 = "fcc2ec42faa68561efa8f00cd72e662fbc06563ebc6de1dc42d96bb2997acd85";
+      name = "qtnetworkauth-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtpurchasing-everywhere-src-5.15.0.tar.xz";
-      sha256 = "2127f180c4889055d88e2b402b62be80a5a213a0e48d2056cc9a01d9913b3a16";
-      name = "qtpurchasing-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtpurchasing-everywhere-src-5.15.2.tar.xz";
+      sha256 = "87120d319ff2f8106e78971f7296d72a66dfe91e763d213199aea55046e93227";
+      name = "qtpurchasing-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtquick3d = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtquick3d-everywhere-src-5.15.0.tar.xz";
-      sha256 = "6d3b91b653ba5e33fd5b37cd785ded6cf1dd83d35250c3addb77eb35f90e52cb";
-      name = "qtquick3d-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtquick3d-everywhere-src-5.15.2.tar.xz";
+      sha256 = "5b0546323365ce34e4716f22f305ebb4902e222c1a0910b65ee448443c2f94bb";
+      name = "qtquick3d-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtquickcontrols-everywhere-src-5.15.0.tar.xz";
-      sha256 = "7072cf4cd27e9f18b36b1c48dec7c79608cf87ba847d3fc3de133f220ec1acee";
-      name = "qtquickcontrols-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtquickcontrols-everywhere-src-5.15.2.tar.xz";
+      sha256 = "c393fb7384b1f047f10e91a6832cf3e6a4c2a41408b8cb2d05af2283e8549fb5";
+      name = "qtquickcontrols-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtquickcontrols2-everywhere-src-5.15.0.tar.xz";
-      sha256 = "839abda9b58cd8656b2e5f46afbb484e63df466481ace43318c4c2022684648f";
-      name = "qtquickcontrols2-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtquickcontrols2-everywhere-src-5.15.2.tar.xz";
+      sha256 = "671b6ce5f4b8ecc94db622d5d5fb29ef4ff92819be08e5ea55bfcab579de8919";
+      name = "qtquickcontrols2-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtquicktimeline = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtquicktimeline-everywhere-src-5.15.0.tar.xz";
-      sha256 = "16ffeb733ba15815121fca5705ed5220ce0a0eb2ec0431ad0d55da9426a03c00";
-      name = "qtquicktimeline-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtquicktimeline-everywhere-src-5.15.2.tar.xz";
+      sha256 = "b9c247227607437acec7c7dd18ad46179d20369c9d22bdb1e9fc128dfb832a28";
+      name = "qtquicktimeline-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtremoteobjects-everywhere-src-5.15.0.tar.xz";
-      sha256 = "86fcfdce77f13c7babdec4dc1d0c4b7b6b02e40120a4250dc59e911c53c08abf";
-      name = "qtremoteobjects-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtremoteobjects-everywhere-src-5.15.2.tar.xz";
+      sha256 = "6781b6bc90888254ea77ce812736dac00c67fa4eeb3095f5cd65e4b9c15dcfc2";
+      name = "qtremoteobjects-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtscript = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtscript-everywhere-src-5.15.0.tar.xz";
-      sha256 = "02dc21b309621876a89671be27cea86a58e74a96aa28da65fe1b37a3aad29373";
-      name = "qtscript-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtscript-everywhere-src-5.15.2.tar.xz";
+      sha256 = "a299715369afbd1caa4d7fa2875d442eab91adcaacafce54a36922442624673e";
+      name = "qtscript-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtscxml-everywhere-src-5.15.0.tar.xz";
-      sha256 = "9c3a72bf5ebd07553b0049cc1943f04cff93b7e53bde8c81d652422dbf12ff72";
-      name = "qtscxml-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtscxml-everywhere-src-5.15.2.tar.xz";
+      sha256 = "60b9590b9a41c60cee7b8a8c8410ee4625f0389c1ff8d79883ec5a985638a7dc";
+      name = "qtscxml-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtsensors-everywhere-src-5.15.0.tar.xz";
-      sha256 = "12b17ed6cbe6c49c8ab71958bc5d8ad1c42bf20e2fa72613ede11001e98144da";
-      name = "qtsensors-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtsensors-everywhere-src-5.15.2.tar.xz";
+      sha256 = "3f0011f9e9942cad119146b54d960438f4568a22a274cdad4fae06bb4e0e4839";
+      name = "qtsensors-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtserialbus-everywhere-src-5.15.0.tar.xz";
-      sha256 = "cee067c84d025e221b83d109b58ea16c4d2dc0af0aea45cc6724acd33a1b7379";
-      name = "qtserialbus-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtserialbus-everywhere-src-5.15.2.tar.xz";
+      sha256 = "aeeb7e5c0d3f8503215b22e1a84c0002ca67cf63862f6e3c6ef44a67ca31bd88";
+      name = "qtserialbus-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtserialport-everywhere-src-5.15.0.tar.xz";
-      sha256 = "ba19369069a707dffddca8d9c477bb2bb4aa26630dfee6792254c4bf9bd57a67";
-      name = "qtserialport-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtserialport-everywhere-src-5.15.2.tar.xz";
+      sha256 = "59c559d748417306bc1b2cf2315c1e63eed011ace38ad92946af71f23e2ef79d";
+      name = "qtserialport-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtspeech-everywhere-src-5.15.0.tar.xz";
-      sha256 = "7219a878c14a24d0ca18d52df1717361b13aee96ac9790baf9ad2b383492dd61";
-      name = "qtspeech-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtspeech-everywhere-src-5.15.2.tar.xz";
+      sha256 = "c810fb9eecb08026434422a32e79269627f3bc2941be199e86ec410bdfe883f5";
+      name = "qtspeech-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtsvg-everywhere-src-5.15.0.tar.xz";
-      sha256 = "ee4d287e2e205ca8c08921b9cbe0fc58bf46be080b5359ad4d7fbdee44aeee0d";
-      name = "qtsvg-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtsvg-everywhere-src-5.15.2.tar.xz";
+      sha256 = "8bc3c2c1bc2671e9c67d4205589a8309b57903721ad14c60ea21a5d06acb585e";
+      name = "qtsvg-everywhere-src-5.15.2.tar.xz";
     };
   };
   qttools = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qttools-everywhere-src-5.15.0.tar.xz";
-      sha256 = "ddbcb49aab3a2e3672582c6e2e7bec0058feff790f67472343c79e2895e0e437";
-      name = "qttools-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qttools-everywhere-src-5.15.2.tar.xz";
+      sha256 = "c189d0ce1ff7c739db9a3ace52ac3e24cb8fd6dbf234e49f075249b38f43c1cc";
+      name = "qttools-everywhere-src-5.15.2.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qttranslations-everywhere-src-5.15.0.tar.xz";
-      sha256 = "45c43268d9df50784d4d8ca345fce9288a1055fd074ac0ef508097f7aeba22fe";
-      name = "qttranslations-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qttranslations-everywhere-src-5.15.2.tar.xz";
+      sha256 = "d5788e86257b21d5323f1efd94376a213e091d1e5e03b45a95dd052b5f570db8";
+      name = "qttranslations-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtvirtualkeyboard-everywhere-src-5.15.0.tar.xz";
-      sha256 = "f22f9204ab65578d9c8aa832a8a39108f826e00a7d391c7884ff490c587f34be";
-      name = "qtvirtualkeyboard-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtvirtualkeyboard-everywhere-src-5.15.2.tar.xz";
+      sha256 = "9a3193913be30f09a896e3b8c2f9696d2e9b3f88a63ae9ca8c97a2786b68cf55";
+      name = "qtvirtualkeyboard-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwayland-everywhere-src-5.15.0.tar.xz";
-      sha256 = "084133e10bfbd32a28125639660c59975f23457bba6a79b30a25802cec76a9fb";
-      name = "qtwayland-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwayland-everywhere-src-5.15.2.tar.xz";
+      sha256 = "193732229ff816f3aaab9a5e2f6bed71ddddbf1988ce003fe8dd84a92ce9aeb5";
+      name = "qtwayland-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwebchannel-everywhere-src-5.15.0.tar.xz";
-      sha256 = "ea80510b363e6f92ce99932f06d176e43459c4a5159fe97b5ef96fcfbab5ed4f";
-      name = "qtwebchannel-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwebchannel-everywhere-src-5.15.2.tar.xz";
+      sha256 = "127fe79c43b386713f151ed7d411cd81e45e29f9c955584f29736f78c9303ec1";
+      name = "qtwebchannel-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwebengine-everywhere-src-5.15.0.tar.xz";
-      sha256 = "c38e2fda7ed1b7d5a90f26abf231ec0715d78a5bc39a94673d8e39d75f04c5df";
-      name = "qtwebengine-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwebengine-everywhere-src-5.15.2.tar.xz";
+      sha256 = "c8afca0e43d84f7bd595436fbe4d13a5bbdb81ec5104d605085d07545b6f91e0";
+      name = "qtwebengine-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwebglplugin = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwebglplugin-everywhere-src-5.15.0.tar.xz";
-      sha256 = "f7b81f25ddf7b3a0046daa7224bc1e18c8b754b00b1a33775f30f827a5cdca15";
-      name = "qtwebglplugin-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwebglplugin-everywhere-src-5.15.2.tar.xz";
+      sha256 = "81e782b517ed29e10bea1aa90c9f59274c98a910f2c8b105fa78368a36b41446";
+      name = "qtwebglplugin-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwebsockets-everywhere-src-5.15.0.tar.xz";
-      sha256 = "87c2f6542778f9b65b3f208740c1d0db643fd0bede21404b9abb265355da5092";
-      name = "qtwebsockets-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwebsockets-everywhere-src-5.15.2.tar.xz";
+      sha256 = "a0b42d85dd34ff6e2d23400e02f83d8b85bcd80e60efd1521d12d9625d4a233f";
+      name = "qtwebsockets-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwebview-everywhere-src-5.15.0.tar.xz";
-      sha256 = "b87ea205ce79c6b438ebe596e91fa80ba11f6aac7e89ffbf52b337d0fc8d6660";
-      name = "qtwebview-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwebview-everywhere-src-5.15.2.tar.xz";
+      sha256 = "be9f46167e4977ead5ef5ecf883fdb812a4120f2436383583792f65557e481e7";
+      name = "qtwebview-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtwinextras-everywhere-src-5.15.0.tar.xz";
-      sha256 = "d77f2cb2ce83bdbfd0a970bc8d7d11c96b2df16befc257d6594f79dfd92abff0";
-      name = "qtwinextras-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtwinextras-everywhere-src-5.15.2.tar.xz";
+      sha256 = "65b8272005dec00791ab7d81ab266d1e3313a3bbd8e54e546d984cf4c4ab550e";
+      name = "qtwinextras-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtx11extras-everywhere-src-5.15.0.tar.xz";
-      sha256 = "c72b6c188284facddcf82835af048240e721dc8d6d9e8a7bd71d76fd876881a1";
-      name = "qtx11extras-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtx11extras-everywhere-src-5.15.2.tar.xz";
+      sha256 = "7014702ee9a644a5a93da70848ac47c18851d4f8ed622b29a72eed9282fc6e3e";
+      name = "qtx11extras-everywhere-src-5.15.2.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.15.0";
+    version = "5.15.2";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.15/5.15.0/submodules/qtxmlpatterns-everywhere-src-5.15.0.tar.xz";
-      sha256 = "2752cf2aa25ebfda89c3736457e27b3d0c7c7ed290dcfd52c209f9f905998507";
-      name = "qtxmlpatterns-everywhere-src-5.15.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.15/5.15.2/submodules/qtxmlpatterns-everywhere-src-5.15.2.tar.xz";
+      sha256 = "76ea2162a7c349188d7e7e4f6c77b78e8a205494c90fee3cea3487a1ae2cf2fa";
+      name = "qtxmlpatterns-everywhere-src-5.15.2.tar.xz";
     };
   };
 }

--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "ppx_tools_versioned";
-  version = "5.3.0";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = pname;
     rev = version;
-    sha256 = "0c735w9mq49dmvkdw9ahfwh0icsk2sbhnfwmdhpibj86phfm17yj";
+    sha256 = "07lnj4yzwvwyh5fhpp1dxrys4ddih15jhgqjn59pmgxinbnddi66";
   };
 
   propagatedBuildInputs = [ ocaml-migrate-parsetree ];

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zerotierone";
-  version = "1.6.1";
+  version = "1.6.2";
 
   src = fetchFromGitHub {
     owner = "zerotier";
     repo = "ZeroTierOne";
     rev = version;
-    sha256 = "0zk1lvjramahjpq94axdic8sgvvmgyg1fmcb89lynqqvh66qsv12";
+    sha256 = "0lky68fjrqjsd62g97jkn5a9hzj53g8wb6d2ncx8s21rknpncdar";
   };
 
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Qt5.15.1 brought 400 bug fixes and Qt5.15.2 anoyther batch of 176, so let's take advantage of it.

Update done using the script in maintainers/scripts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
