### PR TITLE
virtualgl: 2.6.2 -> 2.6.5

### DIFF
--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -1,12 +1,16 @@
-{ stdenv, fetchurl, cmake, libGL, libGLU, libX11, libXv, libXtst, libjpeg_turbo, fltk }:
+{ stdenv, fetchurl, cmake
+, libGL, libGLU, libX11, libXv, libXtst, libjpeg_turbo, fltk
+, xorg
+, opencl-headers, opencl-clhpp, ocl-icd
+}:
 
 stdenv.mkDerivation rec {
   pname = "virtualgl-lib";
-  version = "2.6.2";
+  version = "2.6.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/virtualgl/VirtualGL-${version}.tar.gz";
-    sha256 = "0ngqwsm9bml6lis0igq3bn92amh04rccd6jhjibj3418hrbzipvr";
+    sha256 = "1giin3jmcs6y616bb44bpz30frsmj9f8pz2vg7jvb9vcfc9456rr";
   };
 
   cmakeFlags = [ "-DVGL_SYSTEMFLTK=1" "-DTJPEG_LIBRARY=${libjpeg_turbo.out}/lib/libturbojpeg.so" ];
@@ -15,7 +19,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ libjpeg_turbo libGL libGLU fltk libX11 libXv libXtst ];
+  buildInputs = [ libjpeg_turbo libGL libGLU fltk
+    libX11 libXv libXtst xorg.xcbutilkeysyms
+    opencl-headers opencl-clhpp ocl-icd
+  ];
+
+  fixupPhase = ''
+    substituteInPlace $out/bin/vglrun \
+      --replace "LD_PRELOAD=libvglfaker" "LD_PRELOAD=$out/lib/libvglfaker" \
+      --replace "LD_PRELOAD=libdlfaker" "LD_PRELOAD=$out/lib/libdlfaker" \
+      --replace "LD_PRELOAD=libgefaker" "LD_PRELOAD=$out/lib/libgefaker"
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
Update and fix virtualgl. Also added instructions to [wiki](https://nixos.wiki/index.php?title=OpenGL)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Edit: copy of instructions since struggling with wiki update...

## OpenGL
OpenGL must break purity due to the need for hardware-specific linkage. Intel, AMD, and Nvidia will have different libraries for example. On NixOS, these libraries are mounted at `/run/opengl-driver/lib` and `/run/opengl-driver-32/lib`.

When a program is installed in your environment, these libraries should be found automatically. However, this is not the case in a `nix-shell`. To fix, add this line to your shell.nix:
  LD_LIBRARY_PATH="/run/opengl-driver/lib:/run/opengl-driver-32/lib";

## VirtualGL
X11 forwarding does not work for OpenGL applications. Instead, we can use VirtualGL. You'll need to install VirtualGL on both client and server (nixpkgs.virtualgl). Then, from client
```
  > vglconnect <server>
  $ export LD_LIBRARY_PATH=/run/opengl-driver/lib/
  $ vglrun -c proxy  glxgears
```
For nvidia hardware, an additional workaround is needed to [avoid 1 fps framerate](https://wiki.archlinux.org/index.php/VirtualGL#Problem:_All_applications_run_with_1_frame_per_second). First, run `nvidia-settings` and save a `xorg.conf`file in `/tmp`.
```
  environment.etc = {
    # needed for virtualgl to fix 1 fps problem, see:
    # https://wiki.archlinux.org/index.php/VirtualGL
    "X11/xorg.conf.d/20-nvidia.conf".text = ''
      <text from xorg.conf here>
      Section "Screen"
        [...]
        Option         "HardDPMS" "false"
      EndSection
    ''';
  }
```