### PR TITLE
leiningen: 2.9.1 -> 2.9.4

### DIFF
--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -3,17 +3,19 @@
 
 stdenv.mkDerivation rec {
   pname = "leiningen";
-  version = "2.9.1";
+  version = "2.9.4";
 
+  # This is necessary due to typo in the lein-pkg tagged with 2.9.4
+  lein-pkg-version = "7677dabea40a2d17a42a718ca8c7e450b09e153c";
   src = fetchurl {
-    url = "https://raw.github.com/technomancy/leiningen/${version}/bin/lein-pkg";
-    sha256 = "1h0gpzpr7xk6hvmrrq41bcp2k9aai348baf8ad9bxvci01n4zb12";
+    url = "https://raw.github.com/technomancy/leiningen/${lein-pkg-version}/bin/lein-pkg";
+    sha256 = "0qbxwfj2g75bh322041wjawrd4xzvb4vj28pza1zlx4iv1wp9lc0";
   };
 
   jarsrc = fetchurl {
     # NOTE: This is actually a .jar, Github has issues
     url = "https://github.com/technomancy/leiningen/releases/download/${version}/${pname}-${version}-standalone.zip";
-    sha256 = "1y2mva5s2w2szzn1b9rhz0dvkffls4ravii677ybcf2w9wd86z7a";
+    sha256 = "0v3hi2rv3zk1wrlfb4cdppmpi9flrfn2klqpad2g0z9lh2a36g0f";
   };
 
   JARNAME = "${pname}-${version}-standalone.jar";


### PR DESCRIPTION
- [x] Checked the [nixpkgs master branch](https://github.com/NixOS/nixpkgs)
- [x] Checked the [nixpkgs pull requests](https://github.com/NixOS/nixpkgs/pulls)

current version: 2.9.1
desired version: 2.9.4

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Get latest version of leiningen

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
