### PR TITLE
mpc-qt: Fix compilation failure due to mpv changes

### DIFF
--- a/pkgs/applications/video/mpc-qt/default.nix
+++ b/pkgs/applications/video/mpc-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitLab, pkgconfig, qmake, qtx11extras, qttools, mpv }:
+{ stdenv, mkDerivation, fetchFromGitLab, fetchurl, pkg-config, qmake, qtx11extras, qttools, mpv }:
 
 mkDerivation rec {
   pname = "mpc-qt";
@@ -11,7 +11,14 @@ mkDerivation rec {
     sha256 = "1cis8dl9pm91mpnp696zvwsfp96gkwr8jgs45anbwd7ldw78w4x5";
   };
 
-  nativeBuildInputs = [ pkgconfig qmake qttools ];
+  patches = [
+    (fetchurl {
+      url = "https://gitlab.com/mpc-qt/mpc-qt/-/commit/02f2bc7a22e863a89ba322b9acb61cf1aef23ba0.diff";
+      sha256 = "15gcpcs54k09pndlpcfwb3fa0cg9fszyyb6vbp0hpgspy43183lx";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config qmake qttools ];
 
   buildInputs = [ mpv qtx11extras ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/104865#issuecomment-733677815

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
