### PR TITLE
Change initialHashedPassword to initialPassword

### DIFF
--- a/nixos/doc/manual/installation/changing-config.xml
+++ b/nixos/doc/manual/installation/changing-config.xml
@@ -95,4 +95,3 @@
 </screen>
  </para>
 </chapter>
-

--- a/nixos/doc/manual/installation/changing-config.xml
+++ b/nixos/doc/manual/installation/changing-config.xml
@@ -78,7 +78,7 @@
   <literal>mutableUsers = false</literal>. Another way is to temporarily add
   the following to your configuration:
 <screen>
-<link linkend="opt-users.users._name_.initialHashedPassword">users.users.your-user.initialHashedPassword</link> = "test";
+<link linkend="opt-users.users._name_.initialPassword">users.users.your-user.initialPassword</link> = "test";
 </screen>
   <emphasis>Important:</emphasis> delete the $hostname.qcow2 file if you have
   started the virtual machine at least once without the right users, otherwise
@@ -95,3 +95,4 @@
 </screen>
  </para>
 </chapter>
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixing incorrect documentation. As the value is clear text, not hashed, it should use initialPassword instead, otherwise login won't work with the provided password.

###### Things done

- [X] Tested locally on nixos via `nixos-rebuild build-vm` on release 20.09