### PR TITLE
domination: init at 1.2.3

### DIFF
--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, fetchsvn
+# jdk8 is needed for building, but the game runs on newer jres as well
+, jdk8
+, jre
+, ant
+, makeWrapper
+, makeDesktopItem
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = "Domination";
+    desktopName = "Domination";
+    exec = "domination";
+    icon = "domination";
+  };
+  editorDesktopItem = makeDesktopItem {
+    type = "Application";
+    name = "Domination Map Editor";
+    desktopName = "Domination Map Editor";
+    exec = "domination-map-editor";
+    icon = "domination";
+  };
+
+in stdenv.mkDerivation {
+  pname = "domination";
+  version = "1.2.3";
+
+  # The .zip releases do not contain the build.xml file
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/domination/code/Domination";
+    # There are no tags in the repository.
+    # Look for commits like "new version x.y.z info on website"
+    # or "website update for x.y.z".
+    rev = "1964";
+    sha256 = "0718gns8d69a1dfq3ywc9kddl1khnrmxqyal7brckbjgay8dq42f";
+  };
+
+  nativeBuildInputs = [
+    jdk8
+    ant
+    makeWrapper
+  ];
+
+  buildPhase = "ant";
+
+  installPhase = ''
+    # Remove unnecessary files and launchers (they'd need to be wrapped anyway)
+    rm -r \
+      build/game/src.zip \
+      build/game/*.sh \
+      build/game/*.cmd \
+      build/game/*.exe \
+      build/game/*.app
+
+    mkdir -p $out/share/domination
+    cp -r build/game/* $out/share/domination/
+
+    # Reimplement the two launchers mentioned in Unix_shortcutSpec.xml with makeWrapper
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/domination \
+      --run "cd $out/share/domination" \
+      --add-flags "-jar $out/share/domination/Domination.jar"
+    makeWrapper ${jre}/bin/java $out/bin/domination-map-editor \
+      --run "cd $out/share/domination" \
+      --add-flags "-cp $out/share/domination/Domination.jar net.yura.domination.ui.swinggui.SwingGUIFrame"
+
+    install -Dm644 \
+      ${desktopItem}/share/applications/Domination.desktop \
+      $out/share/applications/Domination.desktop
+    install -Dm644 \
+      "${editorDesktopItem}/share/applications/Domination Map Editor.desktop" \
+      "$out/share/applications/Domination Map Editor.desktop"
+    install -Dm644 build/game/resources/icon.png $out/share/pixmaps/domination.png
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://domination.sourceforge.net/";
+    downloadPage = "http://domination.sourceforge.net/download.shtml";
+    description = "A game that is a bit like the board game Risk or RisiKo";
+    longDescription = ''
+      Domination is a game that is a bit like the well known board game of Risk
+      or RisiKo. It has many game options and includes many maps.
+      It includes a map editor, a simple map format, multiplayer network play,
+      single player, hotseat, 5 user interfaces and many more features.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25224,6 +25224,8 @@ in
 
   displaycal = callPackage ../applications/graphics/displaycal {};
 
+  domination = callPackage ../games/domination { };
+
   drumkv1 = libsForQt5.callPackage ../applications/audio/drumkv1 { };
 
   duckmarines = callPackage ../games/duckmarines { love = love_0_10; };


### PR DESCRIPTION


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
