### PR TITLE
selenium-server-standalone: 3.6.0 -> 3.141.59

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/README.md
+++ b/pkgs/applications/networking/browsers/chromium/README.md
@@ -36,6 +36,9 @@ update `upstream-info.json`. After updates it is important to test at least
 `nixosTests.chromium` (or basic manual testing) and `google-chrome` (which
 reuses `upstream-info.json`).
 
+After updating, please also update pkgs/development/tools/selenium/chromedriver/default.nix
+to a matching version.
+
 ## Backports
 
 All updates are considered security critical and should be ported to the stable

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -6,12 +6,12 @@ let
   allSpecs = {
     x86_64-linux = {
       system = "linux64";
-      sha256 = "0ndig3gq00nr3zs5f7wl1xw5vsnz1hwmjfrk73vbmb8lqjnfm66l";
+      sha256 = "1cpk7mb32z3a7c7cbaaxskpv91il3i8kgsdp2q8zw9w762kql953";
     };
 
     x86_64-darwin = {
       system = "mac64";
-      sha256 = "1ipxla0d8wa2rn3872xpc5akbmk2rnplk9clrdncmdzakw7f66im";
+      sha256 = "06mx2yk6xy46azvkbyvhqm11prxbh67pfi50fcwxb0zqllbq7scr";
     };
   };
 
@@ -28,7 +28,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "chromedriver";
-  version = "86.0.4240.22";
+  version = "87.0.4280.20";
 
   src = fetchurl {
     url = "https://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -4,8 +4,8 @@
 with stdenv.lib;
 
 let
-  minorVersion = "3.6";
-  patchVersion = "0";
+  minorVersion = "3.141";
+  patchVersion = "59";
 
 in stdenv.mkDerivation rec {
   pname = "selenium-server-standalone";
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://selenium-release.storage.googleapis.com/${minorVersion}/selenium-server-standalone-${version}.jar";
-    sha256 = "11v340nm8vzqc2bkmbjfm9a7j4dj0bi9bfk8wdpfan0fb8prf772";
+    sha256 = "1jzkx0ahsb27zzzfvjqv660x9fz2pbcddgmhdzdmasxns5vipxxc";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
###### Motivation for this change
hasn't been updated in a while

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
