### PR TITLE
shotcut: use qt-5.15, rework

### DIFF
--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -4,6 +4,7 @@
 , mkDerivation
 , SDL2
 , frei0r
+, ladspaPlugins
 , gettext
 , mlt
 , jack1
@@ -14,14 +15,12 @@
 , qtwebsockets
 , qtquickcontrols2
 , qtgraphicaleffects
-, libmlt
 , qmake
 , qttools
 , genericUpdater
 , common-updater-scripts
 }:
 
-assert stdenv.lib.versionAtLeast libmlt.version "6.22.1";
 assert stdenv.lib.versionAtLeast mlt.version "6.22.1";
 
 mkDerivation rec {
@@ -40,9 +39,9 @@ mkDerivation rec {
   buildInputs = [
     SDL2
     frei0r
+    ladspaPlugins
     gettext
     mlt
-    libmlt
     qtbase
     qtmultimedia
     qtx11extras
@@ -51,7 +50,7 @@ mkDerivation rec {
     qtgraphicaleffects
   ];
 
-  NIX_CFLAGS_COMPILE = "-I${libmlt}/include/mlt++ -I${libmlt}/include/mlt";
+  NIX_CFLAGS_COMPILE = "-I${mlt.dev}/include/mlt++ -I${mlt.dev}/include/mlt";
   qmakeFlags = [
     "QMAKE_LRELEASE=${stdenv.lib.getDev qttools}/bin/lrelease"
     "SHOTCUT_VERSION=${version}"
@@ -68,6 +67,7 @@ mkDerivation rec {
 
   qtWrapperArgs = [
     "--prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1"
+    "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"
     "--prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ jack1 SDL2 ]}"
     "--prefix PATH : ${mlt}/bin"
   ];

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -1,11 +1,30 @@
-{ stdenv, fetchFromGitHub, SDL, ffmpeg, frei0r, libjack2, libdv, libsamplerate
-, libvorbis, libxml2, makeWrapper, movit, pkgconfig, sox, qtbase, qtsvg
-, fftw, vid-stab, opencv3, ladspa-sdk, genericUpdater, common-updater-scripts
+{ stdenv
+, fetchFromGitHub
+, SDL
+, ffmpeg
+, frei0r
+, libjack2
+, libdv
+, libsamplerate
+, libvorbis
+, libxml2
+, movit
+, pkgconfig
+, sox
+, qtbase
+, qtsvg
+, fftw
+, vid-stab
+, opencv3
+, ladspa-sdk
+, genericUpdater
+, common-updater-scripts
+, ladspaPlugins
+, mkDerivation
+, which
 }:
-
 let inherit (stdenv.lib) getDev; in
-
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "mlt";
   version = "6.22.1";
 
@@ -17,17 +36,36 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    SDL ffmpeg frei0r libjack2 libdv libsamplerate libvorbis libxml2
-    makeWrapper movit pkgconfig qtbase qtsvg sox fftw vid-stab opencv3
+    SDL
+    ffmpeg
+    frei0r
+    libjack2
+    libdv
+    libsamplerate
+    libvorbis
+    libxml2
+    movit
+    pkgconfig
+    qtbase
+    qtsvg
+    sox
+    fftw
+    vid-stab
+    opencv3
     ladspa-sdk
+    ladspaPlugins
   ];
+
+  nativeBuildInputs = [ which ];
 
   outputs = [ "out" "dev" ];
 
   # Mostly taken from:
   # http://www.kdenlive.org/user-manual/downloading-and-installing-kdenlive/installing-source/installing-mlt-rendering-engine
   configureFlags = [
-    "--avformat-swscale" "--enable-gpl" "--enable-gpl" "--enable-gpl3"
+    "--avformat-swscale"
+    "--enable-gpl"
+    "--enable-gpl3"
     "--enable-opengl"
   ];
 
@@ -39,9 +77,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  postInstall = ''
-    wrapProgram $out/bin/melt --prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1
+  qtWrapperArgs = [
+    "--prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1"
+    "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"
+  ];
 
+  postInstall = ''
     # Remove an unnecessary reference to movit.dev.
     s=${movit.dev}/include
     t=$(for ((i = 0; i < ''${#s}; i++)); do echo -n X; done)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22773,9 +22773,7 @@ in
 
   scudcloud = callPackage ../applications/networking/instant-messengers/scudcloud { };
 
-  shotcut = libsForQt514.callPackage ../applications/video/shotcut {
-    libmlt = mlt;
-  };
+  shotcut = libsForQt5.callPackage ../applications/video/shotcut { };
 
   shogun = callPackage ../applications/science/machine-learning/shogun {
     stdenv = gcc8Stdenv;


### PR DESCRIPTION
- use qt-5.15 for shotcut
- use qt mkDerivation for mlt/qt5
- use only mlt/qt5 for shotcut (libmlt -> mlt.dev)
- fix enabling ladspa (configure needs `which`), closes #47440

###### Motivation for this change
Enable LADSPA audio plugins, which never worked, and clean up things a bit. Review is appreciated for I have not much to do with Qt :-)

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
