### PR TITLE
libfaketime: fix build with clang

### DIFF
--- a/pkgs/development/libraries/libfaketime/0001-Remove-unsupported-clang-flags.patch
+++ b/pkgs/development/libraries/libfaketime/0001-Remove-unsupported-clang-flags.patch
@@ -1,0 +1,25 @@
+From f974fe07de9e6820bb1de50b31e480296d1d97b7 Mon Sep 17 00:00:00 2001
+From: Christian Kampka <christian@kampka.net>
+Date: Wed, 25 Nov 2020 20:09:50 +0100
+Subject: [PATCH] Remove unsupported clang flags
+
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index f13a6bb..b305150 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -69,7 +69,7 @@ PREFIX ?= /usr/local
+ LIBDIRNAME ?= /lib/faketime
+ PLATFORM ?=$(shell uname)
+ 
+-CFLAGS += -std=gnu99 -Wall -Wextra -Werror -Wno-nonnull-compare -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
++CFLAGS += -std=gnu99 -Wall -Wextra -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
+ ifeq ($(PLATFORM),SunOS)
+ CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=600
+ endif
+-- 
+2.28.0
+

--- a/pkgs/development/libraries/libfaketime/default.nix
+++ b/pkgs/development/libraries/libfaketime/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-date-in-gzip-man-page.patch
-  ];
+  ] ++ (stdenv.lib.optionals stdenv.cc.isClang [
+    # https://github.com/wolfcw/libfaketime/issues/277
+    ./0001-Remove-unsupported-clang-flags.patch
+  ]);
 
   postPatch = ''
     patchShebangs test src
@@ -24,7 +27,7 @@ stdenv.mkDerivation rec {
   PREFIX = placeholder "out";
   LIBDIRNAME = "/lib";
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type -Wno-error=format-truncation";
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-Wno-error=cast-function-type -Wno-error=format-truncation";
 
   checkInputs = [ perl ];
 


### PR DESCRIPTION
###### Motivation for this change

The options -Wno-nonnull-compare, -Wno-error=cast-function-type and -Wno-error=format-truncation
are unsupported by clang, letting the build fail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
