### PR TITLE
u9fs: 20110513 -> unstable-2020-11-21

### DIFF
--- a/pkgs/servers/u9fs/default.nix
+++ b/pkgs/servers/u9fs/default.nix
@@ -1,24 +1,26 @@
 { stdenv, fetchhg }:
 
 stdenv.mkDerivation {
-  name = "u9fs-20110513";
+  pname = "u9fs";
+  version = "unstable-2020-11-21";
+
   src = fetchhg {
-    url = "https://bitbucket.org/plan9-from-bell-labs/u9fs";
-    rev = "9474edb23b11";
+    url = "https://code.9front.org/hg/plan9front";
+    rev = "6eef4d6a9bce";
     sha256 = "0irwyk8vnvx0fmz8lmbdb2jrlvas8imr61jr76a1pkwi9wpf2wv6";
   };
 
-  installPhase =
-    ''
+  installPhase = ''
       mkdir -p $out/bin $out/share/man4
-      cp u9fs $out/bin; cp u9fs.man $out/share/man4
+      cp u9fs.man $out/share/man4
+      cp u9fs $out/bin
     '';
 
-  meta = with stdenv.lib;
-    { description = "Serve 9P from Unix";
-      homepage = "http://plan9.bell-labs.com/magic/man2html/4/u9fs";
-      license = licenses.free;
-      maintainers = [ maintainers.ehmry ];
-      platforms = platforms.unix;
-    };
+  meta = with stdenv.lib; {
+    description = "Serve 9P from Unix";
+    homepage = "http://plan9.bell-labs.com/magic/man2html/4/u9fs";
+    license = licenses.free;
+    maintainers = [ maintainers.ehmry ];
+    platforms = platforms.unix;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
