### PR TITLE
wayland: fix cross

### DIFF
--- a/pkgs/development/libraries/wayland/0001-add-placeholder-for-nm.patch
+++ b/pkgs/development/libraries/wayland/0001-add-placeholder-for-nm.patch
@@ -1,0 +1,25 @@
+From 378623b0e39b12bb04d3a3a1e08e64b31bd7d99d Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Fri, 27 Nov 2020 10:22:20 +0100
+Subject: [PATCH] add placeholder for @nm@
+
+---
+ egl/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/egl/meson.build b/egl/meson.build
+index dee9b1d..e477546 100644
+--- a/egl/meson.build
++++ b/egl/meson.build
+@@ -11,7 +11,7 @@ wayland_egl = library(
+ 
+ executable('wayland-egl-abi-check', 'wayland-egl-abi-check.c')
+ 
+-nm_path = find_program('nm').path()
++nm_path = find_program('@nm@').path()
+ 
+ test(
+ 	'wayland-egl symbols check',
+-- 
+2.29.2
+

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -1,17 +1,32 @@
-{ lib, stdenv, fetchurl, fetchpatch, meson, pkgconfig, ninja
-, libffi, libxml2, wayland
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, meson
+, pkgconfig
+, substituteAll
+, ninja
+, libffi
+, libxml2
+, wayland
 , expat ? null # Build wayland-scanner (currently cannot be disabled as of 1.7.0)
 , withDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform
-, graphviz-nox, doxygen, libxslt, xmlto, python3
-, docbook_xsl, docbook_xml_dtd_45, docbook_xml_dtd_42
+, graphviz-nox
+, doxygen
+, libxslt
+, xmlto
+, python3
+, docbook_xsl
+, docbook_xml_dtd_45
+, docbook_xml_dtd_42
 }:
 
 # Require the optional to be enabled until upstream fixes or removes the configure flag
 assert expat != null;
-
 let
   isCross = stdenv.buildPlatform != stdenv.hostPlatform;
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "wayland";
   version = "1.18.0";
 
@@ -26,6 +41,10 @@ in stdenv.mkDerivation rec {
       url = "https://gitlab.freedesktop.org/wayland/wayland/-/commit/e53e0edf0f892670f3e8c5dd527b3bb22335d32d.patch";
       sha256 = "15sbhi86m9k72lsj56p7zr20ph2b0y4svl639snsbafn2ir1zdb2";
     })
+    (substituteAll {
+      src = ./0001-add-placeholder-for-nm.patch;
+      nm = "${stdenv.cc.targetPrefix}nm";
+    })
   ];
 
   outputs = [ "out" ] ++ lib.optionals withDocumentation [ "doc" "man" ];
@@ -35,9 +54,6 @@ in stdenv.mkDerivation rec {
 
   postPatch = lib.optionalString withDocumentation ''
     patchShebangs doc/doxygen/gen-doxygen.py
-    substituteInPlace egl/meson.build --replace \
-      "find_program('nm').path()" \
-      "find_program('${stdenv.cc.targetPrefix}nm').path()"
   '';
 
   depsBuildBuild = [
@@ -45,17 +61,28 @@ in stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    meson pkgconfig ninja
+    meson
+    pkgconfig
+    ninja
   ] ++ lib.optionals isCross [
     wayland # For wayland-scanner during the build
   ] ++ lib.optionals withDocumentation [
     (graphviz-nox.override { pango = null; }) # To avoid an infinite recursion
-    doxygen libxslt xmlto python3 docbook_xml_dtd_45
+    doxygen
+    libxslt
+    xmlto
+    python3
+    docbook_xml_dtd_45
   ];
 
-  buildInputs = [ libffi expat libxml2
+  buildInputs = [
+    libffi
+    expat
+    libxml2
   ] ++ lib.optionals withDocumentation [
-    docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_42
+    docbook_xsl
+    docbook_xml_dtd_45
+    docbook_xml_dtd_42
   ];
 
   meta = {
@@ -68,9 +95,9 @@ in stdenv.mkDerivation rec {
       and other interactions that must go through the compositor (but not
       rendering).
     '';
-    homepage    = "https://wayland.freedesktop.org/";
-    license     = lib.licenses.mit; # Expat version
-    platforms   = lib.platforms.linux;
+    homepage = "https://wayland.freedesktop.org/";
+    license = lib.licenses.mit; # Expat version
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ primeos codyopel ];
   };
 


### PR DESCRIPTION
meson needs to invoke nm from binutils during build

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
