### PR TITLE
libmtp: fix sha

### DIFF
--- a/pkgs/development/libraries/libmtp/default.nix
+++ b/pkgs/development/libraries/libmtp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "libmtp";
     repo = "libmtp";
     rev = "libmtp-${builtins.replaceStrings [ "." ] [ "-" ] version}";
-    sha256 = "0lniy0xq397zddlhsv6n4qjn0wwakli5p3ydzxmbzn0z0jgngjja";
+    sha256 = "0rya6dsb67a7ny2i1jzdicnday42qb8njqw6r902k712k5p7d1r9";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
###### Motivation for this change
incorrectly added in c75b9da41d35619b135a3c9ecf4843328f604ca9 #104000

```
hash mismatch in fixed-output derivation '/nix/store/x8zj5b5kjb6r4m7zpkpv9bm1f39y8z3j-source':
  wanted: sha256:0lniy0xq397zddlhsv6n4qjn0wwakli5p3ydzxmbzn0z0jgngjja
  got:    sha256:0rya6dsb67a7ny2i1jzdicnday42qb8njqw6r902k712k5p7d1r9
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
