### PR TITLE
[20.09] firefox-beta-bin: 81.0b4 -> 84.0b4, firefox-devedition-bin: 80.0b8 -> 84.0b4

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "81.0b4";
+  version = "84.0b4";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ach/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ach/firefox-84.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "4b133dd14e8ce1b934e482c4f7f7b5ca4b58751181bed89f6573ba5994ebe644";
+      sha256 = "da9290899d245d86b3d2d378072af403106596ae1e02a36d40a93deea9e57000";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/af/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/af/firefox-84.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8e50a0845eb058ee853fe40b13c88d764e721f7f8ac2eb54695049ab2a66e3e9";
+      sha256 = "28810946bde4c2335714c0f8b0dffad1a1650c167370e38c6eb5e2ee5d2e54be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/an/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/an/firefox-84.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "3edf8e157cac424b1cbfff019240877e7b7c3bf5ed1b576580569c155c5dd660";
+      sha256 = "d32e9e13b2c1f484686d9394f20a87e2c1d833703e0115de1f9c8c552d1e9d8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ar/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ar/firefox-84.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "b2167ff357963e3295eed2ed423a1c3bcf62d645329b8f4cf817ad3c0e101c97";
+      sha256 = "de8348caf98ca0551f3f080eb32ef94c00706676bc8df1723377d98f10221e56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ast/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ast/firefox-84.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "805a87a99a417ff4b762c01a9a2b88c7963f53a04fc19b42015db304b15f4bbe";
+      sha256 = "104cc96b0e14c030848be4bc07a1b2b836a241e9ddba581b9ca24018c54356ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/az/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/az/firefox-84.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "79c61c9515a683731649bcb5d36b26b95dd56165765e5a952339910310c9d259";
+      sha256 = "e96087b52f1dc18c8bd29d486faa00ad06a2165d1e14cbd47e37cafb40602a87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/be/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/be/firefox-84.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "318fece7d1ad734f6a19faa7003e060b1254b31bf62e59580c70a64c4a167ec6";
+      sha256 = "d67c2c1556b6859e0acae5b69b3b7eeac77b3bb1594b48682a97a72742c79d05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/bg/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/bg/firefox-84.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "55616606306dbd0933240d718fef8e83004fd65e4f53dd18f1601f09d0b94e92";
+      sha256 = "b3bad1b330a5d4c515b37cddb3e89e538c5cd66ffce68dbf8d1e9adaf4881431";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/bn/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/bn/firefox-84.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "c38fdef89f6aee7bf03362d2edfe4dcc665d540b1e1dc1dad8c53db20d70087d";
+      sha256 = "9c50c4e12061279133177ade4b22b7e2bb7e14dcc1875464f57efb7c7e360bf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/br/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/br/firefox-84.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "c5ac1c8e9dc2f4c5a1a2b6e33bf699a823a9422bce46922bc36222700a29d2e5";
+      sha256 = "79eb76af707b26fa4d46acf11d0be25ccd144abda6c853373c9ec0cc872c2a8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/bs/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/bs/firefox-84.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "a18718ef7f467ed87c76816fb6797165db3e06bc166c5e88b526c9f2ce5c1d19";
+      sha256 = "2cbf15a604f90c4a6212f5da251372d09e2247f5ed338193ff93a94695bca308";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ca-valencia/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ca-valencia/firefox-84.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "fcfccd0714c965801ce468f6817bf37eb074064e6e0b616c81be7218a6b632fc";
+      sha256 = "a9b6cacf6ee8a6a1f733f3ff3741c1bb12eff823664279205906e8e59b646679";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ca/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ca/firefox-84.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5f08a2b2d357d5a6828865913b9e28fe90bda7a8ce17a0ea60effb25b8441b7a";
+      sha256 = "1ea49a5d59129c820f359fbad2253e051adbb260cedd4b62bb20122562466bfd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/cak/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/cak/firefox-84.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "db41156b75e1148527c51b915e3d9367d1c36a8d24a52132d1cc9cfe63bd9db6";
+      sha256 = "b18651df9ae2e16ea9855c30fa393dd34103cf338a515d41d3c1802e52fb92a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/cs/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/cs/firefox-84.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d3287f28964581e63a3b1a5484e47e8ef33c136b39f13e07d6f3d555c27864cb";
+      sha256 = "4dca051e5349372d6caf5a7f6e8e6e12fe42bf96110a1c6e2f7f6e408f365b80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/cy/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/cy/firefox-84.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "f41fd34cf1cc72d5fc80113cdc9fae7f03f434e45e990e17a94dd68463464c49";
+      sha256 = "3117d47bcec1cf0f5a547a33c62ca5ecfee34435c13a478f23d1d9f0ac187f4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/da/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/da/firefox-84.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "dbbf1611913315ac5294f400c727cd5afbc832efbea56bd839b77cd4d6a5b823";
+      sha256 = "34a38c76997bdd41e6b12cebf08345e7cd19838bd92f5a8d082ba3087cb063c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/de/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/de/firefox-84.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "1047799de5b42b5cb0827371872b7e85b93a4474bde9288da54a573841e156bd";
+      sha256 = "65e417603cf383d92058b8976c1f6499dc5804d02a22bb639e416c4e730b4a62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/dsb/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/dsb/firefox-84.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "602eaa32d32db35d6a6d07f1c0cc53eaa4e432b7ab81d1f23b47d3125ac98d24";
+      sha256 = "08dacb91773d7b49eb8f08668627badae2967193c441ff2fb6b9d88063c5ffb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/el/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/el/firefox-84.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "8a460f9542e213b1605265c6497742e7d55213ac91b42d00a15b3123b47754ef";
+      sha256 = "78e870b673c204e4d9fca2a3fbab06031c724a8b0696a3b6e2dea5ac07a5bb88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/en-CA/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/en-CA/firefox-84.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "9bcc44ca3f4192a2a7a001f27db6884dd481551663b6d0c348ed0b9281dabe87";
+      sha256 = "4c862eb5c53e65af1ddc212a093eb23e33653341fa7db53d935ed8482637aed8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/en-GB/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/en-GB/firefox-84.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "9d241d56362ec52619ce02cdd2f11dc90c2e0f7c515c707ea56eca2e8f0eb306";
+      sha256 = "f505cf16328603d0164e330fcef60fcfeccdad186d1f91e0b4cee1b8cc7c740d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/en-US/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/en-US/firefox-84.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "28972b08f8b3f2d19f5d50a2c9275fc459fc3e57df11c884149d1fdb9d99300b";
+      sha256 = "f0561469f04ab83dd52ae4e3a8ca451d6569845e37d9e04c5a91085654661f8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/eo/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/eo/firefox-84.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "013caa4590462b4bc5dc09cb963cfd85cba4b5419111cdc87316574ca5691e80";
+      sha256 = "c64d227d6b21876ea48182795d6fd8ec3ca486e5328629a0bbfb936e8463b0a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/es-AR/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-AR/firefox-84.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "d6970ccf4d58e2f1219cb0d43a8788084d0863f0f349ab3292e182fb0201e860";
+      sha256 = "73b45f6b8d1e53bef003b3e77cc1217b8a85dde49cb0900b4fa2991895e5c184";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/es-CL/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-CL/firefox-84.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "76fb3c865b3efa1da1d34c8caa7b56b5b6d0af2cbbaeaef873fa96d2b8c93bb1";
+      sha256 = "e7025e4c5fc311aae2798da99ec5e5863bca5ad8b8460981cef86e29ae37d74a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/es-ES/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-ES/firefox-84.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "7b41a2b297df4f0f6d4f44e1eb0ea0cbf02454382d0994f119a77876c578c4b6";
+      sha256 = "e819644eb6337255004fda8286e1f2ed898423c4b97694c8355c28f4d449da61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/es-MX/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-MX/firefox-84.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "733b90640a30df66700397ab0cc2045fcbc25af94ef9f36463a191228b511b77";
+      sha256 = "07de091ca3b06b94e35b84add7fbc5c8fa6ea84ddfe548e5f55b3bc7980a9bd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/et/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/et/firefox-84.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "027286d744b1d9f21157d8242445ccd7610a08d8d541d64635fc16549aac1b4d";
+      sha256 = "d6af9ab39f1a13efc772cbb63dd731dcf988c10f13649f348d7ddb3f6ab6ca60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/eu/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/eu/firefox-84.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "ff555da3aaf1abb2c384772b309fb4129dad57b9fd523fcabef5b2743d3063ce";
+      sha256 = "110e667568429dd2b0c752962e1148884c44aaef9939926c6b0f49ba5bdb1182";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/fa/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fa/firefox-84.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c99f9297568f93eda17058d96dfaf83e587907be9b5005e8f649f693662e4fb6";
+      sha256 = "f7a783f12bb08ccb06074f903bb2eaaab13b348c6a2950a9699beee28ad97b5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ff/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ff/firefox-84.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "91658b195a622afa3c6fde535391eff1aa6b70f4c0cccc5c55e56e6d66459435";
+      sha256 = "b2e47bc8ae8d1e54a1b5799a87b4742d049696edd9913f0cc6beb52a89cc261d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/fi/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fi/firefox-84.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "cbc70d2051c96813ab081251c339f6cacd29ff26bdd8174b35caf9905a874635";
+      sha256 = "f5ee09f1b9d41506ad1023ad05dbdee95ac049eb4bfd38dd99c06cf682e111a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/fr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fr/firefox-84.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "51890621c8c3c0e40103a10e705adbc860937e5dbbb8a3984eb71a5cae3ed63b";
+      sha256 = "f8c33819a6ceab041bed80f1663d94a80ee3bdb6e859eab1eb8ec9d0b67f4222";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/fy-NL/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fy-NL/firefox-84.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "5c3a982a51951901732ec7684514be233fe1c44780531fb38f7205724c241387";
+      sha256 = "6ed233042e570e9a04ecc1e25f6211deb7685c117db75f32a541076d95d1cebf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ga-IE/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ga-IE/firefox-84.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "04b5d338c7557f12fc6fb2206d444a8a00be6814b1ca26de4923449a4425b57d";
+      sha256 = "b28337429a0c1d26653fda1d93b59ea0383061a253be5b763442166fdb21bbca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/gd/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gd/firefox-84.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6bc0de0ac627203b1ba035f7a7ba7dd19bd82a7730c526c217150cc5de668fd4";
+      sha256 = "546bf2f1a4a8a643b161554bc92e771644ff9ae46c6b10fb2a60b920a2454f44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/gl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gl/firefox-84.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "37522d032422af770e37a93e33de6c0b8b79b2d22c6e71f32107cc8808de4d35";
+      sha256 = "cfc32d3e7e3ba5379895a8b348d9399bd3962a819d0677f14a365f6e0c314676";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/gn/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gn/firefox-84.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "f761db975c72d7e419601988c0674acc7fe17227d5569cac85a1fe2d91f5141c";
+      sha256 = "b2b5e826540d3f9b52d67e092fa755b26a34ea9acd0cb1c69eb6f0bc332354d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/gu-IN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gu-IN/firefox-84.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "8565c1965e09060ddc5b253fa126998f827d17dd58692ec4d17d194d29a464a5";
+      sha256 = "497b8a954ed2c9fa13e207462730dd39d2d0de10a38e3762dac3ef1fbd36282c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/he/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/he/firefox-84.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c3cc5911103ce955f89c5104ceb1ee50f7c047e4ec761681c8693b643f5d91a8";
+      sha256 = "8cdac2e9d2cf10171f2744727ddd80e21a4d46e2082947e49f4a255f174db968";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/hi-IN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hi-IN/firefox-84.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "95463325675e56e700eaffb6e6690f4b398adb5cb77aaa34b87e16cb142f3533";
+      sha256 = "d37c55e60329220de3d792894d7b801adf7dc7ab8ff4ab39bd2e24b59443b973";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/hr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hr/firefox-84.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "6332ae812507f79baaed24e4fb79fc6c383418c4c9d41c0f3dbebc2fb72efef5";
+      sha256 = "bebb6709dd3be119be45d9fdb0bac41b81514d78a384a221e2ffbb51b46dbea8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/hsb/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hsb/firefox-84.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "b18a7d31d3ce7373bcbd6bb7ff56adc023c58097126781d5f915828be8fef92b";
+      sha256 = "c43aea7fdd8a57653d6d9af4aa7c0be6e860f5292366ddd91c5860dfde2ee1bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/hu/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hu/firefox-84.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "b1e4c6c9c21b2593f3fa111820a7e6a2e2e72e8b3065738f6a50df6ef4b7f18b";
+      sha256 = "71e6b509dd3a6937d9851c262fc7a1bc9e551cbe0515089586fc22098bc51151";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/hy-AM/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hy-AM/firefox-84.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "562f4d9e094b688cb53860834e425997e65b78222724c48ff4ddd71ccca264fe";
+      sha256 = "c92eaf9f6bfa97651075d2342e45b988ae89c1a4cb55559dad71bfae5912ee83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ia/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ia/firefox-84.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "87299a8aeee6da57666a06cc2d4f479b0c74c220e2b22ddf5254a052f11edacd";
+      sha256 = "3c71aafb7dddcd3f9bcc8e169281614ac1087400d1d0ba02afb18c68b1914128";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/id/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/id/firefox-84.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "0cf1bae8def307d08e4c24fb44f7cfbebf150f1edfde2a3c0855a69775f26539";
+      sha256 = "8075ef0b1d7eb2fc6141262cbb0d3831c3d8508eb43d3e9e142d96946ed2036d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/is/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/is/firefox-84.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "6140d270e99173d995e42d32c0b696a51f72b1c6baa746549bdbbe7e2a08a811";
+      sha256 = "5ef96d77bea5c94e7147a5657d76eb5c7f206208a0464245242cca3fc7fb79f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/it/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/it/firefox-84.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3583cf0223528929141879c085278354927ced41d71321fe8d832ebd356d4614";
+      sha256 = "eb76a1f3bd1ac065772d4ea4a435c53b5f7b1d5b643c7b62b7ccfee205ea4e81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ja/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ja/firefox-84.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "4a1bcf87b3cd09d7c3379bd922ede7a3c6c4a19bf11596e858634b408df95cad";
+      sha256 = "80b644648b9e40ed592ab9ea2b9d7f1e2abcf8d6b0f925aa57cd6cf28d53dcf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ka/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ka/firefox-84.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "320567daf4e4bb12c7209aff34d98efdbb2dead9b34f23d4a2181d2cdddeed71";
+      sha256 = "03c34e7b08a8b6140e612739118c35b05dcdef1257b4857d2fda87a1cf8852ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/kab/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/kab/firefox-84.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "5b9d60703b494a4eb5956e59bc2d6893bc70e8b890d0c940f25d25b605000c89";
+      sha256 = "419a4758cf2e2e24968f4da384dbfb03ef8398713c6070ab29ce379772168f18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/kk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/kk/firefox-84.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "45580e0c3cbb265f718a69ac9de7220d3d89e52e3b8a5cfceb7363c20e63c83e";
+      sha256 = "cfe96420e125dd12c9a9e79e45a8d7ee260d1957abddab5ed887afd1a1e3f499";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/km/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/km/firefox-84.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "24b4879f22829a2a5d72219cba2c5658bf7c7e73ffdc9640f6e897ec613733c7";
+      sha256 = "4b3599a9b30132b6105e4bbda7de370e54e21d8e498bb3c4c3d9807282fbf246";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/kn/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/kn/firefox-84.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "905ed3fa762c73c5ba677b8ca5b620294cb1ad36dea2ac53fdfca5a739c0c0e6";
+      sha256 = "5da3ddc9d9824e3ba59e1cdc89ee3fb8900c661faec1f539c829d0917be5d4d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ko/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ko/firefox-84.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "a6a63ca4106ee9c710331ea50099e2a50842465095d38ea55a63dcb3ee3d80ad";
+      sha256 = "2db9a494693091832e578959144d172d5135b82bbf44c041949da8ffec2de9dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/lij/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/lij/firefox-84.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b6fa42dc9bc68d4b71ae93eebfb1a19416f0cdd06d20fb344c0c0347aa2d4862";
+      sha256 = "2219d5235f0ed9d2015ead5782976727d2b7103afd987eb445f3f274856e6af6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/lt/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/lt/firefox-84.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "c70f6e7c20e252fdef6bf136c99095ebc27672719594df302e58be801a3f06d3";
+      sha256 = "a335e0d835bcc7ae9563bb3efe6b926ad71e08f3ccbd164aa2b9f257acd1341d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/lv/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/lv/firefox-84.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "c64d561be20fc8f0e7507a0b1dc2e5d79af407531a37cc7da3fd880789899fdb";
+      sha256 = "1f89f8f2715254ef335af9b01ca1503caecb1c93b1a900ee1643c3f9e00c6821";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/mk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/mk/firefox-84.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "aa38b13c6bc5288ab491f5ccee3a881474b1f42f1bd959435035782d1c39f407";
+      sha256 = "86eb9f1e8189ce45c03925337a90f1b204dbdc902c1c4a817a924410a26b0048";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/mr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/mr/firefox-84.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e56eea60ca1cd447e30cccc82ce7a4797fa23e9bb4871a5e20e05d44ac35f720";
+      sha256 = "d5214647403f85c5f7a95871e8d6fb4d4c448af92e6475841fd8474857f21067";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ms/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ms/firefox-84.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "9d8445e2bda6a8cc8714a0eaf82e1b9ec03fbd94042c3557f07d9c8b25bc4b6f";
+      sha256 = "23af07562748448a35242a6cd77bce25a5576d2b71177fb682da58adb21671e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/my/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/my/firefox-84.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "4a7527e5e3e6ea0181cc8b9a2f206bbe162a4e1867faa75b4af261f08e89ae0d";
+      sha256 = "bfec2f3ad0853fb36ec4aac9ad97ba14d30a275eff2582c2e9df600b5940c004";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/nb-NO/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/nb-NO/firefox-84.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "c2ae9f5fb235541cc69cc3c4307dd4b7de51a9f4b6e038ef3091a773edec6c5a";
+      sha256 = "32be6fe8aa661f6098b4600d824846738664f254ecd4ab0d0a1e705b28a94e74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ne-NP/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ne-NP/firefox-84.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "05acc175b06ab7f5861a3a7e58e9a92c40e0660224426fc8225fba6c25888726";
+      sha256 = "dfa3e6b9f31fa716a2c80fda07c24717a526ef96033b5b1861fcdad43c99b29e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/nl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/nl/firefox-84.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "640be4e631343c9f2a55c24a4d5c63908627e9ab2d39a5346d1842d8e4a57799";
+      sha256 = "e253d963b66855c44f41c43baba1b5c952b37dd1b83aac8243c60581ca674a49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/nn-NO/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/nn-NO/firefox-84.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "46a898f41e5c3c9853b05fda8f44be01b2fd5a7fe3dad281c21588c2deaaedce";
+      sha256 = "5d9b90cdee03a544a78f44d4f0566b5b59ae802af4fa60367a1a4836c01197f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/oc/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/oc/firefox-84.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "7481c8bad2e905a033f09ec4c20f8d4b184a0f90fce1c10648c4fc57a7a5f301";
+      sha256 = "b37f9a283d9dd2ff9e8998d83e0c147bfbb75e4b64b3936cb344243e1277c370";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/pa-IN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pa-IN/firefox-84.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "a460ed0241c569e1ac62727b17f8c8d0d4091e794900e2e2be7d8d8e2b90ada4";
+      sha256 = "68f6bae2e6f064e22503145b5fd57d027899f23fcf109010a98397dd8c0d7cf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/pl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pl/firefox-84.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d82e300cc8be61ddc2aa66bd4d4ec35cd18e47603bd19530cf48728c5fe67a5c";
+      sha256 = "789d6925c3b17f96bb92eef54c05fc8787f32ce2c9846931e185dc5a1de9f303";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/pt-BR/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pt-BR/firefox-84.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "1ee1560d4597adbd230fb0c556a4d8fa6984ee86bb731f7a5a936d660897eb99";
+      sha256 = "329eecf74dc8d9d1d8f4578389553d92a368c972fcb2468e0b936f21508bd1bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/pt-PT/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pt-PT/firefox-84.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "be7e484f8c3f4d8b7b894a437b70b2f4b448e3a7df518ce6906295df9be7749d";
+      sha256 = "b30ba75dbd5f5ff3ff709722acdf36acf4de9993d230eb27996e81406779dd0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/rm/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/rm/firefox-84.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "819cf6a13d1690dee4e4255aa0c3f551411e2b7076f8ce3447bba47f07c806db";
+      sha256 = "ad90ce4fbcd094bebf77b36a63e38326c613bffb580743c9a4c19df845907dfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ro/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ro/firefox-84.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "2baa8154f358962983c7e0b26c4a7cc8cf97587b646884527fafe46f5d8d92ae";
+      sha256 = "8f7864bc6577724f20829ad79901d92775200860dd8c43bb2443c7bf22d7a435";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ru/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ru/firefox-84.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "eaaa5338ff8ffbc9bad5321ee3eb7410feb9a26a06d3cc49707c0a048f4412e2";
+      sha256 = "8b52d5eaee53805422bb2fd6dd8b2e0c7a5b01feccbc6fb6c77e4fb8678d30a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/si/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/si/firefox-84.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "ce04721a96cea62eb7011c261f740e9e0ad6288ad9ff231538c3a6df86fb40ae";
+      sha256 = "a71df756e97f58271715f3d79a86c0407487dd5820500127cbd9373361bd016f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/sk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sk/firefox-84.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4b19fef341d64f94ad97a0bb8821693b00e4e7e04454156f92f0c82f4fee0005";
+      sha256 = "71eefff1538a2978d9e4e65fdd5a2322ad81ddfee33464c0d70b95eda1649fda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/sl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sl/firefox-84.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "96192922f2012a3e6be634c7ed09017cebf9498c6fc2862336bfddbc4ea40840";
+      sha256 = "91b2938be8230b6301fe3d15c6d9ba3f031c1e5fca886da228f47a2e0a2cd144";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/son/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/son/firefox-84.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "dfb144edeb3712bc0a3bf7e0675de80315c78bea7d7c6ee5f6047c077acbddf9";
+      sha256 = "57e456cd14418c41c2e5f8eb0ec6b0807459f41e15207f6997c7742fd3dc8a1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/sq/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sq/firefox-84.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "54dfab9e843dcde43cf188ae33922371fb90c1bfda53ef629df16576d6a0bac2";
+      sha256 = "0f343e2442523f0e422309cc36518484a242db4116f0e6b7dcfe251cdfea76cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/sr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sr/firefox-84.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f00b5184ccb47223858128aa26481867fb33aa50a914a8c807235c9a2bdf74fa";
+      sha256 = "cf8fb723611506fff356cabd91a0ca3fdd9cc5d806167df6dd385438d467eeff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/sv-SE/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sv-SE/firefox-84.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "d3884cf4a9ff23971badfb1a794c9489e0006e6851a0e501e290d8793054cc1e";
+      sha256 = "258020bbc7a75139fee340e50d41676d234be19c931f0228485f06fcab2eef81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ta/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ta/firefox-84.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "53584d2093feffd36a8a5249ee438b82d21af834a3c2c210944030c127b91cb2";
+      sha256 = "7783166c0f9ceed0f7d037c1e92b988818a70522945af2c96db958966eed8b66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/te/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/te/firefox-84.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "63b65440720bc492fc95d080b191ba452cc87c8501b195e02df66ea4487fb902";
+      sha256 = "02662946b3506da6432c48eb1c7e0f522ffaed2abcfcc474332a799ef3be2b92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/th/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/th/firefox-84.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "3b01fff09734f2206e4aee227ee7f0c13544fb1635f92a5221ee356117955446";
+      sha256 = "1592b372b8e767e5b7369f356fb733a2daf51b4f45c8c4c94041845d63b3c604";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/tl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/tl/firefox-84.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "00f1c65baf63246a9ff44d98171a6ceec6e276488f5d6fbdf6f97760509b3bc7";
+      sha256 = "2b831feaae729c674e8a9ee207dea007df100bbbd8cf7553791aee3eede37224";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/tr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/tr/firefox-84.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "064d6c6036fae215fcb50a87863e6808bd1626084d9144a18f7ea1f4c7072093";
+      sha256 = "aedf8b7684f204109e42a3797ba00bd7a8c5bd3f827c31ea3fd4eea1679d8af5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/trs/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/trs/firefox-84.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "73c892e0b0ab0bcdbcf6af88fdc8de335bcd5c56805675ba7b487ed3b620ed22";
+      sha256 = "232cae54f6120a47455fdd7e0d88dde1f64d5a1931bcd7d54f6bf8bd376583e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/uk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/uk/firefox-84.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8ac48524702e3f177e78fe97e4fcf528752a3ea0ef08e9212037dbd0febea53e";
+      sha256 = "e00de7cbe1f00aa082f9a448857cc19f011bb1d5b579e79457bb0dfc72b7a12d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/ur/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ur/firefox-84.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "154dd642021769aa67a081080f33d87d736686b9e6e46cdfa2bd2201605bda26";
+      sha256 = "7ece4d8af476eef174c0c175b65841da8d826702fb255587c2e1d259bb9ef3ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/uz/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/uz/firefox-84.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "dd36910596d777f49de3dfe8e22f2838b76081cb259107047b9a98c3445c01eb";
+      sha256 = "09c7e7d641f703404aa7927860f2924e6be376b2e39b1f0fe012dc87469edb62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/vi/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/vi/firefox-84.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "3cef9f657f83bbfc68ab4a7c8ab84e1e937553cca98cfc30d3fbbec5c8be7907";
+      sha256 = "18121867e6b8c2a52c5324f653f82afbae97481b5ac3df811e881ec39bbb3b0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/xh/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/xh/firefox-84.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "30a98fa9218cbb07d792629e73a250659b321a3555eedca0a68e6ffb1d5191a7";
+      sha256 = "04f5bb96ef9002eeb0869236f70168e7cbd7842b8e12b66dd6d5d67db9acd28a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/zh-CN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/zh-CN/firefox-84.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "bf15e819d84a3cd3825df2046bd9ffc139008f45fdbbdc64e04cec6a549af3e4";
+      sha256 = "142286cf9136bcb9b6af7ea1df3cf77821c0793ab7b9fe533a2963c453f45a7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-x86_64/zh-TW/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/zh-TW/firefox-84.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b194749cb05fe282f59f2f6621a5d04fba42406d7a3ea71242b667fe94a5a857";
+      sha256 = "fef32e5817140bbcb6d1b614a72a29523235606192078eb04420ff7a2453cb9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ach/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ach/firefox-84.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "203ca1a13f76935935daf2124c662329df93af0e44b4bcee7334ff60092c8027";
+      sha256 = "40e9b7a738e06cec731c69b659b14ca48b119ae20016e0214e1160edf03919b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/af/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/af/firefox-84.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "481d233552b0702a8b8092748b4c71da3c14c8df5e971c5b4662273cd8808022";
+      sha256 = "9bb05361a51f836b2de5614127f8df768e504f4d5bc136e3f169741098f0bcbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/an/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/an/firefox-84.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "a128b96a34eea409a8b5fa412e6a1a36bcc28f2fbed40ba9b474b9d86d23dbae";
+      sha256 = "ee62418444c76b709204962ed47af8ef3d61b80e628600201b5a12293651c70d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ar/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ar/firefox-84.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "a2ab8b556b6b477bb1aa287f630e7ae6aa902fd1b75968c01c2e2c76fe9cdf09";
+      sha256 = "10b5d4f1616e078bf83ab5ff942dabe89a8eaca63f24e96b53726dfb2bc9e36b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ast/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ast/firefox-84.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "193422cbafcaf5ed58f334a9d5b30f9a6181aa1cb649303df18626d9a3484088";
+      sha256 = "a4e5ccae125edaa0696b696a5342320707f0c39c8985437b6aed60faede71de0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/az/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/az/firefox-84.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "c206f5351f0ba474a5277e223514f032c7ff0b66029f570143f2d1d2b8ccf566";
+      sha256 = "c13d9ed183c7b9256801708014f38405749cdfcead9f243e80eef78d06a9b78e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/be/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/be/firefox-84.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "c3d7d04ea43230b6a6e4227b799d47348bc5c2ab6a60e93f4107efa6e7b34ef3";
+      sha256 = "57d8eafc3d45784dbad71eb49d5a4c0483d939719b43b0f16e4db1d5a96ff4a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/bg/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/bg/firefox-84.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "08edf0db8aebd41f25366ef4302214b4ef00540be39406fc780eec288b0de324";
+      sha256 = "0a65ad71cc9d97277535f07a8dbc7ca248508c24dea8520f92fecbb806f87a31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/bn/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/bn/firefox-84.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "a6d5dd5918d94e74ee8ffeb10c4caba65697ecdb81598b0bda815fa5d4830a78";
+      sha256 = "3cead08f4d746def6cfb909107f4739400498c970f10fbd542259c04b84b5852";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/br/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/br/firefox-84.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "4e7ffbc380b6f8716399ee9d7b9ffc5fcdcae72f48b63ae4bcd2011a85efa0b1";
+      sha256 = "40c6e963e8e52ef51cd4d4e63d501f2a6cecec1800541941458b896ad90e5b93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/bs/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/bs/firefox-84.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "ef36dae13dc3c943e5981a16d7ca61b4c6daa9a4873d2cd87022fbbcd01c8907";
+      sha256 = "1e9df53642c442ead4318b0cc886653fdfcecf5275d6e7218acb390bb13e0021";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ca-valencia/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ca-valencia/firefox-84.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "584a0370f79011dd2691461acd573133348a94cc1323d6fb99dea9dd6df1e155";
+      sha256 = "3b5699dad93291921979fc6da21d16f94ef471e9a8ef3d877001400ba4abe316";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ca/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ca/firefox-84.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e280fe05f4e9320fd354407811ea8664d50de3810298e5eb4922b2d3e549ad11";
+      sha256 = "c52b9cc25dc72eeb6ef3e7c3add4066c005399afdba2cd0964e695a891a1d314";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/cak/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/cak/firefox-84.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "3decca8b5b0d44db169abfa20f07b3c109bbea0a68ae3e44a35f97e3b989324b";
+      sha256 = "355df19615fddd85c51b033a413a3de524f19fb2d97a2ba77f3b8001b231338f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/cs/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/cs/firefox-84.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "efccc2a43f961179f61eb7858b1e17ffd069bf7a26027faaad09f1b529ade52c";
+      sha256 = "e10f35795f19ea10c4de34687eacad6f9bd863002e9d66b87cbace01b97c8628";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/cy/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/cy/firefox-84.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "dc8a1945d0230070e2bdf65b673a9aecc4868c9821f7f1e2f6e0d18bb98c912d";
+      sha256 = "f2fd90b19e8c4ac98bd6ee262084ef7842e52a304abe10cfcda2fc14ccb5ce30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/da/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/da/firefox-84.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "058b800e2c9fc464f2a75fa48542269056a88916b9474a953f0d29a3e9041257";
+      sha256 = "01e468f3a445276aea85425b4b8a58e44a2e4cf8552a02aa3d4d31775bff9575";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/de/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/de/firefox-84.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "7fbd0b27073b2c46829fc0d631ed11fd9a38a07d0ce474f6837ad1f5c2adff62";
+      sha256 = "9dd3d806a4ff60c9cfd5b81cdf212f72c281f75ce554555cfd443f0696f700d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/dsb/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/dsb/firefox-84.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "d0b6083098d416366040a877a92b163d469e2764af995c65fced49de23148624";
+      sha256 = "eb26cbad496bc1c4f97e6027a1f2cd9166d479a503a3f0ac566a766c86bdf8b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/el/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/el/firefox-84.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "104258b0e47b661d7c75c72f5a0d7750399a101a9996a3f8837f0f524e9820db";
+      sha256 = "e173622f06f64156d749d0f56d98be72f067077c3e41090aa16a3b0c6d7a5e43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/en-CA/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/en-CA/firefox-84.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "be6750a6946b7ef58869d0c9f0412febffcbe4955c823a573d02822f9a14266e";
+      sha256 = "c1c6aa503e1565cb0c0239d562f11322265a7bce4005211b8007579f8f56c318";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/en-GB/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/en-GB/firefox-84.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "e6d2c60c30aa90b6026cb85d6fc3a1d1b7266263980df652c9a1c158528cfc74";
+      sha256 = "57b2670f515e2a17c10df602d93a6960e5c4710462098d89568efd446e4480e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/en-US/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/en-US/firefox-84.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "be534d43126a7fdd297f3431b579495b6f22832a358a0c793a23bea8adce1c9d";
+      sha256 = "81cf4a4fe610de3342bdea340d450ff67c594e7e4924a08b6b69de75510da698";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/eo/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/eo/firefox-84.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "6ffe84994fe7db178e59ea667495e95e6fba621cd0e4ec812d94dc3d98cf0a3e";
+      sha256 = "dd61c4bacfe39f7887c6d21d139df6a2df17f263c4be5689f5f9dd6bb4ee6e63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/es-AR/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-AR/firefox-84.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "982874a48791db0bc98559de45bb8884da93ee0a0738664c73ae5a08b3b1a2ef";
+      sha256 = "3ae8695c57befa3552033bcb867b48f9ba491a08e31168ba22901fcb3276a3af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/es-CL/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-CL/firefox-84.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "c21fcdeacdf570a9f8bba9c34c64a60776aa8a4de56b5f773b1d26eca6d65b70";
+      sha256 = "5ae14208cdbf0dd50edecb8a56bfe7dba0e7520f2ef135abb092761acc8630ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/es-ES/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-ES/firefox-84.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "bb34dda74d59c862ab24ad9ff0c5ad1e1fb5d73e6029b915f966d0913cf4506a";
+      sha256 = "d786cf3b623a05e5156b020a436897525e80117ab7fa9f25ca42fca9fb4c0eba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/es-MX/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-MX/firefox-84.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "53686263f77643ad4f769faac81697c7e1eca216ed0a7b051c2318b181318d7b";
+      sha256 = "c2ec749bb5befffd81189503d87a57bda462897bba858904924ae999923a4e42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/et/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/et/firefox-84.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "053d8ad6cf01be9f51cd133090e99230dfe797effc749e14c8a21ba712546776";
+      sha256 = "7a2e1078ff1a3bb975baa5488f89e8161e20354d7f55b98c964efa5bfce6f696";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/eu/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/eu/firefox-84.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "77774b9126ccbca2b5716b1701f8eb7933ee67ec5437a00b8ab991f423888a80";
+      sha256 = "c635006a367f68bfabad7a3874f3333ac3f486f0001ca9641ac8ce12dd9bd01e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/fa/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fa/firefox-84.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "4a0554bff8c11ca39f1de223537d595d298e6f61c2590543151e8ab1d8eca36e";
+      sha256 = "f897a5d316c436fc20d8c2737902e29dfd0ece3c9ffdb90fda2fa454ad398257";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ff/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ff/firefox-84.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "272784bfa53ddc48fa43590b3ebd2fce808786b4649efa1d5b417488efbb8911";
+      sha256 = "3a31d43cb5242a0aec516d8fe99dc916144e8b7250b81c7de0b1361b19f067fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/fi/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fi/firefox-84.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "c389eb80f3cdd215549c7ce55402a7c03544eca2fa3c2074842af32755d14cac";
+      sha256 = "50261499bd4725f08684c9042056c9da2029f55b0dee4a856a9de661412c06e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/fr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fr/firefox-84.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "dc5a79229fbdd3e9fada6b6bbb35183c17a703b9c3f29d9172f2b56cd5c0d289";
+      sha256 = "7b793590a975a64b6fcfcccb4e6c07cd5346ec457af1ae31b5fb1032d4217c64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/fy-NL/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fy-NL/firefox-84.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "3eb69867818f0a8448e4f421f0ded4ad1a172bd5c99048065bd4b6cf83e8b25c";
+      sha256 = "468c7463503a34de44a74ff6a751e8614abbe6bd23f39f50308f23000614331e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ga-IE/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ga-IE/firefox-84.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "b09208ca65279e393f512a04712f91b2b170ca6e32777479acb7a03db89e87dd";
+      sha256 = "92b49316d122c8c91995766e28387d5587955e022f844c7a85fe491ca602e222";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/gd/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gd/firefox-84.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "011beadfc3e78ff216a13d55a9b54471ebf84bb1be852aa986ab5ba1648836f4";
+      sha256 = "4bd2901b705f99bd1889b21f4af9ba7dd022f608960807f96f115a110c96a80a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/gl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gl/firefox-84.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "c492314ad418a190484fce335d1dc5a28a515f630c59b1cf2d7e812b6d3c3bf4";
+      sha256 = "391d62de840d53d531130fef0018c71add0ef7134fbc758eb869da7c1cc3b5f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/gn/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gn/firefox-84.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "25b03d5251a69631f5d0cbf9dd89d1ce1dd5355e05efcc233bcf62e5311d4d01";
+      sha256 = "d51f75a7718e78bfb1e9d0974db0a404294e577e186794d3480778c7facce418";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/gu-IN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gu-IN/firefox-84.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "1cc9a3b933b625a26beeb7c31eb062e22ff8dc98c4860bf6ef4aef5567552d63";
+      sha256 = "7cbbf4846153f79fc72e217872fd64b92ed8968aaf618eeededa375ac268a12e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/he/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/he/firefox-84.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "027cd01f51db3b4d27381870ddf95ca2f7252bf7c6588c3d073d303bebb45311";
+      sha256 = "44c0bfad535a4e3c225d948d87935e08e5d77ea22638e971cc833877462edc32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/hi-IN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hi-IN/firefox-84.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "99d6d2159ae34ce2154678e4913145ccb9c96572ef19a18db6a223647b7ec68e";
+      sha256 = "fc64673429972967238b5bb101beb2117cfdb0360e405d4d3b53f013791c0b8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/hr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hr/firefox-84.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "d9b2fbc6474bac73fe7fb5c4eb818f5dc0d74cbbd52c3aacbed0f17db8bce9eb";
+      sha256 = "f256eb4e655a14b1a084af7f72ef4673d33b42d1c23ffc1ff3b4ede42d966246";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/hsb/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hsb/firefox-84.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "dcd0c254c542a50807cbf1d0036a4cab5463c237318fb1d1fec9826d052aef62";
+      sha256 = "9e1e478e501875ac259e22287aece77f1bbc1f898355ab1c29fa26543b38acbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/hu/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hu/firefox-84.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "5a0a94eeb9c8d219b3e34e92fc51163e190c606f975735215177d521b7ed9656";
+      sha256 = "e8605e1b9d2c92c2eafa35cbe647bdda6af22eb030d8656262473b0b17650de9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/hy-AM/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hy-AM/firefox-84.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "2ff26ab884697d226bcfe224ff5c068aed355f6bb00777fa6d9f3bd0b9f9b386";
+      sha256 = "be21fea69e27ce54498b6b003c1db20b42d7d52702ac56d1a1fc2c6fc24558f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ia/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ia/firefox-84.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "7bd9d940f81d76984886463cc10920896247084f91efedf99f787601a47abba6";
+      sha256 = "039f50fc10d95bdef4468174a8486f45bbf9313e1b9b6cecb0d094bb3766ca9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/id/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/id/firefox-84.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "c415b55ec7701219557cc4815ec0975d86f18312a2ef6a8abf3e82876edc5045";
+      sha256 = "ecd6f3e031529e1fed8fb7ae77bf6e0497c9ad0e4996e31a86c4b79489ba9811";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/is/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/is/firefox-84.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "3ee6e83bd9c244b123c1a1989fbcc0524c4101fefe697ea0a9ab7c6a05302ac5";
+      sha256 = "1f6fbf55f1384141826a4b6a39ec617cc798b0c0a0e1ee02d6cd65a79d6784a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/it/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/it/firefox-84.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "de141769375ff5da94ee1030f5af84b309917eeea48cde769419004ca5a015c6";
+      sha256 = "73eebb1d351b5d746d3447c7a68d7a906c4db6df8cd257c6a048ea16cf908e64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ja/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ja/firefox-84.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "69c5c01998a78c17ba55f262493c4e7bfa4fe03bd19a8ca605546f41f0c6f794";
+      sha256 = "ff1c630c6c41cd31c8ecab5fc48e8879dbc4aa295492368cae93061de6558b64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ka/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ka/firefox-84.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "4c37f22f1a20c79c1b391b0f86bde8535c0766980a1b9a42ef912cbf91752392";
+      sha256 = "b6976def40cfd05543b70597347ea7c632c591660a2dd08332f81411a6ce6723";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/kab/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/kab/firefox-84.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "1c6722e18e1eff26918de17454d8103929115f7f036a1c23247695f7fee13051";
+      sha256 = "403bd985ff7ab44324d12c8c7f1386eec9fbae97ac9a0597d12d09d387686db4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/kk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/kk/firefox-84.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "9ef2e2142d2e6d49adf59e6dd190b4ff816cf566cd35e5d288f66794aa2d73c4";
+      sha256 = "3860b0e8d53655669afcb4bece7637e9a1c0daa66d453e9548b2336eb45d94ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/km/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/km/firefox-84.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "bf0899cad62f3331d157c557cbf3cf1f7faadaa7f9aeed3c6547b4533689dd7c";
+      sha256 = "5753474371c7b8663d45f7f9591958afb9e9e2777df3e89840f6f34894ddf491";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/kn/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/kn/firefox-84.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "cfea495b254e1ca8c1be94e95f0c1f126d5f1a1c9d54129562fbec5ded6dec58";
+      sha256 = "d0dbeceacf93c3a581cc581e09507e401636350b763c8c9f5342b33a0640bd8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ko/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ko/firefox-84.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "ba8c93f8567a4f6bbf7af3c38a2d2ee793b05c0246638ded86538f91e6e9112b";
+      sha256 = "095930063eae8e3d6a78a6d9adb3d28cff0bb0c9ccdec977c8c80765a4c60560";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/lij/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/lij/firefox-84.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "c093b95b291af78460396e87ad39aa142d9925a7253f74aef9640fac0134e397";
+      sha256 = "587bced8e4480eba25e8597ab6b838a4f18553dd44b4f0ff48f245406f78e896";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/lt/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/lt/firefox-84.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "b035e58bfe373138626d9c5a22e6b6a8c6f35e8ba30ce821f80a1a85fd16c35c";
+      sha256 = "e214c23914e05152973428f5ed1df20054df054848d99ff23e5eb09e19b4557c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/lv/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/lv/firefox-84.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "6dd5cf66db0207527966532a2728d37438f71d1e79caf9b97916d0e404c9509f";
+      sha256 = "67657d4abb394ef76d37c321625d99dcf228ee00cc109e6d1c80cb3659db9879";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/mk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/mk/firefox-84.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "1308f476d0052e1317b4c7db29d4d2218c60921a9ba7f619dde4455aee7978de";
+      sha256 = "bac0e98b7a68dda441195cbebcdbea583f104188112449b14723c1086c3c4f19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/mr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/mr/firefox-84.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "7336012a19cd650dfb8f842de37da8e29e7b0948cc707880667eca87bb31869a";
+      sha256 = "125a63c875f4be6e246fa01289386295172d999e0e523c1171578adea24b022e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ms/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ms/firefox-84.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "192e12151ed1be4c3f7ea12beedd2c50f6e7fa877ae8c448cc899cd0fa1c6d24";
+      sha256 = "6dc44f34449c915e93bf9c012ce7286b16d6418ca8f576d8a008b7ceb90bcb13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/my/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/my/firefox-84.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "08db2ff728d5bfcf751e95eb9bba34a94c435e53863790ae06daf803d56c227d";
+      sha256 = "af5e2f1f9dcca84f41d3701035a00fc6b581aee2bf00f9f926928b99ab42d06e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/nb-NO/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/nb-NO/firefox-84.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "22cfe518994fff77dc41e6f45550549593564ef2fa2dd34e31af17f5e42d636d";
+      sha256 = "d168631cc1518e17cc9cd85f481f1047f6ae7df593d9197de5710fca0d87965b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ne-NP/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ne-NP/firefox-84.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "605180e46adcaee8fb813dc41c4e7bbe5f509f181b607554137712405c0cc294";
+      sha256 = "4b6065882ddd9e02441eff830808b31e6104d076cefed8386cff4ec7cb12330a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/nl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/nl/firefox-84.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "ba8b45685a1d428d5fa1e38e1a3ec024f55db2f3ce4221fd53b96b0e0801a6b4";
+      sha256 = "96298283a2dbd9e3242c27551ee29829b21c8b9a32ca33b85da3142c47084dd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/nn-NO/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/nn-NO/firefox-84.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "0b76c63f7942576a2deb29cf15b089d2e73aa0b25f07eb1a511ccf033c68234a";
+      sha256 = "19475301d3d93a633a1555b4436d63546a71160a992daa760a8c76a808791b89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/oc/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/oc/firefox-84.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5de508b4039c395b594a0c78d25655113906b95a735d1e94f8e1171ca789da19";
+      sha256 = "48af4af195173b541d76bb623acc357c3a2a8d03227406a21de89ab2d6c8c757";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/pa-IN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pa-IN/firefox-84.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0bf9e4751ef967f4c6f63cb6332fe3940698b3e67d0e4873ea6bf639487159f2";
+      sha256 = "582ec12fbe2f8b07f8f4ae11ddf05c62db2d84508ee63ad6bfead9493a1424cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/pl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pl/firefox-84.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "0fcece8a65132810cb297a599cd4b003604854f0af684b33c9de554fbf7b1e86";
+      sha256 = "df8fcb5fe32325d45fbc1c9349065cd2d7f283e6a33d944282f3ed948c1174ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/pt-BR/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pt-BR/firefox-84.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "8363d209d1eb7e8053acb4805df119e230ab31e74b3389ddb01b53b032c12bf4";
+      sha256 = "fa48bc301c9b7dac4802b50980c573039648eb41bf0c0fb3ef75d0ba1dce9b67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/pt-PT/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pt-PT/firefox-84.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "cf2ecf2a673f0a4f17cecb10b330bec530fd6e37aff9ed821aa68e202f59f864";
+      sha256 = "b0075346738d9a5f61fe4c3265c3a50f639f017551d3bdb2479e622d9561bd33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/rm/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/rm/firefox-84.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "8849e945e79f0f9605e288de967e9f5316c792b150654e23ca65f6c91bba8978";
+      sha256 = "c9ad20ff328c8c0693cab58fbfb1d6c1f85bb63fdd20eb8d371e82d4df5c2e50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ro/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ro/firefox-84.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "452496612b170e53423009a128f092a3d4a372e0e6fe352e649b3c989f6f254b";
+      sha256 = "7816302b6f70c0e24b848d3d396876ee0d870d90561c37e440bb8b7722f54ff2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ru/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ru/firefox-84.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "0e7787bee9fdbb1ca0bd3ef050b1ee5d6c6d8277da941232d6ef10c612003773";
+      sha256 = "8f4969a16f4e70b59dd2da78b73532ff39589c984512d16fcd7106d2cf503342";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/si/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/si/firefox-84.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "bfd6df7b86490aa941f5878ad749d7918bc3c907a177213ab8a60df0270eea69";
+      sha256 = "0dfc4c1c797366ac9e65489b07de756a1b03b5498c9e4a6a10ac0d3a60345471";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/sk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sk/firefox-84.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "87c4827968ac3de5fb7609b9d7685653ef279bafbbb8b15f15f93cc876d6e021";
+      sha256 = "5e16b451058d64ea0cb61fa92e17fd72e591009803170b0b220237cac7180167";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/sl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sl/firefox-84.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6b272ee0cc91ba6114dc777f1833ed5201a96fd905a0d68a71cbafafe1a066cb";
+      sha256 = "36216a3b474d3fd1d27886495f92eca83d24a465690efe7356ca9e7e4c08163d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/son/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/son/firefox-84.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "342f9eedcb359409fb324c13120ed25421435b614e9b5e15585ccf1551c263c4";
+      sha256 = "1116bbb70b7ff8538d3ce4e7df190bd152c98889d1612fa8485cb0197a83868c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/sq/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sq/firefox-84.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "ad11f5878139c46a2344d0bcf6b02ad2c19e59f9861e7ac74668801e14742b73";
+      sha256 = "006948f771f4964f5f4f078615cbb85aee23051e371ff7b871caee7c4659fe64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/sr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sr/firefox-84.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "5e555aafe353036537609b9ba997374d106bb5ecaaa386b5395b7d156ff89901";
+      sha256 = "20b0b9d605603e525d046424d290e6b2a0c963c0eae2a9a6c6ccdb72a9803e9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/sv-SE/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sv-SE/firefox-84.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "cbd33b4fd20d8a7401e384196c28adf9fda6ee2bf24895d75e75f8b727d33e53";
+      sha256 = "a132b97019c75aa8929830f873974e1ab36b69ca7e3c9ab44dd2a5b11bbe4f7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ta/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ta/firefox-84.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "8e4e9919ec79c1847449cc75539f24801d972b67d6895727aafddf7485d95ed3";
+      sha256 = "3f24d965ee5c89edd447e8a52a0241a5d1cedb0aae6ed1ad1c212ba4dbed210a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/te/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/te/firefox-84.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "cb756aa758e69f26eb50d2e81bcb922c2a15a2304ef99debe67a57c44b2c3c52";
+      sha256 = "2b65c7bb7df93b2bdffa687bd4309352f0d73ecdd66767db0db860f33f17c6a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/th/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/th/firefox-84.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "8c2be1458aa4077264ec946181d7ab3160086d12c821dc3d5fa3bbba46de3574";
+      sha256 = "21e2dca4e194a38de97b9b717150441bdd32466ee43e721f41afde004bc8e3e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/tl/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/tl/firefox-84.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "e51e4cf97b79b3720129ed9467b57d393a4ffd5698a9a941cd28feffa1d166fa";
+      sha256 = "9f4dc351f5244b0837a95d4afbfa0af373fe056e5eb106a2b177a57ba4c85ee7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/tr/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/tr/firefox-84.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "9f0a494434bc3d78c43428bc535517b5d61743326fbdbf1836a84f353408a54e";
+      sha256 = "50cabe6fea43e2212d0b0a9a5a382e085fdabc3ff6b6b0694b8f9d3d327c3ffc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/trs/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/trs/firefox-84.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "24cadb7247a254595c29aebe60784d37061465f2c960a8d036096c6df71e4186";
+      sha256 = "c4db90a9a0677430fa591cc387bf1255f260208a4907cb760649cd7a6db03808";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/uk/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/uk/firefox-84.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6aa85e7119fd3ca00cd87d898eb93d954b1e58d01edf14106c41df98bdca4d99";
+      sha256 = "7c92d619dd827a9f7ef9297f784cff582aba44684dca91c3b9873337b4318fb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/ur/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ur/firefox-84.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "6b188379acb89178d08e827a60244c2298eae62434991d53378327c36829fa01";
+      sha256 = "ef46130577072c6fe6b14aa0710c75344dea46124093f483db47cbc8c9cb4ec6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/uz/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/uz/firefox-84.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "782ced50737f68a9fa6db854cde83ef7bbc6f95776a44918248efcedd95230ec";
+      sha256 = "34c28440a7772a7fcf7f920be760f92057d813648372fe7cb8ae9f2c3fb3a846";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/vi/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/vi/firefox-84.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "37b600b306c901080f659955163b1696f5129e71bc3c5f65dc74d280ee6e3024";
+      sha256 = "c02c1737b56e1ae4f20ffa9abd392fb69f19d68348341977d0f39bfefab465b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/xh/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/xh/firefox-84.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "ebdfb9a50a5a7cad0508ade647ef3f81e18837d6b84212de6393a854bbfc652f";
+      sha256 = "6be6defb443480c536639d99d124d8c636d70f049f126a793d627c131035c9c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/zh-CN/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/zh-CN/firefox-84.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "fbc7b8952fa6d2d73b736abf4e60a10512eb983ea4588f7e746bff9512b953ce";
+      sha256 = "454af78f3ea4aa00676c4b97dff278dd404116e1da7993b5a2593167d11db885";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/81.0b4/linux-i686/zh-TW/firefox-81.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/zh-TW/firefox-84.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "5c29c56ef6480703ef9b6a2dc3cae8bc45b2fc01495ba099bd1ee28bbcdce55a";
+      sha256 = "7e6b1b0ad56916759b01df06b23bb6a23b0c59815538cb1edb3e95edf7b772d7";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "80.0b8";
+  version = "84.0b4";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ach/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ach/firefox-84.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "f9b686c12733f6be1c96fcc71727f55e9c79f417df64a4b703c7fadaaf3a85e6";
+      sha256 = "6b548e6e2753e4a0ad2ad5968c063b6f4c7866c297314ba9e807161f7c757275";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/af/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/af/firefox-84.0b4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "dc73e323741c3612607812878d24450b0b5d5274a8e58d25a9c3957d457b2431";
+      sha256 = "f75bfba14ae1a248918c0e433c343328305eb6372dd80aa343506437f631f2b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/an/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/an/firefox-84.0b4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "a84e966f8ac0373f63c7fd76148e16c56af645bb9b83cccee91e20065883f92d";
+      sha256 = "d2e972f7d345720a89081fce3b9257942c93bdeb2a5c7dcede3c30282407f159";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ar/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ar/firefox-84.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9949f976617961c3853fc6e4596bac9a7c18d66b72df22b9b217dbccaea6b0c7";
+      sha256 = "2731722dbd097875bb797a555e9a0ba3843deb159f7917626d8e97c1a3005e7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ast/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ast/firefox-84.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "89f277e215e11c7efd270c6f0952292db5c85057a50b48a3753fb16c1322587d";
+      sha256 = "4d626c7f293226e9e18e28d069b40f75914f9387553d54588c34e7dd70ce1ae9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/az/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/az/firefox-84.0b4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "44c84f6e00f5672c4f4b5d26d727da4aa0e8f5bbdcb4ab484be4015b5ea4bb55";
+      sha256 = "01a647694a6aa2bbd8ad531197565593783946ad248d34f86550d28b8be5b52b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/be/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/be/firefox-84.0b4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "cbcb4dbf931214f01167705529ce410935a378ddf76f32c04a16a019a04dcec6";
+      sha256 = "49639180573943a4bd4d0672c5dec969850b4bfceca00c37575c6d0f2d589a7e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/bg/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/bg/firefox-84.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "6af931944901fc143d9958538aecfcfa5c8604aa928dcad7ff4062e4752b2861";
+      sha256 = "c575261553cbc6afcc60650e21605e1298a122b975f6b6b2845a35725fe2ff25";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/bn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/bn/firefox-84.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "5f44e1a8abf75708aed3c73c217ac6aa31520c32eae8c6a2c28838d4591fd779";
+      sha256 = "5c5ebe2bfaaa7ea16ca4285d9806f3ecef1b29b61e5018920db27e050a4ef521";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/br/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/br/firefox-84.0b4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "7f345832f046770ff20457c902b499a6d2d3650e3cbad696d0a0ce81371b8710";
+      sha256 = "29c764eff10d3756f258f0ac5cc9bec14cc46bb66d804eaca5548cebbaa067d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/bs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/bs/firefox-84.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "539e441b74c8897113d8fe36076473f61cd26f9be24d5197dfa8f92a5ce68169";
+      sha256 = "7730a4c1e7d4d791fe35f000bba72d3652fe7289eb95f5e77b426995a63ef412";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ca-valencia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ca-valencia/firefox-84.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "8f8581a6888dbdce1d357e8a289a0befa20e1679a8cc7bff13ef237bb5498ec9";
+      sha256 = "fe90ef596de4262d803fa282cce7b30c1c9bde896b31d7e47d8e862e38ca1037";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ca/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ca/firefox-84.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "5f3b7553a62465e18e103ffce48f75cc58489349c3cf966e3ba0138ce14d7b8c";
+      sha256 = "f435a47a36affd5b59c7a6543f1c1c7e0dfead407138967a0f295dcd6093bed6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/cak/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/cak/firefox-84.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a1269157c6ec005756c1e0f0bbbf61a524f03b4c69022a2c49661c0375a78839";
+      sha256 = "ec4968ccfaea0a975a4f56aaae8290387707570cf899d078438ac2cb98244fe7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/cs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/cs/firefox-84.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "15a26b351b40964089c8eed80fd5cadafd66ef39abbf19ce50a8b7ef5bdc661d";
+      sha256 = "357c5372b6fade862671db66b90b3382749153c641bcd7c99f7b2a3c68c143fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/cy/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/cy/firefox-84.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8400fc3e6192f2095d4a57bf354dbeee1b771a8aa61ab0d865956cdddfafcaf6";
+      sha256 = "5ce8f5e451fb2271635a2cada6c7b54a53936a1b912b777d54ce640cecb3d37e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/da/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/da/firefox-84.0b4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "83c7818e65c32723c2bd0a4f65a33f19941fdcc5d84055cf2532cf8c4592020b";
+      sha256 = "ac790fdafd2875d180be2375937b38546dd77d6e9b8428f4d44a2b780b4db14f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/de/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/de/firefox-84.0b4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "589b9249ffcff23c388716c24cd09baa8b309d771b97f4dfcf9c979ad9a3342a";
+      sha256 = "6c5205a4d74da62927648f95a069ed6a68ab012f2cbe0c4cded3de8d40c3d325";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/dsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/dsb/firefox-84.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "df57cc439fa74d93921c7c1265b7335e23c0df545e78eccce34e06fa528e75b3";
+      sha256 = "516308e19f0373b3ff75e2e114fc7f1d2d370cd4a0f63f8bf74704eced2e0d56";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/el/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/el/firefox-84.0b4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "7a2b0380cc8733e7d6eb5adc228fd543d8459d7b7d9ffbcb39b73dffd395e5de";
+      sha256 = "d35a67fcfc8c5c334f55d12810bdcbaab6b9cb5fd3aaa75c79977accf7429445";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/en-CA/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/en-CA/firefox-84.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "6e747524fb05aa987e0c24b21fc9ab27901f1cb205b7cffa100d5bdb7ba130c6";
+      sha256 = "e8d36d76d791108a6e514a649eebc9c4814aa8ccd4b21728e56a4e9839eef803";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/en-GB/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/en-GB/firefox-84.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "4e95f0c08c44e6d4830abaf9c2d25b10e63753f1dd48e192d4464a03b82a68de";
+      sha256 = "9bb695670d7ee7a3a35d9adeef579e33f076fc1eca717149a5078134f584bf70";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/en-US/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/en-US/firefox-84.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "2b75be9a3961e734ae16e591c367e76828e9a3adc458629db69fe5fb32a8b476";
+      sha256 = "595b1004380ac96663c2d8889f02a681ad7c5c56e0f12cde4a26a6453d0a0ec5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/eo/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/eo/firefox-84.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "2fb71c60605c4c56432c262f62d72509d520787a7e86a45b496a68e55d08823b";
+      sha256 = "cb6ac56d074e91e2f5154c275c4c3a46e4392586451fdbba52fb419bbe085c64";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-AR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-AR/firefox-84.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3aefd418e20dbb7ae0b8aa87d15be140b4ddd7f6572ae0ca691b98f7f919361b";
+      sha256 = "920e2aa05414fb72be7f24240636e7ce7b431776cc919c5a07c1361da3f66289";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-CL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-CL/firefox-84.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "7d650204f7f717cb39b218919b3654db5cced3fffa4d06fdcbd4eba5cea1263b";
+      sha256 = "9db297046da02c5c8e1f6d5ba0e4f6b35ec8b8d36335dd2f7933e49d86c207b3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-ES/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-ES/firefox-84.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "5870182df6c69538ac1eaad0e61f580165e2e916cb76bbdee8b659a5a58dc68b";
+      sha256 = "ed94f3ded8f803f956290976cfa41a5c46b42da7f3158b4283445ded15fdd789";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/es-MX/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-MX/firefox-84.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "166dc0e61759c879737a10c3b709e5bc94493bfbf01a7997c2d38b48254d6af6";
+      sha256 = "11e2a8b7084ea002c6efd92fc86529e2dd09afbe4fe52285a3165733af95e132";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/et/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/et/firefox-84.0b4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "b8b8ea33ad920876b36abd8d35a61f01548c5a482c7eab0998f83f066bb62e27";
+      sha256 = "0baa470895983b2c85f9ecc79f36fa1b6c8578c5bc22be76ef10d6e7f9e11ee9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/eu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/eu/firefox-84.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "255637aa99002ea1f353098b19787077501efc915a74c2bc88a6ed6c05f12079";
+      sha256 = "271141d85b5a0338445945208d515ab9ec6452253abddb1860c31cd61458de4b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fa/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fa/firefox-84.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "304144942ac8e71f4c29bf4bbc91f17a05bfd712e621cc0029909e0b65e09a95";
+      sha256 = "d467a6e1eff3b2edad56c6b8b58a7fe2d7fa5c07524fc0d567b660b29169ddf9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ff/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ff/firefox-84.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "7ce1b42078fe98783e2da541cdd69dd2083ada20254ef80fb53454950e77eddd";
+      sha256 = "4f117b8bd69c01cb6d38b927ab26cfe79fcd111fc9a4a2e53ae4ef936bc9806d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fi/firefox-84.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "af9271da2138c9c0d73fec09c5356a87b91aecc36a1211a9ce35e0ee1bcedda2";
+      sha256 = "6eb9d0c0d1ef84abf0af2a873334dea463d728ef5aff398417e2ea3104a4503e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fr/firefox-84.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c7f347082b17060c7af21ef12f9fd8b210ee20f877e7e791379c482a63e04ace";
+      sha256 = "85d4b90fabcc03d3ac396bdba0749794bc3fe447c9f2ce793962a2acfc35918f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/fy-NL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fy-NL/firefox-84.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "51d42832b2f58e0d8f011762f9884dd49ab243d45b050258ceeae96bb92daad9";
+      sha256 = "462e14991e34122e2275bedcd6776d9f8a75242c2b06d84ef3dadab08428d48d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ga-IE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ga-IE/firefox-84.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "33a50b14ff9d965deac611e0dd6a85de9caa9cde9b99a8dd955a28916e026d7e";
+      sha256 = "b0b7def94a250ec52fda4e4fe0de931209fe71eb06ce03de13bd7309c7f78d79";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gd/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gd/firefox-84.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "bd3469f5c101682a723eb5b261c591fa619b64dc99466ae919658cf44ae8fed4";
+      sha256 = "e3bc980f579132b68cdf06b06abe2303430df239444971010ef420f5fe1599f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gl/firefox-84.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "eedd3b89b26b6634827e07a5b20b57716f54a604b18d9849a4b2fe30ab7c366e";
+      sha256 = "66b9c65dedd1b57cfa2d960a40df72dca473f39f1cc585e1406abc64d68b1ce5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gn/firefox-84.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "206a292bdf13d98a502ff89ea57e94b37a528e57b88c1611c5094ed64aae2b0d";
+      sha256 = "ad707ad91336de1c0d1f26fddebb95d25a8ff405bc3d576660ad9be0f5643939";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/gu-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gu-IN/firefox-84.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "2ec91a2be77abc9b52e4d466cfaef70ef02b7b92e332fe572cdc3f4e53ac5276";
+      sha256 = "585c76f373ef5c3f3b86a6cef4dfcdbffe3e314ba737a3f514bcd871140e5aaf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/he/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/he/firefox-84.0b4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5f53772c8a24d4fe1be3cc21673a924a5d65e606168f079b8091f4502d1218b7";
+      sha256 = "8f9ed5eb32fe9272f5adc22753997292cd2dab7b1368864b4f001eb0fffd7526";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hi-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hi-IN/firefox-84.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "15e74fb5124e1547f7eb776bd3b6d4096338731f1d97b6c0944e7f3af1b569c9";
+      sha256 = "22d8b3d494f3b0dc5e347c0fedd5ab2ba32690c02993bd2a9066a987bb87aea8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hr/firefox-84.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "5c4a0c766ed006e0f43856104aa8bd96e8d63ca618fda401370633b707e80374";
+      sha256 = "c3a70593633985fcc8974364db75f2998e450359d4a8b621f23e95df24cf8e6b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hsb/firefox-84.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6945e71a060bcbf8a329c65ddcba786beb4f955cc2105806bf5873c07daae988";
+      sha256 = "30701d1b25536a45a6a5613cbff8ac83bdec08d6421f1e37d9f0ae9c39ab6856";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hu/firefox-84.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "5da76038365922aff82c540652132c7763a07f4336ef003a434299240444b036";
+      sha256 = "bcb63dc6211b5c24536062ed6f8a424edf0ad553187b298874d97f75d363b1ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/hy-AM/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hy-AM/firefox-84.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4be5260452b39b707d271b5696710038174c397083f626b3fd877aad36c37142";
+      sha256 = "0278018d35f7be3e4c8da080bcd86e2bf08a544bfd452136483d2b21f91c582e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ia/firefox-84.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "94dac5899d0f2d5afa0dec53472afb329b956347d22581e1b9668a123d200278";
+      sha256 = "d5699f8b946bc551fea78389cc6e82a9ca58ca3a8a492cbe3b985ed655fd60d1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/id/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/id/firefox-84.0b4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d4cade715292ed116c2605dd6a8c70854cad373641982283decbc1e2f0417490";
+      sha256 = "1e2c580382192e88094738a01bc99b7efda5a1010e1bb180e35b5701f03aef55";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/is/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/is/firefox-84.0b4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5f4bf4e8bb2f5e72872e99f8415b864df457c93ddabbcd4377588895c83b1d7a";
+      sha256 = "a541657165e18212f97261b2aba391434246688451cc9f2b643a57891dc0eb1a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/it/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/it/firefox-84.0b4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "5fa9251fd8c8e0d4aebc006ea1f8df15afada7276a1bd0517b89c2a6f8e488b6";
+      sha256 = "5ecf7a03bc8e8d6329db2bca4296cf0d07b943ec9c9e0cbb2ffdaa4ecffcdf3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ja/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ja/firefox-84.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a1557fd84bb39786566b6c11d1efea9464a96b77a690b1b1c3b165283c031185";
+      sha256 = "80d6148dbfa8e95e5292699b5326171f6a44eaa30dc4c84b233191a8505a248b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ka/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ka/firefox-84.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "f9359c7eb9c6536ced999c18571babd932a1b1bd22565d6489bb43cb17893eb8";
+      sha256 = "9f15ef55fab16e0086466e696f35dc3107451c2b9ccab9452901cf66723bf688";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/kab/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/kab/firefox-84.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "9b34875edfbf6383b5bbddd110d969e32e448e47eaf48b7f41c215e6b3f8da62";
+      sha256 = "762be8a3bee38ea5b939611b4fbc9fd5bfe71e80b685cb0a8937373aa19f94d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/kk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/kk/firefox-84.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "78bdac1a7f0bd82440e43c6079332624b1e7e60defe45d55493857b1f9e2c7ce";
+      sha256 = "65196c278a5a70c76315546465915626ed0c5f395af4ed1aed0ab2f27846aac4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/km/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/km/firefox-84.0b4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "9fc753e4fa4a2a3a911dcfe9d8c7c993416833bedec4e94e85d95ef075209377";
+      sha256 = "530010cb0d3393e47324c032d048a377ac5c9da16e73888db026f6cec61c3533";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/kn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/kn/firefox-84.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "1e45e618c6d4db4f870e4d3baf60676d2a76916ce0998ae33d671ab73e8c1bfa";
+      sha256 = "5233a8714e24a915404b3139aa3496812a4203b866cf4d870b013b940eba41ec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ko/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ko/firefox-84.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "afe8410a5be470aa016720f411f33aa0b244fa34dacb138ab145b97a7e195db9";
+      sha256 = "5dfe6629926804ed0820d472e19e51223565b011dee3feb722a81faa58043744";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/lij/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/lij/firefox-84.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "094f4ad0a2b988f0d75938dd6439ad5dacb1eee42584e7d1b424289117512d49";
+      sha256 = "4bb4bd94ac7aa845a062c366ea47871293f7b5281a460d3547fc321b6430a3ec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/lt/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/lt/firefox-84.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "69164a34e2cacc8f68e8e87defe713c4dcd1de278d449e1f9eb7b8cf42aae305";
+      sha256 = "162d3705cbb8ef0b8036520d59e17eefd8e94bf27b9c1df027e9c0b26b3ebcca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/lv/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/lv/firefox-84.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "10262da2e4d50f2e331b3bd0c4d064002a3a5f10719284b96cced812ca0551bb";
+      sha256 = "7498cb5bad8ccde4a82e2acf49e899a652086de5c2e0a63f833d5342e83bfa48";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/mk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/mk/firefox-84.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d310667e306b177191965b40b6cc8556e0fa749a3ebfa6120b0255e701d81ac1";
+      sha256 = "88ffd9ffb56000b42d3878654b6be2413189b93881d29809c5cfcbcd740349db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/mr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/mr/firefox-84.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "2130fd9a56e2e4f4c09ea57cf0a566ade53c255c52e867c40316e14a04a59e0f";
+      sha256 = "cac6e4ea74b146d07afa79e85746d9678e6407c733a38367ed36e94821cc2f4a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ms/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ms/firefox-84.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ac215f60d098eacfb4d03e857e0229d0368a113e5758f00044790953712cc4bf";
+      sha256 = "7e5eaf47c232fd25fb5c1e2de9d81351cfcf33c88c696a193219b0ff86a3c29f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/my/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/my/firefox-84.0b4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "0f89f81cde40821463e9ddbd988616d019d73fc0a27cc3a427dad4c9bd6fc931";
+      sha256 = "20b1756847b2cbfc98153ac0d9a646f129b83f5c1383067d7547e9c70409abfc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/nb-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/nb-NO/firefox-84.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "4d599136e6a8f430f21605895d2ea63aaa3542a2b9dff5fa44d3a618dff1be5b";
+      sha256 = "ac71d2e5520acaa352eba1f26576dc101b7b3a64971b36acbbfe7151b47e1344";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ne-NP/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ne-NP/firefox-84.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "859dc2201e76de7f08b2c29d11382f02bb2eb6f9ec48f65656f578da67cc10d3";
+      sha256 = "90ff28f5e3ed56f5472e524f37288bad57045dc5491bc84f5e76f33d1d2cb046";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/nl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/nl/firefox-84.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "f9b7784f2c626f6bfe8a39a18a593d9f0d10d0f6407d1015969fd3744a483e88";
+      sha256 = "267c1d406006feae8bc350bcb58b4f73cc2403682c5786bb500bcafca4aa1ae9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/nn-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/nn-NO/firefox-84.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6c46d8b833423fe0eed0da6c162ae16f6969b569902c41fa21ee7e19ce7515fd";
+      sha256 = "815e84bf8acb3cec68dd7fc06d7849240f71e73cd710538b9f8a887df73f98da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/oc/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/oc/firefox-84.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "c359b9438f6065adb64baca086b7bed295ffccb825a96b4bcc5721ed4346a061";
+      sha256 = "14717ad07784d231333584150f04118d22a8616fec76aab800d3208c514904fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pa-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pa-IN/firefox-84.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6ae3b82728155e195747176188e30d4ddc3d5e9499ab018902e2e1289b19c171";
+      sha256 = "1c1470816615bb292f51cfd1a52002b5f2ed4444be41a3521ef1a40b4e64b2b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pl/firefox-84.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "45b97c17dcd1042eb205f6c59f5b679fcd224705cd5009dc2e39c8a22099ecb9";
+      sha256 = "872a505769aff03597c71de66121fd007559c3f1cbb22c67661930de6e193634";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pt-BR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pt-BR/firefox-84.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "50b2309fc1b083f739b090729096fe82747dc3e889923d271aae500ee5f0c82d";
+      sha256 = "d0ef34afb32b0f6d1c266b99ea0f4a9015934112524eee0cadc66faa6898ae27";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/pt-PT/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pt-PT/firefox-84.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "aac403c497aa1bb9e37038ea7897f57074278d080e592bf1984f1712a80de632";
+      sha256 = "e0b17a97217c799e4e0067e91374e63a6a99df827442d0193fcf47320af8a737";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/rm/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/rm/firefox-84.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "b8330c7ef733c1d50e320376bdd9c5205fd56f58fc7baf46497f1b0902193dc5";
+      sha256 = "0c031b6ae10918e65274f5ce95fd03d68011e36ab626e03ad9484ff40b36bc7e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ro/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ro/firefox-84.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ae7d39f56d162d7b8bfb4d55c6de9b46a40f45c1bf9a4191e65c7a99a36b22ab";
+      sha256 = "256b81200a5b92763d368b9c5d6f29e191aa4f11b097de1773bc5557d748c3ea";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ru/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ru/firefox-84.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "10e1adf60a23574fd5ccf9ae1be83710c92c902367174f73952d18412228814f";
+      sha256 = "734b7d94b896554d5fedfd94a84c827ad6737808cd1f7b5b13be20702d46315b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/si/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/si/firefox-84.0b4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "fe02265dfb0bb12ad9a5739e802937540425789c8e36220f59001ef4fc256f16";
+      sha256 = "d2c9fee5e64b8063c834610c2671f9c3fa49a5e02fc7e3482890b534aeb66a7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sk/firefox-84.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "73c58bb35f204f875d2c8d293780810be6083d2934fa8d7d7e02a3bc8d41e5a3";
+      sha256 = "edcdf2a8a00e0402992862e28efb33614b9f1a4cdfed16316c5d4bbc229b298f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sl/firefox-84.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "90243b7a75889617085715d6cbb65c220f1fc5eba5d4a70612277dcb6a6df6b6";
+      sha256 = "d097a61adf0908041cb3cce76758f6da274cd7b3a006163b004f70e869947021";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/son/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/son/firefox-84.0b4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ba8ead8c649116edb7e168b25e6eb3735a85cf5c15a2a78ebe8340cd7071adc1";
+      sha256 = "d60731c5976825f0566502f6211d8e22388ec9d02bd122272f70a0830297e1fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sq/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sq/firefox-84.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "6466c44847b3b0370665e996582a2cbed9a8eb56a8b3f683582011cba77e918c";
+      sha256 = "5dffa799eec3baf2e55d7b690cf73c2b190e369bff32dd1800020c0fdf912c9d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sr/firefox-84.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "06869c6fc77aecdf48a991ebd65cc6052c8c3aca976b01cac5e39933c7aa9190";
+      sha256 = "abb5779af704c926ca90bd9b9a01eb8de1b1b4feae658d5911bc523739eda0d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/sv-SE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sv-SE/firefox-84.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e763358e9672fbc8b990bacae8687c7558d9718cc9d1e80798ee9ad220f28b35";
+      sha256 = "2a228577a4d6c11a433b8c0340558aa638de175474491428b05509019920f8e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ta/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ta/firefox-84.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "1669e95f886a7adeac0489c072fb88f1ca09daf3b42027006305857bdbfced4f";
+      sha256 = "82f0bec91719e7b2a355c9b0398b924ce4cf429bb11e99d566af9836f5087acb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/te/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/te/firefox-84.0b4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3d5c9f1596291eba38fa5b5174674fdcfd335e4cff44ecc50ddc7f08ca254b97";
+      sha256 = "9e581d2dc107c385142c3bbb5476e3bd94e700cd8f9e36ead46d284d5708e9c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/th/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/th/firefox-84.0b4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "d583744cc4d1099f23960b0ee7c80992233864c94f877623f0c566a65cd944fe";
+      sha256 = "096ce747a12c0b773d34517efce6aa4aaaf09385c5cf088046f7217639a7ce9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/tl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/tl/firefox-84.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "cb6b8cdf1747e211cceeb07bda07573bc193574fa3603bfebaa537857953ce13";
+      sha256 = "3fc48cd9839ba88f246fb04fe34cc5760aa9e40c8fb782ea57347e32d66030f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/tr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/tr/firefox-84.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e2561f98607ac5dcc67ef825cfe73d1c2af4ef9c5c01ebf48ee4dc0f80b53d07";
+      sha256 = "087c629e5aea8fc698cbc5608c270a7099607b34c5852b3b3f4091af3b7c789f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/trs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/trs/firefox-84.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "de1e1f83c439d17d5489d666f1772ac32e26d70a5b3309176b528de413fae39d";
+      sha256 = "4df467d46c5830a3d96f87294c3dfddcc397b73a372ba566900123f7ab86a6ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/uk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/uk/firefox-84.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7632b4734ffe3106e78ddfc9e5ed81dbd219045f4b954421be4629397436763c";
+      sha256 = "11090c8aa00533c456ce96cbb09691c816fa2f98ac421cf581c86bd2bef5f296";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/ur/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ur/firefox-84.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8e6c6d36546492ae93128c780c80bcae86ebaded38cc753db1f0401d4b5d31e3";
+      sha256 = "8e7a5cc3606dc6cf71de328863a9107c36024001a381baf00daab11bebb857d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/uz/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/uz/firefox-84.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "18c7827cc1337e0a2cb3a1e9603aff8e7c3ac8e5631cb791eb0b7a2de35bb487";
+      sha256 = "bb1846dd3b7bcf3b657d64bbd215301565dafee00eae96cee15fc71b40f49877";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/vi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/vi/firefox-84.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e78c922c13e0207c9cfb4d492e855543979e77b49a18fc63796c7e74cc4fcdeb";
+      sha256 = "375805742481f8f33adccbdc7e10f21ef0b1a0ab383c379e4dc13718c3f8fbf8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/xh/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/xh/firefox-84.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "bd30e089384bac81aacf68c52ac884712bd0c739f517faa6390090d112d9fcf7";
+      sha256 = "a8ce0836980441d1248f8bbd2e4bbc7a8269afe9bf8e3125bd9f4dd3acd06d7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/zh-CN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/zh-CN/firefox-84.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "316ad740bbba808a66b6fa00a9b1391597c949fa217e721563c685ef9fa028f1";
+      sha256 = "8f491d8d1f61bf4a7f036efc047462bb04cf953e2a3a39cb5a326e49ed7a880e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-x86_64/zh-TW/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/zh-TW/firefox-84.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "f92189c808903b314ff4cc30fdfa7d5e2085ce22b9763e95144a7d69e6af719d";
+      sha256 = "dc5a8ca6f8a3f40060d0d2abaf694a066960cbfea355678ac583c3977b37cbed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ach/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ach/firefox-84.0b4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "aaf1bc4cda7e1f1182f701485f5cb186d4b731851aca70611cd478c923b2427b";
+      sha256 = "f5b5a500581e52dfe5192135cfa06bf283ff23ca0b1b569db1f1bdcd359ad0b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/af/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/af/firefox-84.0b4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "1be25b19658c15a88031169c57acda5ebd49b63212f584da6f859370b493ad32";
+      sha256 = "f96a13006c272edf5f60d6c04011e48729b5078fbde2238a0e5c422eb1293372";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/an/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/an/firefox-84.0b4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d461a566f7efc35ac323b0e8e963b8332a349e1b317401c2975cf4c75f7ce8cd";
+      sha256 = "0bdbd429a512499dcd920ae695b61347196527ab30c601e1645385f3cdaff4ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ar/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ar/firefox-84.0b4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "2051bf3ff16a6ebf15ed4fcd97adc2bef65c04500d09ff1f009785f41c0b02a2";
+      sha256 = "e0b6addd1b699c228aa353af879bbd263d1bd0e17aa033754abe864348adfc9a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ast/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ast/firefox-84.0b4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "97951d00f79bed031680ff9676201c9ff0fe79273e4f2697cd19ca9ccdfe95cc";
+      sha256 = "3ffbc1b67d9cae58c2b21227e6456d9e6ca8a387cdbe8b5bbae9b1db553a34b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/az/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/az/firefox-84.0b4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "a461aa41658c34bef1bffba2d34619ea402fdda2e51aa1e0200002b2e9321c8d";
+      sha256 = "36c9ad3b07b6e032b38486e1d2a7a6b85b85dc84d8d0b9218fbd4c4a71e59e70";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/be/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/be/firefox-84.0b4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ff1d2fa9203fce0aac5d91b38034910bbf7b0822b499fe522ed981f3365db8c3";
+      sha256 = "2ac1811463e482205f7dd27e4f98564146f089fb423405a8c3df8d2a10e45147";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/bg/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/bg/firefox-84.0b4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "17553a8566afe02d916b18d76a8850295512d9514bc37bbac459bd28a3bf46ec";
+      sha256 = "174d0ab72bfb1a8ea811c1b77a9eb65871f68641b1703c3bbf02bad4d298460b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/bn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/bn/firefox-84.0b4.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "9863e968594a556a7bd52a43cd3c965687d4116c9fbfb62bed38b1b7ee343728";
+      sha256 = "e6d1b74e56690abd5c2f0d2d1dae0b9ac6d16b28daf1964ecd87138a5de9fadf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/br/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/br/firefox-84.0b4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "762f1f951560f8c85a44cc2a7c318e4f8e5a0b752011cf06f86235e3aedabebf";
+      sha256 = "2ad97986bcdcdc2b988f1d50fef1a71d767119e03065ddc3e51ad38efc7dd351";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/bs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/bs/firefox-84.0b4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "24fc8ac01417df1bbcec358c083f7627ed13bc76921bf0efc14e9f7653e9a819";
+      sha256 = "71c472c8dce7174ee8139360fd5b8528cba89f73dc186bdd08ed368917b8c41d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ca-valencia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ca-valencia/firefox-84.0b4.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "b071e20fadfaa2c06baa1579343c18167f6adf88e1c98fc68413287f6a45225f";
+      sha256 = "4e5245f658f5bf6f47d40e2437841213b03b9f6d12e83766621f5b59fb258eaa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ca/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ca/firefox-84.0b4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e63fc27b2bd404ae9190035d5537822fe76213545d8dd076566abd12ea213e25";
+      sha256 = "4de924505b98c029dbba0762723a3310b3d171f18072a1a51d4f9636aaca8831";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/cak/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/cak/firefox-84.0b4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6f4fc3e51819d9d3914ad624593cfc755d9e8f78263700268dab46c38e8fdbcf";
+      sha256 = "11fa8468ca6b3c51ed615d0375e63d85443beab66c10cbdc95fca817ada02215";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/cs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/cs/firefox-84.0b4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "ee61413b6544ec56d13bebd08ee2ee69f8d1f16e886ba31d46c2a786c0984f7c";
+      sha256 = "c1bc48d54d0ea32731d4400c2b2fd817c5ed222cbe5fea20b3ee26ddeebab9d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/cy/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/cy/firefox-84.0b4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "8f29a8b77732cb1387371538efdf970d0e93d3de866b103c836990a4f0a30933";
+      sha256 = "02cf2dc5bb97e9497655c53ef45dda3495f280a333c94fcc51048852bc993a53";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/da/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/da/firefox-84.0b4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b89854119e139a8e9347b262131ed5da62672f6d728b1017963a11d279861a45";
+      sha256 = "6d36d0aa1ce447770c9a149a1df2c27731a31f5784b9f20ef536836e6e42819a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/de/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/de/firefox-84.0b4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c453a0f5cf528c582a35997a963b944d31666018ffc912ee4e188f795066b925";
+      sha256 = "49eb555372658bf827adfc07b08c8ac46a6351f0ecd0fed0ad6d5c4975553c8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/dsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/dsb/firefox-84.0b4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "bf1f7ebef2aa4a5e0ed824a2c89a0b86101b5cc754feec482f0c39ef2ef3dea4";
+      sha256 = "1c358edc0e6248773103ab92ef0bf6103dfcbfa2945602bbd2f49153ebc7c690";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/el/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/el/firefox-84.0b4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b31ea72af96ecfd2b625d813bf32e08dfbffb9c0acb004e1f279b7937d675a90";
+      sha256 = "a445f9806285ef0b036364a618c8d7ca226da899dfa33adbda5b2e327fe63dcb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/en-CA/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/en-CA/firefox-84.0b4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "31866007d8bc76202fcec3b9531afe237c9822025a14113051a9389cd9f81ec8";
+      sha256 = "6d2590c0cc0aa28a1443185aec54f84973a31e79beccd5ca5700abfd8deebe2c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/en-GB/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/en-GB/firefox-84.0b4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "82b2e6cc268eefb687255fdc5170aa8ab6136d6a07b881d49c044e1700eb9190";
+      sha256 = "71c4040c1326133f18ec7a07ea021b061b0994cf92aa113b358c5c0c10ebc59b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/en-US/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/en-US/firefox-84.0b4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "dcd29328d9b464c16bd034f635a16d1593f98e08becc6a278d265b07bdc208a2";
+      sha256 = "af3bcd19cd78dea23deaff0c2810282a68428eee4d45e2989c75cbce5ff97098";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/eo/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/eo/firefox-84.0b4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "cfd6996e81513426d0534ba62e4f2d22fafcef51ed48da4a593b9d3ead2cb2fb";
+      sha256 = "641def17e0d004f81cb176ccf70cbaa1df50fb204c3ff45a80800b76c21ed006";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-AR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-AR/firefox-84.0b4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9d4c24e1153f723a789c1934c15cf8b4d3925fd34e8fee98d7e5ad19c9f7a9d3";
+      sha256 = "0475e9de47c64b11470edf16f2819bfc1b1013f75ff6dd83da96bff1174db788";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-CL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-CL/firefox-84.0b4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "91364ba1a2ab6c8bdede117f45a855b5968bee492e054123433c0fc034d66415";
+      sha256 = "0f3c14175da4f59b745473df5f0256b582800b3c3dfabaa21e124b9ef100fc72";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-ES/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-ES/firefox-84.0b4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1cef40ebfb1b12813d85a975ac0620b3ed339acf5de8e4d0ff0aba6aadedcc7d";
+      sha256 = "9a33525bcb9d10a10630d4c470877c8698f6da32671cbc47450c7fa4d2cba7de";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/es-MX/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-MX/firefox-84.0b4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "e41ae370750f65e59470e05b2ed501a308f8743cde3291bae2fb8d17af553789";
+      sha256 = "ba397ac159b77c9346b58e5c9e4bdffd21b5ac3fd3d4b67a2b67931916b2f830";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/et/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/et/firefox-84.0b4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "5a279c246cffd27f6c919f451161e87b30ac8743e1a22ac490496b28af7e75de";
+      sha256 = "664672b4f5f713bee16024845f16555da16f758d8db674dc5ec7f0022d2b7000";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/eu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/eu/firefox-84.0b4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "3530e6f3060fd133dfad72532319c6cdb5be5bdd2dc0395d02e379b203264d20";
+      sha256 = "3230da6f19116ccf848855218df3fbace86af2d9085f4109a3006476807f464d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fa/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fa/firefox-84.0b4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "ae1b1fa06440f1038c97fa9d625a2b58ce5ffe11fb53a71afff632a18675f113";
+      sha256 = "faf07d08ce391b1043d4081fc650e3ee78ca067a3a11a6e3ff87916f3ac7a557";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ff/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ff/firefox-84.0b4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "05b47dda3d1fbce0e3dcd79534aef247516e5ded783d1184975ba97b1abb09f8";
+      sha256 = "2c763d737cb112b77919594fe34061db5181a725cf518fc3cd9133be9bfd7cf6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fi/firefox-84.0b4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "689eeeee1a769ec9bb53014044a615f0a5c05d8a15e6dcd408d18ef452c0b441";
+      sha256 = "5a631720534e03e211936255012270e04918461112411e787ea02f138087c6b1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fr/firefox-84.0b4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "c64e31adfc24ba1fca84922b33a71bb74150ddc9b4d5e52f3627d2aac3b11516";
+      sha256 = "2b86ce004a5c42fd6f5cdda28439263357ce5428b6469440046ce6fe4d6157c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/fy-NL/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fy-NL/firefox-84.0b4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "36765f1c9e1b15b43fd7d70c9f9dd1b977c4171ff920710346493214e08f9dc0";
+      sha256 = "e0e81fb1494d86abdcab4cc9feb0f789ab304172c67da013f0a09ab2c2e3e676";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ga-IE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ga-IE/firefox-84.0b4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "026c461de7bba74facc421a58028e46efe32e7e3f441a8ca030911e2e883f56a";
+      sha256 = "ffcf120a36f7268ab2ae03fb1eb6d458fb63b00d41198bf7997290c28997205b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gd/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gd/firefox-84.0b4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c2a21914b4f7cc71d6456e9c395fcf2ebbca12408563decc4a400e3d5d43c865";
+      sha256 = "a99d3471da7fa2e985fc562a4abe086de9096d2461a50841ad5c8e5d2891bf8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gl/firefox-84.0b4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "888aaad1dba8db4d71785fee01c100aa1919d432e8ccaa044e386224abe9494e";
+      sha256 = "01412502c872561564e1dac95b12d27295be5c411d2bb1ebbd53cfb4dbadee3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gn/firefox-84.0b4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "d5b1d103104c2e6e7b8198be649b0628acb4cfe6865422fc9e3db3b6ecc07cc6";
+      sha256 = "a73ee3448bb7888acec856e3e3369e28f5fbb9c5d203892e4992f73b319fa394";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/gu-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gu-IN/firefox-84.0b4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "215b9df33e06685f9b264b06b512d325aa8353b3f3975699b77e9fc8d18531f1";
+      sha256 = "3b7904059b38eea27b7901de41be029ea8ec23c3d2a8bbe8941d8852c55cfb97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/he/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/he/firefox-84.0b4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "8a19ef1eb702a0083c7751cbd7f2437c5fa46ba3f61a5f5d07f797b8ca696d22";
+      sha256 = "0bf4d3aa4f217e12b1f204bdb189625c6daae24cf5253bf4b1cd6288f2717873";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hi-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hi-IN/firefox-84.0b4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "17a84efead836ce54c1c0f0f5486595753f97463fbc2031d78b01e33c7a7775d";
+      sha256 = "4f95852212b0b08aa420c88e2ec7825913e3e82c1d2891fffdb11a8583bf46b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hr/firefox-84.0b4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "41bc47533991b818b26fa149a30825326879cdb3ba92eab0ae5171be595078bd";
+      sha256 = "e30d3274103e39241e233aee994b5b8c2b39dbd190ffa1a9da99f8494ae833b1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hsb/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hsb/firefox-84.0b4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9ee8d0255eaaefe37f00960ed59c83a06b8356a8c6ea05d1f9697edb9880593e";
+      sha256 = "f401baba947e64ef4ef02cc5137c8623a99967ec8597e4e5c8987382dbc505a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hu/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hu/firefox-84.0b4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a9b6dfa44cc8d90a530aeb98ac96a0ac1e63b4a46b9af8ddfd4d6f268fc7eb5a";
+      sha256 = "70ac5b24deabcaf0b250575a0454a35e127cf15023a3546ae41c01942c64c59b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/hy-AM/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hy-AM/firefox-84.0b4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "e93f74803b536d3b12b6e41d064a7adc5dc16615d045a2e6cf792d25477fbdc6";
+      sha256 = "9dfa8b99f67ce66625e0c89c37f4ee36b23421ca89d4445deb5dc82eb0eb05a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ia/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ia/firefox-84.0b4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "931dbb0817dd797c5af61bc683f3d95ed99ad9834efe2f66a50f9e444e708061";
+      sha256 = "4445dc874962b72f7d9096cb46ff98987b56d9c2d3e0acd814fc8c59261363b2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/id/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/id/firefox-84.0b4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "1e1afcecc3bcadfbd6989eefc191f8d5cfd0f4d29c1f6814927370aa647af854";
+      sha256 = "16c6550910555ddfc395b0c9626dd6e41a4bc9bd4a8ddbfb2867faa991cd4ae4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/is/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/is/firefox-84.0b4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4907987557a6a560557d417dcc31f9c7dd45dc0d2767ed050770f6fc6f308641";
+      sha256 = "1c208c0b99cd008d67e8c9c1d118f7b2c8c354b4dcf740554fc2474ff93b8a7c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/it/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/it/firefox-84.0b4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "d895c87359cfb98e236c4b5bac92391528eef07a45dca2d067a7d55fed4ebe7c";
+      sha256 = "cac410ba1679d27565d63d3a70920d3ff262b6171dfe732c3ec7ee88d3386b14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ja/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ja/firefox-84.0b4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "30dc7aee461930bea42c9f2985ff766f4aaf3ec0bd7f09562626b155bf80f202";
+      sha256 = "0b8c20ac0a4394c8c4a106e65d83718f639453e10c54906da04f4da536a218e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ka/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ka/firefox-84.0b4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d452668daf3b5a9f0602417822f7581183dfd5dbcc5d770afa20e1d61d557003";
+      sha256 = "978aad2d0855ed8e364faf4a0522d7271bbd134c699da515db7e5c58dca79d49";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/kab/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/kab/firefox-84.0b4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5e828a4f6abbb80c7b575db2a70ddcff0d734f11eb9bca55c2b8d00f08fa6497";
+      sha256 = "f32b2f9cd504a6d4d5b5d2ce47368cad4317cb1249dbd7d925d0c48098fba8be";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/kk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/kk/firefox-84.0b4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "994e8ccd626f3e640b8a1b687a22ae6e3943b25995278f3333b6814ce61185c2";
+      sha256 = "38e2fef40b71d50b85be7a2d2c44bc0b0bc569410782119fbe07aba00c8193f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/km/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/km/firefox-84.0b4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "a63ad9f77f01523dfb02eb6c2880a4046a556bae6d329a5e5480aa3eea0aec85";
+      sha256 = "c8a617eeaba39e138676c8412594329b00d372c40a0401a77e5bf974a407a3b1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/kn/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/kn/firefox-84.0b4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "5396452efe004c7cb57105bb7134875e073f822927a98db23e96994e11fc7155";
+      sha256 = "d1f19e2edfd1ee97b13b8e42c22f1409174c8fb4b024612d27cbb3ab9586ca1d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ko/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ko/firefox-84.0b4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "a0bd2586531902121344b7c70e9ec9ae4e08514d2c467a17664701735f8d74ab";
+      sha256 = "8e1f68d6bf97644616e8d8a39443061fe99df088b42e5218beb823d8cd18b8e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/lij/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/lij/firefox-84.0b4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ac4f16381c71e3a4f00c6ac615913cc7d5eda77dd9ca337b9a8ec0e63a2e9176";
+      sha256 = "ba22770bc65b0033f424ce30df69a7d21a728245230696b412baf44aa9a111a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/lt/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/lt/firefox-84.0b4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "bbeda439051c1ff43ba08b95de57914237e7b9845fef0d92efa02265cdc81961";
+      sha256 = "27ab65ac4ee08e2714ca7c493a4575352df4a06532773197a2bb3da86e9a18c9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/lv/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/lv/firefox-84.0b4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "bb500de9c32241a7e28828e3f9b89427be1a54475d7b05b9c678d489a457c329";
+      sha256 = "4a8f6944d9b6134d664e08eb404e130a218497b4957437b56e4487a8bc205ca5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/mk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/mk/firefox-84.0b4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "5689b2805b30cece9f9757a1869906529a7094b4a9de5d5180a5bea7582606de";
+      sha256 = "885893b0a9ef75cd623f21c720aee07357ff3b4b21ccfbe456fc11928ef7037f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/mr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/mr/firefox-84.0b4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "fc5ec6938f33c548f52cfb90f8a40b342bc9b4a7b97c3fcc1b3cd2aa5a031270";
+      sha256 = "55aa8e1e4b61eb3b9a26fe9abafa804e7b6d34ac1f36efadf10ee13d2cd934a6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ms/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ms/firefox-84.0b4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "374e2a6ea3c59c7f985606f2e631294b57e20d7aff2bd8256ef9c91189e960b3";
+      sha256 = "61412fde864addb40fa2d0ab42f30cb9a7e1887cd130ab59880763d675b6f7fd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/my/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/my/firefox-84.0b4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d9058df8893da03a707e549d9f133942fa71bf51e06c1a654f3ac588d79af82b";
+      sha256 = "cd7190acda6e20c22edcb99c88c15e87b4676b2dba7de0578d2ab32a22b2bc1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/nb-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/nb-NO/firefox-84.0b4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "11019961c5378bb86b45b2c6d4b74ca1e41e86aed500ec0cd73fbe1785ef7742";
+      sha256 = "97f16d919eb8321c71864daba7accfcd9bd86d4948bc86df44fa86a52649ad8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ne-NP/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ne-NP/firefox-84.0b4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "de45c606c961a38c84196cab1827089b1b22e2dd0c23302ce57bf9fcbfcaf82e";
+      sha256 = "4ebbdfb4c75621a24b52853c3d94e178decfe3bcaaa1f8f92f42bf91eedd874f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/nl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/nl/firefox-84.0b4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "bc2d98ae8f0fcc608d55b394398c45c1bcfcd02956031ca4762cc98d265916d8";
+      sha256 = "4b14585bb554bc346565a69b6a4c10580345923f8e4dbda8b202e6b9e8cf1452";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/nn-NO/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/nn-NO/firefox-84.0b4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b7c1d390a8bdf295ad8951959fcb720f977139592ef0f669005dcca0e6cbb19b";
+      sha256 = "408f34fb48fe1fa93850857118fc4ed972139e273ed2521cd9f7169f8d4148cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/oc/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/oc/firefox-84.0b4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "a61a765b698f48c15cf07ea424e8e69be7630261a94c6514fa739974b51243f0";
+      sha256 = "0f7e1e4df86a931152206159a9f4e99b4241377c5545fb343eff86cd21869bec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pa-IN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pa-IN/firefox-84.0b4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "6721ca2f49b60f5ff1d86e0b1c9a1d6107c5d701b319a2abec7b6fcb9f845d57";
+      sha256 = "c7f85ae2c46585cab0aed8c41117ffd686fe0dac6e0ba64eb41bc22d4b8f01c9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pl/firefox-84.0b4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "a77c0c05be64f027d25feaa75a788c630dd7af831c0c2fa334db7c36ac340144";
+      sha256 = "2669e61a0d7da09684230c67c6d43091b3b51e12f291259a62c72ce124fa4c3c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pt-BR/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pt-BR/firefox-84.0b4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2baf74be32eec18bb235b57ee3816a3c9df916bbd4458aab1613af864581a072";
+      sha256 = "10ac3662c49611f73fb96a13ef464c27b4ce08c25f0f44e253e6e5ce2239a45c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/pt-PT/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pt-PT/firefox-84.0b4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0103da6d53b4a9e9512b8e3b90e583d8592a5bd02f09aedb90f49b1ce73516e6";
+      sha256 = "a6e606c6d4ca032653b46966c0b90e001474907424f4fef46669e2363ffb89f1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/rm/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/rm/firefox-84.0b4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "5dc1ace0d108460d6a57f7b158a1640d822c4e07a2e4d108db9f17e63150e4a1";
+      sha256 = "a8a8ee42020f62b38c125002ff6b5ad975d1a24df4e64f354f58fd949517e3c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ro/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ro/firefox-84.0b4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "1e2ee8f338625bf95da2914e54b22e1a052cce955a92102163e67cacc41129b8";
+      sha256 = "f405c06f8041e4c90caed14e7d6fac38467976fd71a214f06eab8c2113c386c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ru/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ru/firefox-84.0b4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "c57cda1ba6e8895044fbc55b37eb5e241b02904f69337a6430b3b9fd47a57fea";
+      sha256 = "acd2c0812a24b301aafb1278246495b07e346fbd9cd699da406b988dc3d393ee";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/si/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/si/firefox-84.0b4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "e31df32be4babb9b1eeb5f6a5a44d1c94b07fd5c4bf70d8cc78d4061e1e790a0";
+      sha256 = "d444818f1e76a01a1170209497349331175ab9a761c27b31ddb89ff4d542ab9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sk/firefox-84.0b4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "0630c3c617d1a646ab0acdc0c18346ac29066a8a31be9995f96e5daecc74bb24";
+      sha256 = "f2f3c9c4888f0055c10d1aae6cb1c40cc7f4d2bd1653e846768326e11b6ef2c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sl/firefox-84.0b4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "65cc9e3d0e6af8743a768cf23b1dcb281d5ee26cbdf0fb2f0639cfe032f8cc07";
+      sha256 = "aeff79d992488895e47d3682d6b3661cfd1a86d39aff8c91313f057838075068";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/son/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/son/firefox-84.0b4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "7f25deb9d71b23647722745d813e8e115e0d08190811efa4fc0b6456ee5bc634";
+      sha256 = "860900ac8f3fde5511a294a4f41e553d4853c4592d4446441399fda78a91898a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sq/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sq/firefox-84.0b4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e103461a63337bd7905345091edde08056eb267a522a205d6308e33d477f7d49";
+      sha256 = "9122e1837c732b8cf242f211937b3fc445b6a48da3db01cbaa4a0d00117848a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sr/firefox-84.0b4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "cfaead5b0913dd265c18e42793a2a845aeb6e421b6c54a0f979bc80cd7a6cb18";
+      sha256 = "a3c15061deb11e870d83138bf65beb5a838cc3ba96d067d3e72f816f818da3c5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/sv-SE/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sv-SE/firefox-84.0b4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "7343ae52dc3f85d35264fb6cc86daea45deed4cc3b7c3dc3078afdfde9a48919";
+      sha256 = "cb3d2dcf7d80501a8fa38c50d0301af9562050bc64250cc1c6208467990795d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ta/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ta/firefox-84.0b4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "389ae6d8db8280f74944c2c5d61dc031ba4ae4db792c1f851ff72ebfb123b17c";
+      sha256 = "4ece8a45e79aae6e535d56370f8890c5d3045d0ca78bec67fe848367e518339a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/te/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/te/firefox-84.0b4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "e49d8a521ffc7087c8d75f5ecbb9f6c010966c9f92dd4c105278aeeee1eee865";
+      sha256 = "70996e39e5b38f7def90f1eadbdbb294992e4ad27a49d4941b3982a0d3f8421b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/th/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/th/firefox-84.0b4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "a27ff17d3bd090cf5bf798465dbeb3e369ea03a738729b748a0b03bb2d0418f8";
+      sha256 = "36720f87e8b3ee23f15ff48514931747d05638194e9b13b30017e601b8a5c905";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/tl/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/tl/firefox-84.0b4.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "5826bcb2683e74bc5588c7b12099d9d2ac70ecb0026d375bea92d94a3f381f70";
+      sha256 = "d433a22f97bcb69570933b1f371c248ebd2eb83a217bcc1989897c08175cbcd0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/tr/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/tr/firefox-84.0b4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "73d79d2dfc0c7ac86566c1d41a6cbf6367ff57a6c5dcd459e1994d5bb8290fe8";
+      sha256 = "0787dd09f287aab492610d2ce23d0be7bc3a2158e84d7e94345358a750ddb752";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/trs/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/trs/firefox-84.0b4.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "a8b7cab92a7b449ce57a2eaf6a447e4cec99fbd8dd43ffe36dd4b87cd04c19a7";
+      sha256 = "4d3bd35ed7c43eb502f482bb60da0dbf14714b35e2996362c835a0a35008308a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/uk/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/uk/firefox-84.0b4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "af59707ac1141ed356a9bacfa116d0a65236352f6bbbddd69e8544a551064782";
+      sha256 = "8e1c371acd0bd1762c715c8e36dbc8df104351cbb3c37fab64c72b55bc98f006";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/ur/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ur/firefox-84.0b4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "4a6068c0384b69592312bde06631584e612fd1f17d0af4b71dbfe38fe19dd413";
+      sha256 = "14b6149229f49406755a5ee308e0e120964595a1f9a7f2f7e9cc2979a5cf561a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/uz/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/uz/firefox-84.0b4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a6f01fd45fc403dff8a97be0bcdcd2837eff7880ad039eab2cb31a2eca82c6e9";
+      sha256 = "a8adf840548ac5974654234956957b8e53f3e36c83cfad4fa5c840c16e9e4d5c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/vi/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/vi/firefox-84.0b4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b7cc325a09e7e5a6097c81055eec760452ebff160af5e5f9b7a790a2d3fba53d";
+      sha256 = "fc9b023caaabb3a5a18a21a2d65195a7dc7b2655a5d9a1f4c75434cb1f02e4da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/xh/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/xh/firefox-84.0b4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "64e6d44ed8b07fefb110463e1003cab01503a52bcb72c76d6030325cd6c796d9";
+      sha256 = "940b4e34e92a0efa397d3944fb6b8c5afea57f29355c9f9621accb557efd9860";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/zh-CN/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/zh-CN/firefox-84.0b4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "11312a9a212159bb929df04217292481b9aacdebc50ae941729b37f9c7c8312b";
+      sha256 = "b1284ea7ec8e42c6139249b1958380e672dd19e7b8c21d95e256e0d3265bd095";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/80.0b8/linux-i686/zh-TW/firefox-80.0b8.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/zh-TW/firefox-84.0b4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0b3f5974dd951fe9ec988c8608b186a2d5ebbc397fb017d587e869cbe4dcc74b";
+      sha256 = "ac76d109c7817b9c06356918860216a3e2f4f776a31a8690064593ffc43139d9";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change

Backport of #103951

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
