### PR TITLE
firejail: fix -overlay and -build functionality on NixOS

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -20,6 +20,15 @@ stdenv.mkDerivation {
     name = "${s.name}.tar.bz2";
   };
 
+  patches = [
+    # Adds the /nix directory when using an overlay.
+    # Required to run any programs under this mode.
+    ./mount-nix-dir-on-overlay.patch
+    # By default fbuilder hardcodes the firejail binary to the install path.
+    # On NixOS the firejail binary is a setuid wrapper available in $PATH.
+    ./fbuilder-call-firejail-on-path.patch
+  ];
+
   prePatch = ''
     # Allow whitelisting ~/.nix-profile
     substituteInPlace etc/firejail.config --replace \

--- a/pkgs/os-specific/linux/firejail/fbuilder-call-firejail-on-path.patch
+++ b/pkgs/os-specific/linux/firejail/fbuilder-call-firejail-on-path.patch
@@ -1,0 +1,11 @@
+--- a/src/fbuilder/build_profile.c
++++ b/src/fbuilder/build_profile.c
+@@ -67,7 +67,7 @@
+ 		errExit("asprintf");
+ 
+ 	char *cmdlist[] = {
+-	  BINDIR "/firejail",
++	  "firejail",
+ 	  "--quiet",
+ 	  "--noprofile",
+ 	  "--caps.drop=all",

--- a/pkgs/os-specific/linux/firejail/mount-nix-dir-on-overlay.patch
+++ b/pkgs/os-specific/linux/firejail/mount-nix-dir-on-overlay.patch
@@ -1,0 +1,27 @@
+--- a/src/firejail/fs.c
++++ b/src/firejail/fs.c
+@@ -1143,6 +1143,16 @@
+ 		errExit("mounting /dev");
+ 	fs_logger("whitelist /dev");
+ 
++	// mount-bind /nix
++	if (arg_debug)
++		printf("Mounting /nix\n");
++	char *nix;
++	if (asprintf(&nix, "%s/nix", oroot) == -1)
++		errExit("asprintf");
++	if (mount("/nix", nix, NULL, MS_BIND|MS_REC, NULL) < 0)
++		errExit("mounting /nix");
++	fs_logger("whitelist /nix");
++
+ 	// mount-bind run directory
+ 	if (arg_debug)
+ 		printf("Mounting /run\n");
+@@ -1201,6 +1211,7 @@
+ 	free(odiff);
+ 	free(owork);
+ 	free(dev);
++	free(nix);
+ 	free(run);
+ 	free(tmp);
+ }


### PR DESCRIPTION
- The `-overlay` flag runs the specified binary inside an OverlayFS,
  since the /nix store may be in a different mount point than the user
  home, this patch explicitly bind mounts it so it's available inside
  the overlay.

- profile builder: firejail provides facilities to build a new profiles.
  To do so, it execute the helper binary `fbuilder`, which in turn will
  execute firejail back with different options. This patch makes it use
  the binary available in PATH instead of the one produced at compile time.
  The compiled firejail binary doesn't have the necessary permissions,
  so the firejail NixOS module wraps it in a SUID wrapper available on
  PATH at runtime.

Signed-off-by: Roosembert Palacios <roosemberth@posteo.ch>

Mind that testing with `nixos-rebuild build-vm` does not work because `build-vm` itself uses an overlayfs to mount the nix store.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixing non-working functionality of firejail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
