### PR TITLE
QMPlay2: init at 20.07.04

### DIFF
--- a/pkgs/applications/video/qmplay2/default.nix
+++ b/pkgs/applications/video/qmplay2/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, alsaLib
+, ffmpeg
+, libass
+, libcddb
+, libcdio
+, libgme
+, libpulseaudio
+, libsidplayfp
+, libva
+, libXv
+, taglib
+, qtbase
+, qttools
+, vulkan-headers
+, vulkan-tools
+, wrapQtAppsHook
+}:
+
+let
+  pname = "qmplay2";
+  version = "20.07.04";
+in stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "zaps166";
+    repo = "QMPlay2";
+    rev = version;
+    sha256 = "sha256-sUDucxSvsdD2C2FSVrrXeHdNdrjECtJSXVr106OdHzA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+  buildInputs = [
+    alsaLib
+    ffmpeg
+    libass
+    libcddb
+    libcdio
+    libgme
+    libpulseaudio
+    libsidplayfp
+    libva
+    libXv
+    qtbase
+    qttools
+    taglib
+    vulkan-headers
+    vulkan-tools
+  ];
+
+  postInstall = ''
+    # Because we think it is better to use only lowercase letters!
+    ln -s $out/bin/QMPlay2 $out/bin/qmplay2
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/zaps166/QMPlay2/";
+    description = "Qt-based Multimedia player";
+    longDescription = ''
+      QMPlay2 is a video and audio player. It can play all formats supported by
+      FFmpeg, libmodplug (including J2B and SFX). It also supports Audio CD, raw
+      files, Rayman 2 music and chiptunes. It contains YouTube and MyFreeMP3
+      browser.
+    '';
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23371,6 +23371,8 @@ in
     boost = boost17x;
   };
 
+  qmplay2 = libsForQt5.callPackage ../applications/video/qmplay2 { };
+
   qmetro = callPackage ../applications/misc/qmetro { };
 
   qmidiarp = callPackage ../applications/audio/qmidiarp {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
