### PR TITLE
blktrace: adding patch for CVE-2018-10689 from upstream.

### DIFF
--- a/pkgs/os-specific/linux/blktrace/cve-2018-10689.patch
+++ b/pkgs/os-specific/linux/blktrace/cve-2018-10689.patch
@@ -1,0 +1,143 @@
+From d61ff409cb4dda31386373d706ea0cfb1aaac5b7 Mon Sep 17 00:00:00 2001
+From: Jens Axboe <axboe@kernel.dk>
+Date: Wed, 2 May 2018 10:24:17 -0600
+Subject: [PATCH] btt: make device/devno use PATH_MAX to avoid overflow
+
+Herbo Zhang reports:
+
+I found a bug in blktrace/btt/devmap.c. The code is just as follows:
+
+https://git.kernel.org/pub/scm/linux/kernel/git/axboe/blktrace.git/tree/btt/devmap.c?id=8349ad2f2d19422a6241f94ea84d696b21de4757
+
+       struct devmap {
+
+struct list_head head;
+char device[32], devno[32];    // #1
+};
+
+LIST_HEAD(all_devmaps);
+
+static int dev_map_add(char *line)
+{
+struct devmap *dmp;
+
+if (strstr(line, "Device") != NULL)
+return 1;
+
+dmp = malloc(sizeof(struct devmap));
+if (sscanf(line, "%s %s", dmp->device, dmp->devno) != 2) {  //#2
+free(dmp);
+return 1;
+}
+
+list_add_tail(&dmp->head, &all_devmaps);
+return 0;
+}
+
+int dev_map_read(char *fname)
+{
+char line[256];   // #3
+FILE *fp = my_fopen(fname, "r");
+
+if (!fp) {
+perror(fname);
+return 1;
+}
+
+while (fscanf(fp, "%255[a-zA-Z0-9 :.,/_-]\n", line) == 1) {
+if (dev_map_add(line))
+break;
+}
+
+fclose(fp);
+return 0;
+}
+
+ The line length is 256, but the dmp->device, dmp->devno  max length
+is only 32. We can put strings longer than 32 into dmp->device and
+dmp->devno , and then they will be overflowed.
+
+ we can trigger this bug just as follows:
+
+ $ python -c "print 'A'*256" > ./test
+    $ btt -M ./test
+
+    *** Error in btt': free(): invalid next size (fast): 0x000055ad7349b250 ***
+    ======= Backtrace: =========
+    /lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f7f158ce7e5]
+    /lib/x86_64-linux-gnu/libc.so.6(+0x7fe0a)[0x7f7f158d6e0a]
+    /lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f7f158da98c]
+    btt(+0x32e0)[0x55ad7306f2e0]
+    btt(+0x2c5f)[0x55ad7306ec5f]
+    btt(+0x251f)[0x55ad7306e51f]
+    /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f7f15877830]
+    btt(+0x26b9)[0x55ad7306e6b9]
+    ======= Memory map: ========
+    55ad7306c000-55ad7307f000 r-xp 00000000 08:14 3698139
+      /usr/bin/btt
+    55ad7327e000-55ad7327f000 r--p 00012000 08:14 3698139
+      /usr/bin/btt
+    55ad7327f000-55ad73280000 rw-p 00013000 08:14 3698139
+      /usr/bin/btt
+    55ad73280000-55ad73285000 rw-p 00000000 00:00 0
+    55ad7349a000-55ad734bb000 rw-p 00000000 00:00 0
+      [heap]
+    7f7f10000000-7f7f10021000 rw-p 00000000 00:00 0
+    7f7f10021000-7f7f14000000 ---p 00000000 00:00 0
+    7f7f15640000-7f7f15656000 r-xp 00000000 08:14 14942237
+      /lib/x86_64-linux-gnu/libgcc_s.so.1
+    7f7f15656000-7f7f15855000 ---p 00016000 08:14 14942237
+      /lib/x86_64-linux-gnu/libgcc_s.so.1
+    7f7f15855000-7f7f15856000 r--p 00015000 08:14 14942237
+      /lib/x86_64-linux-gnu/libgcc_s.so.1
+    7f7f15856000-7f7f15857000 rw-p 00016000 08:14 14942237
+      /lib/x86_64-linux-gnu/libgcc_s.so.1
+    7f7f15857000-7f7f15a16000 r-xp 00000000 08:14 14948477
+      /lib/x86_64-linux-gnu/libc-2.23.so
+    7f7f15a16000-7f7f15c16000 ---p 001bf000 08:14 14948477
+      /lib/x86_64-linux-gnu/libc-2.23.so
+    7f7f15c16000-7f7f15c1a000 r--p 001bf000 08:14 14948477
+      /lib/x86_64-linux-gnu/libc-2.23.so
+    7f7f15c1a000-7f7f15c1c000 rw-p 001c3000 08:14 14948477
+      /lib/x86_64-linux-gnu/libc-2.23.so
+    7f7f15c1c000-7f7f15c20000 rw-p 00000000 00:00 0
+    7f7f15c20000-7f7f15c46000 r-xp 00000000 08:14 14948478
+      /lib/x86_64-linux-gnu/ld-2.23.so
+    7f7f15e16000-7f7f15e19000 rw-p 00000000 00:00 0
+    7f7f15e42000-7f7f15e45000 rw-p 00000000 00:00 0
+    7f7f15e45000-7f7f15e46000 r--p 00025000 08:14 14948478
+      /lib/x86_64-linux-gnu/ld-2.23.so
+    7f7f15e46000-7f7f15e47000 rw-p 00026000 08:14 14948478
+      /lib/x86_64-linux-gnu/ld-2.23.so
+    7f7f15e47000-7f7f15e48000 rw-p 00000000 00:00 0
+    7ffdebe5c000-7ffdebe7d000 rw-p 00000000 00:00 0
+      [stack]
+    7ffdebebc000-7ffdebebe000 r--p 00000000 00:00 0
+      [vvar]
+    7ffdebebe000-7ffdebec0000 r-xp 00000000 00:00 0
+      [vdso]
+    ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0
+      [vsyscall]
+    [1]    6272 abort      btt -M test
+
+Signed-off-by: Jens Axboe <axboe@kernel.dk>
+---
+ btt/devmap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/btt/devmap.c b/btt/devmap.c
+index 0553a9e..5fc1cb2 100644
+--- a/btt/devmap.c
++++ b/btt/devmap.c
+@@ -23,7 +23,7 @@
+ 
+ struct devmap {
+ 	struct list_head head;
+-	char device[32], devno[32];
++	char device[PATH_MAX], devno[PATH_MAX];
+ };
+ 
+ LIST_HEAD(all_devmaps);
+-- 
+2.25.1
+

--- a/pkgs/os-specific/linux/blktrace/default.nix
+++ b/pkgs/os-specific/linux/blktrace/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ libaio ];
 
+  patches = [ ./cve-2018-10689.patch ];
+
   preConfigure = ''
     sed s,/usr/local,$out, -i Makefile
   '';


### PR DESCRIPTION

###### Motivation for this change

Addresses #90747 - CVE-2018-10689

Applied patch from: https://git.kernel.dk/?p=blktrace.git;a=patch;h=d61ff409cb4dda31386373d706ea0cfb1aaac5b7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
