### PR TITLE
Python: rename internal parameters related to splicing and fix splicing

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -18,8 +18,8 @@
 , ucsEncoding ? 4
 # For the Python package set
 , packageOverrides ? (self: super: {})
-, buildPackages
 , pkgsBuildBuild
+, pkgsBuildHost
 , pkgsBuildTarget
 , pkgsHostHost
 , pkgsTargetTarget
@@ -28,6 +28,7 @@
 , passthruFun
 , static ? false
 , enableOptimizations ? (!stdenv.isDarwin)
+, pythonAttr ? "python${sourceVersion.major}${sourceVersion.minor}"
 }:
 
 assert x11Support -> tcl != null
@@ -38,9 +39,8 @@ assert x11Support -> tcl != null
 with stdenv.lib;
 
 let
-
-  pythonAttr = "python${sourceVersion.major}${sourceVersion.minor}";
-  pythonForBuild = buildPackages.${pythonAttr};
+  buildPackages = pkgsBuildHost;
+  inherit (passthru) pythonForBuild;
 
   passthru = passthruFun rec {
     inherit self sourceVersion packageOverrides;
@@ -49,8 +49,9 @@ let
     executable = libPrefix;
     pythonVersion = with sourceVersion; "${major}.${minor}";
     sitePackages = "lib/${libPrefix}/site-packages";
-    inherit hasDistutilsCxxPatch pythonForBuild;
+    inherit hasDistutilsCxxPatch;
     pythonPackagesBuildBuild = pkgsBuildBuild.${pythonAttr};
+    pythonPackagesBuildHost = pkgsBuildHost.${pythonAttr};
     pythonPackagesBuildTarget = pkgsBuildTarget.${pythonAttr};
     pythonPackagesHostHost = pkgsHostHost.${pythonAttr};
     pythonPackagesTargetTarget = pkgsTargetTarget.${pythonAttr} or {};

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -50,11 +50,11 @@ let
     pythonVersion = with sourceVersion; "${major}.${minor}";
     sitePackages = "lib/${libPrefix}/site-packages";
     inherit hasDistutilsCxxPatch;
-    pythonPackagesBuildBuild = pkgsBuildBuild.${pythonAttr};
-    pythonPackagesBuildHost = pkgsBuildHost.${pythonAttr};
-    pythonPackagesBuildTarget = pkgsBuildTarget.${pythonAttr};
-    pythonPackagesHostHost = pkgsHostHost.${pythonAttr};
-    pythonPackagesTargetTarget = pkgsTargetTarget.${pythonAttr} or {};
+    pythonOnBuildForBuild = pkgsBuildBuild.${pythonAttr};
+    pythonOnBuildForHost = pkgsBuildHost.${pythonAttr};
+    pythonOnBuildForTarget = pkgsBuildTarget.${pythonAttr};
+    pythonOnHostForHost = pkgsHostHost.${pythonAttr};
+    pythonOnTargetForTarget = pkgsTargetTarget.${pythonAttr} or {};
   } // {
     inherit ucsEncoding;
   };

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -68,11 +68,11 @@ let
     pythonVersion = with sourceVersion; "${major}.${minor}";
     sitePackages = "lib/${libPrefix}/site-packages";
     inherit hasDistutilsCxxPatch;
-    pythonPackagesBuildBuild = pkgsBuildBuild.${pythonAttr};
-    pythonPackagesBuildHost = pkgsBuildHost.${pythonAttr};
-    pythonPackagesBuildTarget = pkgsBuildTarget.${pythonAttr};
-    pythonPackagesHostHost = pkgsHostHost.${pythonAttr};
-    pythonPackagesTargetTarget = pkgsTargetTarget.${pythonAttr} or {};
+    pythonOnBuildForBuild = pkgsBuildBuild.${pythonAttr};
+    pythonOnBuildForHost = pkgsBuildHost.${pythonAttr};
+    pythonOnBuildForTarget = pkgsBuildTarget.${pythonAttr};
+    pythonOnHostForHost = pkgsHostHost.${pythonAttr};
+    pythonOnTargetForTarget = pkgsTargetTarget.${pythonAttr} or {};
   };
 
   version = with sourceVersion; "${major}.${minor}.${patch}${suffix}";

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -19,12 +19,11 @@
 , nukeReferences
 # For the Python package set
 , packageOverrides ? (self: super: {})
-, buildPackages
 , pkgsBuildBuild
+, pkgsBuildHost
 , pkgsBuildTarget
 , pkgsHostHost
 , pkgsTargetTarget
-, pythonForBuild ? buildPackages.${pythonAttr}
 , sourceVersion
 , sha256
 , passthruFun
@@ -58,7 +57,8 @@ assert bluezSupport -> bluez != null;
 with stdenv.lib;
 
 let
