### PR TITLE
zombietrackergps: 1.01 → 1.03

### DIFF
--- a/pkgs/applications/gis/zombietrackergps/default.nix
+++ b/pkgs/applications/gis/zombietrackergps/default.nix
@@ -2,7 +2,6 @@
 , lib
 , fetchFromGitLab
 , qmake
-, qtbase
 , qtcharts
 , qtsvg
 , marble
@@ -12,18 +11,17 @@
 
 mkDerivation rec {
   pname = "zombietrackergps";
-  version = "1.01";
+  version = "1.03";
 
   src = fetchFromGitLab {
     owner = "ldutils-projects";
     repo = pname;
     rev = "v_${version}";
-    sha256 = "0h354ydbahy8rpkmzh5ym5bddbl6irjzklpcg6nbkv6apry84d48";
+    sha256 = "1rmdy6kijmcxamm4mqmz8638xqisijlnpv8mimgxywpf90h9rrwq";
   };
 
   buildInputs = [
     ldutils
-    qtbase
     qtcharts
     qtsvg
     marble.dev
@@ -49,7 +47,8 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "GPS track manager for Qt using KDE Marble maps";
-    homepage = "https://gitlab.com/ldutils-projects/zombietrackergps";
+    homepage = "https://www.zombietrackergps.net/ztgps/";
+    changelog = "https://www.zombietrackergps.net/ztgps/history.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ sohalt ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/ldutils/default.nix
+++ b/pkgs/development/libraries/ldutils/default.nix
@@ -1,7 +1,6 @@
 { mkDerivation
 , lib
 , fetchFromGitLab
-, qtbase
 , qtcharts
 , qtsvg
 , qmake
@@ -9,17 +8,16 @@
 
 mkDerivation rec {
   pname = "ldutils";
-  version = "1.01";
+  version = "1.03";
 
   src = fetchFromGitLab {
     owner = "ldutils-projects";
     repo = pname;
     rev = "v_${version}";
-    sha256 = "09k2d5wj70xfr3sb4s9ajczq0lh65705pggs54zqqqjxazivbmgk";
+    sha256 = "0pi05py71hh5vlhl0kjh9wxmd7yixw10s0kr2wb4l4c0abqxr82j";
   };
 
   buildInputs = [
-    qtbase
     qtcharts
     qtsvg
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25036,7 +25036,7 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  zombietrackergps = libsForQt514.callPackage ../applications/gis/zombietrackergps { };
+  zombietrackergps = libsForQt5.callPackage ../applications/gis/zombietrackergps { };
 
   zoom-us = libsForQt5.callPackage ../applications/networking/instant-messengers/zoom-us { };
 


### PR DESCRIPTION
###### Motivation for this change
* update to 1.0.3 ([changelog](https://www.zombietrackergps.net/ztgps/history.html))
* use latest qt version instead of 5.14 #104474
* fix homepage

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
