### PR TITLE
libnova: 0.12.3 -> 0.16

### DIFF
--- a/pkgs/development/libraries/libnova/default.nix
+++ b/pkgs/development/libraries/libnova/default.nix
@@ -1,17 +1,25 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchgit, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "libnova-0.12.3";
+  pname = "libnova";
+  version = "0.16";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libnova/${name}.tar.gz";
-    sha256 = "18mkx79gyhccp5zqhf6k66sbhv97s7839sg15534ijajirkhw9dc";
+  # pull from git repo because upstream stopped tarball releases after v0.15
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/libnova/${pname}";
+    rev = "v${version}";
+    sha256 = "0icwylwkixihzni0kgl0j8dx3qhqvym6zv2hkw2dy6v9zvysrb1b";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   meta = with stdenv.lib; {
     description = "Celestial Mechanics, Astrometry and Astrodynamics Library";
     homepage = "http://libnova.sf.net";
-    platforms = platforms.unix;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ hjones2199 ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update libnova to version 0.16 to receive bugfixes and new library features. Switch from x.x.x version numbers to x.x is necessary to move from defunct upstream tarball releases to git tags. Also added myself to the maintainer list since there are no maintainers listed for libnova.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
