### PR TITLE
awscli2: 2.0.54 -> 2.1.3

### DIFF
--- a/pkgs/tools/admin/awscli2/default.nix
+++ b/pkgs/tools/admin/awscli2/default.nix
@@ -8,12 +8,13 @@ let
   py = python3.override {
     packageOverrides = self: super: {
       botocore = super.botocore.overridePythonAttrs (oldAttrs: rec {
-        version = "2.0.0dev58";
+        version = "2.0.0dev71";
         src = fetchFromGitHub {
           owner = "boto";
           repo = "botocore";
-          rev = "2d65a1bdf85d24b40a40bc681b44d167ce1cc8cb";
-          hash = "sha256-HPeNWLhNFjRoD4TZ54ZGgJPp8fsnh8Rt6DMJ8Q0nPkY=";
+          rev = "f8b31e2a01a8797f8331c6af2c93a26ff82b2b4b";
+          hash = "sha256-25WV64RPXpGlq9mZYxUVKUdUjU+e1UnuVTLf9Z9I8Tc=
+";
         };
       });
       prompt_toolkit = super.prompt_toolkit.overridePythonAttrs (oldAttrs: rec {
@@ -29,16 +30,17 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.0.54"; # N.B: if you change this, change botocore to a matching version too
+  version = "2.1.3"; # N.B: if you change this, change botocore to a matching version too
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     rev = version;
-    hash = "sha256-RVF9/2s5oy3Re6hdvbhwPf0nXSoizBDwOgtXCc7cwgc=";
+    hash = "sha256-7klM8jLNptaMyOjKkrsldUdw10vABgIc+Fs3Kj/z0V0=";
   };
 
   postPatch = ''
+    substituteInPlace setup.py --replace "colorama>=0.2.5,<0.4.4" "colorama>=0.2.5"
     substituteInPlace setup.py --replace "cryptography>=2.8.0,<=2.9.0" "cryptography>=2.8.0"
     substituteInPlace setup.py --replace "docutils>=0.10,<0.16" "docutils>=0.10"
     substituteInPlace setup.py --replace "ruamel.yaml>=0.15.0,<0.16.0" "ruamel.yaml>=0.15.0"


### PR DESCRIPTION
###### Motivation for this change

Fix for compatibility issue with `python3Packages.colorama`: https://github.com/NixOS/nixpkgs/issues/104421 (blocking: https://github.com/NixOS/nixpkgs/pull/103718)

Related PR: https://github.com/NixOS/nixpkgs/pull/102134

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
