### PR TITLE
ocamlPackages.faraday: 0.7.0 → 0.7.2

### DIFF
--- a/pkgs/development/ocaml-modules/faraday/default.nix
+++ b/pkgs/development/ocaml-modules/faraday/default.nix
@@ -2,7 +2,9 @@
 
 buildDunePackage rec {
   pname = "faraday";
-  version = "0.7.0";
+  version = "0.7.2";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02";
 
@@ -10,12 +12,12 @@ buildDunePackage rec {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    sha256 = "0z6ikwlqad91iac0q5z88p3wzq5k15y86ckzmhdq1aqwrcm14bq2";
+    sha256 = "0gdysszzk6b6npic4nhpdnz2nbq7rma6aml0rbn113bfh0rmb36x";
   };
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigstringaf ];
-  doCheck = lib.versions.majorMinor ocaml.version != "4.07";
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
 
   meta = {
     description = "Serialization library built for speed and memory efficiency";


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
