### PR TITLE
poweralertd: init at 0.1.0

### DIFF
--- a/pkgs/tools/misc/poweralertd/default.nix
+++ b/pkgs/tools/misc/poweralertd/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromSourcehut, meson, ninja, pkg-config, scdoc, systemd }:
+
+stdenv.mkDerivation rec {
+  pname = "poweralertd";
+  version = "0.1.0";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromSourcehut {
+    owner = "~kennylevinsen";
+    repo = "poweralertd";
+    rev = version;
+    sha256 = "136xcrp7prilh905a6v933vryqy20l7nw24ahc4ycax8f0s906x9";
+  };
+
+  patchPhase = ''
+    substituteInPlace meson.build --replace "systemd.get_pkgconfig_variable('systemduserunitdir')" "'${placeholder "out"}/lib/systemd/user'"
+  '';
+
+  buildInputs = [
+    systemd
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  depsBuildBuild = [
+    scdoc
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "UPower-powered power alerter";
+    homepage = "https://git.sr.ht/~kennylevinsen/poweralertd";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thibautmarty ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2860,6 +2860,8 @@ in
 
   playerctl = callPackage ../tools/audio/playerctl { };
 
+  poweralertd = callPackage ../tools/misc/poweralertd { };
+
   ps_mem = callPackage ../tools/system/ps_mem { };
 
   psstop = callPackage ../tools/system/psstop { };


### PR DESCRIPTION
###### Motivation for this change

poweralertd package from https://git.sr.ht/~kennylevinsen/poweralertd.

###### Things done

The package ships with a systemd user file which works, although I patched the `meson.build` file to put the service file in the derivation's output instead or trying to put it in `/nix/store/…-systemd-246.6/lib/systemd/user`.

Note: depends on #104920 for the maintainer entry.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
