### PR TITLE
awscli: 1.18.150 -> 1.18.183

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -7,6 +7,14 @@
 let
   py = python3.override {
     packageOverrides = self: super: {
+      botocore = super.botocore.overridePythonAttrs (oldAttrs: rec {
+        pname = "botocore";
+        version = "1.19.23";
+        src = super.fetchPypi {
+          inherit pname version;
+          sha256 = "07j851gc3zxz7q9894hh201jcgabgqvzmsnf6g0xkcia9fjgr7lz";
+        };
+      });
       rsa = super.rsa.overridePythonAttrs (oldAttrs: rec {
         version = "3.4.2";
         src = oldAttrs.src.override {
@@ -19,15 +27,16 @@ let
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "awscli";
-  version = "1.18.150"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.18.183"; # N.B: if you change this, change botocore to a matching version too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0jrxzr4dx2s6ychmrz19yz8i4kqcwj7f8ly82ydwvrr0ff62374g";
+    sha256 = "0n1pmdl33r1v8qnrcg08ihvri9zm4fvsp14605vwmlkxvs8nb7s5";
   };
 
   postPatch = ''
     substituteInPlace setup.py --replace "docutils>=0.10,<0.16" "docutils>=0.10"
+    substituteInPlace setup.py --replace "colorama>=0.2.5,<0.4.4" "colorama>=0.2.5"
   '';
 
   # No tests included


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix for compatibility issue with python3Packages.colorama: #104421 
Related PR: https://github.com/NixOS/nixpkgs/pull/104453

###### Things done
I override the botocore to match with awscli required version.
(not sure if i should have instead bumped the standard botocore)
And also postPatch substitute colorama requirement.

@flokli asked me if I could make this pr in https://github.com/NixOS/nixpkgs/issues/104421


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

I did, and got this fault, 
```
error: build of '/nix/store/7xwcd09hb8hn1ffjqx4xws97h5zjbhrs-env.drv' failed
1 package failed to build:
gitAndTools.git-remote-codecommit
```
But that shouldnt be related to this change.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

This works when i run it from my own nixrepo here:
https://github.com/afreakk/mynixrepo/commit/5feeb9f29b00b1d4f0508c27952a0f1c0f5de02d
