### PR TITLE
Make logstash packages run pre/postInstall hooks

### DIFF
--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     cp -r {Gemfile*,modules,vendor,lib,bin,config,data,logstash-core,logstash-core-plugin-api} $out
 
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/logstash-plugin \
        --set JAVA_HOME "${jre}"
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     cp -r {Gemfile*,modules,vendor,lib,bin,config,data,logstash-core,logstash-core-plugin-api} $out
 
@@ -41,6 +42,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/logstash-plugin \
        --set JAVA_HOME "${jre}"
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/logstash/contrib.nix
+++ b/pkgs/tools/misc/logstash/contrib.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchzip }:
 
 # Note that plugins are supposed to be installed as:
-#   $path/logstash/{inputs,codecs,filters,outputs}/*.rb 
+#   $path/logstash/{inputs,codecs,filters,outputs}/*.rb
 stdenv.mkDerivation rec {
   version = "1.4.2";
   pname = "logstash-contrib";
@@ -17,8 +17,10 @@ stdenv.mkDerivation rec {
   dontPatchShebangs = true;
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/logstash
     cp -r lib/* $out
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When trying to hook into logstash7, I noticed this hook was missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
