### PR TITLE
freac: init 1.1.3

### DIFF
--- a/pkgs/applications/audio/freac/default.nix
+++ b/pkgs/applications/audio/freac/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, boca
+, smooth
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "freac";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "enzo1982";
+    repo = "freac";
+    rev = "v${version}";
+    sha256 = "1sdrsc5pn5901bbds7dj02n71zn5rs4wnv2xxs8ffql4b7jjva0m";
+  };
+
+  buildInputs = [
+    boca
+    smooth
+    systemd
+  ];
+
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "The fre:ac audio converter project";
+    license = licenses.gpl2Plus;
+    homepage = "https://www.freac.org/";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/boca/default.nix
+++ b/pkgs/development/libraries/boca/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+
+, expat
+, libcdio
+, libcdio-paranoia
+, libpulseaudio
+, smooth
+, uriparser
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "BoCA";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "enzo1982";
+    repo = "boca";
+    rev = "v${version}";
+    sha256 = "0x6pqd5cdag0l283lkq01qaqwyf1skxbncdwig8b2s742nbzjlz8";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    expat
+    libcdio
+    libcdio-paranoia
+    libpulseaudio
+    smooth
+    uriparser
+    zlib
+  ];
+
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+
+  meta = with lib; {
+    description = "A component library used by the fre:ac audio converter";
+    license = licenses.gpl2Plus;
+    homepage = "https://github.com/enzo1982/boca";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/smooth/default.nix
+++ b/pkgs/development/libraries/smooth/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+
+, gtk3
+, curl
+, libxml2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "smooth";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "enzo1982";
+    repo = "smooth";
+    rev = "v${version}";
+    sha256 = "05j5gk6kz2089x8bcq2l0kjspfiiymxn69jcxl4dh9lw96blbadr";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+
+  buildInputs = [
+    gtk3
+    curl
+    libxml2
+  ];
+
+  meta = with lib; {
+    description = "The smooth Class Library";
+    license = licenses.artistic2;
+    homepage = "http://www.smooth-project.org/";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1719,6 +1719,8 @@ in
 
   bmake = callPackage ../development/tools/build-managers/bmake { };
 
+  boca = callPackage ../development/libraries/boca { };
+
   bochs = callPackage ../applications/virtualization/bochs { };
 
   bubblewrap = callPackage ../tools/admin/bubblewrap { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4374,6 +4374,8 @@ in
     mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
   };
 
+  freac = callPackage ../applications/audio/freac { };
+
   freedroid = callPackage ../games/freedroid { };
 
   freedroidrpg = callPackage ../games/freedroidrpg { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23006,6 +23006,8 @@ in
 
   smallwm = callPackage ../applications/window-managers/smallwm { };
 
+  smooth = callPackage ../development/libraries/smooth { };
+
   smos = callPackage ../applications/misc/smos { };
 
   spectrwm = callPackage ../applications/window-managers/spectrwm { };


### PR DESCRIPTION
###### Motivation for this change
Closes: https://github.com/NixOS/nixpkgs/issues/104671

###### Things done
Packaged fre:ac at 1.1.3, and deps.
*I don't know if this is my configuration but running freac (which I've never used) had some weird rendering issues*

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
