### PR TITLE
wezterm: initial package

### DIFF
--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -53,8 +53,9 @@ rustPlatform.buildRustPackage {
     repo = pname;
     rev = "3bd8d8c84591f4d015ff9a47ddb478e55c231fda";
     sha256 = "13xf3685kir4p159hsxrqkj9p2lwgfp0n13h9zadslrd44l8b8j8";
+    fetchSubmodules = true;
   };
-  cargoSha256 = "1i983ix7kdq7kd1i14kk3ra7jiihrd7n4pxmfifbj48g3kyxn2pq";
+  cargoSha256 = "1ghjpyd3f5dqi6bblr6d2lihdschpyj5djfd1600hvb41x75lmhx";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -1,0 +1,85 @@
+{ rustPlatform
+, lib
+, fetchFromGitHub
+
+, pkg-config
+, fontconfig
+, python3
+, openssl
+, perl
+
+, dbus
+, libX11
+, xcbutil
+, libxcb
+, xcbutilkeysyms
+, xcbutilwm # contains xcb-ewmh among others
+, libxkbcommon
+, libglvnd # libEGL.so.1
+, egl-wayland
+, wayland
+, libGLU
+, libGL
+, freetype
+, zlib
+}:
+let
+  runtimeDeps = [
+    libX11
+    xcbutil
+    libxcb
+    xcbutilkeysyms
+    xcbutilwm
+    libxkbcommon
+    dbus
+    libglvnd
+    zlib
+    egl-wayland
+    wayland
+    libGLU
+    libGL
+    fontconfig
+    freetype
+  ];
+  pname = "wezterm";
+in
+
+rustPlatform.buildRustPackage {
+  inherit pname;
+  version = "unstable-2020-11-22";
+
+  src = fetchFromGitHub {
+    owner = "wez";
+    repo = pname;
+    rev = "3bd8d8c84591f4d015ff9a47ddb478e55c231fda";
+    sha256 = "13xf3685kir4p159hsxrqkj9p2lwgfp0n13h9zadslrd44l8b8j8";
+  };
+  cargoSha256 = "1i983ix7kdq7kd1i14kk3ra7jiihrd7n4pxmfifbj48g3kyxn2pq";
+
+  nativeBuildInputs = [
+    pkg-config
+    python3
+    openssl.dev
+    perl
+  ];
+
+  buildInputs = runtimeDeps;
+
+  installPhase = ''
+    for artifact in wezterm wezterm-gui wezterm-mux-server strip-ansi-escapes; do
+      patchelf --set-rpath "${lib.makeLibraryPath runtimeDeps}" $releaseDir/$artifact
+      install -D $releaseDir/$artifact -t $out/bin
+    done
+  '';
+
+  # prevent further changes to the RPATH
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
+    homepage = "https://wezfurlong.org/wezterm";
+    license = licenses.mit;
+    maintainers = with maintainers; [ steveej ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -784,6 +784,8 @@ in
 
   wayst = callPackage ../applications/terminal-emulators/wayst { };
 
+  wezterm = callPackage ../applications/terminal-emulators/wezterm { };
+
   x3270 = callPackage ../applications/terminal-emulators/x3270 { };
 
   xterm = callPackage ../applications/terminal-emulators/xterm { };


### PR DESCRIPTION
###### Motivation for this change
Closes #90696.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
