### PR TITLE
gnome-passwordsafe: fix build

### DIFF
--- a/pkgs/applications/misc/gnome-passwordsafe/default.nix
+++ b/pkgs/applications/misc/gnome-passwordsafe/default.nix
@@ -5,7 +5,7 @@
 , gettext
 , fetchFromGitLab
 , python3
-, libhandy
+, libhandy_0
 , libpwquality
 , wrapGAppsHook
 , gtk3
@@ -44,7 +44,7 @@ python3.pkgs.buildPythonApplication rec {
     gtk3
     glib
     gdk-pixbuf
-    libhandy
+    libhandy_0
   ];
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updating libhandy to 1 broke this.

###### Things done
Switched to libhandy_0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
