### PR TITLE
nixos/chrony: systemd service hardening

### DIFF
--- a/nixos/modules/services/networking/ntp/chrony.nix
+++ b/nixos/modules/services/networking/ntp/chrony.nix
@@ -5,6 +5,7 @@ with lib;
 let
   cfg = config.services.chrony;
 
+  runDir = "/var/run/chrony";
   stateDir = "/var/lib/chrony";
   driftFile = "${stateDir}/chrony.drift";
   keyFile = "${stateDir}/chrony.keys";
@@ -116,9 +117,34 @@ in
           { Type = "simple";
             ExecStart = "${pkgs.chrony}/bin/chronyd ${chronyFlags}";
 
-            ProtectHome = "yes";
-            ProtectSystem = "full";
+            KeyringMode = "private";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            NoNewPrivileges = true;
+            PrivateMounts = "yes";
             PrivateTmp = "yes";
+            ProtectControlGroups = true;
+            ProtectHome = "yes";
+            ProtectHostname = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectSystem = "strict";
+            ReadWritePaths = [ runDir stateDir ];
+            RemoveIPC = true;
+            RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallFilter = "@system-service @clock";
+            SystemCallArchitectures = "native";
+
+            # even though in the default configuration chrony does not access the rtc clock,
+            # it may be configured to so so either with the 'rtcfile' configuration option
+            # or using the '-s' flag. so we make sure rtc devices can still be used by it.
+            # at the same time there is no need for chrony to access any other device types.
+            DeviceAllow = "char-rtc";
+            DevicePolicy = "closed";
+
           };
 
       };


### PR DESCRIPTION
The service can successfully work with more systemd sandboxing
in place. Changing `ProtectSystem` from `full` to `strict` makes
the entire filesystem read-only, with the exception of two
directories listed under `ReadWritePaths`. Many other sandbox
options added as well, unfortunately I couldn't source them
from the project itself as they only provide a very basic
systemd service template.

The `/var/run/chrony` path is compiled in the `chronyd` binary,
as well as in the `chronyc` client. This is why I am not referencing it for anything else other than `ReadWritePaths`.

I've been running this config for a while and it seems stable.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
