### PR TITLE
platformio: 5.0.2 -> 5.0.3

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -1,11 +1,11 @@
-{ lib, buildFHSUserEnv, fetchFromGitHub }:
+{ lib, buildFHSUserEnv, version, src }:
 
 let
   pio-pkgs = pkgs:
     let
       python = pkgs.python3.override {
         packageOverrides = self: super: {
-          platformio = self.callPackage ./core.nix { };
+          platformio = self.callPackage ./core.nix { inherit version src; };
         };
       };
     in (with pkgs; [
@@ -18,14 +18,6 @@ let
       bottle
       platformio
     ]);
-
-  src = fetchFromGitHub {
-    owner = "platformio";
-    repo = "platformio-core";
-    rev = "v5.0.2";
-    sha256 = "1hbw8nbllyj0xyx1rz2chx9vyqf9949dcdx4v9hnfbsjwwpcfi0a";
-  };
-
 
 in buildFHSUserEnv {
   name = "platformio";

--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,9 +1,10 @@
-{ stdenv, lib, buildPythonApplication, fetchFromGitHub, fetchpatch
+{ stdenv, lib, buildPythonApplication, fetchpatch
 , bottle, click, colorama, semantic-version
 , lockfile, pyserial, requests
 , tabulate, pyelftools, marshmallow
 , pytest, tox, jsondiff
 , git, spdx-license-list-data
+, version, src
 }:
 
 let
@@ -75,15 +76,7 @@ let
 
 in buildPythonApplication rec {
   pname = "platformio";
-  version = "5.0.2";
-
-  # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
-  src = fetchFromGitHub {
-    owner = "platformio";
-    repo = "platformio-core";
-    rev = "v${version}";
-    sha256 = "1hbw8nbllyj0xyx1rz2chx9vyqf9949dcdx4v9hnfbsjwwpcfi0a";
-  };
+  inherit version src;
 
   propagatedBuildInputs =  [
     bottle click colorama git lockfile

--- a/pkgs/development/arduino/platformio/default.nix
+++ b/pkgs/development/arduino/platformio/default.nix
@@ -1,11 +1,21 @@
 
-{ newScope }:
+{ newScope, fetchFromGitHub }:
 
 let
   callPackage = newScope self;
 
+  version = "5.0.3";
+
+  # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
+  src = fetchFromGitHub {
+    owner = "platformio";
+    repo = "platformio-core";
+    rev = "v${version}";
+    sha256 = "0sf5dy0cmhy66rmk0hq1by7nrmf7qz0a99hrk55dpbp6r6vnk3hw";
+  };
+
   self = {
-      platformio-chrootenv = callPackage ./chrootenv.nix { };
+    platformio-chrootenv = callPackage ./chrootenv.nix { inherit version src; };
   };
 
 in self


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump.
In addition to the version change, the source is managed in a central location, since previously the same change had to be made in two places.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
