### PR TITLE
rescuetime: add multiPlatform updateScript

### DIFF
--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, patchelf, qt5, libXtst, libXext, libX11, mkDerivation, makeWrapper, libXScrnSaver, writeScript }:
+{ stdenv, lib, fetchurl, dpkg, patchelf, qt5, libXtst, libXext, libX11, mkDerivation, makeWrapper, libXScrnSaver, writeScript, common-updater-scripts, curl, pup }:
 
 let
   version = "2.16.4.2";
@@ -12,7 +12,7 @@ let
       url = "https://www.rescuetime.com/installers/rescuetime_${version}_amd64.deb";
       sha256 = "03bmnkxhip1wilnfqs8akmy1hppahxrmnm8gasnmw5s922vn06cv";
     };
-in mkDerivation {
+in mkDerivation rec {
   # https://www.rescuetime.com/updates/linux_release_notes.html
   inherit version;
   pname = "rescuetime";
@@ -35,12 +35,18 @@ in mkDerivation {
       $out/bin/rescuetime
   '';
 
-  passthru.updateScript = writeScript "rescuetime-updater" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl pup common-updater-scripts
+  passthru.updateScript = writeScript "${pname}-updater" ''
+    #!${stdenv.shell}
     set -eu -o pipefail
+    PATH=${stdenv.lib.makeBinPath [curl pup common-updater-scripts]}:$PATH
     latestVersion="$(curl -sS https://www.rescuetime.com/release-notes/linux | pup '.release:first-of-type h2 strong text{}' | tr -d '\n')"
-    update-source-version rescuetime "$latestVersion"
+
+    for platform in ${stdenv.lib.concatStringsSep " " meta.platforms}; do
+      # The script will not perform an update when the version attribute is up to date from previous platform run
+      # We need to clear it before each run
+      update-source-version ${pname} 0 $(yes 0 | head -64 | tr -d "\n") --system=$platform
+      update-source-version ${pname} "$latestVersion" --system=$platform
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Include different platforms in the updateScript

###### Things done
Run a loop for each platform to `update-source-version`

```
Going to be running update for following packages:
 - rescuetime-2.16.4.2

Press Enter key to continue...

Running update for:
 - rescuetime-2.16.4.2: UPDATING ...
 - rescuetime-2.16.4.2: DONE.

Packages updated!
```
results in
```diff
 let
-  version = "2.16.4.2";
+  version = "2.16.5.1";
   src =
     if stdenv.hostPlatform.system == "i686-linux" then fetchurl {
       name = "rescuetime-installer.deb";
       url = "https://www.rescuetime.com/installers/rescuetime_${version}_i386.deb";
-      sha256 = "0zyal9n3rfj8i13v1q25inq6qyil7897483cdhqvwpb8wskrij4c";
+      sha256 = "1xrvyy0higc1fbc8ascpaszvg2bl6x0a35bzmdq6dkay48hnrd8b";
     } else fetchurl {
       name = "rescuetime-installer.deb";
       url = "https://www.rescuetime.com/installers/rescuetime_${version}_amd64.deb";
-      sha256 = "03bmnkxhip1wilnfqs8akmy1hppahxrmnm8gasnmw5s922vn06cv";
+      sha256 = "09ng0yal66d533vzfv27k9l2va03rqbqmsni43qi3hgx7w9wx5ii";
     };
 in mkDerivation rec {
   # https://www.rescuetime.com/updates/linux_release_notes.html
```

/cc @cstrahan 