### PR TITLE
libvirt: Add reasonable memory_backing_dir default for qemu.

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -81,11 +81,12 @@ in {
       type = types.lines;
       default = ''
         namespaces = []
+        memory_backing_dir = "/dev/shm"
       '';
       description = ''
         Contents written to the qemu configuration file, qemu.conf.
-        Make sure to include a proper namespace configuration when
-        supplying custom configuration.
+        Make sure to include a proper namespace and memory_backing_dir 
+        configuration when supplying custom configuration.
       '';
     };
 


### PR DESCRIPTION
When VMs are run with "<memoryBacking><access mode='shared'/></memoryBacking>",
qemu creates a backing file to make memory accessible to the guest and
other host processes. Without specifying memory_backing_dir, the
backing file actually lands on disk inside /var/lib/libvirt, which
makes every memory access inside the guest an actual filesystem IO.

This commit provides a reasonable default inside qemuVerbatimConfig.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
