### PR TITLE
plex: Add an updateScript

### DIFF
--- a/pkgs/servers/plex/raw.nix
+++ b/pkgs/servers/plex/raw.nix
@@ -1,6 +1,10 @@
 { stdenv
 , fetchurl
 , dpkg
+, writeScript
+, curl
+, jq
+, common-updater-scripts
 }:
 
 # The raw package that fetches and extracts the Plex RPM. Override the source
@@ -51,6 +55,27 @@ stdenv.mkDerivation rec {
   dontStrip = true;
   dontPatchELF = true;
   dontAutoPatchelf = true;
+
+  passthru.updateScript = writeScript "${pname}-updater" ''
+    #!${stdenv.shell}
+    set -eu -o pipefail
+    PATH=${stdenv.lib.makeBinPath [curl jq common-updater-scripts]}:$PATH
+
+    plexApiJson=$(curl -sS https://plex.tv/api/downloads/5.json)
+    latestVersion="$(echo $plexApiJson | jq .computer.Linux.version | tr -d '"\n')"
+
+    for platform in ${stdenv.lib.concatStringsSep " " meta.platforms}; do
+      arch=$(echo $platform | cut -d '-' -f1)
+      dlUrl="$(echo $plexApiJson | jq --arg arch "$arch" -c '.computer.Linux.releases[] | select(.distro == "debian") | select(.build | contains($arch)) .url' | tr -d '"\n')"
+
+      latestSha="$(nix-prefetch-url $dlUrl)"
+
+      # The script will not perform an update when the version attribute is up to date from previous platform run
+      # We need to clear it before each run
+      update-source-version plexRaw 0 $(yes 0 | head -64 | tr -d "\n") --system=$platform
+      update-source-version plexRaw "$latestVersion" "$latestSha" --system=$platform
+    done
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://plex.tv/";


### PR DESCRIPTION
###### Motivation for this change
Plex has a JSON API endpoint with download links and checksums for the media server. These checksums are `sha1` so it's convenient to change the current `sha256` to match that `sha1`

###### Things done
- Use the Plex JSON API to fetch checksums
- Switch current `sha256` checksums with `sha1` versions
- Add an updateScript that sets version and checksums based on this JSON API