### PR TITLE
Add `buildDhall*Package` support for generating documentation

### DIFF
--- a/pkgs/development/interpreters/dhall/build-dhall-directory-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-directory-package.nix
@@ -14,12 +14,17 @@ lib.makePackageOverridable
     , src
     , # The file to import, relative to the root directory
       file ? "package.dhall"
+      # Set to `true` to generate documentation for the package
+    , document ? false
     }:
 
-    buildDhallPackage {
-      inherit name dependencies source;
+    buildDhallPackage
+      ( { inherit name dependencies source;
 
-      code = "${src}/${file}";
-    }
+          code = "${src}/${file}";
+
+        }
+      // lib.optionalAttrs document { documentationRoot = src; }
+      )
   )
 

--- a/pkgs/development/interpreters/dhall/build-dhall-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-package.nix
@@ -1,4 +1,4 @@
-{ dhall, haskell, lib, lndir, runCommand, writeText }:
+{ dhall, dhall-docs, haskell, lib, lndir, runCommand, writeText }:
 
 { name
 
@@ -31,6 +31,12 @@
   # space within the Nix store, but if you set the following `source` option to
   # `true` then the package will also include `source.dhall`.
 , source ? false
+
+  # Directory to generate documentation for (i.e. as the `--input` option to the
+  # `dhall-docs` command.)
+  #
+  # If `null`, then no documentation is generated.
+, documentationRoot ? null
 }:
 
 let
@@ -42,7 +48,11 @@ let
 
   cache = ".cache";
 
+  data = ".local/share";
+
   cacheDhall = "${cache}/dhall";
+
+  dataDhall = "${data}/dhall";
 
   sourceFile = "source.dhall";
 
@@ -71,4 +81,10 @@ in
     echo "missing $SHA_HASH" > $out/binary.dhall
 
     ${lib.optionalString (!source) "rm $out/${sourceFile}"}
+
+    ${lib.optionalString (documentationRoot != null) ''
+    mkdir -p $out/${dataDhall}
+
+    XDG_DATA_HOME=$out/${data} ${dhall-docs}/bin/dhall-docs --input '${documentationRoot}' --output-link $out/docs
+    ''}
   ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10257,13 +10257,15 @@ in
 
   dhall = haskell.lib.justStaticExecutables haskellPackages.dhall;
 
-  dhall-nix = haskell.lib.justStaticExecutables haskellPackages.dhall-nix;
-
   dhall-bash = haskell.lib.justStaticExecutables haskellPackages.dhall-bash;
+
+  dhall-docs = haskell.lib.justStaticExecutables haskellPackages.dhall-docs;
+
+  dhall-lsp-server = haskell.lib.justStaticExecutables haskellPackages.dhall-lsp-server;
 
   dhall-json = haskell.lib.justStaticExecutables haskellPackages.dhall-json;
 
-  dhall-lsp-server = haskell.lib.justStaticExecutables haskellPackages.dhall-lsp-server;
+  dhall-nix = haskell.lib.justStaticExecutables haskellPackages.dhall-nix;
 
   dhall-text = haskell.lib.justStaticExecutables haskellPackages.dhall-text;
 


### PR DESCRIPTION
The `buildDhall{Directory,GitHub}Package` utilities now take an
optional `document` argument for generating documentation using
`dhall-docs`.  The documentation is stored underneath the `./docs`
subdirectory of the build product.

###### Motivation for this change

These utilities will be used to generate package documentation served
under a subdomain of dhall-lang.org

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
