### PR TITLE
dns-over-https: init at 2.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2371,6 +2371,16 @@
     githubId = 2025623;
     name = "Luc Chabassier";
   };
+  dwoffinden = {
+    email = "daw@hey.com";
+    github = "dwoffinden";
+    githubId = 1432131;
+    name = "Daniel Woffinden";
+    keys = [{
+      longkeyid = "rsa4096/0xF3EA503B360FBD40";
+      fingerprint = "46FC 889E BC38 100E 51E8  3245 F3EA 503B 360F BD40";
+    }];
+  };
   dxf = {
     email = "dingxiangfei2009@gmail.com";
     github = "dingxiangfei2009";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -615,6 +615,7 @@
   ./services/networking/ddclient.nix
   ./services/networking/dhcpcd.nix
   ./services/networking/dhcpd.nix
+  ./services/networking/dns-over-https.nix
   ./services/networking/dnscache.nix
   ./services/networking/dnscrypt-proxy2.nix
   ./services/networking/dnscrypt-wrapper.nix

--- a/nixos/modules/services/networking/dns-over-https.nix
+++ b/nixos/modules/services/networking/dns-over-https.nix
@@ -1,0 +1,201 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dns-over-https;
+  clientBootstrap = concatMapStringsSep "," (x: "\"${x}\"") cfg.client.bootstrap;
+  clientListen = concatMapStringsSep "," (x: "\"${x}\"") cfg.client.listen;
+  clientPassthrough = concatMapStringsSep "," (x: "\"${x}\"") cfg.client.passthrough;
+  clientUpstream = concatMapStrings (s: "[[upstream.upstream_ietf]]\n  url = \"${s.url}\"\n  weight = ${toString s.weight}\n") cfg.client.upstream;
+  serverListen = concatMapStringsSep "," (x: "\"${x}\"") cfg.server.listen;
+  serverUpstream = concatMapStringsSep "," (x: "\"${x}\"") cfg.server.upstream;
+
+  # See upstream: https://github.com/m13253/dns-over-https/blob/master/doh-client/doh-client.conf
+  clientConf = pkgs.writeText "doh-client.conf" ''
+    listen = [${clientListen}]
+
+    [upstream]
+    upstream_selector = "${cfg.client.upstreamSelector}"
+
+    ${clientUpstream}
+
+    [others]
+    bootstrap = [${clientBootstrap}]
+    passthrough = [${clientPassthrough}]
+    timeout = 30
+    no_cookies = true
+    no_ecs = false
+    no_ipv6 = false
+    no_user_agent = false
+    verbose = ${boolToString cfg.verbose}
+  '';
+  # See upstream: https://github.com/m13253/dns-over-https/blob/master/doh-server/doh-server.conf
+  serverConf = pkgs.writeText "doh-server.conf" ''
+    listen = [${serverListen}]
+    local_addr = ""
+    cert = ""
+    key = ""
+    path = "/dns-query"
+    upstream = [${serverUpstream}]
+    timeout = 10
+    tries = 3
+    verbose = ${boolToString cfg.verbose}
+    log_guessed_client_ip = false
+  '';
+
+in
+{
+  options = {
+    services.dns-over-https = {
+      verbose = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable logging";
+      };
+      client = mkOption {
+        description = "DNS-over-HTTPS Client";
+        type = types.submodule {
+          options = {
+            enable = mkEnableOption "DNS-over-HTTPS Client";
+            bootstrap = mkOption {
+              description = "Bootstrap DNS server to resolve the address of the upstream resolver";
+              type = types.listOf types.str;
+              default = [ "8.8.8.8:53" "8.8.4.4:53" ];
+              example = [
+                # Google's resolver
+                "8.8.8.8:53"
+                "8.8.4.4:53"
+                # CloudFlare's resolver
+                "1.1.1.1:53"
+                "1.0.0.1:53"
+              ];
+            };
+            listen = mkOption {
+              description = "DNS listen port";
+              type = types.listOf types.str;
+              default = [
+                "127.0.0.1:53"
+                "127.0.0.1:5380"
+                "[::1]:53"
+                "[::1]:5380"
+              ];
+              example = [ ":53" ];
+            };
+            upstreamSelector = mkOption {
+              type = types.enum [ "random" "weighted_round_robin" "lvs_weighted_round_robin" ];
+              description = "upstream selection algorithm";
+              default = "random";
+            };
+            upstream = mkOption {
+              description = "list of upstream servers to query";
+              type = with types; listOf(submodule {
+                options = {
+                  url = mkOption {
+                    type = str;
+                    description = "URL for the backend, usually 'https://.../dns-query'";
+                  };
+                  weight = mkOption {
+                    type = ints.u8;
+                    description =
+                      "weight should be in (0, 100], if upstream_selector is random, weight will be ignored";
+                    default = 50;
+                  };
+                };
+              });
+              default = [ { url = "https://cloudflare-dns.com/dns-query"; } ];
+              example = [
+                # Google's resolver, good ECS, good DNSSEC
+                { url = "https://dns.google/dns-query"; }
+                # CloudFlare's resolver, bad ECS, good DNSSEC
+                { url = "https://cloudflare-dns.com/dns-query"; }
+                # CloudFlare's resolver, bad ECS, good DNSSEC
+                { url = "https://1.1.1.1/dns-query"; }
+                # DNS.SB's resolver, good ECS, good DNSSEC
+                { url = "https://doh.dns.sb/dns-query"; }
+                # Quad9's resolver, bad ECS, good DNSSEC
+                { url = "https://9.9.9.9/dns-query"; }
+                # CloudFlare's resolver via Tor
+                { url = "https://dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion/dns-query"; }
+              ];
+            };
+            passthrough = mkOption {
+              description =
+                "Domain names to directly pass to bootstrap servers, allowing captive portal detection to work";
+              type = types.listOf types.str;
+              default = [
+                "captive.apple.com"
+                "connectivitycheck.gstatic.com"
+                "detectportal.firefox.com"
+                "msftconnecttest.com"
+                "nmcheck.gnome.org"
+                "pool.ntp.org"
+                "time.apple.com"
+                "time.asia.apple.com"
+                "time.euro.apple.com"
+                "time.nist.gov"
+                "time.windows.com"
+              ];
+            };
+          };
+        };
+        default = {};
+      };
+      server = mkOption {
+        description = "DNS-over-HTTPS Server";
+        type = types.submodule {
+          options = {
+            enable = mkEnableOption "DNS-over-HTTPS Server";
+            listen = mkOption {
+              description = "HTTP listen port";
+              type = types.listOf types.str;
+              default = [ "127.0.0.1:8053" "[::1]:8053" ];
+              example = [ ":8053" ];
+            };
+            upstream = mkOption {
+              description = "Upstream DNS resolver";
+              type = types.listOf types.str;
+              default = [
+                "udp:1.1.1.1:53"
+                "udp:1.0.0.1:53"
+                "udp:8.8.8.8:53"
+                "udp:8.8.4.4:53"
+              ];
+              example = [ "udp:127.0.0.1:53" ];
+            };
+          };
+        };
+        default = {};
+      };
+    };
+  };
+
+  config = {
+    systemd.services.doh-client = mkIf cfg.client.enable {
+      description = "DNS-over-HTTPS Client";
+      after = [ "network.target" ];
+      before = [ "nss-lookup.target" ];
+      wants = [ "nss-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        ExecStart = "${pkgs.dns-over-https}/bin/doh-client -conf ${clientConf}";
+        DynamicUser = true;
+      };
+    };
+    systemd.services.doh-server = mkIf cfg.server.enable {
+      description = "DNS-over-HTTPS Server";
+      after = [ "network.target" ];
+      before = [ "nss-lookup.target" ];
+      wants = [ "nss-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        ExecStart = "${pkgs.dns-over-https}/bin/doh-server -conf ${serverConf}";
+        DynamicUser = true;
+      };
+    };
+  };
+}

