### PR TITLE
mpc-qt: use fetchpatch instead of fetchurl

### DIFF
--- a/pkgs/applications/video/mpc-qt/default.nix
+++ b/pkgs/applications/video/mpc-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitLab, fetchurl, pkg-config, qmake, qtx11extras, qttools, mpv }:
+{ stdenv, mkDerivation, fetchFromGitLab, fetchpatch, pkg-config, qmake, qtx11extras, qttools, mpv }:
 
 mkDerivation rec {
   pname = "mpc-qt";
@@ -12,9 +12,9 @@ mkDerivation rec {
   };
 
   patches = [
-    (fetchurl {
+    (fetchpatch {
       url = "https://gitlab.com/mpc-qt/mpc-qt/-/commit/02f2bc7a22e863a89ba322b9acb61cf1aef23ba0.diff";
-      sha256 = "15gcpcs54k09pndlpcfwb3fa0cg9fszyyb6vbp0hpgspy43183lx";
+      sha256 = "0khld55i194zgi18d0wch5459lfzzkbfdbl1im8akvq8ks5xijis";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/104892#discussion_r530411253

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
