### PR TITLE
vips: add librsvg dependency

### DIFF
--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -13,6 +13,7 @@
 , libgsf
 , libexif
 , libheif
+, librsvg
 , ApplicationServices
 , python27
 , libpng
@@ -63,6 +64,7 @@ stdenv.mkDerivation rec {
     libexif
     libheif
     libpng
+    librsvg
     python27
     libpng
     expat


### PR DESCRIPTION
Some vips operations on SVG files require librsvg.

###### Motivation for this change

Certain operations by the npm sharp package which uses vips will fail (with a confusing message about magick) with librsvg.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
