### PR TITLE
gnomeExtensions.easyScreenCast: init at unstable-2020-11-25

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/EasyScreenCast/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/EasyScreenCast/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, substituteAll, glib, gnome3, gettext }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-EasyScreenCast";
+  version = "unstable-2020-11-25";
+
+  src = fetchFromGitHub {
+    # To make it work with gnome 3.38, using effectively: https://github.com/EasyScreenCast/EasyScreenCast/pull/276
+    owner = "Ian2020";
+    repo = "EasyScreenCast";
+    rev = "b1ab4a999bc7110ecbf68b5fe42c37fa67d7cb0d";
+    sha256 = "s9b0ITKUzgG6XOd1bK7i3mGxfc+T+UHrTZhBp0Ff8zQ=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-gi-path.patch;
+      gnomeShell = gnome3.gnome-shell;
+    })
+  ];
+
+  nativeBuildInputs = [
+    glib gettext
+  ];
+
+  makeFlags = [ "INSTALLBASE=$(out)/share/gnome-shell/extensions" ];
+
+  uuid = "EasyScreenCast@iacopodeenosee.gmail.com";
+
+  meta = with stdenv.lib; {
+    description = "Simplifies the use of the video recording function integrated in gnome shell";
+    homepage = "https://github.com/EasyScreenCast/EasyScreenCast";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/desktops/gnome-3/extensions/EasyScreenCast/fix-gi-path.patch
+++ b/pkgs/desktops/gnome-3/extensions/EasyScreenCast/fix-gi-path.patch
@@ -1,0 +1,16 @@
+diff --git i/utilaudio.js w/utilaudio.js
+index 983b29c..7a94de8 100644
+--- i/utilaudio.js
++++ w/utilaudio.js
+@@ -11,10 +11,7 @@
+ */
+ 
+ const GIRepository = imports.gi.GIRepository;
+-GIRepository.Repository.prepend_search_path("/usr/lib/gnome-shell");
+-GIRepository.Repository.prepend_library_path("/usr/lib/gnome-shell");
+-GIRepository.Repository.prepend_search_path("/usr/lib64/gnome-shell");
+-GIRepository.Repository.prepend_library_path("/usr/lib64/gnome-shell");
++GIRepository.Repository.prepend_search_path("@gnomeShell@/lib/gnome-shell");
+ const Gvc = imports.gi.Gvc;
+ const Lang = imports.lang;
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26066,6 +26066,7 @@ in
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
+    easyScreenCast = callPackage ../desktops/gnome-3/extensions/EasyScreenCast { };
     emoji-selector = callPackage ../desktops/gnome-3/extensions/emoji-selector { };
     freon = callPackage ../desktops/gnome-3/extensions/freon { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
