### PR TITLE
[20.09] webkitgtk: 2.28.4 -> 2.30.3

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -49,6 +49,7 @@
 , woff2
 , bubblewrap
 , libseccomp
+, systemd
 , xdg-dbus-proxy
 , substituteAll
 , glib
@@ -62,13 +63,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.28.4";
+  version = "2.30.0";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "0r4lkk21pny2g4mmsw0ds14m5hhjys1l47gvy59dfgihr7l546c2";
+    sha256 = "04axfmzsb9gnyqaz5v7ljapiycxnzwpiya1l9rhp4c1qsbrdpwya";
   };
 
   patches = optionals stdenv.isLinux [
@@ -140,6 +141,7 @@ stdenv.mkDerivation rec {
   ] ++ optionals stdenv.isLinux [
     bubblewrap
     libseccomp
+    systemd
     wayland
     xdg-dbus-proxy
   ] ++ optional enableGeoLocation geoclue2

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  separateDebugInfo = stdenv.isLinux;
+
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
     sha256 = "04axfmzsb9gnyqaz5v7ljapiycxnzwpiya1l9rhp4c1qsbrdpwya";
@@ -180,7 +182,7 @@ stdenv.mkDerivation rec {
     description = "Web content rendering engine, GTK port";
     homepage = "https://webkitgtk.org/";
     license = licenses.bsd2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = teams.gnome.members;
   };
 }

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -63,7 +63,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.30.0";
+  version = "2.30.1";
 
   outputs = [ "out" "dev" ];
 
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "04axfmzsb9gnyqaz5v7ljapiycxnzwpiya1l9rhp4c1qsbrdpwya";
+    sha256 = "1cfnsl5kvwrbclmp7v9q9ynrz702i9ncb6xmx6972dxpmpyrvi8p";
   };
 
   patches = optionals stdenv.isLinux [

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -41,8 +41,6 @@
 , enableGeoLocation ? true
 , geoclue2
 , sqlite
-, enableGtk2Plugins ? false
-, gtk2 ? null
 , enableGLES ? true
 , gst-plugins-base
 , gst-plugins-bad
@@ -56,8 +54,6 @@
 }:
 
 assert enableGeoLocation -> geoclue2 != null;
-assert enableGtk2Plugins -> gtk2 != null;
-assert stdenv.isDarwin -> !enableGtk2Plugins;
 
 with stdenv.lib;
 
@@ -146,8 +142,7 @@ stdenv.mkDerivation rec {
     systemd
     wayland
     xdg-dbus-proxy
-  ] ++ optional enableGeoLocation geoclue2
-    ++ optional enableGtk2Plugins gtk2;
+  ] ++ optional enableGeoLocation geoclue2;
 
   propagatedBuildInputs = [
     gtk3
@@ -171,8 +166,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_X11_TARGET=OFF"
     "-DUSE_ACCELERATE=0"
     "-DUSE_SYSTEM_MALLOC=ON"
-  ] ++ optional (!enableGtk2Plugins) "-DENABLE_PLUGIN_PROCESS_GTK2=OFF"
-    ++ optional (stdenv.isLinux && enableGLES) "-DENABLE_GLES2=ON";
+  ] ++ optional (stdenv.isLinux && enableGLES) "-DENABLE_GLES2=ON";
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -59,7 +59,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.30.2";
+  version = "2.30.3";
 
   outputs = [ "out" "dev" ];
 
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "0ak8slddg7gpk6m096xzkiqw9bfsrrizvqr815bw44665fyf0ry4";
+    sha256 = "0zsy3say94d9bhaan0l6mfr59z03a5x4kngyy8b2i20n77q19skd";
   };
 
   patches = optionals stdenv.isLinux [

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -59,7 +59,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "webkitgtk";
-  version = "2.30.1";
+  version = "2.30.2";
 
   outputs = [ "out" "dev" ];
 
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/${pname}-${version}.tar.xz";
-    sha256 = "1cfnsl5kvwrbclmp7v9q9ynrz702i9ncb6xmx6972dxpmpyrvi8p";
+    sha256 = "0ak8slddg7gpk6m096xzkiqw9bfsrrizvqr815bw44665fyf0ry4";
   };
 
   patches = optionals stdenv.isLinux [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://webkitgtk.org/security/WSA-2020-0008.html

It's unclear what patches have to be backported and even Debian backported 2.30.3 to buster-security. I think we should do the same.

I successfully tested this against epiphany.

I'm not sure if all of this should be backported, but it seemed like the least error-prone approach to doing this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
