### PR TITLE
wacomtablet: Fix build with Qt5.15, pending new release

### DIFF
--- a/pkgs/tools/misc/wacomtablet/default.nix
+++ b/pkgs/tools/misc/wacomtablet/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchurl, extra-cmake-modules, qtx11extras,
+{ lib, mkDerivation, fetchurl, fetchpatch, extra-cmake-modules, qtx11extras,
   plasma-workspace, libwacom, xf86_input_wacom
 }:
 
@@ -9,6 +9,12 @@ mkDerivation rec {
     url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
     sha256 = "197pwpl87gqlnza36bp68jvw8ww25znk08acmi8bpz7n84xfc368";
   };
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/system/wacomtablet/commit/4f73ff02b3efd5e8728b18fcf1067eca166704ee.patch";
+      sha256 = "0185gbh1vywfz8a3wnvncmzdk0dd189my4bzimkbh85rlrqq2nf8";
+    })
+  ];
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
@@ -22,7 +28,7 @@ mkDerivation rec {
       This module implements a GUI for the Wacom Linux Drivers and extends it
       with profile support to handle different button / pen layouts per profile.
     '';
-    homepage = "https://cgit.kde.org/wacomtablet.git/about/";
+    homepage = "https://invent.kde.org/system/wacomtablet";
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.Thra11 ];
     platforms = lib.platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28118,7 +28118,7 @@ in
 
   vttest = callPackage ../tools/misc/vttest { };
 
-  wacomtablet = libsForQt514.callPackage ../tools/misc/wacomtablet { };
+  wacomtablet = libsForQt5.callPackage ../tools/misc/wacomtablet { };
 
   wasmer = callPackage ../development/interpreters/wasmer { };
 


### PR DESCRIPTION
Also update homepage

###### Motivation for this change
Hopefully fix #104384

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
