### PR TITLE
tautulli: 2.2.4 -> 2.6.1

### DIFF
--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -1,54 +1,48 @@
-{stdenv, fetchFromGitHub, python }:
+{ lib, fetchFromGitHub, python, buildPythonApplication, bash, setuptools, wrapPython, makeWrapper }:
 
-stdenv.mkDerivation rec {
-  version = "2.2.4";
+buildPythonApplication rec {
   pname = "Tautulli";
+  version = "2.6.1";
+  format = "other";
 
-  pythonPath = [ python.pkgs.setuptools ];
-  buildInputs = [ python.pkgs.setuptools ];
-  nativeBuildInputs = [ python.pkgs.wrapPython ];
+  pythonPath = [ setuptools ];
+  nativeBuildInputs = [ wrapPython makeWrapper ];
 
   src = fetchFromGitHub {
     owner = "Tautulli";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0yg7r7yscx6jbs1lnl9nbax3v9r6ppvhr4igdm3gbvd2803j8fs7";
+    sha256 = "QHpVIOtGFzNqAEcBCv48YWO4pYatbTe/CWwcwjbj+34=";
   };
 
-  buildPhase = ":";
+  doBuild = false;
 
   installPhase = ''
-    mkdir -p $out
-    cp -R * $out/
+    mkdir -p $out/bin $out/libexec/tautulli
+    cp -R contrib data lib plexpy Tautulli.py $out/libexec/tautulli
 
-    # Remove the PlexPy.py compatibility file as it won't work after wrapping.
-    # We still have the plexpy executable in bin for compatibility.
-    rm $out/PlexPy.py
-
-    # Remove superfluous Python checks from main script;
-    # prepend shebang
-    echo "#!${python.interpreter}" > $out/Tautulli.py
-    tail -n +7 Tautulli.py >> $out/Tautulli.py
-
-
-    mkdir $out/bin
     # Can't just symlink to the main script, since it uses __file__ to
     # import bundled packages and manage the service
-    echo "#!/bin/bash" > $out/bin/tautulli
-    echo "$out/Tautulli.py \$*" >> $out/bin/tautulli
-    chmod +x $out/bin/tautulli
+    makeWrapper $out/libexec/tautulli/Tautulli.py $out/bin/tautulli
+    wrapPythonProgramsIn "$out/libexec/tautulli" "$pythonPath"
 
     # Creat backwards compatibility symlink to bin/plexpy
     ln -s $out/bin/tautulli $out/bin/plexpy
-
-    wrapPythonProgramsIn "$out" "$out $pythonPath"
   '';
 
-  meta  = with stdenv.lib; {
+  checkPhase = ''
+    runHook preCheck
+
+    $out/bin/tautulli --help
+
+    runHook postCheck
+  '';
+
+  meta  = with lib; {
     description = "A Python based monitoring and tracking tool for Plex Media Server";
     homepage = "https://tautulli.com/";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ csingley ];
+    maintainers = with maintainers; [ csingley ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6507,7 +6507,7 @@ in
 
   tab = callPackage ../tools/text/tab { };
 
-  tautulli = callPackage ../servers/tautulli { python = python2; };
+  tautulli = python3Packages.callPackage ../servers/tautulli { };
 
   ploticus = callPackage ../tools/graphics/ploticus {
     libpng = libpng12;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream update, cleanup of the code to reduce the size of the closure (it contained stuff to build rpm and windows launcher), and migration to python3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
