### PR TITLE
nixos/wireless: fix failure with no interfaces

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -233,9 +233,10 @@ in {
       path = [ pkgs.wpa_supplicant ];
 
       script = ''
-        if [ -f /etc/wpa_supplicant.conf -a "/etc/wpa_supplicant.conf" != "${configFile}" ]
-        then echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
+        if [ -f /etc/wpa_supplicant.conf -a "/etc/wpa_supplicant.conf" != "${configFile}" ]; then
+          echo >&2 "<3>/etc/wpa_supplicant.conf present but ignored. Generated ${configFile} is used instead."
         fi
+
         iface_args="-s -u -D${cfg.driver} -c ${configFile}"
         ${if ifaces == [] then ''
           for i in $(cd /sys/class/net && echo *); do
@@ -248,6 +249,10 @@ in {
               fi
             fi
           done
+          if [ -z "$args" ]; then
+            echo >&2 "<3>No wireless interfaces detected (yet)."
+            exit 1
+          fi
         '' else ''
           args="${concatMapStringsSep " -N " (i: "-i${i} $iface_args") ifaces}"
         ''}
@@ -261,7 +266,7 @@ in {
 
     # Restart wpa_supplicant when a wlan device appears or disappears.
     services.udev.extraRules = ''
-      ACTION=="add|remove", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", RUN+="/run/current-system/systemd/bin/systemctl try-restart wpa_supplicant.service"
+      ACTION=="add|remove", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", RUN+="/run/current-system/systemd/bin/systemctl restart wpa_supplicant.service"
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change

This resolves issue #101963.

When the service is started and no interface is ready yet, wpa_supplicant
is being exec'd with no `-i` flags, thus failing. Once the interfaces
are ready, the udev rule would fire but wouldn't restart the unit because
it wasn't currently running (see systemctl(1) try-restart).

The solution is to exit (with a clear error message) but always restart
wpa_supplicant when the interfaces are modified.

###### Things done

- [x] Tested wpa_supplicant service is restarted
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
