### PR TITLE
systemd: use withPortabled in mesonFlags

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -57,11 +57,12 @@
 
 , withAnalyze ? true
 , withApparmor ? true
-, withCoredump ? true
 , withCompression ? true  # adds bzip2, lz4 and xz
+, withCoredump ? true
 , withCryptsetup ? true
 , withDocumentation ? true
 , withEfi ? stdenv.hostPlatform.isEfi
+, withHomed ? false
 , withHostnamed ? true
 , withHwdb ? true
 , withImportd ? true
@@ -72,14 +73,15 @@
 , withNss ? true
 , withPCRE2 ? true
 , withPolkit ? true
+, withPortabled ? false
 , withRemote ? true
 , withResolved ? true
 , withShellCompletions ? true
 , withTimedated ? true
 , withTimesyncd ? true
 , withUserDb ? true
-, withHomed ? false, p11-kit, libfido2
-# , withPortabled ? false TODO
+, p11-kit
+, libfido2
 
   # name argument
 , pname ? "systemd"
@@ -94,7 +96,7 @@
 assert withResolved -> (libgcrypt != null && libgpgerror != null);
 assert withImportd ->
 (curl.dev != null && zlib != null && xz != null && libgcrypt != null
-  && gnutar != null && gnupg != null && withCompression );
+  && gnutar != null && gnupg != null && withCompression);
 
 assert withEfi -> (gnu-efi != null);
 assert withRemote -> lib.getDev curl != null;
@@ -104,7 +106,6 @@ assert withHomed -> withCryptsetup;
 
 assert withCryptsetup ->
 (cryptsetup != null);
-
 let
   wantCurl = withRemote || withImportd;
 
@@ -196,20 +197,20 @@ stdenv.mkDerivation {
       pam
     ]
 
-    ++ lib.optional  withApparmor libapparmor
-    ++ lib.optional  wantCurl (lib.getDev curl)
+    ++ lib.optional withApparmor libapparmor
+    ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz ]
-    ++ lib.optional  withCryptsetup (lib.getDev cryptsetup.dev)
-    ++ lib.optional  withEfi gnu-efi
-    ++ lib.optional  withKexectools kexectools
-    ++ lib.optional  withLibseccomp libseccomp
-    ++ lib.optional  withNetworkd iptables
-    ++ lib.optional  withPCRE2 pcre2
-    ++ lib.optional  withResolved libgpgerror
-    ++ lib.optional  withSelinux libselinux
-    ++ lib.optional  withRemote libmicrohttpd
+    ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
+    ++ lib.optional withEfi gnu-efi
+    ++ lib.optional withKexectools kexectools
+    ++ lib.optional withLibseccomp libseccomp
+    ++ lib.optional withNetworkd iptables
+    ++ lib.optional withPCRE2 pcre2
+    ++ lib.optional withResolved libgpgerror
+    ++ lib.optional withSelinux libselinux
+    ++ lib.optional withRemote libmicrohttpd
     ++ lib.optionals withHomed [ p11-kit libfido2 ]
-    ;
+  ;
 
   #dontAddPrefix = true;
 
@@ -240,7 +241,7 @@ stdenv.mkDerivation {
     "-Dnetworkd=${lib.boolToString withNetworkd}"
     "-Dpolkit=${lib.boolToString withPolkit}"
     "-Dcryptsetup=${lib.boolToString withCryptsetup}"
-    "-Dportabled=false"
+    "-Dportabled=${lib.boolToString withPortabled}"
     "-Dhwdb=${lib.boolToString withHwdb}"
     "-Dremote=${lib.boolToString withRemote}"
     "-Dsysusers=false"


### PR DESCRIPTION
No matter what withPortabled was being set, we always passed
-Dportabled=false in mesonFlags. Fix this.

Also, nixpkgs-fmt the file for consistency.

This contains zero changes, so no rebuild and targetting master. I verified it applies cleanly with what's currently in staging and staging-next.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
