### PR TITLE
qmapshack: 1.15.0 → 1.15.1

### DIFF
--- a/pkgs/applications/gis/qmapshack/default.nix
+++ b/pkgs/applications/gis/qmapshack/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "qmapshack";
-  version = "1.15.0";
+  version = "1.15.1";
 
   src = fetchFromGitHub {
     owner = "Maproom";
     repo = pname;
     rev = "V_${version}";
-    sha256 = "157bssrbwcc1w58b0v60jb3wrjf2ig4z6z6crjnpvflkqj5p8vwy";
+    sha256 = "1q8qczp9bgk3dzdswb1x64fcn3xg339s0yx31nablb518hcb8jkr";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -21,8 +21,6 @@ mkDerivation rec {
     "-DQUAZIP_INCLUDE_DIR=${quazip}/include/quazip5"
     "-DLIBQUAZIP_LIBRARY=${quazip}/lib/libquazip.so"
   ];
-
-  enableParallelBuilding = true;
 
   patches = [
     "${src}/FindPROJ4.patch"
@@ -36,7 +34,7 @@ mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/Maproom/qmapshack";
     description = "Consumer grade GIS software";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dotlambda sikmir ];
     platforms = with platforms; linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23365,7 +23365,7 @@ in
 
   garmindev = callPackage ../applications/misc/qlandkartegt/garmindev.nix {};
 
-  qmapshack = libsForQt514.callPackage ../applications/misc/qmapshack { };
+  qmapshack = libsForQt5.callPackage ../applications/gis/qmapshack { };
 
   qmediathekview = libsForQt5.callPackage ../applications/video/qmediathekview {
     boost = boost17x;


### PR DESCRIPTION
###### Motivation for this change
* update to 1.15.1 ([Changelog](https://github.com/Maproom/qmapshack/blob/dev/changelog.txt))
* use latest qt version instead of 5.14 #104474
* move from `applications/misc` to `applications/gis`
* fix license
* remove `enableParallelBuilding = true`, cmake enables it by default

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
