### PR TITLE
rustc: allow building for musl targets

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,4 +1,5 @@
 { stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
+, targetPackages
 , fetchurl, file, python3
 , llvm_10, darwin, cmake, rust, rustPlatform
 , pkgconfig, openssl
@@ -92,6 +93,8 @@ in stdenv.mkDerivation rec {
     "${setTarget}.llvm-config=${llvmSharedForTarget}/bin/llvm-config"
   ] ++ optionals (stdenv.isLinux && !stdenv.targetPlatform.isRedox) [
     "--enable-profiler" # build libprofiler_builtins
+  ] ++ optionals stdenv.targetPlatform.isMusl [
+    "${setTarget}.musl-root=${targetPackages.stdenv.cc.libc}"
   ];
 
   # The bootstrap.py will generated a Makefile that then executes the build.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Makes `pkgsCross.<platform>.pkgsStatic.buildPackages.rustc` work.

It might be worthwhile to add similar things for `hostPlatform` or even `buildPlatform`, but this would require a lot more building to test so I haven't tried it yet.

I have tested this with a modified version of @joprice's [rust-nix-test](https://github.com/joprice/rust-nix-test). @joprice I know this doesn't solve [your problem](https://github.com/kolloch/crate2nix/pull/152#issuecomment-710308125), but it is a step in the general direction.

cc @Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