--- a/nixos/tests/dns-over-https.nix
+++ b/nixos/tests/dns-over-https.nix
@@ -1,0 +1,63 @@
+import ./make-test-python.nix ({ pkgs, ... }: let
+  domain = "example.com";
+  fakeIp = "203.0.113.42";
+in {
+  name = "dns-over-https";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ dwoffinden ];
+  };
+  nodes = {
+    server = { nodes, ... }:
+    {
+      services.unbound = {
+        enable = true;
+        extraConfig = ''
+          local-zone: "${domain}." static
+          local-data: "${domain}. 10800 IN A ${fakeIp}"
+        '';
+      };
+      services.dns-over-https = {
+        verbose = true;
+        server = {
+          enable = true;
+          listen = [ ":80" ];
+          upstream = [ "udp:127.0.0.1:53" ];
+        };
+      };
+      networking.firewall.allowedTCPPorts = [ 80 ];
+    };
+    client = { config, lib, nodes, ... }:
+    {
+      services.dns-over-https = {
+        verbose = true;
+        client = {
+          enable = true;
+          bootstrap = [];
+          listen = [ ":53" ];
+          upstream = [
+            { url = "http://${nodes.server.config.networking.primaryIPAddress}/dns-query"; }
+          ];
+        };
+      };
+    };
+  };
+  testScript = { nodes,  ... }: let
+    serverIp = nodes.server.config.networking.primaryIPAddress;
+  in ''
+    start_all()
+    server.wait_for_unit("unbound")
+    server.wait_for_unit("doh-server")
+    client.wait_for_unit("doh-client")
+
+    with subtest("Server correctly configured"):
+        assert "${fakeIp}" in server.succeed("host ${domain} localhost")
+
+    with subtest("Server returns correct result over HTTP"):
+        assert "${fakeIp}" in client.succeed(
+            "curl 'http://${serverIp}/dns-query?name=${domain}&type=A'"
+        )
+
+    with subtest("Client fetches correct result over HTTP"):
+        assert "${fakeIp}" in client.succeed("host ${domain} localhost")
+  '';
+})

