### PR TITLE
ghostscript: fix broken rpath on Darwin

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -103,8 +103,20 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  # dynamic library name only contains maj.min, eg. '9.53'
+  dylib_version = lib.versions.majorMinor version;
   preFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -change libgs.dylib.${version} $out/lib/libgs.dylib.${version} $out/bin/gs
+    install_name_tool -change libgs.dylib.$dylib_version $out/lib/libgs.dylib.$dylib_version $out/bin/gs
+  '';
+
+  # validate dynamic linkage
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/gs --version
+
+    runHook postInstallCheck
   '';
 
   meta = {


### PR DESCRIPTION
Dynamic library name on Darwin contains only 'maj.min' eg "9.53";
the build however used $version to set rpath;
this broke on 2029ca37 when $version went from "9.52" to "9.53.3".

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>
