### PR TITLE
dart: support x86_64-darwin platform

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -12,6 +12,10 @@ let
     aarch64 = "arm64";
 
   in {
+    "1.24.3-x86_64-darwin" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "1n4cq4jrms4j0yl54b3w14agcgy8dbipv5788jziwk8q06a8c69l";
+    };
     "1.24.3-x86_64-linux" = fetchurl {
       url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
       sha256 = "16sm02wbkj328ni0z1z4n4msi12lb8ijxzmbbfamvg766mycj8z3";
@@ -23,6 +27,10 @@ let
     "1.24.3-aarch64-linux" = fetchurl {
       url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
       sha256 = "1p5bn04gr91chcszgmw5ng8mlzgwsrdr2v7k7ppwr1slkx97fsrh";
+    };
+    "2.7.2-x86_64-darwin" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "111zl075qdk2zd4d4mmfkn30jmzsri9nq3nspnmc2l245gdq34jj";
     };
     "2.7.2-x86_64-linux" = fetchurl {
       url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
@@ -36,9 +44,17 @@ let
       url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
       sha256 = "1p66fkdh1kv0ypmadmg67c3y3li3aaf1lahqh2g6r6qrzbh5da2p";
     };
+    "2.10.0-x86_64-darwin" = fetchurl {
+      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "1n4qgsax5wi7krgvvs0dy7fz39nlykiw8gr0gdacc85hgyhqg09j";
+    };
     "2.10.0-x86_64-linux" = fetchurl {
       url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
       sha256 = "0dncmsfbwcn3ygflhp83i6z4bvc02fbpaq1vzdzw8xdk3sbynchb";
+    };
+    "2.9.0-4.0.dev-x86_64-darwin" = fetchurl {
+      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "0gj91pbvqrxsvxaj742cllqha2z65867gggzq9hq5139vkkpfj9s";
     };
     "2.9.0-4.0.dev-x86_64-linux" = fetchurl {
       url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
@@ -51,6 +67,10 @@ let
     "2.9.0-4.0.dev-aarch64-linux" = fetchurl {
       url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
       sha256 = "1x6mlmc4hccmx42k7srhma18faxpxvghjwqahna80508rdpljwgc";
+    };
+    "2.11.0-161.0.dev-x86_64-darwin" = fetchurl {
+      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
+      sha256 = "0mlwxp7jkkjafxkc4vqlgwl62y0hk1arhfrvc9hpm9dv98g3bdjj";
     };
     "2.11.0-161.0.dev-x86_64-linux" = fetchurl {
       url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
@@ -93,7 +113,7 @@ stdenv.mkDerivation {
       with C-style syntax. It offers compilation to JavaScript, interfaces,
       mixins, abstract classes, reified generics, and optional typing.
     '';
-    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" ];
     license = licenses.bsd3;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Nix works on MacOS, Dart works on MacOS, so let's make Dart available through Nix on MacOS too. Later, we can do the same for Flutter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] ~NixOS~ (n/a: only adding support for Darwin.)
   - [x] macOS
     ```
     $ cat /etc/nix/nix.conf
     build-users-group = nixbld
     sandbox = true
     $ for v in 1.24.3 2.7.2 2.10.0 2.9.0-4.0.dev 2.11.0-161.0.dev ; do
       nix-build -E "with import <nixpkgs> {}; callPackage ./default.nix {version=\"$v\";}"
       r="$r $v:$?"
     done ; echo "$r"
     /nix/store/mw3v7784iz85gp2rw8j1gld6qsjnwcji-dart-1.24.3
     /nix/store/pnzn2vdpp7m0xxmwlwnghq57fh2fkn6b-dart-2.7.2
     /nix/store/83pvpas75ancdfxrghw6lzkkzai3gim9-dart-2.10.0
     /nix/store/s0k4p9b8pxw0fd0pp4h0ziz1xx44dmz1-dart-2.9.0-4.0.dev
     /nix/store/76znscxn89433yc9n80hwh7p472czaky-dart-2.11.0-161.0.dev
      1.24.3:0 2.7.2:0 2.10.0:0 2.9.0-4.0.dev:0 2.11.0-161.0.dev:0
     ```
   - [x] ~other Linux distributions~ (n/a: only adding support for Darwin.)
- [x] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~ (n/a: there are no relevant tests yet.)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  ```
  [...]
  No diff detected, stopping review...
  [...]
  ```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  ```
  $ for v in 1.24.3 2.7.2 2.10.0 2.9.0-4.0.dev 2.11.0-161.0.dev ; do
      nix-build -E "with import <nixpkgs> {}; callPackage ./default.nix {version=\"$v\";}" && for f in result/bin/* ; do
        if [ -f $f ]; then
          $f --help 2>/dev/null 1>/dev/null || ( echo "\$ $f --help"; $f --help )
        fi
      done 
    done
  /nix/store/mw3v7784iz85gp2rw8j1gld6qsjnwcji-dart-1.24.3
  /nix/store/pnzn2vdpp7m0xxmwlwnghq57fh2fkn6b-dart-2.7.2
  /nix/store/83pvpas75ancdfxrghw6lzkkzai3gim9-dart-2.10.0
  $ result/bin/dartdevc --help
  Please specify the output file location. For example:
      -o PATH/TO/OUTPUT_FILE.js
  /nix/store/s0k4p9b8pxw0fd0pp4h0ziz1xx44dmz1-dart-2.9.0-4.0.dev
  $ result/bin/dartdevc --help
  Please specify the output file location. For example:
      -o PATH/TO/OUTPUT_FILE.js
  /nix/store/76znscxn89433yc9n80hwh7p472czaky-dart-2.11.0-161.0.dev
  $ result/bin/dartdevc --help
  Please specify the output file location. For example:
      -o PATH/TO/OUTPUT_FILE.js
  ```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - (I'm not sure how to do that just yet!)
- [x] ~Ensured that relevant documentation is up to date~ (n/a: I searched and haven't found any relevant documentation.)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
