### PR TITLE
cassandra: 3.11.4 -> 3.11.9

### DIFF
--- a/pkgs/servers/nosql/cassandra/3.11.nix
+++ b/pkgs/servers/nosql/cassandra/3.11.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "3.11.4";
-  sha256 = "11wr0vcps8w8g2sd8qwp1yp8y873c4q32azc041xpi7zqciqwnax";
+  version = "3.11.9";
+  sha256 = "1ckaacc1z0j72llklrc4587ia6a0pab02bdyac6g3kl6kqvcz40c";
 })


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2020-13946 Apache Cassandra RMI Rebind Vulnerability

It is possible for a local attacker without access to the Apache Cassandra
process or configuration files to manipulate the RMI registry to perform a
man-in-the-middle attack and capture user names and passwords used to access
the JMX interface. The attacker can then use these credentials to access
the JMX interface and perform unauthorised operations.

Users should also be aware of CVE-2019-2684, a JRE vulnerability that enables
this issue to be exploited remotely.

3.11.x users should upgrade to 3.11.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
