### PR TITLE
rehex: init at 0.3.1

### DIFF
--- a/pkgs/applications/editors/rehex/default.nix
+++ b/pkgs/applications/editors/rehex/default.nix
@@ -1,0 +1,39 @@
+{ capstone
+, fetchFromGitHub
+, jansson
+, lib
+, stdenv
+, wxGTK30
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rehex";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "solemnwarning";
+    repo = pname;
+    rev = version;
+    sha256 = "1yj9a63j7534mmz8cl1ifg2wmgkxmk6z75jd8lkmc2sfrjbick32";
+  };
+
+  buildInputs = [
+    capstone
+    jansson
+    wxGTK30
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "Reverse Engineers' Hex Editor";
+    longDescription = ''
+      A cross-platform (Windows, Linux, Mac) hex editor for reverse
+      engineering, and everything else.
+    '';
+    homepage = "https://github.com/solemnwarning/rehex";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ markus1189 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6672,6 +6672,8 @@ in
 
   remarshal = callPackage ../development/tools/remarshal { };
 
+  rehex = callPackage ../applications/editors/rehex { };
+
   rig = callPackage ../tools/misc/rig {
     stdenv = gccStdenv;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Init `rehex`, the "Reverse Engineers' Hex Editor" at version `0.3.1`

(website is https://github.com/solemnwarning/rehex)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
