### PR TITLE
Add fcitx5

### DIFF
--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -29,7 +29,7 @@ in
   options.i18n = {
     inputMethod = {
       enabled = mkOption {
-        type    = types.nullOr (types.enum [ "ibus" "fcitx" "nabi" "uim" "hime" ]);
+        type    = types.nullOr (types.enum [ "ibus" "fcitx" "fcitx5" "nabi" "uim" "hime" ]);
         default = null;
         example = "fcitx";
         description = ''

--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  im = config.i18n.inputMethod;
+  cfg = im.fcitx5;
+  fcitx5Package = pkgs.fcitx5-with-addons.override { inherit (cfg) addons; };
+in
+  {
+    options = {
+      i18n.inputMethod.fcitx5 = {
+        addons = mkOption {
+          type = with types; listOf package;
+          default = [];
+          example = with pkgs; [ fcitx5-rime ];
+          description = ''
+            Enabled Fcitx5 addons.
+          '';
+        };
+      };
+    };
+
+    config = mkIf (im.enabled == "fcitx5") {
+      i18n.inputMethod.package = fcitx5Package;
+
+      environment.variables = {
+        GTK_IM_MODULE = "fcitx";
+        QT_IM_MODULE = "fcitx";
+        XMODIFIERS = "@im=fcitx";
+      };
+    };
+  }

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -82,6 +82,7 @@
   ./hardware/xpadneo.nix
   ./i18n/input-method/default.nix
   ./i18n/input-method/fcitx.nix
+  ./i18n/input-method/fcitx5.nix
   ./i18n/input-method/hime.nix
   ./i18n/input-method/ibus.nix
   ./i18n/input-method/nabi.nix

--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, boost
+, python3
+, fcitx5
+}:
+
+let
+  table = fetchurl {
+    url = "https://download.fcitx-im.org/data/table.tar.gz";
+    sha256 = "1dw7mgbaidv3vqy0sh8dbfv8631d2zwv5mlb7npf69a1f8y0b5k1";
+  };
+  arpaVer = "20140820";
+  arpa = fetchurl {
+    url = "https://download.fcitx-im.org/data/lm_sc.3gm.arpa-${arpaVer}.tar.bz2";
+    sha256 = "0bqy3l7mif0yygjrcm65qallszgn17mvgyxhvz7a54zaamyan6vm";
+  };
+  dictVer = "20200715";
+  dict = fetchurl {
+    url = "https://download.fcitx-im.org/data/dict.utf8-${dictVer}.tar.xz";
+    sha256 = "1ln7r64j8mc7wz4j0q4v8wd68wy7qqz4bz1dpxk7zqbdvza6rhr3";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "libime";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "libime";
+    rev = version;
+    sha256 = "hDfxuDIj9qx5d+UFwxDdP2PCboPnUV1n+VVoEIGsucM=";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    ln -s ${table} data/$(stripHash ${table})
+    ln -s ${arpa} data/$(stripHash ${arpa})
+    ln -s ${dict} data/$(stripHash ${dict})
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    python3
+  ];
+
+  buildInputs = [
+    boost
+    fcitx5
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A library to support generic input method implementation";
+    homepage = "https://github.com/fcitx/libime";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/xcb-imdkit/default.nix
+++ b/pkgs/development/libraries/xcb-imdkit/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, uthash
+, xcbutil
+, xcbutilkeysyms
+, xorgproto
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xcb-imdkit";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "xcb-imdkit";
+    rev = version;
+    sha256 = "dvax+Wj8+tHdiL6txcuugrOlRnxdIW25DYO4iNAYK8M=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    xorgproto
+    uthash
+  ];
+
+  buildInputs = [
+    xcbutil
+    xcbutilkeysyms
+  ];
+
+  meta = with stdenv.lib; {
+    description = "input method development support for xcb";
+    homepage = "https://github.com/fcitx/xcb-imdkit";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -1,0 +1,100 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, pkg-config
+, cmake
+, extra-cmake-modules
+, cairo
+, cldr-emoji-annotation
+, pango
+, fribidi
+, fmt
+, wayland
+, systemd
+, wayland-protocols
+, json_c
+, isocodes
+, xkeyboard_config
+, enchant
+, gdk-pixbuf
+, libGL
+, libevent
+, libuuid
+, libselinux
+, libXdmcp
+, libsepol
+, libxkbcommon
+, libthai
+, libdatrie
+, xcbutilkeysyms
+, pcre
+, xcbutilwm
+, xcb-imdkit
+, libxkbfile
+}:
+let
+  enDictVer = "20121020";
+  enDict = fetchurl {
+    url = "https://download.fcitx-im.org/data/en_dict-${enDictVer}.tar.gz";
+    sha256 = "1svcb97sq7nrywp5f2ws57cqvlic8j6p811d9ngflplj8xw5sjn4";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "fcitx5";
+  version = "5.0.3";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5";
+    rev = version;
+    sha256 = "QYMH0WbhHqDKUvpj1VOB8U5sbBD89H6moLFkQBJijZA=";
+  };
+
+  prePatch = ''
+    ln -s ${enDict} src/modules/spell/dict/$(stripHash ${enDict})
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkg-config
+  ];
+
+  buildInputs = [
+    fmt
+    isocodes
+    cairo
+    enchant
+    pango
+    libthai
+    libdatrie
+    fribidi
+    systemd
+    gdk-pixbuf
+    wayland
+    wayland-protocols
+    cldr-emoji-annotation
+    json_c
+    libGL
+    libevent
+    libuuid
+    libselinux
+    libsepol
+    libXdmcp
+    libxkbcommon
+    pcre
+    xcbutilwm
+    xcbutilkeysyms
+    xcb-imdkit
+    xkeyboard_config
+    libxkbfile
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Next generation of fcitx";
+    homepage = "https://github.com/fcitx/fcitx5";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, mkDerivation
+, fetchurl
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, boost
+, libime
+, fcitx5
+, fcitx5-qt
+, fcitx5-lua
+, qtwebengine
+, opencc
+, curl
+, fmt
+, luaSupport ? true
+}:
+
+let
+  pyStrokeVer = "20121124";
+  pyStroke = fetchurl {
+    url = "http://download.fcitx-im.org/data/py_stroke-${pyStrokeVer}.tar.gz";
+    sha256 = "0j72ckmza5d671n2zg0psg7z9iils4gyxz7jgkk54fd4pyljiccf";
+  };
+  pyTableVer = "20121124";
+  pyTable = fetchurl {
+    url = "http://download.fcitx-im.org/data/py_table-${pyTableVer}.tar.gz";
+    sha256 = "011cg7wssssm6hm564cwkrrnck2zj5rxi7p9z5akvhg6gp4nl522";
+  };
+in
+
+mkDerivation rec {
+  pname = "fcitx5-chinese-addons";
+  version = "5.0.2";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-chinese-addons";
+    rev = version;
+    sha256 = "11UIMrwzZqO8nrQx5oubeoQN8hspL1mvHw5Dc9sVOqQ=";
+  };
+
+  cmakeFlags = [
+    "-DUSE_WEBKIT=off"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    boost
+    fcitx5-lua
+  ];
+
+  prePatch = ''
+    ln -s ${pyStroke} modules/pinyinhelper/$(stripHash ${pyStroke})
+    ln -s ${pyTable} modules/pinyinhelper/$(stripHash ${pyTable})
+  '';
+
+  buildInputs = [
+    fcitx5
+    fcitx5-qt
+    libime
+    curl
+    opencc
+    qtwebengine
+    fmt
+  ] ++ stdenv.lib.optional luaSupport fcitx5-lua;
+
+  meta = with stdenv.lib; {
+    description = "Addons related to Chinese, including IME previous bundled inside fcitx4";
+    homepage = "https://github.com/fcitx/fcitx5-chinese-addons";
+    license = with licenses; [ gpl2Plus lgpl21Plus ];
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, fcitx5
+, fcitx5-qt
+, qtx11extras
+, kwidgetsaddons
+, kdeclarative
+, kirigami2
+, isocodes
+, xkeyboardconfig
+, libxkbfile
+, libXdmcp
+, kcmSupport ? true
+}:
+
+mkDerivation rec {
+  pname = "fcitx5-configtool";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-configtool";
+    rev = version;
+    sha256 = "npSqd0R6bqKc+JxYCGcfVzgNLpuLtnHq6zM58smZ8/I=";
+  };
+
+  cmakeFlags = [
+    "-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    fcitx5
+    fcitx5-qt
+    qtx11extras
+    kirigami2
+    isocodes
+    xkeyboardconfig
+    libxkbfile
+    libXdmcp
+  ] ++ stdenv.lib.optionals kcmSupport [
+    kdeclarative
+    kwidgetsaddons
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Configuration Tool for Fcitx5";
+    homepage = "https://github.com/fcitx/fcitx5-configtool";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, fcitx5
+, gobject-introspection
+, gtk2
+, gtk3
+, pcre
+, libuuid
+, libselinux
+, libsepol
+, libthai
+, libdatrie
+, libXdmcp
+, libxkbcommon
+, epoxy
+, dbus
+, at-spi2-core
+, libXtst
+, withGTK2 ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-gtk";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-gtk";
+    rev = version;
+    sha256 = "rkusIqMRQMTjcpJR335as1xUQrzD9dLVB/wrLstPXPY=";
+  };
+
+  cmakeFlags = [
+    "-DGOBJECT_INTROSPECTION_GIRDIR=share/gir-1.0"
+    "-DGOBJECT_INTROSPECTION_TYPELIBDIR=lib/girepository-1.0"
+  ] ++ stdenv.lib.optional (! withGTK2) "-DENABLE_GTK2_IM_MODULE=off";
+
+  buildInputs = [
+    gtk3
+    gobject-introspection
+    fcitx5
+    pcre
+    libuuid
+    libselinux
+    libsepol
+    libthai
+    libdatrie
+    libXdmcp
+    libxkbcommon
+    epoxy
+    dbus
+    at-spi2-core
+    libXtst
+  ] ++ stdenv.lib.optional withGTK2 gtk2;
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Fcitx5 gtk im module and glib based dbus client library";
+    homepage = "https://github.com/fcitx/fcitx5-gtk";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, fcitx5
+, lua5_3
+, luaPackage ? lua5_3
+, gettext
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-lua";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-lua";
+    rev = "${version}";
+    sha256 = "OiTk9ldqBqF7WT1KY71hacLD6OQQNO05F7+cSXlli40=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    fcitx5
+    luaPackage
+    gettext
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Lua support for Fcitx 5";
+    homepage = "https://github.com/fcitx/fcitx5-lua";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, fcitx5
+, qtx11extras
+, libxcb
+, libXdmcp
+}:
+
+mkDerivation rec {
+  pname = "fcitx5-qt";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-qt";
+    rev = version;
+    sha256 = "BVOumk2xj3vmwmm4KwiktQhWyTuUA2OFwYXNR6HgwyM=";
+  };
+
+  cmakeFlags = [
+    "-DENABLE_QT4=0"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    fcitx5
+    qtx11extras
+    libxcb
+    libXdmcp
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Fcitx5 Qt Library";
+    homepage = "https://github.com/fcitx/fcitx5-qt";
+    license = with licenses; [ lgpl21Plus bsd3 ];
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, pkgconfig
+, cmake
+, extra-cmake-modules
+, gettext
+, fcitx5
+, librime
+, brise
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-rime";
+  version = "5.0.2";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-rime";
+    rev = version;
+    sha256 = "cVCTsD1Iw6OtyYFpxff3ix2CubRTnDaBevAYA4I9Ai8=";
+  };
+
+  cmakeFlags = [
+    "-DRIME_DATA_DIR=${brise}/share/rime-data"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    pkgconfig
+    gettext
+  ];
+
+  buildInputs = [
+    fcitx5
+    librime
+  ];
+
+  meta = with stdenv.lib; {
+    description = "RIME support for Fcitx5";
+    homepage = "https://github.com/fcitx/fcitx5-rime";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-table-extra.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-table-extra.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, gettext
+, libime
+, boost
+, fcitx5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-table-extra";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-table-extra";
+    rev = version;
+    sha256 = "UHhiWm2Khh6JBB9jz0ZKFofkAJPlqn6SqHeK9etoaxs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    gettext
+    libime
+    boost
+    fcitx5
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Extra table for Fcitx, including Boshiamy, Zhengma, Cangjie, and Quick";
+    homepage = "https://github.com/fcitx/fcitx5-table-extra";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-table-other.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-table-other.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, gettext
+, libime
+, boost
+, fcitx5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fcitx5-table-other";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "fcitx5-table-other";
+    rev = version;
+    sha256 = "hQlrjDPImDof2+3/uOtTdJ27cInevbxH9B+lNwquKbs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    gettext
+    libime
+    boost
+    fcitx5
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Some other tables for Fcitx";
+    homepage = "https://github.com/fcitx/fcitx5-table-other";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ poscat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -1,0 +1,18 @@
+{ symlinkJoin, makeWrapper, fcitx5, fcitx5-lua, fcitx5-configtool, fcitx5-qt, fcitx5-gtk, addons ? [] }:
+
+symlinkJoin {
+  name = "fcitx5-with-addons-${fcitx5.version}";
+
+  paths = [ fcitx5 fcitx5-configtool fcitx5-lua fcitx5-qt fcitx5-gtk ] ++ addons;
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/fcitx5 \
+      --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
+      --suffix XDG_DATA_DIRS : "$out/share" \
+      --suffix PATH : "$out/bin"
+  '';
+
+  meta = fcitx5.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,6 +3934,8 @@ in
 
   fcitx5 = libsForQt5.callPackage ../tools/inputmethods/fcitx5 { };
 
+  fcitx5-chinese-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
+
   fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
 
   fcitx5-lua = callPackage ../tools/inputmethods/fcitx5/fcitx5-lua.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,6 +3934,8 @@ in
 
   fcitx5 = libsForQt5.callPackage ../tools/inputmethods/fcitx5 { };
 
+  fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
+
   fcitx5-gtk = callPackage ../tools/inputmethods/fcitx5/fcitx5-gtk.nix { };
 
   fcppt = callPackage ../development/libraries/fcppt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,6 +3934,8 @@ in
 
   fcitx5 = libsForQt5.callPackage ../tools/inputmethods/fcitx5 { };
 
+  fcitx5-with-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/with-addons.nix { };
+
   fcitx5-chinese-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
 
   fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3936,6 +3936,8 @@ in
 
   fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
 
+  fcitx5-lua = callPackage ../tools/inputmethods/fcitx5/fcitx5-lua.nix { };
+
   fcitx5-gtk = callPackage ../tools/inputmethods/fcitx5/fcitx5-gtk.nix { };
 
   fcitx5-rime = callPackage ../tools/inputmethods/fcitx5/fcitx5-rime.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3938,6 +3938,8 @@ in
 
   fcitx5-gtk = callPackage ../tools/inputmethods/fcitx5/fcitx5-gtk.nix { };
 
+  fcitx5-rime = callPackage ../tools/inputmethods/fcitx5/fcitx5-rime.nix { };
+
   fcppt = callPackage ../development/libraries/fcppt { };
 
   fcrackzip = callPackage ../tools/security/fcrackzip { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3932,6 +3932,8 @@ in
 
   chewing-editor = libsForQt5.callPackage ../applications/misc/chewing-editor { };
 
+  fcitx5 = libsForQt5.callPackage ../tools/inputmethods/fcitx5 { };
+
   fcppt = callPackage ../development/libraries/fcppt { };
 
   fcrackzip = callPackage ../tools/security/fcrackzip { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,6 +3934,8 @@ in
 
   fcitx5 = libsForQt5.callPackage ../tools/inputmethods/fcitx5 { };
 
+  fcitx5-gtk = callPackage ../tools/inputmethods/fcitx5/fcitx5-gtk.nix { };
+
   fcppt = callPackage ../development/libraries/fcppt { };
 
   fcrackzip = callPackage ../tools/security/fcrackzip { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12442,6 +12442,8 @@ in
 
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };
 
+  xcb-imdkit = callPackage ../development/libraries/xcb-imdkit { };
+
   xcodebuild = callPackage ../development/tools/xcbuild/wrapper.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices CoreGraphics ImageIO;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3948,6 +3948,8 @@ in
 
   fcitx5-table-extra = callPackage ../tools/inputmethods/fcitx5/fcitx5-table-extra.nix { };
 
+  fcitx5-table-other = callPackage ../tools/inputmethods/fcitx5/fcitx5-table-other.nix { };
+
   fcppt = callPackage ../development/libraries/fcppt { };
 
   fcrackzip = callPackage ../tools/security/fcrackzip { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3946,6 +3946,8 @@ in
 
   fcitx5-rime = callPackage ../tools/inputmethods/fcitx5/fcitx5-rime.nix { };
 
+  fcitx5-table-extra = callPackage ../tools/inputmethods/fcitx5/fcitx5-table-extra.nix { };
+
   fcppt = callPackage ../development/libraries/fcppt { };
 
   fcrackzip = callPackage ../tools/security/fcrackzip { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15842,6 +15842,8 @@ in
 
     fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };
 
+    fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
+
     qgpgme = callPackage ../development/libraries/gpgme { };
 
     grantlee = callPackage ../development/libraries/grantlee/5 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14591,6 +14591,8 @@ in
 
   libimagequant = callPackage ../development/libraries/libimagequant {};
 
+  libime = callPackage ../development/libraries/libime { };
+
   libinfinity = callPackage ../development/libraries/libinfinity { };
 
   libinput = callPackage ../development/libraries/libinput {


### PR DESCRIPTION
closes #102626

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
