### PR TITLE
pythonPackages.crytic-compile: fix missing dependency

### DIFF
--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pysha3 }:
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pysha3, setuptools }:
 
 buildPythonPackage rec {
   pname = "crytic-compile";
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     sha256 = "01mis7bqsh0l5vjl6jwibzy99djza35fxmywy56q8k4jbxwmdcna";
   };
 
-  propagatedBuildInputs = [ pysha3 ];
+  propagatedBuildInputs = [ pysha3 setuptools ];
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`crytic-compile` uses `setuptools` as a runtime dependency and fails to run without it:
```
$ crytic-compile
Traceback (most recent call last):
  File "/nix/store/2v4m2kxrg39307wy4a0w4sdp0biqy222-python3.8-crytic-compile-0.1.9/bin/.crytic-compile-wrapped", line 6, in <module>
    from crytic_compile.__main__ import main
  File "/nix/store/2v4m2kxrg39307wy4a0w4sdp0biqy222-python3.8-crytic-compile-0.1.9/lib/python3.8/site-packages/crytic_compile/__main__.py", line 10, in <module>
    from pkg_resources import require
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
