### PR TITLE
hybridreverb2: 2.1.1 -> 2.1.2

### DIFF
--- a/pkgs/applications/audio/hybridreverb2/default.nix
+++ b/pkgs/applications/audio/hybridreverb2/default.nix
@@ -4,7 +4,7 @@
 
 let
   pname = "HybridReverb2";
-  version = "2.1.1";
+  version = "2.1.2";
   owner = "jpcima";
   DBversion = "1.0.0";
 in
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     inherit owner;
     repo = pname;
     rev = "v${version}";
-    sha256 = "15mba9qvlis0qrklr50wp3jdysvmk33m7pvclp0k1is9pirj97cb";
+    sha256 = "16r20plz1w068bgbkrydv01a991ygjybdya3ah7bhp3m5xafjwqb";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Src was broken [upstream](https://github.com/jpcima/HybridReverb2/issues/6#issuecomment-732179467).
See  https://github.com/NixOS/nixpkgs/issues/104048
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
