### PR TITLE
plex-media-player: remove myself as a maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4801,12 +4801,6 @@
       fingerprint = "5A9A 1C9B 2369 8049 3B48  CF5B 81A1 5409 4816 2372";
     }];
   };
-  kylewlacy = {
-    email = "kylelacy+nix@pm.me";
-    github = "kylewlacy";
-    githubId = 1362179;
-    name = "Kyle Lacy";
-  };
   laikq = {
     email = "gwen@quasebarth.de";
     github = "laikq";

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -41,7 +41,7 @@ in mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Streaming media player for Plex";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ kylewlacy ];
+    maintainers = with maintainers; [ ];
     homepage = "https://plex.tv";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I jumped on the Nix train some years ago, but since then I've stepped away from the ecosystem at large. Since then, my situation is pretty different, and it's hard for me to find the time to review even minor changes these days (however sporadic). As such, I don't want to give the false impression that I can act as an active maintainer for the package, so I think it's best if I remove myself from the `maintainers` list.

@B4dM4n I know you've done some version bumps and done general maintenance on `plex-media-player`... I don't want to impose, but would you be interested in picking it up?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
