### PR TITLE
nixos/release-notes: Warn on wpa_supplicant changes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -1344,6 +1344,12 @@ CREATE ROLE postgres LOGIN SUPERUSER;
       that makes it unsuitable to be a default app.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       If you want to manage the configuration of <package>wpa_supplicant</package> outside of NixOS you must ensure that none of <xref linkend="opt-networking.wireless.networks" />, <xref linkend="opt-networking.wireless.extraConfig" /> or <xref linkend="opt-networking.wireless.userControlled.enable" /> is being used or <literal>true</literal>.
+       Using any of those options will cause <package>wpa_supplicant</package> to be started with a NixOS generated configuration file instead of your own.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
###### Motivation for this change
Warning about the changes as discussed in #102457 


If this is merged it obviously should be backported to be visible in the 20.09 release notes.
