### PR TITLE
viber: 7.0.0.1035 -> 13.3.1.22

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -1,15 +1,16 @@
 {fetchurl, stdenv, dpkg, makeWrapper,
- alsaLib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1, harfbuzz, libcap,
- libpulseaudio, libxml2, libxslt, libGLU, libGL, nspr, nss, openssl, systemd, wayland, xorg, zlib, ...
+ alsaLib, cups, curl, dbus, expat, fontconfig, freetype, glib, gst_all_1,
+ harfbuzz, libcap, libGL, libGLU, libpulseaudio, libxkbcommon, libxml2, libxslt,
+ nspr, nss, openssl, systemd, wayland, xorg, zlib, ...
 }:
 
 stdenv.mkDerivation {
   pname = "viber";
-  version = "7.0.0.1035";
+  version = "13.3.1.22";
 
   src = fetchurl {
     url = "https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb";
-    sha256 = "06mp2wvqx4y6rd5gs2mh442qcykjrrvwnkhlpx0lara331i2p0lj";
+    sha256 = "0rs26x0lycavybn6k1hbb5kzms0zzcmxlrmi4g8k7vyafj6s8dqh";
   };
 
   buildInputs = [ dpkg makeWrapper ];
@@ -29,10 +30,11 @@ stdenv.mkDerivation {
       gst_all_1.gstreamer
       harfbuzz
       libcap
+      libGLU libGL
       libpulseaudio
+      libxkbcommon
       libxml2
       libxslt
-      libGLU libGL
       nspr
       nss
       openssl


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
```console
trying https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 95.0M  100 95.0M    0     0  10.7M      0  0:00:08  0:00:08 --:--:-- 11.1M
hash mismatch in fixed-output derivation '/nix/store/gb3nafqslnmmrz3853wxll4k4vdjj68b-viber.deb':
  wanted: sha256:06mp2wvqx4y6rd5gs2mh442qcykjrrvwnkhlpx0lara331i2p0lj
  got:    sha256:0rs26x0lycavybn6k1hbb5kzms0zzcmxlrmi4g8k7vyafj6s8dqh
cannot build derivation '/nix/store/5hlb0lc3bqg9zq2c5pwff4fyih67f8ip-viber-7.0.0.1035.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/j6l7p7x7azmk1ayf7j102jgv51iwl9zi-system-path.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/3rdwp8765ck93vwblwqcql73a1lbpaa8-nixos-system-mac-21.03pre253060.a322b32e9d7.drv': 1 dependencies couldn't be built
error: build of '/nix/store/3rdwp8765ck93vwblwqcql73a1lbpaa8-nixos-system-mac-21.03pre253060.a322b32e9d7.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
