### PR TITLE
yed: mark as broken if jre.gtk3 is not available

### DIFF
--- a/pkgs/applications/graphics/yed/default.nix
+++ b/pkgs/applications/graphics/yed/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper unzip wrapGAppsHook ];
   # For wrapGAppsHook setup hook
-  buildInputs = [ jre.gtk3 ];
+  buildInputs = [ (jre.gtk3 or null) ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     description = "A powerful desktop application that can be used to quickly and effectively generate high-quality diagrams";
     platforms = jre.meta.platforms;
     maintainers = with maintainers; [ abbradar ];
+    broken = !("gtk3" ? jre);
   };
 }


### PR DESCRIPTION
This cleans up nixpkgs-review report on darwin

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Should remove a following message seen in nixpkgs-review on macOS:

```
error: while querying the derivation named 'yEd-3.20.1':
while evaluating the attribute 'buildInputs' of the derivation 'yEd-3.20.1' at ~/.cache/nixpkgs-review/rev-31487784f9ae66e715b2df1e7727119890d05a39-dirty/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:192:11:
while evaluating 'getOutput' at ~/.cache/nixpkgs-review/rev-31487784f9ae66e715b2df1e7727119890d05a39-dirty/nixpkgs/lib/attrsets.nix:464:23, called from undefined position:
while evaluating anonymous function at ~/.cache/nixpkgs-review/rev-31487784f9ae66e715b2df1e7727119890d05a39-dirty/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:143:17, called from undefined position:
attribute 'gtk3' missing, at ~/.cache/nixpkgs-review/rev-31487784f9ae66e715b2df1e7727119890d05a39-dirty/nixpkgs/pkgs/applications/graphics/yed/default.nix:14:19
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
