### PR TITLE
[20.03] mutt: apply patch for CVE-2020-28896

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -34,10 +34,18 @@ stdenv.mkDerivation rec {
     sha256 = "0i0q6vwhnb1grimsrpmz8maw255rh9k0laijzxkry6xqa80jm5s7";
   };
 
-  patches = optional smimeSupport (fetchpatch {
-    url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
-    sha256 = "0b4i00chvx6zj9pcb06x2jysmrcb2znn831lcy32cgfds6gr3nsi";
-  });
+  patches = [
+    # CVE-2020-28896
+    (fetchpatch {
+      url = "https://gitlab.com/muttmua/mutt/-/commit/04b06aaa3e0cc0022b9b01dbca2863756ebbf59a.patch";
+      sha256 = "117mm757yj4k4cb9f1cmc9p0dqmi2mf92qsxvi8a794b9kdj5m2z";
+    })
+  ] ++ optional smimeSupport [
+    (fetchpatch {
+      url = "https://salsa.debian.org/mutt-team/mutt/raw/debian/1.10.1-2/debian/patches/misc/smime.rc.patch";
+      sha256 = "0b4i00chvx6zj9pcb06x2jysmrcb2znn831lcy32cgfds6gr3nsi";
+    })
+  ];
 
   buildInputs =
     [ ncurses which perl ]


### PR DESCRIPTION
###### Motivation for this change

mutt has improper handling of broken IMAP connections, this could result
in authentication credentials being sent over an unencrypted connection,
without $ssl_force_tls being consulted.

https://security.archlinux.org/CVE-2020-28896
https://gitlab.com/muttmua/mutt/-/commit/04b06aaa3e0cc0022b9b01dbca2863756ebbf59a

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested using a basic `imaps` connection OK

Result of `nixpkgs-review pr 104583` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>grepm</li>
    <li>mutt (mutt-with-sidebar)</li>
  </ul>
</details>

