### PR TITLE
sssd: fix build on glibc-2.32

### DIFF
--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -54,6 +54,16 @@ stdenv.mkDerivation rec {
     configureFlagsArray+=("--with-sudo")
   '';
 
+  preBuild = ''
+    # glibc-2.32 includes a full set of NSS stub module declarations
+    # that conflict with the ones in sssd source. Define _NSS_H to
+    # prevent them from breaking the compilation, but just for this
+    # one file.
+    cat >> Makefile <<EOF
+      src/responder/nss/nss_cmd.\$(OBJEXT) : DEFS = -DHAVE_CONFIG_H -D_NSS_H
+    EOF
+  '';
+
   enableParallelBuilding = true;
   buildInputs = [ augeas dnsutils c-ares curl cyrus_sasl ding-libs libnl libunistring nss
                   samba nfs-utils doxygen python python3 popt


### PR DESCRIPTION
For https://hydra.nixos.org/build/128488320 which errored with:

    src/responder/nss/nss_cmd.c:733:16: error: 'nss_setnetgrent' redeclared as different kind of symbol
      733 | static errno_t nss_setnetgrent(struct cli_ctx *cli_ctx,
          |                ^~~~~~~~~~~~~~~
    In file included from ./src/sss_client/sss_cli.h:28,
                     from ./src/db/sysdb.h:27,
                     from src/responder/nss/nss_cmd.c:26:
    /nix/store/a2n8nrsf215x01a7fv8l94crdjwf69pa-glibc-2.32-dev/include/nss.h:184:25: note: previous declaration of 'nss_setnetgrent' was here
      184 | typedef enum nss_status nss_setnetgrent (const char *, struct __netgrent *);
          |                         ^~~~~~~~~~~~~~~
    make[2]: *** [Makefile:17818: src/responder/nss/nss_cmd.o] Error 1
    make[2]: Leaving directory '/build/sssd-1.16.4'
    make[1]: *** [Makefile:33824: all-recursive] Error 1
    make[1]: Leaving directory '/build/sssd-1.16.4'
    make: *** [Makefile:10123: all] Error 2

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
