### PR TITLE
botan2: update 2.7.0 -> 2.9.0

### DIFF
--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -1,9 +1,9 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  baseVersion = "2.7";
+  baseVersion = "2.9";
   revision = "0";
-  sha256 = "142aqabwc266jxn8wrp0f1ffrmcvdxwvyh8frb38hx9iaqazjbg4";
+  sha256 = "06fiyalvc68p11qqh953azx2vrbav5vr00yvcfp67p9l4csn8m9h";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';


### PR DESCRIPTION

###### Motivation for this change

Addresses #90758 - CVE-2018-12435 CVE-2018-20187 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
