### PR TITLE
buildRubyGem: fix to support bundler install --redownload

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -49,6 +49,11 @@ lib.makeOverridable (
 , propagatedUserEnvPkgs ? []
 , buildFlags ? []
 , passthru ? {}
+# bundler expects gems to be stored in the cache directory for certain actions
+# such as `bundler install --redownload`.
+# At the cost of increasing the store size, you can keep the gems to have closer
+# alignment with what Bundler expects.
+, keepGemCache ? false
 , ...} @ attrs:
 
 let
@@ -208,7 +213,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     pushd $out/${ruby.gemPath}
     rm -fv doc/*/*/created.rid || true
     rm -fv {gems/*/ext/*,extensions/*/*/*}/{Makefile,mkmf.log,gem_make.out} || true
-    rm -fvr cache
+    ${if keepGemCache then "" else "rm -fvr cache"}
     popd
 
     # write out metadata and binstubs


### PR DESCRIPTION
###### Motivation for this change

The way in which Nixpks builds Ruby gems means that certain operations by bundler *will not work*, namely `bundle install --redownload`.

According to the source the _cache/_ directory should have been kept, however it seems through revisions to the file it has been purged.

Here was the comment from the original commit that introduced buildRubyGem (still **present in the source**)
https://github.com/NixOS/nixpkgs/blob/8585991bfb629edda1e42c191bef935d9d70d690/pkgs/development/ruby-modules/gem/default.nix#L156-L160

Why is the _/cache_ directory needed?

Bundler and RubyGems uses the cache as a source of truth. When bundler executes `bundler install --redownload`, any gems it
discovers in the _GEM_PATH_ it assumes must have their _.gem_ file present in the cache (unaware it was installed from Nix).

Rather than downloading the gem from RubyGems the bundler code forcibly re-installs the gem from the cache directory instead and **fails** if it does not exist.

I've opened https://github.com/rubygems/rubygems/issues/4088 to see if this failure should be soft and not so explicit; or fallback to fetching the gem from scratch.

Without this change the following is the error:
```bash
[nix-shell:~/code/nix/playground/jruby-bundler-rake]$ bundle install --redownload
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/nix/store/fis6nzrpw9pmcivr84qh5byfgm07qn10-jruby-9.2.13.0/lib/ruby/stdlib/jopenssl.jar) to field java.security.MessageDigest.provider
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Fetching gem metadata from https://rubygems.org/.
Using bundler 2.1.4
Installing hello-world 1.2.0
Bundler::GemNotFound: Could not find hello-world-1.2.0.gem for installation
An error occurred while installing hello-world (1.2.0), and Bundler
cannot continue.
Make sure that `gem install hello-world -v '1.2.0' --source
'https://rubygems.org/'` succeeds before bundling.
```

Wth the fix the following no error occurs:
```bash
[nix-shell:~/code/nix/playground/jruby-bundler-rake]$ bundle install --redownload
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/nix/store/69wjlj4yirp48rv1q03zxgd4xvf0150d-jruby-9.2.13.0/lib/ruby/stdlib/jopenssl.jar) to field java.security.MessageDigest.provider
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Fetching gem metadata from https://rubygems.org/.
Using bundler 2.1.4
Installing hello-world 1.2.0
Bundle complete! 1 Gemfile dependency, 2 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

Here we can see the _/cache_ directory hydrated.
```
[nix-shell:~/code/nix/playground/jruby-bundler-rake]$ ls -l /nix/store/cwl9n5073hqgpfhnw4wic13nrrgg9dn8-gem-env/lib/jruby/gems/2.5.0/cache/
total 8
lrwxrwxrwx 1 fmzakari primarygroup 102 Dec 31  1969 bundler-2.1.4.gem -> /nix/store/ifc8a0gsfkrhkv953rd4rz8bcspahi8y-bundler-2.1.4/lib/jruby/gems/2.5.0/cache/bundler-2.1.4.gem
lrwxrwxrwx 1 fmzakari primarygroup 110 Dec 31  1969 hello-world-1.2.0.gem -> /nix/store/xi9ln6n1mz2is5ppykjxqhhkpjq9zm6i-hello-world-1.2.0/lib/jruby/gems/2.5.0/cache/hello-world-1.2.0.gem
```

I have a minimal project that demonstrates this issue at https://github.com/fzakaria/jruby-bundler-nix-failure however it boils down to the following _shell.nix_ file

```nix
let nixpkgs = import <nixpkgs> {};
in with nixpkgs;
with stdenv;
with stdenv.lib;
let gems = buildEnv {
  name = "gem-env";
  pathsToLink = ["/lib" "/bin" "nix-support"];
  paths = [
    (bundler.override {
      ruby = jruby;
    })
    (buildRubyGem rec {
      ruby = jruby;
      name = "${gemName}-${version}";
      gemName = "hello-world";
      version = "1.2.0";
      source.sha256 = "141r6pafbwjf8aczsilxxhdrdbbmdhimgbsq8m9qsvjm522ln15p";
    })

  ];
};
in
mkShell {
  name = "jruby-bundler-shell";
  buildInputs = [ jruby ];
  shellHook = ''
      export GEM_NIX_ENV=${gems}/${jruby.gemPath}
      export GEM_USER_DIR=$(pwd)/.gem
      export GEM_DEFAULT_DIR=$(${jruby}/bin/ruby -e 'puts Gem.default_dir')
      export GEM_PATH=$GEM_DEFAULT_DIR:$GEM_PATH:$GEM_NIX_ENV
      export GEM_HOME=$GEM_USER_DIR
      export PATH=$GEM_HOME/bin:$GEM_NIX_ENV/bin:$PATH
  '';
}
```
```ruby
source "https://rubygems.org"

gem 'hello-world', '1.2.0'
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @cstrahan @zimbatm @alyssais @manveru 