### PR TITLE
 [20.03] thunderbird, thunderbird-bin: 78.4.0 -> 78.5.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.1";
+  version = "78.4.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/af/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/af/thunderbird-78.4.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "36268a7fe6ec5a0ea0243f83ffbd73204d5c4ef257b0c8857a50428304b2d4c2";
+      sha256 = "8b1c2e12bd1de45251131d9fe444b06681577cafc019219dac4aa13b3abf989b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ar/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ar/thunderbird-78.4.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "831e70f807f05ce2f82bb11db35d05ed80dac53ad00c12ff6e191a627d0d42d0";
+      sha256 = "708ce9ae434ae78bd21d2c8a608a732d6ebdc88c2cc3c91c748d2b6a4eab24bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ast/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ast/thunderbird-78.4.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "e6efde72ce7aeeda5f7c6d7cc0f3a08265c44546a0f8fc84a2adbc11cc038601";
+      sha256 = "46aadaa73a4e214c016f05eb9e0dc0a3daa6a87fc72988c696bf243d475d0285";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/be/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/be/thunderbird-78.4.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "07fe33390caf37a96c000e0f5435d07711f7a95dbe04f85a222b17ae5a13f1bc";
+      sha256 = "06abeef2331df228ad303d9280d077ef4a74af8658c4ac0147ae59e181dfc42e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/bg/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/bg/thunderbird-78.4.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d460e201cbe4a1d6548a52121a33c2aaa7cbbf0e126fa1c4e8a431423424fb9e";
+      sha256 = "3aa13c52a514f5331bf626f9e3138bfe995c6a223559a9fbd6d590858484d9c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/br/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/br/thunderbird-78.4.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "9e85928f1145391d9c3f238612b93e6344a2ad5e6179bf09502b1b69c8ad1b03";
+      sha256 = "1f2d9ee7090e96e3e5611011c9fef8389b514dda4edbf47e889019312df6ab5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ca/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ca/thunderbird-78.4.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1516236c252f22933adf23bfe93d73fa272a4574deb674aef6e1f35006a6cc50";
+      sha256 = "f48d5d02a04212ca14cd4c175102a0e45483299d8a4615ff96232431c4ffa4a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cak/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cak/thunderbird-78.4.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "c46508321d32c468d067d86c04973ca345b09b0e983954eaa123d02778d61fbd";
+      sha256 = "28b541daeac6aa6274f4185f9471ce8b2a46e18fe55ae1e373246d9f23d78ec6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cs/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cs/thunderbird-78.4.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "227209429c07238f38d334e5ac8a5fd895a4c87f51b21b4376df89c50bb6a789";
+      sha256 = "d4f061ac86da0b6279b81b30c8949cca93aca5b2f90d0e5dafc5cdecc2868e05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cy/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cy/thunderbird-78.4.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "b272926205e5470df8aec8b22d6733e4f47993e76123fe81d4be26ad5a153062";
+      sha256 = "824c703a570ae23d8e7b86d93baabb193842ac36fbc9d4ec65ae686e3d540de1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/da/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/da/thunderbird-78.4.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "13f9fe10c84d2b8d8d0215cb58a9852486741f5bc8c6979f0a701bef14a70f4f";
+      sha256 = "8dd27d2596346853e3fddab12ad0dabd700c5216310922e768faacb019b5b3d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/de/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/de/thunderbird-78.4.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "590f9a5a975544d2effedda942e3989a13be23b95f4e6707f9905fed3fc08214";
+      sha256 = "3920c60073ee3066fbe35a1d2c34ab03a7b7e2dfbbe22af97fa32814000f6942";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/dsb/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/dsb/thunderbird-78.4.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "5b572c847f9ec76b25c225652c23ecf8c56523ffc3071b437310f0d8f9049b05";
+      sha256 = "fd09bbf80996e3aaf12dba79c366c4cfff41a0db0cdf7f6ed4d9722fd2623ff1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/el/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/el/thunderbird-78.4.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7cad76ea5a07dce6bdd3db78485f83a998ff27037f8ca68f8617659a06910a05";
+      sha256 = "a9df959b2df9c381b9881fe3015e654ac82ca441a3cfc25036c1e658401bf810";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-CA/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-CA/thunderbird-78.4.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f261b38fbc8d83c20be63015a444644a95f7d8b6584fcfc193145abcc69a4164";
+      sha256 = "126e6fffa28b9c2a7eb7bb49254786fd0884aba62524dcf7d8352d6542903f77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-GB/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-GB/thunderbird-78.4.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "5c0c364b1408182c0cbae1c2d05041781e2e4f3a17fb1735d61196c9b647dba4";
+      sha256 = "099ef4c54072c6a4a134badd02a51255573e876c8b630c3b9eaecfde997f9e03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-US/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-US/thunderbird-78.4.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "a152c3b8c6ad4ba3a92a8a1f909b99599d8c3ded62b57e9721fb333b47f6509d";
+      sha256 = "e6041bd8ad2a21f0a8f8d78fd395239f1f41e2948584770673aaa0f3a9978b3e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/es-AR/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/es-AR/thunderbird-78.4.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "dc06a64e0b20dd174d6158e5d2f393bf6a6907f8f515120220bb2a8480f58d1c";
+      sha256 = "d4055f3134cd255f8e91ee2ef012bd4e4443e6db519cb7bf2543d4e193f59f61";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/es-ES/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/es-ES/thunderbird-78.4.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "7d3b7ff0ffb9b19f10bd7c2cffb5dbff8216c65c01fd4032ba5b7924c73ce343";
+      sha256 = "39f3c8e5262b1125f21e2bc0e51d53b09283ef4922a7bbec6146605ea0bd1d51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/et/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/et/thunderbird-78.4.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a9a8e610bc1c696137ee650fa11f2cbf8dece4ba32d1f0961ae697f6433cf1b2";
+      sha256 = "60331d65f98b68397a0d53a08a169b97654aae3d26efe48f494f575e1a51fe13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/eu/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/eu/thunderbird-78.4.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "6835e8459b4191cd4bb5ae8011d032d475631e7a532450b98f0b087ed0a80fb6";
+      sha256 = "206026522eb361b599dccf433887b1314b554adfea90ee558f36d116ae6c8f70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fa/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fa/thunderbird-78.4.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "7cfd8681a7ed38364a823881fbb42af8cf33d17bf911e9f5b97dd18102b412f5";
+      sha256 = "88f1421d251e0bc5288f2c8ca333345ec97ca0a86d491b242471d1af82c04776";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fi/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fi/thunderbird-78.4.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "8c84662afb60e3dc94eace5a493f7feef6598b78613fe99f195408e4ee2b0a11";
+      sha256 = "4abbc607c3d6ec03a8416636e88ffdfd61fc0b062aa135d14fb3918c284f9ebd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fr/thunderbird-78.4.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "24449816c690757b05d1913ff1fa12eed47f316ac13c76a195ae0628c6950da0";
+      sha256 = "406437d8cf7a695b636c3c1005df5a65f174bbb10d0d961ddda08833ee2c808d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fy-NL/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fy-NL/thunderbird-78.4.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9a0334f032333eda16cdabd5dffb05f5a22edb1dcf4bcd0b47495defd0d9f3dc";
+      sha256 = "456f51fbef14e1de16fdb3d7c31b6736e0e7b43c509ac38bdb8a88cb4a2de0d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ga-IE/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ga-IE/thunderbird-78.4.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "33e5a54e2259984ff29d3394fe936b5af8830e489e0775ff36eace4c6b3dc145";
+      sha256 = "0f1ab856deed39280ab9d6a43afd6f719470d4aafc4404e0662da0e14b64308a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/gd/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/gd/thunderbird-78.4.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "b91c4b3aafa2166cd27c52977711c55aa425f68c5f7cca64be1dd07fd533bc05";
+      sha256 = "07f2fc13f34a70d4e6ecc65d465e33f5bcff63196996fe057f8584ef2e7e595c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/gl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/gl/thunderbird-78.4.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d1c03b3b92bef4f3c94518981cf99840944c8a36aab7b2cfe3f72f1f0e57e045";
+      sha256 = "f4cb60a537ffba88823c8c8a60f2c164e62fbba13d448f2931c71e7d98d6abe0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/he/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/he/thunderbird-78.4.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "7fdaf0e83eeb39b66a6d1c2600f2c6f1b69ec4f67dd7b33a39132e838a699f06";
+      sha256 = "425a0bd38d231308fa5cac5d362b7818ccfb6b5fc06924ce312433ba4d5bf2b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hr/thunderbird-78.4.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4ba99eaa25964bde6108eeab702b096ba50b45d8db7e36f3203b0a71cc1e30cf";
+      sha256 = "37d3f14aeed404bad5cab35c256473a5927787f889afee3da112e510999373f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hsb/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hsb/thunderbird-78.4.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "187a5f2b2e1b16fad948356f31b2ac903fe318432d9a3f105055c23d1225d11b";
+      sha256 = "3249467db25d25866a4d1e0acd9a18a26bad13e2ca683df04ca5f8ca19affac3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hu/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hu/thunderbird-78.4.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "8f6b79692143e6e27cc844985366004d06c8e55184a73477fd20020575947ad8";
+      sha256 = "f3a82c5917757f221ca59c4b6a950991b52b10f2782b1dffe21c7a7ca6a26272";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hy-AM/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hy-AM/thunderbird-78.4.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4066683e4a635b163b9b14e1921d834b37a95cee8dd04fc6885094c5e0394dee";
+      sha256 = "cb917c1ff3fa342a8ad3253a03a1dbb4a417c0bc3cdfd1422ef5ff06dcfcca74";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/id/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/id/thunderbird-78.4.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1fed6d3a9a11d303db2f2c6f7a92639b92ca144ce3b45eed4607696ea4617511";
+      sha256 = "1599ddf22093c6a99ccd3ec3e1492e65ce0b5ebdc3a69aafb321ec26f22b6a13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/is/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/is/thunderbird-78.4.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a627c95d2284b4e828a466865aa19262aa84a1a2267235c3f62d13c52081c580";
+      sha256 = "8cb02ca7ce8c28c10aa1f16ed08417342e93da2dd00f15c5a89fd71306f9afb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/it/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/it/thunderbird-78.4.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "6b01e88da702deee95a3a6d526e563e854be7ae13414fed3a2c9cc427e906ffa";
+      sha256 = "16f3c54980e614b20ef6a8c0a09ebe7707e298d753d373da79bb2d52d1cc43b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ja/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ja/thunderbird-78.4.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3b63cf4c45945f4a40159a417ed217b77128905de82812fe2165c0c5f66410a7";
+      sha256 = "e4ec88dd86b46d814232662a4d558361043ac97b348a8fbb2076ec856087be6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ka/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ka/thunderbird-78.4.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c9d11ae298691f2e302078f865b047b1c2b568ae763495fbfe2f2d4f04a9ef6a";
+      sha256 = "9c2a110ed4df58c334b533255c0f3bf46d777960967e46e74f7f376203bf467b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/kab/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/kab/thunderbird-78.4.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "b6367ccb74b2ced8708ca9f4c2c06aeaaf4f3bcba0b2b2fdf2c552aa10fcfc03";
+      sha256 = "1f5cf7b8a03fb4273d9ce4d657c3a77ac4a26b7716e3bed700e14f05a398163d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/kk/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/kk/thunderbird-78.4.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "99ece9975a3981fa33887d3b5d60cd6874e1dab7c51d830dc0d13c28c103ca79";
+      sha256 = "002ac92fee28c3ec9c05587025eddb4065a842df0430ace7f468ed8f3ec2df27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ko/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ko/thunderbird-78.4.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d81c844cbd490e5eeeb2739a9b040062baf3bbdf13ddfbceb59b5630019b935d";
+      sha256 = "277f0fdfbda0d215a03ccd663f0986cf1b0a1c4e68e3ef36e81c8505d6eb7d09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/lt/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/lt/thunderbird-78.4.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "56b5813a5b0debfe90fa2a20fb9a13ea210e2eed37f180f3e23e851f871241e2";
+      sha256 = "65b6737b4ff528453bdaf57cc525a74c79899a9563d189123f87db729aa0f529";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ms/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ms/thunderbird-78.4.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "8dc3f341a69b9ef458c1203ff15779beecf3db2dede1cd8740ee19a9552f22f3";
+      sha256 = "cd40e14d4dbcf03ea7e5ab672678abc9b3b46c5b67fdbb961928a860c2f3218b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nb-NO/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nb-NO/thunderbird-78.4.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "0fe431d3773de39431cd777cf301d2c3d8074dd41596bf6a6f1bef96870413b4";
+      sha256 = "49c9633a0552a704b06df87ea91991017be920684d12f66c72f6795dafd1cd5d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nl/thunderbird-78.4.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4127bdb6338210d9928fc84838a57cfb731aa3254aa5427471deca00bb12beca";
+      sha256 = "4514d79caa1e2b44cafdc9ef06aa54c4708763c888a489d6bdf4473597221316";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nn-NO/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nn-NO/thunderbird-78.4.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "cf0c6d67115ee36b80010d93d50991a544af332ca19f1ed1199f49c7dd125049";
+      sha256 = "f6aab88e4708659658be8cfb457c40533969a261af489a976f4010439a833458";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pa-IN/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pa-IN/thunderbird-78.4.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "283c2be7f9bc0aa3d505f1838f1c03721a4b956870ac2b1e762b966e87767ce0";
+      sha256 = "10f5a885550f2cbee158fedc7111b96a0f07764b5d6d60004d17c233153f304b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pl/thunderbird-78.4.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "4c07e4500ad4c0d698942e3c47ced3bbd6142e4a70292629ebbe53ef5f1816f9";
+      sha256 = "1a192c0a9b8ac2f9b18445e69024462b8e95b78bff48014b55dd451e260aaf73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pt-BR/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pt-BR/thunderbird-78.4.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "c6ace3452d1720681e668da50d16811286c1e73021bd06ab9b538c6f6fc5fda6";
+      sha256 = "b9dc3db4d8cf4fc2b958695f9077c50d48d355e850618320adff179d33a116d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pt-PT/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pt-PT/thunderbird-78.4.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "b9ab4d38b271e2987b5e425a277042dc149794cf461283114553133e7fed5f06";
+      sha256 = "0a3887ff46f9ecc1576bda76e1469eed8ef43813ccec25536e2dbae289196bd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/rm/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/rm/thunderbird-78.4.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "50fc69135b789b2bb5d8008292d3fc25f1a0a30bba35c6e24ddfeabe55231407";
+      sha256 = "1a13d443c00da4300aaf58d0af0620541de04e02e87218fa0774cad4b2aaa34f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ro/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ro/thunderbird-78.4.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "1e050b33a942dc815e739c57944a0d705982e18e74637172b0366a9b06916f7b";
+      sha256 = "62bd15566895dc9462b985f2f5e1afcc7057ef4e93f69005b9ebe89821a2a73a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ru/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ru/thunderbird-78.4.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "c295bda57db84e07f28affa4201c4f612478efce733cb9c69962f6d7a797218b";
+      sha256 = "e0624e745da31cafe1b885393e11622bac6ddd2e3e4c0cd35432eb5e0e57a47c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/si/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/si/thunderbird-78.4.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "63dc83cfab8be94893ca6a0d60e448d14db1afcae55192149a882456dca77e9a";
+      sha256 = "46e286fd0913b07ede577514b8e64ce279afd7bda3054b7cba4ec1f9981eef03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sk/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sk/thunderbird-78.4.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5ab5ea76649582ddf10fa77bbb95040d157883e0905df72f5bc0ae79167d97be";
+      sha256 = "3ab838c25d5e10d318705bed69e690d287e6b988412a3f9d5d94f2b7c8cd831b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sl/thunderbird-78.4.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "da3f8a30797386bc7c9ba135ba360cee01143bc76a2315e7a2223bab90e2283e";
+      sha256 = "c04e1a339c4fb2ca8748da6bbc0f5a4dc9eb032b565d6f2333c7d1751eaaaa9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sq/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sq/thunderbird-78.4.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "f2f9639c4b4dc4bfba476aa92814fee65ecd3fca27652177614d1107e4200246";
+      sha256 = "ae9052f081baf3f25c43b2b1e109ce50abeacb5b2322ef38f8d42fb070417908";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sr/thunderbird-78.4.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "3bcad0c845e4481a22c1b330b6cd94c3c6fc46c33597ce5af0594368579a8260";
+      sha256 = "c4eec55d9be21e02158e8266b9b7b424aa1f5d1078d9de2f0dfce4fef5f801d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sv-SE/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sv-SE/thunderbird-78.4.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "9b09d4ab71000429c5015dd8a0642cfe0eeeaa785d2cac6e876b1cd6aadaeb44";
+      sha256 = "c7c01c580e1201e2948d0bfe3e029b6bd3a98e9845e6ff648d8bd4fbc8189d37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/th/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/th/thunderbird-78.4.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "b33e42f0271ee84a581a737513197d5f036695706b19697a53000834c199c75f";
+      sha256 = "f09079980e41c156e62f8d008d600850ca8a62fc88917f3cc06d10321bb3e500";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/tr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/tr/thunderbird-78.4.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "f419ed9f0f06575da2f89486d830ab7fd2b439dcfcac92f1b31c573901e7b9ea";
+      sha256 = "2b99f6fcf904c7cdf67de2ed957167b6e1fe7d997c5a422641bba0af8a22b7f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/uk/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/uk/thunderbird-78.4.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "bcecec66a6ef8b928da2aa5d52d89f4f1587d4e45bf0e836b71912b0e5a43f7c";
+      sha256 = "d502f4447e1e0c02e9384435e1b552c4da6d083225555b03f90d71ed04314324";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/uz/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/uz/thunderbird-78.4.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2b33f40b9da386e61f3bdcacd9c16fc06dac18d2b36865292700744dfbe2da25";
+      sha256 = "7b9548f91dcf0ee6bfaed9d735baf9254842a633e3f06986d00d9d86b0f645d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/vi/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/vi/thunderbird-78.4.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b5d005c45221c41e1e81234b755f6a9d380220cc03f43012c40440a0378c19e0";
+      sha256 = "32f78b425fd56900d1b3319e571af151214edee83a22321a449556e8ddebea69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/zh-CN/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/zh-CN/thunderbird-78.4.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c08765cc8562cce08b4cda04123cd8672f5abb130b597f36f4c143d74b09b9b3";
+      sha256 = "a6252fdd66dbfbd33444a3ebdacef38f8b600891af324d31f22f2fcf59b1e7fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/zh-TW/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/zh-TW/thunderbird-78.4.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "56f84ea43a5288a6cd34f8de5f69dde05737474f11c70d638981ef2ff4ea5bfa";
+      sha256 = "b97a176fc12f156d8503e07819e9a0536b338850b8527c3896d93a36d64083aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/af/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/af/thunderbird-78.4.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "95384cf3d0ab6ad8d3bb133e8ff7c1881523c0f7be840c5ab6016325ebc7f9ff";
+      sha256 = "e1f0a03f540da701f9e742cf7a05e21a1216ba5c60c402968799ff494ffb1fcc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ar/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ar/thunderbird-78.4.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "c2cf87579a092bec69042b35743574872b8b791d54628c35c28d44c1dc605b6b";
+      sha256 = "5bbee34fe9c5cf02f2f3c8160264f3a0ca3ad880bd75fd1ede87f906b886c7fd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ast/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ast/thunderbird-78.4.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "127ce24b2c06606e9567e2106ba5cb9628d8bda10620b01cbfe60bc287977c94";
+      sha256 = "8a5e481e9aa16619513260d532ec6f7e2c6338b41a0a44468950ec26287b2a26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/be/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/be/thunderbird-78.4.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "e8acd7cc25f91af91caee7487598cf1f60512864cf1fee714d2289a65f0cc195";
+      sha256 = "27f600f0d4b977cde9ede5bd39efd97bfa1abc04f3d1c7a3290339e7eedaef47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/bg/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/bg/thunderbird-78.4.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "461e4ec0b0f3dcb78426a99f0b8dc32b14dbc561b89e8d422433f5360425448d";
+      sha256 = "a9a6c127461ca7da6b5fca5e2d2ca8b1eecbbe78b42a9e18e16bc7a343c761ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/br/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/br/thunderbird-78.4.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ba3902a457d0570d3eeaa63cc83a67e35532e547127b71f38781158bc3cc5e60";
+      sha256 = "b8f363ca9ada5b2ed80a9526d1f775d9c17bfecd6b84113391fd6a5b1966bd90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ca/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ca/thunderbird-78.4.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "609de3623c6f4075bedee741533843f6f9fd1afc5933fe3a8709f5c16c7d7bc5";
+      sha256 = "e1c5035ab818ce7525c2bd659622b14b3fe544b7f4c8432bca2b018c7ba1bfa5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cak/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cak/thunderbird-78.4.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "4a5aa707eca53cf5490189a09d222abaa8290ea3366d4bf081273c23e89b3fc0";
+      sha256 = "f42d03442c8ab4bd844b0414e6d6c8ee168230714b55bbff1704117315f26a0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cs/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cs/thunderbird-78.4.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "0450c73284b274af21f3f0c4c21842e11fa2a86fcb38f96332c1ca8984149c62";
+      sha256 = "c45a3b75c5106377d73f72b905814972a58604b4f2bfe49f05f5177584f2e0d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cy/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cy/thunderbird-78.4.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "5686316ec53a76dab272934dbd274a47802c5c31f2ae8719bcf85c22e12cc3f7";
+      sha256 = "e8e1f70703c9c22fceb2efe10f55a2f25da4085822ada1a3a3a3736ae41c0503";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/da/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/da/thunderbird-78.4.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "2025f5946989905fd197fe5bf6c51160e7c9d281d6cfd220ea3ee0393cc54ca0";
+      sha256 = "d8fb3be7bc41ae6ae0d064bdf9ab9cc569f65dc18f720de960ace84bb2514b68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/de/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/de/thunderbird-78.4.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "906e8a5de0aa12b496f4d4447df25432b11c88d79b7ab4a55291a9d65434aa03";
+      sha256 = "373f50cb99608779e502d76af0e4a301ef0b8b75a6ec235f64da7626188157c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/dsb/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/dsb/thunderbird-78.4.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "d6bfb2b790d8391344916515d1cc6ca2eb68a3e58934cacba14e77788aec6b09";
+      sha256 = "07518d32b488fb805adceea1126ca104f2e86e3a1245f6cc4fe108b70335c995";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/el/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/el/thunderbird-78.4.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "5f96345a945697326b24fcd73a96fa2f49edb66b02f4c23b6d392fad87935e08";
+      sha256 = "97699a80d96422dad4c95658c9c4d472bd1d69e1823f5a5f7dce5fdaddf1211f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-CA/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-CA/thunderbird-78.4.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "b57e44fd16e33b178778a60f0bd47519585a3e648b3b621f1fd693836c5fb598";
+      sha256 = "0b2dc377399c4f27acb717c7f0e59e9e735ad3d2ba1e617a93a3fa337b6dd2c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-GB/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-GB/thunderbird-78.4.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6f656dcbd7aaab5995beb11a9847e32f8820199272e2f9ce27583cd3d7e50a76";
+      sha256 = "679fd1138a8795b0e7d64a4b8d8a2821deb8b30d40092e9df98b0a08d6cc6539";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-US/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-US/thunderbird-78.4.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8c6bccc757df947bed74a3f7448a3885932a4f6c21d24ab6b5c7a94ab83ebae5";
+      sha256 = "a86f2780353dff8a449f323d5f54d83ce70b724db1a2d77dc3cecf6d1e849ada";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/es-AR/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/es-AR/thunderbird-78.4.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "55bbc629ceadf359e0ad05e763a31479f6c57c38f372e55812b028681a5ff32a";
+      sha256 = "1fbd2312a971f658243dd6733067157fe3de509a88b2cce766ee8e45c243d23d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/es-ES/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/es-ES/thunderbird-78.4.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "bf30dd8882b2b35bfaa62a6c4b40a823333476128a6d5dd3e3d2c8eb16303b9a";
+      sha256 = "e51217ca711a307c67f538d487eb836d49e4ccd6b8ff9b1a1926bd481322d46f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/et/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/et/thunderbird-78.4.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "5b977eab7f203e230d6a03b36afebdb32c481f1eb8129e454977791469ed5651";
+      sha256 = "345ccfa0e703893795d226aacf95645cc2cdc7dc99f5f9fba108466f74af19fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/eu/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/eu/thunderbird-78.4.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f2d606a6f825640c0f344cf470d87a1dea5fc6ff538239ce25c3d7c9fc76237d";
+      sha256 = "47e95ce28a229dbd01d8598d3a5b7f00d8e2c1934f8da4ff92052693dbb0c7c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fa/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fa/thunderbird-78.4.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "95d0d3d1b456c035cc6ed09df970e9e772a71af3703f05e9388e844d7f80edab";
+      sha256 = "6c05b6a34a1ae3232b417e37c6c71bb05e46a296019b55192331cd441f212e1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fi/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fi/thunderbird-78.4.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "e0be2532774bbe017a6091d7e1ec79901f692c39e04e01fe4094f7c8179fbaf4";
+      sha256 = "fe043a86dd6679dc20ed17920e008894d78562d099861c0cda598c74aff3b176";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fr/thunderbird-78.4.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "48cc16a61958160f369b32e8a0dcd2979ee65e18efe3d1dd3a4af1109842718b";
+      sha256 = "950fa73e6f5fcf2fd66da9af7b79e43420e3ce75c9227fee095ea65ce2769a7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fy-NL/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fy-NL/thunderbird-78.4.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "386d0a2ed01b158f0fe18eb6820ff9a17fbbea61241eaf873782271ac84eb103";
+      sha256 = "e01f59e5b7abde309421515240229d16cc0ec6ad4ea52ef1a54fb65f0bc49091";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ga-IE/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ga-IE/thunderbird-78.4.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "c0c15410e6812e8652181ab347b3fe60fdce3b5b9958d54ef3f96ecc46a4d344";
+      sha256 = "53a7b0b5a2046525701120101fbab5c581b99de56caadf3aed4732f444c35569";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/gd/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/gd/thunderbird-78.4.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "3989f0c0f87ebfca3e4cfad0ac9ca2964791ab8f1163f1bec340444ae4a72a7b";
+      sha256 = "eaea6b3770d5bc51a00e25fee02110f5614d9ef52049fc092d90dc1e8de4c210";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/gl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/gl/thunderbird-78.4.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "eb1b58c93e492a79f92660909e671ee7ec504701b8e074d3dc6f3d3fe3619660";
+      sha256 = "b0c5d871785d1efa23bdbe341d8186b96394375ac56bb541d5d9a75bc784b471";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/he/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/he/thunderbird-78.4.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "f584e117ba4fbfbb7d2c28b68377a88aad87929657141adac5ce960bcf5f4fa3";
+      sha256 = "cef410178a3cf310c7bf158eba5c12093385dfda1de334d6d6e0c28ada16c7ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hr/thunderbird-78.4.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "633eab2f8ac99426dd85b614f04d96509125f0799c187305b7678496d9ceff0f";
+      sha256 = "9040e2235a752a50cbe09207684df928b84787629d21c8d53e6b9bfc708b09a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hsb/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hsb/thunderbird-78.4.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "80e4b98bbc9874de9b4c8e35633f6eea7b5707cfc4943df7264cf0bbfba49d99";
+      sha256 = "b0bb84d18c588abf2f05abc8ecb1f3a169221fcdf4117e48b3169362cfc69aa6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hu/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hu/thunderbird-78.4.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "5a9339a876a7e0dced6769a99a948329f6eaa400acb6920a24d06695120f682a";
+      sha256 = "6d5d0ded325cf7852ef638d7f5d8dd4d7ce127ad7f4eace22ce696541f9485a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hy-AM/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hy-AM/thunderbird-78.4.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "286542d67a76a6e8f0c34e7aca9c23c8922bf85f8be77c913285e208f8b195a7";
+      sha256 = "cbb8de1462385ef9bdb42cec5e8c81664347dc9e7573f602f41ff586c217d8ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/id/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/id/thunderbird-78.4.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "930cbbe1520c544a25cfbdf8d10b4e6ae19a812c8a20ce51053ba0d5fc2b4b24";
+      sha256 = "358a95d7d87adc85cd39bf6da1373026de5b8631139ee1ec44e9410b027e00cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/is/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/is/thunderbird-78.4.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "7fca3c4c9d3a309ec182d1486438973741fe2f1e39afd3ccb769256657db20a6";
+      sha256 = "c7b27e5311737cd5f3d314830aba0ec165669d8c949edb37482fb4df3b460f9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/it/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/it/thunderbird-78.4.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "3b44f63975cfe7460f3eadd9f71f13db9ded5d9e5622ec322f556692f979434b";
+      sha256 = "a302c50190fb992fcdaa66a8de9c5f5d177a5563fcec55e5f433761646ccfcbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ja/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ja/thunderbird-78.4.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "1284e52cda834b1ef9b5ac6a1dc29858f6e1519d0fd47d330744c0d294338650";
+      sha256 = "d2357cc5bb5b5493035a79b504db8db2750f5880705b693554e2170d8d840cb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ka/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ka/thunderbird-78.4.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "b12a79e20fce3db2541dcde61e04206e82530d1d79b58637bfcede87294fd801";
+      sha256 = "2d150d1160d92499fd9dc4d632e006170a27929f88909715c0d0210005516ff7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/kab/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/kab/thunderbird-78.4.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "9766eab276e77b0e33ad7ecbf8f26b84aa2a079a4fc9e4dfc992c41074513e40";
+      sha256 = "4f9879d5a106ec9fc3bd423fdb5df25a3e0d47690cfec652654472addd21a2c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/kk/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/kk/thunderbird-78.4.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "aec202db7c28ae69c9f7684a2e4f30a16ab29ec983aacb32bbe4b5bd31b76e94";
+      sha256 = "f8d7fe1f39af2019bb37e117545e8cb2901feb0d31a92287eb4b30da2e431a6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ko/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ko/thunderbird-78.4.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b0e553c14925413461a87f1d81591bfa4e2ce2c5ad87e8ec609fef76ba4f17d8";
+      sha256 = "bd9abd627205fe33430717a60eea8b54498325a8fe4d92fb5572a2719ba50341";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/lt/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/lt/thunderbird-78.4.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6036247e3025c2b513762577e7de1d1eda050572f674c31391e583ccd16e80f8";
+      sha256 = "69ab343eb79c42c4a1a9ea480aa2ac50d95e9140968690fd99b3d13824be17ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ms/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ms/thunderbird-78.4.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "0852cb745130e22af327e2ce39249751ed482c8216c18f4545bd294f4afb4e29";
+      sha256 = "fb1246094e22ff59f8671a6aa0827c8e51a7fa8dc2bb565a3cb446d35c098f16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nb-NO/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nb-NO/thunderbird-78.4.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "eebec58d3a20956894711266715ce5a4afcfd44b5eb7b334dc0c22068fbb10a6";
+      sha256 = "0ffcd2db855686c4b7e8751884aa4a8729b0fc8da597d256d37d6c73a50c7585";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nl/thunderbird-78.4.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "0c6d35960d89681087bcfbf403ff727f53ba2e67de9c69d04f96b68447b616d8";
+      sha256 = "615205a37248619a664b4649f808ddce9b019aae60a900fe4d2ca2dfdd717fe2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nn-NO/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nn-NO/thunderbird-78.4.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b761b921ba2e604dcde7ac0e03a83ef29a3311309cb95bc39801b8bcfd80ef98";
+      sha256 = "8813d2b40da457d5d7c0da88d54b8b0c13d2ea0215b9bee2966215d366d79a81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pa-IN/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pa-IN/thunderbird-78.4.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "fa350ad64a3ff760a6e2cc6ac6b6ad1d6b9ad300b6c3420477148152bc207499";
+      sha256 = "31feb987ff8493d96e15395deb93506b13089db28d91c0bf6ee4da271db8a0d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pl/thunderbird-78.4.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "8b187d44bc1364dc76258ff3452610483b2ab3d060c9de43e47c25fd3103c5d9";
+      sha256 = "a9c30450e918ec4c0a95da51c071f8c4ec4f870976ac494ae6042aa3fdbc4a56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pt-BR/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pt-BR/thunderbird-78.4.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "1ff199f91e49d72bd9821bfe3e2d33cb4a750a6c46aaf16a80554c195694ed43";
+      sha256 = "157d64059b2a7a1082f233c05fdc0302f92dfa496c0075761bd54327b439594c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pt-PT/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pt-PT/thunderbird-78.4.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "098043202612b362a16353c84a5b9e662331c2311679357592b5a77a6690b68d";
+      sha256 = "d8a403996d56e22809e9124fc4c9dec98cda19a5fad7144fa87e452ae75a990e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/rm/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/rm/thunderbird-78.4.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "ab9bb22e53da48744885634a14886ddb23dd5ccab376e5323824daa3f22ae0cf";
+      sha256 = "97524948b2f9259d1b08b9bbc6533b79fd5e592b08fb5fc5cc63bdb749d5866c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ro/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ro/thunderbird-78.4.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "fb3e61830c5693c7f3b84eb4e3c60ff97324c5654352008aabbe9f16ea40cb0e";
+      sha256 = "99e2c94054fd01001555fdcf4e9ee8a04fbae77e5ff9d34ebc42a6415b939bbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ru/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ru/thunderbird-78.4.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f9fceef81a605ebc66fd90e2759205c4eb7160095312579eb7543b4293dd7a7d";
+      sha256 = "f1996c3f3b6b5371f853f6854edd15ee030b6238f396870a2cff39320eac111a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/si/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/si/thunderbird-78.4.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "0903c3d1bf790c5c10167839e3bc60d80a23e4230895703f7c931856cb617038";
+      sha256 = "10df360a1d5a94ccd218a265024fb3f3d9d9a72b8c749ab93d797a3879cbad03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sk/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sk/thunderbird-78.4.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "2018e5685fbcb5c2cc8925be39b04f6d98347cb59446af62846378818d6435f6";
+      sha256 = "a5f9e0b983961cc4e4ff7cb6f03c197cd8729eead74d6c0b657b441a91635326";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sl/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sl/thunderbird-78.4.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "d20b13b5caa2f5c9c431f3e69095f094800fa520b3a5a57c27a4c9c565961fb8";
+      sha256 = "10526684f3066322066f204a2cf978c779bb895d5c7ba73880ee32caf63d62a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sq/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sq/thunderbird-78.4.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "164041c3958f57f90d17fe1457205a420f326c17e88da0197732435cf6a5dfca";
+      sha256 = "d422e42397d2012efaeeb37101a5b1b29feb34e9e9dbaf87a85f9e2f881511ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sr/thunderbird-78.4.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "8ffcd2dea1b4980519220a27346b5c0fa955b89580836c38711c21c8eb7d26c8";
+      sha256 = "1e9b5637581c2c4973efcc5b0844ca228f66c4fbb0a44e88201973623aad0b83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sv-SE/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sv-SE/thunderbird-78.4.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "83536011e7bfe2e7a0a760ed879e041b4caa3ee27e95829331faefd29e8deebb";
+      sha256 = "592daeeebdb5f56f486a4e6efa1c51e709d834a65c861e76e5b6fd86f8a4bb09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/th/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/th/thunderbird-78.4.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "13be237b698dc9b468af7a2b8ff062118421a7b798771f1db4f82bcb1098f83c";
+      sha256 = "00f883ed3d542d0bf3da3e744523cfd1b3405ae0b928dd83c42e55e5f1bab4e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/tr/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/tr/thunderbird-78.4.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c70d085f6ceed58e7ea55ab01d121627a55df2f5e961ef160f4965db941660b3";
+      sha256 = "ab69a35eebbd1cdef80b22a398c4d570c17e13a8a36e5399b892974d7ed29b10";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/uk/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/uk/thunderbird-78.4.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "c1b7b0efe7af03a488c80020247e2d8038d6dffa313188083bb75c1bc09c35fc";
+      sha256 = "efbd5bf9552333d78c68191265b3ecccb2a59ae19f2bfe7a1d8b096a44c9fcdc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/uz/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/uz/thunderbird-78.4.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "f4b8d20603c5e1dcc72760623803fc4cb34fffffd7b394c1998b860b5e3bc129";
+      sha256 = "db90d47b59efeb5c847ecdf8b7438a4f99d0954283f1deda39a0ee08f54fdfd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/vi/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/vi/thunderbird-78.4.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "6d9d7885ba742ae28766ed98e64aa59892ffb51ad67eb9bc47d5a3974b8a7f50";
+      sha256 = "1d616c682f04f7c0ec976d41eb71d3ac929eaa3199b4af749a80c906a3f2a212";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/zh-CN/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/zh-CN/thunderbird-78.4.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "e47c2e9b66c99c8ba02c60f739d31ea2d679cdc4d6f1f407257ef3372cabf364";
+      sha256 = "490e4e310606846836d93ca9704b7de11bf307b918933fd0187aa5d3795a82bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/zh-TW/thunderbird-78.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/zh-TW/thunderbird-78.4.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "1cbab249ae670a204e464a9082365967a74ce2533bdab60682c14fe65dafba16";
+      sha256 = "c62476ac43d302ad9895524f6f66350122edfdf393697111d5868cf25b996c1a";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.0";
+  version = "78.4.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/af/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/af/thunderbird-78.4.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "589fe4c9a7ceffb4d027f493e0b074647bb958a62046deef5b8268fd43e6aae9";
+      sha256 = "36268a7fe6ec5a0ea0243f83ffbd73204d5c4ef257b0c8857a50428304b2d4c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ar/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ar/thunderbird-78.4.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b94d46899a7458f9c94849db71975e0028004bf93d5b0695a454fbac24a41ec6";
+      sha256 = "831e70f807f05ce2f82bb11db35d05ed80dac53ad00c12ff6e191a627d0d42d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ast/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ast/thunderbird-78.4.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "c6057f5e2937a05f84decc3c2f26de4555314c627210a961882773b2c745ddbf";
+      sha256 = "e6efde72ce7aeeda5f7c6d7cc0f3a08265c44546a0f8fc84a2adbc11cc038601";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/be/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/be/thunderbird-78.4.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "94d7bd38e35745f4829abe6cf3ada8e947a2df881dcb1e5f6ef823bbd6e0aa75";
+      sha256 = "07fe33390caf37a96c000e0f5435d07711f7a95dbe04f85a222b17ae5a13f1bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/bg/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/bg/thunderbird-78.4.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d482c6a6873ddb34dc49002b8ecac94e82579fde7d24514500f2de28fc777e18";
+      sha256 = "d460e201cbe4a1d6548a52121a33c2aaa7cbbf0e126fa1c4e8a431423424fb9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/br/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/br/thunderbird-78.4.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "18fc5e174942874ecc41838451aec780485a263584121decfb9f9607ee35322c";
+      sha256 = "9e85928f1145391d9c3f238612b93e6344a2ad5e6179bf09502b1b69c8ad1b03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ca/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ca/thunderbird-78.4.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "269762ee175f69ecc9ffdeab2ad66788d24d2b9ba1e8d05f74ff222848077735";
+      sha256 = "1516236c252f22933adf23bfe93d73fa272a4574deb674aef6e1f35006a6cc50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/cak/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cak/thunderbird-78.4.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "735baa9541d1dfad828db27a2cba54caa681973f792c0712300e4f952803dbfb";
+      sha256 = "c46508321d32c468d067d86c04973ca345b09b0e983954eaa123d02778d61fbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/cs/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cs/thunderbird-78.4.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "04763e1461106c76b51c31522de9bd6376d531c9f93e79d4a4c00d5bacb9de29";
+      sha256 = "227209429c07238f38d334e5ac8a5fd895a4c87f51b21b4376df89c50bb6a789";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/cy/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/cy/thunderbird-78.4.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "974885f8e17be1b744f65c0e392747921508d7e0f286ab9fa20580cc205a56ee";
+      sha256 = "b272926205e5470df8aec8b22d6733e4f47993e76123fe81d4be26ad5a153062";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/da/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/da/thunderbird-78.4.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f0e13b8952478b5ebc46552405421b796d645fbb0a16aa759a045b48fd43739d";
+      sha256 = "13f9fe10c84d2b8d8d0215cb58a9852486741f5bc8c6979f0a701bef14a70f4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/de/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/de/thunderbird-78.4.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "735eb8e1d318e09d9dca6560074960cf9ce2fcd5a720754608886f6e51e87266";
+      sha256 = "590f9a5a975544d2effedda942e3989a13be23b95f4e6707f9905fed3fc08214";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/dsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/dsb/thunderbird-78.4.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "b1b5fad405049cc62784dbb6e938cce6492df3b620c25a0987a594a88d0caaa1";
+      sha256 = "5b572c847f9ec76b25c225652c23ecf8c56523ffc3071b437310f0d8f9049b05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/el/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/el/thunderbird-78.4.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "1bb01c5fa05d3dae7d1216a0b3e01354655e96f728f63b8213d1ac4ca08e5b8e";
+      sha256 = "7cad76ea5a07dce6bdd3db78485f83a998ff27037f8ca68f8617659a06910a05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/en-CA/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-CA/thunderbird-78.4.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "cc7280af5ca21c82ae8e4fbcceac117b1b3c2a2e95db418cd60322161eeaa0ba";
+      sha256 = "f261b38fbc8d83c20be63015a444644a95f7d8b6584fcfc193145abcc69a4164";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/en-GB/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-GB/thunderbird-78.4.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6bf5112867c3493df18880858e483b684946b657bd10960f55a0e55bc364d8a5";
+      sha256 = "5c0c364b1408182c0cbae1c2d05041781e2e4f3a17fb1735d61196c9b647dba4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/en-US/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/en-US/thunderbird-78.4.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "24780daa2b17799f263a6c16b770b0e6710d14f7f1f502f4868fe48d81ca8e48";
+      sha256 = "a152c3b8c6ad4ba3a92a8a1f909b99599d8c3ded62b57e9721fb333b47f6509d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/es-AR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/es-AR/thunderbird-78.4.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "ac6e82b950f6cd0d7a964815c58a28f602580813ce29cb33bfcde36205d06def";
+      sha256 = "dc06a64e0b20dd174d6158e5d2f393bf6a6907f8f515120220bb2a8480f58d1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/es-ES/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/es-ES/thunderbird-78.4.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "67a03e3c7b00d5e0953ae9eae031ddb42337e23ff9e65ed7c0b759e1c2fa4426";
+      sha256 = "7d3b7ff0ffb9b19f10bd7c2cffb5dbff8216c65c01fd4032ba5b7924c73ce343";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/et/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/et/thunderbird-78.4.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "fe5af4823e15422da39c49c3fed60fe460ad23b7c78f6b4fc85ce247a09cd0a8";
+      sha256 = "a9a8e610bc1c696137ee650fa11f2cbf8dece4ba32d1f0961ae697f6433cf1b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/eu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/eu/thunderbird-78.4.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "94699170301daed68a6d8554816c37cc8c51d72fbd1642cc5a066ae4d5a394b2";
+      sha256 = "6835e8459b4191cd4bb5ae8011d032d475631e7a532450b98f0b087ed0a80fb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fa/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fa/thunderbird-78.4.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "fd22c75cb11bf3fe1a3d2faec1cb7a2332131ac62324bffdd51cc8f03e95a372";
+      sha256 = "7cfd8681a7ed38364a823881fbb42af8cf33d17bf911e9f5b97dd18102b412f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fi/thunderbird-78.4.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "df3632903e77b9eb5fda1ff1d8a155b1f3c4861a8821efeb1fef4d39878a9349";
+      sha256 = "8c84662afb60e3dc94eace5a493f7feef6598b78613fe99f195408e4ee2b0a11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fr/thunderbird-78.4.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5100b9facddae8451550fa0a65b9bd345066e7e465916ed3728b40cc9ac06e65";
+      sha256 = "24449816c690757b05d1913ff1fa12eed47f316ac13c76a195ae0628c6950da0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/fy-NL/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/fy-NL/thunderbird-78.4.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "40c7fe9bea5b5edc5a3e62f7d1cf18ae036544c0172954440d036086f90ee119";
+      sha256 = "9a0334f032333eda16cdabd5dffb05f5a22edb1dcf4bcd0b47495defd0d9f3dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ga-IE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ga-IE/thunderbird-78.4.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "4ec2f91ba73d3a7ab99d69af2a7d99cfb2280c3872fd4dcd7436ae9362586d06";
+      sha256 = "33e5a54e2259984ff29d3394fe936b5af8830e489e0775ff36eace4c6b3dc145";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/gd/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/gd/thunderbird-78.4.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "f6d168939a0157c2d450c43d818005e3b9a59e8caad5796492e8078947234b29";
+      sha256 = "b91c4b3aafa2166cd27c52977711c55aa425f68c5f7cca64be1dd07fd533bc05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/gl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/gl/thunderbird-78.4.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "2fb6b4995f722e82503bf88fbb3b5275faa4d392bfa5832735ac1d40bbe3ee38";
+      sha256 = "d1c03b3b92bef4f3c94518981cf99840944c8a36aab7b2cfe3f72f1f0e57e045";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/he/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/he/thunderbird-78.4.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "70f0bf4db60ad4f1656f0aca1575fadce3a697634f60353bc3d63e3336225d2f";
+      sha256 = "7fdaf0e83eeb39b66a6d1c2600f2c6f1b69ec4f67dd7b33a39132e838a699f06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hr/thunderbird-78.4.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "d37ac64cd63a4cd66fff1bd30ee3643be75cb977581f2182a95c27a16607f3a0";
+      sha256 = "4ba99eaa25964bde6108eeab702b096ba50b45d8db7e36f3203b0a71cc1e30cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hsb/thunderbird-78.4.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "85e823db225258e9f74e04c61faa89e7c9553445900083f22b7aceb22ef3d901";
+      sha256 = "187a5f2b2e1b16fad948356f31b2ac903fe318432d9a3f105055c23d1225d11b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hu/thunderbird-78.4.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "da897b48a2e4a5a3734016ef18c503864792d5c0943bcb2644c272c1a7c63f16";
+      sha256 = "8f6b79692143e6e27cc844985366004d06c8e55184a73477fd20020575947ad8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/hy-AM/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/hy-AM/thunderbird-78.4.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "dbe1276b14b5864be5fc2de3708ea320d2dcc80eb654e9bad56950f818903484";
+      sha256 = "4066683e4a635b163b9b14e1921d834b37a95cee8dd04fc6885094c5e0394dee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/id/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/id/thunderbird-78.4.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "86c7be9b6385ef437323069a7e2497b3a18a552af9d9c4523789be4ee2e07b22";
+      sha256 = "1fed6d3a9a11d303db2f2c6f7a92639b92ca144ce3b45eed4607696ea4617511";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/is/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/is/thunderbird-78.4.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8e062c75b579d52d1a887d2165bcd3eb1d0c4e435dffc05d0d76d4404dd061eb";
+      sha256 = "a627c95d2284b4e828a466865aa19262aa84a1a2267235c3f62d13c52081c580";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/it/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/it/thunderbird-78.4.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "932de1926441066a472d5e68b933fd4035f2e858fdabd4b9d4e71ee6e64202a3";
+      sha256 = "6b01e88da702deee95a3a6d526e563e854be7ae13414fed3a2c9cc427e906ffa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ja/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ja/thunderbird-78.4.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "2bacdb192fda85f10f747a8c8a2ef3bc60345075c1ba33947594fcc66eb35e5a";
+      sha256 = "3b63cf4c45945f4a40159a417ed217b77128905de82812fe2165c0c5f66410a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ka/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ka/thunderbird-78.4.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "110d71951f0f3235ab63c02e8d979b2777de4abd4906409b96107fac1f6d7466";
+      sha256 = "c9d11ae298691f2e302078f865b047b1c2b568ae763495fbfe2f2d4f04a9ef6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/kab/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/kab/thunderbird-78.4.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f765a32900f0100f03aac4cdce7f33abb44e53911011cef6f6db8f9dddd11124";
+      sha256 = "b6367ccb74b2ced8708ca9f4c2c06aeaaf4f3bcba0b2b2fdf2c552aa10fcfc03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/kk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/kk/thunderbird-78.4.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "9af2ab317e0736e0dbab419f5061a6a5c83e521d15f38911455a2d57f6bae945";
+      sha256 = "99ece9975a3981fa33887d3b5d60cd6874e1dab7c51d830dc0d13c28c103ca79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ko/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ko/thunderbird-78.4.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "06669829857f1c49acf7a58f6a7f0e5a4d8e4ce93703cde0d36525f5bb9697cb";
+      sha256 = "d81c844cbd490e5eeeb2739a9b040062baf3bbdf13ddfbceb59b5630019b935d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/lt/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/lt/thunderbird-78.4.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f85e547d17b6bae2597d4b780b14f9076d70dc7c63ae85427b54c01f0c559b72";
+      sha256 = "56b5813a5b0debfe90fa2a20fb9a13ea210e2eed37f180f3e23e851f871241e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ms/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ms/thunderbird-78.4.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "e21639c89686480be875a0514c1b1d99fefca6b79da80a5406f37a63e316348d";
+      sha256 = "8dc3f341a69b9ef458c1203ff15779beecf3db2dede1cd8740ee19a9552f22f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/nb-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nb-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "652d43cabbab6ab158b3d3ab70cf83d8ed3ae3524232aa340d17c248dc5fa869";
+      sha256 = "0fe431d3773de39431cd777cf301d2c3d8074dd41596bf6a6f1bef96870413b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/nl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nl/thunderbird-78.4.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "2c5f173545ef0ddd0c93c921931850e9a7f457575188a91d243245236fe09384";
+      sha256 = "4127bdb6338210d9928fc84838a57cfb731aa3254aa5427471deca00bb12beca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/nn-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/nn-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f89082f26cb871befb4f8c82c31a9d1cdd5587d20ad3a9a1e78515f947ce4271";
+      sha256 = "cf0c6d67115ee36b80010d93d50991a544af332ca19f1ed1199f49c7dd125049";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pa-IN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pa-IN/thunderbird-78.4.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "75d7f3bbe88ef2bab33e62834a765f814f75a28e2277afef2517a91be98201ba";
+      sha256 = "283c2be7f9bc0aa3d505f1838f1c03721a4b956870ac2b1e762b966e87767ce0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pl/thunderbird-78.4.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "c016668ef5f80043eb3e3eff6c8d2327adc3ed86375e81318fb8a4a9fc4689bb";
+      sha256 = "4c07e4500ad4c0d698942e3c47ced3bbd6142e4a70292629ebbe53ef5f1816f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pt-BR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pt-BR/thunderbird-78.4.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "637a97f3b584e315ebec350a08fa54d17cde8825385736a2bc4ca1937dd552f3";
+      sha256 = "c6ace3452d1720681e668da50d16811286c1e73021bd06ab9b538c6f6fc5fda6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/pt-PT/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/pt-PT/thunderbird-78.4.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9719af4fc96ecc0e01f8ad4829f8a94004cdeb518d10f12deb41073f6b0d6f32";
+      sha256 = "b9ab4d38b271e2987b5e425a277042dc149794cf461283114553133e7fed5f06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/rm/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/rm/thunderbird-78.4.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d3467e689f512a3032f9dd8b022af58bf7d61dcdcb1c69317629f0c0b37aa2d4";
+      sha256 = "50fc69135b789b2bb5d8008292d3fc25f1a0a30bba35c6e24ddfeabe55231407";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ro/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ro/thunderbird-78.4.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "25985053e562792ffdc5757f201d6171cd7f30199eae7ae2f50cf39b5090feeb";
+      sha256 = "1e050b33a942dc815e739c57944a0d705982e18e74637172b0366a9b06916f7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/ru/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/ru/thunderbird-78.4.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "2c0769be95e0a21471197a1f1b979bd36b9793f4242f7ac329c7fe0fe88fc5a3";
+      sha256 = "c295bda57db84e07f28affa4201c4f612478efce733cb9c69962f6d7a797218b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/si/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/si/thunderbird-78.4.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "2a6d7e47e92166ac1636495e5cbd1849285576cdd812d650767130730002aa6c";
+      sha256 = "63dc83cfab8be94893ca6a0d60e448d14db1afcae55192149a882456dca77e9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sk/thunderbird-78.4.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "5d0de7356dd46a9ac1cb98254167fa7be34b6897e5ea69ca093e71a850d53363";
+      sha256 = "5ab5ea76649582ddf10fa77bbb95040d157883e0905df72f5bc0ae79167d97be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sl/thunderbird-78.4.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "8c7e69e7fbe49ba34277e8cb7cbf45eeade086eb460a92e243698824cdf3d5ce";
+      sha256 = "da3f8a30797386bc7c9ba135ba360cee01143bc76a2315e7a2223bab90e2283e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sq/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sq/thunderbird-78.4.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "95cfe7b956bb590c790c156f22ac3c5cdc1dd3e4d7b64422583597fc9ccd8c28";
+      sha256 = "f2f9639c4b4dc4bfba476aa92814fee65ecd3fca27652177614d1107e4200246";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sr/thunderbird-78.4.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "82573f011da92f7d93d6cf0a700c9eae31a46c6d09671afa63afa533f063e5bd";
+      sha256 = "3bcad0c845e4481a22c1b330b6cd94c3c6fc46c33597ce5af0594368579a8260";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/sv-SE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/sv-SE/thunderbird-78.4.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "5fda7b6e8095bc456e684887a82cb2adcc14fdfdd9f14731f2bdf2789eac4930";
+      sha256 = "9b09d4ab71000429c5015dd8a0642cfe0eeeaa785d2cac6e876b1cd6aadaeb44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/th/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/th/thunderbird-78.4.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "0e33b43cb7fdb2ae4c30480e264e00651181f2034af42d7a3ac2bfb57c148896";
+      sha256 = "b33e42f0271ee84a581a737513197d5f036695706b19697a53000834c199c75f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/tr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/tr/thunderbird-78.4.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "05019602190a28ecefbdc5100b40409d3d6288f076d589136724d07e111bf324";
+      sha256 = "f419ed9f0f06575da2f89486d830ab7fd2b439dcfcac92f1b31c573901e7b9ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/uk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/uk/thunderbird-78.4.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "2940500895c734857b258550b85f846e9eb5be68b6faaf808ed7a9867c423d14";
+      sha256 = "bcecec66a6ef8b928da2aa5d52d89f4f1587d4e45bf0e836b71912b0e5a43f7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/uz/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/uz/thunderbird-78.4.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "de82b265c6e19495abc70c36f377cef705137f352da0aa7d01aa874e2a9f1f70";
+      sha256 = "2b33f40b9da386e61f3bdcacd9c16fc06dac18d2b36865292700744dfbe2da25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/vi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/vi/thunderbird-78.4.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "cf02606c0eff0b941c1c2ef654e250d5d6a8cb7deda752468e779af1b616c0e1";
+      sha256 = "b5d005c45221c41e1e81234b755f6a9d380220cc03f43012c40440a0378c19e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/zh-CN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/zh-CN/thunderbird-78.4.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "54a1a869a746ff3af8d5ec27b11f1d3a0efeb49480043fbf776e9646b5be944d";
+      sha256 = "c08765cc8562cce08b4cda04123cd8672f5abb130b597f36f4c143d74b09b9b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-x86_64/zh-TW/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-x86_64/zh-TW/thunderbird-78.4.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "0c9530adcb5029ae570a8d25d790f243c0a3d6ad7701ed071fad326d3718bea3";
+      sha256 = "56f84ea43a5288a6cd34f8de5f69dde05737474f11c70d638981ef2ff4ea5bfa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/af/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/af/thunderbird-78.4.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "29b39333cfd9919830cecf1b0043faf4dd829c36554fdcbcff6a8dbf11882060";
+      sha256 = "95384cf3d0ab6ad8d3bb133e8ff7c1881523c0f7be840c5ab6016325ebc7f9ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ar/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ar/thunderbird-78.4.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "49896345d391f22f262592e055b2bc5fc1852d5fe1f9812392ef09b9f329afee";
+      sha256 = "c2cf87579a092bec69042b35743574872b8b791d54628c35c28d44c1dc605b6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ast/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ast/thunderbird-78.4.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "71a952590eec188661f8cf95f62efb2c9f2465aadec361c990bb62481938b128";
+      sha256 = "127ce24b2c06606e9567e2106ba5cb9628d8bda10620b01cbfe60bc287977c94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/be/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/be/thunderbird-78.4.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d99a81043f6c158376c960d0dbd60f6d2e73ee1e6a015aee55ff42786e58fc21";
+      sha256 = "e8acd7cc25f91af91caee7487598cf1f60512864cf1fee714d2289a65f0cc195";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/bg/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/bg/thunderbird-78.4.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "1226b669b2b2e7c890a1de0a628e663069c2279369587a8b819756584be2ba0d";
+      sha256 = "461e4ec0b0f3dcb78426a99f0b8dc32b14dbc561b89e8d422433f5360425448d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/br/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/br/thunderbird-78.4.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "2f656a4269f37dd8513cf2f0b799d97225ffe55b00e778dbeedac66bf7b00d47";
+      sha256 = "ba3902a457d0570d3eeaa63cc83a67e35532e547127b71f38781158bc3cc5e60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ca/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ca/thunderbird-78.4.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "34dcc816776f2da32bf7412a802a8d3d7a0b31afcfb1811c617f1295ced05adc";
+      sha256 = "609de3623c6f4075bedee741533843f6f9fd1afc5933fe3a8709f5c16c7d7bc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/cak/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cak/thunderbird-78.4.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "f9fb448edc5238b69fe3c08c665a30320e5662c1df78101ba4807d371a6a15d4";
+      sha256 = "4a5aa707eca53cf5490189a09d222abaa8290ea3366d4bf081273c23e89b3fc0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/cs/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cs/thunderbird-78.4.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "156c36781f43fbaa3eb5d1d32ca7d6b3c9573261757dc9c78e8cf0be24a6c717";
+      sha256 = "0450c73284b274af21f3f0c4c21842e11fa2a86fcb38f96332c1ca8984149c62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/cy/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/cy/thunderbird-78.4.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "0e48e453cddf00929e189546f0dd478e273dcd8bc891fe875f553825f0b4fcc4";
+      sha256 = "5686316ec53a76dab272934dbd274a47802c5c31f2ae8719bcf85c22e12cc3f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/da/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/da/thunderbird-78.4.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "e614911f79a2a86055e6914aa0f4922979eebe4229b26b18f6ff31cc6bb49c89";
+      sha256 = "2025f5946989905fd197fe5bf6c51160e7c9d281d6cfd220ea3ee0393cc54ca0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/de/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/de/thunderbird-78.4.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "a8c916da07945657672b5b71a722485fa7117dd912896bc9eec8b9b82dfcc48b";
+      sha256 = "906e8a5de0aa12b496f4d4447df25432b11c88d79b7ab4a55291a9d65434aa03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/dsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/dsb/thunderbird-78.4.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0b3ac7ec984e26b66cd3c5df733c3cac6b83f4388cd65344dc40310651798c05";
+      sha256 = "d6bfb2b790d8391344916515d1cc6ca2eb68a3e58934cacba14e77788aec6b09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/el/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/el/thunderbird-78.4.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "dbfd90c1810dcad51bda6a7d2de6a132f428a5c6151c107cd09a98a48b2ce98d";
+      sha256 = "5f96345a945697326b24fcd73a96fa2f49edb66b02f4c23b6d392fad87935e08";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/en-CA/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-CA/thunderbird-78.4.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "3ccd8193d486596ebd70e3e1803563a3a8d59ca25c29eeaaeab78ab78cb0e72c";
+      sha256 = "b57e44fd16e33b178778a60f0bd47519585a3e648b3b621f1fd693836c5fb598";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/en-GB/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-GB/thunderbird-78.4.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6d74ef15e0196a2b07302f40bc3992acc8ffc94ff7d90433a00d766a0840226a";
+      sha256 = "6f656dcbd7aaab5995beb11a9847e32f8820199272e2f9ce27583cd3d7e50a76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/en-US/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/en-US/thunderbird-78.4.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "718e57f9b1d7f1ca5c52dfa8aa109f8cdda279cfb6dea649add651b6637fc6bc";
+      sha256 = "8c6bccc757df947bed74a3f7448a3885932a4f6c21d24ab6b5c7a94ab83ebae5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/es-AR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/es-AR/thunderbird-78.4.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "26dea055b9c6ea2b8f7e15b0c93cd3d880c83bd1c9f23f8d572a92659740986a";
+      sha256 = "55bbc629ceadf359e0ad05e763a31479f6c57c38f372e55812b028681a5ff32a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/es-ES/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/es-ES/thunderbird-78.4.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "90d115cb34ae852332e5bd792067c66f1bad920721da68f59b38a2a86a8a0105";
+      sha256 = "bf30dd8882b2b35bfaa62a6c4b40a823333476128a6d5dd3e3d2c8eb16303b9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/et/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/et/thunderbird-78.4.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a82aed816b1ea065e21120a8e6e0345c477b90f9c672c04cee9d15ffed85ef28";
+      sha256 = "5b977eab7f203e230d6a03b36afebdb32c481f1eb8129e454977791469ed5651";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/eu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/eu/thunderbird-78.4.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "7f1bf5742159e15fd566827db713421778262377a8da9ac269fc6af635f1b20b";
+      sha256 = "f2d606a6f825640c0f344cf470d87a1dea5fc6ff538239ce25c3d7c9fc76237d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fa/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fa/thunderbird-78.4.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "25d97499486a7c3d38c4686f7ff5daf930694f6614d3d556af85c3cb99193403";
+      sha256 = "95d0d3d1b456c035cc6ed09df970e9e772a71af3703f05e9388e844d7f80edab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fi/thunderbird-78.4.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "5531179571b0306ae2c1d5f4af40047ea9a5fdf65137bc7c255ee7f5dae2bab6";
+      sha256 = "e0be2532774bbe017a6091d7e1ec79901f692c39e04e01fe4094f7c8179fbaf4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fr/thunderbird-78.4.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "12e33246e17aebac0547801d5d4e23db0523ff260b5345b8f0a19fc5cf44f2b5";
+      sha256 = "48cc16a61958160f369b32e8a0dcd2979ee65e18efe3d1dd3a4af1109842718b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/fy-NL/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/fy-NL/thunderbird-78.4.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "50c6dff9614b113ea57d4c75dd0768a8524743a7b9f462f84f27f10daadbc1f5";
+      sha256 = "386d0a2ed01b158f0fe18eb6820ff9a17fbbea61241eaf873782271ac84eb103";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ga-IE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ga-IE/thunderbird-78.4.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "6c6229aa064098560b13369a0d11133156d47193a8f8b2fdc241fbcba3cb3f9c";
+      sha256 = "c0c15410e6812e8652181ab347b3fe60fdce3b5b9958d54ef3f96ecc46a4d344";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/gd/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/gd/thunderbird-78.4.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "6e5f686d98b02bc97e14f5788eac7b93e5e2652e9feaab0906cb026a883b1485";
+      sha256 = "3989f0c0f87ebfca3e4cfad0ac9ca2964791ab8f1163f1bec340444ae4a72a7b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/gl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/gl/thunderbird-78.4.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "2ccde2411bb2c3e4b492b4cacbe8d756dc22c2164fbe7364bc2381c1ff582f75";
+      sha256 = "eb1b58c93e492a79f92660909e671ee7ec504701b8e074d3dc6f3d3fe3619660";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/he/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/he/thunderbird-78.4.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "30fe226741e47f86f07c5acbb8fe3d2aa2fb7102fb4743189f12612c817415c1";
+      sha256 = "f584e117ba4fbfbb7d2c28b68377a88aad87929657141adac5ce960bcf5f4fa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hr/thunderbird-78.4.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4230396816f72ce2784bab21fa2fe731ea378f1ceeace609e0423e2b5e7ea83e";
+      sha256 = "633eab2f8ac99426dd85b614f04d96509125f0799c187305b7678496d9ceff0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hsb/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hsb/thunderbird-78.4.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "155a4e98c597f7876ab44276ab8814ab185a5a59e1fdb743260bef2f78b27e4a";
+      sha256 = "80e4b98bbc9874de9b4c8e35633f6eea7b5707cfc4943df7264cf0bbfba49d99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hu/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hu/thunderbird-78.4.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "bb0b46dc74b926e9d13c4bd8b0371d730ce03aeffa5c41689eeb797ae1ce4382";
+      sha256 = "5a9339a876a7e0dced6769a99a948329f6eaa400acb6920a24d06695120f682a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/hy-AM/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/hy-AM/thunderbird-78.4.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7ee0ee79ac2143fe3ce8930c3916f201910d6d7a40437fdc49a8c617d49871d8";
+      sha256 = "286542d67a76a6e8f0c34e7aca9c23c8922bf85f8be77c913285e208f8b195a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/id/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/id/thunderbird-78.4.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "e1a4072dfdccfdf35401e9a58e77cbff2277703ff2c78a52fc0df801bca8f91a";
+      sha256 = "930cbbe1520c544a25cfbdf8d10b4e6ae19a812c8a20ce51053ba0d5fc2b4b24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/is/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/is/thunderbird-78.4.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "d4d63add23724c58fd92d992165748f7002540f73df591914540f6361dc0089b";
+      sha256 = "7fca3c4c9d3a309ec182d1486438973741fe2f1e39afd3ccb769256657db20a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/it/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/it/thunderbird-78.4.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "28ec9beacfb8b27b80e1f1deba83d81324a2d3baa0d9572a41a94f920c8c60aa";
+      sha256 = "3b44f63975cfe7460f3eadd9f71f13db9ded5d9e5622ec322f556692f979434b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ja/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ja/thunderbird-78.4.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ad1f9e091cfd66683964f8d683653b3134068174daf24fe061aad00d0c864176";
+      sha256 = "1284e52cda834b1ef9b5ac6a1dc29858f6e1519d0fd47d330744c0d294338650";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ka/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ka/thunderbird-78.4.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "9074e7b2eb10943f6b87e79be9ec9ae706eeb4300c85ffe456bb34f11798b81a";
+      sha256 = "b12a79e20fce3db2541dcde61e04206e82530d1d79b58637bfcede87294fd801";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/kab/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/kab/thunderbird-78.4.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "7b7d17a26dc9914d46de8959c08d56ed92b263d3eae383ca71d45a1b37a9650f";
+      sha256 = "9766eab276e77b0e33ad7ecbf8f26b84aa2a079a4fc9e4dfc992c41074513e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/kk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/kk/thunderbird-78.4.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "b38db92efa1b4bc1067eeee7eaf7307d6e86e6c6d3f4dd1b81496768c981d5af";
+      sha256 = "aec202db7c28ae69c9f7684a2e4f30a16ab29ec983aacb32bbe4b5bd31b76e94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ko/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ko/thunderbird-78.4.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "951a2e6e2cae525618646f8f054d127b32a535028930eeb3be7dfd2720c4ccea";
+      sha256 = "b0e553c14925413461a87f1d81591bfa4e2ce2c5ad87e8ec609fef76ba4f17d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/lt/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/lt/thunderbird-78.4.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5e76866c25f63aa283e54c871e1014a10e4ecdb8182ca6bc3ac1d16a344ae8f8";
+      sha256 = "6036247e3025c2b513762577e7de1d1eda050572f674c31391e583ccd16e80f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ms/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ms/thunderbird-78.4.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "74e28f4ed81a233bd8aa721515667b31e83f7a6d6bad0aaef421f1f1e4b0c4c9";
+      sha256 = "0852cb745130e22af327e2ce39249751ed482c8216c18f4545bd294f4afb4e29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/nb-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nb-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "4cfa6097b0879de04314773d96d3e03aee3b7e1680e97cee3dbb6fca9e4010ca";
+      sha256 = "eebec58d3a20956894711266715ce5a4afcfd44b5eb7b334dc0c22068fbb10a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/nl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nl/thunderbird-78.4.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "e097065367e8bcaa331803c779ff71e43dfa7dcc5b516fd5d73f60b1c614c7a0";
+      sha256 = "0c6d35960d89681087bcfbf403ff727f53ba2e67de9c69d04f96b68447b616d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/nn-NO/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/nn-NO/thunderbird-78.4.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e3bc6a3754f13db3dc5f70c3fd9b70b4250be494a47c7d20546dccb57b914ae5";
+      sha256 = "b761b921ba2e604dcde7ac0e03a83ef29a3311309cb95bc39801b8bcfd80ef98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pa-IN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pa-IN/thunderbird-78.4.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "80a785335bd49d5d0e8c669a7d548c0e077c413c184eb50133aaf5790fe1148a";
+      sha256 = "fa350ad64a3ff760a6e2cc6ac6b6ad1d6b9ad300b6c3420477148152bc207499";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pl/thunderbird-78.4.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "bc20f221babef7c3a3992d57ab5a3afcad12faa0263ff8978c96a1267af54c28";
+      sha256 = "8b187d44bc1364dc76258ff3452610483b2ab3d060c9de43e47c25fd3103c5d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pt-BR/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pt-BR/thunderbird-78.4.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "6dd040a2046c418d51bd7103d93a50b58e3345de5ed0c8917c0a8a8c7bf87c7c";
+      sha256 = "1ff199f91e49d72bd9821bfe3e2d33cb4a750a6c46aaf16a80554c195694ed43";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/pt-PT/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/pt-PT/thunderbird-78.4.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "45f67266e6af96dccae07d6db4f5d62c3d6d26e1a76e4951f08591c664122359";
+      sha256 = "098043202612b362a16353c84a5b9e662331c2311679357592b5a77a6690b68d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/rm/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/rm/thunderbird-78.4.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "1d53a7290332375212c0d58af23265d59502bce1a6a4629b56bc86d048be65a9";
+      sha256 = "ab9bb22e53da48744885634a14886ddb23dd5ccab376e5323824daa3f22ae0cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ro/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ro/thunderbird-78.4.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "de3e5496ce5b8c4dff6fcbcf2b8a47b0c81d026fb5334e2668b8f9fc293c5216";
+      sha256 = "fb3e61830c5693c7f3b84eb4e3c60ff97324c5654352008aabbe9f16ea40cb0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/ru/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/ru/thunderbird-78.4.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "838b9a02684541ef7df67a23b9966282ff9d8b12b64dfcbcfea8e8381b24951a";
+      sha256 = "f9fceef81a605ebc66fd90e2759205c4eb7160095312579eb7543b4293dd7a7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/si/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/si/thunderbird-78.4.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "202f815bdf7538d50f4770e601d10c8a1ffddb042a3c7dfd1a1b65e9b5dc5ec6";
+      sha256 = "0903c3d1bf790c5c10167839e3bc60d80a23e4230895703f7c931856cb617038";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sk/thunderbird-78.4.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "44c5aa3723919798493e7f43c927ac48891eecf94a69c79b86be107984e9e068";
+      sha256 = "2018e5685fbcb5c2cc8925be39b04f6d98347cb59446af62846378818d6435f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sl/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sl/thunderbird-78.4.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "2d5125d9625f916788265db46ee1fb47ace3b6099dae26ecb734aecf36160949";
+      sha256 = "d20b13b5caa2f5c9c431f3e69095f094800fa520b3a5a57c27a4c9c565961fb8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sq/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sq/thunderbird-78.4.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "2aa337b0fd8ccfe86feadef605ca863499f21c3ca7f194121064fc060d5a3de7";
+      sha256 = "164041c3958f57f90d17fe1457205a420f326c17e88da0197732435cf6a5dfca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sr/thunderbird-78.4.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "fe690670c6702ed63684eac68a3f3f29f12bd27af7d34c63af768e0362a1eb11";
+      sha256 = "8ffcd2dea1b4980519220a27346b5c0fa955b89580836c38711c21c8eb7d26c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/sv-SE/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/sv-SE/thunderbird-78.4.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "74525ce44ca330e8fd29785842992c62cf3b5494675ec9a8148ea14d945fcaae";
+      sha256 = "83536011e7bfe2e7a0a760ed879e041b4caa3ee27e95829331faefd29e8deebb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/th/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/th/thunderbird-78.4.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "0503e2ed79dae95302bf2d9d8055589ed1ca511c16c35a9b84445548a7a306d4";
+      sha256 = "13be237b698dc9b468af7a2b8ff062118421a7b798771f1db4f82bcb1098f83c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/tr/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/tr/thunderbird-78.4.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c4b14f4f22549c66f5f445a2ad5826d0e90332c9d76783851078625245625bbb";
+      sha256 = "c70d085f6ceed58e7ea55ab01d121627a55df2f5e961ef160f4965db941660b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/uk/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/uk/thunderbird-78.4.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "cf06114027f9bf14ef506fe37e6a7ef6a1cbdb201cde061a754c82d9b3ef0c39";
+      sha256 = "c1b7b0efe7af03a488c80020247e2d8038d6dffa313188083bb75c1bc09c35fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/uz/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/uz/thunderbird-78.4.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "c805d88694b105412f05dd840e038edfef90b4a48b5a79b0bac5b5575d50a14a";
+      sha256 = "f4b8d20603c5e1dcc72760623803fc4cb34fffffd7b394c1998b860b5e3bc129";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/vi/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/vi/thunderbird-78.4.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ca30574d981964eed7c3a100dd76f90c518a24d7dcde74f0790ede4a0a8d3285";
+      sha256 = "6d9d7885ba742ae28766ed98e64aa59892ffb51ad67eb9bc47d5a3974b8a7f50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/zh-CN/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/zh-CN/thunderbird-78.4.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "6cb1566d330e36b03e86bcfe96ad887fee511ba314167d235facba6c47871688";
+      sha256 = "e47c2e9b66c99c8ba02c60f739d31ea2d679cdc4d6f1f407257ef3372cabf364";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.0/linux-i686/zh-TW/thunderbird-78.4.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.1/linux-i686/zh-TW/thunderbird-78.4.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7af0d92565a54bef6c962dd8b9b100198e2cac8d47ede749bade87c30d5ee37b";
+      sha256 = "1cbab249ae670a204e464a9082365967a74ce2533bdab60682c14fe65dafba16";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.3";
+  version = "78.5.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/af/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/af/thunderbird-78.5.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "03d4e32b23408b003de5347b2a26d9e3e734f7c3e811510ba81114eff80e6fa3";
+      sha256 = "011468ce085f2b5da8968b0622733d9fa25b47ec5e83b3bf4171323948aebb35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ar/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ar/thunderbird-78.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "5aefbc61f46d59de19061a0e76949642e254a13867881b40b6bac289791c281e";
+      sha256 = "661b0f1981b21df20b910f9d833d86c2812b189097ad7e1affc7338abb4f0c5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ast/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ast/thunderbird-78.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "1e328339808efed1db23ed372841ff65f64e1bda8e1d4be81fd00039468bbb1f";
+      sha256 = "c1acc2b6d5dd22adeab3106c3c6925ce0c1a434e1d38b3f699fab4ca319eab14";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/be/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/be/thunderbird-78.5.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f42230768f2907fb3d23a03a56fc20f14ff5ded7b4418debb3e77c4942eb7db8";
+      sha256 = "6f76341164c182dd8392d2d1abbb0408a3ab773a7389dbf1eb9bb4042d49f500";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/bg/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/bg/thunderbird-78.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "27a72288cbaaaaee6a24a36bb2e463a0426810e97938cbfe012dceb1a3800fd0";
+      sha256 = "4e97b38383d3a145645ca518449e37e42b5b25cbb98cb72f52657b4813f2b343";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/br/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/br/thunderbird-78.5.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "fa1b6c891e3d9d097857a08181030e1df2201240ae466c4adc6fc0be0982d002";
+      sha256 = "1d5bcb706bf2eb589aa0c64589fc5b22021977947d6e1099f339a46c55a56f84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ca/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ca/thunderbird-78.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6bcc123c7ecccbf42022e302b63683cdf77f6f6f2a615b12c5ea9e6a081fb900";
+      sha256 = "3284b98707ee67977f148bd20d88750cc03799d9ba4aa5668c44901846fb8bcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cak/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cak/thunderbird-78.5.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "392cc166ee9be6c5cf8294f727f97cb21b6ad7ebb77d263bba273f02cb15e661";
+      sha256 = "7998d66eaf3edc4ee156dff06a30de8abae08ff66b380ea93d7ec0b827a0ea29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cs/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cs/thunderbird-78.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "60f5ea97e75f965ac0947e51c8cb8e709e5fa8f67ea478babe936032dee5a912";
+      sha256 = "5ba37c9dd7a1fc291bcc8b24ef025432dbd5f8a45ea2a4d1273177c6a7c8f6bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cy/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cy/thunderbird-78.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "93aa92633d2414ad59aedea8b1a820b158a21c042cbfaedd8abd2b5a41e31c5c";
+      sha256 = "baaad2ef28f51b6f57fa6f0583e8e0125c50ea3b4c94dea5854faf9826aecad0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/da/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/da/thunderbird-78.5.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "dc263e9d186f4ca8cd404b6e5bd13f9d2874e0e2507eaa55e99a6b5ab3b05179";
+      sha256 = "6113ed3f5a36f16e64f0cc499eb683a0d7d377d0cce37882f46f203893b789d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/de/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/de/thunderbird-78.5.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d9dbf07f3c57f688b08f75673074562ad9d4a9b138159f353415d63f9ccac80b";
+      sha256 = "81490e8cd8110285177c27f4057ff48ed1bdb55c94c83cc78e262b9cfcbd87ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/dsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/dsb/thunderbird-78.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "084ef3ef3628d003c75dea9a9fa5897424e6e564cb18fb5bca33b341c8c511cc";
+      sha256 = "4c6abc365842c902ff184b403a6c271760bd8e71da9efa90d30310e032b03729";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/el/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/el/thunderbird-78.5.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "4e91e7d21d0a3d524de7e41201ce8af58518a7e0292c11fc2961a84e9b7d04fb";
+      sha256 = "d492a83d3ddaf5beead77fd90a2334ca4ed90023d4c4ad478249a360f49cd5be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-CA/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-CA/thunderbird-78.5.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "922220811fb0083e8dc51c7cbd703530acdfeb0e9403d1a0909ba1618db020bf";
+      sha256 = "d7ddc5a22e89827067255726824e46d3355906441051c9faa04e6241cb833955";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-GB/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-GB/thunderbird-78.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "090806f6ebf12efbc5c20a920451feeb0d88d1e7366a074553b79080869687c4";
+      sha256 = "10ff106bb933374661e3398ea4ce02c205242d1f7a647504161e295b5e3d1e11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-US/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-US/thunderbird-78.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7fa3769297600c47c54902bac696e718053c48fc02e54698cb05ef81a4eec873";
+      sha256 = "297429aff3f10ab7c2859a37ec351b6b0a478495b8a34e8b492ae3473f052c7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-AR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/es-AR/thunderbird-78.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "51be3a453bb3e3f1353b88ab31fffa3fc0c135cb91facb7807c967a9d4afa659";
+      sha256 = "c8bafb3476d127d28f565ea5dd749b0c870087f395e0aabfb848a004846498e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-ES/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/es-ES/thunderbird-78.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "8828e5ff82e84c5f69afd60ae5dbba445d766e2a2d7fbbcd8f0dc8f255d8fc02";
+      sha256 = "d8c5350627e7e6f48fbfa863bed1971254104ee299d81d1f36b99d6c6ee54313";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/et/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/et/thunderbird-78.5.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d58404701341bcd9b859f1afb87cb3340fc4b8334cc9490e8ea21446e3f308eb";
+      sha256 = "f2a1001b0bb87965e40cd832102d2233b732273930d36715ff2db900b37c9ed2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/eu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/eu/thunderbird-78.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "5570472164329f23d3f0be51911402c2b454ea704419ef16b46b359a2c93e821";
+      sha256 = "30c6da377a8fc4596f6a67b189c1c9f7a9075df96ed3a59b4da7e0e77157d950";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fa/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fa/thunderbird-78.5.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "cc56e14f1fa17e8b4ec9431ae9ada10159bd90bcade39432c647ba401791e3fe";
+      sha256 = "8f98dd01764a5d244c25c3c409b8dbcaa1d3daf7b3a970c60d3d37fd5ffc4294";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fi/thunderbird-78.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "5175e312e8957490b013dd515b84fe4dfcdf57d30c6806f8bdee67caf39659f7";
+      sha256 = "be5f152b28ee21d916b184999023a1a5adddd1d2c7448e7eb37bd08948f6a14c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fr/thunderbird-78.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "5239f8a07f0f6bc4f69b3d4315570dab33c331ab775479a9df39479b71542cc7";
+      sha256 = "c1b2d725c43196dfe3f9bfd291dfae84ba392151222589d80e3921e627667d59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fy-NL/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fy-NL/thunderbird-78.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "5747be2c7f9d5463f9c14fd02fd5e66a8f6c4c8adca3a1bf8c3b4333f1ea2adf";
+      sha256 = "622c42950cc7d3889372b6e0c5833dc5c5f608ab23ca9962e0af67ce4b2f8ff5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ga-IE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ga-IE/thunderbird-78.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "8e15ffc9235742ad88a1ecaf587a178f5aeb0bc57e075b33f792e2d458362ab9";
+      sha256 = "7293859380e07d362192cd9dcf88b8da04cde6e102f0b8d51a00021bf8fd9e98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gd/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/gd/thunderbird-78.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "72f53918cd04e587319d59100da05657a3084f97d70acba7d1ef7b7321add6ff";
+      sha256 = "f54b892150bd49d028337a88d3a0b2df896a47a6904067b381d385281d2c681e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/gl/thunderbird-78.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "28beb85fe0ea27a659e5063f7094877e906729602ef2e155f0e55e9e9f6d56ad";
+      sha256 = "58c88bf739fde7e0f7e279106622abde617a0aa267f34f1c10f8d886800dc50b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/he/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/he/thunderbird-78.5.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "718f8605fc8d418c645a0485ce86d97ae1eeded8b776a990e137ced78eb91a68";
+      sha256 = "8278c7580356c360c74ad161a6ee052e9398e39a2a5b75217ac0239db28ee4cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hr/thunderbird-78.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "febadac023152dc30e72026f6df203c8051b65ad4da0c4e7059a14ab0b4b5f37";
+      sha256 = "b20bef1b7fab8d63c5cc6336dd59264e7c62a9a4c6f2db4232ed27624b26a3cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hsb/thunderbird-78.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "faaaf4606fde4baca3216ed5801209f13cd1bbf34c9671cfc7a7648bb0ac7351";
+      sha256 = "ad4797a36c713b5026a4da131fc46f341cb8b72e5ad2f07a677bfedca8401163";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hu/thunderbird-78.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "353633956336852193510c8e77251834355c92ec503ab827a389a0dbc21c05bc";
+      sha256 = "1f3dea138c4f82f91b9aaf891b9959d1cdda273f20af811d967ed55058f69064";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hy-AM/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hy-AM/thunderbird-78.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1b5dba6f05ecc8449522d8a54c1d4e7aa5ec7a2e26fafbaefbd754ee3ea5780f";
+      sha256 = "836668531a555d9bd23fbb3c3b27cc647a327d02e6db1903248fc6b3d59c5dc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/id/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/id/thunderbird-78.5.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "470151868d745ce829f0f38c6377f4ead87be829d43f4383d2e5c3541b93e8d2";
+      sha256 = "1d74cd88cddf7b22ef8b19ee6cfedaaade15cecf68712ec8568888d0708c9c81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/is/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/is/thunderbird-78.5.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e9d6b36beb61445c3f96ffe6e11b238a8539b398d5f3911f2ded7ee96ec0766c";
+      sha256 = "a6e3320211b207e9a36c6197dbf97e746d2e9e9b7bda444a8511550b5846d329";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/it/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/it/thunderbird-78.5.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "95a02afcebb834b14986b8ccd92d5381a8ac64d3ebbba13860ffbd0313a594e1";
+      sha256 = "f0e659e6888590394a652033f3d15b29ff9318b4c88faae51d6347f1441201b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ja/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ja/thunderbird-78.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "d1c4e2a551a5266839da96b843372e71616346ea00361dccc8e1a62628e6315f";
+      sha256 = "a2ffc461e6d942222bef4229a820bf8536ef41dce83efc458d82476d5f98f5a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ka/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ka/thunderbird-78.5.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9eb37a69a370b2619724c91c6789471b9ef579190c08363f633f320563dc4df1";
+      sha256 = "6a374b791fac25bfc3f10726d93497291163dd95b1372dc09db70c098822f4f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kab/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/kab/thunderbird-78.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "bce07886dc5251ef401141d387c926f27f61d13450f35cb9a9cbc8403b43260a";
+      sha256 = "a23dc5cfef7bcbe32c32363d0048813a24cfbb19f17c3041b23fc751936dcadc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/kk/thunderbird-78.5.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "222647dd8106134d46bbad6dad8638090e5441a64aa2a6725aa5b1d959a2832a";
+      sha256 = "2187f7d763d34787de0d9870f746548459bd0a2ef0676286d2f9ce9bc9092ef1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ko/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ko/thunderbird-78.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "be2346d5a48e5323d5cc8c1077adf054927d8aececd2fb45fc2f5c0a9f0b8dc2";
+      sha256 = "ff88da9f6c77e8f5c1bebab542abc51266ba03d97fc5d22b86cf52a26db75e63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/lt/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/lt/thunderbird-78.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "da5cde252d5e167025fb06861a32b67a2d0f7171c767bdd8c5d2ba9fc90d7739";
+      sha256 = "77531cad8587aba9c4091bd22c79e40e45d3c57083b5af3e54af3576ed45134b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ms/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ms/thunderbird-78.5.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "d6ab0652184cbbfe9126a49f61c25fe8852725b88460ad92c37dc1c4d969368f";
+      sha256 = "aaa346d9bcc1cbd84beedb75c9949d4a2cd8bf80496a31e2018c2493fed68339";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nb-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nb-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "2485cc4df1b1dafd0c5fb7d7723e923e7fea10af1dbf9764d5d7447f38825e49";
+      sha256 = "dac3f1eeef73c247f9c79a09b7ffab1498be6c96865b5f21ee28d398941430a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nl/thunderbird-78.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "0795d2ae4364def43056e77106ea19053c3111e2f95758dbb41875071655ba47";
+      sha256 = "e0b3df7064e08e34f85b9a83d2bef990f66ad0e1bc86f764139fc57d005d1aa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nn-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nn-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b774035d8bff615646d3b3d73228277531d50309fb5dbf3978346e2b988b2491";
+      sha256 = "eb420586e8be191ffc41f4a920506336cc9dccbf229c260a7f193cbe169a6da4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pa-IN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pa-IN/thunderbird-78.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "2a38813c8aa0eaef3d2ec0ac379ab5c85d0b8c2df1f6a2d36ae066f7b0445447";
+      sha256 = "12f7c97b130ce40dd1dcd00a16a20000113b7be33c87ab9002848439ce626abd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pl/thunderbird-78.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "21cdb977bff1f0c07bf913b4feab2075a429b4594760de52ac358538179d9c66";
+      sha256 = "5ad96dee4b422c820da8a76ab64e62e919c21d99b01b92f346a55acada7cf8ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-BR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pt-BR/thunderbird-78.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d903ccd23367c39779ac2cdd3abe636a0f9e72f8d133a567bead8a739e651589";
+      sha256 = "7d6568c067796f21079a4f6bf3374a1b91807a9b30270587cf815892d86e1590";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-PT/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pt-PT/thunderbird-78.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f220a8bc90b05dd796c402aa5e79c62a8aa91a4d80dacbdf57abf77ec51d73b0";
+      sha256 = "22058d65e2ba94f39ca6ada6750beacf2bacac0f296a34542fde01e897e4a4e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/rm/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/rm/thunderbird-78.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "805d08f629e9dda7d6db36bd41dbcc128defe59b4610e4b7d5d47408a07e47b8";
+      sha256 = "c61ff10e4260eb2650fc1a4e0ca8df6c4e4e2e9525168ceaef86a9b8b2ddba54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ro/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ro/thunderbird-78.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "3b09b2c59f32a09938a45270e04740616b2a13f8b8a6f40503650d9b0f72fc35";
+      sha256 = "2ec34bfd9fe4a0f0cf17f132146ab2a589c986a8b4317124f3bfc34ac48f732a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ru/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ru/thunderbird-78.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "2022473752da127d2ebe4eef7f834ac5feafe38dedbe64ad30defb8ae69c6ebd";
+      sha256 = "b835dd1757f5cdc580a2b91f01a8089c1396d9eacee665fe9976019f8523fdec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/si/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/si/thunderbird-78.5.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "dc5166b0b24bd0a9e98f7dfc483a6bff184a4bfffb0eff8a4007b96fe8205254";
+      sha256 = "3722e47d39024c13dd799e0c89cf79a1302817605f7025388cd5f62fea15d168";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sk/thunderbird-78.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d30e4d3218fbf13a5c531d45f55f0f366aac10aa2d180886ced778c7459c0610";
+      sha256 = "4717620562c338f533053677d8956490d2d42abfd52beb6a0d41466ba3e72a36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sl/thunderbird-78.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f968618f7b13b6dc4441a09882ac5c826017a5b0ca3887b7cdca8ef6a3b3c266";
+      sha256 = "d712c5b3dddfa181877353d28667d410bea3a1f3d85e92dc058a3f3ac5ff4824";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sq/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sq/thunderbird-78.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "f4400c6e55859e07705b353cbf211e863e8c3f373490f3fff6bd3e6d360d5b7f";
+      sha256 = "8443ae1161c6b3e807c9d4abc01824e894a11b6f6c9a52d3097b8301461ac0c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sr/thunderbird-78.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f6437ffb64b1a98b5c5630f3b386b12866a514467c641fb02c8e86560e4b62d9";
+      sha256 = "13f093880d41748efa8f1566e5884d632f2fa80d4eb4f1a8dd1dc20ea626cee8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sv-SE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sv-SE/thunderbird-78.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "f1af8019698347ac94bad5c33b5e094b65e8ebed9181f5fed5e740cf2029bcef";
+      sha256 = "ee9d7262a8b6cd8460b2f1c4c0102b68f9a0983e1f021f2283ead172f07e3f37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/th/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/th/thunderbird-78.5.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "75830b637302032bbc70342b71012f391b333a2645d8fefb8f4232d432c9dde1";
+      sha256 = "09cd7b862cb8caa511b6d550bb668f0fd51fdfee5b2f6a31814282785688e4de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/tr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/tr/thunderbird-78.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "3691e5aca6b9713fab9c8a15952d1ceae50d67cc60e362eacc9513a362875dfd";
+      sha256 = "0d9f63aa7b63d571d7414755bd4e8bc27b7c5fd093ee46ed0fc2db469940dcd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/uk/thunderbird-78.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c4aca974c3a541c312029eb66fb8fdb1c5ecd787deb67a10bda3195f0ca06263";
+      sha256 = "0aa64449381edeed7c37d18e03f74dac2f5038a6c3c5de9fa6ad037b139bb5bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uz/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/uz/thunderbird-78.5.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2052c0a9a41c81a37aa23fbf28775e286b8350594b01aff629604ccbd74ae90d";
+      sha256 = "eabd24b838a072cb1aa9bebf3c573b3a6e7a364b759aebd62d12b16911956a00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/vi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/vi/thunderbird-78.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b142f463cd953bfc423be210eb891f66e948308129de74cdfd415409d4b0cb03";
+      sha256 = "ce9b5afcb60fc0f17a384a9096b26626f3d3f570222910a46872688009aee262";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-CN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/zh-CN/thunderbird-78.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0664f379ce4e464e2e6dcc3cfa749bd6ae4a597b008b7fd1c97bb6219727da6d";
+      sha256 = "9d69c7ef37282a7741d2392456c9ef5f5700fa1b718889e93bf7010fa99617db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-TW/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/zh-TW/thunderbird-78.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2ba4d49b52e6cd699f7bb1fa8f024c330f67d6b9df543a77fea7c3dc87985cc4";
+      sha256 = "6001d4e74212b72b2a3583438925d2431bb28994a661b4b47e77268e7790e526";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/af/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/af/thunderbird-78.5.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "60f62dc28a8433e571b894d33c0d9670c3aebc6a8c556c65f12d8d574e5edceb";
+      sha256 = "e30adc9074f08e04a4477f59eff6af83bcdf22ccafa1aef5ace219a830c50f38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ar/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ar/thunderbird-78.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "cf0fc7d7af09b20dbb35364ac0e47615919ae1627a0b729acf2f13dd99198400";
+      sha256 = "6d9456fd3f76de33a3f7c46d8197d83c36c832922b83de64cf4c2f5a56f7729d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ast/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ast/thunderbird-78.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "cb7ed53eedb55858fa5a5aadab1ed0ae4f2f9e2714406488b211660e56785d21";
+      sha256 = "1427f7741ba5c5da163ecfce3053bdab7b14c8fc2e8c046c244f7eea6d015a2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/be/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/be/thunderbird-78.5.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b04239a6caf488d3fcb5be0373ddf83554643897d41bd197edb6dbaee15b9a4d";
+      sha256 = "97258efe6425869e4710c07e880df2a3f6c14d626e6512374043cff226f141fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/bg/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/bg/thunderbird-78.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "fabd2c79cee02328166954d6b793b70bb94cb41162b904ecb124cdf91e5cff0d";
+      sha256 = "a30496a969a954525dbcf1ec0e94d8533baea3809e61d6c1c6e299f883d9676d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/br/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/br/thunderbird-78.5.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "66584e5c63c58c10cb4f2f8fb81048c4201046adbad03d58faf8f36e405a8e40";
+      sha256 = "16dfc1b869bb10ce7c56f1b22981586678cd81a42e13c4075ebc1da76728258d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ca/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ca/thunderbird-78.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "eca54850e9ed41a19bb4cd23de9c11d9d2851ac1573507b32b4fd33431ad7889";
+      sha256 = "bd29d4b8376355090adca0185194d3c9b6124c336bec0dababaa4a214f9945fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cak/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cak/thunderbird-78.5.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "ff8e285bf3198c225c2b5b216678bde7f978443c1f354193e39c0c5d3d7237bd";
+      sha256 = "b9723a8f8b8a61d01f09b18f1dff6529d22c89653586ad032831c87683da12b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cs/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cs/thunderbird-78.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "72a18f3ac0168478c7b9c8d2641922ba7be5d129b63b711b7f7f133ba3cb1d75";
+      sha256 = "55ff98744b2f120a855c8a3bc435d39209504b7eda92560be40b8cb3fbe007f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cy/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cy/thunderbird-78.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "16fecfef3f81870befcadf833db5ecf54b7b83d587f2a211c5eaceeaf7a5796f";
+      sha256 = "818a93f5a4f02e8cf7b3373c31c435dffca3fc1f86d5acc3fd4355bca21f9cf0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/da/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/da/thunderbird-78.5.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7aac88184c6e2539003905b3a7609116cb2180943a8df219449354297b323455";
+      sha256 = "7df66098805f276e1498fa28c00aa7eaa8a8993b561261c54f7091a808ff6766";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/de/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/de/thunderbird-78.5.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f3f487f8852b7f50ed49b5375ae97376470282a0f5639c8fc4cb7040da30f946";
+      sha256 = "194831e85294b41a4c1bcec8a2f20f337786054525d50e2fd6dfd6134385d2d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/dsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/dsb/thunderbird-78.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "842a084fc74c29d3c7573e473666cfa01f205b75fe6c1ee83acc25cca68d3666";
+      sha256 = "e7344c6b2c90bca56adfca1619e1bfdc0e473f7230d4c1059d6516cee8d51759";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/el/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/el/thunderbird-78.5.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "8df4c2a688b435f60fe0d5646ac5172dad33d254fdd68e35a29a6a83c4bda905";
+      sha256 = "e2d4680ced58f78699f7bdc2c3493d6157cf2c9261aa697cd6092ed0687a7bbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-CA/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-CA/thunderbird-78.5.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "8eab7a0b08e3c65eb5c373eb018d5e1df519b28f8774b06203a5b7743b146cd5";
+      sha256 = "6afd7bb703c62763b787d77b7467881f07d12e73d32d07c6461642307e3b9f5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-GB/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-GB/thunderbird-78.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "23c819e15ca0ff1ad366f2d5fb76e934dcea0fae9cec6674b39339e14a3c4254";
+      sha256 = "78114f1a1dff6c5430b148fbb8707e03cd3ec1d05af48082755190ae45e94dd4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-US/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-US/thunderbird-78.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "5cdf4b40f337352a8e966046a2eb1a368c0feef4fb069fd4c22d4f986ea1ed3f";
+      sha256 = "beb328b15c7b981b10f26cad6325a04257be20e25e819fa771f88fe5e5c98aec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-AR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/es-AR/thunderbird-78.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e7947542ef45cb432991ac5435523987c79811889e9bd5cb6fe4c698897a241e";
+      sha256 = "3c096d5225f8fe273b6f0adc119ea419cf60e7a7723fb3a63a6dec1be6e4c3ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-ES/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/es-ES/thunderbird-78.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "95121f74bc1389e62dfe7acb286d2a4cd60a536f28054c8e367cdfd867babde1";
+      sha256 = "68796cda86944bfb70207b79c162c0b2fdb66b17511300c799204fce58d2c2b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/et/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/et/thunderbird-78.5.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "87aedd276bc54360887e81bf2e3b07c54a365b78814d7e478f7ad5ec15c1d451";
+      sha256 = "6187058a289cb43e89916e484ac46c2359fc9c452d07dd4dab2e3ff8ae397c47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/eu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/eu/thunderbird-78.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "66168f09ed77b7f31faaf21daff48e9a8bf75314fcab585fad67160db52471b9";
+      sha256 = "ad587a3b25de553b69ab9aa61b9d99c4f4d7dd37b05672540eda7907b21f2857";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fa/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fa/thunderbird-78.5.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "2848f0277f75dc58f371e2025bebdeca1c37d543055fa78258df67d05c67f5bc";
+      sha256 = "8c06bbd83b5485b113bf4d0ca69af9ca21c7854ff38b19831eadae0c586dc606";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fi/thunderbird-78.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "725f0dcd456245e188e32a32401ecd40400b7786da3a39d9f6965c1f674ee954";
+      sha256 = "bac6ecf3d22f6097f8cccb7da81866941426ee7bbb690937a2333b411a305fbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fr/thunderbird-78.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d24ab35a8db7cb32d6098defb9f7b6b007b5c993a070c1a3a5c8991451165e37";
+      sha256 = "859457a9c0bae23e4acf901d38de814858c60fe1a5e28ee897b2c2f4c86bc29a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fy-NL/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fy-NL/thunderbird-78.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ea3a88b57166b3b8f04922a5c2f6d8d9f94f1a7bb5f3a9e2d6b5f11a13528c18";
+      sha256 = "d5a91d212e0c9c6c533bd7f05edca3dbea93eba0bf0d34eabd1e9ba7c7138e8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ga-IE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ga-IE/thunderbird-78.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "763bc901967ec61e1f7f543bbf248bb03ea68b01c000677505408ec8e8c3cbb4";
+      sha256 = "980e053f0bcd5096753213fd6cc252be388312980032132bf912af2d4249278a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gd/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/gd/thunderbird-78.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "7394f43ae2ff5816dcf9b37255fd9770dc48dd7309d685ab378bc2de8a5a39b1";
+      sha256 = "7b61b433d2f55191f7ecc63e04ceabcebcc85ab211553b71de575bbf14db05ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/gl/thunderbird-78.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "7daaacf6af75b34d37d440e2c0b252ef03c3b432523f5acb8ef71f83b5d7b6cb";
+      sha256 = "2dbb2021eacf17f5d42d0f8edc32a3f4d0ae3964cc8b44b0875fcee9bbd8ebbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/he/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/he/thunderbird-78.5.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4831ef263de0a08df6494b13a280475642c3eed7f34c7415fd7b59af192398dc";
+      sha256 = "b64fdf97d7f3029ffe465bbe621735970c73682cbde03935c2ad94325a7a77cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hr/thunderbird-78.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "6860b40fc2ba7f9b8ddedcaf50acca8ac01b6451c0895c325b36485f188b5dda";
+      sha256 = "05606268efa91e8266a75f9f53dae8e8095fd70bc1095e2cc160171eb32e9a0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hsb/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hsb/thunderbird-78.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "681fc8200f6f9346e911c21d6a1c8206e5ee5ad1adfaa56ddfbc5088225fc561";
+      sha256 = "8a2dd27b17cbfad0846a40b4863c72e0754137e4ae581998ff291b4428a069ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hu/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hu/thunderbird-78.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8909d02e58f5b333fa51b15e4ddb5df162d01e36a8052827482c479949da2cb4";
+      sha256 = "01daa9ab4f5d096a9a5e138db4debeee302fb875f885e644eea88103c5c62111";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hy-AM/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hy-AM/thunderbird-78.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "12dee2dbe126d2243b674bed4617ffcec7c93f850d266f6253d802c6af5b6d6d";
+      sha256 = "69159084189c5700e5c8c27bf4cc0345fcafe0879b7f7cca285246a41e411578";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/id/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/id/thunderbird-78.5.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "5564c24b01f9a952def885a4fb56e3246643ca30bc5066d6ffa4ed6c6982b33b";
+      sha256 = "798203a12f76cb3c698363da72b235fc9abfc5a68913f3265c9b17b14318eb73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/is/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/is/thunderbird-78.5.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "fedea70297479b2c828aa19a9a4aa3090597c5490ee842a0f521d0096615d6db";
+      sha256 = "19544548a0b0217f5f5256949d74897c784298dfe762174487ab2ba2557a55e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/it/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/it/thunderbird-78.5.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8466f3dc9988270d4a9166b82dba764d8dbfa14e8c26a1931d35abe011c3160a";
+      sha256 = "b1ae17f3d4533db0107ab280ec4e8ecc610db9581d44ed52d8ca87c821c37c1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ja/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ja/thunderbird-78.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "3ffe4ae508896ac961a27940a93f5955bb8b29640c88e5378a8251827b4e9ab8";
+      sha256 = "c16c27372c28063a06e31fc440294a655fb72bc033efbfd797d150e99e6ebaed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ka/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ka/thunderbird-78.5.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "7c099596fbc4666e053bd1079f6b7c45511b2b44db73cd5c099fd392bec8e3e3";
+      sha256 = "3057efd5078776f1690890d601153a73e2450051a0edb61e92d196318b644679";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kab/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/kab/thunderbird-78.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5e64e5a276a6e77250ad7647f9b4ecc2b8c9dc360c486f9504b3b17b8da3e467";
+      sha256 = "ce8010b362b601819fac825ce27b9efd8af8f0965f8f1cabb21bfcddb2ec7315";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/kk/thunderbird-78.5.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "4562bced5900bc447a79c53d381b250a1e13b9f076979cb9760f9adaa89c54b3";
+      sha256 = "b73930d1508bdcaecfb9ce280f0d86fd5dc7a3d26160caa0eabbe47243956139";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ko/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ko/thunderbird-78.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b6cb53893d67bedb077547f1262a833a5487e49395187a49eb977659d019e7f8";
+      sha256 = "24d6e557b6419bb3a512646edb6e1e4d01ce1c0e134b9bb9cc54ad5acb6a0675";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/lt/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/lt/thunderbird-78.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6291d36e9347729920f89a28b949c943d8c92863cba1a03624801c7136eff997";
+      sha256 = "c9dc7dc77a1c1acdc1e244e6b1201ecd3305b5c10ef946ceb880fb66d57c249a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ms/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ms/thunderbird-78.5.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "5dee2e40dbceea93fbe3b35b744d00472b89b88e745025127a1d07afc79d7df8";
+      sha256 = "d3a0b9fc5b38de919515df9dc6ca696c7c70f629b192e8cae099a55432d466d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nb-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nb-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "491115e7ad1c4245da34dc328e179de3916291d4e42a85ee5fd4fadeae1fcdcd";
+      sha256 = "80f552a61288f1d1a6346d302919fd90f63c2d349a2d33921eac9a65c341a7d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nl/thunderbird-78.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "c4631681eb3354a3093acd5a76d5c7ca5ef3e76ac2cef9f1fa4007c40c1e282d";
+      sha256 = "89007857be04b59bf724a2f6c295c0948a885c8da8c7a7060922e04f616baf30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nn-NO/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nn-NO/thunderbird-78.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "aa4d383b90b7cd48ff18f098c9bba429f09fcfb72a2f2a086a992778718a3b1d";
+      sha256 = "b7a8060d3138a55a29374d890b326e77105f41e809053d34c24464a892c6bdbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pa-IN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pa-IN/thunderbird-78.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c5fb66455a59383494890e06559d4529c0762ecf76d17e5ad784eb413277438d";
+      sha256 = "69f803555cc9b3ba7fbf638e101b76bef10a234747cd0764e906e5d2adbb9a97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pl/thunderbird-78.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "720eea0998d9934960a5dc97466f57c7e68b2048f88125a987569539a8a00579";
+      sha256 = "4cd4da857d9cbdc5d89e07529d30df28a758c3c105160d2217b50206147c21e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-BR/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pt-BR/thunderbird-78.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "d27ab836f5d8753d740e980291a4403656735c206cedbaf7d5c13df26d327150";
+      sha256 = "43fca4ac927932589b58e60f7b3b1cdcdc1d73b6f9073e0c1eb2993527afe9be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-PT/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pt-PT/thunderbird-78.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "2b996d07174c24df1b066c41bd92c8b24ebab82767c47d8c658f2205eeff9cb4";
+      sha256 = "25591b73b7ae5d28441baeeae3fb3a5a47f36ea21db763b95782494fd8491122";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/rm/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/rm/thunderbird-78.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "206b2bf82b88ab733bf585e11a3eba49a779c8b8fb7bb249716022fc7ee1a18a";
+      sha256 = "14a0725f1083ab9c4baafe6944604cc5781cc9d3d44cbc406874b5ce01df785d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ro/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ro/thunderbird-78.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "2d06d671114d70ba4e39b2c639eab1debe7ad33de11795113f30f27708d13ae4";
+      sha256 = "f32af00602a13e262e6b34c8b5783b31a991dee72d82c841086d21e37d669dcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ru/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ru/thunderbird-78.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "08e71802964c340dfbcddf963382d1ccc5b8fd2e262daa1316488cffd04f449f";
+      sha256 = "367e7865f1c5d10eb912fce96a34bf6ce25ca48e4ec9209bce8af06412be7781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/si/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/si/thunderbird-78.5.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "0f59d187fa15bd08ffe0e08e643bb76954f7eb7730c3768079514385c53df5d3";
+      sha256 = "da0494be7a26f0a531d108ca20a0bc9763860e44adaa6149ea059f46daabbe0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sk/thunderbird-78.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5109939226907517fac9ae9c4e6ee96d732de9a67b9139e390d32cbdea892ef7";
+      sha256 = "1c5078f413207049a35c69be32c6996cad169cadc009b3f079b3adc8a932ca22";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sl/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sl/thunderbird-78.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "c56fb54ad65dd453b487813b1f0dde8d83ed6a2f7e428af55c40a80d1c9a35ca";
+      sha256 = "d8a5edf78b5a87c0b3baf0199231e6e9224e1afdf4eff05780b6c9b98657c1ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sq/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sq/thunderbird-78.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "0b3814c80014108032c9f0376a62c09864704441f36a084accba1c7c0f8156de";
+      sha256 = "fefcb88c0c5f6ee62ba8224417a629d8a4f0c18b20fcb037c36af772b0d2b71c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sr/thunderbird-78.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "80b01424fae7d18c98a77a0026dd4b50f1913f5f3cce2d3f85d9e56da633a537";
+      sha256 = "c42818c409de6447c1aa00f8aa6422a9fbb6fa16f01d5076331937c1145a4b87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sv-SE/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sv-SE/thunderbird-78.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "ef0154595d85c13d0eac381a907a51da19e9d93d2758c7dc0f052b7b76a7f31f";
+      sha256 = "c27d87cde88f38f3611358b5fb3622611c38860ee37d1d90aaabcb4db614a031";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/th/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/th/thunderbird-78.5.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "939f56c4951e8dbfdff257efe7f0212e93c1bb55547ce1e934f7d908932d3116";
+      sha256 = "df9b827a723675e70131d147fa6f6325f6e6a14a6b95f6f5b6fae4552501c6b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/tr/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/tr/thunderbird-78.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "66f4f2cb06f20fca47e59b37d52f07a9e1215b03f0bbf9320cd1436e1d1a7c35";
+      sha256 = "7a9d6e1b5927c7c54b73062a59d366cd5153896a89e95005177fdf4b789eda42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uk/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/uk/thunderbird-78.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "33f3b9812b442184c075056cbe7da924655729865d849856093bdaa2d7d84660";
+      sha256 = "c421df09d5bbb5e4de273258757df28e5a6eba291a4eabbf28db71a50cb11da7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uz/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/uz/thunderbird-78.5.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "5abbc17bb66700093eeef5eb97bcab0a5d040ffe20ecf79d8239123248b1affb";
+      sha256 = "296ca42b0c9f67ef0bb545f458334ec26e03be3327fd1e1b066d8324965704b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/vi/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/vi/thunderbird-78.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "de5071c3b4a5cf7494f91c69f4a7cf4678bcf57227115e1b6e50cc65a3e716dd";
+      sha256 = "46579d9723f5ccc84700c2544f3d1235db338471306d87a1caa0ac4fb337c8bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-CN/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/zh-CN/thunderbird-78.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "07afc2b794439475d0d4db82c7b694728aa5b8e6e80ac79789bae662757ae8d2";
+      sha256 = "9bf0df6568eadf611891f49591975166da95eb4e78e1191eb3354a81637907d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-TW/thunderbird-78.4.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/zh-TW/thunderbird-78.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "70a71d0c26fd2cd18dd599374cc6f1c39d22246f3b3c8e8d17659cb7c33a5a77";
+      sha256 = "8fee4fd8980d551317fc8f98f29938034f5ff90b765e73ef8cd09f8fe68f90c8";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.4.2";
+  version = "78.4.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/af/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/af/thunderbird-78.4.3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8b1c2e12bd1de45251131d9fe444b06681577cafc019219dac4aa13b3abf989b";
+      sha256 = "03d4e32b23408b003de5347b2a26d9e3e734f7c3e811510ba81114eff80e6fa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ar/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ar/thunderbird-78.4.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "708ce9ae434ae78bd21d2c8a608a732d6ebdc88c2cc3c91c748d2b6a4eab24bd";
+      sha256 = "5aefbc61f46d59de19061a0e76949642e254a13867881b40b6bac289791c281e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ast/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ast/thunderbird-78.4.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "46aadaa73a4e214c016f05eb9e0dc0a3daa6a87fc72988c696bf243d475d0285";
+      sha256 = "1e328339808efed1db23ed372841ff65f64e1bda8e1d4be81fd00039468bbb1f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/be/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/be/thunderbird-78.4.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "06abeef2331df228ad303d9280d077ef4a74af8658c4ac0147ae59e181dfc42e";
+      sha256 = "f42230768f2907fb3d23a03a56fc20f14ff5ded7b4418debb3e77c4942eb7db8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/bg/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/bg/thunderbird-78.4.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "3aa13c52a514f5331bf626f9e3138bfe995c6a223559a9fbd6d590858484d9c1";
+      sha256 = "27a72288cbaaaaee6a24a36bb2e463a0426810e97938cbfe012dceb1a3800fd0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/br/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/br/thunderbird-78.4.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1f2d9ee7090e96e3e5611011c9fef8389b514dda4edbf47e889019312df6ab5f";
+      sha256 = "fa1b6c891e3d9d097857a08181030e1df2201240ae466c4adc6fc0be0982d002";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ca/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ca/thunderbird-78.4.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "f48d5d02a04212ca14cd4c175102a0e45483299d8a4615ff96232431c4ffa4a5";
+      sha256 = "6bcc123c7ecccbf42022e302b63683cdf77f6f6f2a615b12c5ea9e6a081fb900";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cak/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cak/thunderbird-78.4.3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "28b541daeac6aa6274f4185f9471ce8b2a46e18fe55ae1e373246d9f23d78ec6";
+      sha256 = "392cc166ee9be6c5cf8294f727f97cb21b6ad7ebb77d263bba273f02cb15e661";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cs/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cs/thunderbird-78.4.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d4f061ac86da0b6279b81b30c8949cca93aca5b2f90d0e5dafc5cdecc2868e05";
+      sha256 = "60f5ea97e75f965ac0947e51c8cb8e709e5fa8f67ea478babe936032dee5a912";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/cy/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/cy/thunderbird-78.4.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "824c703a570ae23d8e7b86d93baabb193842ac36fbc9d4ec65ae686e3d540de1";
+      sha256 = "93aa92633d2414ad59aedea8b1a820b158a21c042cbfaedd8abd2b5a41e31c5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/da/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/da/thunderbird-78.4.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "8dd27d2596346853e3fddab12ad0dabd700c5216310922e768faacb019b5b3d9";
+      sha256 = "dc263e9d186f4ca8cd404b6e5bd13f9d2874e0e2507eaa55e99a6b5ab3b05179";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/de/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/de/thunderbird-78.4.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "3920c60073ee3066fbe35a1d2c34ab03a7b7e2dfbbe22af97fa32814000f6942";
+      sha256 = "d9dbf07f3c57f688b08f75673074562ad9d4a9b138159f353415d63f9ccac80b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/dsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/dsb/thunderbird-78.4.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "fd09bbf80996e3aaf12dba79c366c4cfff41a0db0cdf7f6ed4d9722fd2623ff1";
+      sha256 = "084ef3ef3628d003c75dea9a9fa5897424e6e564cb18fb5bca33b341c8c511cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/el/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/el/thunderbird-78.4.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "a9df959b2df9c381b9881fe3015e654ac82ca441a3cfc25036c1e658401bf810";
+      sha256 = "4e91e7d21d0a3d524de7e41201ce8af58518a7e0292c11fc2961a84e9b7d04fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-CA/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-CA/thunderbird-78.4.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "126e6fffa28b9c2a7eb7bb49254786fd0884aba62524dcf7d8352d6542903f77";
+      sha256 = "922220811fb0083e8dc51c7cbd703530acdfeb0e9403d1a0909ba1618db020bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-GB/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-GB/thunderbird-78.4.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "099ef4c54072c6a4a134badd02a51255573e876c8b630c3b9eaecfde997f9e03";
+      sha256 = "090806f6ebf12efbc5c20a920451feeb0d88d1e7366a074553b79080869687c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/en-US/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/en-US/thunderbird-78.4.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "e6041bd8ad2a21f0a8f8d78fd395239f1f41e2948584770673aaa0f3a9978b3e";
+      sha256 = "7fa3769297600c47c54902bac696e718053c48fc02e54698cb05ef81a4eec873";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/es-AR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-AR/thunderbird-78.4.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "d4055f3134cd255f8e91ee2ef012bd4e4443e6db519cb7bf2543d4e193f59f61";
+      sha256 = "51be3a453bb3e3f1353b88ab31fffa3fc0c135cb91facb7807c967a9d4afa659";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/es-ES/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/es-ES/thunderbird-78.4.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "39f3c8e5262b1125f21e2bc0e51d53b09283ef4922a7bbec6146605ea0bd1d51";
+      sha256 = "8828e5ff82e84c5f69afd60ae5dbba445d766e2a2d7fbbcd8f0dc8f255d8fc02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/et/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/et/thunderbird-78.4.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "60331d65f98b68397a0d53a08a169b97654aae3d26efe48f494f575e1a51fe13";
+      sha256 = "d58404701341bcd9b859f1afb87cb3340fc4b8334cc9490e8ea21446e3f308eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/eu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/eu/thunderbird-78.4.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "206026522eb361b599dccf433887b1314b554adfea90ee558f36d116ae6c8f70";
+      sha256 = "5570472164329f23d3f0be51911402c2b454ea704419ef16b46b359a2c93e821";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fa/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fa/thunderbird-78.4.3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "88f1421d251e0bc5288f2c8ca333345ec97ca0a86d491b242471d1af82c04776";
+      sha256 = "cc56e14f1fa17e8b4ec9431ae9ada10159bd90bcade39432c647ba401791e3fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fi/thunderbird-78.4.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "4abbc607c3d6ec03a8416636e88ffdfd61fc0b062aa135d14fb3918c284f9ebd";
+      sha256 = "5175e312e8957490b013dd515b84fe4dfcdf57d30c6806f8bdee67caf39659f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fr/thunderbird-78.4.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "406437d8cf7a695b636c3c1005df5a65f174bbb10d0d961ddda08833ee2c808d";
+      sha256 = "5239f8a07f0f6bc4f69b3d4315570dab33c331ab775479a9df39479b71542cc7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/fy-NL/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/fy-NL/thunderbird-78.4.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "456f51fbef14e1de16fdb3d7c31b6736e0e7b43c509ac38bdb8a88cb4a2de0d9";
+      sha256 = "5747be2c7f9d5463f9c14fd02fd5e66a8f6c4c8adca3a1bf8c3b4333f1ea2adf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ga-IE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ga-IE/thunderbird-78.4.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "0f1ab856deed39280ab9d6a43afd6f719470d4aafc4404e0662da0e14b64308a";
+      sha256 = "8e15ffc9235742ad88a1ecaf587a178f5aeb0bc57e075b33f792e2d458362ab9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/gd/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gd/thunderbird-78.4.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "07f2fc13f34a70d4e6ecc65d465e33f5bcff63196996fe057f8584ef2e7e595c";
+      sha256 = "72f53918cd04e587319d59100da05657a3084f97d70acba7d1ef7b7321add6ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/gl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/gl/thunderbird-78.4.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "f4cb60a537ffba88823c8c8a60f2c164e62fbba13d448f2931c71e7d98d6abe0";
+      sha256 = "28beb85fe0ea27a659e5063f7094877e906729602ef2e155f0e55e9e9f6d56ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/he/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/he/thunderbird-78.4.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "425a0bd38d231308fa5cac5d362b7818ccfb6b5fc06924ce312433ba4d5bf2b0";
+      sha256 = "718f8605fc8d418c645a0485ce86d97ae1eeded8b776a990e137ced78eb91a68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hr/thunderbird-78.4.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "37d3f14aeed404bad5cab35c256473a5927787f889afee3da112e510999373f9";
+      sha256 = "febadac023152dc30e72026f6df203c8051b65ad4da0c4e7059a14ab0b4b5f37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hsb/thunderbird-78.4.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3249467db25d25866a4d1e0acd9a18a26bad13e2ca683df04ca5f8ca19affac3";
+      sha256 = "faaaf4606fde4baca3216ed5801209f13cd1bbf34c9671cfc7a7648bb0ac7351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hu/thunderbird-78.4.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "f3a82c5917757f221ca59c4b6a950991b52b10f2782b1dffe21c7a7ca6a26272";
+      sha256 = "353633956336852193510c8e77251834355c92ec503ab827a389a0dbc21c05bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/hy-AM/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/hy-AM/thunderbird-78.4.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "cb917c1ff3fa342a8ad3253a03a1dbb4a417c0bc3cdfd1422ef5ff06dcfcca74";
+      sha256 = "1b5dba6f05ecc8449522d8a54c1d4e7aa5ec7a2e26fafbaefbd754ee3ea5780f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/id/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/id/thunderbird-78.4.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1599ddf22093c6a99ccd3ec3e1492e65ce0b5ebdc3a69aafb321ec26f22b6a13";
+      sha256 = "470151868d745ce829f0f38c6377f4ead87be829d43f4383d2e5c3541b93e8d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/is/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/is/thunderbird-78.4.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8cb02ca7ce8c28c10aa1f16ed08417342e93da2dd00f15c5a89fd71306f9afb3";
+      sha256 = "e9d6b36beb61445c3f96ffe6e11b238a8539b398d5f3911f2ded7ee96ec0766c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/it/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/it/thunderbird-78.4.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "16f3c54980e614b20ef6a8c0a09ebe7707e298d753d373da79bb2d52d1cc43b6";
+      sha256 = "95a02afcebb834b14986b8ccd92d5381a8ac64d3ebbba13860ffbd0313a594e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ja/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ja/thunderbird-78.4.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "e4ec88dd86b46d814232662a4d558361043ac97b348a8fbb2076ec856087be6e";
+      sha256 = "d1c4e2a551a5266839da96b843372e71616346ea00361dccc8e1a62628e6315f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ka/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ka/thunderbird-78.4.3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9c2a110ed4df58c334b533255c0f3bf46d777960967e46e74f7f376203bf467b";
+      sha256 = "9eb37a69a370b2619724c91c6789471b9ef579190c08363f633f320563dc4df1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/kab/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kab/thunderbird-78.4.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1f5cf7b8a03fb4273d9ce4d657c3a77ac4a26b7716e3bed700e14f05a398163d";
+      sha256 = "bce07886dc5251ef401141d387c926f27f61d13450f35cb9a9cbc8403b43260a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/kk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/kk/thunderbird-78.4.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "002ac92fee28c3ec9c05587025eddb4065a842df0430ace7f468ed8f3ec2df27";
+      sha256 = "222647dd8106134d46bbad6dad8638090e5441a64aa2a6725aa5b1d959a2832a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ko/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ko/thunderbird-78.4.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "277f0fdfbda0d215a03ccd663f0986cf1b0a1c4e68e3ef36e81c8505d6eb7d09";
+      sha256 = "be2346d5a48e5323d5cc8c1077adf054927d8aececd2fb45fc2f5c0a9f0b8dc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/lt/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/lt/thunderbird-78.4.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "65b6737b4ff528453bdaf57cc525a74c79899a9563d189123f87db729aa0f529";
+      sha256 = "da5cde252d5e167025fb06861a32b67a2d0f7171c767bdd8c5d2ba9fc90d7739";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ms/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ms/thunderbird-78.4.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "cd40e14d4dbcf03ea7e5ab672678abc9b3b46c5b67fdbb961928a860c2f3218b";
+      sha256 = "d6ab0652184cbbfe9126a49f61c25fe8852725b88460ad92c37dc1c4d969368f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nb-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nb-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "49c9633a0552a704b06df87ea91991017be920684d12f66c72f6795dafd1cd5d";
+      sha256 = "2485cc4df1b1dafd0c5fb7d7723e923e7fea10af1dbf9764d5d7447f38825e49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nl/thunderbird-78.4.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "4514d79caa1e2b44cafdc9ef06aa54c4708763c888a489d6bdf4473597221316";
+      sha256 = "0795d2ae4364def43056e77106ea19053c3111e2f95758dbb41875071655ba47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/nn-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/nn-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f6aab88e4708659658be8cfb457c40533969a261af489a976f4010439a833458";
+      sha256 = "b774035d8bff615646d3b3d73228277531d50309fb5dbf3978346e2b988b2491";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pa-IN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pa-IN/thunderbird-78.4.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "10f5a885550f2cbee158fedc7111b96a0f07764b5d6d60004d17c233153f304b";
+      sha256 = "2a38813c8aa0eaef3d2ec0ac379ab5c85d0b8c2df1f6a2d36ae066f7b0445447";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pl/thunderbird-78.4.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "1a192c0a9b8ac2f9b18445e69024462b8e95b78bff48014b55dd451e260aaf73";
+      sha256 = "21cdb977bff1f0c07bf913b4feab2075a429b4594760de52ac358538179d9c66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pt-BR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-BR/thunderbird-78.4.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "b9dc3db4d8cf4fc2b958695f9077c50d48d355e850618320adff179d33a116d0";
+      sha256 = "d903ccd23367c39779ac2cdd3abe636a0f9e72f8d133a567bead8a739e651589";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/pt-PT/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/pt-PT/thunderbird-78.4.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "0a3887ff46f9ecc1576bda76e1469eed8ef43813ccec25536e2dbae289196bd5";
+      sha256 = "f220a8bc90b05dd796c402aa5e79c62a8aa91a4d80dacbdf57abf77ec51d73b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/rm/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/rm/thunderbird-78.4.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "1a13d443c00da4300aaf58d0af0620541de04e02e87218fa0774cad4b2aaa34f";
+      sha256 = "805d08f629e9dda7d6db36bd41dbcc128defe59b4610e4b7d5d47408a07e47b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ro/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ro/thunderbird-78.4.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "62bd15566895dc9462b985f2f5e1afcc7057ef4e93f69005b9ebe89821a2a73a";
+      sha256 = "3b09b2c59f32a09938a45270e04740616b2a13f8b8a6f40503650d9b0f72fc35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/ru/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/ru/thunderbird-78.4.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e0624e745da31cafe1b885393e11622bac6ddd2e3e4c0cd35432eb5e0e57a47c";
+      sha256 = "2022473752da127d2ebe4eef7f834ac5feafe38dedbe64ad30defb8ae69c6ebd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/si/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/si/thunderbird-78.4.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "46e286fd0913b07ede577514b8e64ce279afd7bda3054b7cba4ec1f9981eef03";
+      sha256 = "dc5166b0b24bd0a9e98f7dfc483a6bff184a4bfffb0eff8a4007b96fe8205254";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sk/thunderbird-78.4.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "3ab838c25d5e10d318705bed69e690d287e6b988412a3f9d5d94f2b7c8cd831b";
+      sha256 = "d30e4d3218fbf13a5c531d45f55f0f366aac10aa2d180886ced778c7459c0610";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sl/thunderbird-78.4.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c04e1a339c4fb2ca8748da6bbc0f5a4dc9eb032b565d6f2333c7d1751eaaaa9a";
+      sha256 = "f968618f7b13b6dc4441a09882ac5c826017a5b0ca3887b7cdca8ef6a3b3c266";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sq/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sq/thunderbird-78.4.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "ae9052f081baf3f25c43b2b1e109ce50abeacb5b2322ef38f8d42fb070417908";
+      sha256 = "f4400c6e55859e07705b353cbf211e863e8c3f373490f3fff6bd3e6d360d5b7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sr/thunderbird-78.4.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c4eec55d9be21e02158e8266b9b7b424aa1f5d1078d9de2f0dfce4fef5f801d2";
+      sha256 = "f6437ffb64b1a98b5c5630f3b386b12866a514467c641fb02c8e86560e4b62d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/sv-SE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/sv-SE/thunderbird-78.4.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "c7c01c580e1201e2948d0bfe3e029b6bd3a98e9845e6ff648d8bd4fbc8189d37";
+      sha256 = "f1af8019698347ac94bad5c33b5e094b65e8ebed9181f5fed5e740cf2029bcef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/th/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/th/thunderbird-78.4.3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "f09079980e41c156e62f8d008d600850ca8a62fc88917f3cc06d10321bb3e500";
+      sha256 = "75830b637302032bbc70342b71012f391b333a2645d8fefb8f4232d432c9dde1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/tr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/tr/thunderbird-78.4.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "2b99f6fcf904c7cdf67de2ed957167b6e1fe7d997c5a422641bba0af8a22b7f4";
+      sha256 = "3691e5aca6b9713fab9c8a15952d1ceae50d67cc60e362eacc9513a362875dfd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/uk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uk/thunderbird-78.4.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d502f4447e1e0c02e9384435e1b552c4da6d083225555b03f90d71ed04314324";
+      sha256 = "c4aca974c3a541c312029eb66fb8fdb1c5ecd787deb67a10bda3195f0ca06263";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/uz/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/uz/thunderbird-78.4.3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "7b9548f91dcf0ee6bfaed9d735baf9254842a633e3f06986d00d9d86b0f645d6";
+      sha256 = "2052c0a9a41c81a37aa23fbf28775e286b8350594b01aff629604ccbd74ae90d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/vi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/vi/thunderbird-78.4.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "32f78b425fd56900d1b3319e571af151214edee83a22321a449556e8ddebea69";
+      sha256 = "b142f463cd953bfc423be210eb891f66e948308129de74cdfd415409d4b0cb03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/zh-CN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-CN/thunderbird-78.4.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "a6252fdd66dbfbd33444a3ebdacef38f8b600891af324d31f22f2fcf59b1e7fb";
+      sha256 = "0664f379ce4e464e2e6dcc3cfa749bd6ae4a597b008b7fd1c97bb6219727da6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-x86_64/zh-TW/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-x86_64/zh-TW/thunderbird-78.4.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b97a176fc12f156d8503e07819e9a0536b338850b8527c3896d93a36d64083aa";
+      sha256 = "2ba4d49b52e6cd699f7bb1fa8f024c330f67d6b9df543a77fea7c3dc87985cc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/af/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/af/thunderbird-78.4.3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e1f0a03f540da701f9e742cf7a05e21a1216ba5c60c402968799ff494ffb1fcc";
+      sha256 = "60f62dc28a8433e571b894d33c0d9670c3aebc6a8c556c65f12d8d574e5edceb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ar/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ar/thunderbird-78.4.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "5bbee34fe9c5cf02f2f3c8160264f3a0ca3ad880bd75fd1ede87f906b886c7fd";
+      sha256 = "cf0fc7d7af09b20dbb35364ac0e47615919ae1627a0b729acf2f13dd99198400";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ast/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ast/thunderbird-78.4.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "8a5e481e9aa16619513260d532ec6f7e2c6338b41a0a44468950ec26287b2a26";
+      sha256 = "cb7ed53eedb55858fa5a5aadab1ed0ae4f2f9e2714406488b211660e56785d21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/be/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/be/thunderbird-78.4.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "27f600f0d4b977cde9ede5bd39efd97bfa1abc04f3d1c7a3290339e7eedaef47";
+      sha256 = "b04239a6caf488d3fcb5be0373ddf83554643897d41bd197edb6dbaee15b9a4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/bg/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/bg/thunderbird-78.4.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "a9a6c127461ca7da6b5fca5e2d2ca8b1eecbbe78b42a9e18e16bc7a343c761ec";
+      sha256 = "fabd2c79cee02328166954d6b793b70bb94cb41162b904ecb124cdf91e5cff0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/br/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/br/thunderbird-78.4.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "b8f363ca9ada5b2ed80a9526d1f775d9c17bfecd6b84113391fd6a5b1966bd90";
+      sha256 = "66584e5c63c58c10cb4f2f8fb81048c4201046adbad03d58faf8f36e405a8e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ca/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ca/thunderbird-78.4.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e1c5035ab818ce7525c2bd659622b14b3fe544b7f4c8432bca2b018c7ba1bfa5";
+      sha256 = "eca54850e9ed41a19bb4cd23de9c11d9d2851ac1573507b32b4fd33431ad7889";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cak/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cak/thunderbird-78.4.3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "f42d03442c8ab4bd844b0414e6d6c8ee168230714b55bbff1704117315f26a0d";
+      sha256 = "ff8e285bf3198c225c2b5b216678bde7f978443c1f354193e39c0c5d3d7237bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cs/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cs/thunderbird-78.4.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "c45a3b75c5106377d73f72b905814972a58604b4f2bfe49f05f5177584f2e0d6";
+      sha256 = "72a18f3ac0168478c7b9c8d2641922ba7be5d129b63b711b7f7f133ba3cb1d75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/cy/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/cy/thunderbird-78.4.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "e8e1f70703c9c22fceb2efe10f55a2f25da4085822ada1a3a3a3736ae41c0503";
+      sha256 = "16fecfef3f81870befcadf833db5ecf54b7b83d587f2a211c5eaceeaf7a5796f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/da/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/da/thunderbird-78.4.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "d8fb3be7bc41ae6ae0d064bdf9ab9cc569f65dc18f720de960ace84bb2514b68";
+      sha256 = "7aac88184c6e2539003905b3a7609116cb2180943a8df219449354297b323455";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/de/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/de/thunderbird-78.4.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "373f50cb99608779e502d76af0e4a301ef0b8b75a6ec235f64da7626188157c6";
+      sha256 = "f3f487f8852b7f50ed49b5375ae97376470282a0f5639c8fc4cb7040da30f946";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/dsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/dsb/thunderbird-78.4.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "07518d32b488fb805adceea1126ca104f2e86e3a1245f6cc4fe108b70335c995";
+      sha256 = "842a084fc74c29d3c7573e473666cfa01f205b75fe6c1ee83acc25cca68d3666";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/el/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/el/thunderbird-78.4.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "97699a80d96422dad4c95658c9c4d472bd1d69e1823f5a5f7dce5fdaddf1211f";
+      sha256 = "8df4c2a688b435f60fe0d5646ac5172dad33d254fdd68e35a29a6a83c4bda905";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-CA/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-CA/thunderbird-78.4.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "0b2dc377399c4f27acb717c7f0e59e9e735ad3d2ba1e617a93a3fa337b6dd2c0";
+      sha256 = "8eab7a0b08e3c65eb5c373eb018d5e1df519b28f8774b06203a5b7743b146cd5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-GB/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-GB/thunderbird-78.4.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "679fd1138a8795b0e7d64a4b8d8a2821deb8b30d40092e9df98b0a08d6cc6539";
+      sha256 = "23c819e15ca0ff1ad366f2d5fb76e934dcea0fae9cec6674b39339e14a3c4254";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/en-US/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/en-US/thunderbird-78.4.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "a86f2780353dff8a449f323d5f54d83ce70b724db1a2d77dc3cecf6d1e849ada";
+      sha256 = "5cdf4b40f337352a8e966046a2eb1a368c0feef4fb069fd4c22d4f986ea1ed3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/es-AR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-AR/thunderbird-78.4.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "1fbd2312a971f658243dd6733067157fe3de509a88b2cce766ee8e45c243d23d";
+      sha256 = "e7947542ef45cb432991ac5435523987c79811889e9bd5cb6fe4c698897a241e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/es-ES/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/es-ES/thunderbird-78.4.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "e51217ca711a307c67f538d487eb836d49e4ccd6b8ff9b1a1926bd481322d46f";
+      sha256 = "95121f74bc1389e62dfe7acb286d2a4cd60a536f28054c8e367cdfd867babde1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/et/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/et/thunderbird-78.4.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "345ccfa0e703893795d226aacf95645cc2cdc7dc99f5f9fba108466f74af19fe";
+      sha256 = "87aedd276bc54360887e81bf2e3b07c54a365b78814d7e478f7ad5ec15c1d451";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/eu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/eu/thunderbird-78.4.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "47e95ce28a229dbd01d8598d3a5b7f00d8e2c1934f8da4ff92052693dbb0c7c9";
+      sha256 = "66168f09ed77b7f31faaf21daff48e9a8bf75314fcab585fad67160db52471b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fa/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fa/thunderbird-78.4.3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "6c05b6a34a1ae3232b417e37c6c71bb05e46a296019b55192331cd441f212e1b";
+      sha256 = "2848f0277f75dc58f371e2025bebdeca1c37d543055fa78258df67d05c67f5bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fi/thunderbird-78.4.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "fe043a86dd6679dc20ed17920e008894d78562d099861c0cda598c74aff3b176";
+      sha256 = "725f0dcd456245e188e32a32401ecd40400b7786da3a39d9f6965c1f674ee954";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fr/thunderbird-78.4.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "950fa73e6f5fcf2fd66da9af7b79e43420e3ce75c9227fee095ea65ce2769a7f";
+      sha256 = "d24ab35a8db7cb32d6098defb9f7b6b007b5c993a070c1a3a5c8991451165e37";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/fy-NL/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/fy-NL/thunderbird-78.4.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "e01f59e5b7abde309421515240229d16cc0ec6ad4ea52ef1a54fb65f0bc49091";
+      sha256 = "ea3a88b57166b3b8f04922a5c2f6d8d9f94f1a7bb5f3a9e2d6b5f11a13528c18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ga-IE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ga-IE/thunderbird-78.4.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "53a7b0b5a2046525701120101fbab5c581b99de56caadf3aed4732f444c35569";
+      sha256 = "763bc901967ec61e1f7f543bbf248bb03ea68b01c000677505408ec8e8c3cbb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/gd/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gd/thunderbird-78.4.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "eaea6b3770d5bc51a00e25fee02110f5614d9ef52049fc092d90dc1e8de4c210";
+      sha256 = "7394f43ae2ff5816dcf9b37255fd9770dc48dd7309d685ab378bc2de8a5a39b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/gl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/gl/thunderbird-78.4.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "b0c5d871785d1efa23bdbe341d8186b96394375ac56bb541d5d9a75bc784b471";
+      sha256 = "7daaacf6af75b34d37d440e2c0b252ef03c3b432523f5acb8ef71f83b5d7b6cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/he/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/he/thunderbird-78.4.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "cef410178a3cf310c7bf158eba5c12093385dfda1de334d6d6e0c28ada16c7ca";
+      sha256 = "4831ef263de0a08df6494b13a280475642c3eed7f34c7415fd7b59af192398dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hr/thunderbird-78.4.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9040e2235a752a50cbe09207684df928b84787629d21c8d53e6b9bfc708b09a3";
+      sha256 = "6860b40fc2ba7f9b8ddedcaf50acca8ac01b6451c0895c325b36485f188b5dda";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hsb/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hsb/thunderbird-78.4.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "b0bb84d18c588abf2f05abc8ecb1f3a169221fcdf4117e48b3169362cfc69aa6";
+      sha256 = "681fc8200f6f9346e911c21d6a1c8206e5ee5ad1adfaa56ddfbc5088225fc561";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hu/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hu/thunderbird-78.4.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "6d5d0ded325cf7852ef638d7f5d8dd4d7ce127ad7f4eace22ce696541f9485a5";
+      sha256 = "8909d02e58f5b333fa51b15e4ddb5df162d01e36a8052827482c479949da2cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/hy-AM/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/hy-AM/thunderbird-78.4.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "cbb8de1462385ef9bdb42cec5e8c81664347dc9e7573f602f41ff586c217d8ea";
+      sha256 = "12dee2dbe126d2243b674bed4617ffcec7c93f850d266f6253d802c6af5b6d6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/id/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/id/thunderbird-78.4.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "358a95d7d87adc85cd39bf6da1373026de5b8631139ee1ec44e9410b027e00cd";
+      sha256 = "5564c24b01f9a952def885a4fb56e3246643ca30bc5066d6ffa4ed6c6982b33b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/is/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/is/thunderbird-78.4.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "c7b27e5311737cd5f3d314830aba0ec165669d8c949edb37482fb4df3b460f9e";
+      sha256 = "fedea70297479b2c828aa19a9a4aa3090597c5490ee842a0f521d0096615d6db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/it/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/it/thunderbird-78.4.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "a302c50190fb992fcdaa66a8de9c5f5d177a5563fcec55e5f433761646ccfcbd";
+      sha256 = "8466f3dc9988270d4a9166b82dba764d8dbfa14e8c26a1931d35abe011c3160a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ja/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ja/thunderbird-78.4.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d2357cc5bb5b5493035a79b504db8db2750f5880705b693554e2170d8d840cb0";
+      sha256 = "3ffe4ae508896ac961a27940a93f5955bb8b29640c88e5378a8251827b4e9ab8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ka/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ka/thunderbird-78.4.3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2d150d1160d92499fd9dc4d632e006170a27929f88909715c0d0210005516ff7";
+      sha256 = "7c099596fbc4666e053bd1079f6b7c45511b2b44db73cd5c099fd392bec8e3e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/kab/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kab/thunderbird-78.4.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "4f9879d5a106ec9fc3bd423fdb5df25a3e0d47690cfec652654472addd21a2c2";
+      sha256 = "5e64e5a276a6e77250ad7647f9b4ecc2b8c9dc360c486f9504b3b17b8da3e467";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/kk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/kk/thunderbird-78.4.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "f8d7fe1f39af2019bb37e117545e8cb2901feb0d31a92287eb4b30da2e431a6b";
+      sha256 = "4562bced5900bc447a79c53d381b250a1e13b9f076979cb9760f9adaa89c54b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ko/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ko/thunderbird-78.4.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "bd9abd627205fe33430717a60eea8b54498325a8fe4d92fb5572a2719ba50341";
+      sha256 = "b6cb53893d67bedb077547f1262a833a5487e49395187a49eb977659d019e7f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/lt/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/lt/thunderbird-78.4.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "69ab343eb79c42c4a1a9ea480aa2ac50d95e9140968690fd99b3d13824be17ef";
+      sha256 = "6291d36e9347729920f89a28b949c943d8c92863cba1a03624801c7136eff997";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ms/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ms/thunderbird-78.4.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "fb1246094e22ff59f8671a6aa0827c8e51a7fa8dc2bb565a3cb446d35c098f16";
+      sha256 = "5dee2e40dbceea93fbe3b35b744d00472b89b88e745025127a1d07afc79d7df8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nb-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nb-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "0ffcd2db855686c4b7e8751884aa4a8729b0fc8da597d256d37d6c73a50c7585";
+      sha256 = "491115e7ad1c4245da34dc328e179de3916291d4e42a85ee5fd4fadeae1fcdcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nl/thunderbird-78.4.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "615205a37248619a664b4649f808ddce9b019aae60a900fe4d2ca2dfdd717fe2";
+      sha256 = "c4631681eb3354a3093acd5a76d5c7ca5ef3e76ac2cef9f1fa4007c40c1e282d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/nn-NO/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/nn-NO/thunderbird-78.4.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8813d2b40da457d5d7c0da88d54b8b0c13d2ea0215b9bee2966215d366d79a81";
+      sha256 = "aa4d383b90b7cd48ff18f098c9bba429f09fcfb72a2f2a086a992778718a3b1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pa-IN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pa-IN/thunderbird-78.4.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "31feb987ff8493d96e15395deb93506b13089db28d91c0bf6ee4da271db8a0d2";
+      sha256 = "c5fb66455a59383494890e06559d4529c0762ecf76d17e5ad784eb413277438d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pl/thunderbird-78.4.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a9c30450e918ec4c0a95da51c071f8c4ec4f870976ac494ae6042aa3fdbc4a56";
+      sha256 = "720eea0998d9934960a5dc97466f57c7e68b2048f88125a987569539a8a00579";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pt-BR/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-BR/thunderbird-78.4.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "157d64059b2a7a1082f233c05fdc0302f92dfa496c0075761bd54327b439594c";
+      sha256 = "d27ab836f5d8753d740e980291a4403656735c206cedbaf7d5c13df26d327150";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/pt-PT/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/pt-PT/thunderbird-78.4.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "d8a403996d56e22809e9124fc4c9dec98cda19a5fad7144fa87e452ae75a990e";
+      sha256 = "2b996d07174c24df1b066c41bd92c8b24ebab82767c47d8c658f2205eeff9cb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/rm/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/rm/thunderbird-78.4.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "97524948b2f9259d1b08b9bbc6533b79fd5e592b08fb5fc5cc63bdb749d5866c";
+      sha256 = "206b2bf82b88ab733bf585e11a3eba49a779c8b8fb7bb249716022fc7ee1a18a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ro/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ro/thunderbird-78.4.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "99e2c94054fd01001555fdcf4e9ee8a04fbae77e5ff9d34ebc42a6415b939bbd";
+      sha256 = "2d06d671114d70ba4e39b2c639eab1debe7ad33de11795113f30f27708d13ae4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/ru/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/ru/thunderbird-78.4.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f1996c3f3b6b5371f853f6854edd15ee030b6238f396870a2cff39320eac111a";
+      sha256 = "08e71802964c340dfbcddf963382d1ccc5b8fd2e262daa1316488cffd04f449f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/si/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/si/thunderbird-78.4.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "10df360a1d5a94ccd218a265024fb3f3d9d9a72b8c749ab93d797a3879cbad03";
+      sha256 = "0f59d187fa15bd08ffe0e08e643bb76954f7eb7730c3768079514385c53df5d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sk/thunderbird-78.4.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "a5f9e0b983961cc4e4ff7cb6f03c197cd8729eead74d6c0b657b441a91635326";
+      sha256 = "5109939226907517fac9ae9c4e6ee96d732de9a67b9139e390d32cbdea892ef7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sl/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sl/thunderbird-78.4.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "10526684f3066322066f204a2cf978c779bb895d5c7ba73880ee32caf63d62a7";
+      sha256 = "c56fb54ad65dd453b487813b1f0dde8d83ed6a2f7e428af55c40a80d1c9a35ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sq/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sq/thunderbird-78.4.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d422e42397d2012efaeeb37101a5b1b29feb34e9e9dbaf87a85f9e2f881511ea";
+      sha256 = "0b3814c80014108032c9f0376a62c09864704441f36a084accba1c7c0f8156de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sr/thunderbird-78.4.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "1e9b5637581c2c4973efcc5b0844ca228f66c4fbb0a44e88201973623aad0b83";
+      sha256 = "80b01424fae7d18c98a77a0026dd4b50f1913f5f3cce2d3f85d9e56da633a537";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/sv-SE/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/sv-SE/thunderbird-78.4.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "592daeeebdb5f56f486a4e6efa1c51e709d834a65c861e76e5b6fd86f8a4bb09";
+      sha256 = "ef0154595d85c13d0eac381a907a51da19e9d93d2758c7dc0f052b7b76a7f31f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/th/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/th/thunderbird-78.4.3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "00f883ed3d542d0bf3da3e744523cfd1b3405ae0b928dd83c42e55e5f1bab4e1";
+      sha256 = "939f56c4951e8dbfdff257efe7f0212e93c1bb55547ce1e934f7d908932d3116";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/tr/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/tr/thunderbird-78.4.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ab69a35eebbd1cdef80b22a398c4d570c17e13a8a36e5399b892974d7ed29b10";
+      sha256 = "66f4f2cb06f20fca47e59b37d52f07a9e1215b03f0bbf9320cd1436e1d1a7c35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/uk/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uk/thunderbird-78.4.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "efbd5bf9552333d78c68191265b3ecccb2a59ae19f2bfe7a1d8b096a44c9fcdc";
+      sha256 = "33f3b9812b442184c075056cbe7da924655729865d849856093bdaa2d7d84660";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/uz/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/uz/thunderbird-78.4.3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "db90d47b59efeb5c847ecdf8b7438a4f99d0954283f1deda39a0ee08f54fdfd1";
+      sha256 = "5abbc17bb66700093eeef5eb97bcab0a5d040ffe20ecf79d8239123248b1affb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/vi/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/vi/thunderbird-78.4.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "1d616c682f04f7c0ec976d41eb71d3ac929eaa3199b4af749a80c906a3f2a212";
+      sha256 = "de5071c3b4a5cf7494f91c69f4a7cf4678bcf57227115e1b6e50cc65a3e716dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/zh-CN/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-CN/thunderbird-78.4.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "490e4e310606846836d93ca9704b7de11bf307b918933fd0187aa5d3795a82bf";
+      sha256 = "07afc2b794439475d0d4db82c7b694728aa5b8e6e80ac79789bae662757ae8d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.2/linux-i686/zh-TW/thunderbird-78.4.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.4.3/linux-i686/zh-TW/thunderbird-78.4.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c62476ac43d302ad9895524f6f66350122edfdf393697111d5868cf25b996c1a";
+      sha256 = "70a71d0c26fd2cd18dd599374cc6f1c39d22246f3b3c8e8d17659cb7c33a5a77";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -73,13 +73,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.0";
+  version = "78.4.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "04b6n3gsan0a5abh371ws3c3rry4dcb3c6rbqmcxkzrdjg2xr5vn6xhlg3dgl3l01p0hp1xqpckj8g5yb2dq2x07xgg1hnyhs9aadh5";
+      "2mbb139xdi69bnvvg7zabwbw181xnz7y154viynmkwyh4iww0hcsvr88q246gnif8a7jns3pi4qgqxgzflyl6mzpsvfdrbjs5hylanx";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -73,13 +73,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.3";
+  version = "78.5.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "0h5ddqp1z2dphyy4mjcb7v9mrrxlnjw8rwklm0yqsbvs9m96pc1yyp4clb3wmgs7kzh3wxdwi450842m3b13wdg5h0ls7rhamd1yi0c";
+      "0c32dz8p7rrr0w13l2ynf9snj59ij1v2ld3s75vz1hvks4dikwgcbm44wmvmbisvgyfgzdsphafzlq3kz3j1ja30qjigl0dj709vr6s";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -73,13 +73,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.1";
+  version = "78.4.2";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "2mbb139xdi69bnvvg7zabwbw181xnz7y154viynmkwyh4iww0hcsvr88q246gnif8a7jns3pi4qgqxgzflyl6mzpsvfdrbjs5hylanx";
+      "1bd8z6fm2nky4p3qxc5jh9dca7v7g77i6kdn6p5dzzm4gyadqvk00bfa4nzglzi9nwwyld14r3ydjd6ms012yk07q4aqdsrf51b9k4y";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -73,13 +73,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.4.2";
+  version = "78.4.3";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "1bd8z6fm2nky4p3qxc5jh9dca7v7g77i6kdn6p5dzzm4gyadqvk00bfa4nzglzi9nwwyld14r3ydjd6ms012yk07q4aqdsrf51b9k4y";
+      "0h5ddqp1z2dphyy4mjcb7v9mrrxlnjw8rwklm0yqsbvs9m96pc1yyp4clb3wmgs7kzh3wxdwi450842m3b13wdg5h0ls7rhamd1yi0c";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#104480 and previous updates for 20.03. Not tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
