### PR TITLE
photoflow: 2018-08-28 -> 2020-08-28

### DIFF
--- a/pkgs/applications/graphics/photoflow/CMakeLists.patch
+++ b/pkgs/applications/graphics/photoflow/CMakeLists.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9b48beea..078ba20d 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -603,7 +603,7 @@ ENDIF(APPLE)
+ #
+ # photoflow executable
+ #
+-add_executable(photoflow main.cc ${RESOURCE_OBJECT})
++add_executable(photoflow main.cc version.cc ${RESOURCE_OBJECT})
+ IF(APPLE)
+   set_target_properties(photoflow PROPERTIES LINK_FLAGS " -framework ApplicationServices ")
+ ENDIF(APPLE)

--- a/pkgs/applications/graphics/photoflow/default.nix
+++ b/pkgs/applications/graphics/photoflow/default.nix
@@ -1,42 +1,75 @@
-{ stdenv, fetchFromGitHub, gettext, glib, libxml2, pkgconfig, swig, automake, gobject-introspection, cmake, ninja, libtiff, libjpeg, fftw, exiv2, lensfun, gtkmm2, libraw, lcms2, libexif, vips, expat, pcre, pugixml }:
+{ automake
+, cmake
+, exiv2
+, expat
+, fetchFromGitHub
+, fftw
+, fftwFloat
+, gettext
+, glib
+, gobject-introspection
+, gtkmm2
+, lcms2
+, lensfun
+, libexif
+, libiptcdata
+, libjpeg
+, libraw
+, libtiff
+, libxml2
+, ninja
+, openexr
+, pcre
+, pkgconfig
+, pugixml
+, stdenv
+, swig
+, vips
+}:
 
-stdenv.mkDerivation {
-  name = "photoflow-unstable-2018-08-28";
+stdenv.mkDerivation rec {
+  pname = "photoflow";
+  version = "2020-08-28";
 
   src = fetchFromGitHub {
     owner = "aferrero2707";
-    repo = "PhotoFlow";
-    rev = "df03f2538ddd232e693c307db4ab63eb5bdfea38";
-    sha256 = "08ybhv08h24y4li8wb4m89xgrz1szlwpksf6vjharp8cznn4y4x9";
+    repo = pname;
+    rev = "8472024fb91175791e0eb23c434c5b58ecd250eb";
+    sha256 = "1bq4733hbh15nwpixpyhqfn3bwkg38amdj2xc0my0pii8l9ln793";
   };
 
+  patches = [ ./CMakeLists.patch ];
+
   nativeBuildInputs = [
+    automake
+    cmake
     gettext
     glib
+    gobject-introspection
     libxml2
+    ninja
     pkgconfig
     swig
-    automake
-    gobject-introspection
-    cmake
-    ninja
   ];
 
   buildInputs = [
-    libtiff
-    libjpeg
-    fftw
     exiv2
-    lensfun
+    expat
+    fftw
+    fftwFloat
     gtkmm2  # Could be build with gtk3 but proper UI theme is missing and therefore not very usable with gtk3
             # See: https://discuss.pixls.us/t/help-needed-for-gtk3-theme/5803
-    libraw
     lcms2
+    lensfun
     libexif
-    vips
-    expat
+    libiptcdata
+    libjpeg
+    libraw
+    libtiff
+    openexr
     pcre
     pugixml
+    vips
   ];
 
   cmakeFlags = [
@@ -51,6 +84,7 @@ stdenv.mkDerivation {
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.MtP ];
     platforms = platforms.linux;
-    broken = true;
+    # sse3 is not supported on aarch64
+    badPlatforms = [ "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Noticed photoflow was broken while reviewing #104855

This unbreaks it, as well as updates it to the latest commit in upstream's `stable` branch - it now matches the debian packages in the ppa linked in the upstream README.

I haven't tested extensively, but it compiles and was able to manipulate a random photo I loaded without crashing, so seems better off than before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
