### PR TITLE
py-spy: init at 0.3.3

### DIFF
--- a/pkgs/development/tools/py-spy/default.nix
+++ b/pkgs/development/tools/py-spy/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, pkgsBuildBuild, rustPlatform, fetchFromGitHub, pkgconfig, libunwind, python3 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "py-spy";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "benfred";
+    repo = "py-spy";
+    rev = "v${version}";
+    sha256 = "1w9nwsmazafr78ghif6njdcqjisr0f1jb6cm1w4ngvigx5qlrbkv";
+  };
+
+  NIX_CFLAGS_COMPILE = "-L${libunwind}/lib";
+
+  # error: linker `arm-linux-gnueabihf-gcc` not found
+  preConfigure = stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    export RUSTFLAGS="-Clinker=$CC"
+  '';
+
+  checkInputs = [ python3 ];
+
+  cargoSha256 = "0hrzmpwd2k4l8gjbry8ddrkv9q9qh8ag096md4q0fyn5bgnxhkah";
+
+  meta = with stdenv.lib; {
+    description = "Sampling profiler for Python programs";
+    license = licenses.mit;
+    maintainers = [ maintainers.lnl7 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6676,6 +6676,8 @@ in
     pythonPackages = python27Packages;
   };
 
+  py-spy = callPackage ../development/tools/py-spy { };
+
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
   pywal = with python3Packages; toPythonApplication pywal;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
