### PR TITLE
libvirt: Shrink closure by disabling zfs by default

### DIFF
--- a/pkgs/development/libraries/libvirt/5.9.0.nix
+++ b/pkgs/development/libraries/libvirt/5.9.0.nix
@@ -4,15 +4,16 @@
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
-, curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, glib, rpcsvc-proto, libtirpc
+, curl, libiconv, gmp, parted, bridge-utils, dmidecode, glib, rpcsvc-proto, libtirpc
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
 , enableCeph ? false, ceph
+, enableZfs ? false, zfs
 }:
 
 with stdenv.lib;
 
-# if you update, also bump <nixpkgs/pkgs/development/python-modules/libvirt/default.nix> and SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
+# if you update, also bump <nixpkgs/pkgs/development/python-modules/libvirt/5.9.0.nix> and SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
 let
   buildFromTarball = stdenv.isDarwin;
 in stdenv.mkDerivation rec {
@@ -40,7 +41,7 @@ in stdenv.mkDerivation rec {
   ] ++ optionals (!buildFromTarball) [
     libtool autoconf automake
   ] ++ optionals stdenv.isLinux [
-    libpciaccess lvm2 utillinux systemd libnl numad zfs
+    libpciaccess lvm2 utillinux systemd libnl numad
     libapparmor libcap_ng numactl attr parted libtirpc
   ] ++ optionals (enableXen && stdenv.isLinux && stdenv.isx86_64) [
     xen
@@ -48,6 +49,8 @@ in stdenv.mkDerivation rec {
     openiscsi
   ] ++ optionals enableCeph [
     ceph
+  ] ++ optionals enableZfs [
+    zfs
   ] ++ optionals stdenv.isDarwin [
     libiconv gmp
   ];
@@ -84,7 +87,7 @@ in stdenv.mkDerivation rec {
     "--with-macvtap"
     "--with-virtualport"
     "--with-storage-disk"
-  ] ++ optionals (stdenv.isLinux && zfs != null) [
+  ] ++ optionals (stdenv.isLinux && enableZfs) [
     "--with-storage-zfs"
   ] ++ optionals enableIscsi [
     "--with-storage-iscsi"

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -4,10 +4,11 @@
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
-, curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, dbus, libtirpc, rpcsvc-proto, darwin
+, curl, libiconv, gmp, parted, bridge-utils, dmidecode, dbus, libtirpc, rpcsvc-proto, darwin
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
 , enableCeph ? false, ceph
+, enableZfs ? false, zfs
 }:
 
 with stdenv.lib;
@@ -47,7 +48,7 @@ in stdenv.mkDerivation rec {
     libxml2 gnutls perl python2 readline gettext libtasn1 libgcrypt yajl
     libxslt xhtml1 perlPackages.XMLXPath curl libpcap glib dbus
   ] ++ optionals stdenv.isLinux [
-    libpciaccess lvm2 utillinux systemd libnl numad zfs
+    libpciaccess lvm2 utillinux systemd libnl numad
     libapparmor libcap_ng numactl attr parted libtirpc
   ] ++ optionals (enableXen && stdenv.isLinux && stdenv.isx86_64) [
     xen
@@ -55,6 +56,8 @@ in stdenv.mkDerivation rec {
     openiscsi
   ] ++ optionals enableCeph [
     ceph
+  ] ++ optionals enableZfs [
+    zfs
   ] ++ optionals stdenv.isDarwin [
     libiconv gmp
   ];
@@ -97,7 +100,7 @@ in stdenv.mkDerivation rec {
     "--with-macvtap"
     "--with-virtualport"
     "--with-storage-disk"
-  ] ++ optionals (stdenv.isLinux && zfs != null) [
+  ] ++ optionals (stdenv.isLinux && enableZfs) [
     "--with-storage-zfs"
   ] ++ optionals enableIscsi [
     "--with-storage-iscsi"


### PR DESCRIPTION
###### Motivation for this change

I don't think the zfs integration (i.e. direct zvol support) is widely used.

`nix path-info -S` reports `509285216` → `362482320`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
