### PR TITLE
pythonPackages.pyqtgraph: convert to pyqt5

### DIFF
--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -1,10 +1,10 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, scipy
 , numpy
-, pyqt4
 , pyopengl
+, pyqt5
+, scipy
 }:
 
 buildPythonPackage rec {
@@ -16,13 +16,16 @@ buildPythonPackage rec {
     sha256 = "0p5k73wjfh0zzjvby8b5107cx7x0c2rdj66zh1nc8y95i0anf2na";
   };
 
-  propagatedBuildInputs = [ scipy numpy pyqt4 pyopengl ];
+  propagatedBuildInputs = [ numpy pyopengl pyqt5 scipy ];
 
-  doCheck = false;  # "PyQtGraph requires either PyQt4 or PySide; neither package could be imported."
+  doCheck = false;  # tries to create windows (QApps) on collection, which fails (probably due to no display)
+
+  pythonImportsCheck = [ "pyqtgraph" ];
 
   meta = with stdenv.lib; {
     description = "Scientific Graphics and GUI Library for Python";
     homepage = "http://www.pyqtgraph.org/";
+    changelog = "https://github.com/pyqtgraph/pyqtgraph/blob/master/CHANGELOG";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ koral ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update ``pythonPackages.pyqtgraph`` to use ``pyqt5`` instead of ``pyqt4``.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
