### PR TITLE
autofs: fix compilation fail due to libtirpc changes

### DIFF
--- a/pkgs/os-specific/linux/autofs/default.nix
+++ b/pkgs/os-specific/linux/autofs/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, flex, bison, linuxHeaders, libtirpc, mount, umount, nfs-utils, e2fsprogs
-, libxml2, kerberos, kmod, openldap, sssd, cyrus_sasl, openssl }:
+, libxml2, kerberos, kmod, openldap, sssd, cyrus_sasl, openssl, rpcsvc-proto }:
 
 let
   version = "5.1.6";
@@ -28,13 +28,16 @@ in stdenv.mkDerivation {
     unset STRIP # Makefile.rules defines a usable STRIP only without the env var.
   '';
 
+  # configure script is not finding the right path
+  NIX_CFLAGS_COMPILE = [ "-I${libtirpc.dev}/include/tirpc" ];
+
   installPhase = ''
     make install SUBDIRS="lib daemon modules man" # all but samples
     #make install SUBDIRS="samples" # impure!
   '';
 
   buildInputs = [ linuxHeaders libtirpc libxml2 kerberos kmod openldap sssd
-                  openssl cyrus_sasl ];
+                  openssl cyrus_sasl rpcsvc-proto ];
 
   nativeBuildInputs = [ flex bison ];
 


### PR DESCRIPTION
Fixes

```
checking for ranlib... /nix/store/p3kn26g5nhmx6spn37ar3mn0xjbzks3g-binutils-2.31.1/bin/ranlib
checking for rpcgen... no
configure: error: required program RPCGEN not found
``` 
and 
```
In file included from ../include/automount.h:33,
                 from cache.c:25:
../include/rpc_subs.h:19:10: fatal error: rpc/rpc.h: No such file or directory
   19 | #include <rpc/rpc.h>
      |          ^~~~~~~~~~~
compilation terminated.
```

Merge after #104774

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/104774#issuecomment-733142650

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
