### PR TITLE
rustscan: 1.10.1 -> 2.0.1

### DIFF
--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rustscan";
-  version = "1.10.1";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "RustScan";
     repo = pname;
     rev = version;
-    sha256 = "0dhy7b73ipsxsr7wlc3r5yy39i3cjrdszhsw9xwjj31692s3b605";
+    sha256 = "0fdbsz1v7bb5dm3zqjs1qf73lb1m4qzkqyb3h3hbyrp9vklgxsgw";
   };
 
-  cargoSha256 = "00s1iv8yw06647ijw9p3l5n7d899gsks5j8ljag6ha7hgl5vs4ci";
+  cargoSha256 = "039xarscwqndpyrr3sgzkhqna3c908zh06id8x2qaykm8l248zs9";
 
   postPatch = ''
     substituteInPlace src/main.rs \
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage rec {
     "--skip=google_dns_runs"
     "--skip=parse_correct_host_addresses"
     "--skip=parse_hosts_file_and_incorrect_hosts"
+    "--skip=run_perl_script"
+    "--skip=run_python_script"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump rustscan to `2.0.1` (version reports as `2.0.0`, Cargo.toml still says `2.0.0` https://github.com/RustScan/RustScan/issues/320)
`./result/bin/rustscan -a 127.0.0.1` works

Since this is a breaking version change (`1` to `2`) change is there any documentation that needs updating?

Ignored new tests that required perl and python. Could add them but they don't look too valuable...
https://github.com/RustScan/RustScan/blob/21b92a1d1b8f9a5895705617881551e26bbbf0cf/src/scripts/mod.rs#L454-L473

https://github.com/RustScan/RustScan/blob/master/fixtures/.rustscan_scripts/test_script.py

```python
import sys

print('Python script ran with arguments', str(sys.argv))
```

https://github.com/RustScan/RustScan/blob/master/fixtures/.rustscan_scripts/test_script.pl

```perl
my $total = $#ARGV + 1;
my $counter = 1;
 
# get script name
my $scriptname = $0;
 
print "Total args passed to $scriptname : $total\n";
 
# Use loop to print all args stored in an array called @ARGV
foreach my $a(@ARGV) {
	print "Arg # $counter : $a\n";
	$counter++;
}
```

Maintainer ping: @SuperSandro2000 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
