### PR TITLE
pythonPackages.mesa: unstable-2019-12-09 -> 0.8.7

### DIFF
--- a/pkgs/development/python-modules/mesa/default.nix
+++ b/pkgs/development/python-modules/mesa/default.nix
@@ -4,8 +4,7 @@
 
 buildPythonPackage rec {
   pname = "mesa";
-  # contains several fixes for networkx 2.4 bump
-  version = "unstable-2019-12-09";
+  version = "0.8.7";
 
   # According to their docs, this library is for Python 3+.
   disabled = isPy27;
@@ -13,8 +12,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "projectmesa";
     repo = "mesa";
-    rev = "86b343b42630e94d939029ff2cc609ff04ed40e9";
-    sha256 = "1y41s1vd89vcsm4aia18ayfff4w2af98lwn5l9fcwp157li985vw";
+    rev = "v${version}";
+    sha256 = "0i1bpdqjrx4avgrzyqxpwxx86j11yhrq1j4kca854xahvhmwis19";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Using unstable (the version currently in nixpkgs) fixed some problems. By now, there exists a working stable (which fixes additional issues and, I think, stable releases are generally preferred(?)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
