### PR TITLE
krusader: add qtbase

### DIFF
--- a/pkgs/applications/misc/krusader/default.nix
+++ b/pkgs/applications/misc/krusader/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, fetchurl, lib,
+  mkDerivation, fetchurl, lib, qtbase,
   extra-cmake-modules, kdoctools, wrapGAppsHook,
   karchive, kconfig, kcrash, kguiaddons, kinit, kparts, kwindowsystem
 }:


### PR DESCRIPTION
###### Motivation for this change
#103033
Error description is here: https://nixos.wiki/wiki/Qt Paragraph: qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
#65399
https://github.com/NixOS/nixpkgs/pull/103094

###### Things done
add qtbase

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
