### PR TITLE
rakudo: 2020.10 -> 2020.11

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rakudo";
-  version = "2020.10";
+  version = "2020.11";
 
   src = fetchurl {
     url    = "https://www.rakudo.org/dl/rakudo/rakudo-${version}.tar.gz";
-    sha256 = "0wvsinmpz8icd0409f8rg93mqdb5ml76m0vb4r26ngz237ph69dn";
+    sha256 = "107sskgf0p6npm3vjpv5wrqgfa007af6bxxiv1wgiyzx7maqdw5n";
   };
 
   buildInputs = [ icu zlib gmp perl ];

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "moarvm";
-  version = "2020.10";
+  version = "2020.11";
 
   src = fetchurl {
     url = "https://www.moarvm.org/releases/MoarVM-${version}.tar.gz";
-    sha256 = "1i7jjjwv4av3rsfgbqb213fhb9ns25jfm19nzn7kki0n7w486y33";
+    sha256 = "1163zv1fglgwbk6pppzbjwcgzpp13ilg5cz7fawsfnzdnrrq40kd";
    };
 
   buildInputs = [ perl ] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];

--- a/pkgs/development/interpreters/rakudo/nqp.nix
+++ b/pkgs/development/interpreters/rakudo/nqp.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nqp";
-  version = "2020.10";
+  version = "2020.11";
 
   src = fetchurl {
     url    = "https://github.com/raku/nqp/releases/download/${version}/nqp-${version}.tar.gz";
-    sha256 = "0nb0vdycz2wrd5yspvps2wy7a21066csr18v786085qim347830h";
+    sha256 = "03whmlc6bmwmwrddwd5vqmir0gzwnmf0apvl2q1na09qqj3zb1br";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/rakudo/rakudo/blob/2020.11/docs/ChangeLog

dependencies:
nqp: 2020.10 -> 2020.11
moarvm: 2020.10 -> 2020.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested OK on `linux x64` and `darwin x64`

Result of `nixpkgs-review pr 104644` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>moarvm</li>
    <li>nqp</li>
    <li>rakudo</li>
    <li>zef</li>
  </ul>
</details>

