### PR TITLE
linuxPackages.xpadneo: 0.8.4 -> 0.9

### DIFF
--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xpadneo";
-  version = "0.8.4";
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "atar-axis";
     repo = pname;
     rev = "v${version}";
-    sha256 = "113xa2mxs2hc4fpjdk3jhhchy81kli6jxdd6vib7zz61n10cjb85";
+    sha256 = "1f146snbjkr3dgg3g1dav4q2621560zg5ixsip2wsvp7wfvahnhy";
   };
 
   setSourceRoot = ''
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # Set kernel module version
-    substituteInPlace hid-xpadneo.c \
+    substituteInPlace version.h \
       --subst-var-by DO_NOT_CHANGE ${version}
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest release: https://github.com/atar-axis/xpadneo/releases/tag/v0.9

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files. Enabled with `hardware.xpadneo.enable = true` & tested through use of Xbox One controller.

  Tested:
  - Bluetooth connectivity
  - All buttons
  - Rumble support
  <br/>

  ```
  > modinfo hid_xpadneo
  filename:       /run/current-system/kernel-modules/lib/modules/5.9.8/extra/hid-xpadneo.ko.xz
  version:        0.9
  description:    Linux kernel driver for Xbox ONE S+ gamepads (BT), incl. FF
  author:         Florian Dollinger <dollinger.florian@gmx.de>
  license:        GPL
  srcversion:     92CA97B6556AAA2B6867C29
  alias:          hid:b0005g*v0000045Ep00000B13
  alias:          hid:b0005g*v0000045Ep00000B05
  alias:          hid:b0005g*v0000045Ep000002E0
  alias:          hid:b0005g*v0000045Ep000002FD
  depends:        hid,ff-memless
  retpoline:      Y
  name:           hid_xpadneo
  vermagic:       5.9.8 SMP mod_unload
  parm:           combined_z_axis:(bool) Combine the triggers to form a single axis. 1: combine, 0: do not combine. (bool)
  parm:           trigger_rumble_mode:(u8) Trigger rumble mode. 0: pressure, 1: directional, 2: disable. (byte)
  parm:           rumble_attenuation:(u8) Attenuate the rumble strength: all[,triggers] 0 (none, full rumble) to 100 (max, no rumble). (array of byte)
  parm:           ff_connect_notify:(bool) Connection notification using force feedback. 1: enable, 0: disable. (bool)
  parm:           gamepad_compliance:(bool) Adhere to Linux Gamepad Specification by using signed axis values. 1: enable, 0: disable. (bool)
  parm:           disable_deadzones:(bool) Disable dead zone handling for raw processing by Wine/Proton, confuses joydev. 0: disable, 1: enable. (bool)
  parm:           quirks:(string) Override device quirks, specify as: "MAC1:quirks1[,...16]", MAC format = 11:22:33:44:55:66, no pulse parameters = 1, no trigger rumble = 2, no motor masking = 4, hardware profile switch = 8, use Linux button mappings = 16, use Nintendo mappings = 32, use Share button mappings = 64 (array of charp)
  ```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).