### PR TITLE
rsync: reproducible

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation rec {
                 ++ stdenv.lib.optional enableXXHash xxHash;
   nativeBuildInputs = [perl];
 
+  preConfigure = ''
+    export CXXFLAGS="$CXXFLAGS -frandom-seed=123456"
+  '';
+
   configureFlags = [
     "--with-nobody-group=nogroup"
 


### PR DESCRIPTION
g++ used for SIMD operations will mangle names. Options are to either
disable SIMD, or provide deterministic mangling via -frandom-seed

###### Motivation for this change
https://r13y.com/
@zimbatm 

###### Things done
Found that disabling SIMD provided a reproducible build, but then found that only providing `-frandom-seed=123456` provides deterministic name mangling and order in the resulting binary.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
