### PR TITLE
sssd: fix nss collision with upstream patch

### DIFF
--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/SSSD/sssd/commit/bc56b10aea999284458dcc293b54cf65288e325d.patch";
       sha256 = "0q74sx5n41srq3kdn55l5j1sq4xrjsnl5y4v8yh5mwsijj74yh4g";
     })
+    # Fix collision with external nss symbol
+    (fetchpatch {
+      url = "https://github.com/SSSD/sssd/commit/fe9eeb51be06059721e873f77092b1e9ba08e6c1.patch";
+      sha256 = "0b83b2w0rnvm26pg03a4lpmkmi7n3gqxg7lk751q61q79gnzrpz4";
+    })
   ];
 
   # Something is looking for <libxml/foo.h> instead of <libxml2/libxml/foo.h>
@@ -52,16 +57,6 @@ stdenv.mkDerivation rec {
     )
   '' + stdenv.lib.optionalString withSudo ''
     configureFlagsArray+=("--with-sudo")
-  '';
-
-  preBuild = ''
-    # glibc-2.32 includes a full set of NSS stub module declarations
-    # that conflict with the ones in sssd source. Define _NSS_H to
-    # prevent them from breaking the compilation, but just for this
-    # one file.
-    cat >> Makefile <<EOF
-      src/responder/nss/nss_cmd.\$(OBJEXT) : DEFS = -DHAVE_CONFIG_H -D_NSS_H
-    EOF
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
IRC
#104774

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
