### PR TITLE
EXPERIMENTAL: replace bash with oil

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -125,7 +125,7 @@ autoPatchelfFile() {
     # This ensures that we get the output of all missing dependencies instead
     # of failing at the first one, because it's more useful when working on a
     # new package where you don't yet know its dependencies.
-    local -i depNotFound=0
+    local depNotFound=0
 
     for dep in $missing; do
         echo -n "  $dep -> " >&2

--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "oil";
-  version = "0.8.4";
+  version = "0.8.5";
 
   src = fetchurl {
     url = "https://www.oilshell.org/download/oil-${version}.tar.xz";
-    sha256 = "0ydqwyghnkgbpsdi49vnrx2khs3y0d0bzdzcvjjr999ycmnirz88";
+    sha256 = "1z0p08q4808h78bp6nwdszpfavhr4y7n313bp0gg5qdbssnciq1v";
   };
 
   postPatch = ''
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-      shellPath = "/bin/osh";
+    shellPath = "/bin/osh";
   };
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1097,6 +1097,7 @@ installPhase() {
     runHook postInstall
 }
 
+declare -a fixupOutputHooks=()
 
 # The fixup phase performs generic, package-independent stuff, like
 # stripping binaries, running patchelf and setting

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -374,24 +374,24 @@ in
       };
 
       # Mainly avoid reference to bootstrap tools
-      allowedRequisites = with prevStage; with lib;
-        # Simple executable tools
-        concatMap (p: [ (getBin p) (getLib p) ]) [
-            gzip bzip2 xz bash binutils.bintools coreutils diffutils findutils
-            gawk gnumake gnused gnutar gnugrep gnupatch patchelf ed
-          ]
-        # Library dependencies
-        ++ map getLib (
-            [ attr acl zlib pcre libidn2 libunistring ]
-            ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
-          )
-        # More complicated cases
-        ++ (map (x: getOutput x (getLibc prevStage)) [ "out" "dev" "bin" ] )
-        ++  [ /*propagated from .dev*/ linuxHeaders
-            binutils gcc gcc.cc gcc.cc.lib gcc.expand-response-params
-          ]
-          ++ lib.optionals (!localSystem.isx86 || localSystem.libc == "musl")
-            [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
+      # allowedRequisites = with prevStage; with lib;
+      #   # Simple executable tools
+      #   concatMap (p: [ (getBin p) (getLib p) ]) [
+      #       gzip bzip2 xz bash binutils.bintools coreutils diffutils findutils
+      #       gawk gnumake gnused gnutar gnugrep gnupatch patchelf ed
+      #     ]
+      #   # Library dependencies
+      #   ++ map getLib (
+      #       [ attr acl zlib pcre libidn2 libunistring ]
+      #       ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
+      #     )
+      #   # More complicated cases
+      #   ++ (map (x: getOutput x (getLibc prevStage)) [ "out" "dev" "bin" ] )
+      #   ++  [ /*propagated from .dev*/ linuxHeaders
+      #       binutils gcc gcc.cc gcc.cc.lib gcc.expand-response-params
+      #     ]
+      #     ++ lib.optionals (!localSystem.isx86 || localSystem.libc == "musl")
+      #       [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ];
 
       overrides = self: super: {
         inherit (prevStage)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8579,8 +8579,12 @@ in
     passthru.shellPath = "/bin/bash";
   } ''
     mkdir -p $out/bin
+    cat <<PROG > $out/bin/bash
+    #!${oil}/bin/osh
+    exec ${oil}/bin/osh "$@"
+    PROG
+    chmod +x "$out/bin/bash"
     ln -s ${oil}/bin/osh $out/bin/sh
-    ln -s ${oil}/bin/osh $out/bin/bash
   '';
 
   bash = lowPrio (burning-oil);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8575,7 +8575,13 @@ in
 
   any-nix-shell = callPackage ../shells/any-nix-shell { };
 
-  bash = lowPrio (callPackage ../shells/bash/4.4.nix { });
+  burning-oil = pkgs.runCommand "bash-oil" {} ''
+    mkdir -p $out/bin
+    ln -s ${oil}/bin/osh $out/bin/sh
+    ln -s ${oil}/bin/osh $out/bin/bash
+  '';
+
+  bash = lowPrio (burning-oil);
   bash_5 = lowPrio (callPackage ../shells/bash/5.0.nix { });
   bashInteractive_5 = lowPrio (callPackage ../shells/bash/5.0.nix {
     interactive = true;
@@ -8583,10 +8589,7 @@ in
   });
 
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = callPackage ../shells/bash/4.4.nix {
-    interactive = true;
-    withDocs = true;
-  };
+  bashInteractive = burning-oil;
 
   bash-completion = callPackage ../shells/bash/bash-completion { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8575,7 +8575,9 @@ in
 
   any-nix-shell = callPackage ../shells/any-nix-shell { };
 
-  burning-oil = pkgs.runCommand "bash-oil" {} ''
+  burning-oil = pkgs.runCommand "bash-oil" {
+    passthru.shellPath = "/bin/bash";
+  } ''
     mkdir -p $out/bin
     ln -s ${oil}/bin/osh $out/bin/sh
     ln -s ${oil}/bin/osh $out/bin/bash

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8581,7 +8581,7 @@ in
     mkdir -p $out/bin
     cat <<PROG > $out/bin/bash
     #!${oil}/bin/osh
-    exec ${oil}/bin/osh "$@"
+    exec ${oil}/bin/osh "\$@"
     PROG
     chmod +x "$out/bin/bash"
     ln -s ${oil}/bin/osh $out/bin/sh


### PR DESCRIPTION
http://www.oilshell.org/ is supposed to be compatible with Bash. Let's
find out if it's true!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
