### PR TITLE
herbstluftwm 0.8.3 -> 0.9.1 + add tests

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9061,6 +9061,12 @@
     githubId = 844343;
     name = "Thiago K. Okada";
   };
+  thibautmarty = {
+    email = "github@thibautmarty.fr";
+    github = "ThibautMarty";
+    githubId = 3268082;
+    name = "Thibaut Marty";
+  };
   thmzlt = {
     email = "git@thomazleite.com";
     github = "thmzlt";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -147,6 +147,7 @@ in
   haproxy = handleTest ./haproxy.nix {};
   hardened = handleTest ./hardened.nix {};
   hedgedoc = handleTest ./hedgedoc.nix {};
+  herbstluftwm = handleTest ./herbstluftwm.nix {};
   installed-tests = pkgs.recurseIntoAttrs (handleTest ./installed-tests {});
   oci-containers = handleTestOn ["x86_64-linux"] ./oci-containers.nix {};
   # 9pnet_virtio used to mount /nix partition doesn't support

--- a/nixos/tests/herbstluftwm.nix
+++ b/nixos/tests/herbstluftwm.nix
@@ -1,0 +1,38 @@
+import ./make-test-python.nix ({ lib, ...} : {
+  name = "herbstluftwm";
+
+  meta = {
+    maintainers = with lib.maintainers; [ thibautmarty ];
+    timeout = 30;
+  };
+
+  machine = { pkgs, lib, ... }: {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+    test-support.displayManager.auto.user = "alice";
+    services.xserver.displayManager.defaultSession = lib.mkForce "none+herbstluftwm";
+    services.xserver.windowManager.herbstluftwm.enable = true;
+    environment.systemPackages = [ pkgs.dzen2 ]; # needed for upstream provided panel
+  };
+
+  testScript = ''
+    with subtest("ensure x starts"):
+        machine.wait_for_x()
+        machine.wait_for_file("/home/alice/.Xauthority")
+        machine.succeed("xauth merge ~alice/.Xauthority")
+
+    with subtest("ensure client is available"):
+        machine.succeed("herbstclient --version")
+
+    with subtest("ensure keybindings are set"):
+        machine.wait_until_succeeds("herbstclient list_keybinds | grep xterm")
+
+    with subtest("ensure panel starts"):
+        machine.wait_for_window("dzen title")
+
+    with subtest("ensure we can open a new terminal"):
+        machine.send_key("alt-ret")
+        machine.wait_for_window(r"alice.*?machine")
+        machine.sleep(2)
+        machine.screenshot("terminal")
+  '';
+})

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,35 +1,37 @@
-{ lib, stdenv, fetchurl, cmake, pkgconfig, glib, libX11, libXext, libXinerama, libXrandr
-, withDoc ? stdenv.buildPlatform == stdenv.targetPlatform, asciidoc ? null }:
+{ lib, stdenv, fetchurl, cmake, pkgconfig, python3, libX11, libXext, libXinerama, libXrandr, asciidoc
+, xdotool, xorgserver, xsetroot, xterm, runtimeShell }:
 
 # Doc generation is disabled by default when cross compiling because asciidoc
-# does not cross compile for now
+# dependency is broken when cross compiling for now
 
-assert withDoc -> asciidoc != null;
+let
+  cross = stdenv.buildPlatform != stdenv.targetPlatform;
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "herbstluftwm";
-  version = "0.8.3";
+  version = "0.9.1";
 
   src = fetchurl {
     url = "https://herbstluftwm.org/tarballs/herbstluftwm-${version}.tar.gz";
-    sha256 = "1qmb4pjf2f6g0dvcg11cw9njwmxblhqzd70ai8qnlgqw1iz3nkm1";
+    sha256 = "0r4qaklv97qcq8p0pnz4f2zqg69vfai6c2qi1ydi2kz24xqjf5hy";
   };
 
   outputs = [
     "out"
-  ] ++ lib.optionals withDoc [
-    "doc"
+    "doc" # share/doc exists with examples even without generated html documentation
+  ] ++ lib.optionals (!cross) [
     "man"
   ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_SYSCONF_PREFIX=${placeholder "out"}/etc"
-  ] ++ lib.optional (!withDoc) "-DWITH_DOCUMENTATION=OFF";
+  ] ++ lib.optional cross "-DWITH_DOCUMENTATION=OFF";
 
   nativeBuildInputs = [
     cmake
     pkgconfig
-  ] ++ lib.optional withDoc asciidoc;
+    python3
+  ] ++ lib.optional (!cross) asciidoc;
 
   buildInputs = [
     libX11
@@ -37,6 +39,41 @@ stdenv.mkDerivation rec {
     libXinerama
     libXrandr
   ];
+
+  patches = [
+    ./test-path-environment.patch
+  ];
+
+  postPatch = ''
+    patchShebangs doc/gendoc.py
+
+    # fix /etc/xdg/herbstluftwm paths in documentation and scripts
+    grep -rlZ /etc/xdg/herbstluftwm share/ doc/ scripts/ | while IFS="" read -r -d "" path; do
+      substituteInPlace "$path" --replace /etc/xdg/herbstluftwm $out/etc/xdg/herbstluftwm
+    done
+
+    # fix shebang in generated scripts
+    substituteInPlace tests/conftest.py --replace "/usr/bin/env bash" ${runtimeShell}
+    substituteInPlace tests/test_herbstluftwm.py --replace "/usr/bin/env bash" ${runtimeShell}
+  '';
+
+  doCheck = true;
+
+  checkInputs = [
+    (python3.withPackages (ps: with ps; [ ewmh pytest xlib ]))
+    xdotool
+    xorgserver
+    xsetroot
+    xterm
+    python3.pkgs.pytestCheckHook
+  ];
+
+  # make the package's module avalaible
+  preCheck = ''
+    export PYTHONPATH="$PYTHONPATH:../python"
+  '';
+
+  pytestFlagsArray = [ "../tests" ];
 
   meta = with lib; {
     description = "A manual tiling window manager for X";

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, cmake, pkgconfig, python3, libX11, libXext, libXinerama, libXrandr, asciidoc
-, xdotool, xorgserver, xsetroot, xterm, runtimeShell }:
+, xdotool, xorgserver, xsetroot, xterm, runtimeShell
+, nixosTests }:
 
 # Doc generation is disabled by default when cross compiling because asciidoc
 # dependency is broken when cross compiling for now
