### PR TITLE
Extend nix-prefetch-git to support passing tree hashes as "rev"

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -149,7 +149,19 @@ checkout_hash(){
     fi
 
     clean_git fetch -t ${builder:+--progress} origin || return 1
-    clean_git checkout -b "$branchName" "$hash" || return 1
+
+    local object_type=$(git cat-file -t "$hash")
+    if [[ "$object_type" == "commit" ]]; then
+        clean_git checkout -b "$branchName" "$hash" || return 1
+    elif [[ "$object_type" == "tree" ]]; then
+        clean_git config user.email "nix-prefetch-git@localhost"
+        clean_git config user.name "nix-prefetch-git"
+        local commit_id=$(git commit-tree "$hash" -m "Commit created from tree hash $hash")
+        clean_git checkout -b "$branchName" "$commit_id" || return 1
+    else
+        echo "Unrecognized git object type: $object_type"
+        return 1
+    fi
 }
 
 # Fetch only a branch/tag and checkout it.


### PR DESCRIPTION

###### Motivation for this change

I'm working on Julia packages in Nix. Julia's package manager organizes its dependencies a `Manifest.toml` file, which is almost perfect to use with Nix because it contains Git hashes we can pull out and pass to `fetchgit`. However, Julia uses Git tree hashes rather than commit hashes; see [here](https://julialang.github.io/Pkg.jl/v1/toml-files/#Manifest.toml-entries). 

It would be convenient if `fetchgit` could understand tree hashes when they're passed as the `rev` argument. It seems straightforward to support, as this PR shows.

I've tested this with my prototype Julia packaging tool and it works. If this could be accepted then I'd be happy to update the documentation and stuff. Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Ubuntu 20.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
