### PR TITLE
proverif: install emacs mode

### DIFF
--- a/pkgs/applications/science/logic/proverif/default.nix
+++ b/pkgs/applications/science/logic/proverif/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp ./proverif      $out/bin
     cp ./proveriftotex $out/bin
+    install -D -t $out/share/emacs/site-lisp/ emacs/proverif.el
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Use proverif-mode in emacs!

cc maintainer @thoughtpolice 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
