### PR TITLE
pythonPackages.browsermob-proxy: drop insecure python-cryptography tr…

### DIFF
--- a/pkgs/development/python-modules/browsermob-proxy/default.nix
+++ b/pkgs/development/python-modules/browsermob-proxy/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , requests
+, urllib3
 }:
 
 buildPythonPackage rec {
@@ -13,7 +14,10 @@ buildPythonPackage rec {
     sha256 = "1bxvmghm834gsfz3pm69772wzhh15p8ci526b25dpk3z4315nd7v";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ (requests.override { urllib3 = urllib3.override {
+    pyopenssl = null;
+    cryptography = null;
+  };}) ];
 
   meta = {
     description = "A library for interacting with Browsermob Proxy";


### PR DESCRIPTION
…ansitive dependency; only used for Marionette anyway

###### Motivation for this change

python2Packages.cryptography is marked insecure

will self-merge once tests pass

Tested marionette-harness working

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
