### PR TITLE
linuxPackages.akvcam: init at 1.1.1

### DIFF
--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, kernel, qmake }:
+
+stdenv.mkDerivation rec {
+  pname = "akvcam";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "webcamoid";
+    repo = "akvcam";
+    rev = version;
+    sha256 = "ULEhfF+uC/NcVUGAtmP1+BnrcgRgftNS97nLp81avQ8=";
+  };
+
+  nativeBuildInputs = [ qmake ];
+
+  qmakeFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -m644 -b -D src/akvcam.ko $out/lib/modules/${kernel.modDirVersion}/akvcam.ko
+  '';
+
+  meta = with lib; {
+    description = "Virtual camera driver for Linux";
+    homepage = "https://github.com/webcamoid/akvcam";
+    maintainers = with maintainers; [ freezeboy ];
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18266,6 +18266,10 @@ in
 
     acpi_call = callPackage ../os-specific/linux/acpi-call {};
 
+    akvcam = callPackage ../os-specific/linux/akvcam {
+      inherit (qt5) qmake;
+    };
+
     amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { };
 
     anbox = callPackage ../os-specific/linux/anbox/kmod.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add this driver to let webcamoid support more applications as an output.
In order to work, it needs a [configuration file](https://github.com/webcamoid/akvcam/wiki/Configure-the-cameras).

Currently, I use a hardcoded file, it would require work to produce a flexible module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
