### PR TITLE
homeassistant: 0.118.3 -> 0.118.4

### DIFF
--- a/pkgs/development/python-modules/zigpy-zigate/default.nix
+++ b/pkgs/development/python-modules/zigpy-zigate/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy-zigate";
-  version = "0.7.2";
+  version = "0.7.3";
   # https://github.com/Martiusweb/asynctest/issues/152
   # broken by upstream python bug with asynctest and
   # is used exclusively by home-assistant with python 3.8
@@ -21,8 +21,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy-zigate";
-    rev = "v${version}";
-    sha256 = "0ycrsmp3n3awiyj0gbq6xnaa2s9mpc5l7mlmfc00rfnx7rr2z4ha";
+    rev = version;
+    sha256 = "068v8n8yimmpnwqcdz5m9g35z1x0dir478cbc1s1nyhw1xn50vg1";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.118.3";
+  version = "0.118.4";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -62,7 +62,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.118.3";
+  hassVersion = "0.118.4";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -78,7 +78,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1b58r3gn838naqcrvmzhqcnf2sdjfjwfapnn8v8cnc51pz58vazq";
+    sha256 = "0b289ijxpay6yb2ahkfm7n9k423f8xlbwg8z903iwakiqg54ghip";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/0.118.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
