### PR TITLE
enamlx: fix use of function that was removed upstream

### DIFF
--- a/pkgs/development/python-modules/enamlx/default.nix
+++ b/pkgs/development/python-modules/enamlx/default.nix
@@ -17,6 +17,12 @@ buildPythonPackage rec {
     sha256 = "1rlrx3cw6h1zl9svnqbzwdfy8469qa1y7w6576lbhdwpfhpipscy";
   };
 
+  patches = [
+    # Minimally modified version of https://github.com/frmdstryr/enamlx/commit/16df11227b8cee724624541d274e481802ea67e3
+    # (without the change to setup.py), already on master and expected in the first post-0.4.3 release
+    ./replace-unicode-with-str.patch
+  ];
+
   propagatedBuildInputs = [
     enaml
     # Until https://github.com/inkcut/inkcut/issues/105 perhaps

--- a/pkgs/development/python-modules/enamlx/replace-unicode-with-str.patch
+++ b/pkgs/development/python-modules/enamlx/replace-unicode-with-str.patch
@@ -1,0 +1,274 @@
+From 16df11227b8cee724624541d274e481802ea67e3 Mon Sep 17 00:00:00 2001
+From: frmdstryr <frmdstryr@protonmail.com>
+Date: Tue, 3 Nov 2020 21:41:52 -0500
+Subject: [PATCH] Replace Unicode with Str
+
+---
+ enamlx/widgets/abstract_item.py      |  4 ++--
+ enamlx/widgets/console.py            |  4 ++--
+ enamlx/widgets/graphics_view.py      |  8 ++++----
+ enamlx/widgets/plot_area.py          | 14 +++++++-------
+ examples/occ_viewer/advanced.enaml   | 12 ++++++------
+ examples/occ_viewer/occ/part.py      |  6 +++---
+ examples/plot_area/plot_area.enaml   |  2 +-
+ examples/table_view/table_view.enaml |  6 +++---
+ examples/tree_view/tree_view.enaml   |  6 +++---
+ setup.py                             |  2 +-
+ 10 files changed, 32 insertions(+), 32 deletions(-)
+
+diff --git a/enamlx/widgets/abstract_item.py b/enamlx/widgets/abstract_item.py
+index 29a3d87..67a5c6e 100644
+--- a/enamlx/widgets/abstract_item.py
++++ b/enamlx/widgets/abstract_item.py
+@@ -6,7 +6,7 @@
+ Created on Aug 24, 2015
+ """
+ from atom.api import (
+-    Int, Enum, Bool, Unicode, Typed, 
++    Int, Enum, Bool, Str, Typed, 
+     Coerced, Event, Property, ForwardInstance, observe
+ )
+ from enaml.icon import Icon
+@@ -96,7 +96,7 @@ class AbstractWidgetItem(AbstractWidgetItemGroup):
+     column = d_(Int(), writable=False)
+     
+     #: Text to display within the cell
+-    text = d_(Unicode())
++    text = d_(Str())
+     
+     #: Text alignment within the cell
+     text_alignment = d_(Enum(*[(h, v)
+diff --git a/enamlx/widgets/console.py b/enamlx/widgets/console.py
+index bc61e90..2f1e981 100644
+--- a/enamlx/widgets/console.py
++++ b/enamlx/widgets/console.py
+@@ -7,7 +7,7 @@
+ """
+ 
+ from atom.api import (
+-    Instance, Coerced, Int, Enum, Unicode, Dict, Bool,
++    Instance, Coerced, Int, Enum, Str, Dict, Bool,
+     Typed, ForwardTyped, observe
+ )
+ from enaml.core.api import d_
+@@ -47,7 +47,7 @@ class Console(Container):
+     proxy = Typed(ProxyConsole)
+     
+     #: Font family, leave blank for default
+-    font_family = d_(Unicode())
++    font_family = d_(Str())
+     
+     #: Font size, leave 0 for default
+     font_size = d_(Int(0))
+diff --git a/enamlx/widgets/graphics_view.py b/enamlx/widgets/graphics_view.py
+index f7e3e47..e672c63 100644
+--- a/enamlx/widgets/graphics_view.py
++++ b/enamlx/widgets/graphics_view.py
+@@ -7,7 +7,7 @@
+ import sys
+ from atom.api import (
+     Atom, Float, Int, Typed, Bool, Coerced, ForwardTyped, Enum, List, IntEnum,
+-    Instance, Unicode, Value, Event, Property, observe, set_default
++    Instance, Str, Value, Event, Property, observe, set_default
+ )
+ from enaml.colors import ColorMember
+ from enaml.core.declarative import d_, d_func
+@@ -419,10 +419,10 @@ class GraphicsItem(ToolkitObject, ConstrainableMixin):
+     visible = d_(Bool(True))
+     
+     #: Tool tip
+-    tool_tip = d_(Unicode())
++    tool_tip = d_(Str())
+     
+     #: Status tip
+-    status_tip = d_(Unicode())
++    status_tip = d_(Str())
+     
+     # --------------------------------------------------------------------------
+     # Item interaction
+@@ -919,7 +919,7 @@ class GraphicsTextItem(AbstractGraphicsShapeItem):
+     proxy = Typed(ProxyGraphicsTextItem)
+     
+     #: Text
+-    text = d_(Unicode())
++    text = d_(Str())
+     
+     #: Font
+     font = d_(FontMember())
+diff --git a/enamlx/widgets/plot_area.py b/enamlx/widgets/plot_area.py
+index 5136693..383957b 100644
+--- a/enamlx/widgets/plot_area.py
++++ b/enamlx/widgets/plot_area.py
+@@ -8,7 +8,7 @@
+ import sys
+ from atom.atom import set_default
+ from atom.api import (Callable, Int, Tuple, Instance, Enum, Float,
+-                      ContainerList, Bool, FloatRange, Unicode, Dict, Typed,
++                      ContainerList, Bool, FloatRange, Str, Dict, Typed,
+                       ForwardTyped, observe)
+ from enaml.core.declarative import d_
+ from enaml.widgets.api import Container
+@@ -41,10 +41,10 @@ class PlotArea(Container):
+ 
+ class PlotItem(Control):
+     #: Title of data series
+-    title = d_(Unicode())
++    title = d_(Str())
+ 
+     #: Name
+-    name = d_(Unicode())
++    name = d_(Str())
+ 
+     #: Row in plot area
+     row = d_(Int(0))
+@@ -89,10 +89,10 @@ class PlotItem(Control):
+     #: Show legend
+     show_legend = d_(Bool(False))
+ 
+-    label_left = d_(Unicode())
+-    label_right = d_(Unicode())
+-    label_top = d_(Unicode())
+-    label_bottom = d_(Unicode())
++    label_left = d_(Str())
++    label_right = d_(Str())
++    label_top = d_(Str())
++    label_bottom = d_(Str())
+ 
+     # H, V
+     grid = d_(Tuple(bool, default=(False, False)))
+diff --git a/examples/occ_viewer/advanced.enaml b/examples/occ_viewer/advanced.enaml
+index 872d44d..f1c48d5 100644
+--- a/examples/occ_viewer/advanced.enaml
++++ b/examples/occ_viewer/advanced.enaml
+@@ -15,7 +15,7 @@ is then used to unroll a list of these controls into the body of a form.
+ 
+ << autodoc-me >>
+ """
+-from atom.api import Atom, Bool, Enum, Event, Float, Int, Str, Unicode
++from atom.api import Atom, Bool, Enum, Event, Float, Int, Str, Str
+ 
+ from enaml.core.api import DynamicTemplate
+ from enaml.stdlib.fields import FloatField
+@@ -73,8 +73,8 @@ template FormControl(Attr, MemberType: Str):
+         text :: setattr(model, Attr, str(text))
+ 
+ 
+-template FormControl(Attr, MemberType: Unicode):
+-    """ A form control template specialization for Unicode members.
++template FormControl(Attr, MemberType: Str):
++    """ A form control template specialization for Str members.
+ 
+     This control uses a Field to represent the value.
+ 
+@@ -174,7 +174,7 @@ def form_spec(obtype, model):
+     
+     typemap = {int:Int,
+                float:Float,
+-               unicode:Unicode,
++               unicode:Str,
+                str:Str}
+     for name, member in obtype.members().iteritems():
+         if (not name.startswith('_') 
+@@ -263,14 +263,14 @@ class FooModel(Atom):
+     ham = Int(42)
+     first = Str('first')
+     last = Str('last')
+-    owner = Unicode('owner')
++    owner = Str('owner')
+     time = Float(42.56)
+     click = Bool()
+     clack = Bool()
+ 
+ 
+ class BarModel(Atom):
+-    name = Unicode('name')
++    name = Str('name')
+     trigger = Event()
+     choices = Enum('first', 'second', 'third')
+     def _observe_trigger(self, change):
+diff --git a/examples/occ_viewer/occ/part.py b/examples/occ_viewer/occ/part.py
+index 1fe2b85..144354f 100644
+--- a/examples/occ_viewer/occ/part.py
++++ b/examples/occ_viewer/occ/part.py
+@@ -5,7 +5,7 @@
+ '''
+ 
+ from atom.api import (
+-    Typed, ForwardTyped, Unicode
++    Typed, ForwardTyped, Str
+ )
+ from enaml.core.declarative import d_
+ 
+@@ -26,10 +26,10 @@ class Part(ToolkitObject):
+     proxy = Typed(ProxyPart)
+     
+     #: Optional name of the part
+-    name = d_(Unicode())
++    name = d_(Str())
+     
+     #: Optional description of the part
+-    description = d_(Unicode())
++    description = d_(Str())
+     
+     @property
+     def shapes(self):
+diff --git a/examples/plot_area/plot_area.enaml b/examples/plot_area/plot_area.enaml
+index 2085c8f..b5cd3c4 100644
+--- a/examples/plot_area/plot_area.enaml
++++ b/examples/plot_area/plot_area.enaml
+@@ -2,7 +2,7 @@
+ Demonstrating the examples from pyqtgraph
+ """
+ 
+-from atom.api import (Atom, Unicode, Range, List, Bool)
++from atom.api import (Atom, Str, Range, List, Bool)
+ 
+ from enaml.widgets.api import (
+     Window, Container, DockArea,DockItem,PushButton, CheckBox, RadioButton
+diff --git a/examples/table_view/table_view.enaml b/examples/table_view/table_view.enaml
+index 6d7a35e..6fef544 100644
+--- a/examples/table_view/table_view.enaml
++++ b/examples/table_view/table_view.enaml
+@@ -2,7 +2,7 @@ import os
+ import time
+ import random
+ from threading import Thread
+-from atom.api import (Atom, Unicode, Range, ContainerList, Bool)
++from atom.api import (Atom, Str, Range, ContainerList, Bool)
+ 
+ from enamlx.widgets.table_view import (
+     TableView, TableViewRow, TableViewItem
+@@ -38,9 +38,9 @@ class Person(Atom):
+     """ A simple class representing a person object.
+ 
+     """
+-    last_name = Unicode()
++    last_name = Str()
+ 
+-    first_name = Unicode()
++    first_name = Str()
+ 
+     age = Range(low=0)
+ 
+diff --git a/examples/tree_view/tree_view.enaml b/examples/tree_view/tree_view.enaml
+index 37f991f..e88e1fd 100644
+--- a/examples/tree_view/tree_view.enaml
++++ b/examples/tree_view/tree_view.enaml
+@@ -1,5 +1,5 @@
+ import os
+-from atom.api import (Atom, Unicode, Range, List, Bool, ForwardInstance)
++from atom.api import (Atom, Str, Range, List, Bool, ForwardInstance)
+ 
+ from enamlx.widgets.api import (
+     TreeView, TreeViewItem, TreeViewColumn, 
+@@ -33,9 +33,9 @@ class Person(Atom):
+     """ A simple class representing a person object.
+ 
+     """
+-    last_name = Unicode()
++    last_name = Str()
+ 
+-    first_name = Unicode()
++    first_name = Str()
+     
+     children = List(ForwardInstance(lambda:Person))


### PR DESCRIPTION
###### Motivation for this change

Causes a crash in inkcut.

(another similar problem in inkcut remains, but this fixes the enamlx part)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).