### PR TITLE
mpv: fix vapoursynth path

### DIFF
--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -37,7 +37,7 @@ let
       "--prefix" "LUA_CPATH" ";" "${mpv.luaEnv}/lib/lua/${mpv.lua.luaversion}/?.so"
       "--prefix" "LUA_PATH" ";" "${mpv.luaEnv}/share/lua/${mpv.lua.luaversion}/?.lua"
     ] ++ lib.optionals mpv.vapoursynthSupport [
-      "--prefix" "PYTHONPATH" ":" "${mpv.vapoursynth}/lib/${mpv.vapoursynth.python3.sitePackages}"
+      "--prefix" "PYTHONPATH" ":" "${mpv.vapoursynth}/${mpv.vapoursynth.python3.sitePackages}"
     ] ++ lib.optionals (binPath != "") [
       "--prefix" "PATH" ":" binPath
     ] ++ (lib.lists.flatten (map


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

MPV fails with `[vapoursynth] Could not initialize VapourSynth scripting.`, because python can't find vapoursynth module because of wrong path being set in wrapper:
```sh
export PYTHONPATH='/nix/store/lr6am5dlv3367d0ng4h04w8hpbhcwbvc-vapoursynth-R49/lib/lib/python3.8/site-packages'${PYTHONPATH:+':'}$PYTHONPATH
```

(Notice /lib/lib in path)

Can be reproduced with
```sh
cd ~/.config/mpv
echo > script.vpy
echo "vf=vapoursynth=~~/script.vpy" >> mpv.conf
```
And then opening any video

This issue is caused by f93918bdc387d353285f458c06c6a111ae90b7b2
In this commit line
```
      --prefix PYTHONPATH : "${vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
```
was replaced by
```
       "--prefix" "PYTHONPATH" ":" "${mpv.vapoursynth}/lib/${mpv.vapoursynth.python3.sitePackages}"
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
