### PR TITLE
ocamlPackages.functoria: 3.1.0 → 3.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/functoria/default.nix
+++ b/pkgs/development/ocaml-modules/functoria/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchurl, buildDunePackage, alcotest, cmdliner
+{ lib, fetchurl, buildDunePackage, alcotest, cmdliner
 , rresult, astring, fmt, ocamlgraph, logs, bos, fpath, ptime
 }:
 
 buildDunePackage rec {
   pname   = "functoria";
-  version = "3.1.0";
+  version = "3.1.1";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "15jdqdj1vfi0x9gjydrrnbwzwbzw34w1iir032jrji820xlblky2";
+    sha256 = "0bihxbq16zwsi7frk4b8wz8993mvy2ym3n6288jhv0n0gb7c2f7m";
   };
 
   propagatedBuildInputs = [ cmdliner rresult astring fmt ocamlgraph logs bos fpath ptime ];
@@ -18,7 +20,7 @@ buildDunePackage rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A DSL to organize functor applications";
     homepage    = "https://github.com/mirage/functoria";
     license     = licenses.isc;

--- a/pkgs/development/ocaml-modules/functoria/runtime.nix
+++ b/pkgs/development/ocaml-modules/functoria/runtime.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "functoria-runtime";
 
-  inherit (functoria) version src;
+  inherit (functoria) version useDune2 src;
 
   propagatedBuildInputs = [ cmdliner fmt ];
   checkInputs = [ alcotest functoria];


### PR DESCRIPTION
###### Motivation for this change

Use dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
