### PR TITLE
thunar: fix wrapper build

### DIFF
--- a/pkgs/desktops/xfce/core/thunar/wrapper.nix
+++ b/pkgs/desktops/xfce/core/thunar/wrapper.nix
@@ -14,7 +14,14 @@ symlinkJoin {
     wrapProgram "$out/bin/thunar-settings" \
       --set "THUNARX_MODULE_DIR" "$out/lib/thunarx-3"
 
-    for file in "lib/systemd/user/thunar.service" "share/dbus-1/services/org.xfce.FileManager.service" \
+    # NOTE: we need to remove the folder symlink itself and create
+    # a new folder before trying to substitute any file below.
+    rm -f "$out/lib/systemd/user"
+    mkdir -p "$out/lib/systemd/user"
+
+    # point to wrapped binary in all service files
+    for file in "lib/systemd/user/thunar.service" \
+      "share/dbus-1/services/org.xfce.FileManager.service" \
       "share/dbus-1/services/org.xfce.Thunar.FileManager1.service" \
       "share/dbus-1/services/org.xfce.Thunar.service"
     do
@@ -24,7 +31,7 @@ symlinkJoin {
     done
   '';
 
-   meta = with lib; {
+  meta = with lib; {
     inherit (thunar.meta) homepage license platforms maintainers;
 
     description = thunar.meta.description + optionalString


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #101647.

The issue was that we were trying to remove the target `thunar.service` file rather than the symlinked directory pointing to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
