### PR TITLE
python3.pkgs.httpbin: 0.6.2 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/httpbin/default.nix
+++ b/pkgs/development/python-modules/httpbin/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , fetchpatch
 , flask
-, flask-common
 , flask-limiter
 , markupsafe
 , decorator
@@ -15,24 +14,14 @@
 
 buildPythonPackage rec {
   pname = "httpbin";
-  version = "0.6.2";
+  version = "0.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0afa0486a76305cac441b5cc80d5d4ccd82b20875da7c5119ecfe616cefef45f";
+    sha256 = "1yldvf3585zcwj4vxvfm4yr9wwlz3pa2mx2pazqz8x8mr687gcyb";
   };
 
-  patches = [
-    # https://github.com/kennethreitz/httpbin/issues/403
-    # https://github.com/kennethreitz/flask-common/issues/7
-    # https://github.com/evansd/whitenoise/issues/166
-    (fetchpatch {
-      url = "https://github.com/javabrett/httpbin/commit/5735c888e1e51b369fcec41b91670a90535e661e.patch";
-      sha256 = "167h8mscdjagml33dyqk8nziiz3dqbggnkl6agsirk5270nl5f7q";
-    })
-  ];
-
-  propagatedBuildInputs = [ brotlipy flask flask-common flask-limiter markupsafe decorator itsdangerous raven six ];
+  propagatedBuildInputs = [ brotlipy flask flask-limiter markupsafe decorator itsdangerous raven six ];
 
   # No tests
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