-
+  buildPackages = pkgsBuildHost;
+  inherit (passthru) pythonForBuild;
 
   passthru = passthruFun rec {
     inherit self sourceVersion packageOverrides;
@@ -67,8 +67,9 @@ let
     executable = libPrefix;
     pythonVersion = with sourceVersion; "${major}.${minor}";
     sitePackages = "lib/${libPrefix}/site-packages";
-    inherit hasDistutilsCxxPatch pythonForBuild;
+    inherit hasDistutilsCxxPatch;
     pythonPackagesBuildBuild = pkgsBuildBuild.${pythonAttr};
+    pythonPackagesBuildHost = pkgsBuildHost.${pythonAttr};
     pythonPackagesBuildTarget = pkgsBuildTarget.${pythonAttr};
     pythonPackagesHostHost = pkgsHostHost.${pythonAttr};
     pythonPackagesTargetTarget = pkgsTargetTarget.${pythonAttr} or {};
@@ -94,8 +95,6 @@ let
     ++ optionals stdenv.isDarwin [ configd ]);
 
   hasDistutilsCxxPatch = !(stdenv.cc.isGNU or false);
-
-  inherit pythonForBuild;
 
   pythonForBuildInterpreter = if stdenv.hostPlatform == stdenv.buildPlatform then
     "$out/bin/python"

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -14,12 +14,12 @@ with pkgs;
     , packageOverrides
     , sitePackages
     , hasDistutilsCxxPatch
