### PR TITLE
[staging] glibc: fix cross-compile to ppc64le

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -160,6 +160,10 @@ stdenv.mkDerivation ({
       "libc_cv_as_needed=no"
     ] ++ lib.optional withGd "--with-gd";
 
+  makeFlags = [
+    "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
+  ];
+
   installFlags = [ "sysconfdir=$(out)/etc" ];
 
   outputs = [ "out" "bin" "dev" "static" ];


### PR DESCRIPTION
Fixes cross-compilation when build == host != target == ppc64le. Glibc invokes objcopy during cross-compilation to ppc64le, which fails when the nonprefixed objcopy can't understand the target format.

Needed to build cross bootstrap tools since glibc v2.32.

Error can be reproduced by attempting to build `pkgsCross.powernv.stdenv.cc.libc`:
```
objcopy: Unable to recognise the format of the input file `/build/build/no_ldbl_gnu_attribute.o'
make[2]: *** [../sysdeps/powerpc/powerpc64/le/Makefile:31: /build/build/no_ldbl_gnu_attribute.bin] Error 1
```

Checked for regressions locally by building:
* stdenv
* pkgsCross.powernv.stdenv.cc.libc
* pkgsCross.raspberryPi.stdenv.cc.libc
* powernv cross bootstrapTools

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
