### PR TITLE
bombadillo: init at 2.3.3

### DIFF
--- a/pkgs/applications/networking/browsers/bombadillo/default.nix
+++ b/pkgs/applications/networking/browsers/bombadillo/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchgit, buildGoModule }:
+
+buildGoModule rec {
+  pname = "bombadillo";
+  version = "2.3.3";
+
+  src = fetchgit {
+    url = "https://tildegit.org/sloum/bombadillo.git";
+    rev = version;
+    sha256 = "02w6h44sxzmk3bkdidl8xla0i9rwwpdqljnvcbydx5kyixycmg0q";
+  };
+
+  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+
+  meta = with lib; {
+    description = "Non-web client for the terminal, supporting Gopher, Gemini and more";
+    homepage = "https://bombadillo.colorfield.space/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ehmry ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20367,6 +20367,8 @@ in
 
   blugon = callPackage ../applications/misc/blugon { };
 
+  bombadillo = callPackage ../applications/networking/browsers/bombadillo { };
+
   bombono = callPackage ../applications/video/bombono {};
 
   bomi = libsForQt5.callPackage ../applications/video/bomi {


### PR DESCRIPTION
###### Motivation for this change
Closes #87780

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
