### PR TITLE
copyDesktopItems: add new setup-hook

### DIFF
--- a/pkgs/applications/audio/goattracker/default.nix
+++ b/pkgs/applications/audio/goattracker/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl
 , unzip
+, copyDesktopItems
 , makeDesktopItem
 , imagemagick
 , SDL
@@ -37,7 +38,7 @@ in stdenv.mkDerivation rec {
   };
   sourceRoot = (if isStereo then "gt2stereo/trunk" else "goattrk2") + "/src";
 
-  nativeBuildInputs = [ unzip imagemagick ];
+  nativeBuildInputs = [ copyDesktopItems unzip imagemagick ];
   buildInputs = [ SDL ];
 
   # PREFIX gets treated as BINDIR.
@@ -51,10 +52,15 @@ in stdenv.mkDerivation rec {
 
   # Other files get installed during the build phase.
   installPhase = ''
+    runHook preInstall
+
     convert goattrk2.bmp goattracker.png
     install -Dm644 goattracker.png $out/share/icons/hicolor/32x32/apps/goattracker.png
-    ${desktopItem.buildCommand}
+
+    runHook postInstall
   '';
+
+  desktopItems = [ desktopItem ];
 
   meta = {
     description = "A crossplatform music editor for creating Commodore 64 music. Uses reSID library by Dag Lem and supports alternatively HardSID & CatWeasel devices"
@@ -66,4 +72,3 @@ in stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/applications/networking/mailreaders/thunderbird/68.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/68.nix
@@ -4,6 +4,7 @@
 , bzip2
 , cargo
 , common-updater-scripts
+, copyDesktopItems
 , coreutils
 , curl
 , dbus
@@ -83,6 +84,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoconf213
     cargo
+    copyDesktopItems
     gnused
     llvmPackages.llvm
     m4
@@ -262,8 +264,8 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  postInstall = let
-    desktopItem = makeDesktopItem {
+  desktopItems = [
+    (makeDesktopItem {
       categories = lib.concatStringsSep ";" [ "Application" "Network" ];
       desktopName = "Thunderbird";
       genericName = "Mail Reader";
@@ -283,12 +285,11 @@ stdenv.mkDerivation rec {
         "x-scheme-handler/snews"
         "x-scheme-handler/nntp"
       ];
-    };
-  in ''
+    })
+  ];
+  postInstall = ''
     # TODO: Move to a dev output?
     rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
-
-    ${desktopItem.buildCommand}
   '';
 
   preFixup = ''

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -2,6 +2,7 @@
 , bzip2
 , cargo
 , common-updater-scripts
+, copyDesktopItems
 , coreutils
 , curl
 , dbus
@@ -82,6 +83,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoconf213
     cargo
+    copyDesktopItems
     gnused
     llvmPackages.llvm
     m4
@@ -257,8 +259,8 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  postInstall = let
-    desktopItem = makeDesktopItem {
+  desktopItems = [
+    (makeDesktopItem {
       categories = lib.concatStringsSep ";" [ "Application" "Network" ];
       desktopName = "Thunderbird";
       genericName = "Mail Reader";
@@ -278,12 +280,12 @@ stdenv.mkDerivation rec {
         "x-scheme-handler/snews"
         "x-scheme-handler/nntp"
       ];
-    };
-  in ''
+    })
+  ];
+
+  postInstall = ''
     # TODO: Move to a dev output?
     rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
-
-    ${desktopItem.buildCommand}
   '';
 
   preFixup = ''

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoPatchelfHook, makeDesktopItem, makeWrapper
+{ stdenv, fetchurl, autoPatchelfHook, makeDesktopItem, makeWrapper, copyDesktopItems
 
   # Dynamic Libraries
 , curl, libGL, libX11, libXext, libXmu, libXrandr, libXrender
@@ -27,6 +27,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     makeWrapper
   ];
 
@@ -110,16 +111,13 @@ in stdenv.mkDerivation {
     # remove broken symbolic links
     find $out -xtype l -ls -exec rm {} \;
 
-    # Add desktop items
-    ${desktopItems.planmaker.buildCommand}
-    ${desktopItems.presentations.buildCommand}
-    ${desktopItems.textmaker.buildCommand}
-
     # Add mime types
     install -D -t $out/share/mime/packages ${pname}/mime/softmaker-*office*${shortEdition}.xml
 
     runHook postInstall
   '';
+
+  desktopItems = builtins.attrValues desktopItems;
 
   meta = with stdenv.lib; {
     description = "An office suite with a word processor, spreadsheet and presentation program";

--- a/pkgs/build-support/setup-hooks/copy-desktop-items.sh
+++ b/pkgs/build-support/setup-hooks/copy-desktop-items.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=bash
+
+# Setup hook that installs specified desktop items.
+#
+# Example usage in a derivation:
+#
+#   { …, makeDesktopItem, copyDesktopItems, … }:
+#
+#   let desktopItem = makeDesktopItem { … }; in
+#   stdenv.mkDerivation {
+#     …
+#     nativeBuildInputs = [ copyDesktopItems ];
+#
+#     desktopItems =  [ desktopItem ];
+#     …
+#   }
+#
+# This hook will copy files which are either given by full path
+# or all '*.desktop' files placed inside the 'share/applications'
+# folder of each `desktopItems` argument.
+
+postInstallHooks+=(copyDesktopItems)
+
+copyDesktopItems() {
+    if [ "${dontCopyDesktopItems-}" = 1 ]; then return; fi
+
+    if [ -z "$desktopItems" ]; then
+        return
+    fi
+
+    for desktopItem in $desktopItems; do
+        if [[ -f "$desktopItem" ]]; then
+            echo "Copying '$f' into '$out/share/applications'"
+            install -D -m 444 -t "$out"/share/applications "$f"
+        else
+            for f in "$desktopItem"/share/applications/*.desktop; do
+                echo "Copying '$f' into '$out/share/applications'"
+                install -D -m 444 -t "$out"/share/applications "$f"
+            done
+        fi
+    done
+}

--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchurl
 , nixosTests
+, copyDesktopItems
 , makeDesktopItem
 , makeWrapper
 , wrapGAppsHook
@@ -38,7 +39,6 @@ let
     comment = "Official launcher for Minecraft, a sandbox-building game";
     desktopName = "Minecraft Launcher";
     categories = "Game;";
-    fileValidation = false;
   };
 
   envLibPath = stdenv.lib.makeLibraryPath [
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
     sha256 = "0w8z21ml79kblv20wh5lz037g130pxkgs8ll9s3bi94zn2pbrhim";
   };
 
-  nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [ makeWrapper wrapGAppsHook copyDesktopItems ];
   buildInputs = [ gobject-introspection ];
 
   sourceRoot = ".";
@@ -110,11 +110,14 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/opt
     mv minecraft-launcher $out/opt
 
-    ${desktopItem.buildCommand}
     install -D $icon $out/share/icons/hicolor/symbolic/apps/minecraft-launcher.svg
+
+    runHook postInstall
   '';
 
   preFixup = ''
@@ -139,6 +142,8 @@ stdenv.mkDerivation rec {
       --run "cd /tmp" \
       "''${gappsWrapperArgs[@]}"
   '';
+
+  desktopItems = [ desktopItem ];
 
   meta = with stdenv.lib; {
     description = "Official launcher for Minecraft, a sandbox-building game";

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchzip, makeWrapper, runCommandNoCC, makeDesktopItem
-, xonotic-data
+, xonotic-data, copyDesktopItems
 , # required for both
   unzip, libjpeg, zlib, libvorbis, curl
 , # glx
@@ -131,7 +131,8 @@ in rec {
 
   xonotic = runCommandNoCC "xonotic${variant}-${version}" {
     inherit xonotic-unwrapped;
-    buildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+    desktopItems = [ desktopItem ];
     passthru = {
       inherit version;
       meta = meta // {
@@ -151,7 +152,7 @@ in rec {
   '' + lib.optionalString (withSDL || withGLX) ''
     mkdir -p $out/share
     ln -s ${xonotic-unwrapped}/share/icons $out/share/icons
-    ${desktopItem.buildCommand}
+    copyDesktopItems
   '' + ''
     for binary in $out/bin/xonotic-*; do
       wrapProgram $binary --add-flags "-basedir ${xonotic-data}"

--- a/pkgs/tools/misc/jdiskreport/default.nix
+++ b/pkgs/tools/misc/jdiskreport/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, jre, makeDesktopItem }:
+{ stdenv, fetchurl, unzip, jre, makeDesktopItem, copyDesktopItems }:
 
 let
   desktopItem = makeDesktopItem {
@@ -18,11 +18,12 @@ stdenv.mkDerivation {
     sha256 = "0d5mzkwsbh9s9b1vyvpaawqc09b0q41l2a7pmwf7386b1fsx6d58";
   };
 
+  nativeBuildInputs = [ copyDesktopItems ];
   buildInputs = [ unzip ];
   inherit jre;
 
   installPhase = ''
-    source $stdenv/setup
+    runHook preInstall
 
     unzip $src
 
@@ -38,8 +39,10 @@ stdenv.mkDerivation {
     EOF
     chmod +x $out/bin/jdiskreport
 
-    ${desktopItem.buildCommand}
+    runHook postInstall
   '';
+
+  desktopItems = [ desktopItem ];
 
   meta = with stdenv.lib; {
     homepage = "http://www.jgoodies.com/freeware/jdiskreport/";

--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, jdk, gradle_5, makeDesktopItem, perl, writeText, runtimeShell }:
+{ stdenv, fetchFromGitHub, jre, jdk, gradle_5, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell }:
 
 let
   pname = "jd-gui";
@@ -55,9 +55,9 @@ let
     }
   '';
 
-  desktopItem = launcher: makeDesktopItem {
+  desktopItem = makeDesktopItem {
     name = "jd-gui";
-    exec = "${launcher} %F";
+    exec = "jd-gui %F";
     icon = "jd-gui";
     comment = "Java Decompiler JD-GUI";
     desktopName = "JD-GUI";
@@ -71,7 +71,7 @@ in stdenv.mkDerivation rec {
   inherit pname version src;
   name = "${pname}-${version}";
 
-  nativeBuildInputs = [ jdk gradle_5 ];
+  nativeBuildInputs = [ jdk gradle_5 copyDesktopItems ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)
@@ -81,6 +81,8 @@ in stdenv.mkDerivation rec {
   installPhase = let
     jar = "$out/share/jd-gui/${name}.jar";
   in ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/{jd-gui,icons/hicolor/128x128/apps}
     cp build/libs/${name}.jar ${jar}
     cp src/linux/resources/jd_icon_128.png $out/share/icons/hicolor/128x128/apps/jd-gui.png
@@ -92,8 +94,10 @@ in stdenv.mkDerivation rec {
     EOF
     chmod +x $out/bin/jd-gui
 
-    ${(desktopItem "$out/bin/jd-gui").buildCommand}
+    runHook postInstall
   '';
+
+  desktopItems = [ desktopItem ];
 
   meta = with stdenv.lib; {
     description = "Fast Java Decompiler with powerful GUI";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -463,6 +463,8 @@ in
 
   madonctl = callPackage ../applications/misc/madonctl { };
 
+  copyDesktopItems = makeSetupHook { } ../build-support/setup-hooks/copy-desktop-items.sh;
+
   makeDesktopItem = callPackage ../build-support/make-desktopitem { };
 
   makeAutostartItem = callPackage ../build-support/make-startupitem { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A change made to the `makeDesktopItem` helper introduced by #105099 broke the build of some packages.

These packages used the `desktopItem.buildCommand` string to install their desktop files directly, instead of using the `desktopItem` output:

https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/applications/audio/goattracker/default.nix#L56
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/applications/networking/mailreaders/thunderbird/68.nix#L291
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/applications/networking/mailreaders/thunderbird/default.nix#L286
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/applications/office/softmaker/generic.nix#L114-L116
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/games/minecraft/default.nix#L114
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/games/xonotic/default.nix#L154
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/tools/misc/jdiskreport/default.nix#L41
https://github.com/NixOS/nixpkgs/blob/05d408e639f03be0c5db6e5c0d6621081f7106f2/pkgs/tools/security/jd-gui/default.nix#L95

This PR adds the `copyDesktopItems` setup hook, which simplifies the process of adding desktop files to a package. It is invoked as a `postInstallHook` and will install the files given to the `desktopItems` attribute into the `out` output.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC: @flokli @samueldr