### PR TITLE
cassandra_3_0: 3.0.17 -> 3.0.23

### DIFF
--- a/pkgs/servers/nosql/cassandra/3.0.nix
+++ b/pkgs/servers/nosql/cassandra/3.0.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "3.0.17";
-  sha256 = "0568r5xdy78pl29zby5g4m9qngf29cb9222sc1q1wisapb7zkl2p";
+  version = "3.0.23";
+  sha256 = "0cbia20bggq85q2p6gsybw045qdfqxd5xv8ihppq1hwl21sb2klz";
 })


### PR DESCRIPTION
###### Motivation for this change

Issue: #99744
Reason: Fixes CVE-2020-13946 Apache Cassandra RMI Rebind Vulnerability

Description:
It is possible for a local attacker without access to the Apache Cassandra
process or configuration files to manipulate the RMI registry to perform a
man-in-the-middle attack and capture user names and passwords used to access
the JMX interface. The attacker can then use these credentials to access
the JMX interface and perform unauthorised operations.

Users should also be aware of CVE-2019-2684, a JRE vulnerability that enables
this issue to be exploited remotely.

3.0.x users should upgrade to 3.0.22

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
