### PR TITLE
{fprintd,libfprint}-tod: init, plus  libfprint-2-tod1-goodix: init at 0.0.6 

### DIFF
--- a/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
+++ b/pkgs/development/libraries/libfprint-2-tod1-goodix/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchgit, libfprint-tod }:
+stdenv.mkDerivation {
+  pname = "libfprint-2-tod1-goodix";
+  version = "0.0.6";
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-goodix/+git/libfprint-2-tod1-goodix";
+    rev = "882735c6366fbe30149eea5cfd6d0ddff880f0e4"; # droped-lp1880058 on 20202-11-25
+    sha256 = "sha256-Uv+Rr4V31DyaZFOj79Lpyfl3G6zVWShh20roI0AvMPU=";
+  };
+
+  buildPhase = ''
+    patchelf \
+      --set-rpath ${lib.makeLibraryPath [ libfprint-tod ]} \
+      usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-0.0.6.so
+
+    ldd usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-0.0.6.so
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/usr/lib/libfprint-2/tod-1/"
+    mkdir -p "$out/usr/lib/udev/rules.d/"
+
+    cp usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-tod-goodix-53xc-$version.so "$out/usr/lib/libfprint-2/tod-1/"
+    cp lib/udev/rules.d/60-libfprint-2-tod1-goodix.rules "$out/usr/lib/udev/rules.d/"
+  '';
+
+  meta = with lib; {
+    description = "Goodix driver module for libfprint-2-tod Touch OEM Driver";
+    homepage = "https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-goodix/+git/libfprint-2-tod1-goodix/";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ grahamc ];
+  };
+}

--- a/pkgs/development/libraries/libfprint-tod/default.nix
+++ b/pkgs/development/libraries/libfprint-tod/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, libfprint
+, fetchFromGitLab
+}:
+
+# for the curious, "tod" means "Touch OEM Drivers" meaning it can load
+# external .so's.
+libfprint.overrideAttrs ({ postPatch ? "", mesonFlags ? [], ... }: let
+  version = "1.90.7+git20210222+tod1";
+in  {
+  pname = "libfprint-tod";
+  inherit version;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "3v1n0";
+    repo = "libfprint";
+    rev = "v${version}";
+    sha256 = "0cj7iy5799pchyzqqncpkhibkq012g3bdpn18pfb19nm43svhn4j";
+  };
+
+  mesonFlags = mesonFlags ++ [
+    "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
+  ];
+
+
+  postPatch = ''
+    ${postPatch}
+    patchShebangs ./tests/*.py ./tests/*.sh
+  '';
+
+
+  meta = with lib; {
+    homepage = "https://gitlab.freedesktop.org/3v1n0/libfprint";
+    description = "A library designed to make it easy to add support for consumer fingerprint readers, with support for loaded drivers";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ grahamc ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15226,6 +15226,8 @@ in
 
   libfprint = callPackage ../development/libraries/libfprint { };
 
+  libfprint-tod = callPackage ../development/libraries/libfprint-tod { };
+
   libfpx = callPackage ../development/libraries/libfpx { };
 
   libgadu = callPackage ../development/libraries/libgadu { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15232,6 +15232,8 @@ in
 
   libfprint-tod = callPackage ../development/libraries/libfprint-tod { };
 
+  libfprint-2-tod1-goodix = callPackage ../development/libraries/libfprint-2-tod1-goodix { };
+
   libfpx = callPackage ../development/libraries/libfpx { };
 
   libgadu = callPackage ../development/libraries/libgadu { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4470,6 +4470,10 @@ in
 
   fprintd = callPackage ../tools/security/fprintd { };
 
+  fprintd-tod = callPackage ../tools/security/fprintd {
+    libfprint = libfprint-tod;
+  };
+
   ferdi = callPackage ../applications/networking/instant-messengers/ferdi {
     mkFranzDerivation = callPackage ../applications/networking/instant-messengers/franz/generic.nix { };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fingerprint sensor support for the Dell XPS 9300.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