-    , pythonPackagesBuildBuild
-    , pythonPackagesBuildHost
-    , pythonPackagesBuildTarget
-    , pythonPackagesHostHost
-    , self # is pythonPackagesHostTarget
-    , pythonPackagesTargetTarget
+    , pythonOnBuildForBuild
+    , pythonOnBuildForHost
+    , pythonOnBuildForTarget
+    , pythonOnHostForHost
+    , pythonOnTargetForTarget
+    , self # is pythonOnHostForTarget
     }: let
       pythonPackages = callPackage
         ({ pkgs, stdenv, python, overrides }: let
@@ -28,11 +28,11 @@ with pkgs;
             python = self;
           };
           otherSplices = {
-            selfBuildBuild = pythonPackagesBuildBuild;
-            selfBuildHost = pythonPackagesBuildHost;
-            selfBuildTarget = pythonPackagesBuildTarget;
-            selfHostHost = pythonPackagesHostHost;
-            selfTargetTarget = pythonPackagesTargetTarget;
+            selfBuildBuild = pythonOnBuildForBuild;
+            selfBuildHost = pythonOnBuildForHost;
+            selfBuildTarget = pythonOnBuildForTarget;
+            selfHostHost = pythonOnHostForHost;
+            selfTargetTarget = pythonOnTargetForTarget;
           };
           keep = self: {
             # TODO maybe only define these here so nothing is needed to be kept in sync.
@@ -100,7 +100,7 @@ with pkgs;
         pythonAtLeast = lib.versionAtLeast pythonVersion;
         pythonOlder = lib.versionOlder pythonVersion;
         inherit hasDistutilsCxxPatch;
-        pythonForBuild = pythonPackagesBuildHost;
+        pythonForBuild = pythonOnBuildForHost;
 
         tests = callPackage ./tests.nix {
           python = self;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -28,11 +28,11 @@ with pkgs;
             python = self;
           };
           otherSplices = {
-            selfBuildBuild = pythonOnBuildForBuild;
-            selfBuildHost = pythonOnBuildForHost;
-            selfBuildTarget = pythonOnBuildForTarget;
-            selfHostHost = pythonOnHostForHost;
-            selfTargetTarget = pythonOnTargetForTarget;
+            selfBuildBuild = pythonOnBuildForBuild.pkgs;
+            selfBuildHost = pythonOnBuildForHost.pkgs;
+            selfBuildTarget = pythonOnBuildForTarget.pkgs;
+            selfHostHost = pythonOnHostForHost.pkgs;
+            selfTargetTarget = pythonOnTargetForTarget.pkgs or {}; # There is no Python TargetTarget.
           };
           keep = self: {
             # TODO maybe only define these here so nothing is needed to be kept in sync.

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -100,6 +100,8 @@ with pkgs;
         pythonAtLeast = lib.versionAtLeast pythonVersion;
         pythonOlder = lib.versionOlder pythonVersion;
         inherit hasDistutilsCxxPatch;
+        # TODO: rename to pythonOnBuild
+        # Not done immediately because its likely used outside Nixpkgs.
         pythonForBuild = pythonOnBuildForHost;
 
         tests = callPackage ./tests.nix {

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -15,7 +15,7 @@ with pkgs;
     , sitePackages
     , hasDistutilsCxxPatch
     , pythonPackagesBuildBuild
-    , pythonForBuild # provides pythonPackagesBuildHost
+    , pythonPackagesBuildHost
     , pythonPackagesBuildTarget
     , pythonPackagesHostHost
     , self # is pythonPackagesHostTarget
@@ -29,7 +29,7 @@ with pkgs;
           };
           otherSplices = {
             selfBuildBuild = pythonPackagesBuildBuild;
-            selfBuildHost = pythonForBuild.pkgs;
+            selfBuildHost = pythonPackagesBuildHost;
             selfBuildTarget = pythonPackagesBuildTarget;
             selfHostHost = pythonPackagesHostHost;
             selfTargetTarget = pythonPackagesTargetTarget;
@@ -99,7 +99,8 @@ with pkgs;
         inherit sourceVersion;
         pythonAtLeast = lib.versionAtLeast pythonVersion;
         pythonOlder = lib.versionOlder pythonVersion;
-        inherit hasDistutilsCxxPatch pythonForBuild;
+        inherit hasDistutilsCxxPatch;
+        pythonForBuild = pythonPackagesBuildHost;
 
         tests = callPackage ./tests.nix {
           python = self;
@@ -188,7 +189,6 @@ in {
   # Minimal versions of Python (built without optional dependencies)
   python3Minimal = (python38.override {
     self = python3Minimal;
-    pythonForBuild = pkgs.buildPackages.python3Minimal;
     # strip down that python version as much as possible
     openssl = null;
     readline = null;

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -5,10 +5,16 @@
 , python-setup-hook
 # For the Python package set
 , packageOverrides ? (self: super: {})
+, pkgsBuildBuild
+, pkgsBuildHost
+, pkgsBuildTarget
+, pkgsHostHost
+, pkgsTargetTarget
 , sourceVersion
 , pythonVersion
 , sha256
 , passthruFun
+, pythonAttr ? "pypy${stdenv.lib.substring 0 1 pythonVersion}${stdenv.lib.substring 2 3 pythonVersion}"
 }:
 
 assert zlibSupport -> zlib != null;
@@ -25,12 +31,11 @@ let
     sitePackages = "site-packages";
     hasDistutilsCxxPatch = false;
 
-    # No cross-compiling for now.
-    pythonForBuild = self;
-    pythonPackagesBuildBuild = {};
-    pythonPackagesBuildTarget = {};
-    pythonPackagesHostHost = {};
-    pythonPackagesTargetTarget = {};
+    pythonPackagesBuildBuild = pkgsBuildBuild.${pythonAttr};
+    pythonPackagesBuildHost = pkgsBuildHost.${pythonAttr};
+    pythonPackagesBuildTarget = pkgsBuildTarget.${pythonAttr};
+    pythonPackagesHostHost = pkgsHostHost.${pythonAttr};
+    pythonPackagesTargetTarget = pkgsTargetTarget.${pythonAttr} or {};
   };
   pname = passthru.executable;
   version = with sourceVersion; "${major}.${minor}.${patch}";

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -31,11 +31,11 @@ let
     sitePackages = "site-packages";
     hasDistutilsCxxPatch = false;
 
-    pythonPackagesBuildBuild = pkgsBuildBuild.${pythonAttr};
-    pythonPackagesBuildHost = pkgsBuildHost.${pythonAttr};
-    pythonPackagesBuildTarget = pkgsBuildTarget.${pythonAttr};
-    pythonPackagesHostHost = pkgsHostHost.${pythonAttr};
-    pythonPackagesTargetTarget = pkgsTargetTarget.${pythonAttr} or {};
+    pythonOnBuildForBuild = pkgsBuildBuild.${pythonAttr};
+    pythonOnBuildForHost = pkgsBuildHost.${pythonAttr};
+    pythonOnBuildForTarget = pkgsBuildTarget.${pythonAttr};
+    pythonOnHostForHost = pkgsHostHost.${pythonAttr};
+    pythonOnTargetForTarget = pkgsTargetTarget.${pythonAttr} or {};
   };
   pname = passthru.executable;
   version = with sourceVersion; "${major}.${minor}.${patch}";

--- a/pkgs/development/interpreters/python/tests/test_nix_pythonprefix/default.nix
+++ b/pkgs/development/interpreters/python/tests/test_nix_pythonprefix/default.nix
@@ -4,7 +4,7 @@ let
 
   python = let
     packageOverrides = self: super: {
-      typeddep = super.callPackage ./typeddep {};
+      typeddep = self.callPackage ./typeddep {};
     };
   in interpreter.override {inherit packageOverrides; self = python;};
 


### PR DESCRIPTION
Follow-up to #104201, related to #105113.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
