### PR TITLE
pythonPackages.pyscard: Remove patch that is included in 1.9.9 and 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pyscard/default.nix
+++ b/pkgs/development/python-modules/pyscard/default.nix
@@ -30,21 +30,6 @@ buildPythonPackage rec {
   NIX_CFLAGS_COMPILE = optionalString (! withApplePCSC)
     "-I ${getDev pcsclite}/include/PCSC";
 
-  # The error message differs depending on the macOS host version.
-  # Since Nix reports a constant host version, but proxies to the
-  # underlying library, it's not possible to determine the correct
-  # expected error message.  This patch allows both errors to be
-  # accepted.
-  # See: https://github.com/LudovicRousseau/pyscard/issues/77
-  # Building with python from nix on macOS version 10.13 or
-  # greater still causes this issue to occur.
-  patches = optionals withApplePCSC [
-    (fetchpatch {
-      url = "https://github.com/LudovicRousseau/pyscard/commit/945e9c4cd4036155691f6ce9706a84283206f2ef.patch";
-      sha256 = "19n8w1wzn85zywr6xf04d8nfg7sgzjyvxp1ccp3rgfr4mcc36plc";
-    })
-  ];
-
   propagatedBuildInputs = if withApplePCSC then [ PCSC ] else [ pcsclite ];
   nativeBuildInputs = [ swig ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#102846

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
