### PR TITLE
influxdb2: init at v2.0.2

### DIFF
--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -1,0 +1,123 @@
+{ buildGoModule
+, buildGoPackage
+, fetchFromGitHub
+, go-bindata
+, lib
+, llvmPackages
+, mkYarnPackage
+, pkg-config
+, rustPlatform
+, ... }:
+let
+  version = "2.0.2";
+  shorthash = "84496e507a"; # git rev-parse HEAD with 2.0.2 checked out
+  libflux_version = "0.95.0";
+
+  src = fetchFromGitHub {
+    owner = "influxdata";
+    repo = "influxdb";
+    rev = "v${version}";
+    sha256 = "05s09crqgbyfdck33zwax5l47jpc4wh04yd8zsm658iksdgzpmnn";
+  };
+
+  ui = mkYarnPackage {
+    src = src;
+    packageJSON = "${src}/ui/package.json";
+    yarnLock = "${src}/ui/yarn.lock";
+    configurePhase = ''
+      cp -r $node_modules ui/node_modules
+      rsync -r $node_modules/../deps/chronograf-ui/node_modules/ ui/node_modules
+    '';
+    INFLUXDB_SHA = shorthash;
+    buildPhase = ''
+      pushd ui
+      yarn build:ci
+      popd
+    '';
+    installPhase = ''
+      mv ui/build $out
+    '';
+    distPhase = "true";
+  };
+
+  flux = rustPlatform.buildRustPackage {
+    pname = "libflux";
+    version = "v${libflux_version}";
+    src = fetchFromGitHub {
+      owner = "influxdata";
+      repo = "flux";
+      rev = "v${libflux_version}";
+      sha256 = "07jz2nw3zswg9f4p5sb5r4hpg3n4qibjcgs9sk9csns70h5rp9j3";
+    };
+    sourceRoot = "source/libflux";
+    cargoSha256 = "0y5xjkqpaxp9qq1qj39zw3mnvkbbb9g4fa5cli77nhfwz288xx6h";
+    nativeBuildInputs = [ llvmPackages.libclang ];
+    LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+    pkgcfg = ''
+      Name: flux
+      Version: ${libflux_version}
+      Description: Library for the InfluxData Flux engine
+      Cflags: -I/out/include
+      Libs: -L/out/lib -lflux -ldl -lpthread
+    '';
+    passAsFile = [ "pkgcfg" ];
+    postInstall = ''
+      mkdir -p $out/include $out/pkgconfig
+      cp -r $NIX_BUILD_TOP/source/libflux/include/influxdata $out/include
+      substitute $pkgcfgPath $out/pkgconfig/flux.pc \
+        --replace /out $out
+    '';
+  };
+
+  # Can't use the nixpkgs version of go-bindata, it's an ancient
+  # ancestor of this more modern one.
+  bindata = buildGoPackage {
+    pname = "go-bindata";
+    version = "v3.22.0";
+    src = fetchFromGitHub {
+      owner = "kevinburke";
+      repo = "go-bindata";
+      rev = "v3.22.0";
+      sha256 = "10dq77dml5jvvq2jkdq81a9yjg7rncq8iw8r84cc3dz6l9hxzj0x";
+    };
+
+    goPackagePath = "github.com/kevinburke/go-bindata";
+    subPackages = [ "go-bindata" ];
+  };
+in buildGoModule {
+  pname = "influxdb";
+  version = version;
+  src = src;
+
+  nativeBuildInputs = [ bindata pkg-config ];
+
+  vendorSha256 = "0lviz7l5zbghyfkp0lvlv8ykpak5hhkfal8d7xwvpsm8q3sghc8a";
+  subPackages = [ "cmd/influxd" "cmd/influx" ];
+
+  PKG_CONFIG_PATH = "${flux}/pkgconfig";
+  # We have to run a bunch of go:generate commands to embed the UI
+  # assets into the source code. Ideally we'd run `make generate`, but
+  # that ends up running a ton of non-hermetic stuff. Instead, we find
+  # the relevant go:generate directives, and run them by hand without
+  # breaking hermeticity.
+  preBuild = ''
+    ln -s ${ui} ui/build
+    grep -RI -e 'go:generate.*go-bindata' | cut -f1 -d: | while read -r filename; do
+      sed -i -e 's/go:generate.*go-bindata/go:generate go-bindata/' $filename
+      pushd $(dirname $filename)
+      go generate
+      popd
+    done
+    export buildFlagsArray=(
+      -tags="assets"
+      -ldflags="-X main.commit=${shorthash} -X main.version=${version}"
+    )
+  '';
+
+  meta = with lib; {
+    description = "An open-source distributed time series database";
+    license = licenses.mit;
+    homepage = "https://influxdata.com/";
+    maintainers = with maintainers; [ danderson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17199,6 +17199,7 @@ in
   };
 
   influxdb = callPackage ../servers/nosql/influxdb { };
+  influxdb2 = callPackage ../servers/nosql/influxdb2 { };
 
   mysql57 = callPackage ../servers/sql/mysql/5.7.x.nix {
     inherit (darwin) cctools developer_cmds;


### PR DESCRIPTION
###### Motivation for this change

InfluxDB 2.0 has been released upstream. It has major changes and improvements compared to 1.x, and also breaks compatibility (although there is a one-way manual upgrade path).

Because it's an incompatible thing, I'm proposing to package it as a separate derivation, to be followed by a separate NixOS module from 1.x. I welcome opinions to the contrary, I'm happy to mv this over the existing 1.x derivation as well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
