### PR TITLE
mcomix3: init at 20201123

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1755,6 +1755,12 @@
     githubId = 1740337;
     name = "Chris Ostrouchov";
   };
+  confus = {
+    email = "con-f-use@gmx.net";
+    github = "con-f-use";
+    githubId = 11145016;
+    name = "J.C.";
+  };
   contrun = {
     email = "uuuuuu@protonmail.com";
     github = "contrun";

--- a/pkgs/applications/graphics/mcomix3/default.nix
+++ b/pkgs/applications/graphics/mcomix3/default.nix
@@ -1,0 +1,99 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3
+, wrapGAppsHook
+, gobject-introspection
+, gtk3
+, gdk-pixbuf
+# Recommended Dependencies:
+, unrarSupport ? false
+, unrar
+, p7zip
+, lhasa
+, mupdf
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "mcomix3";
+  version = "unstable-2020-11-23";
+
+  # fetch from github because no official release on pypi/github and no build system
+  src = fetchFromGitHub {
+    repo   = "${pname}";
+    owner  = "multiSnow";
+    rev = "cdcb27533dc7ee2ebf7b0a8ab5ba10e61c0b8ff8";
+    sha256 = "0q9xgl60ryf7qmy5vgzgfry4rvw5j9rb4d1ilxmpjmvm7dd3fm2k";
+  };
+
+  buildInputs = [ gobject-introspection gtk3 gdk-pixbuf ];
+  nativeBuildInputs = [ wrapGAppsHook ];
+  propagatedBuildInputs = (with python3.pkgs; [ pillow pygobject3 pycairo ]);
+
+  format = "other";
+
+  # Correct wrapper behavior, see https://github.com/NixOS/nixpkgs/issues/56943
+  # until https://github.com/NixOS/nixpkgs/pull/102613
+  strictDeps = false;
+
+  preInstall = ''
+    libdir=$out/lib/${python3.libPrefix}/site-packages
+    mkdir -p $out/share/{icons/hicolor,man/man1,applications,metainfo,thumbnailers}
+    mkdir -p $out/bin $libdir
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${python3.executable} installer.py --srcdir=mcomix --target=$libdir
+    mv $libdir/mcomix/mcomixstarter.py $out/bin/${pname}
+    mv $libdir/mcomix/comicthumb.py $out/bin/comicthumb
+    mv $libdir/mcomix/mcomix/* $libdir/mcomix
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    rmdir $libdir/mcomix/mcomix
+    cp man/* $out/share/man/man1/
+    cp -r mime/icons/* $out/share/icons/hicolor/
+    cp mime/*.desktop $out/share/applications/
+    cp mime/*.appdata.xml $out/share/metainfo/
+    cp mime/*.thumbnailer $out/share/thumbnailers/
+    for folder in $out/share/icons/hicolor/*; do
+        mkdir $folder/{apps,mimetypes}
+        mv $folder/*.png $folder/mimetypes
+        cp $folder/mimetypes/application-x-cbt.png $folder/mimetypes/application-x-cbr.png
+        cp $folder/mimetypes/application-x-cbt.png $folder/mimetypes/application-x-cbz.png
+    done
+  '';
+
+  # to prevent double wrapping
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      "--prefix" "PATH" ":" "${lib.makeBinPath ([ p7zip lhasa mupdf ] ++ lib.optional (unrarSupport) unrar)}"
+    )
+  '';
+
+  # real pytests seem to be broken upstream
+  checkPhase = ''
+    $out/bin/comicthumb --help > /dev/null
+    $out/bin/${pname} --help > /dev/null
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Comic book reader and image viewer; python3 fork of mcomix";
+    longDescription = ''
+      User-friendly, customizable image viewer, specifically designed to handle
+      comic books and manga supporting a variety of container formats
+      (including CBR, CBZ, CB7, CBT, LHA and PDF)
+    '';
+    homepage = "https://github.com/multiSnow/mcomix3";
+    changelog = "https://github.com/multiSnow/mcomix3/blob/gtk3/ChangeLog";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ confus ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -307,7 +307,7 @@ mapAliases ({
   mbedtls_1_3 = throw "mbedtls_1_3 is end of life, see https://tls.mbed.org/kb/how-to/upgrade-2.0"; # added 2019-12-08
   mess = mame; # added 2019-10-30
   mcgrid = throw "mcgrid has been removed from nixpkgs, as it's not compatible with rivet 3"; # added 2020-05-23
-  mcomix = throw "mcomix has been removed from nixpkgs, as it's unmaintained"; # added 2019-12-10
+  mcomix = throw "mcomix has been removed from nixpkgs, as it's unmaintained; try mcomix3 a Python 3 fork"; # added 2019-12-10, modified 2020-11-25
   mirage = throw "mirage has been femoved from nixpkgs, as it's unmaintained"; # added 2019-12-10
   mopidy-local-images = throw "mopidy-local-images has been removed as it's unmaintained. It's functionality has been merged into the mopidy-local extension."; # added 2020-10-18
   mopidy-local-sqlite = throw "mopidy-local-sqlite has been removed as it's unmaintained. It's functionality has been merged into the mopidy-local extension."; # added 2020-10-18

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22368,6 +22368,8 @@ in
 
   mblaze = callPackage ../applications/networking/mailreaders/mblaze { };
 
+  mcomix3 = callPackage ../applications/graphics/mcomix3 {};
+
   mcpp = callPackage ../development/compilers/mcpp { };
 
   mda_lv2 = callPackage ../applications/audio/mda-lv2 { };


### PR DESCRIPTION
###### Motivation for this change
The [original mcomix](https://sourceforge.net/projects/mcomix/) used to be in nixpkgs, but became unmaintained and is not Python 3 compatible. It was subsequently [removed](https://github.com/NixOS/nixpkgs/commit/28d42831217fb8661c3b7a5756998326f0605360). Debian, Archlinux, Fedora and others have switched to it's actively maintained Python 3 fork, [mcomix3](https://github.com/multiSnow/mcomix3). This PR packages mcomix3 for nixpkgs.

It is @con-f-use first contribution to nixpkgs, so apologies for any errors or breach of protocol. 

Closes #75028.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
