### PR TITLE
ocamlPackages.rpclib: 7.0.0 → 8.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
@@ -1,13 +1,16 @@
-{ lib, buildDunePackage, rpclib, ppxlib, ppx_deriving }:
+{ lib, buildDunePackage, rpclib, alcotest, ppxlib, ppx_deriving, yojson }:
 
 buildDunePackage rec {
   pname = "ppx_deriving_rpc";
 
-  inherit (rpclib) version src;
+  inherit (rpclib) version useDune2 src;
 
-  buildInputs = [ ppxlib ];
+  minimumOCamlVersion = "4.08";
 
-  propagatedBuildInputs = [ rpclib ppx_deriving ];
+  propagatedBuildInputs = [ ppxlib rpclib ppx_deriving ];
+
+  checkInputs = [ alcotest yojson ];
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/mirage/ocaml-rpc";

--- a/pkgs/development/ocaml-modules/rpclib/default.nix
+++ b/pkgs/development/ocaml-modules/rpclib/default.nix
@@ -1,20 +1,22 @@
-{ lib, fetchFromGitHub, buildDunePackage, alcotest, cmdliner, rresult, result, xmlm, yojson }:
+{ lib, fetchurl, buildDunePackage
+, alcotest
+, base64, cmdliner, rresult, xmlm, yojson
+}:
 
 buildDunePackage rec {
   pname = "rpclib";
-  version = "7.0.0";
+  version = "8.0.0";
 
-  minimumOCamlVersion = "4.04";
+  useDune2 = true;
 
-  src = fetchFromGitHub {
-    owner = "mirage";
-    repo = "ocaml-rpc";
-    rev = "v${version}";
-    sha256 = "0d8nb272mjxkq5ddn65cy9gjpa8yvd0v3jv3wp5xfh9gj29wd2jj";
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-rpc/releases/download/v${version}/rpclib-v${version}.tbz";
+    sha256 = "1kqbixk4d9y15ns566fiyzid5jszkamm1kv7iks71invv33v7krz";
   };
 
-  buildInputs = [ alcotest cmdliner yojson ];
-  propagatedBuildInputs = [ rresult result xmlm ];
+  buildInputs = [ cmdliner yojson ];
+  propagatedBuildInputs = [ base64 rresult xmlm ];
+  checkInputs = [ alcotest ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/rpclib/lwt.nix
+++ b/pkgs/development/ocaml-modules/rpclib/lwt.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage, rpclib
+, lwt
+, alcotest-lwt, ppx_deriving_rpc, yojson
+}:
+
+buildDunePackage {
+  pname = "rpclib-lwt";
+  inherit (rpclib) version useDune2 src;
+
+  propagatedBuildInputs = [ lwt rpclib ];
+
+  checkInputs = [ alcotest-lwt ppx_deriving_rpc yojson ];
+  doCheck = true;
+
+  meta = rpclib.meta // {
+    description = "A library to deal with RPCs in OCaml - Lwt interface";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -874,9 +874,7 @@ let
 
     ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
 
-    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc {
-      ppxlib = ppxlib.override { legacy = true; };
-    };
+    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
 
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -932,6 +932,8 @@ let
 
     rpclib = callPackage ../development/ocaml-modules/rpclib { };
 
+    rpclib-lwt = callPackage ../development/ocaml-modules/rpclib/lwt.nix { };
+
     rresult = callPackage ../development/ocaml-modules/rresult { };
 
     safepass = callPackage ../development/ocaml-modules/safepass { };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.10

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
