### PR TITLE
Platform config improvements

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -25,7 +25,7 @@ rec {
       system = parse.doubleFromSystem final.parsed;
       config = parse.tripleFromSystem final.parsed;
       # Just a guess, based on `system`
-      platform = platforms.selectBySystem final.system;
+      platform = platforms.select final;
       # Determine whether we are compatible with the provided CPU
       isCompatible = platform: parse.isCompatible final.parsed.cpu platform.parsed.cpu;
       # Derived meta-data

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -7,7 +7,7 @@ let
 
   riscv = bits: {
     config = "riscv${bits}-unknown-linux-gnu";
-    platform = platforms.riscv-multiplatform bits;
+    platform = platforms.riscv-multiplatform;
   };
 in
 
@@ -105,13 +105,13 @@ rec {
   riscv64-embedded = {
     config = "riscv64-none-elf";
     libc = "newlib";
-    platform = platforms.riscv-multiplatform "64";
+    platform = platforms.riscv-multiplatform;
   };
 
   riscv32-embedded = {
     config = "riscv32-none-elf";
     libc = "newlib";
-    platform = platforms.riscv-multiplatform "32";
+    platform = platforms.riscv-multiplatform;
   };
 
   mmix = {

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -456,7 +456,7 @@ rec {
   ## Other
   ##
 
-  riscv-multiplatform = bits: {
+  riscv-multiplatform = {
     name = "riscv-multiplatform";
     kernelArch = "riscv";
     kernelTarget = "vmlinux";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -459,7 +459,6 @@ rec {
   riscv-multiplatform = bits: {
     name = "riscv-multiplatform";
     kernelArch = "riscv";
-    bfdEmulation = "elf${bits}lriscv";
     kernelTarget = "vmlinux";
     kernelAutoModules = true;
     kernelBaseConfig = "defconfig";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -469,17 +469,22 @@ rec {
     '';
   };
 
-  selectBySystem = system: {
-      i486-linux = pc32;
-      i586-linux = pc32;
-      i686-linux = pc32;
-      x86_64-linux = pc64;
-      armv5tel-linux = sheevaplug;
-      armv6l-linux = raspberrypi;
-      armv7a-linux = armv7l-hf-multiplatform;
-      armv7l-linux = armv7l-hf-multiplatform;
-      aarch64-linux = aarch64-multiplatform;
-      mipsel-linux = fuloong2f_n32;
-      powerpc64le-linux = powernv;
-    }.${system} or pcBase;
+  select = platform:
+    # x86
+    /**/ if platform.isx86_32 then pc32
+    else if platform.isx86_64 then pc64
+
+    # ARM
+    else if platform.isAarch32 then let
+      version = platform.parsed.cpu.version or "";
+      in     if lib.versionOlder version "6" then sheevaplug
+        else if lib.versionOlder version "7" then raspberrypi
+        else armv7l-hf-multiplatform
+    else if platform.isAarch64 then aarch64-multiplatform
+
+    else if platform.parsed.cpu == lib.systems.parse.cpuTypes.mipsel then fuloong2f_n32
+
+    else if platform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le then powernv
+
+    else pcBase;
 }

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -167,7 +167,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isWindows then "pe"
       else "elf" + toString targetPlatform.parsed.cpu.bits;
     endianPrefix = if targetPlatform.isBigEndian then "big" else "little";
-    sep = optionalString (!targetPlatform.isMips && !targetPlatform.isPower) "-";
+    sep = optionalString (!targetPlatform.isMips && !targetPlatform.isPower && !targetPlatform.isRiscV) "-";
     arch =
       /**/ if targetPlatform.isAarch64 then endianPrefix + "aarch64"
       else if targetPlatform.isAarch32     then endianPrefix + "arm"
@@ -187,6 +187,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isAlpha then "alpha"
       else if targetPlatform.isVc4 then "vc4"
       else if targetPlatform.isOr1k then "or1k"
+      else if targetPlatform.isRiscV then "lriscv"
       else throw "unknown emulation for platform: ${targetPlatform.config}";
     in if targetPlatform.useLLVM or false then ""
        else targetPlatform.platform.bfdEmulation or (fmt + sep + arch);


### PR DESCRIPTION
###### Motivation for this change

The first commit is about making the selection of a "platform" less haphazard. The rest are about trying to clean up exactly what's there so it's a bit less ad-hoc. (I hope to do more on that front later.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
