### PR TITLE
pipewire: Fix screen sharing with Chromium

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -65,6 +65,11 @@ stdenv.mkDerivation rec {
     ./alsa-profiles-use-libdir.patch
     # Move installed tests into their own output.
     ./installed-tests-path.patch
+    # Fix older clients (e.g. Chrome/Chromium):
+    (fetchpatch { # protocol-native: do version check on HELLO
+      url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/b8c7b36d3b8be16593f554964cf2f852c21b5c2c.patch";
+      sha256 = "18461grisrgqbad6bfa1bm17mslddgfmjfprc9vjvab2mmpsjss9";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
See https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/270.
E.g. Fedora and Arch have already backported that patch.

This avoids errors like:
Chromium: [E][module-protocol-native.c:562 on_remote_data()] protocol-native 0x33df5483c780: got connection error
pipewire[1168]: [E][000002106.051912][module-protocol-native.c:305 connection_data()] protocol-native 0x1b96900: client 0x1d084f0 error -22 (Invalid argument)

I've successfully tested screen sharing with Chromium 87.0.4280.66.

cc https://github.com/NixOS/nixpkgs/issues/91218

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

cc @jtojnar

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
