### PR TITLE
pythonPackages.class-registry: Add typing as propagatedBuildInput when python2

### DIFF
--- a/pkgs/development/python-modules/class-registry/default.nix
+++ b/pkgs/development/python-modules/class-registry/default.nix
@@ -4,6 +4,8 @@
   lib,
   nose,
   six,
+  typing,
+  isPy27,
 }:
 
 buildPythonPackage rec {
@@ -15,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "0zjf9nczl1ifzj07bgs6mwxsfd5xck9l0lchv2j0fv2n481xp2v7";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [ six ] ++ lib.optional isPy27 typing;
   checkInputs = [ nose ];
 
   # Tests currently failing.


### PR DESCRIPTION
###### Motivation for this change
When using python2 the package `class-registry` expects the dependency `typing`. This PR addresses this fact.

Reference: https://github.com/lenddoefl/class-registry/blob/master/setup.py#L32

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
