### PR TITLE
release-lib: Don't use tryEval for packagePlatforms

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -142,15 +142,13 @@ rec {
   /* Recursively map a (nested) set of derivations to an isomorphic
      set of meta.platforms values. */
   packagePlatforms = mapAttrs (name: value:
-    let res = builtins.tryEval (
       if isDerivation value then
         value.meta.hydraPlatforms
           or (value.meta.platforms or [ "x86_64-linux" ])
       else if value.recurseForDerivations or false || value.recurseForRelease or false then
         packagePlatforms value
       else
-        []);
-    in if res.success then res.value else []
+        []
     );
 
 


### PR DESCRIPTION
###### Motivation for this change

This use of `builtins.tryEval` causes hydra to fully ignore evaluation failures of
packages that occur while trying to evaluate the hydra platforms it should be
built on. This includes failures that occur during evaluation of:
- The `.type` attribute value
- The `.meta.hydraPlatforms` or `.meta.platforms` attribute value
  - The `.version` attribute, since this can determine whether
    `.meta.position` is set
- For non-derivations, `.recurseForDerivations` or `.recurseForRelease`

Here's a minimal `release.nix` file, showcasing how a `.version` failure
is ignored:

```nix
let
  packages = pkgs: {
    success = pkgs.stdenv.mkDerivation {
      name = "success";
    };
    ignoredFailure = pkgs.stdenv.mkDerivation {
      pname = "ignored-failure";
      version = throw "version error";
    };
    caughtFailure = pkgs.stdenv.mkDerivation {
      name = "caught-failure";
      src = throw "src error";
    };
  };

  releaseLib = import <nixpkgs/pkgs/top-level/release-lib.nix> {
    packageSet = args: packages (import <nixpkgs> args);
    supportedSystems = [ "x86_64-linux" ];
  };
in
releaseLib.mapTestOn (releaseLib.packagePlatforms releaseLib.pkgs)
```
Evaluating this with `hydra-eval-jobs` before this change yields:

```
$ hydra-eval-jobs release.nix -I nixpkgs=/path/to/nixpkgs
warning: `--gc-roots-dir' not specified
error: "error: --- ThrownError --- hydra-eval-jobs\nsrc error"
{
  "caughtFailure.x86_64-linux": {
    "error": "error: --- ThrownError --- hydra-eval-jobs\nsrc error"
  },
  "success.x86_64-linux": {
    "description": "",
    "drvPath": "/nix/store/q1sw933xd9bxfx6rcp0kqksbprj1wmwj-success.drv",
    "homepage": "",
    "isChannel": false,
    "license": "",
    "maintainers": "",
    "maxSilent": 7200,
    "nixName": "success",
    "outputs": {
      "out": "/nix/store/7awrz6hss4jjxvgbwi4wlyikncmslb7a-success"
    },
    "schedulingPriority": 100,
    "system": "x86_64-linux",
    "timeout": 36000
  }
}
```

Where you can see that there is no job for the `ignoredFailure`
derivation. Compare this to after this change:

```
$ hydra-eval-jobs release.nix -I nixpkgs=/path/to/nixpkgs
warning: `--gc-roots-dir' not specified
error: "error: --- ThrownError --- hydra-eval-jobs\nsrc error"
error: "error: --- ThrownError --- hydra-eval-jobs\nversion error"
{
  "caughtFailure.x86_64-linux": {
    "error": "error: --- ThrownError --- hydra-eval-jobs\nsrc error"
  },
  "ignoredFailure": {
    "error": "error: --- ThrownError --- hydra-eval-jobs\nversion error"
  },
  "success.x86_64-linux": {
    "description": "",
    "drvPath": "/nix/store/q1sw933xd9bxfx6rcp0kqksbprj1wmwj-success.drv",
    "homepage": "",
    "isChannel": false,
    "license": "",
    "maintainers": "",
    "maxSilent": 7200,
    "nixName": "success",
    "outputs": {
      "out": "/nix/store/7awrz6hss4jjxvgbwi4wlyikncmslb7a-success"
    },
    "schedulingPriority": 100,
    "system": "x86_64-linux",
    "timeout": 36000
  }
}
```

Notice how `ignoredFailure` is now part of the result.

Originally, this `builtins.tryEval` was introduced by @7c6f434c in 2009: d109e4cd95fd34f43cf07dfd293b7dc67dc42fc6, though no reason was given.

Ping @edolstra @domenkozar @shlevy 

###### Things done

- [x] Verified that `hydra-eval-jobs` now catches these failures with the above example
- [x] Ran `hydra-eval-jobs` on `pkgs/top-level/release.nix` to see the impact of this change on the full nixpkgs set