### PR TITLE
nixos/nullmailer: add missing directory /var/spool/nullmailer/failed

### DIFF
--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -219,7 +219,7 @@ with lib;
       after = [ "network.target" ];
 
       preStart = ''
-        mkdir -p /var/spool/nullmailer/{queue,tmp}
+        mkdir -p /var/spool/nullmailer/{queue,tmp,failed}
         rm -f /var/spool/nullmailer/trigger && mkfifo -m 660 /var/spool/nullmailer/trigger
       '';
 


### PR DESCRIPTION
Without the /var/spool/nullmailer/failed directory, failed messages stay
in /var/spool/nullmailer/queue, but should not.


###### Motivation for this change

When a message fails, nullmailer should move it from the 'queue' directory to the 'failed' directory, but it cannot because the 'failed' directory does not exist.

See issue #104413 for more details.


###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [y] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [y ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`

But I suspect I am not doing this correctly.

```[frank@oak2:~/mynix/nixpkgs]$ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 67, done.
remote: Counting objects: 100% (67/67), done.
remote: Compressing objects: 100% (31/31), done.
remote: Total 84 (delta 53), reused 43 (delta 36), pack-reused 17
Unpacking objects: 100% (84/84), 164.08 KiB | 4.43 MiB/s, done.
From https://github.com/NixOS/nixpkgs
 * [new branch]              master     -> refs/nixpkgs-review/0
$ git worktree add /home/frank/.cache/nixpkgs-review/rev-119a27a5494127f0d47c2241cccff6d413669c5b-dirty/nixpkgs 0be35abecdffc532173524de5a86984780088a07
Preparing worktree (detached HEAD 0be35abecdf)
Updating files: 100% (23295/23295), done.
HEAD is now at 0be35abecdf Merge pull request #104319 from magnetophon/m32edit
$ nix-env -f /home/frank/.cache/nixpkgs-review/rev-119a27a5494127f0d47c2241cccff6d413669c5b-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```


- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
