### PR TITLE
bitcash: init at 0.6.0, coincurve: init at 13.0.0

### DIFF
--- a/pkgs/development/python-modules/bitcash/default.nix
+++ b/pkgs/development/python-modules/bitcash/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, buildPythonPackage, fetchPypi, coincurve, requests, cashaddress-regtest, click }:
+
+buildPythonPackage rec {
+  pname = "bitcash";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09i6fvjc2mrz4s956pcjrrb5xab8wf542pirybzf6wbh4n57kisq";
+  };
+
+  propagatedBuildInputs = [ coincurve requests cashaddress-regtest ];
+
+  checkInputs = [ click ];
+
+  meta = with lib; {
+    description = "Python 3 Bitcoin Cash Library";
+    homepage = "https://github.com/pybitcash/bitcash";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/cashaddress-regtest/default.nix
+++ b/pkgs/development/python-modules/cashaddress-regtest/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, buildPythonPackage, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "cashaddress-regtest";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nicolaiskye";
+    repo = "cashaddress-regtest";
+    rev = version;
+    sha256 = "1z4iq60n685z5bfksl8lvcqawhxh8dz8rqqf933cq3mj8zk98jpz";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Tool for converting bitcoin cash legacy addresses";
+    homepage = "https://github.com/nicolaiskye/cashaddress-regtest";
+    license = licenses.mit;
+    maintainers = with maintainers; [ siraben ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/coincurve/default.nix
+++ b/pkgs/development/python-modules/coincurve/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, pytest,
+  asn1crypto, cffi, pkg-config, autoconf, automake, libtool, libffi,
+  requests }:
+
+buildPythonPackage rec {
+  pname = "coincurve";
+  version = "14.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ofek";
+    repo = "coincurve";
+    rev = "v${version}";
+    sha256 = "0z765x9vpb82nx9d0kvqknyl5ad4fldha3nqsx1cydghskdd100r";
+  };
+
+  postPatch = ''
+      rm coincurve/_windows_libsecp256k1.py
+  '';
+
+  checkInputs = [ pytest ];
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+  propagatedBuildInputs = [ asn1crypto cffi libffi requests ];
+
+  meta = with lib; {
+    description = "Cross-platform Python CFFI bindings for libsecp256k1";
+    homepage = "https://github.com/ofek/coincurve";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ siraben ];
+    platforms = lib.platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1082,6 +1082,8 @@ in {
 
   case = callPackage ../development/python-modules/case { };
 
+  cashaddress-regtest = callPackage ../development/python-modules/cashaddress-regtest { };
+
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };
 
   casttube = callPackage ../development/python-modules/casttube { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1265,6 +1265,8 @@ in {
 
   coilmq = callPackage ../development/python-modules/coilmq { };
 
+  coincurve = callPackage ../development/python-modules/coincurve { };
+
   coinmarketcap = callPackage ../development/python-modules/coinmarketcap { };
 
   ColanderAlchemy = callPackage ../development/python-modules/colanderalchemy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -872,6 +872,8 @@ in {
 
   bitbucket-cli = callPackage ../development/python-modules/bitbucket-cli { };
 
+  bitcash = callPackage ../development/python-modules/bitcash { };
+
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };
 
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add bitcash and coincurve Python packages.

Blocked by https://github.com/ofek/coincurve/issues/47

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
