### PR TITLE
tor-browser-bundle-bin: 10.0.4 → 10.0.5

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -91,19 +91,19 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "10.0.4";
+  version = "10.0.5";
 
   lang = "en-US";
 
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz";
-      sha256 = "sha256-2Ye1+mhFnkZnAYQXgKZ5YIOiIVaiunTCyCOM+ZExw2I==";
+      sha256 = "1cxh39x69m4lgqin5k5p67gs9g26w7cnlbdpjqi8dw47y0bpr9xw";
     };
 
     i686-linux = fetchurl {
       url = "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz";
-      sha256 = "sha256-B0WGkIt8KDtma/WGyenQ04ctKE7AantUtYnwsjAZZb0=";
+      sha256 = "1cyg5ic7mrj6x1gxw5w609933d9ripa5b5gxyqnvnxfa23dkh608";
     };
   };
 in


### PR DESCRIPTION
###### Motivation for this change
Update to latest tor-browser-bundle-bin before the current version's src is removed & it fails to build (tor-browser-bundle-bin's src doesn't get cached in tarballs.nixos.org).

Also, this release includes fixes for these security vulnerabilities:

- CVE-2020-26951: Parsing mismatches could confuse and bypass security sanitizer for chrome privileged code
- CVE-2020-16012: Variable time processing of cross-origin images during drawImage calls
- CVE-2020-26953: Fullscreen could be enabled without displaying the security UI
- CVE-2020-26956: XSS through paste (manual and clipboard API)
- CVE-2020-26958: Requests intercepted through ServiceWorkers lacked MIME type restrictions
- CVE-2020-26959: Use-after-free in WebRequestService
- CVE-2020-26960: Potential use-after-free in uses of nsTArray
- CVE-2020-15999: Heap buffer overflow in freetype
- CVE-2020-26961: DoH did not filter IPv4 mapped IP Addresses
- CVE-2020-26965: Software keyboards may have remembered typed passwords
- CVE-2020-26966: Single-word search queries were also broadcast to local network
- CVE-2020-26968: Memory safety bugs fixed in Firefox 83 and Firefox ESR 78.5

Release notes: https://blog.torproject.org/new-release-tor-browser-1005

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    838,565,624 → 838,588,592
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FYI maintainers: @joachifm @doublec @hax404 @KarlJoad @matejc @offlinehacker @scaredmushroom @thoughtpolice