### PR TITLE
toybox: Add option to enable shell support

### DIFF
--- a/pkgs/tools/misc/toybox/default.nix
+++ b/pkgs/tools/misc/toybox/default.nix
@@ -2,6 +2,7 @@
   stdenv, lib, fetchFromGitHub, which,
   enableStatic ? false,
   enableMinimal ? false,
+  enableShell ? false,
   extraConfig ? ""
 }:
 
@@ -36,7 +37,11 @@ stdenv.mkDerivation rec {
           "defconfig"
     }
 
-    cat $extraConfigPath .config > .config-
+    ${lib.optionalString enableShell ''
+      echo "CONFIG_SH=y" >> .config-
+    ''}
+    cat $extraConfigPath .config >> .config-
+
     mv .config- .config
 
     make oldconfig
@@ -54,6 +59,10 @@ stdenv.mkDerivation rec {
   checkTarget = "tests";
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  passthru = lib.mkIf enableShell ({
+    shellPath = "/bin/bash";
+  });
 
   meta = with stdenv.lib; {
     description = "Lightweight implementation of some Unix command line utilities";


### PR DESCRIPTION
###### Motivation for this change

`toybox` can provide a shell, which has to be enabled specifically via compile time config.
This settings can be enabled via `override`, but `NixOS` uses `passthrugh.shell` to advertise that a package provides a shell, which has footguns when used with `override` and `overrideAttr`.
Therefore it makes sense to expose an option to do this correctly.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
