### PR TITLE
factorio: fail fetch early if no credentials provided

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -104,10 +104,15 @@ let
               ];
             })
             (_: { # This preHook hides the credentials from /proc
-                  preHook = ''
-                    echo -n "${username}" >username
-                    echo -n "${token}"    >token
-                  '';
+                  preHook =
+                    if username != "" && token != "" then ''
+                      echo -n "${username}" >username
+                      echo -n "${token}"    >token
+                    '' else ''
+                      # Deliberately failing since username/token was not provided, so we can't fetch.
+                      # We can't use builtins.throw since we want the result to be used if the tar is in the store already.
+                      exit 1
+                    '';
                   failureHook = ''
                     cat <<EOF
                     ${helpMsg}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The download URL will redirect to the login page if credentials are not
present, but will return an error if the credentials are wrong.

Since we know we always expect credentials, we can fail the fetch in
the preHook if they're not provided.

We can't use e.g. builtins.throw because we want the fetchurl derivation
to be evaluated in all cases - because that's the mechanism which allows
you to just manually add the tarball to the Nix store.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Manually tested with:

- `nix-build . -A factorio` - fails, as expected
- `nix-build -E '((import ./. {}).factorio.override { username = ...; token = ...; }'` - works, as expected
- `nix-build -E '((import ./. {}).factorio.override { username = ...; token = "wrong"; }'` - fails, as expected
- `nix-build -E '((import ./. {}).factorio.override { username = ...; }'` - fails, as expected
- `nix-build -E '((import ./. {}).factorio.override { token = ...; }'` - fails, as expected