### PR TITLE
[haskell-updates] fix hercules-ci-agent (after hackage2nix update to agent 0.7.5)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -96,4 +96,7 @@ self: super: {
   # Break out of "Cabal < 3.2" constraint.
   stylish-haskell = doJailbreak super.stylish-haskell;
 
+  # cxx-options is broken in Cabal 3.2.0.0
+  hercules-ci-agent = addSetupDepend super.hercules-ci-agent self.Cabal_3_2_1_0;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -73,6 +73,9 @@ self: super: {
   shellmet = doJailbreak super.shellmet;
   shower = doJailbreak super.shower;
 
+  # Broken test compile
+  servant-swagger = dontCheck super.servant-swagger;
+
   # The shipped Setup.hs file is broken.
   csv = overrideCabal super.csv (drv: { preCompileBuildDriver = "rm Setup.hs"; });
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2712,6 +2712,9 @@ package-maintainers:
     - Agda
   roberth:
     - arion-compose
+    - hercules-ci-agent
+    - hercules-ci-api-agent
+    - hercules-ci-api-core
   cdepillabout:
     - pretty-simple
     - spago
@@ -6208,9 +6211,6 @@ broken-packages:
   - HERA
   - herbalizer
   - HerbiePlugin
-  - hercules-ci-agent
-  - hercules-ci-api-agent
-  - hercules-ci-api-core
   - heredocs
   - Hermes
   - hermit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix hercules-ci-agent build on nixos-unstable. (after running hackage2nix, which I'm not supposed to do here)

Broken by in https://github.com/NixOS/nixpkgs/pull/103740


This took a while to fix, because
 - cachix was broken. That's what I started on, proposing a different fix, but my effort was duplicated
 - GHC 8.10 / Cabal 3.2.0.0 combination was broken wrt cxx-sources and inline-c-cpp
 - cachix forced an update of protolude but the updates also broke my tooling, making the migration needlessly time consuming
 - the update required a new release and my release tooling also broke with the update

Please, please, please _announce_ default GHC upgrades and allow some time for maintainers to actually fix packages before breaking master.

Some (many?) users regard nixos-unstable as a rolling release, so we should at least make *some* effort to allow fixes.

That said, I do immensely appreciate @peti's and other maintainers' efforts.

I just hope that with the next upgrade you could give us some time to fix things. IIRC something like that was mentioned in the live stream.
This upgrade really took the better part of a week to make work. I don't know where I'd have been if I had to do this before the Cabal 3.2.1.0 update...


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (out of tree, cabal2nix)
   - [x] macOS (out of tree, cabal2nix)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
