### PR TITLE
ocamlPackages.mirage-types{,-lwt}: init at 3.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage/types-lwt.nix
+++ b/pkgs/development/ocaml-modules/mirage/types-lwt.nix
@@ -1,0 +1,13 @@
+{ lib, buildDunePackage, mirage-types
+}:
+
+buildDunePackage {
+  pname = "mirage-types-lwt";
+  inherit (mirage-types) version src useDune2;
+
+  propagatedBuildInputs = [ mirage-types ];
+
+  meta = mirage-types.meta // {
+    description = "Lwt module type definitions for MirageOS applications";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage/types.nix
+++ b/pkgs/development/ocaml-modules/mirage/types.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, mirage
+, mirage-block, mirage-channel, mirage-clock, mirage-console, mirage-device
+, mirage-flow, mirage-fs, mirage-kv, mirage-net, mirage-protocols, mirage-random
+, mirage-stack, mirage-time
+}:
+
+buildDunePackage {
+  pname = "mirage-types";
+  inherit (mirage) src version useDune2;
+
+  propagatedBuildInputs = [ mirage-block mirage-channel mirage-clock
+    mirage-console mirage-device mirage-flow mirage-fs mirage-kv mirage-net
+    mirage-protocols mirage-random mirage-stack mirage-time
+  ];
+
+  meta = mirage.meta // {
+    description = "Module type definitions for MirageOS applications";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -601,6 +601,8 @@ let
 
     mirage-types = callPackage ../development/ocaml-modules/mirage/types.nix { };
 
+    mirage-types-lwt = callPackage ../development/ocaml-modules/mirage/types-lwt.nix { };
+
     mirage-unix = callPackage ../development/ocaml-modules/mirage-unix { };
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -599,6 +599,8 @@ let
 
     mirage-time-unix = callPackage ../development/ocaml-modules/mirage-time/unix.nix { };
 
+    mirage-types = callPackage ../development/ocaml-modules/mirage/types.nix { };
+
     mirage-unix = callPackage ../development/ocaml-modules/mirage-unix { };
 
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };


### PR DESCRIPTION
###### Motivation for this change

#23955

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
