### PR TITLE
chroma: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/tools/text/chroma/default.nix
+++ b/pkgs/tools/text/chroma/default.nix
@@ -1,15 +1,31 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, git }:
 
 buildGoModule rec {
   pname = "chroma";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner  = "alecthomas";
-    repo   = "chroma";
+    repo   = pname;
     rev    = "v${version}";
-    sha256 = "1gwwfn26aipzzvyy466gi6r54ypfy3ylnbi8c4xwch9pkgw16w98";
+    sha256 = "0vzxd0jvjaakwjvkkkjppakjb00z44k7gb5ng1i4924agh24n5ka";
+    leaveDotGit = true;
+    fetchSubmodules = true;
   };
+
+  nativeBuildInputs = [ git ];
+
+  # populate values otherwise taken care of by goreleaser
+  # https://github.com/alecthomas/chroma/issues/435
+  postPatch = ''
+    commit="$(git rev-parse HEAD)"
+    date=$(git show -s --format=%aI "$commit")
+
+    substituteInPlace cmd/chroma/main.go \
+      --replace 'version = "?"' 'version = "${version}"' \
+      --replace 'commit  = "?"' "commit = \"$commit\"" \
+      --replace 'date    = "?"' "date = \"$date\""
+  '';
 
   vendorSha256 = "16cnc4scgkx8jan81ymha2q1kidm6hzsnip5mmgbxpqcc2h7hv9m";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/alecthomas/chroma/releases/tag/v0.8.2>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
