### PR TITLE
dart: Add update script; update versions

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,97 +1,30 @@
-{ stdenv, fetchurl, unzip, version ? "2.7.2" }:
-
-let
-
-  sources = let
-
-    base = "https://storage.googleapis.com/dart-archive/channels";
-    stable_version = "stable";
-    dev_version = "dev";
-    x86_64 = "x64";
-    i686 = "ia32";
-    aarch64 = "arm64";
-
-  in {
-    "1.24.3-x86_64-darwin" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "1n4cq4jrms4j0yl54b3w14agcgy8dbipv5788jziwk8q06a8c69l";
-    };
-    "1.24.3-x86_64-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "16sm02wbkj328ni0z1z4n4msi12lb8ijxzmbbfamvg766mycj8z3";
-    };
-    "1.24.3-i686-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "0a559mfpb0zfd49zdcpld95h2g1lmcjwwsqf69hd9rw6j67qyyyn";
-    };
-    "1.24.3-aarch64-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "1p5bn04gr91chcszgmw5ng8mlzgwsrdr2v7k7ppwr1slkx97fsrh";
-    };
-    "2.7.2-x86_64-darwin" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "111zl075qdk2zd4d4mmfkn30jmzsri9nq3nspnmc2l245gdq34jj";
-    };
-    "2.7.2-x86_64-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "0vvsgda1smqdjn35yiq9pxx8f5haxb4hqnspcsfs6sn5c36k854v";
-    };
-    "2.7.2-i686-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "0dj01d2wwrp3cc5x73vs6fzhs6db60gkbjlrw3w9j04wcx69i38m";
-    };
-    "2.7.2-aarch64-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "1p66fkdh1kv0ypmadmg67c3y3li3aaf1lahqh2g6r6qrzbh5da2p";
-    };
-    "2.10.0-x86_64-darwin" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "1n4qgsax5wi7krgvvs0dy7fz39nlykiw8gr0gdacc85hgyhqg09j";
-    };
-    "2.10.0-x86_64-linux" = fetchurl {
-      url = "${base}/${stable_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "0dncmsfbwcn3ygflhp83i6z4bvc02fbpaq1vzdzw8xdk3sbynchb";
-    };
-    "2.9.0-4.0.dev-x86_64-darwin" = fetchurl {
-      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "0gj91pbvqrxsvxaj742cllqha2z65867gggzq9hq5139vkkpfj9s";
-    };
-    "2.9.0-4.0.dev-x86_64-linux" = fetchurl {
-      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "16d9842fb3qbc0hy0zmimav9zndfkq96glgykj20xssc88qpjk2r";
-    };
-    "2.9.0-4.0.dev-i686-linux" = fetchurl {
-      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${i686}-release.zip";
-      sha256 = "105wgyxmi491c7qw0z3zhn4lv52h80ngyz4ch9dyj0sq8nndz2rc";
-    };
-    "2.9.0-4.0.dev-aarch64-linux" = fetchurl {
-      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${aarch64}-release.zip";
-      sha256 = "1x6mlmc4hccmx42k7srhma18faxpxvghjwqahna80508rdpljwgc";
-    };
-    "2.11.0-161.0.dev-x86_64-darwin" = fetchurl {
-      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-macos-${x86_64}-release.zip";
-      sha256 = "0mlwxp7jkkjafxkc4vqlgwl62y0hk1arhfrvc9hpm9dv98g3bdjj";
-    };
-    "2.11.0-161.0.dev-x86_64-linux" = fetchurl {
-      url = "${base}/${dev_version}/release/${version}/sdk/dartsdk-linux-${x86_64}-release.zip";
-      sha256 = "05difz4w2fyh2yq5p5pkrqk59jqljlxhc1i6lmy5kihh6z69r12i";
-    };
-  };
-
-in
+{ stdenv, fetchurl, unzip, channel ? "stable" }:
 
 with stdenv.lib;
 
