### PR TITLE
python2Packages.cryptography: mark insecure, CVE-2020-25659

### DIFF
--- a/pkgs/development/python-modules/cryptography/2.9.nix
+++ b/pkgs/development/python-modules/cryptography/2.9.nix
@@ -70,5 +70,6 @@ buildPythonPackage rec {
       + replaceStrings [ "." ] [ "-" ] version;
     license = with licenses; [ asl20 bsd3 psfl ];
     maintainers = with maintainers; [ primeos ];
+    knownVulnerabilities = [ "CVE-2020-25659" "https://github.com/advisories/GHSA-hggm-jpg3-v476" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
closes: #101964

```
$ nix-build -A pythonPackages.cryptography
error: Package ‘python2.7-cryptography-2.9.2’ in /home/jon/projects/nixpkgs/pkgs/development/python-modules/cryptography/2.9.nix:60 is marked as insecure, refusing to evaluate.


Known issues:
 - CVE-2020-25659
 - https://github.com/advisories/GHSA-hggm-jpg3-v476

You can install it anyway by whitelisting this package, using the
following methods:
...
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
