### PR TITLE
poetry2nix: cross fixes

### DIFF
--- a/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/mk-poetry-dep.nix
@@ -27,6 +27,7 @@ pythonPackages.callPackage
     , ...
     }@args:
     let
+      inherit (pkgs) stdenv;
       inherit (poetryLib) isCompatible getManyLinuxDeps fetchFromPypi moduleName;
 
       inherit (import ./pep425.nix {
@@ -113,9 +114,10 @@ pythonPackages.callPackage
 
       buildInputs = (
         baseBuildInputs
+        ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) pythonPackages.setuptools
         ++ lib.optional (!isSource) (getManyLinuxDeps fileInfo.name).pkg
         ++ lib.optional isLocal buildSystemPkgs
-        ++ lib.optional (!__isBootstrap) [ pythonPackages.poetry ]
+        ++ lib.optional (!__isBootstrap) pythonPackages.poetry
       );
 
       propagatedBuildInputs =

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -604,8 +604,8 @@ self: super:
     # "Vendor" dependencies (for build-system support)
     postPatch = ''
       echo "import sys" >> poetry/__init__.py
-      for path in ''${PYTHONPATH//:/ }; do echo $path; done | uniq | while read path; do
-        echo "sys.path.insert(0, \"$path\")" >> poetry/__init__.py
+      for path in $propagatedBuildInputs; do
+          echo "sys.path.insert(0, \"$path\")" >> poetry/__init__.py
       done
     '';
 

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -93,7 +93,7 @@ self: super:
     (
       super.cffi.overridePythonAttrs (
         old: {
-          buildInputs = old.buildInputs ++ [ pkgs.libffi ];
+          buildInputs = old.buildInputs or [] ++ [ pkgs.libffi ];
         }
       )
     );
@@ -120,6 +120,8 @@ self: super:
 
   cryptography = super.cryptography.overridePythonAttrs (
     old: {
+      nativeBuildInputs = old.nativeBuildInputs or []
+        ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) self.python.pythonForBuild.pkgs.cffi;
       buildInputs = old.buildInputs ++ [ pkgs.openssl ];
     }
   );
@@ -584,8 +586,8 @@ self: super:
       withMysql = old.passthru.withMysql or false;
     in
     {
-      buildInputs = old.buildInputs ++ [ self.cython pkgs.sqlite ];
-      propagatedBuildInputs = old.propagatedBuildInputs
+      buildInputs = old.buildInputs or [] ++ [ pkgs.sqlite ];
+      propagatedBuildInputs = old.propagatedBuildInputs or []
         ++ lib.optional withPostgres self.psycopg2
         ++ lib.optional withMysql self.mysql-connector;
     }

--- a/pkgs/development/tools/poetry2nix/poetry2nix/pkgs/poetry/default.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/pkgs/poetry/default.nix
@@ -15,8 +15,8 @@ poetry2nix.mkPoetryApplication {
   # "Vendor" dependencies (for build-system support)
   postPatch = ''
     echo "import sys" >> poetry/__init__.py
-    for path in ''${PYTHONPATH//:/ }; do echo $path; done | uniq | while read path; do
-      echo "sys.path.insert(0, \"$path\")" >> poetry/__init__.py
+    for path in $propagatedBuildInputs; do
+        echo "sys.path.insert(0, \"$path\")" >> poetry/__init__.py
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Make poetry2nix builds work when cross compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (x86_64 -> armv7)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
