### PR TITLE
eddie-ui: init at 2.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10970,4 +10970,10 @@
     github = "zupo";
     githubId = 311580;
   };
+  vanbeast = {
+    name = "Ivan Shramko";
+    email = "vanbeast@gmail.com";
+    github = "vanbeast";
+    githubId = 641935;
+  };
 }

--- a/pkgs/applications/networking/eddie-ui/default.nix
+++ b/pkgs/applications/networking/eddie-ui/default.nix
@@ -1,0 +1,104 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, mono
+, dotnet-sdk
+, which
+, pkg-config
+, gtk2
+, libappindicator-gtk2
+, lzma
+, libselinux
+, libsepol
+, fribidi
+, libthai
+, libdatrie
+, xorg
+, openvpn
+, stunnel
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eddie-ui";
+  version = "2.20.0";
+
+  arch = if stdenv.system == "i686-linux"
+    then "x86"
+    else "x64";
+
+  src = fetchFromGitHub {
+    owner = "AirVPN";
+    repo = "Eddie";
+    rev = version;
+    sha256 = "0wack2xc5vk2b5i6knhqqcppdc3cml1swys3kprdpazrcim79yvg";
+  };
+
+  buildInputs = [ openvpn mono stunnel ];
+  nativeBuildInputs = [
+    pkg-config which cmake dotnet-sdk gtk2 lzma.dev libappindicator-gtk2.dev
+    libselinux libsepol fribidi libthai libdatrie xorg.libXdmcp
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  postPatch = ''
+    # Fix libappindicator include directory
+    substituteInPlace src/UI.GTK.Linux.Tray/CMakeLists.txt \
+      --replace '/usr/include/libappindicator-0.1' '${libappindicator-gtk2.dev}/include/libappindicator-0.1';
+
+    # doesn't build with '-static' option, so removing it in line 35
+    substituteInPlace src/App.CLI.Linux.Elevated/build.sh --replace '-static -pthread' '-pthread'
+
+    chmod -R +w .
+    find . -type f -iname "*.sh" -exec chmod +x {} \;
+    patchShebangs .
+  '';
+
+  buildPhase = ''
+    # Compile C# sources
+    xbuild /verbosity:minimal /p:Configuration="Release" /p:Platform="$arch" src/eddie2.linux.ui.sln
+
+    # Compile C sources (Tray)
+    cd src/UI.GTK.Linux.Tray
+    ./build-$arch.sh
+    cd ../..
+
+    # Compile C sources
+    src/eddie.linux.postbuild.sh "src/App.Forms.Linux/bin/$arch/Release/" ui $arch Release
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/lib/eddie-ui
+    cp repository/linux_arch/bundle/eddie-ui/usr/bin/eddie-ui $out/bin/eddie-ui
+    substituteInPlace $out/bin/eddie-ui --replace '/usr/' $out/
+    chmod +x $out/bin/eddie-ui
+    cp -r ./src/App.Forms.Linux/bin/$arch/Release/* $out/lib/eddie-ui
+    mv $out/lib/eddie-ui/App.Forms.Linux.exe $out/lib/eddie-ui/eddie-ui.exe
+    mkdir -p $out/share/eddie-ui/lang
+    cp common/cacert.pem $out/share/eddie-ui/
+    cp common/icon.png $out/share/eddie-ui/
+    cp common/icon_gray.png $out/share/eddie-ui/
+    cp common/icon.png $out/share/eddie-ui/tray.png
+    cp common/icon_gray.png $out/share/eddie-ui/tray_gray.png
+    cp common/iso-3166.json $out/share/eddie-ui/iso-3166.json
+    cp common/lang/inv.json $out/share/eddie-ui/lang/inv.json
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "AirVPN GUI Client";
+    longDescription = ''
+        Eddie is a OpenVPN GUI for AirVPN. AirVPN is based on OpenVPN and operated by activists and hacktivists in defence of net neutrality, privacy and against censorship.
+    '';
+    homepage = "https://eddie.website/";
+    changelog = "https://eddie.website/changelog/?software=client&format=html";
+    maintainers = with maintainers; [vanbeast];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22203,6 +22203,8 @@ in
 
   edbrowse = callPackage ../applications/editors/edbrowse { };
 
+  eddie-ui = callPackage ../applications/networking/eddie-ui/default.nix { };
+
   ekho = callPackage ../applications/audio/ekho { };
 
   electron-cash = libsForQt5.callPackage ../applications/misc/electron-cash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/73233
Used build scripts for Arch as a reference. 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
