### PR TITLE
vscode-extensions: fix aliases with recursiveUpdate overlay

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -68,6 +68,24 @@ rec {
   #
   extends = f: rattrs: self: let super = rattrs self; in super // f self super;
 
+  # Similar to the function `extends`, but the attrs are merged recursively
+  #
+  #     f = self: { foo.bar = "fizz"; }
+  #     g = self: super: { foo.baq = super.foo.bar + "buzz"; }
+  #
+  #     nix-repl> fix (recursiveExtends g f)
+  #     { foo = {
+  #         baq = "fizzbuzz"; # created from "g"
+  #         bar = "fizz";     # still remains from the initial attr set in "f"
+  #       };
+  #     }
+  #
+  # Caution should be used when applying this function, as recursing deeply into attrs
+  # is much more expensive than overriding top-level attrs with //.
+  #
+  #   Type: recursiveExtends :: AttrSet a => (a -> a -> a) -> (a -> a) -> (a -> a)
+  recursiveExtends = f: rattrs: self: let super = rattrs self; in lib.recursiveUpdate super (f self super);
+
   # Compose two extending functions of the type expected by 'extends'
   # into one where changes made in the first are available in the
   # 'super' of the second

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -247,9 +247,10 @@ let
       WakaTime.vscode-wakatime = callPackage ./wakatime {};
     };
 
+    # overlays
     aliases = self: super: {
       # aliases
-      ms-vscode = lib.recursiveUpdate super.ms-vscode { inherit (super.golang) Go; };
+      ms-vscode.Go = super.golang.Go;
     };
 
     # TODO: add overrides overlay, so that we can have a generated.nix
@@ -258,6 +259,6 @@ let
     # overlays will be applied left to right, overrides should come after aliases.
     overlays = lib.optionals (config.allowAliases or true) [ aliases ];
 
-    toFix = lib.foldl' (lib.flip lib.extends) baseExtensions overlays;
+    toFix = lib.foldl' (lib.flip lib.fixedPoints.recursiveExtends) baseExtensions overlays;
 in
   lib.fix toFix


### PR DESCRIPTION
###### Motivation for this change
alternate solution to #104796

but adds another lib function.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
