### PR TITLE
platforms.nix: Remove now unused kernelMajor

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -47,7 +47,6 @@ rec {
       arch = "armv5te";
     };
 
-    kernelMajor = "2.6";
     kernelBaseConfig = "multi_v5_defconfig";
     kernelArch = "arm";
     kernelAutoModules = false;
@@ -70,7 +69,6 @@ rec {
 
   sheevaplug = {
     name = "sheevaplug";
-    kernelMajor = "2.6";
     kernelBaseConfig = "multi_v5_defconfig";
     kernelArch = "arm";
     kernelAutoModules = false;
@@ -182,7 +180,6 @@ rec {
 
   raspberrypi = {
     name = "raspberrypi";
-    kernelMajor = "2.6";
     kernelBaseConfig = "bcm2835_defconfig";
     kernelDTB = true;
     kernelArch = "arm";
@@ -212,7 +209,6 @@ rec {
 
   utilite = {
     name = "utilite";
-    kernelMajor = "2.6";
     kernelBaseConfig = "multi_v7_defconfig";
     kernelArch = "arm";
     kernelAutoModules = false;
@@ -265,7 +261,6 @@ rec {
 
   armv7l-hf-multiplatform = {
     name = "armv7l-hf-multiplatform";
-    kernelMajor = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
     kernelBaseConfig = "multi_v7_defconfig";
     kernelArch = "arm";
     kernelDTB = true;
@@ -313,7 +308,6 @@ rec {
 
   aarch64-multiplatform = {
     name = "aarch64-multiplatform";
-    kernelMajor = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
     kernelBaseConfig = "defconfig";
     kernelArch = "arm64";
     kernelDTB = true;
@@ -352,7 +346,6 @@ rec {
 
   ben_nanonote = {
     name = "ben_nanonote";
-    kernelMajor = "2.6";
     kernelArch = "mips";
     gcc = {
       arch = "mips32";
@@ -362,7 +355,6 @@ rec {
 
   fuloong2f_n32 = {
     name = "fuloong2f_n32";
-    kernelMajor = "2.6";
     kernelBaseConfig = "lemote2f_defconfig";
     kernelArch = "mips";
     kernelAutoModules = false;


### PR DESCRIPTION
###### Motivation for this change

The last use of `kernelMajor` in Nixpkgs was removed in 2018.

Even then, I'm not positive it was actually in an exercised code path.

AFAIUI this is now totally redundant and useless as it really was meant
for the 2.4 -> 2.6 transition.

Context:

 - https://logs.nix.samueldr.com/nixos/2020-11-23#1606100144-1606100762;

If this is still in use, educate us :). I think it's simply that all parts using this were removed one by one, and we're left with this now-unused option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
