### PR TITLE
libmicrohttpd dependents: fix build

### DIFF
--- a/pkgs/applications/audio/faust/faustlive.nix
+++ b/pkgs/applications/audio/faust/faustlive.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, llvm, qt48Full, qrencode, libmicrohttpd, libjack2, alsaLib, faust, curl
+, llvm, qt48Full, qrencode, libmicrohttpd_0_9_70, libjack2, alsaLib, faust, curl
 , bc, coreutils, which, libsndfile, pkg-config
 }:
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    llvm qt48Full qrencode libmicrohttpd libjack2 alsaLib faust curl
+    llvm qt48Full qrencode libmicrohttpd_0_9_70 libjack2 alsaLib faust curl
     bc coreutils which libsndfile pkg-config
   ];
 

--- a/pkgs/applications/misc/xmr-stak/default.nix
+++ b/pkgs/applications/misc/xmr-stak/default.nix
@@ -1,5 +1,5 @@
 { stdenv, stdenvGcc6, lib
-, fetchFromGitHub, cmake, libmicrohttpd, openssl
+, fetchFromGitHub, cmake, libmicrohttpd_0_9_70, openssl
 , opencl-headers, ocl-icd, hwloc, cudatoolkit
 , devDonationLevel ? "0.0"
 , cudaSupport ? false
@@ -27,7 +27,7 @@ stdenv'.mkDerivation rec {
     ++ lib.optional (!openclSupport) "-DOpenCL_ENABLE=OFF";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ libmicrohttpd openssl hwloc ]
+  buildInputs = [ libmicrohttpd_0_9_70 openssl hwloc ]
     ++ lib.optional cudaSupport cudatoolkit
     ++ lib.optionals openclSupport [ opencl-headers ocl-icd ];
 

--- a/pkgs/development/libraries/libmicrohttpd/0.9.70.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.70.nix
@@ -1,0 +1,10 @@
+{ stdenv, callPackage, fetchurl }:
+
+callPackage ./generic.nix ( rec {
+  version = "0.9.70";
+
+  src = fetchurl {
+    url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
+    sha256 = "01vkjy89b1ylmh22dy5yza2r414nfwcfixxh3v29nvzrjv9s7l4h";
+  };
+})

--- a/pkgs/development/libraries/libmicrohttpd/0.9.71.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.71.nix
@@ -1,0 +1,10 @@
+{ stdenv, callPackage, fetchurl }:
+
+callPackage ./generic.nix ( rec {
+  version = "0.9.71";
+
+  src = fetchurl {
+    url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
+    sha256 = "10mii4mifmfs3v7kgciqml7f0fj7ljp0sngrx64pnwmgbzl4bx78";
+  };
+})

--- a/pkgs/development/libraries/libmicrohttpd/generic.nix
+++ b/pkgs/development/libraries/libmicrohttpd/generic.nix
@@ -1,13 +1,8 @@
-{ stdenv, fetchurl, libgcrypt, curl, gnutls, pkgconfig, libiconv, libintl }:
+{ stdenv, libgcrypt, curl, gnutls, pkgconfig, libiconv, libintl, version, src }:
 
 stdenv.mkDerivation rec {
   pname = "libmicrohttpd";
-  version = "0.9.71";
-
-  src = fetchurl {
-    url = "mirror://gnu/libmicrohttpd/${pname}-${version}.tar.gz";
-    sha256 = "10mii4mifmfs3v7kgciqml7f0fj7ljp0sngrx64pnwmgbzl4bx78";
-  };
+  inherit version src;
 
   outputs = [ "out" "dev" "devdoc" "info" ];
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/fileshare/default.nix
+++ b/pkgs/servers/fileshare/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, pkgconfig, git, libmicrohttpd }:
+{ stdenv, lib, fetchgit, pkgconfig, git, libmicrohttpd_0_9_70 }:
 
 stdenv.mkDerivation rec {
   pname = "fileshare";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkgconfig git ];
-  buildInputs = [ libmicrohttpd ];
+  buildInputs = [ libmicrohttpd_0_9_70 ];
 
   makeFlags = [ "BUILD=release" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14289,7 +14289,9 @@ in
 
   libmemcached = callPackage ../development/libraries/libmemcached { };
 
-  libmicrohttpd = callPackage ../development/libraries/libmicrohttpd { };
+  libmicrohttpd_0_9_70 = callPackage ../development/libraries/libmicrohttpd/0.9.70.nix { };
+  libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
+  libmicrohttpd = libmicrohttpd_0_9_71;
 
   libmikmod = callPackage ../development/libraries/libmikmod {
     inherit (darwin.apple_sdk.frameworks) CoreAudio;


### PR DESCRIPTION
###### Motivation for this change

microhttpd 0.9.71 introduced a breaking change that broke xmr-stak (and possibly other packages, I will be checking others)

This PR updates the libmicrohttpd derivation to allow for having multiple versions of it in nixpkgs, and updates xmr-stak, fileshare, and faustlive to use 0.9.70, prior to the breaking change.

cpp-ethereum (now known as aleth) is also broken due to this - however, it requires libjon-rpc-cpp to be fixed as well.

Additionally, aleth is now abandon ware (https://gitter.im/ethereum/aleth?at=5e7cb22c2520175199ead0ba), it may be worthwhile to consider removing it since nothing seems to depend on it, and actually running it will not get you very far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
