### PR TITLE
GH Action: merge staging(-next) periodically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 
 # GitHub actions
 /.github/workflows @Mic92 @zowoq
+/.github/workflows/merge-staging @FRidh
 
 # EditorConfig
 /.editorconfig @Mic92 @zowoq

--- a/.github/workflows/merge-staging.yml
+++ b/.github/workflows/merge-staging.yml
@@ -1,0 +1,30 @@
+name: "merge staging(-next)"
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Merge every 6 hours
+    - cron:  '* */6 * * *'
+
+jobs:
+  sync-branch:
+    if: github.repository == 'NixOS/nixpkgs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Merge master into staging-next
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: master
+          target_branch: staging-next
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge staging-next into staging
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: staging-next
+          target_branch: staging
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-staging.yml
+++ b/.github/workflows/merge-staging.yml
@@ -28,3 +28,12 @@ jobs:
           from_branch: staging-next
           target_branch: staging
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on failure
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ failure() }}
+        with:
+          issue-number: 105153
+          body: |
+            An automatic merge [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
+


### PR DESCRIPTION
Automate the merging of `master` -> `staging-next` -> `staging`.

Our main development branch is `master`. Large rebuilds go to `staging`.
Periodically, `staging` is merged into `staging-next` for stabilization.
When considered sufficiently stable, `staging-next` is merged into
`master`.

As changes arrive on these branches, it is important that they're all
updated regularly with eachothers changes. This commit automates that
part.

https://github.com/NixOS/nixpkgs/issues/104594

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
