### PR TITLE
python3Packages.drivelib: init at 0.3.0, python3Packages.expiringdict: init at 1.2.1, git-annex-remote-googledrive: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3609,6 +3609,12 @@
     githubId = 76716;
     name = "Graham Christensen";
   };
+  gravndal = {
+    email = "gaute.ravndal+nixos@gmail.com";
+    github = "gravndal";
+    githubId = 4656860;
+    name = "Gaute Ravndal";
+  };
   grburst = {
     email = "GRBurst@protonmail.com";
     github = "GRBurst";

--- a/pkgs/applications/version-management/git-and-tools/git-annex-remote-googledrive/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-remote-googledrive/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, annexremote
+, drivelib
+, GitPython
+, tenacity
+, humanfriendly
+}:
+
+buildPythonApplication rec {
+  pname = "git-annex-remote-googledrive";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "118w0fyy6pck8hyj925ym6ak0xxqhkaq2vharnpl9b97nab4mqg8";
+  };
+
+  propagatedBuildInputs = [ annexremote drivelib GitPython tenacity humanfriendly ];
+
+  # while git-annex does come with a testremote command that *could* be used,
+  # testing this special remote obviously depends on authenticating with google
+  doCheck = false;
+
+  pythonImportsCheck = [ "git_annex_remote_googledrive" ];
+
+  meta = with lib; {
+    description = "A git-annex special remote for Google Drive";
+    homepage = "https://pypi.org/project/git-annex-remote-googledrive/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ gravndal ];
+  };
+}

--- a/pkgs/development/python-modules/drivelib/default.nix
+++ b/pkgs/development/python-modules/drivelib/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, expiringdict
+, google-auth-httplib2
+, google-auth-oauthlib
+, google-api-python-client
+}:
+
+buildPythonApplication rec {
+  pname = "drivelib";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bz3dn6wm9mlm2w8czwjmhvf3ws3iggr57hvd8z8acl1qafr2g4m";
+  };
+
+  propagatedBuildInputs = [
+    google-api-python-client
+    google-auth-oauthlib
+    google-auth-httplib2
+    expiringdict
+  ];
+
+  # tests depend on a google auth token
+  doCheck = false;
+
+  pythonImportsCheck = [ "drivelib" ];
+
+  meta = with lib; {
+    description = "Easy access to the most common Google Drive API calls";
+    homepage = "https://pypi.org/project/drivelib/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ gravndal ];
+  };
+}

--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, dill
+, coverage
+, coveralls
+, mock
+, nose
+}:
+
+buildPythonApplication rec {
+  pname = "expiringdict";
+  version = "1.2.1";
+
+  # use fetchFromGitHub instead of fetchPypi because the test suite of
+  # the package is not included into the PyPI tarball
+  src = fetchFromGitHub {
+    owner = "mailgun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07g1vxznmim78bankfl9brr01s31sksdcpwynq1yryh6xw9ri5xs";
+  };
+
+  checkInputs = [
+    dill
+    coverage
+    coveralls
+    mock
+    nose
+  ];
+
+  checkPhase = ''
+    nosetests -v --with-coverage --cover-package=expiringdict
+  '';
+
+  pythonImportsCheck = [ "expiringdict" ];
+
+  meta = with lib; {
+    description = "Dictionary with auto-expiring values for caching purposes";
+    homepage = "https://pypi.org/project/expiringdict/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gravndal ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4670,6 +4670,17 @@ in
     humanfriendly;
   };
 
+  git-annex-remote-googledrive = callPackage ../applications/version-management/git-and-tools/git-annex-remote-googledrive {
+    inherit (python3Packages)
+    buildPythonApplication
+    fetchPypi
+    annexremote
+    drivelib
+    GitPython
+    tenacity
+    humanfriendly;
+  };
+
   git-annex-remote-rclone = callPackage ../applications/version-management/git-and-tools/git-annex-remote-rclone { };
 
   git-annex-utils = callPackage ../applications/version-management/git-and-tools/git-annex-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2233,6 +2233,8 @@ in {
 
   exifread = callPackage ../development/python-modules/exifread { };
 
+  expiringdict = callPackage ../development/python-modules/expiringdict { };
+
   exrex = callPackage ../development/python-modules/exrex { };
 
   extras = callPackage ../development/python-modules/extras { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2059,6 +2059,8 @@ in {
 
   drf-yasg = callPackage ../development/python-modules/drf-yasg { };
 
+  drivelib = callPackage ../development/python-modules/drivelib { };
+
   drms = callPackage ../development/python-modules/drms { };
 
   dropbox = callPackage ../development/python-modules/dropbox { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#46554 doesn't look to have gone anywhere.

I've never added any packages to nixpkgs before, do tell me if I missed anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
