### PR TITLE
ccache: 4.0 -> 4.1

### DIFF
--- a/pkgs/development/tools/misc/ccache/default.nix
+++ b/pkgs/development/tools/misc/ccache/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , substituteAll
 , binutils
 , asciidoc
@@ -14,33 +13,16 @@
 
 let ccache = stdenv.mkDerivation rec {
   pname = "ccache";
-  version = "4.0";
+  version = "4.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1frcplrv61m2iwc6jwycpbcz1101xl6s4sh8p87prdj98l60lyrx";
+    sha256 = "1az11q3wmr8wc7alx9l70wq9am41cm0y17g5gsaqmahws3dxfi8m";
   };
 
-  # TODO: Remove patches from upstream in next release
-  patches = [
-    # Fix badly named man page filename
-    (fetchpatch {
-      url = "https://github.com/ccache/ccache/commit/223e706fb24ce86eb0ad86079a97e6f345b9ef40.patch";
-      sha256 = "1h7amp3ka45a79zwlxh8qnzx6n371gnfpfgijcqljps7skhl5gjg";
-    })
-    # Build and install man page by default
-    (fetchpatch {
-      url = "https://github.com/ccache/ccache/commit/294ff2face26448afa68e3ef7b68bf4898d6dc77.patch";
-      sha256 = "0rx69qn41bgksc4m3p59nk5d6rz72rwnfska9mh5j62pzfm8axja";
-    })
-    # Fixes use of undeclared identifier 'CLONE_NOOWNERCOPY' on darwin
-    (fetchpatch {
-      url = "https://github.com/ccache/ccache/commit/411c010c3a5ee690cd42b23ffcf026ae009e2897.patch";
-      sha256 = "062s424d0d0psp6wjhmfnfn1s5dsrz403hdid5drm6l2san0jhq0";
-    })
-  ] ++ lib.optional stdenv.isDarwin (substituteAll {
+  patches = lib.optional stdenv.isDarwin (substituteAll {
     src = ./force-objdump-on-darwin.patch;
     objdump = "${binutils.bintools}/bin/objdump";
   });


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version & remove the upstream patches: https://github.com/ccache/ccache/releases/tag/v4.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@r-burns