### PR TITLE
plex: Add aarch64 platform

### DIFF
--- a/pkgs/servers/plex/raw.nix
+++ b/pkgs/servers/plex/raw.nix
@@ -1,6 +1,6 @@
 { stdenv
 , fetchurl
-, rpmextract
+, dpkg
 }:
 
 # The raw package that fetches and extracts the Plex RPM. Override the source
@@ -12,19 +12,22 @@ stdenv.mkDerivation rec {
   pname = "plexmediaserver";
 
   # Fetch the source
-  src = fetchurl {
-    url = "https://downloads.plex.tv/plex-media-server-new/${version}/redhat/plexmediaserver-${version}.x86_64.rpm";
-    sha256 = "0vqsmmgqcvvhxiqaw87qz9fdisyf9smp6ab069dz3nq39x7n9na0";
+  src = if stdenv.hostPlatform.system == "aarch64-linux" then fetchurl {
+    url = "https://downloads.plex.tv/plex-media-server-new/${version}/debian/plexmediaserver_${version}_arm64.deb";
+    sha256 = "18zj4baa085gbgc0y5gx7gnwzl131xyk34m5xcipfvfb434y98cp";
+  } else fetchurl {
+    url = "https://downloads.plex.tv/plex-media-server-new/${version}/debian/plexmediaserver_${version}_amd64.deb";
+    sha256 = "01rq2q6avjsvnns7jsd2a9vnmd4584fwdkp833gjgrrrqkf6h45y";
   };
 
   outputs = [ "out" "basedb" ];
 
-  nativeBuildInputs = [ rpmextract ];
+  nativeBuildInputs = [ dpkg ];
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" "distPhase" ];
 
   unpackPhase = ''
-    rpmextract $src
+    dpkg-deb -R $src .
   '';
 
   installPhase = ''
@@ -52,7 +55,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://plex.tv/";
     license = licenses.unfree;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [
       badmutex
       colemickens


### PR DESCRIPTION
#### Motivation for this change
The package fails to install in `aarch64` architectures even though its marked for `platform.linux` which contains `aarch64-linux`

###### Things done
I've added the `aarch64` build and moved the `x86-64` build to Debian since there is no `aarch64` build for RedHat.

building on `x86-64`
```
these derivations will be built:
  /nix/store/j8fywrsa852jgnn9026kpai33b7b0j97-plexmediaserver_1.20.5.3600-47c0d9038_amd64.deb.drv
  /nix/store/z670b91lg9p97zhmiwskky5ysq1a3nbj-plexmediaserver-1.20.5.3600-47c0d9038.drv
building '/nix/store/j8fywrsa852jgnn9026kpai33b7b0j97-plexmediaserver_1.20.5.3600-47c0d9038_amd64.deb.drv'...

trying https://downloads.plex.tv/plex-media-server-new/1.20.5.3600-47c0d9038/debian/plexmediaserver_1.20.5.3600-47c0d9038_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 76.8M  100 76.8M    0     0  12.2M      0  0:00:06  0:00:06 --:--:-- 13.1M
building '/nix/store/z670b91lg9p97zhmiwskky5ysq1a3nbj-plexmediaserver-1.20.5.3600-47c0d9038.drv'...
unpacking sources
installing
post-installation fixup
checking for references to /build/ in /nix/store/n1lpwzhnkb6lpa3qp29iwx6wfwr4d9fb-plexmediaserver-1.20.5.3600-47c0d9038...
checking for references to /build/ in /nix/store/459n9xyb794380cdg2a6xi7zgaalv0sv-plexmediaserver-1.20.5.3600-47c0d9038-basedb...
/nix/store/n1lpwzhnkb6lpa3qp29iwx6wfwr4d9fb-plexmediaserver-1.20.5.3600-47c0d9038

```

and on a raspberry pi 4 (`aarch64`)
```
these derivations will be built:
  /nix/store/jn1w2l96mmwrj3639w793fdlp5n998cc-plexmediaserver_1.20.5.3600-47c0d9038_arm64.deb.drv
  /nix/store/ngn9gb730z7ibvg18pspaj71rvq0p00i-plexmediaserver-1.20.5.3600-47c0d9038.drv
building '/nix/store/jn1w2l96mmwrj3639w793fdlp5n998cc-plexmediaserver_1.20.5.3600-47c0d9038_arm64.deb.drv'...

trying https://downloads.plex.tv/plex-media-server-new/1.20.5.3600-47c0d9038/debian/plexmediaserver_1.20.5.3600-47c0d9038_arm64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 67.5M  100 67.5M    0     0  8052k      0  0:00:08  0:00:08 --:--:-- 4033k
building '/nix/store/ngn9gb730z7ibvg18pspaj71rvq0p00i-plexmediaserver-1.20.5.3600-47c0d9038.drv'...
unpacking sources
installing
post-installation fixup
checking for references to /build/ in /nix/store/x6zly5r8ssybk45pg8xhnli1g9asw4g4-plexmediaserver-1.20.5.3600-47c0d9038...
checking for references to /build/ in /nix/store/nsr4wm4kq4dhqj3q8x8mg9v2rcm4rnb4-plexmediaserver-1.20.5.3600-47c0d9038-basedb...
/nix/store/x6zly5r8ssybk45pg8xhnli1g9asw4g4-plexmediaserver-1.20.5.3600-47c0d9038
```