### PR TITLE
ceph: 15.2.5 -> 15.2.6

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -135,11 +135,6 @@ in rec {
     patches = [
       ./0000-fix-SPDK-build-env.patch
       ./ceph-glibc-2-32-sigdescr_np.patch
-      (fetchpatch {
-        name = "CVE-2020-25660";
-        url = "https://github.com/ceph/ceph/compare/2c93eff00150f0cc5f106a559557a58d3d7b6f1f...6c14c2fb5650426285428dfe6ca1597e5ea1d07d.patch";
-        sha256 = "032hl15q34gq7y6bnljmklpsbd3bpkzmg7r3w0x0ly786iz7zwhm";
-      })
     ];
 
     nativeBuildInputs = [

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -122,10 +122,10 @@ let
   ]);
   sitePackages = ceph-python-env.python.sitePackages;
 
-  version = "15.2.5";
+  version = "15.2.6";
   src = fetchurl {
     url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-    sha256 = "05p7ssbfypf5x8bry361rrnyaihf89xzbqzhygdyrg7w1rxpna8d";
+    sha256 = "093pphgqrkrbv3484ayl0vac6a6s53zxa01yad0cbvnx0kyj55hh";
   };
 in rec {
   ceph = stdenv.mkDerivation {


### PR DESCRIPTION
Supercedes #104082 

Master still won't build until python issues are fixed in staging, but I want to get this into 20.09 soon, so I will cherry-pick from this.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
