### PR TITLE
inchi: init at 1.05

### DIFF
--- a/pkgs/development/libraries/inchi/default.nix
+++ b/pkgs/development/libraries/inchi/default.nix
@@ -1,0 +1,51 @@
+{ pkgs, fetchurl, stdenv, unzip }:
+stdenv.mkDerivation {
+  pname = "inchi";
+  version = "1.05";
+  src = fetchurl {
+    url = "http://www.inchi-trust.org/download/105/INCHI-1-SRC.zip";
+    sha1 = "e3872a46d58cb321a98f4fd4b93a989fb6920b9c";
+  };
+
+  nativeBuildInputs = [ pkgs.unzip ];
+  outputs = [ "out" "doc" ];
+
+  enableParallelBuilding = true;
+
+  preBuild = ''
+    cd ./INCHI_API/libinchi/gcc
+  '';
+  installPhase = ''
+    cd ../../..
+    mkdir -p $out/lib
+    mkdir -p $out/include/inchi
+    mkdir -p $doc/share/
+
+    install -m 755 INCHI_API/bin/Linux/libinchi.so.1.05.00 $out/lib
+    ln -s $out/lib/libinchi.so.1.05.00 $out/lib/libinchi.so.1
+    ln -s $out/lib/libinchi.so.1.05.00 $out/lib/libinchi.so
+    install -m 644 INCHI_BASE/src/*.h $out/include/inchi
+
+    runHook postInstall
+  '';
+
+  postInstall =
+    let
+      src-doc = fetchurl {
+        url = "http://www.inchi-trust.org/download/105/INCHI-1-DOC.zip";
+        sha1 = "2f54y0san34v01c215kk0cigzsn76js5";
+      };
+    in
+    ''
+      unzip '${src-doc}'
+      install -m 644 INCHI-1-DOC/*.pdf $doc/share
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.inchi-trust.org/";
+    description = "IUPAC International Chemical Identifier library";
+    license = licenses.lgpl2Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rmcgibbo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2312,6 +2312,8 @@ in
 
   icdiff = callPackage ../tools/text/icdiff {};
 
+  inchi = callPackage ../development/libraries/inchi {};
+
   ifm = callPackage ../tools/graphics/ifm {};
 
   ink = callPackage ../tools/misc/ink { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds InChI library for cheminformations (https://www.inchi-trust.org/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
