### PR TITLE
haskellPackages.*: unbreak glirc/matterhorn/QuickCheck/etc

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -295,6 +295,9 @@ self: super: {
   github-rest = dontCheck super.github-rest;  # test suite needs the network
   gitlib-cmdline = dontCheck super.gitlib-cmdline;
   GLFW-b = dontCheck super.GLFW-b;                      # https://github.com/bsl/GLFW-b/issues/50
+  #next release supports random 1.1; jailbroken because i didn't know about vty when glguy was updating the bounds
+  #should be fixed soon. maybe even before this is merged. currently glirc is 2.37
+  glirc = doJailbreak (super.glirc.override { random = self.random_1_2_0; });
   hackport = dontCheck super.hackport;
   hadoop-formats = dontCheck super.hadoop-formats;
   haeredes = dontCheck super.haeredes;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -366,6 +366,9 @@ self: super: {
   punycode = dontCheck super.punycode;
   pwstore-cli = dontCheck super.pwstore-cli;
   quantities = dontCheck super.quantities;
+  QuickCheck_2_14_2 = super.QuickCheck_2_14_2.override( {
+    splitmix = self.splitmix_0_1_0_3;
+  });
   redis-io = dontCheck super.redis-io;
   rethinkdb = dontCheck super.rethinkdb;
   Rlang-QQ = dontCheck super.Rlang-QQ;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -338,7 +338,8 @@ self: super: {
     then dontCheck super.math-functions # "erf table" test fails on Darwin https://github.com/bos/math-functions/issues/63
     else super.math-functions;
   matplotlib = dontCheck super.matplotlib;
-
+  # https://github.com/matterhorn-chat/matterhorn/issues/679 they do not want to be on stackage
+  matterhorn = doJailbreak super.matterhorn; # this is needed until the end of time :')
   memcache = dontCheck super.memcache;
   metrics = dontCheck super.metrics;
   milena = dontCheck super.milena;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -399,6 +399,7 @@ self: super: {
   xsd = dontCheck super.xsd;
   zip-archive = dontCheck super.zip-archive;  # https://github.com/jgm/zip-archive/issues/57
 
+  random_1_2_0 = super.random_1_2_0.override ({ splitmix = self.splitmix_0_1_0_3; });
   # These test suites run for ages, even on a fast machine. This is nuts.
   Random123 = dontCheck super.Random123;
   systemd = dontCheck super.systemd;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2694,6 +2694,8 @@ package-maintainers:
     # - pipes-mongodb
     - streaming-wai
   kiwi:
+    - config-schema
+    - config-value
     - irc-core
     - QuickCheck_2_14_2
     - random_1_2_0
@@ -4142,9 +4144,7 @@ broken-packages:
   - conffmt
   - confide
   - config-parser
-  - config-schema
   - config-select
-  - config-value
   - config-value-getopt
   - ConfigFileTH
   - Configger

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2701,8 +2701,6 @@ package-maintainers:
     - matterhorn
     - mattermost-api
     - mattermost-api-qc
-    - QuickCheck_2_14_2
-    - random_1_2_0
     - Unique
   psibi:
     - path-pieces

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2695,6 +2695,7 @@ package-maintainers:
     - streaming-wai
   kiwi:
     - irc-core
+    - QuickCheck_2_14_2
     - random_1_2_0
     - Unique
   psibi:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2694,6 +2694,7 @@ package-maintainers:
     # - pipes-mongodb
     - streaming-wai
   kiwi:
+    - irc-core
     - Unique
   psibi:
     - path-pieces
@@ -6994,7 +6995,6 @@ broken-packages:
   - iptadmin
   - IPv6DB
   - Irc
-  - irc-core
   - irc-dcc
   - irc-fun-bot
   - irc-fun-client

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2695,6 +2695,7 @@ package-maintainers:
     - streaming-wai
   kiwi:
     - irc-core
+    - random_1_2_0
     - Unique
   psibi:
     - path-pieces

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2698,6 +2698,9 @@ package-maintainers:
     - config-value
     - glirc
     - irc-core
+    - matterhorn
+    - mattermost-api
+    - mattermost-api-qc
     - QuickCheck_2_14_2
     - random_1_2_0
     - Unique
@@ -7739,9 +7742,6 @@ broken-packages:
   - matrix-market
   - matrix-sized
   - matsuri
-  - matterhorn
-  - mattermost-api
-  - mattermost-api-qc
   - maude
   - maxent
   - maxent-learner-hw

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2696,6 +2696,7 @@ package-maintainers:
   kiwi:
     - config-schema
     - config-value
+    - glirc
     - irc-core
     - QuickCheck_2_14_2
     - random_1_2_0
@@ -5533,7 +5534,6 @@ broken-packages:
   - gli
   - glicko
   - glider-nlp
-  - glirc
   - GLMatrix
   - glob-posix
   - global


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
they were broken or marked broken and at least two people use a few of them :)

###### Things done
i fixed them and marked them not broken
tested glirc and matterhorn (now on macos as well)

mattermost-api{-qc} weren't even actually broken? *shrug*
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
am trying to compile them for macos but that might take a while... (glirc worked waiting on matterhorn) and doing nixpkgs-review on aarch64 because why not? (found out why; it doesn't work!)
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
