### PR TITLE
ytt: init at 0.30.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1252,6 +1252,16 @@
     githubId = 3043718;
     name = "Brett Lyons";
   };
+  brodes = {
+    email = "me@brod.es";
+    github = "brhoades";
+    githubId = 4763746;
+    name = "Billy Rhoades";
+    keys = [{
+      longkeyid = "rsa4096/0x8AE74787A4B7C07E";
+      fingerprint = "BF4FCB85C69989B4ED95BF938AE74787A4B7C07E";
+    }];
+  };
   bryanasdev000 = {
     email = "bryanasdev000@gmail.com";
     github = "bryanasdev000";

--- a/pkgs/development/tools/ytt/default.nix
+++ b/pkgs/development/tools/ytt/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "ytt";
+  version = "0.30.0";
+
+  src = fetchFromGitHub {
+    owner = "vmware-tanzu";
+    repo = "carvel-ytt";
+    rev = "v${version}";
+    sha256 = "0v9wp15aj4r7wif8i897zwj3c6bg41b95kk7vi3a3bzin814qn6l";
+  };
+
+  goPackagePath = "github.com/vmware-tanzu/carvel-ytt";
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/ytt" ];
+
+  meta = with lib; {
+    description = "YAML templating tool that allows configuration of complex software via reusable templates with user-provided values";
+    homepage = "https://get-ytt.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ brodes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12156,6 +12156,8 @@ in
 
   yq-go = callPackage ../development/tools/yq-go { };
 
+  ytt = callPackage ../development/tools/ytt {};
+
   winpdb = callPackage ../development/tools/winpdb { };
 
   grabserial = callPackage ../development/tools/grabserial { };


### PR DESCRIPTION
https://github.com/vmware-tanzu/carvel-ytt

###### Motivation for this change
ytt is not already available in nixpkgs. Tests ran by checkPhase fail due to YAML marshaling issues but failures are unrelated to the result binary.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
