### PR TITLE
SDL2_mixer: enable midi by default, cleanup package

### DIFF
--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -1,7 +1,19 @@
-{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig, which
-, SDL2, libogg, libvorbis, smpeg2, flac, libmodplug, opusfile, mpg123
-, CoreServices, AudioUnit, AudioToolbox
-, enableNativeMidi ? false, fluidsynth ? null }:
+{ stdenv
+, fetchurl
+, pkg-config
+, AudioToolbox
+, AudioUnit
+, CoreServices
+, SDL2
+, flac
+, fluidsynth
+, libmodplug
+, libogg
+, libvorbis
+, mpg123
+, opusfile
+, smpeg2
+}:
 
 stdenv.mkDerivation rec {
   pname = "SDL2_mixer";
@@ -12,19 +24,37 @@ stdenv.mkDerivation rec {
     sha256 = "0694vsz5bjkcdgfdra6x9fq8vpzrl8m6q96gh58df7065hw5mkxl";
   };
 
-  preAutoreconf = ''
-    aclocal
-  '';
+  nativeBuildInputs = [ pkg-config ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig which ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    AudioToolbox
+    AudioUnit
+    CoreServices
+  ];
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices AudioUnit AudioToolbox ];
+  propagatedBuildInputs = [
+    SDL2
+    flac
+    fluidsynth
+    libmodplug
+    libogg
+    libvorbis
+    mpg123
+    opusfile
+    smpeg2
+  ];
 
-  propagatedBuildInputs = [ SDL2 libogg libvorbis fluidsynth smpeg2 flac libmodplug opusfile mpg123 ];
-
-  configureFlags = [ "--disable-music-ogg-shared" ]
-    ++ lib.optional enableNativeMidi "--enable-music-native-midi-gpl"
-    ++ lib.optionals stdenv.isDarwin [ "--disable-sdltest" "--disable-smpegtest" ];
+  configureFlags = [
+    "--disable-music-ogg-shared"
+    "--disable-music-flac-shared"
+    "--disable-music-mod-modplug-shared"
+    "--disable-music-mp3-mpg123-shared"
+    "--disable-music-opus-shared"
+    "--disable-music-midi-fluidsynth-shared"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "--disable-sdltest"
+    "--disable-smpegtest"
+  ];
 
   meta = with stdenv.lib; {
     description = "SDL multi-channel audio mixer library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* rework of https://github.com/NixOS/nixpkgs/pull/70421

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
