### PR TITLE
deno: 1.5.3 -> 1.5.4 -> 1.6.0 -> 1.6.1 -> 1.6.2 -> 1.6.3

### DIFF
--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0irqwpvg7763pdbdkf0pvmch4ip6wjvbclv0ba5z8p3n2b3v5hd6";
+    sha256 = "07hz0hnx2shqjgk3x4gymvd6j24gzkxaknqvxg1nff42bx65jvfi";
     fetchSubmodules = true;
   };
-  cargoSha256 = "0187xg9k399d5zdj4yg7fl8qhpyw7gvi8vfjs0ifa9rlc7g6ndjz";
+  cargoSha256 = "1vspqqx5g65flwqnxvism1aq34cg7h3xf076siy91iw5iphmwqd8";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];
@@ -58,10 +58,8 @@ rustPlatform.buildRustPackage rec {
 
     installShellCompletion --cmd deno \
       --bash <($out/bin/deno completions bash) \
-      --fish <($out/bin/deno completions fish)
-    # deno zsh completion broken since 1.5.4
-    # waiting for fix https://github.com/denoland/deno/issues/8472
-    # --zsh <($out/bin/deno completions zsh)
+      --fish <($out/bin/deno completions fish) \
+      --zsh <($out/bin/deno completions zsh)
   '';
 
   passthru.updateScript = ./update/update.ts;

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.6.1";
+  version = "1.6.2";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07hz0hnx2shqjgk3x4gymvd6j24gzkxaknqvxg1nff42bx65jvfi";
+    sha256 = "0hfs2059ps9hzmg55qsvh59wnw68gj3vy9j857bdrbdxhmaabk2k";
     fetchSubmodules = true;
   };
-  cargoSha256 = "1vspqqx5g65flwqnxvism1aq34cg7h3xf076siy91iw5iphmwqd8";
+  cargoSha256 = "0d15rzrjymcpajz9pnnzib3wij4fgvsbmxjrfhj3knmxmzr3l8kq";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0hfs2059ps9hzmg55qsvh59wnw68gj3vy9j857bdrbdxhmaabk2k";
+    sha256 = "1wmkx458fpsfw57ysawxc0ghxag8v051hiyswm7nnb7gckrm6j8z";
     fetchSubmodules = true;
   };
-  cargoSha256 = "0d15rzrjymcpajz9pnnzib3wij4fgvsbmxjrfhj3knmxmzr3l8kq";
+  cargoSha256 = "08vzsp53019gmxkn8lpa6l84w3fvbrnr11lzrfgf99nmii6l2hq5";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.5.3";
+  version = "1.5.4";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0dxjcab10kqfkflq1x9np5wxlysq33swdwi2f28bi7q312sw5x2y";
+    sha256 = "1m1hcnfy93lw9qgihkdsj4b8kwqa1za00d44rffc3wrcrkriks53";
     fetchSubmodules = true;
   };
-  cargoSha256 = "0lhdrsvmf5b4fq2yg9vc00q1sgc1fjk0fh5axs2zffcpsp73ay2k";
+  cargoSha256 = "0fhiba7ng4jcq0ngpcfwh31dz0b25absg74g3f8kflz2a49fhwp9";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];
@@ -58,8 +58,10 @@ rustPlatform.buildRustPackage rec {
 
     installShellCompletion --cmd deno \
       --bash <($out/bin/deno completions bash) \
-      --fish <($out/bin/deno completions fish) \
-      --zsh <($out/bin/deno completions zsh)
+      --fish <($out/bin/deno completions fish)
+    # deno zsh completion broken since 1.5.4
+    # waiting for fix https://github.com/denoland/deno/issues/8472
+    # --zsh <($out/bin/deno completions zsh)
   '';
 
   passthru.updateScript = ./update/update.ts;

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -18,16 +18,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.5.4";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1m1hcnfy93lw9qgihkdsj4b8kwqa1za00d44rffc3wrcrkriks53";
+    sha256 = "0irqwpvg7763pdbdkf0pvmch4ip6wjvbclv0ba5z8p3n2b3v5hd6";
     fetchSubmodules = true;
   };
-  cargoSha256 = "0fhiba7ng4jcq0ngpcfwh31dz0b25absg74g3f8kflz2a49fhwp9";
+  cargoSha256 = "0187xg9k399d5zdj4yg7fl8qhpyw7gvi8vfjs0ifa9rlc7g6ndjz";
 
   # Install completions post-install
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/development/web/deno/deps.nix
+++ b/pkgs/development/web/deno/deps.nix
@@ -2,11 +2,11 @@
 {}:
 rec {
   rustyV8Lib = {
-    version = "0.13.0";
+    version = "0.14.0";
     sha256s = {
-      x86_64-linux = "14xp5kac99ixrgx0d45kls54ihfs8g2qqnqir9r8fgsybl3imhyx";
-      aarch64-linux = "01b98cvazbzmb540j1w8b770xb9j23af61qb9f9kslb510k1jcdr";
-      x86_64-darwin = "0qw2whg8xqvp49mfv0li6baalzj2ydc9y2xn61bnyvif8ykpgw7h";
+      x86_64-linux = "0wsq2xziq1f6xx1wv4v7qbg7ljmgapjd0jh87s2ybzqzh1k4l1kv";
+      aarch64-linux = "1qvk7ylng7ys1vbq9f2kwd14j3zx70cq4gbfj08lh3b69m2b9yid";
+      x86_64-darwin = "10v1axydnigdrpd7y3x26ypr6fizc2r7kzfn4mzykvif4q4pblmf";
     };
   };
 }

