### PR TITLE
keyutils: fix build with llvm/clang

### DIFF
--- a/pkgs/os-specific/linux/keyutils/0001-Remove-unused-function-after_eq.patch
+++ b/pkgs/os-specific/linux/keyutils/0001-Remove-unused-function-after_eq.patch
@@ -1,0 +1,28 @@
+From 59d91e57d103fb4686d2f45ee3c688878244367a Mon Sep 17 00:00:00 2001
+From: Christian Kampka <christian@kampka.net>
+Date: Tue, 24 Nov 2020 22:12:40 +0100
+Subject: [PATCH] Remove unused function 'after_eq'
+
+---
+ keyctl_watch.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/keyctl_watch.c b/keyctl_watch.c
+index a70a19a..c4ca7f7 100644
+--- a/keyctl_watch.c
++++ b/keyctl_watch.c
+@@ -47,11 +47,6 @@ static struct watch_notification_filter filter = {
+ 	},
+ };
+ 
+-static inline bool after_eq(unsigned int a, unsigned int b)
+-{
+-        return (signed int)(a - b) >= 0;
+-}
+-
+ static void consumer_term(int sig)
+ {
+ 	consumer_stop = 1;
+-- 
+2.28.0
+

--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
       sha256 = "0wnvbjfrbk7rghd032z684l7vk7mhy3bd41zvhkrhgp3cd5id0bm";
     })
     ./conf-symlink.patch
+  ] ++ [
+    # This patch solves a duplicate symbol error when building with a clang stdenv
+    # Before removing this patch, please ensure the package still builds by running eg.
+    # nix-build -E 'with import ./. {}; pkgs.keyutils.override { stdenv = pkgs.llvmPackages_latest.stdenv; }'
+    ./0001-Remove-unused-function-after_eq.patch
   ];
 
   makeFlags = lib.optionals stdenv.hostPlatform.isStatic "NO_SOLIB=1";

--- a/pkgs/os-specific/linux/keyutils/default.nix
+++ b/pkgs/os-specific/linux/keyutils/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
       sha256 = "0wnvbjfrbk7rghd032z684l7vk7mhy3bd41zvhkrhgp3cd5id0bm";
     })
     ./conf-symlink.patch
-  ] ++ [
     # This patch solves a duplicate symbol error when building with a clang stdenv
     # Before removing this patch, please ensure the package still builds by running eg.
     # nix-build -E 'with import ./. {}; pkgs.keyutils.override { stdenv = pkgs.llvmPackages_latest.stdenv; }'


### PR DESCRIPTION
###### Motivation for this change

clang build currently fails because the code contains an unused function.
The patch has also been sent upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
