### PR TITLE
Add pgweb, a light and fast web-based PostgreSQL database browser

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9998,4 +9998,10 @@
     github = "pulsation";
     githubId = 1838397;
   };
+  zupo = {
+    name = "Nejc Zupan";
+    email = "nejczupan+nix@gmail.com";
+    github = "zupo";
+    githubId = 311580;
+  };
 }

--- a/pkgs/development/tools/database/pgweb/default.nix
+++ b/pkgs/development/tools/database/pgweb/default.nix
@@ -1,0 +1,26 @@
+{ buildGoPackage, fetchFromGitHub, lib }:
+
+buildGoPackage rec {
+  pname = "pgweb";
+  version = "0.11.7";
+
+  src = fetchFromGitHub {
+    owner = "sosedoff";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1df3vixxca80i040apbim80nqni94q882ykn3cglyccyl0iz59ix";
+  };
+
+  goPackagePath = "github.com/sosedoff/pgweb";
+
+  meta = with lib; {
+    description = "A web-based database browser for PostgreSQL";
+    longDescription = ''
+      A simple postgres browser that runs as a web server. You can view data,
+      run queries and examine tables and indexes.
+    '';
+    homepage = "https://sosedoff.github.io/pgweb/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zupo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13051,6 +13051,8 @@ in
 
   pgpkeyserver-lite = callPackage ../servers/web-apps/pgpkeyserver-lite {};
 
+  pgweb = callPackage ../development/tools/database/pgweb { };
+
   gpgstats = callPackage ../tools/security/gpgstats { };
 
   gpshell = callPackage ../development/tools/misc/gpshell { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Pgweb is a light & fast browser-based PostgreSQL browser that I have been using for years. Recently I moved from homebrew to darwin-nixos and added the code from this PR into my `configuration.nix` file. Then came the realization that I could/should upstream it! So here we are. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
