### PR TITLE
qucs-s: init at 0.0.22

### DIFF
--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub, flex, bison, qt4, libX11, cmake, gperf, adms,
+ngspice, wrapGAppsHook,
+kernels ? [ ngspice ] }:
+
+stdenv.mkDerivation rec {
+  pname = "qucs-s";
+  version = "0.0.22";
+
+  src = fetchFromGitHub {
+    owner = "ra3xdh";
+    repo = "qucs_s";
+    rev = version;
+    sha256 = "0rrq2ddridc09m6fixdmbngn42xmv8cmdf6r8zzn2s98fqib5qd6";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook cmake ];
+  buildInputs = [ flex bison qt4 libX11 gperf adms ] ++ kernels;
+
+  preConfigure = ''
+    # Make custom kernels avaible from qucs-s
+    gappsWrapperArgs+=(--prefix PATH ":" ${lib.makeBinPath kernels})
+  '';
+
+  QTDIR=qt4;
+
+  doInstallCheck = true;
+  installCheck = ''
+    $out/bin/qucs-s --version
+  '';
+
+  meta = with lib; {
+    description = "Spin-off of Qucs that allows custom simulation kernels";
+    longDescription = ''
+      Spin-off of Qucs that allows custom simulation kernels.
+      Default version is installed with ngspice.
+    '';
+    homepage = "https://ra3xdh.github.io/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ mazurel ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26784,6 +26784,8 @@ in
 
   qucs = callPackage ../applications/science/electronics/qucs { };
 
+  qucs-s = callPackage ../applications/science/electronics/qucs-s { };
+
   xcircuit = callPackage ../applications/science/electronics/xcircuit { };
 
   xoscope = callPackage ../applications/science/electronics/xoscope { };


### PR DESCRIPTION
###### Motivation for this change
Qucs-s is a fork of Qucs that supports custom circuit simulators. I have added ngspice as a default runtime dependency as it is the most default circuit simulator to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
