### PR TITLE
ocamlPackages.mirage-protocols: 4.0.1 -> 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-protocols/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-protocols/default.nix
@@ -2,12 +2,13 @@
 
 buildDunePackage rec {
   pname = "mirage-protocols";
-  version = "4.0.1";
+  version = "5.0.0";
+
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-protocols/releases/download/v${version}/mirage-protocols-v${version}.tbz";
-    sha256 = "188m8x6xdw1bllwrpa8f8bqbdqy20kjfk7q8p8jf8j0daf7kl3mi";
+    sha256 = "1bd6zgxhq2qliyzzarfvaj3ksr20ryghxq6h24i2hha7rwim63bk";
   };
 
   propagatedBuildInputs = [ duration ipaddr mirage-device mirage-flow ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/mirage-protocols/releases/tag/v5.0.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
