### PR TITLE
rgp: 1.8 -> 1.9

### DIFF
--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -7,6 +7,7 @@
 , fontconfig
 , freetype
 , glib
+, libGLU
 , libglvnd
 , libX11
 , libxcb
@@ -18,15 +19,15 @@
 }:
 
 let
-  buildNum = "2020-09-11-26";
+  buildNum = "2020-11-19-376";
 in
 stdenv.mkDerivation rec {
   pname = "rgp";
-  version = "1.8";
+  version = "1.9";
 
   src = fetchurl {
-    url = "https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/download/v${lib.versions.majorMinor version}/RadeonDeveloperTools-${buildNum}.tgz";
-    sha256 = "1lpkh7sfpq697lm4xnkpjfchh8zpy49f4mb3c5qcn7brav5iqwfh";
+    url = "https://gpuopen.com/download/radeon-developer-tool-suite/RadeonDeveloperToolSuite-${buildNum}.tgz";
+    sha256 = "f71ibuMerd0SmXKSDjaTj7xtyy1dWzkZ5s0PlGtQ1+k=";
   };
 
   nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
     fontconfig
     freetype
     glib
+    libGLU
     libglvnd
     libX11
     libxcb
@@ -54,12 +56,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/opt/rgp $out/bin
     cp -r . $out/opt/rgp/
-    # Breaks autoPatchelfHook and has no known usage
-    rm $out/opt/rgp/AMDToolsDownloader
 
-    for prog in RadeonGPUProfiler RadeonDeveloperPanel RadeonDeveloperService RadeonDeveloperServiceCLI; do
+    for prog in RadeonDeveloperPanel RadeonDeveloperService RadeonDeveloperServiceCLI RadeonGPUAnalyzer RadeonGPUProfiler rga rtda; do
       # makeWrapper is needed so that executables are started from the opt
-      # directory, where qt.conf is
+      # directory, where qt.conf and other tools are
       makeWrapper \
         $out/opt/rgp/$prog \
         $out/bin/$prog
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A tool from AMD that allows for deep inspection of GPU workloads";
-    homepage = "https://gpuopen.com/gaming-product/radeon-gpu-profiler-rgp/";
+    homepage = "https://gpuopen.com/rgp/";
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ Flakebi ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
RGP 1.9 was published: https://github.com/GPUOpen-Tools/radeon_gpu_profiler/releases/tag/v1.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @danieldk 