### PR TITLE
python3Packages.py-air-control: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/coapthon3/default.nix
+++ b/pkgs/development/python-modules/coapthon3/default.nix
@@ -1,19 +1,25 @@
-{ buildPythonPackage, cachetools, fetchPypi, lib }:
+{ buildPythonPackage, cachetools, fetchFromGitHub, lib }:
 
 buildPythonPackage rec {
   pname = "CoAPthon3";
   version = "1.0.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1w6bwwd3qjp4b4fscagqg9wqxpdgvf4sxgzbk2d2rjqwlkyr1lnx";
+  src = fetchFromGitHub {
+    owner = "Tanganelli";
+    repo = pname;
+    rev = version;
+    sha256 = "1im35i5i72y1p9qj8ixkwq7q6ksbrmi42giqiyfgjp1ym38snl69";
   };
 
   propagatedBuildInputs = [ cachetools ];
 
+  # tests take in the order of 10 minutes to execute and sometimes hang forever on tear-down
+  doCheck = false;
+  pythonImportsCheck = [ "coapthon" ];
+
   meta = with lib; {
+    inherit (src.meta) homepage;
     description = "Python3 library to the CoAP protocol compliant with the RFC.";
-    homepage = "https://github.com/Tanganelli/${pname}";
     license = licenses.mit;
     maintainers = with maintainers; [ urbas ];
   };

--- a/pkgs/development/python-modules/coapthon3/default.nix
+++ b/pkgs/development/python-modules/coapthon3/default.nix
@@ -1,8 +1,9 @@
-{ buildPythonPackage, cachetools, fetchFromGitHub, lib }:
+{ buildPythonPackage, cachetools, fetchFromGitHub, isPy27, lib }:
 
 buildPythonPackage rec {
   pname = "CoAPthon3";
   version = "1.0.1";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "Tanganelli";

--- a/pkgs/development/python-modules/py-air-control/default.nix
+++ b/pkgs/development/python-modules/py-air-control/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, coapthon3, fetchFromGitHub, isPy27, lib, pycryptodomex }:
+
+buildPythonPackage rec {
+  pname = "py-air-control";
+  version = "2.1.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "rgerganov";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mkggl5hwmj90djxbbz4svim6iv7xl8k324cb4rlc75p5rgcdwmh";
+  };
+
+  propagatedBuildInputs = [ pycryptodomex coapthon3 ];
+
+  # tests sometimes hang forever on tear-down
+  doCheck = false;
+  pythonImportsCheck = [ "pyairctrl" ];
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "Command Line App for Controlling Philips Air Purifiers.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urbas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4837,6 +4837,8 @@ in {
 
   pxml = callPackage ../development/python-modules/pxml { };
 
+  py-air-control = callPackage ../development/python-modules/py-air-control { };
+
   py2bit = callPackage ../development/python-modules/py2bit { };
 
   py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This Python package was not yet packaged in nixpkgs.

Package size:
```
$ nix path-info -sh $(nix-build . -A python3Packages.py-air-control)
/nix/store/07ssfnqs4gp89pscij442nd51bvdj771-python3.8-py-air-control-2.1.0       116.9K
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @SuperSandro2000 
