### PR TITLE
uwc: Init at 1.0.4

### DIFF
--- a/pkgs/tools/text/uwc/default.nix
+++ b/pkgs/tools/text/uwc/default.nix
@@ -1,0 +1,24 @@
+{ rustPlatform, lib, fetchFromGitLab }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "uwc";
+  version = "1.0.4";
+
+  src = fetchFromGitLab {
+    owner = "dead10ck";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ywqq9hrrm3frvd2sswknxygjlxi195kcy7g7phwq63j7hkyrn50";
+  };
+
+  cargoSha256 = "0ra62cf75b1c4knxxpbdg8m0sy2k02r52j606fp5l9crp0fml8l0";
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Like wc, but unicode-aware, and with per-line mode";
+    homepage = "https://gitlab.com/dead10ck/uwc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7901,6 +7901,8 @@ in
 
   usync = callPackage ../applications/misc/usync { };
 
+  uwc = callPackage ../tools/text/uwc { };
+
   uwsgi = callPackage ../servers/uwsgi { };
 
   v2ray = callPackage ../tools/networking/v2ray { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
uwc is a Unicode-aware word counter with per-line mode written in Rust
If applied, users will be able to count the
number of unicode characters and words
(e.g. Chinese characters) from files or through the pipe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
       - [X] NixOnDroid
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (No reverse dependency yet)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) (33039552)
- [ ] Ensured that relevant documentation is up to date (No related documentation)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
