### PR TITLE
fetch-kde-qt.sh: support current layout of download.kde.org

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -24,8 +24,6 @@ wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sig' -A '*.tar.xz.mirr
 # Delete *.mirrorlist (they were only needed to find *.sha256 files)
 find -type f -name '*.mirrorlist' -delete
 
-#read -p "See current files in $(pwd)"
-
 csv=$(mktemp)
 # KDE sig files
 find . -type f -name '*.sig' | while read src; do
@@ -53,8 +51,6 @@ find . -type f -name '*.sha256' | while read src; do
     path=$(dirname ${src:2})
     echo "$name,$version,$sha256,$filename,$path" >>$csv
 done
-
-#read -p "See CSV in $csv"
 
 cat >"$SRCS" <<EOF
 # DO NOT EDIT! This file is generated automatically.

--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -5,9 +5,9 @@ set -efuo pipefail
 
 print_usage() {
     echo "Usage: $0 [PATH|FILE]"
-    echo "This file expects a file 'fetch.sh' containing"
+    echo "This file expects a 'fetch.sh' containing"
     echo "   WGET_ARGS=(<base url>)"
-    echo "in PATH or as a sibling of FILE. If fetches all *.tar.xz.(sig|mirrorlist|sha256) files"
+    echo "in PATH or passed as FILE. If fetches all *.tar.xz.(sig|mirrorlist|sha256) files"
     echo "from <base url> and constructs a 'srcs.nix' file from them."
     echo ""
     echo "Sample invocation: $0 pkgs/development/libraries/kde-frameworks/"

--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -3,13 +3,31 @@
 
 set -efuo pipefail
 
+print_usage() {
+    echo "Usage: $0 [PATH|FILE]"
+    echo "This file expects a file 'fetch.sh' containing"
+    echo "   WGET_ARGS=(<base url>)"
+    echo "in PATH or as a sibling of FILE. If fetches all *.tar.xz.(sig|mirrorlist|sha256) files"
+    echo "from <base url> and constructs a 'srcs.nix' file from them."
+    echo ""
+    echo "Sample invocation: $0 pkgs/development/libraries/kde-frameworks/"
+}
+
+if [ $# -eq 0 ]; then
+    print_usage
+    exit -2
+fi
+
 SRCS=
 if [ -d "$1" ]; then
     SRCS="$(pwd)/$1/srcs.nix"
     . "$1/fetch.sh"
-else
+elif [ -f "$1" ]; then
     SRCS="$(pwd)/$(dirname $1)/srcs.nix"
     . "$1"
+else
+    print_usage
+    exit -1
 fi
 
 tmp=$(mktemp -d)
@@ -88,3 +106,4 @@ popd >/dev/null
 rm -fr $tmp >/dev/null
 
 rm -f $csv >/dev/null
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The script fetch-kde-qt.sh stopped working for the (new?) layout of download.kde.org. This PR restores functionality to fetch source package names and sha256 sums for plasma, kde and qt to write them into srcs.nix files.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
