### PR TITLE
gnome3.gnome-tweaks: use buildPythonApplication

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
@@ -1,40 +1,67 @@
-{ stdenv, meson, ninja, gettext, fetchurl
-, pkgconfig, gtk3, glib, libsoup, gsettings-desktop-schemas
-, itstool, libxml2, python3Packages, libhandy_0
-, gnome3, gdk-pixbuf, libnotify, gobject-introspection, wrapGAppsHook }:
+{ lib
+, meson
+, ninja
+, fetchurl
+, gdk-pixbuf
+, gettext
+, glib
+, gnome3
+, gobject-introspection
+, gsettings-desktop-schemas
+, gtk3
+, itstool
+, libhandy_0
+, libnotify
+, libsoup
+, libxml2
+, pkg-config
+, python3Packages
+, wrapGAppsHook }:
 
-let
+python3Packages.buildPythonApplication rec {
   pname = "gnome-tweaks";
   version = "3.34.0";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  format = "other";
+  strictDeps = false; # https://github.com/NixOS/nixpkgs/issues/56943
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0l2j42ba7v866iknygamnkiq7igh0fjvq92r93cslvvfnkx2ccq0";
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext itstool libxml2 wrapGAppsHook python3Packages.python
+    gettext
+    gobject-introspection
+    itstool
+    libxml2
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
   ];
+
   buildInputs = [
-    gtk3 glib gsettings-desktop-schemas
-    gdk-pixbuf gnome3.adwaita-icon-theme
-    libnotify gnome3.gnome-shell python3Packages.pygobject3
-    libsoup gnome3.gnome-settings-daemon gnome3.nautilus
-    gnome3.mutter gnome3.gnome-desktop gobject-introspection
-    gnome3.nautilus libhandy_0
+    gdk-pixbuf
+    glib
+    gnome3.gnome-desktop
+    gnome3.gnome-settings-daemon
+    gnome3.gnome-shell
     # Makes it possible to select user themes through the `user-theme` extension
     gnome3.gnome-shell-extensions
+    gnome3.mutter
+    gsettings-desktop-schemas
+    gtk3
+    libhandy_0
+    libnotify
+    libsoup
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
   ];
 
   postPatch = ''
     patchShebangs meson-postinstall.py
-  '';
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:$PYTHONPATH")
   '';
 
   passthru = {
@@ -44,7 +71,7 @@ in stdenv.mkDerivation rec {
     };
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://wiki.gnome.org/action/show/Apps/GnomeTweakTool";
     description = "A tool to customize advanced GNOME 3 options";
     maintainers = teams.gnome.members;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/projects/30#card-45845339

###### Things done
Change from stdenv.mkDerivation to python3Packages.buildPythonApplication
removed nautilus dependency, I think that is only for desktop icons on gnome <= 3.26

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
