### PR TITLE
libxml2: upstream patch for Python 3.9.

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -37,6 +37,13 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/libxml2/commit/6088a74bcf7d0c42e24cff4594d804e1d3c9fbca.patch";
       sha256 = "070s7al2r2k92320h9cdfc2097jy4kk04d0disc98ddc165r80jl";
     })
+    # Fix compatibility with Python 3.9.
+    # https://gitlab.gnome.org/GNOME/libxml2/-/issues/149
+    (fetchpatch {
+      name = "python39.patch";
+      url = "https://gitlab.gnome.org/nwellnhof/libxml2/-/commit/e4fb36841800038c289997432ca547c9bfef9db1.patch";
+      sha256 = "0h3vpy9fg3339b14qa64640ypp65z3hrrrmpjl8qm72srkp24ci5";
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "man" "doc" ]


### PR DESCRIPTION
###### Motivation for this change

`libxml2` is broken with Python 3.9 (and, presumably, 3.10). This patch doesn't change any functionality, it simply fixes a parsing error.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
