### PR TITLE
libconfuse: 3.2.2 -> 3.3

### DIFF
--- a/pkgs/development/libraries/libconfuse/default.nix
+++ b/pkgs/development/libraries/libconfuse/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     owner = "martinh";
   };
 
+  postPatch = ''
+    substituteInPlace tests/Makefile.am \
+      --replace 'TESTS            += empty_string' "" \
+      --replace 'TESTS            += print_filter' ""
+  '';
+
   nativeBuildInputs = [ autoreconfHook flex ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libconfuse/default.nix
+++ b/pkgs/development/libraries/libconfuse/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "libconfuse";
-  version = "3.2.2";
+  version = "3.3";
 
   src = fetchFromGitHub {
-    sha256 = "0djjq7j9iiyqxqqrlzm476xkibjasqvgzjwkalgj1l3f2smi53aw";
+    sha256 = "1npfk5jv59kk4n8pkyx89fn9s6p8x3gbffs42jaw24frgxfgp8ca";
     rev = "v${version}";
     repo = "libconfuse";
     owner = "martinh";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #91619

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
