### PR TITLE
mopidy-subidy: init at 1.0.0

### DIFF
--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -41,6 +41,8 @@ let
     mopidy-tunein = callPackage ./tunein.nix { };
 
     mopidy-youtube = callPackage ./youtube.nix { };
+
+    mopidy-subidy = callPackage ./subidy.nix { };
   };
 
 in self

--- a/pkgs/applications/audio/mopidy/subidy.nix
+++ b/pkgs/applications/audio/mopidy/subidy.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, pythonPackages, mopidy }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "mopidy-subidy";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Prior99";
+    repo = pname;
+    rev = version;
+    sha256 = "0c5ghhhrj5v3yp4zmll9ari6r5c6ha8c1izwqshvadn40b02q7xz";
+  };
+
+  propagatedBuildInputs = [ mopidy pythonPackages.py-sonic ];
+
+  checkInputs = with pythonPackages; [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://www.mopidy.com/";
+    description = "Mopidy extension for playing music from a Subsonic-compatible Music Server";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ wenngle ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23592,6 +23592,7 @@ in
     mopidy-soundcloud
     mopidy-spotify
     mopidy-spotify-tunigo
+    mopidy-subidy
     mopidy-tunein
     mopidy-youtube;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Mopidy-Subidy is a subsonic backend for Mopidy using the py-sonic library. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
