### PR TITLE
parted: build with python3

### DIFF
--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -8,7 +8,7 @@
 , dosfstools
 , e2fsprogs
 , perl
-, python2
+, python3
 , util-linux
 , check
 , enableStatic ? false
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   # Tests were previously failing due to Hydra running builds as uid 0.
   # That should hopefully be fixed now.
   doCheck = !stdenv.hostPlatform.isMusl; /* translation test */
-  checkInputs = [ check dosfstools e2fsprogs perl python2 util-linux ];
+  checkInputs = [ check dosfstools e2fsprogs perl python3 util-linux ];
 
   meta = {
     description = "Create, destroy, resize, check, and copy partitions";


### PR DESCRIPTION
###### Motivation for this change

Moving away from python2. Seems to work at first glance, and
http://www.linuxfromscratch.org/blfs/view/svn/postlfs/parted.html
also suggests it should be possible to use on a system with
only python3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).