-stdenv.mkDerivation {
+let
+  source =
+    let
+      sources = builtins.fromJSON (builtins.readFile ./sources.json);
+      matches = x: x.channel == channel && stdenv.hostPlatform.system == x.platform;
+    in
+      findFirst matches
+        (throw "unsupported channel/system: ${channel}/${stdenv.hostPlatform.system}")
+        sources;
 
+in
+
+stdenv.mkDerivation {
   pname = "dart";
-  inherit version;
+  inherit (source) version;
 
   nativeBuildInputs = [
     unzip
   ];
 
-  src = sources."${version}-${stdenv.hostPlatform.system}" or (throw "unsupported version/system: ${version}/${stdenv.hostPlatform.system}");
+  src = fetchurl {
+    inherit (source) url sha256;
+  };
 
   installPhase = ''
     mkdir -p $out
@@ -103,6 +36,8 @@ stdenv.mkDerivation {
   libPath = makeLibraryPath [ stdenv.cc.cc ];
 
   dontStrip = true;
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     homepage = "https://www.dartlang.org/";

--- a/pkgs/development/interpreters/dart/sources.json
+++ b/pkgs/development/interpreters/dart/sources.json
@@ -1,0 +1,107 @@
+[
+  {
+    "channel": "stable",
+    "version": "2.10.4",
+    "platform": "i686-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-ia32-release.zip",
+    "sha256": "0fyqfikbd85jrckzvxvq7npb2l2kqzifg8pm2jy0ivr5lb1021r8"
+  },
+  {
+    "channel": "stable",
+    "version": "2.10.4",
+    "platform": "x86_64-darwin",
+    "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-macos-x64-release.zip",
+    "sha256": "1d18l8ja8dckzs2y0fxwdbwh06fxzlx0fyhabcgxsvh3xg9qxhj5"
+  },
+  {
+    "channel": "stable",
+    "version": "2.10.4",
+    "platform": "armv7l-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-arm-release.zip",
+    "sha256": "10zcpqm4vdc95y04ys1199srrzpf9ifrxyk0ppq51za2hlf0jhcz"
+  },
+  {
+    "channel": "stable",
+    "version": "2.10.4",
+    "platform": "aarch64-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-arm64-release.zip",
+    "sha256": "04743g0z8fcv757jlcrbf6v8m3f0fz5smjmv9n4a6fprfzj8bw0k"
+  },
+  {
+    "channel": "stable",
+    "version": "2.10.4",
+    "platform": "x86_64-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-x64-release.zip",
+    "sha256": "0pjqj2bsliq13q8b2mk2v07w4vzjqcmr984ygnwv5kx0dp5md7vq"
+  },
+  {
+    "channel": "beta",
+    "version": "2.12.0-29.10.beta",
+    "platform": "i686-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/beta/release/2.12.0-29.10.beta/sdk/dartsdk-linux-ia32-release.zip",
+    "sha256": "0z46bfpki0gazy5dkkv7ln3mwbkhb9vcyfhxqa3p303p4qmk75vr"
+  },
+  {
+    "channel": "beta",
+    "version": "2.12.0-29.10.beta",
+    "platform": "x86_64-darwin",
+    "url": "https://storage.googleapis.com/dart-archive/channels/beta/release/2.12.0-29.10.beta/sdk/dartsdk-macos-x64-release.zip",
+    "sha256": "0dnkyz8179nigd0nl1v86jlwz8wcvfw8yhykgf3cwrrmi51v62lz"
+  },
+  {
+    "channel": "beta",
+    "version": "2.12.0-29.10.beta",
+    "platform": "armv7l-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/beta/release/2.12.0-29.10.beta/sdk/dartsdk-linux-arm-release.zip",
+    "sha256": "0i6q05kpmpvjx2riaq0daj751x4mhaxf42cd5k68xq6bdkqbjsxc"
+  },
+  {
+    "channel": "beta",
+    "version": "2.12.0-29.10.beta",
+    "platform": "aarch64-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/beta/release/2.12.0-29.10.beta/sdk/dartsdk-linux-arm64-release.zip",
+    "sha256": "1jx77wyvvyj13ix2rh7imhizj7rpppyh9isxfs62gw8wrxkvygvz"
+  },
+  {
+    "channel": "beta",
+    "version": "2.12.0-29.10.beta",
+    "platform": "x86_64-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/beta/release/2.12.0-29.10.beta/sdk/dartsdk-linux-x64-release.zip",
+    "sha256": "07kl23ygdffmypwv8qa32krp1xl5cq700dq58makhik8apcsc2ny"
+  },
+  {
+    "channel": "dev",
+    "version": "2.12.0-79.0.dev",
+    "platform": "i686-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/2.12.0-79.0.dev/sdk/dartsdk-linux-ia32-release.zip",
+    "sha256": "0hm1jphz9y9mdnci1xgwb87kw9dg5v80sh6ic75049siqx08ld4g"
+  },
+  {
+    "channel": "dev",
+    "version": "2.12.0-79.0.dev",
+    "platform": "x86_64-darwin",
+    "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/2.12.0-79.0.dev/sdk/dartsdk-macos-x64-release.zip",
+    "sha256": "0mjxvppaq1qyf1g18njwkbcrglhjq4h9zpsgzb1pb184hw6b4ffc"
+  },
+  {
+    "channel": "dev",
+    "version": "2.12.0-79.0.dev",
+    "platform": "armv7l-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/2.12.0-79.0.dev/sdk/dartsdk-linux-arm-release.zip",
+    "sha256": "1cb1v7bwghmkcr0psqyr7ljngd0rgd83n5mzaahh159yqcm6plf0"
+  },
+  {
+    "channel": "dev",
+    "version": "2.12.0-79.0.dev",
+    "platform": "aarch64-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/2.12.0-79.0.dev/sdk/dartsdk-linux-arm64-release.zip",
+    "sha256": "1rwa24sylcqqdsznnnclk8x795i5gjhca71vvxpfb91x6zcvdgay"
+  },
+  {
+    "channel": "dev",
+    "version": "2.12.0-79.0.dev",
+    "platform": "x86_64-linux",
+    "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/2.12.0-79.0.dev/sdk/dartsdk-linux-x64-release.zip",
+    "sha256": "11b4lb2k81zd8fyxqfg63klfcvrlmby853qc0kz01v8c8lg4qnxv"
+  }
+]

--- a/pkgs/development/interpreters/dart/update.sh
+++ b/pkgs/development/interpreters/dart/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq
+
+set -euo pipefail
+
+CHANNELS=(stable beta dev)
+declare -A PLATFORMS=(
+    [macos-x64]=x86_64-darwin
+    [linux-ia32]=i686-linux
+    [linux-x64]=x86_64-linux
+    [linux-arm]=armv7l-linux
+    [linux-arm64]=aarch64-linux
+)
+BASE="https://storage.googleapis.com/dart-archive/channels"
+
+TMP=sources.tmp.json
+echo '' > $TMP
+
+for channel in ${CHANNELS[@]}; do
+  version=$(curl "${BASE}/${channel}/release/latest/VERSION" | jq -r '.version')
+  for platform in "${!PLATFORMS[@]}"; do
+    url="${BASE}/${channel}/release/${version}/sdk/dartsdk-${platform}-release.zip"
+    sha256=$(nix-prefetch-url "$url")
+    nixPlatform=${PLATFORMS[$platform]}
+    jq --arg channel $channel \
+       --arg version $version \
+       --arg platform $nixPlatform \
+       --arg url "$url" \
+       --arg sha256 $sha256 \
+       -n '$ARGS.named' >> $TMP
+  done
+done
+
+jq -s '.' $TMP > sources.json
+rm $TMP

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -100,6 +100,9 @@ mapAliases ({
   cv = progress; # added 2015-09-06
   d1x_rebirth = dxx-rebirth; # added 2018-04-25
   d2x_rebirth = dxx-rebirth; # added 2018-04-25
+  dart_old = throw "dart_old has been removed. Please use dart-stable, dart-beta, or dart-dev."; # added 2020-11-28
+  dart_stable = dart-stable; # added 2020-11-28
+  dart_dev = dart-dev; # added 2020-11-28
   dat = nodePackages.dat;
   dbvisualizer = throw "dbvisualizer has been removed from nixpkgs, as it's unmaintained"; # added 2020-09-20
   dbus_daemon = dbus.daemon; # added 2018-04-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28412,10 +28412,10 @@ in
 
   spdlog = spdlog_1;
 
-  dart = callPackage ../development/interpreters/dart { };
-  dart_old = dart.override    { version = "1.24.3"; };
-  dart_stable = dart.override { version = "2.7.2"; };
-  dart_dev = dart.override    { version = "2.9.0-4.0.dev"; };
+  dart = dart-stable;
+  dart-stable = callPackage ../development/interpreters/dart { channel = "stable"; };
+  dart-beta = callPackage ../development/interpreters/dart { channel = "beta"; };
+  dart-dev = callPackage ../development/interpreters/dart { channel = "dev"; };
 
   httrack = callPackage ../tools/backup/httrack { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Automate Dart updates with an `updateScript`. This produces `sources.json` which is parsed at eval time.
- Dart updates also require updating top-level dart attributes with specific version names, which isn't consistent with other packages using multiple release channels/branches, and was missed for the last update. Remove these and pass the channel name to the derivation.
- Rename the channel-specific dart attributes using `kebab-case` to be consistent with other packages. Aliases have been added to map the old `snake_case` names.
- Remove `dart_old` as nothing in nixpkgs relies on it.
- Update Dart versions:
  - stable: 2.7.2 -> 2.10.4
  - beta: init at 2.12.0-29.10.beta
  - dev: 2.9.0-4.0.dev -> 2.12.0-79.0.dev

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
