### PR TITLE
vdirsyncer: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -53,7 +53,10 @@ buildPythonPackage rec {
     export DETERMINISTIC_TESTS=true
   '';
 
-  disabledTests = [ "test_verbosity" ];
+  disabledTests = [
+    "test_verbosity"
+    "test_create_collections" # Flaky test exceeds deadline on hydra: https://github.com/pimutils/vdirsyncer/issues/837
+  ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/pimutils/vdirsyncer";


### PR DESCRIPTION
###### Motivation for this change

Since #103073 the hydra build of vdirsyncer was broken.

Disables sync_test:test_create_collection, a flaky test which exceeds its
deadline and breaks the build on hydra, e.g [this hydra build log](https://hydra.nixos.org/build/130683519/nixlog/1)

Upstream vdirsyncer issue: https://github.com/pimutils/vdirsyncer/issues/837

Since things seem to work for most people, my guess is that it works on beefier machines than my laptop or the hydra builder. I don't know if there is some way to increase the test timeout easily or if this is actually some performance regression.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev fixVdirsyncerTest"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
