### PR TITLE
mpv: enable sixel support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -31,28 +31,29 @@
   , mesa   ? null
 
 , alsaSupport        ? stdenv.isLinux, alsaLib       ? null
+, archiveSupport     ? true,           libarchive    ? null
 , bluraySupport      ? true,           libbluray     ? null
 , bs2bSupport        ? true,           libbs2b       ? null
 , cacaSupport        ? true,           libcaca       ? null
 , cmsSupport         ? true,           lcms2         ? null
 , dvdnavSupport      ? stdenv.isLinux, libdvdnav     ? null
+, jackaudioSupport   ? false,          libjack2      ? null
 , libpngSupport      ? true,           libpng        ? null
+, openalSupport      ? true,           openalSoft    ? null
 , pulseSupport       ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , rubberbandSupport  ? stdenv.isLinux, rubberband    ? null
 , screenSaverSupport ? true,           libXScrnSaver ? null
 , sdl2Support        ? true,           SDL2          ? null
+, sixelSupport       ? false,          libsixel      ? null
 , speexSupport       ? true,           speex         ? null
 , swiftSupport       ? false,          swift         ? null
 , theoraSupport      ? true,           libtheora     ? null
 , vaapiSupport       ? stdenv.isLinux, libva         ? null
+, vapoursynthSupport ? false,          vapoursynth   ? null
 , vdpauSupport       ? true,           libvdpau      ? null
 , xineramaSupport    ? stdenv.isLinux, libXinerama   ? null
 , xvSupport          ? stdenv.isLinux, libXv         ? null
 , zimgSupport        ? true,           zimg          ? null
-, archiveSupport     ? true,           libarchive    ? null
-, jackaudioSupport   ? false,          libjack2      ? null
-, openalSupport      ? true,           openalSoft    ? null
-, vapoursynthSupport ? false,          vapoursynth   ? null
 }:
 
 with stdenv.lib;
@@ -76,6 +77,7 @@ assert pulseSupport       -> available libpulseaudio;
 assert rubberbandSupport  -> available rubberband;
 assert screenSaverSupport -> available libXScrnSaver;
 assert sdl2Support        -> available SDL2;
+assert sixelSupport       -> available libsixel;
 assert speexSupport       -> available speex;
 assert theoraSupport      -> available libtheora;
 assert vaapiSupport       -> available libva;
@@ -134,6 +136,7 @@ in stdenv.mkDerivation rec {
     (enableFeature dvdnavSupport   "dvdnav")
     (enableFeature openalSupport   "openal")
     (enableFeature sdl2Support     "sdl2")
+    (enableFeature sixelSupport    "sixel")
     (enableFeature vaapiSupport    "vaapi")
     (enableFeature waylandSupport  "wayland")
     (enableFeature stdenv.isLinux  "dvbin")
@@ -161,6 +164,7 @@ in stdenv.mkDerivation rec {
     ++ optional rubberbandSupport  rubberband
     ++ optional screenSaverSupport libXScrnSaver
     ++ optional sdl2Support        SDL2
+    ++ optional sixelSupport       libsixel
     ++ optional speexSupport       speex
     ++ optional theoraSupport      libtheora
     ++ optional vaapiSupport       libva


### PR DESCRIPTION
###### Motivation for this change

The newest release of mpv added support for sixel output.

Test:
``` console
$ nix run 'nixpkgs#mlterm' 
# Inside mlterm
$ mpv --vo=sixel path-to-a-video
```

![image](https://user-images.githubusercontent.com/20448408/100187339-ea4ff900-2eb5-11eb-911e-3300dac9e362.png)

Tested using a 4K 60fps video from YouTube.

Closure:
- From: `/nix/store/xbxpclh4pbvx5is95935y9vhnvdbky7b-mpv-with-scripts-0.33.0	 426.6M`
- To:     `/nix/store/iddyc4azrdd334lkiilmmpmc48fb3qdv-mpv-with-scripts-0.33.0	 427.2M`

cc: @Ma27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