--- a/pkgs/tools/networking/dns-over-https/default.nix
+++ b/pkgs/tools/networking/dns-over-https/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "dns-over-https";
+  version = "2.2.2";
+  goPackagePath = "github.com/m13253/dns-over-https";
+  subPackages = [ "doh-client" "doh-server" ];
+  src = fetchFromGitHub {
+    owner = "m13253";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12xklf7k07vlqbd7xv9p4c6385h874k8g5sagpcg891lib174bad";
+  };
+  vendorSha256 = "07jnrhrn45diw7mgscsiwagsdqbh0p69dnwx5bi10v2jrc66zkjd";
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/m13253/dns-over-https";
+    description = "High performance DNS over HTTPS client & server";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dwoffinden ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20681,6 +20681,8 @@ in
 
   denemo = callPackage ../applications/audio/denemo { };
 
+  dns-over-https = callPackage ../tools/networking/dns-over-https { };
+
   dvdauthor = callPackage ../applications/video/dvdauthor { };
 
   dvdbackup = callPackage ../applications/video/dvdbackup { };


### PR DESCRIPTION
https://github.com/m13253/dns-over-https

This is a Go implementation of a DoH client and server.

Includes a nixos module with rudimentary customisation and tests.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I couldn't find another server in nixpkgs that allows proxying dns-over-https requests, nor a package for this one.

I wanted the ability to host my own DoH server that applications supporting it directly (e.g. Chrome/Firefox) can be configured to talk to. In my case I have nginx in front of it, and point it at a local unbound.

The package also supports a DoH client, which I haven't tested as thoroughly. unbound natively supports DoT upstreams, and there are other packages like stubby, https-dns-proxy and dnscrypt-proxy2 competing in this space.

Actually, it looks like dnsproxy may do this and more, but I haven't tried it, and it doesn't look to have a service? (https://github.com/AdguardTeam/dnsproxy https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/networking/dnsproxy/default.nix)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
