### PR TITLE
pythonPackages.pypandoc: fix tests for pandoc >= 2.11.2

### DIFF
--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch
 , pandoc, haskellPackages, texlive }:
 
 buildPythonPackage rec {
@@ -11,6 +11,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "1lpslfns6zxx7b0xr13bzg921lwrj5am8za0b2dviywk6iiib0ld";
   };
+
+  # https://github.com/bebraw/pypandoc/pull/204
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/sternenseemann/pypandoc/commit/e422e277dd667c77dae11fad931dbb6015e9a784.patch";
+      sha256 = "11l11kh2a4k0h1g4yvijb60076kzxlkrvda3x6dc1s8fz352bpg3";
+    })
+  ];
 
   postPatch = ''
     # set pandoc path statically


### PR DESCRIPTION
###### Motivation for this change

A change in the Markdown output of pandoc breaks the unicode input test
of pypandoc.

See also <https://github.com/bebraw/pypandoc/pull/204>.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
