### PR TITLE
obelisk: 0.4.0 → 0.5.2

### DIFF
--- a/pkgs/development/tools/ocaml/obelisk/default.nix
+++ b/pkgs/development/tools/ocaml/obelisk/default.nix
@@ -1,24 +1,20 @@
-{ stdenv, fetchFromGitHub, ocamlPackages }:
+{ lib, fetchurl, ocamlPackages }:
 
-stdenv.mkDerivation rec {
+ocamlPackages.buildDunePackage rec {
 	pname = "obelisk";
-	version = "0.4.0";
-	src = fetchFromGitHub {
-		owner = "lelio-brun";
-		repo = "obelisk";
-		rev = "v${version}";
-		sha256 = "0rw85knbwqj2rys1hh5qy8sfdqb4mb1wsriy38n7zcpbwim47vb8";
+	version = "0.5.2";
+	useDune2 = true;
+	src = fetchurl {
+		url = "https://github.com/Lelio-Brun/Obelisk/releases/download/v${version}/obelisk-v${version}.tbz";
+		sha256 = "0s86gkypyrkrp83xnay258ijri3yjwj3marsjnjf8mz58z0zd9g6";
 	};
 
-	buildInputs = with ocamlPackages; [ ocaml findlib ocamlbuild menhir ];
-
-	installFlags = [ "BINDIR=$(out)/bin" ];
+	buildInputs = with ocamlPackages; [ menhir re ];
 
 	meta = {
 		description = "A simple tool which produces pretty-printed output from a Menhir parser file (.mly)";
-		license = stdenv.lib.licenses.mit;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
-		inherit (ocamlPackages.ocaml.meta) platforms;
+		license = lib.licenses.mit;
+		maintainers = [ lib.maintainers.vbgl ];
+		homepage = "https://github.com/Lelio-Brun/Obelisk";
 	};
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/Lelio-Brun/Obelisk/blob/v0.5.2/CHANGES.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
