### PR TITLE
opustags: 1.4.0 -> 1.5.1, mark broken darwin

### DIFF
--- a/pkgs/applications/audio/opustags/default.nix
+++ b/pkgs/applications/audio/opustags/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, cmake, pkgconfig, libogg, fetchFromGitHub, libiconv }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config, libiconv, libogg
+, ffmpeg, glibcLocales, perl, perlPackages }:
+
 stdenv.mkDerivation rec {
   pname = "opustags";
   version = "1.5.1";
@@ -10,14 +12,37 @@ stdenv.mkDerivation rec {
     sha256 = "1dicv4s395b9gb4jpr0rnxdq9azr45pid62q3x08lb7cvyq3yxbh";
   };
 
+  patches = [
+    # Fix building on darwin
+    (fetchpatch {
+      url = "https://github.com/fmang/opustags/commit/64fc6f8f6d20e034892e89abff0236c85cae98dc.patch";
+      sha256 = "1djifzqhf1w51gbpqbndsh3gnl9iizp6hppxx8x2a92i9ns22zpg";
+    })
+    (fetchpatch {
+      url = "https://github.com/fmang/opustags/commit/f98208c1a1d10c15f98b127bbfdf88a7b15b08dc.patch";
+      sha256 = "1h3v0r336fca0y8zq1vl2wr8gaqs3vvrrckx7pvji4k1jpiqvp38";
+    })
+  ];
+
   buildInputs = [ libogg ];
 
-  nativeBuildInputs = [ cmake pkgconfig ] ++ lib.optional stdenv.isDarwin libiconv;
+  nativeBuildInputs = [ cmake pkg-config ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
-  meta = with lib; {
+  doCheck = true;
+
+  checkInputs = [ ffmpeg glibcLocales perl ] ++ (with perlPackages; [ ListMoreUtils ]);
+
+  checkPhase = ''
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
+    make check
+  '';
+
+  meta = with stdenv.lib; {
     homepage = "https://github.com/fmang/opustags";
     description = "Ogg Opus tags editor";
     platforms = platforms.all;
+    broken = stdenv.isDarwin;
     maintainers = [ maintainers.kmein ];
     license = licenses.bsd3;
   };

--- a/pkgs/applications/audio/opustags/default.nix
+++ b/pkgs/applications/audio/opustags/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, cmake, pkgconfig, libogg, fetchFromGitHub, libiconv }:
 stdenv.mkDerivation rec {
   pname = "opustags";
-  version = "1.5.0";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "fmang";
     repo = "opustags";
     rev = version;
-    sha256 = "191zx2g3lijybgcy3a4fz5l35cagdrcdr0difhcfz0zn60hwnvqc";
+    sha256 = "1dicv4s395b9gb4jpr0rnxdq9azr45pid62q3x08lb7cvyq3yxbh";
   };
 
   buildInputs = [ libogg ];

--- a/pkgs/applications/audio/opustags/default.nix
+++ b/pkgs/applications/audio/opustags/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     description = "Ogg Opus tags editor";
     platforms = platforms.all;
     broken = stdenv.isDarwin;
-    maintainers = [ maintainers.kmein ];
+    maintainers = with maintainers; [ kmein SuperSandro2000 ];
     license = licenses.bsd3;
   };
 }

--- a/pkgs/applications/audio/opustags/default.nix
+++ b/pkgs/applications/audio/opustags/default.nix
@@ -1,13 +1,13 @@
 { stdenv, lib, cmake, pkgconfig, libogg, fetchFromGitHub, libiconv }:
 stdenv.mkDerivation rec {
   pname = "opustags";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "fmang";
     repo = "opustags";
     rev = version;
-    sha256 = "1y0czl72paawy342ff9ickaamkih43k59yfcdw7bnddypyfa7nbg";
+    sha256 = "191zx2g3lijybgcy3a4fz5l35cagdrcdr0difhcfz0zn60hwnvqc";
   };
 
   buildInputs = [ libogg ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #103484

Fails on darwin with

```
�[1m/tmp/nix-build-opustags-1.5.0.drv-0/source/src/system.cc:182:13: �[0m�[0;1;31merror: �[0m�[1mno member named 'st_mtim' in 'stat'�[0m
        mtime = st.st_mtim; // more precise than st_mtime
�[0;1;32m                ~~ ^
�[0m1 error generated.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
