### PR TITLE
pipewire: 0.3.15 -> 0.3.16

### DIFF
--- a/pkgs/development/libraries/pipewire/pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/pipewire-pulse-path.patch
@@ -1,0 +1,24 @@
+diff --git a/meson_options.txt b/meson_options.txt
+index 4b9e46b8..9d73ed06 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -147,3 +147,6 @@ option('pw-cat',
+ option('udevrulesdir',
+        type : 'string',
+        description : 'Directory for udev rules (defaults to /lib/udev/rules.d)')
++option('pipewire_pulse_prefix',
++       type : 'string',
++       description : 'Install directory for the pipewire-pulse daemon')
+diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
+index 29fc93d4..f78946f2 100644
+--- a/src/daemon/systemd/user/meson.build
++++ b/src/daemon/systemd/user/meson.build
+@@ -6,7 +6,7 @@ install_data(
+ 
+ systemd_config = configuration_data()
+ systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))
+-systemd_config.set('PW_PULSE_BINARY', join_paths(pipewire_bindir, 'pipewire-pulse'))
++systemd_config.set('PW_PULSE_BINARY', join_paths(get_option('pipewire_pulse_prefix'), 'bin/pipewire-pulse'))
+ 
+ configure_file(input : 'pipewire.service.in',
+                output : 'pipewire.service',


### PR DESCRIPTION
Changes: https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/09d373f094f0e6797aef3d97cde2c0167dccc986

Follow-up on #104504. Feel free to open a replacement PR if someone ends up finishing work on this while I'm asleep. (@primeos)

Not sure if we want to deal with coexistence actual pulseaudio and pipewire.pulse-server in the nixos module at all, feel free to remove that bit if the consensus is no.

Bluetooth would be nice to have a setting for since it is off by default due to conflicts with pulseaudio, but that can be done separately if it takes too much time to figure out now. I'm not familiar with modifying applications' config files from within nix.

###### Motivation for this change

Upstream update that should fix a lot of the current pulseaudio woes by throwing out the libpulseaudio shim and instead providing a module that acts as a fake pulseaudio server.

###### Things done

* [ ] Tested using sandboxing (nix.useSandbox on NixOS, or option sandbox in nix.conf on non-NixOS linux)
* Built on platform(s)
  * [x] NixOS
  * [ ] macOS
  * [ ] other Linux distributions

* [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)
* [ ] Tested compilation of all pkgs that depend on this change using nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
* [ ] Tested execution of all binary files (usually in ./result/bin/)
* [ ] Determined the impact on package closure size (by running nix path-info -S before and after)
* [ ] Ensured that relevant documentation is up to date
* [x] Fits CONTRIBUTING.md.