### PR TITLE
gnomeExtensions.gsconnect: fix installed tests

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -9,15 +9,12 @@
 , gobject-introspection
 , wrapGAppsHook
 , glib
+, glib-networking
 , gtk3
 , openssh
 , gnome3
 , gjs
 , nixosTests
-, atk
-, harfbuzz
-, pango
-, gdk-pixbuf
 , gsettings-desktop-schemas
 }:
 
@@ -55,6 +52,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib # libgobject
+    glib-networking
     gtk3
     gsound
     gjs # for running daemon
@@ -87,20 +85,18 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  postFixup = let
-    testDeps = [
-      gtk3 harfbuzz atk pango.out gdk-pixbuf
-    ];
-  in ''
+  postFixup = ''
     # Let’s wrap the daemons
     for file in $out/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/{daemon,nativeMessagingHost}.js; do
       echo "Wrapping program $file"
       wrapGApp "$file"
     done
 
-    wrapProgram "$installedTests/libexec/installed-tests/gsconnect/minijasmine" \
-      --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
-      --prefix GI_TYPELIB_PATH : "${stdenv.lib.makeSearchPath "lib/girepository-1.0" testDeps}"
+    # Wrap jasmine runner for tests
+    for file in $installedTests/libexec/installed-tests/gsconnect/minijasmine; do
+      echo "Wrapping program $file"
+      wrapGApp "$file"
+    done
   '';
 
   uuid = "gsconnect@andyholmes.github.io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
"try to fix LAN test in gsconnect's installed tests"
https://github.com/NixOS/nixpkgs/projects/30#card-47310308

###### Things done
add glib-networking to GIO_EXTRA_MODULES of minijasmine of gsconnect test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
