### PR TITLE
gitAndTools.pass-git-helper: 0.4 -> 1.1.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, buildPythonApplication, fetchFromGitHub, pyxdg }:
+{ stdenv, buildPythonApplication, fetchFromGitHub, pyxdg, pytest }:
 
 buildPythonApplication rec {
   pname   = "pass-git-helper";
-  version = "0.4";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner  = "languitar";
     repo   = "pass-git-helper";
-    rev    = version;
-    sha256 = "1zccbmq5l6asl9qm1f90vg9467y3spmv3ayrw07qizrj43yfd9ap";
+    rev    = "v${version}";
+    sha256 = "18nvwlp0w4aqj268wly60rnjzqw2d8jl0hbs6bkwp3hpzzz5g6yd";
   };
 
   propagatedBuildInputs = [ pyxdg ];
+  checkInputs = [ pytest ];
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/languitar/pass-git-helper";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Simple package update.  The old version 0.4 is ancient and a lot of improvements have been made in the meantime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