--- a/pkgs/development/web/deno/deps.nix
+++ b/pkgs/development/web/deno/deps.nix
@@ -2,11 +2,11 @@
 {}:
 rec {
   rustyV8Lib = {
-    version = "0.14.0";
+    version = "0.15.0";
     sha256s = {
-      x86_64-linux = "0wsq2xziq1f6xx1wv4v7qbg7ljmgapjd0jh87s2ybzqzh1k4l1kv";
-      aarch64-linux = "1qvk7ylng7ys1vbq9f2kwd14j3zx70cq4gbfj08lh3b69m2b9yid";
-      x86_64-darwin = "10v1axydnigdrpd7y3x26ypr6fizc2r7kzfn4mzykvif4q4pblmf";
+      x86_64-linux = "1j789pvqh44vsffzl5wg3pp3awrlixjrhbnjx2klsml7jv0lp0mq";
+      aarch64-linux = "13srja4vc275ygm806hcsr8mxjnd9qkzaqs58lxnp0702qs5xls6";
+      x86_64-darwin = "0aij9yb5i1r3pz0pyl51qdbgfspfdngwbk1qgkp4gxzl3cbnysx1";
     };
   };
 }

--- a/pkgs/development/web/deno/deps.nix
+++ b/pkgs/development/web/deno/deps.nix
@@ -2,11 +2,11 @@
 {}:
 rec {
   rustyV8Lib = {
-    version = "0.12.0";
+    version = "0.13.0";
     sha256s = {
-      x86_64-linux = "18pim960fh18wrdkhirlj4hnnbxrk172r7yksdn2k5z9lgccighg";
-      aarch64-linux = "0d1c8kcz44n1mqprspnshzbqlqw7mq7vryxpmd49gw3fvhcy66y7";
-      x86_64-darwin = "1pc2dfq8p1a8dahkc4g8r6b9zwnvds60zc2lgbf8cj5n0ijd06y1";
+      x86_64-linux = "14xp5kac99ixrgx0d45kls54ihfs8g2qqnqir9r8fgsybl3imhyx";
+      aarch64-linux = "01b98cvazbzmb540j1w8b770xb9j23af61qb9f9kslb510k1jcdr";
+      x86_64-darwin = "0qw2whg8xqvp49mfv0li6baalzj2ydc9y2xn61bnyvif8ykpgw7h";
     };
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump deno to ~`1.5.4`~ ~`1.6.0`~ ~`1.6.1`~ ~`1.6.2`~ `1.6.3`

Big change in `1.6.0`: can now use deno to compile/bundle a binary

It bundles and runs successfully on nix. Since it's using the underlying deno binary it's linked to all the same dependencies and will only work on a nix machine with said pinned dependencies.
I think that's fine for now, this is an early implementation of the feature.

I haven't seen much on a static version. I'm guessing in theory a static rust binary could be created with the `86_64-unknown-linux-musl` toolchain but [there isn't a pre-compiled `rusty_v8` library for it](https://github.com/denoland/rusty_v8/releases) and that'll take ages for us to compile so I'm not planning on trying that until there's a pre-compiled lib file.

```
$ ./result/bin/deno compile --unstable https://deno.land/std@0.79.0/examples/cat.ts
Download https://deno.land/std@0.79.0/examples/cat.ts
Check https://deno.land/std@0.79.0/examples/cat.ts
Bundle https://deno.land/std@0.79.0/examples/cat.ts
Compile https://deno.land/std@0.79.0/examples/cat.ts
Emit cat
```

```
$ ./cat README.md
<p align="center">
  <a href="https://nixos.org/nixos"><img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="NixOS logo" /></a>
</p>
# ...
```

```
$ ldd cat
	linux-vdso.so.1 (0x00007ffce21ec000)
	libgcc_s.so.1 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libgcc_s.so.1 (0x00007f0a7f613000)
	libc.so.6 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libc.so.6 (0x00007f0a7f452000)
	/nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/ld-linux-x86-64.so.2 => /nix/store/a3syww9igm49zdzq3ibzw9m8ccvsgxla-glibc-2.32/lib64/ld-linux-x86-64.so.2 (0x00007f0a817b8000)
	libm.so.6 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libm.so.6 (0x00007f0a7f30f000)
	libpthread.so.0 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libpthread.so.0 (0x00007f0a7f2ee000)
	libdl.so.2 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libdl.so.2 (0x00007f0a7f2e9000)
```

```
ldd ./result/bin/deno
	linux-vdso.so.1 (0x00007ffc60d80000)
	libgcc_s.so.1 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libgcc_s.so.1 (0x00007fa711ede000)
	libc.so.6 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libc.so.6 (0x00007fa711d1d000)
	/nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/ld-linux-x86-64.so.2 => /nix/store/a3syww9igm49zdzq3ibzw9m8ccvsgxla-glibc-2.32/lib64/ld-linux-x86-64.so.2 (0x00007fa714083000)
	libm.so.6 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libm.so.6 (0x00007fa711bda000)
	libpthread.so.0 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libpthread.so.0 (0x00007fa711bb9000)
	libdl.so.2 => /nix/store/9l06v7fc38c1x3r2iydl15ksgz0ysb82-glibc-2.32/lib/libdl.so.2 (0x00007fa711bb4000)
```

---

~had to remove ZSH completion in `1.5.4` until it's fixed~ fixed in `1.6.1`

```
    Finished release [optimized] target(s) in 12m 14s
installing
thread 'main' panicked at 'Fatal internal error. Please consider filing a bug report at https://github.com/clap-rs/clap/issues', /build/deno-1.5.4-vendor.tar.gz/clap/src/completions/zsh.rs:407:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/5cpmhqpfz2mql2jmmmyjnj1piiilknmj-deno-1.5.4
# ... etc
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
