### PR TITLE
[20.09] thunderbird, thunderbird-bin: 78.4.3 -> 78.5.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.3";
+  version = "78.5.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/af/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/af/thunderbird-78.5.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "03d4e32b23408b003de5347b2a26d9e3e734f7c3e811510ba81114eff80e6fa3";
+      sha256 = "011468ce085f2b5da8968b0622733d9fa25b47ec5e83b3bf4171323948aebb35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ar/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ar/thunderbird-78.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "5aefbc61f46d59de19061a0e76949642e254a13867881b40b6bac289791c281e";
+      sha256 = "661b0f1981b21df20b910f9d833d86c2812b189097ad7e1affc7338abb4f0c5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ast/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ast/thunderbird-78.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "1e328339808efed1db23ed372841ff65f64e1bda8e1d4be81fd00039468bbb1f";
+      sha256 = "c1acc2b6d5dd22adeab3106c3c6925ce0c1a434e1d38b3f699fab4ca319eab14";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/be/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/be/thunderbird-78.5.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f42230768f2907fb3d23a03a56fc20f14ff5ded7b4418debb3e77c4942eb7db8";
+      sha256 = "6f76341164c182dd8392d2d1abbb0408a3ab773a7389dbf1eb9bb4042d49f500";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/bg/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/bg/thunderbird-78.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "27a72288cbaaaaee6a24a36bb2e463a0426810e97938cbfe012dceb1a3800fd0";
+      sha256 = "4e97b38383d3a145645ca518449e37e42b5b25cbb98cb72f52657b4813f2b343";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/br/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/br/thunderbird-78.5.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "fa1b6c891e3d9d097857a08181030e1df2201240ae466c4adc6fc0be0982d002";
+      sha256 = "1d5bcb706bf2eb589aa0c64589fc5b22021977947d6e1099f339a46c55a56f84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ca/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ca/thunderbird-78.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6bcc123c7ecccbf42022e302b63683cdf77f6f6f2a615b12c5ea9e6a081fb900";
+      sha256 = "3284b98707ee67977f148bd20d88750cc03799d9ba4aa5668c44901846fb8bcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cak/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cak/thunderbird-78.5.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "392cc166ee9be6c5cf8294f727f97cb21b6ad7ebb77d263bba273f02cb15e661";
+      sha256 = "7998d66eaf3edc4ee156dff06a30de8abae08ff66b380ea93d7ec0b827a0ea29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cs/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cs/thunderbird-78.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "60f5ea97e75f965ac0947e51c8cb8e709e5fa8f67ea478babe936032dee5a912";
+      sha256 = "5ba37c9dd7a1fc291bcc8b24ef025432dbd5f8a45ea2a4d1273177c6a7c8f6bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cy/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cy/thunderbird-78.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "93aa92633d2414ad59aedea8b1a820b158a21c042cbfaedd8abd2b5a41e31c5c";
+      sha256 = "baaad2ef28f51b6f57fa6f0583e8e0125c50ea3b4c94dea5854faf9826aecad0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/da/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/da/thunderbird-78.5.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "dc263e9d186f4ca8cd404b6e5bd13f9d2874e0e2507eaa55e99a6b5ab3b05179";
+      sha256 = "6113ed3f5a36f16e64f0cc499eb683a0d7d377d0cce37882f46f203893b789d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/de/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/de/thunderbird-78.5.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d9dbf07f3c57f688b08f75673074562ad9d4a9b138159f353415d63f9ccac80b";
+      sha256 = "81490e8cd8110285177c27f4057ff48ed1bdb55c94c83cc78e262b9cfcbd87ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/dsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/dsb/thunderbird-78.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "084ef3ef3628d003c75dea9a9fa5897424e6e564cb18fb5bca33b341c8c511cc";
+      sha256 = "4c6abc365842c902ff184b403a6c271760bd8e71da9efa90d30310e032b03729";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/el/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/el/thunderbird-78.5.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "4e91e7d21d0a3d524de7e41201ce8af58518a7e0292c11fc2961a84e9b7d04fb";
+      sha256 = "d492a83d3ddaf5beead77fd90a2334ca4ed90023d4c4ad478249a360f49cd5be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-CA/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-CA/thunderbird-78.5.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "922220811fb0083e8dc51c7cbd703530acdfeb0e9403d1a0909ba1618db020bf";
+      sha256 = "d7ddc5a22e89827067255726824e46d3355906441051c9faa04e6241cb833955";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-GB/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-GB/thunderbird-78.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "090806f6ebf12efbc5c20a920451feeb0d88d1e7366a074553b79080869687c4";
+      sha256 = "10ff106bb933374661e3398ea4ce02c205242d1f7a647504161e295b5e3d1e11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-US/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-US/thunderbird-78.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7fa3769297600c47c54902bac696e718053c48fc02e54698cb05ef81a4eec873";
+      sha256 = "297429aff3f10ab7c2859a37ec351b6b0a478495b8a34e8b492ae3473f052c7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-AR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/es-AR/thunderbird-78.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "51be3a453bb3e3f1353b88ab31fffa3fc0c135cb91facb7807c967a9d4afa659";
+      sha256 = "c8bafb3476d127d28f565ea5dd749b0c870087f395e0aabfb848a004846498e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-ES/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/es-ES/thunderbird-78.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "8828e5ff82e84c5f69afd60ae5dbba445d766e2a2d7fbbcd8f0dc8f255d8fc02";
+      sha256 = "d8c5350627e7e6f48fbfa863bed1971254104ee299d81d1f36b99d6c6ee54313";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/et/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/et/thunderbird-78.5.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d58404701341bcd9b859f1afb87cb3340fc4b8334cc9490e8ea21446e3f308eb";
+      sha256 = "f2a1001b0bb87965e40cd832102d2233b732273930d36715ff2db900b37c9ed2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/eu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/eu/thunderbird-78.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "5570472164329f23d3f0be51911402c2b454ea704419ef16b46b359a2c93e821";
+      sha256 = "30c6da377a8fc4596f6a67b189c1c9f7a9075df96ed3a59b4da7e0e77157d950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fa/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fa/thunderbird-78.5.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "cc56e14f1fa17e8b4ec9431ae9ada10159bd90bcade39432c647ba401791e3fe";
+      sha256 = "8f98dd01764a5d244c25c3c409b8dbcaa1d3daf7b3a970c60d3d37fd5ffc4294";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fi/thunderbird-78.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "5175e312e8957490b013dd515b84fe4dfcdf57d30c6806f8bdee67caf39659f7";
+      sha256 = "be5f152b28ee21d916b184999023a1a5adddd1d2c7448e7eb37bd08948f6a14c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fr/thunderbird-78.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5239f8a07f0f6bc4f69b3d4315570dab33c331ab775479a9df39479b71542cc7";
+      sha256 = "c1b2d725c43196dfe3f9bfd291dfae84ba392151222589d80e3921e627667d59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fy-NL/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fy-NL/thunderbird-78.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "5747be2c7f9d5463f9c14fd02fd5e66a8f6c4c8adca3a1bf8c3b4333f1ea2adf";
+      sha256 = "622c42950cc7d3889372b6e0c5833dc5c5f608ab23ca9962e0af67ce4b2f8ff5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ga-IE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ga-IE/thunderbird-78.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "8e15ffc9235742ad88a1ecaf587a178f5aeb0bc57e075b33f792e2d458362ab9";
+      sha256 = "7293859380e07d362192cd9dcf88b8da04cde6e102f0b8d51a00021bf8fd9e98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gd/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/gd/thunderbird-78.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "72f53918cd04e587319d59100da05657a3084f97d70acba7d1ef7b7321add6ff";
+      sha256 = "f54b892150bd49d028337a88d3a0b2df896a47a6904067b381d385281d2c681e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/gl/thunderbird-78.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "28beb85fe0ea27a659e5063f7094877e906729602ef2e155f0e55e9e9f6d56ad";
+      sha256 = "58c88bf739fde7e0f7e279106622abde617a0aa267f34f1c10f8d886800dc50b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/he/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/he/thunderbird-78.5.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "718f8605fc8d418c645a0485ce86d97ae1eeded8b776a990e137ced78eb91a68";
+      sha256 = "8278c7580356c360c74ad161a6ee052e9398e39a2a5b75217ac0239db28ee4cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hr/thunderbird-78.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "febadac023152dc30e72026f6df203c8051b65ad4da0c4e7059a14ab0b4b5f37";
+      sha256 = "b20bef1b7fab8d63c5cc6336dd59264e7c62a9a4c6f2db4232ed27624b26a3cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hsb/thunderbird-78.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "faaaf4606fde4baca3216ed5801209f13cd1bbf34c9671cfc7a7648bb0ac7351";
+      sha256 = "ad4797a36c713b5026a4da131fc46f341cb8b72e5ad2f07a677bfedca8401163";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hu/thunderbird-78.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "353633956336852193510c8e77251834355c92ec503ab827a389a0dbc21c05bc";
+      sha256 = "1f3dea138c4f82f91b9aaf891b9959d1cdda273f20af811d967ed55058f69064";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hy-AM/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hy-AM/thunderbird-78.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1b5dba6f05ecc8449522d8a54c1d4e7aa5ec7a2e26fafbaefbd754ee3ea5780f";
+      sha256 = "836668531a555d9bd23fbb3c3b27cc647a327d02e6db1903248fc6b3d59c5dc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/id/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/id/thunderbird-78.5.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "470151868d745ce829f0f38c6377f4ead87be829d43f4383d2e5c3541b93e8d2";
+      sha256 = "1d74cd88cddf7b22ef8b19ee6cfedaaade15cecf68712ec8568888d0708c9c81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/is/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/is/thunderbird-78.5.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e9d6b36beb61445c3f96ffe6e11b238a8539b398d5f3911f2ded7ee96ec0766c";
+      sha256 = "a6e3320211b207e9a36c6197dbf97e746d2e9e9b7bda444a8511550b5846d329";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/it/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/it/thunderbird-78.5.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "95a02afcebb834b14986b8ccd92d5381a8ac64d3ebbba13860ffbd0313a594e1";
+      sha256 = "f0e659e6888590394a652033f3d15b29ff9318b4c88faae51d6347f1441201b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ja/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ja/thunderbird-78.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "d1c4e2a551a5266839da96b843372e71616346ea00361dccc8e1a62628e6315f";
+      sha256 = "a2ffc461e6d942222bef4229a820bf8536ef41dce83efc458d82476d5f98f5a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ka/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ka/thunderbird-78.5.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9eb37a69a370b2619724c91c6789471b9ef579190c08363f633f320563dc4df1";
+      sha256 = "6a374b791fac25bfc3f10726d93497291163dd95b1372dc09db70c098822f4f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kab/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/kab/thunderbird-78.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "bce07886dc5251ef401141d387c926f27f61d13450f35cb9a9cbc8403b43260a";
+      sha256 = "a23dc5cfef7bcbe32c32363d0048813a24cfbb19f17c3041b23fc751936dcadc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/kk/thunderbird-78.5.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "222647dd8106134d46bbad6dad8638090e5441a64aa2a6725aa5b1d959a2832a";
+      sha256 = "2187f7d763d34787de0d9870f746548459bd0a2ef0676286d2f9ce9bc9092ef1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ko/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ko/thunderbird-78.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "be2346d5a48e5323d5cc8c1077adf054927d8aececd2fb45fc2f5c0a9f0b8dc2";
+      sha256 = "ff88da9f6c77e8f5c1bebab542abc51266ba03d97fc5d22b86cf52a26db75e63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/lt/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/lt/thunderbird-78.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "da5cde252d5e167025fb06861a32b67a2d0f7171c767bdd8c5d2ba9fc90d7739";
+      sha256 = "77531cad8587aba9c4091bd22c79e40e45d3c57083b5af3e54af3576ed45134b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ms/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ms/thunderbird-78.5.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "d6ab0652184cbbfe9126a49f61c25fe8852725b88460ad92c37dc1c4d969368f";
+      sha256 = "aaa346d9bcc1cbd84beedb75c9949d4a2cd8bf80496a31e2018c2493fed68339";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nb-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nb-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "2485cc4df1b1dafd0c5fb7d7723e923e7fea10af1dbf9764d5d7447f38825e49";
+      sha256 = "dac3f1eeef73c247f9c79a09b7ffab1498be6c96865b5f21ee28d398941430a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nl/thunderbird-78.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "0795d2ae4364def43056e77106ea19053c3111e2f95758dbb41875071655ba47";
+      sha256 = "e0b3df7064e08e34f85b9a83d2bef990f66ad0e1bc86f764139fc57d005d1aa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nn-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nn-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b774035d8bff615646d3b3d73228277531d50309fb5dbf3978346e2b988b2491";
+      sha256 = "eb420586e8be191ffc41f4a920506336cc9dccbf229c260a7f193cbe169a6da4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pa-IN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pa-IN/thunderbird-78.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "2a38813c8aa0eaef3d2ec0ac379ab5c85d0b8c2df1f6a2d36ae066f7b0445447";
+      sha256 = "12f7c97b130ce40dd1dcd00a16a20000113b7be33c87ab9002848439ce626abd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pl/thunderbird-78.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "21cdb977bff1f0c07bf913b4feab2075a429b4594760de52ac358538179d9c66";
+      sha256 = "5ad96dee4b422c820da8a76ab64e62e919c21d99b01b92f346a55acada7cf8ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-BR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pt-BR/thunderbird-78.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d903ccd23367c39779ac2cdd3abe636a0f9e72f8d133a567bead8a739e651589";
+      sha256 = "7d6568c067796f21079a4f6bf3374a1b91807a9b30270587cf815892d86e1590";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-PT/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pt-PT/thunderbird-78.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f220a8bc90b05dd796c402aa5e79c62a8aa91a4d80dacbdf57abf77ec51d73b0";
+      sha256 = "22058d65e2ba94f39ca6ada6750beacf2bacac0f296a34542fde01e897e4a4e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/rm/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/rm/thunderbird-78.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "805d08f629e9dda7d6db36bd41dbcc128defe59b4610e4b7d5d47408a07e47b8";
+      sha256 = "c61ff10e4260eb2650fc1a4e0ca8df6c4e4e2e9525168ceaef86a9b8b2ddba54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ro/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ro/thunderbird-78.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "3b09b2c59f32a09938a45270e04740616b2a13f8b8a6f40503650d9b0f72fc35";
+      sha256 = "2ec34bfd9fe4a0f0cf17f132146ab2a589c986a8b4317124f3bfc34ac48f732a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ru/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ru/thunderbird-78.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "2022473752da127d2ebe4eef7f834ac5feafe38dedbe64ad30defb8ae69c6ebd";
+      sha256 = "b835dd1757f5cdc580a2b91f01a8089c1396d9eacee665fe9976019f8523fdec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/si/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/si/thunderbird-78.5.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "dc5166b0b24bd0a9e98f7dfc483a6bff184a4bfffb0eff8a4007b96fe8205254";
+      sha256 = "3722e47d39024c13dd799e0c89cf79a1302817605f7025388cd5f62fea15d168";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sk/thunderbird-78.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d30e4d3218fbf13a5c531d45f55f0f366aac10aa2d180886ced778c7459c0610";
+      sha256 = "4717620562c338f533053677d8956490d2d42abfd52beb6a0d41466ba3e72a36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sl/thunderbird-78.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f968618f7b13b6dc4441a09882ac5c826017a5b0ca3887b7cdca8ef6a3b3c266";
+      sha256 = "d712c5b3dddfa181877353d28667d410bea3a1f3d85e92dc058a3f3ac5ff4824";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sq/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sq/thunderbird-78.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "f4400c6e55859e07705b353cbf211e863e8c3f373490f3fff6bd3e6d360d5b7f";
+      sha256 = "8443ae1161c6b3e807c9d4abc01824e894a11b6f6c9a52d3097b8301461ac0c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sr/thunderbird-78.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f6437ffb64b1a98b5c5630f3b386b12866a514467c641fb02c8e86560e4b62d9";
+      sha256 = "13f093880d41748efa8f1566e5884d632f2fa80d4eb4f1a8dd1dc20ea626cee8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sv-SE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sv-SE/thunderbird-78.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "f1af8019698347ac94bad5c33b5e094b65e8ebed9181f5fed5e740cf2029bcef";
+      sha256 = "ee9d7262a8b6cd8460b2f1c4c0102b68f9a0983e1f021f2283ead172f07e3f37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/th/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/th/thunderbird-78.5.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "75830b637302032bbc70342b71012f391b333a2645d8fefb8f4232d432c9dde1";
+      sha256 = "09cd7b862cb8caa511b6d550bb668f0fd51fdfee5b2f6a31814282785688e4de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/tr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/tr/thunderbird-78.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "3691e5aca6b9713fab9c8a15952d1ceae50d67cc60e362eacc9513a362875dfd";
+      sha256 = "0d9f63aa7b63d571d7414755bd4e8bc27b7c5fd093ee46ed0fc2db469940dcd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/uk/thunderbird-78.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c4aca974c3a541c312029eb66fb8fdb1c5ecd787deb67a10bda3195f0ca06263";
+      sha256 = "0aa64449381edeed7c37d18e03f74dac2f5038a6c3c5de9fa6ad037b139bb5bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uz/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/uz/thunderbird-78.5.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2052c0a9a41c81a37aa23fbf28775e286b8350594b01aff629604ccbd74ae90d";
+      sha256 = "eabd24b838a072cb1aa9bebf3c573b3a6e7a364b759aebd62d12b16911956a00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/vi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/vi/thunderbird-78.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b142f463cd953bfc423be210eb891f66e948308129de74cdfd415409d4b0cb03";
+      sha256 = "ce9b5afcb60fc0f17a384a9096b26626f3d3f570222910a46872688009aee262";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-CN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/zh-CN/thunderbird-78.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0664f379ce4e464e2e6dcc3cfa749bd6ae4a597b008b7fd1c97bb6219727da6d";
+      sha256 = "9d69c7ef37282a7741d2392456c9ef5f5700fa1b718889e93bf7010fa99617db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-TW/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/zh-TW/thunderbird-78.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2ba4d49b52e6cd699f7bb1fa8f024c330f67d6b9df543a77fea7c3dc87985cc4";
+      sha256 = "6001d4e74212b72b2a3583438925d2431bb28994a661b4b47e77268e7790e526";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/af/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/af/thunderbird-78.5.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "60f62dc28a8433e571b894d33c0d9670c3aebc6a8c556c65f12d8d574e5edceb";
+      sha256 = "e30adc9074f08e04a4477f59eff6af83bcdf22ccafa1aef5ace219a830c50f38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ar/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ar/thunderbird-78.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "cf0fc7d7af09b20dbb35364ac0e47615919ae1627a0b729acf2f13dd99198400";
+      sha256 = "6d9456fd3f76de33a3f7c46d8197d83c36c832922b83de64cf4c2f5a56f7729d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ast/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ast/thunderbird-78.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "cb7ed53eedb55858fa5a5aadab1ed0ae4f2f9e2714406488b211660e56785d21";
+      sha256 = "1427f7741ba5c5da163ecfce3053bdab7b14c8fc2e8c046c244f7eea6d015a2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/be/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/be/thunderbird-78.5.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b04239a6caf488d3fcb5be0373ddf83554643897d41bd197edb6dbaee15b9a4d";
+      sha256 = "97258efe6425869e4710c07e880df2a3f6c14d626e6512374043cff226f141fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/bg/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/bg/thunderbird-78.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "fabd2c79cee02328166954d6b793b70bb94cb41162b904ecb124cdf91e5cff0d";
+      sha256 = "a30496a969a954525dbcf1ec0e94d8533baea3809e61d6c1c6e299f883d9676d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/br/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/br/thunderbird-78.5.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "66584e5c63c58c10cb4f2f8fb81048c4201046adbad03d58faf8f36e405a8e40";
+      sha256 = "16dfc1b869bb10ce7c56f1b22981586678cd81a42e13c4075ebc1da76728258d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ca/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ca/thunderbird-78.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "eca54850e9ed41a19bb4cd23de9c11d9d2851ac1573507b32b4fd33431ad7889";
+      sha256 = "bd29d4b8376355090adca0185194d3c9b6124c336bec0dababaa4a214f9945fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cak/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cak/thunderbird-78.5.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "ff8e285bf3198c225c2b5b216678bde7f978443c1f354193e39c0c5d3d7237bd";
+      sha256 = "b9723a8f8b8a61d01f09b18f1dff6529d22c89653586ad032831c87683da12b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cs/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cs/thunderbird-78.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "72a18f3ac0168478c7b9c8d2641922ba7be5d129b63b711b7f7f133ba3cb1d75";
+      sha256 = "55ff98744b2f120a855c8a3bc435d39209504b7eda92560be40b8cb3fbe007f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cy/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cy/thunderbird-78.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "16fecfef3f81870befcadf833db5ecf54b7b83d587f2a211c5eaceeaf7a5796f";
+      sha256 = "818a93f5a4f02e8cf7b3373c31c435dffca3fc1f86d5acc3fd4355bca21f9cf0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/da/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/da/thunderbird-78.5.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7aac88184c6e2539003905b3a7609116cb2180943a8df219449354297b323455";
+      sha256 = "7df66098805f276e1498fa28c00aa7eaa8a8993b561261c54f7091a808ff6766";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/de/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/de/thunderbird-78.5.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f3f487f8852b7f50ed49b5375ae97376470282a0f5639c8fc4cb7040da30f946";
+      sha256 = "194831e85294b41a4c1bcec8a2f20f337786054525d50e2fd6dfd6134385d2d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/dsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/dsb/thunderbird-78.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "842a084fc74c29d3c7573e473666cfa01f205b75fe6c1ee83acc25cca68d3666";
+      sha256 = "e7344c6b2c90bca56adfca1619e1bfdc0e473f7230d4c1059d6516cee8d51759";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/el/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/el/thunderbird-78.5.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "8df4c2a688b435f60fe0d5646ac5172dad33d254fdd68e35a29a6a83c4bda905";
+      sha256 = "e2d4680ced58f78699f7bdc2c3493d6157cf2c9261aa697cd6092ed0687a7bbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-CA/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-CA/thunderbird-78.5.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "8eab7a0b08e3c65eb5c373eb018d5e1df519b28f8774b06203a5b7743b146cd5";
+      sha256 = "6afd7bb703c62763b787d77b7467881f07d12e73d32d07c6461642307e3b9f5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-GB/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-GB/thunderbird-78.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "23c819e15ca0ff1ad366f2d5fb76e934dcea0fae9cec6674b39339e14a3c4254";
+      sha256 = "78114f1a1dff6c5430b148fbb8707e03cd3ec1d05af48082755190ae45e94dd4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-US/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-US/thunderbird-78.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "5cdf4b40f337352a8e966046a2eb1a368c0feef4fb069fd4c22d4f986ea1ed3f";
+      sha256 = "beb328b15c7b981b10f26cad6325a04257be20e25e819fa771f88fe5e5c98aec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-AR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/es-AR/thunderbird-78.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e7947542ef45cb432991ac5435523987c79811889e9bd5cb6fe4c698897a241e";
+      sha256 = "3c096d5225f8fe273b6f0adc119ea419cf60e7a7723fb3a63a6dec1be6e4c3ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-ES/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/es-ES/thunderbird-78.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "95121f74bc1389e62dfe7acb286d2a4cd60a536f28054c8e367cdfd867babde1";
+      sha256 = "68796cda86944bfb70207b79c162c0b2fdb66b17511300c799204fce58d2c2b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/et/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/et/thunderbird-78.5.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "87aedd276bc54360887e81bf2e3b07c54a365b78814d7e478f7ad5ec15c1d451";
+      sha256 = "6187058a289cb43e89916e484ac46c2359fc9c452d07dd4dab2e3ff8ae397c47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/eu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/eu/thunderbird-78.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "66168f09ed77b7f31faaf21daff48e9a8bf75314fcab585fad67160db52471b9";
+      sha256 = "ad587a3b25de553b69ab9aa61b9d99c4f4d7dd37b05672540eda7907b21f2857";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fa/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fa/thunderbird-78.5.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "2848f0277f75dc58f371e2025bebdeca1c37d543055fa78258df67d05c67f5bc";
+      sha256 = "8c06bbd83b5485b113bf4d0ca69af9ca21c7854ff38b19831eadae0c586dc606";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fi/thunderbird-78.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "725f0dcd456245e188e32a32401ecd40400b7786da3a39d9f6965c1f674ee954";
+      sha256 = "bac6ecf3d22f6097f8cccb7da81866941426ee7bbb690937a2333b411a305fbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fr/thunderbird-78.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d24ab35a8db7cb32d6098defb9f7b6b007b5c993a070c1a3a5c8991451165e37";
+      sha256 = "859457a9c0bae23e4acf901d38de814858c60fe1a5e28ee897b2c2f4c86bc29a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fy-NL/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fy-NL/thunderbird-78.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ea3a88b57166b3b8f04922a5c2f6d8d9f94f1a7bb5f3a9e2d6b5f11a13528c18";
+      sha256 = "d5a91d212e0c9c6c533bd7f05edca3dbea93eba0bf0d34eabd1e9ba7c7138e8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ga-IE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ga-IE/thunderbird-78.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "763bc901967ec61e1f7f543bbf248bb03ea68b01c000677505408ec8e8c3cbb4";
+      sha256 = "980e053f0bcd5096753213fd6cc252be388312980032132bf912af2d4249278a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gd/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/gd/thunderbird-78.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "7394f43ae2ff5816dcf9b37255fd9770dc48dd7309d685ab378bc2de8a5a39b1";
+      sha256 = "7b61b433d2f55191f7ecc63e04ceabcebcc85ab211553b71de575bbf14db05ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/gl/thunderbird-78.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "7daaacf6af75b34d37d440e2c0b252ef03c3b432523f5acb8ef71f83b5d7b6cb";
+      sha256 = "2dbb2021eacf17f5d42d0f8edc32a3f4d0ae3964cc8b44b0875fcee9bbd8ebbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/he/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/he/thunderbird-78.5.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4831ef263de0a08df6494b13a280475642c3eed7f34c7415fd7b59af192398dc";
+      sha256 = "b64fdf97d7f3029ffe465bbe621735970c73682cbde03935c2ad94325a7a77cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hr/thunderbird-78.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "6860b40fc2ba7f9b8ddedcaf50acca8ac01b6451c0895c325b36485f188b5dda";
+      sha256 = "05606268efa91e8266a75f9f53dae8e8095fd70bc1095e2cc160171eb32e9a0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hsb/thunderbird-78.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "681fc8200f6f9346e911c21d6a1c8206e5ee5ad1adfaa56ddfbc5088225fc561";
+      sha256 = "8a2dd27b17cbfad0846a40b4863c72e0754137e4ae581998ff291b4428a069ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hu/thunderbird-78.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8909d02e58f5b333fa51b15e4ddb5df162d01e36a8052827482c479949da2cb4";
+      sha256 = "01daa9ab4f5d096a9a5e138db4debeee302fb875f885e644eea88103c5c62111";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hy-AM/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hy-AM/thunderbird-78.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "12dee2dbe126d2243b674bed4617ffcec7c93f850d266f6253d802c6af5b6d6d";
+      sha256 = "69159084189c5700e5c8c27bf4cc0345fcafe0879b7f7cca285246a41e411578";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/id/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/id/thunderbird-78.5.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "5564c24b01f9a952def885a4fb56e3246643ca30bc5066d6ffa4ed6c6982b33b";
+      sha256 = "798203a12f76cb3c698363da72b235fc9abfc5a68913f3265c9b17b14318eb73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/is/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/is/thunderbird-78.5.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "fedea70297479b2c828aa19a9a4aa3090597c5490ee842a0f521d0096615d6db";
+      sha256 = "19544548a0b0217f5f5256949d74897c784298dfe762174487ab2ba2557a55e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/it/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/it/thunderbird-78.5.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8466f3dc9988270d4a9166b82dba764d8dbfa14e8c26a1931d35abe011c3160a";
+      sha256 = "b1ae17f3d4533db0107ab280ec4e8ecc610db9581d44ed52d8ca87c821c37c1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ja/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ja/thunderbird-78.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "3ffe4ae508896ac961a27940a93f5955bb8b29640c88e5378a8251827b4e9ab8";
+      sha256 = "c16c27372c28063a06e31fc440294a655fb72bc033efbfd797d150e99e6ebaed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ka/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ka/thunderbird-78.5.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "7c099596fbc4666e053bd1079f6b7c45511b2b44db73cd5c099fd392bec8e3e3";
+      sha256 = "3057efd5078776f1690890d601153a73e2450051a0edb61e92d196318b644679";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kab/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/kab/thunderbird-78.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5e64e5a276a6e77250ad7647f9b4ecc2b8c9dc360c486f9504b3b17b8da3e467";
+      sha256 = "ce8010b362b601819fac825ce27b9efd8af8f0965f8f1cabb21bfcddb2ec7315";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/kk/thunderbird-78.5.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "4562bced5900bc447a79c53d381b250a1e13b9f076979cb9760f9adaa89c54b3";
+      sha256 = "b73930d1508bdcaecfb9ce280f0d86fd5dc7a3d26160caa0eabbe47243956139";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ko/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ko/thunderbird-78.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b6cb53893d67bedb077547f1262a833a5487e49395187a49eb977659d019e7f8";
+      sha256 = "24d6e557b6419bb3a512646edb6e1e4d01ce1c0e134b9bb9cc54ad5acb6a0675";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/lt/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/lt/thunderbird-78.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6291d36e9347729920f89a28b949c943d8c92863cba1a03624801c7136eff997";
+      sha256 = "c9dc7dc77a1c1acdc1e244e6b1201ecd3305b5c10ef946ceb880fb66d57c249a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ms/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ms/thunderbird-78.5.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "5dee2e40dbceea93fbe3b35b744d00472b89b88e745025127a1d07afc79d7df8";
+      sha256 = "d3a0b9fc5b38de919515df9dc6ca696c7c70f629b192e8cae099a55432d466d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nb-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nb-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "491115e7ad1c4245da34dc328e179de3916291d4e42a85ee5fd4fadeae1fcdcd";
+      sha256 = "80f552a61288f1d1a6346d302919fd90f63c2d349a2d33921eac9a65c341a7d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nl/thunderbird-78.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "c4631681eb3354a3093acd5a76d5c7ca5ef3e76ac2cef9f1fa4007c40c1e282d";
+      sha256 = "89007857be04b59bf724a2f6c295c0948a885c8da8c7a7060922e04f616baf30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nn-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nn-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "aa4d383b90b7cd48ff18f098c9bba429f09fcfb72a2f2a086a992778718a3b1d";
+      sha256 = "b7a8060d3138a55a29374d890b326e77105f41e809053d34c24464a892c6bdbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pa-IN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pa-IN/thunderbird-78.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c5fb66455a59383494890e06559d4529c0762ecf76d17e5ad784eb413277438d";
+      sha256 = "69f803555cc9b3ba7fbf638e101b76bef10a234747cd0764e906e5d2adbb9a97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pl/thunderbird-78.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "720eea0998d9934960a5dc97466f57c7e68b2048f88125a987569539a8a00579";
+      sha256 = "4cd4da857d9cbdc5d89e07529d30df28a758c3c105160d2217b50206147c21e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-BR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pt-BR/thunderbird-78.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "d27ab836f5d8753d740e980291a4403656735c206cedbaf7d5c13df26d327150";
+      sha256 = "43fca4ac927932589b58e60f7b3b1cdcdc1d73b6f9073e0c1eb2993527afe9be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-PT/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pt-PT/thunderbird-78.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "2b996d07174c24df1b066c41bd92c8b24ebab82767c47d8c658f2205eeff9cb4";
+      sha256 = "25591b73b7ae5d28441baeeae3fb3a5a47f36ea21db763b95782494fd8491122";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/rm/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/rm/thunderbird-78.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "206b2bf82b88ab733bf585e11a3eba49a779c8b8fb7bb249716022fc7ee1a18a";
+      sha256 = "14a0725f1083ab9c4baafe6944604cc5781cc9d3d44cbc406874b5ce01df785d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ro/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ro/thunderbird-78.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "2d06d671114d70ba4e39b2c639eab1debe7ad33de11795113f30f27708d13ae4";
+      sha256 = "f32af00602a13e262e6b34c8b5783b31a991dee72d82c841086d21e37d669dcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ru/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ru/thunderbird-78.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "08e71802964c340dfbcddf963382d1ccc5b8fd2e262daa1316488cffd04f449f";
+      sha256 = "367e7865f1c5d10eb912fce96a34bf6ce25ca48e4ec9209bce8af06412be7781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/si/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/si/thunderbird-78.5.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "0f59d187fa15bd08ffe0e08e643bb76954f7eb7730c3768079514385c53df5d3";
+      sha256 = "da0494be7a26f0a531d108ca20a0bc9763860e44adaa6149ea059f46daabbe0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sk/thunderbird-78.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5109939226907517fac9ae9c4e6ee96d732de9a67b9139e390d32cbdea892ef7";
+      sha256 = "1c5078f413207049a35c69be32c6996cad169cadc009b3f079b3adc8a932ca22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sl/thunderbird-78.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "c56fb54ad65dd453b487813b1f0dde8d83ed6a2f7e428af55c40a80d1c9a35ca";
+      sha256 = "d8a5edf78b5a87c0b3baf0199231e6e9224e1afdf4eff05780b6c9b98657c1ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sq/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sq/thunderbird-78.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "0b3814c80014108032c9f0376a62c09864704441f36a084accba1c7c0f8156de";
+      sha256 = "fefcb88c0c5f6ee62ba8224417a629d8a4f0c18b20fcb037c36af772b0d2b71c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sr/thunderbird-78.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "80b01424fae7d18c98a77a0026dd4b50f1913f5f3cce2d3f85d9e56da633a537";
+      sha256 = "c42818c409de6447c1aa00f8aa6422a9fbb6fa16f01d5076331937c1145a4b87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sv-SE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sv-SE/thunderbird-78.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "ef0154595d85c13d0eac381a907a51da19e9d93d2758c7dc0f052b7b76a7f31f";
+      sha256 = "c27d87cde88f38f3611358b5fb3622611c38860ee37d1d90aaabcb4db614a031";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/th/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/th/thunderbird-78.5.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "939f56c4951e8dbfdff257efe7f0212e93c1bb55547ce1e934f7d908932d3116";
+      sha256 = "df9b827a723675e70131d147fa6f6325f6e6a14a6b95f6f5b6fae4552501c6b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/tr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/tr/thunderbird-78.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "66f4f2cb06f20fca47e59b37d52f07a9e1215b03f0bbf9320cd1436e1d1a7c35";
+      sha256 = "7a9d6e1b5927c7c54b73062a59d366cd5153896a89e95005177fdf4b789eda42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/uk/thunderbird-78.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "33f3b9812b442184c075056cbe7da924655729865d849856093bdaa2d7d84660";
+      sha256 = "c421df09d5bbb5e4de273258757df28e5a6eba291a4eabbf28db71a50cb11da7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uz/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/uz/thunderbird-78.5.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "5abbc17bb66700093eeef5eb97bcab0a5d040ffe20ecf79d8239123248b1affb";
+      sha256 = "296ca42b0c9f67ef0bb545f458334ec26e03be3327fd1e1b066d8324965704b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/vi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/vi/thunderbird-78.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "de5071c3b4a5cf7494f91c69f4a7cf4678bcf57227115e1b6e50cc65a3e716dd";
+      sha256 = "46579d9723f5ccc84700c2544f3d1235db338471306d87a1caa0ac4fb337c8bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-CN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/zh-CN/thunderbird-78.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "07afc2b794439475d0d4db82c7b694728aa5b8e6e80ac79789bae662757ae8d2";
+      sha256 = "9bf0df6568eadf611891f49591975166da95eb4e78e1191eb3354a81637907d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-TW/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/zh-TW/thunderbird-78.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "70a71d0c26fd2cd18dd599374cc6f1c39d22246f3b3c8e8d17659cb7c33a5a77";
+      sha256 = "8fee4fd8980d551317fc8f98f29938034f5ff90b765e73ef8cd09f8fe68f90c8";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -70,13 +70,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.3";
+  version = "78.5.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "0h5ddqp1z2dphyy4mjcb7v9mrrxlnjw8rwklm0yqsbvs9m96pc1yyp4clb3wmgs7kzh3wxdwi450842m3b13wdg5h0ls7rhamd1yi0c";
+      "0c32dz8p7rrr0w13l2ynf9snj59ij1v2ld3s75vz1hvks4dikwgcbm44wmvmbisvgyfgzdsphafzlq3kz3j1ja30qjigl0dj709vr6s";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#104378 for 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
