### PR TITLE
python3Packages.hjson: init at 3.0.2

### DIFF
--- a/pkgs/development/python-modules/hjson/default.nix
+++ b/pkgs/development/python-modules/hjson/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "hjson";
+  version = "3.0.2";
+
+  # N.B. pypi src tarball does not have tests
+  src = fetchFromGitHub {
+    owner = "hjson";
+    repo = "hjson-py";
+    rev = "v${version}";
+    sha256 = "1jc7j790rcqnhbrfj4lhnz3f6768dc55aij840wmx16jylfqpc2n";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A user interface for JSON";
+    homepage = "https://github.com/hjson/hjson-py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2757,6 +2757,8 @@ in {
 
   hiyapyco = callPackage ../development/python-modules/hiyapyco { };
 
+  hjson = callPackage ../development/python-modules/hjson { };
+
   hkdf = callPackage ../development/python-modules/hkdf { };
 
   hmmlearn = callPackage ../development/python-modules/hmmlearn { };


### PR DESCRIPTION
This library provides a human readable extension to JSON and is used as a
dependency in packages like [qmk](https://github.com/qmk/qmk_cli)


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).