### PR TITLE
python3Packages.kivy: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/kivy-garden/default.nix
+++ b/pkgs/development/python-modules/kivy-garden/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage, fetchPypi
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "kivy-garden";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wkcpr2zc1q5jb0bi7v2dgc0vs5h1y7j42mviyh764j2i0kz8mn2";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  pythonImportsCheck = [ "garden" ];
+
+  # There are no tests in the Pypi archive and building from source is not
+  # easily feasible because the build is done using buildozer and multiple
+  # repositories.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "The kivy garden installation script, split into its own package for convenient use in buildozer.";
+    homepage = "https://pypi.python.org/pypi/kivy-garden";
+    license = licenses.mit;
+    maintainers = with maintainers; [ risson ];
+  };
+}

--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage, fetchPypi
+, pkg-config, cython, docutils
+, kivy-garden
+, mesa, mtdev, SDL2, SDL2_image, SDL2_ttf, SDL2_mixer, gst_all_1
+, pillow, requests, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "Kivy";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1n0j9046vgjncy50v06r3wcg3q2l37jp8n0cznr64dz48kml8pnj";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cython
+    docutils
+  ];
+
+  buildInputs = [
+    mesa
+    mtdev
+    SDL2
+    SDL2_image
+    SDL2_ttf
+    SDL2_mixer
+
+    # NOTE: The degree to which gstreamer actually works is unclear
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+  ];
+
+  propagatedBuildInputs = [
+    kivy-garden
+    pillow
+    pygments
+    requests
+  ];
+
+  KIVY_NO_CONFIG = 1;
+  KIVY_NO_ARGS = 1;
+  KIVY_NO_FILELOG = 1;
+
+  postPatch = ''
+    substituteInPlace kivy/lib/mtdev.py \
+      --replace "LoadLibrary('libmtdev.so.1')" "LoadLibrary('${mtdev}/lib/libmtdev.so.1')"
+  '';
+
+  /*
+    We cannot run tests as Kivy tries to import itself before being fully
+    installed.
+  */
+  doCheck = false;
+  pythonImportsCheck = [ "kivy" ];
+
+  meta = with lib; {
+    description = "Library for rapid development of hardware-accelerated multitouch applications.";
+    homepage = "https://pypi.python.org/pypi/kivy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ risson ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3507,6 +3507,8 @@ in {
 
   kitchen = callPackage ../development/python-modules/kitchen { };
 
+  kivy-garden = callPackage ../development/python-modules/kivy-garden { };
+
   kiwisolver = if isPy3k then
     callPackage ../development/python-modules/kiwisolver { }
   else

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3507,6 +3507,10 @@ in {
 
   kitchen = callPackage ../development/python-modules/kitchen { };
 
+  kivy = callPackage ../development/python-modules/kivy {
+    inherit (pkgs) mesa;
+  };
+
   kivy-garden = callPackage ../development/python-modules/kivy-garden { };
 
   kiwisolver = if isPy3k then


### PR DESCRIPTION
###### Motivation for this change

Building on top of #29305, and finally having Kivy in nixpkgs!

I actually don't know how to test this work so I'm asking @vanschelven and @ddorn to help me out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
