### PR TITLE
pynac: use python3 instead of python2

### DIFF
--- a/pkgs/applications/science/math/pynac/default.nix
+++ b/pkgs/applications/science/math/pynac/default.nix
@@ -4,8 +4,9 @@
 , pkgconfig
 , flint
 , gmp
-, python2
+, python3
 , singular
+, ncurses
 }:
 
 stdenv.mkDerivation rec {
@@ -23,8 +24,8 @@ stdenv.mkDerivation rec {
     flint
     gmp
     singular
-    singular
-    python2
+    python3
+    ncurses
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
The use of python2 was a problem with the future sage 9.2. Python3 is supported upstream since sage (the major software using this library) moved itself to python3. 
I don't really know about this project so I can't test in depth.

###### Motivation for this change
Make sage 9.2  run. See https://github.com/NixOS/nixpkgs/pull/101447#issuecomment-731238863 for details about the original problem.

###### Things done
Change python2 to python3. 
Add dependencies to ncurses since it was used in the configure step.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
