### PR TITLE
vyper: init at 0.2.8

### DIFF
--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi, writeText, asttokens
+, pycryptodome, pytest_xdist, pytestcov, recommonmark, semantic-version, sphinx
+, sphinx_rtd_theme, pytestrunner }:
+
+let
+  sample-contract = writeText "example.vy" ''
+    count: int128
+
+    @external
+    def __init__(foo: address):
+        self.count = 1
+  '';
+in
+
+buildPythonPackage rec {
+  pname = "vyper";
+  version = "0.2.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0d9fv630ayd1989qnklldh08vksa2lf0r06lm914qy5r5cvbl1v2";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'asttokens==' 'asttokens>=' \
+      --replace 'subprocess.check_output("git rev-parse HEAD".split())' "' '" \
+      --replace 'commithash.decode("utf-8").strip()' "'069936fa3fee8646ff362145593128d7ef07da38'"
+  '';
+
+  propagatedBuildInputs = [
+    asttokens
+    pycryptodome
+    pytest_xdist
+    pytestcov
+    recommonmark
+    semantic-version
+    sphinx
+    sphinx_rtd_theme
+  ];
+
+  checkPhase = ''
+    $out/bin/vyper "${sample-contract}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pythonic Smart Contract Language for the EVM";
+    homepage = "https://github.com/vyperlang/vyper";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ siraben ];
+  };
+}

--- a/pkgs/development/compilers/vyper/default.nix
+++ b/pkgs/development/compilers/vyper/default.nix
@@ -33,10 +33,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     asttokens
     pycryptodome
-    pytest_xdist
-    pytestcov
-    recommonmark
     semantic-version
+
+    # docs
+    recommonmark
     sphinx
     sphinx_rtd_theme
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10131,6 +10131,8 @@ in
     vala_0_48
     vala;
 
+  vyper = with python3Packages; toPythonApplication vyper;
+
   wcc = callPackage ../development/compilers/wcc { };
 
   wla-dx = callPackage ../development/compilers/wla-dx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7615,6 +7615,8 @@ in {
 
   vxi11 = callPackage ../development/python-modules/vxi11 { };
 
+  vyper = callPackage ../development/compilers/vyper { };
+
   w3lib = callPackage ../development/python-modules/w3lib { };
 
   wadllib = callPackage ../development/python-modules/wadllib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [Vyper](https://github.com/vyperlang/vyper) compiler.

<details>
<summary>vyper.py</summary>

```python
storedData: public(int128)

@external
def __init__(_x: int128):
  self.storedData = _x

@external
def set(_x: int128):
  self.storedData = _x
```
</details>

```
$ ./result/bin/vyper contract.vy | sha256sum
3bbc19c98dcb167c54eee82987c7ad85a806554cd1e351713c85447374d9f755  -
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
