### PR TITLE
dash: add patch to prevent code execution when noexec is set

### DIFF
--- a/pkgs/shells/dash/default.nix
+++ b/pkgs/shells/dash/default.nix
@@ -1,17 +1,25 @@
 { stdenv, buildPackages, autoreconfHook, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "dash-0.5.11.2";
+  pname = "dash";
+  version = "0.5.11.2";
 
   src = fetchurl {
-    url = "http://gondor.apana.org.au/~herbert/dash/files/${name}.tar.gz";
+    url = "http://gondor.apana.org.au/~herbert/dash/files/${pname}-${version}.tar.gz";
     sha256 = "0pvdpm1cgfbc25ramn4305a0158yq031q1ain4dc972rnxl7vyq0";
   };
 
   hardeningDisable = [ "format" ];
 
   # Temporary fix until a proper one is accepted upstream
-  patches = stdenv.lib.optional stdenv.isDarwin ./0001-fix-dirent64-et-al-on-darwin.patch;
+  patches = [
+    (fetchurl {
+      # Dash executes code when noexec ("-n") is specified
+      # https://www.openwall.com/lists/oss-security/2020/11/11/3
+      url = "https://git.kernel.org/pub/scm/utils/dash/dash.git/patch/?id=29d6f2148f10213de4e904d515e792d2cf8c968e";
+      sha256 = "08q90bx36ixwlcj331dh7420qyj8i0qh1cc1gljrhd83fhl9w0y5";
+    })
+  ] ++ stdenv.lib.optional stdenv.isDarwin ./0001-fix-dirent64-et-al-on-darwin.patch;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin autoreconfHook;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Dashs noexec flag `-n` did not work as documented, which could result in
code being inadvertently executed.

https://bugzilla.suse.com/show_bug.cgi?id=1178978

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
