### PR TITLE
nixos-rebuild: support --extra-substituters

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -85,6 +85,10 @@
     <option>--builders</option> <replaceable>builder-spec</replaceable>
    </arg>
 
+   <arg>
+    <option>--extra-substituters</option> <replaceable>substituter-spec</replaceable>
+   </arg>
+
    <sbr/>
 
    <arg>
@@ -441,6 +445,21 @@
       existing builders specified in <filename>/etc/nix/machines</filename> can
       be ignored: <command>--builders ""</command> for example when they are
       not reachable due to network connectivity.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--extra-substituters</option> <replaceable>substituter-spec</replaceable>
+    </term>
+    <listitem>
+     <para>
+      Allow ad-hoc addition of binary cache substituters for building the new
+      system. This requires the user executing <command>nixos-rebuild</command>
+      (usually root) to be configured as a trusted user in the Nix daemon.
+      This can be achieved by using the <literal>nix.trustedUsers</literal> NixOS
+      option.
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -64,7 +64,7 @@ while [ "$#" -gt 0 ]; do
         repair=1
         extraBuildFlags+=("$i")
         ;;
-      --max-jobs|-j|--cores|-I|--builders)
+      --max-jobs|-j|--cores|-I|--builders|--extra-substituters)
         j="$1"; shift 1
         extraBuildFlags+=("$i" "$j")
         ;;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

So I can enable a module which requires an additional substituter, without a two-stepped switch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
