### PR TITLE
postgresqlPackages.pg_topn: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_topn.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_topn.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pg_topn";
-  version = "2.3.0";
+  version = "2.3.1";
 
   buildInputs = [ postgresql ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner  = "citusdata";
     repo   = "postgresql-topn";
     rev    = "refs/tags/v${version}";
-    sha256 = "05mjzm7rz5j7byzag23526hhsqsg4dsyxxsg8q9ray1rwxjbr392";
+    sha256 = "0ai07an90ywhk10q52hajgb33va5q76j7h8vj1r0rvq6dyii0wal";
   };
 
   installPhase = ''
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Efficient querying of 'top values' for PostgreSQL";
     homepage    = "https://github.com/citusdata/postgresql-topn";
+    changelog   = "https://github.com/citusdata/postgresql-topn/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [ thoughtpolice ];
     platforms   = postgresql.meta.platforms;
     license     = licenses.agpl3;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
>https://github.com/citusdata/postgresql-topn/blob/v2.3.1/CHANGELOG.md
>* Adds PostgreSQL 13 support
>* Supports parallel queries and aggregates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
