### PR TITLE
gforth: fix cross-compilation

### DIFF
--- a/pkgs/by-name/gf/gforth/package.nix
+++ b/pkgs/by-name/gf/gforth/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  callPackage,
+  buildPackages,
   autoreconfHook,
   gitUpdater,
   texinfo,
@@ -11,8 +11,8 @@
 }:
 
 let
-  swig = callPackage ./swig.nix { };
-  bootForth = callPackage ./boot-forth.nix { };
+  swig = buildPackages.callPackage ./swig.nix { };
+  bootForth = buildPackages.callPackage ./boot-forth.nix { };
   lispDir = "${placeholder "out"}/share/emacs/site-lisp";
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -32,9 +32,14 @@ stdenv.mkDerivation (finalAttrs: {
     writableTmpDirAsHomeHook
     autoreconfHook
     texinfo
-    bootForth
     swig
-  ];
+  ]
+  ++ (
+    if (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) then
+      [ buildPackages.gforth ]
+    else
+      [ bootForth ]
+  );
 
   buildInputs = [
     libffi
@@ -47,10 +52,39 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     "--build=x86_64-apple-darwin"
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    # Tries to run ./engine/gforth-ll
+    "--without-check"
+    # Use build-platform CC for helper programs that must run during build
+    "HOSTCC=${buildPackages.stdenv.cc}/bin/cc"
+    # Tell gforth's libcc where to find the cross compiler
+    "CROSS_PREFIX=${stdenv.hostPlatform.config}-"
+  ];
+
+  env = lib.optionalAttrs (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) {
+    # Tell gforth's libcc to prefix compiler commands with the cross-compilation target
+    CROSS_PREFIX = "${stdenv.hostPlatform.config}-";
+  };
+
+  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "DITCENGINE=${buildPackages.gforth}/bin/gforth-ditc"
+    "GFORTH=${buildPackages.gforth}/bin/gforth"
+    "ENGINE=${buildPackages.gforth}/bin/gforth" # for ./preforth
   ];
 
   preConfigure = ''
     mkdir -p ${lispDir}
+  '';
+
+  postConfigure = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # Put the project-local (cross-aware) libtool first in PATH
+    mkdir -p .cross-bin
+    ln -sf "$PWD/libtool" .cross-bin/libtool
+    ln -sf "$PWD/libtool" ".cross-bin/${stdenv.hostPlatform.config}-libtool"
+    export PATH="$PWD/.cross-bin:$PATH"
+    # Remove 'check' from the default 'all' target (can't run cross binaries)
+    sed -i 's/^\(all:.*\) check/\1/' Makefile
   '';
 
   passthru.updateScript = gitUpdater { };


### PR DESCRIPTION
**Note: Claude helped out with the process here**

Fix cross-compilation of gforth (e.g. `pkgsCross.aarch64-multiplatform.gforth`).

## Summary

When cross-compiling gforth, several issues arise:

1. **Build tools vs cross tools**: `swig` and `bootForth` must be built for the build platform via `buildPackages.callPackage`.
2. **Cross gforth as native build input**: When cross-compiling, a build-platform `gforth` is needed instead of `bootForth` to generate the target image.
3. **`HOSTCC` misconfiguration**: gforth's `unix/Makefile` compiles helper programs (`pthread-types`, `stat`) that must run during the build, but `HOSTCC` defaults to the cross compiler. Fixed by pointing `HOSTCC` to the build-platform CC.
4. **`CROSS_PREFIX` for libcc**: gforth's `libcc` mechanism compiles C wrappers via libtool. Without `CROSS_PREFIX`, it looks for bare `gcc` which doesn't exist in the cross environment. Setting `CROSS_PREFIX` to the target triple prefix fixes this.
5. **System libtool vs project-local libtool**: The system libtool has the build-platform linker hardcoded. The project-local `./libtool` (generated by `./configure`) is cross-aware. Symlinks are created so both `libtool` and `${target}-libtool` resolve to the project-local one.
6. **`check` in default target**: gforth's `all` make target includes `check`, which tries to run cross-compiled binaries. Removed from `all` for cross builds.
7. **`ENGINE`/`GFORTH`/`DITCENGINE` make variables**: Must point to the build-platform gforth for image generation during cross builds.

Tested: `nix-build -A pkgsCross.aarch64-multiplatform.gforth` builds successfully, producing aarch64 ELF binaries. Native `nix-build -A gforth` still works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test