### PR TITLE
[20.09] python36Packages.ipython: 7.17 -> 7.16.1 (downgrade)

### DIFF
--- a/pkgs/development/python-modules/ipython/7.16.nix
+++ b/pkgs/development/python-modules/ipython/7.16.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "7.17.0";
-  disabled = pythonOlder "3.7";
+  version = "7.16.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b70974aaa2674b05eb86a910c02ed09956a33f2dd6c71afc60f0b128a77e7f28";
+    sha256 = "9f4fcb31d3b2c533333893b9172264e4821c1ac91839500f31bd43f2c59b3ccf";
   };
 
   prePatch = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2931,6 +2931,8 @@ in {
 
   ipython = if isPy27 then
     callPackage ../development/python-modules/ipython/5.nix { }
+  else if isPy36 then
+    callPackage ../development/python-modules/ipython/7.16.nix { }
   else
     callPackage ../development/python-modules/ipython { };
 


### PR DESCRIPTION
Backport of #98024.

----

IPython versions 7.17 and higher don't support Python 3.6 anymore, so
this commit adds back the old expression for 7.16.1 from before
ba1038a98bc2e3aa399c5ef3c4b03d42c94e1bea for use in python36Packages
only.

    nix-repl> :b python36.withPackages (ps: [ ps.ipython ])
    builder for '/nix/store/q8v4f89xwv35a3idb9z345z6n3nzfycb-python3.6-ipython-7.17.0.drv' failed with exit code 1; last 10 log lines:
      Python 3.5 was supported with IPython 7.0 to 7.9.
      Python 3.6 was supported with IPython up to 7.16.

      See IPython `README.rst` file for more information:

          https://github.com/ipython/ipython/blob/master/README.rst

      Python sys.version_info(major=3, minor=6, micro=12, releaselevel='final', serial=0) detected.
    cannot build derivation '/nix/store/mhpdarp18z6skzswrl7sbgzv8hr4gwih-python3-3.6.12-env.drv': 1 dependencies couldn't be built
    [0 built (1 failed)]
    error: build of '/nix/store/mhpdarp18z6skzswrl7sbgzv8hr4gwih-python3-3.6.12-env.drv' failed

(cherry picked from commit eabba0daf0b3a9192a54576a3249e5cc8dc6bf52)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

IPython doesn't build from `<nixos>` on Python 3.6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
