### PR TITLE
recoll: refactor and 1.24.5 -> 1.27.12

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -1,60 +1,88 @@
-{ mkDerivation, stdenv, fetchurl, lib, bison
-, qtbase, xapian, file, python, perl
-, djvulibre, groff, libxslt, unzip, poppler_utils, antiword, catdoc, lyx
-, libwpd, unrtf, untex
-, ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconv, zlib
-, withGui ? true }:
+{ stdenv
+, fetchurl
+, lib
+, mkDerivation
+, antiword
+, bison
+, catdoc
+, chmlib
+, djvulibre
+, file
+, gawk
+, ghostscript
+, gnugrep
+, gnused
+, gnutar
+, groff
+, gzip
+, libiconv
+, libwpd
+, libxslt
+, lyx
+, perl
+, pkg-config
+, poppler_utils
+, python3Packages
+, qtbase
+, unrtf
+, untex
+, unzip
+, which
+, xapian
+, zlib
+, withGui ? true
+}:
 
 assert stdenv.hostPlatform.system != "powerpc-linux";
 
 mkDerivation rec {
-  ver = "1.24.5";
-  name = "recoll-${ver}";
+  pname = "recoll";
+  version = "1.27.12";
 
   src = fetchurl {
-    url = "https://www.lesbonscomptes.com/recoll/${name}.tar.gz";
-    sha256 = "10m3a0ghnyipjcxapszlr8adyy2yaaxx4vgrkxrfmz13814z89cv";
+    url = "https://www.lesbonscomptes.com/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0bgadm8p319fws66ca4rpv9fx2bllbphgn892rh78db81lz20i5v";
   };
 
   configureFlags = [ "--enable-recollq" "--disable-webkit" ]
     ++ lib.optionals (!withGui) [ "--disable-qtgui" "--disable-x11mon" ]
     ++ (if stdenv.isLinux then [ "--with-inotify" ] else [ "--without-inotify" ]);
 
-  buildInputs = [ xapian file python bison zlib ]
-    ++ lib.optional withGui qtbase
-    ++ lib.optional stdenv.isDarwin libiconv;
+  nativeBuildInputs = [ pkg-config ];
 
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
-    sed -i 's/-Wl,--no-undefined -Wl,--warn-unresolved-symbols//' Makefile.am
-    sed -i 's/-Wl,--no-undefined -Wl,--warn-unresolved-symbols//' Makefile.in
-  '';
+  buildInputs = with python3Packages; [
+    bison chmlib file python setuptools which xapian zlib
+  ] ++ lib.optional withGui qtbase
+    ++ lib.optional stdenv.isDarwin libiconv;
 
   # the filters search through ${PATH} using a sh proc 'checkcmds' for the
   # filtering utils. Short circuit this by replacing the filtering command with
   # the absolute path to the filtering command.
   postInstall = ''
+    substituteInPlace $out/lib/*/site-packages/recoll/rclconfig.py --replace /usr/share/recoll $out/share/recoll
+    substituteInPlace $out/share/recoll/filters/rclconfig.py       --replace /usr/share/recoll $out/share/recoll
     for f in $out/share/recoll/filters/* ; do
       if [[ ! "$f" =~ \.zip$ ]]; then
-        substituteInPlace  $f --replace '"antiword"'      '"${lib.getBin antiword}/bin/antiword"'
-        substituteInPlace  $f --replace '"awk"'           '"${lib.getBin gawk}/bin/awk"'
-        substituteInPlace  $f --replace '"catppt"'        '"${lib.getBin catdoc}/bin/catppt"'
-        substituteInPlace  $f --replace '"djvused"'       '"${lib.getBin djvulibre}/bin/djvused"'
-        substituteInPlace  $f --replace '"djvutxt"'       '"${lib.getBin djvulibre}/bin/djvutxt"'
-        substituteInPlace  $f --replace '"egrep"'         '"${lib.getBin gnugrep}/bin/egrep"'
-        substituteInPlace  $f --replace '"groff"'         '"${lib.getBin groff}/bin/groff"'
-        substituteInPlace  $f --replace '"gunzip"'        '"${lib.getBin gzip}/bin/gunzip"'
-        substituteInPlace  $f --replace '"iconv"'         '"${lib.getBin libiconv}/bin/iconv"'
-        substituteInPlace  $f --replace '"pdftotext"'     '"${lib.getBin poppler_utils}/bin/pdftotext"'
-        substituteInPlace  $f --replace '"pstotext"'      '"${lib.getBin ghostscript}/bin/ps2ascii"'
-        substituteInPlace  $f --replace '"sed"'           '"${lib.getBin gnused}/bin/sed"'
-        substituteInPlace  $f --replace '"tar"'           '"${lib.getBin gnutar}/bin/tar"'
-        substituteInPlace  $f --replace '"unzip"'         '"${lib.getBin unzip}/bin/unzip"'
-        substituteInPlace  $f --replace '"xls2csv"'       '"${lib.getBin catdoc}/bin/xls2csv"'
-        substituteInPlace  $f --replace '"xsltproc"'      '"${lib.getBin libxslt}/bin/xsltproc"'
-        substituteInPlace  $f --replace '"unrtf"'         '"${lib.getBin unrtf}/bin/unrtf"'
-        substituteInPlace  $f --replace '"untex"'         '"${lib.getBin untex}/bin/untex"'
-        substituteInPlace  $f --replace '"wpd2html"'      '"${lib.getBin libwpd}/bin/wpd2html"'
-        substituteInPlace  $f --replace /usr/bin/perl ${lib.getBin perl}/bin/perl
+        substituteInPlace $f --replace '"antiword"'  '"${lib.getBin antiword}/bin/antiword"'
+        substituteInPlace $f --replace '"awk"'       '"${lib.getBin gawk}/bin/awk"'
+        substituteInPlace $f --replace '"catppt"'    '"${lib.getBin catdoc}/bin/catppt"'
+        substituteInPlace $f --replace '"djvused"'   '"${lib.getBin djvulibre}/bin/djvused"'
+        substituteInPlace $f --replace '"djvutxt"'   '"${lib.getBin djvulibre}/bin/djvutxt"'
+        substituteInPlace $f --replace '"egrep"'     '"${lib.getBin gnugrep}/bin/egrep"'
+        substituteInPlace $f --replace '"groff"'     '"${lib.getBin groff}/bin/groff"'
+        substituteInPlace $f --replace '"gunzip"'    '"${lib.getBin gzip}/bin/gunzip"'
+        substituteInPlace $f --replace '"iconv"'     '"${lib.getBin libiconv}/bin/iconv"'
+        substituteInPlace $f --replace '"pdftotext"' '"${lib.getBin poppler_utils}/bin/pdftotext"'
+        substituteInPlace $f --replace '"pstotext"'  '"${lib.getBin ghostscript}/bin/ps2ascii"'
+        substituteInPlace $f --replace '"sed"'       '"${lib.getBin gnused}/bin/sed"'
+        substituteInPlace $f --replace '"tar"'       '"${lib.getBin gnutar}/bin/tar"'
+        substituteInPlace $f --replace '"unzip"'     '"${lib.getBin unzip}/bin/unzip"'
+        substituteInPlace $f --replace '"xls2csv"'   '"${lib.getBin catdoc}/bin/xls2csv"'
+        substituteInPlace $f --replace '"xsltproc"'  '"${lib.getBin libxslt}/bin/xsltproc"'
+        substituteInPlace $f --replace '"unrtf"'     '"${lib.getBin unrtf}/bin/unrtf"'
+        substituteInPlace $f --replace '"untex"'     '"${lib.getBin untex}/bin/untex"'
+        substituteInPlace $f --replace '"wpd2html"'  '"${lib.getBin libwpd}/bin/wpd2html"'
+        substituteInPlace $f --replace /usr/bin/perl   ${lib.getBin perl}/bin/perl
       fi
     done
   '' + stdenv.lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
Changes:

- add pkg-config
- name -> pname + version
- python2 -> python3
- patch /usr/share/recoll to $out/share/recoll
- remove Makefile patch for macOS that has been merged upstream (
  https://framagit.org/medoc92/recoll/-/commit/b5c5734d064c638b702601fd391037a35b5bb2a1 )

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
