### PR TITLE
make-desktopitem: desktop-file-utils is a nativeBuildInput

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -12,16 +12,16 @@
 , mimeType ? null
 , categories ? null
 , startupNotify ? null
-, extraDesktopEntries ? {} # Extra key-value pairs to add to the [Desktop Entry] section. This may override other values
+, extraDesktopEntries ? { } # Extra key-value pairs to add to the [Desktop Entry] section. This may override other values
 , extraEntries ? "" # Extra configuration. Will be appended to the end of the file and may thus contain extra sections
 , fileValidation ? true # whether to validate resulting desktop file.
 }:
-
 let
   # like builtins.toString, but null -> null instead of null -> ""
-  nullableToString = value: if value == null then null
-        else if builtins.isBool value then lib.boolToString value
-        else builtins.toString value;
+  nullableToString = value:
+    if value == null then null
+    else if builtins.isBool value then lib.boolToString value
+    else builtins.toString value;
 
   # The [Desktop entry] section of the desktop file, as attribute set.
   mainSection = {
@@ -39,16 +39,19 @@ let
 
   # Map all entries to a list of lines
   desktopFileStrings =
-    ["[Desktop Entry]"]
+    [ "[Desktop Entry]" ]
     ++ builtins.filter
       (v: v != null)
       (lib.mapAttrsToList
         (name: value: if value != null then "${name}=${value}" else null)
         mainSection
       )
-    ++ (if extraEntries == "" then [] else ["${extraEntries}"]);
+    ++ (if extraEntries == "" then [ ] else [ "${extraEntries}" ]);
 in
-runCommandLocal "${name}.desktop" {}
+runCommandLocal "${name}.desktop"
+{
+  nativeBuildInputs = [ desktop-file-utils ];
+}
   (''
     mkdir -p "$out/share/applications"
     cat > "$out/share/applications/${name}.desktop" <<EOF
@@ -56,5 +59,5 @@ runCommandLocal "${name}.desktop" {}
     EOF
   '' + lib.optionalString fileValidation ''
     echo "Running desktop-file validation"
-    ${desktop-file-utils}/bin/desktop-file-validate "$out/share/applications/${name}.desktop"
+    desktop-file-validate "$out/share/applications/${name}.desktop"
   '')


### PR DESCRIPTION
This fixes cross-compilation of a NixOS with the manual enabled.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
