### PR TITLE
xorg.xprop: 1.2.4 -> 1.2.5

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2731,11 +2731,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xprop = callPackage ({ stdenv, pkgconfig, fetchurl, libX11, xorgproto }: stdenv.mkDerivation {
-    name = "xprop-1.2.4";
+    name = "xprop-1.2.5";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/app/xprop-1.2.4.tar.bz2";
-      sha256 = "0lzp7kyhpwd5hm83j2zm6j3w3z1z5i4ykgg2nwr01ij6dq4znxwc";
+      url = "mirror://xorg/individual/app/xprop-1.2.5.tar.bz2";
+      sha256 = "18ckr8g1z50zkc01hprkpm1npwbq32yqib4b3l98c95z2q1yv4lv";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -60,7 +60,7 @@ mirror://xorg/individual/app/xmessage-1.0.5.tar.bz2
 mirror://xorg/individual/app/xmodmap-1.0.10.tar.bz2
 mirror://xorg/individual/app/xmore-1.0.3.tar.bz2
 mirror://xorg/individual/app/xpr-1.0.5.tar.bz2
-mirror://xorg/individual/app/xprop-1.2.4.tar.bz2
+mirror://xorg/individual/app/xprop-1.2.5.tar.bz2
 mirror://xorg/individual/app/xrandr-1.5.0.tar.bz2
 mirror://xorg/individual/app/xrdb-1.2.0.tar.bz2
 mirror://xorg/individual/app/xrefresh-1.0.6.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2020-November/003064.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).