### PR TITLE
Refresh instance metadata on boot

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -211,6 +211,22 @@
       and <literal>slaptest</literal> is buggy with schemas directly in the config file.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       Amazon EC2 and OpenStack Compute (nova) images now re-fetch instance meta data and user data from the instance
+       metadata service (IMDS) on each boot. For example: stopping an EC2 instance, changing its user data, and
+       restarting the instance will now cause it to fetch and apply the new user data.
+     </para>
+     <warning>
+       <para>
+         Specifically, <literal>/etc/ec2-metadata</literal> is re-populated on each boot. Some NixOS scripts that read
+         from this directory are guarded to only run if the files they want to manipulate do not already exist, and so
+         will not re-apply their changes if the IMDS response changes. Examples: <literal>root</literal>'s SSH key is
+         only added if <literal>/root/.ssh/authorized_keys</literal> does not exist, and SSH host keys are only set from
+         user data if they do not exist in <literal>/etc/ssh</literal>.
+       </para>
+     </warning>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
@@ -61,19 +61,23 @@
 
   echo "getting EC2 instance metadata..."
 
+  wget_imds() {
+    wget ${wgetExtraOptions} --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" "$@";
+  }
+
   if ! [ -e "$metaDir/ami-manifest-path" ]; then
-    wget ${wgetExtraOptions} --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
+    wget_imds -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
   fi
 
   if ! [ -e "$metaDir/user-data" ]; then
-    wget ${wgetExtraOptions} --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
+    wget_imds -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
   fi
 
   if ! [ -e "$metaDir/hostname" ]; then
-    wget ${wgetExtraOptions} --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
+    wget_imds -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
   fi
 
   if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-    wget ${wgetExtraOptions} --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
+    wget_imds -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
   fi
 ''

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.nix
@@ -8,9 +8,14 @@
 # Make sure that every package you depend on here is already listed as
 # a channel blocker for both the full-sized and small channels.
 # Otherwise, we risk breaking user deploys in released channels.
+#
+# Also note: OpenStack's metadata service for its instances aims to be
+# compatible with the EC2 IMDS. Where possible, try to keep the set of
+# fetched metadata in sync with ./openstack-metadata-fetcher.nix .
 ''
   metaDir=${targetRoot}etc/ec2-metadata
   mkdir -m 0755 -p "$metaDir"
+  rm -f "$metaDir/*"
 
   get_imds_token() {
     # retry-delay of 1 selected to give the system a second to get going,
@@ -65,19 +70,8 @@
     wget ${wgetExtraOptions} --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" "$@";
   }
 
-  if ! [ -e "$metaDir/ami-manifest-path" ]; then
-    wget_imds -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
-  fi
-
-  if ! [ -e "$metaDir/user-data" ]; then
-    wget_imds -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
-  fi
-
-  if ! [ -e "$metaDir/hostname" ]; then
-    wget_imds -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
-  fi
-
-  if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-    wget_imds -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
-  fi
+  wget_imds -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
+  wget_imds -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
+  wget_imds -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
+  wget_imds -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
 ''

--- a/nixos/modules/virtualisation/openstack-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/openstack-metadata-fetcher.nix
@@ -5,19 +5,23 @@
 
   echo "getting instance metadata..."
 
+  wget_imds() {
+    wget ${wgetExtraOptions} "$@"
+  }
+
   if ! [ -e "$metaDir/ami-manifest-path" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
+    wget_imds -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
   fi
 
   if ! [ -e "$metaDir/user-data" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
+    wget_imds -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
   fi
 
   if ! [ -e "$metaDir/hostname" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
+    wget_imds -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
   fi
 
   if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-    wget ${wgetExtraOptions} -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
+    wget_imds -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
   fi
 ''

--- a/nixos/modules/virtualisation/openstack-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/openstack-metadata-fetcher.nix
@@ -3,7 +3,7 @@
   metaDir=${targetRoot}etc/ec2-metadata
   mkdir -m 0755 -p "$metaDir"
 
-  echo "getting EC2 instance metadata..."
+  echo "getting instance metadata..."
 
   if ! [ -e "$metaDir/ami-manifest-path" ]; then
     wget ${wgetExtraOptions} -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path

--- a/nixos/modules/virtualisation/openstack-metadata-fetcher.nix
+++ b/nixos/modules/virtualisation/openstack-metadata-fetcher.nix
@@ -1,7 +1,12 @@
 { targetRoot, wgetExtraOptions }:
+
+# OpenStack's metadata service aims to be EC2-compatible. Where
+# possible, try to keep the set of fetched metadata in sync with
+# ./ec2-metadata-fetcher.nix .
 ''
   metaDir=${targetRoot}etc/ec2-metadata
   mkdir -m 0755 -p "$metaDir"
+  rm -f "$metaDir/*"
 
   echo "getting instance metadata..."
 
@@ -9,19 +14,8 @@
     wget ${wgetExtraOptions} "$@"
   }
 
-  if ! [ -e "$metaDir/ami-manifest-path" ]; then
-    wget_imds -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
-  fi
-
-  if ! [ -e "$metaDir/user-data" ]; then
-    wget_imds -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
-  fi
-
-  if ! [ -e "$metaDir/hostname" ]; then
-    wget_imds -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
-  fi
-
-  if ! [ -e "$metaDir/public-keys-0-openssh-key" ]; then
-    wget_imds -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
-  fi
+  wget_imds -O "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
+  wget_imds -O "$metaDir/user-data" http://169.254.169.254/1.0/user-data && chmod 600 "$metaDir/user-data"
+  wget_imds -O "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
+  wget_imds -O "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
 ''


### PR DESCRIPTION
###### Motivation for this change

Re-fetch instance meta data/user data on each boot. This means that we can stop instances, change user data, reboot the instance, and expect the new user data to actually be applied.

~~**NOTE** I tried to cargo-cult the docbook but I must have screwed it up. Help please?~~ Never mind, my test instance ran out of memory trying to rebuild docs.

###### Things done

* Built an EC2 AMI at commit f2ca527 (i.e., everything but the docbook changes), launched that AMI with no user data, stopped the instance, set up some user data and rebooted the instance, and checked that the user data was being applied.

Ping @grahamc