@@ -74,6 +75,10 @@ in stdenv.mkDerivation rec {
   '';
 
   pytestFlagsArray = [ "../tests" ];
+
+  passthru = {
+    tests.herbstluftwm = nixosTests.herbstluftwm;
+  };
 
   meta = with lib; {
     description = "A manual tiling window manager for X";

--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -38,10 +38,11 @@ stdenv.mkDerivation rec {
     libXrandr
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A manual tiling window manager for X";
     homepage = "https://herbstluftwm.org/";
-    license = lib.licenses.bsd2;
-    platforms = lib.platforms.linux;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thibautmarty ];
   };
 }

--- a/pkgs/applications/window-managers/herbstluftwm/test-path-environment.patch
+++ b/pkgs/applications/window-managers/herbstluftwm/test-path-environment.patch
@@ -1,0 +1,10 @@
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -43,6 +43,7 @@
+         self.next_client_id = 0
+         self.env = {
+             'DISPLAY': display,
++            'PATH': os.environ['PATH']
+         }
+         self.env = extend_env_with_whitelist(self.env)
+         self.hlwm_process = hlwm_process


### PR DESCRIPTION
###### Motivation for this change

- update herbstluftwm to 0.9.0
- run the package's tests
- add a NixOS test (similar to i3wm test)

I checked that cross compilation still works (`crossSystem.config = "aarch64-unknown-linux-gnu"`).

Replace #87003.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
