### PR TITLE
fribidi: fix cross

### DIFF
--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, buildPackages
 , fetchurl
 , meson
 , ninja
@@ -25,6 +26,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   doCheck = true;
   checkInputs = [ python3 ];


### PR DESCRIPTION
Meson needs a native compiler to produce some binaries:

> gen.tab/meson.build:32:0: ERROR: No build machine compiler for "gen.tab/gen-unicode-version.c"

Tested building `pkgsCross.armv7l-hf-multiplatform.fribidi` and `pkgsCross.aarch64-multiplatform.fribidi` after this.

###### Motivation for this change
`fribidi` is needed for `smartmontools`, which is part of `nixos/modules/profiles/base.nix`. It's also needed by zfs, so this fixes more cross-NixOS things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
