### PR TITLE
[20.09] packet-sd: init at 0.0.3

### DIFF
--- a/pkgs/development/tools/packet-sd/default.nix
+++ b/pkgs/development/tools/packet-sd/default.nix
@@ -1,0 +1,24 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+buildGoModule rec {
+  pname = "prometheus-packet-sd";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "packethost";
+    repo = "prometheus-packet-sd";
+    rev = "v${version}";
+    sha256 = "sha256-2k8AsmyhQNNZCzpVt6JdgvI8IFb5pRi4ic6Yn2NqHMM=";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Prometheus service discovery for Equinix Metal";
+    homepage = "https://github.com/packethost/prometheus-packet-sd";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.andir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22447,6 +22447,8 @@ in
 
   packet = callPackage ../development/tools/packet { };
 
+  packet-sd = callPackage ../development/tools/packet-sd { };
+
   packet-cli = callPackage ../development/tools/packet-cli { };
 
   pb_cli = callPackage ../tools/misc/pb_cli {};


### PR DESCRIPTION
###### Motivation for this change

Backport of #104500

This is currently being used as part of the NixOS.org infrastructure [1]
and should probably be included here and not just "downstream" (in the
nixops configs).

[1] https://github.com/NixOS/nixos-org-configurations/blob/26105e7afac604d3e02f68e3985830dce21c405d/delft/prometheus/packet-sd.nix

cc @grahamc 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
