### PR TITLE
clickhouse: use system LLVM

### DIFF
--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DENABLE_TESTS=OFF"
+    "-DUSE_INTERNAL_LLVM_LIBRARY=OFF"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Building LLVM pieces is a huge contributor to build times, and probably
bloats binary size as well. Fortunately, there's a knob for this
specific thing (-DUNBUNDLED=ON seems broken and requires some libraries
which aren't packaged for Nix at the moment).

Hopefully this will make clickhouse able to build on OfBorg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    - Before: /nix/store/y9xf1fq0im7pj7d9xk914l5k4r88hpxi-clickhouse-20.5.2.7	  786664240
    - After: /nix/store/4yii8i5ap6miyg5c6hrxas2lmr0cvp0z-clickhouse-20.5.2.7	  702939080
    - ~89% in size
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


