### PR TITLE
nixos/systemd: make services with DynamicUser depend on nscd

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -215,38 +215,44 @@ let
     in "${out}/bin/${scriptName}";
 
   unitConfig = { config, options, ... }: {
-    config = {
-      unitConfig =
-        optionalAttrs (config.requires != [])
-          { Requires = toString config.requires; }
-        // optionalAttrs (config.wants != [])
-          { Wants = toString config.wants; }
-        // optionalAttrs (config.after != [])
-          { After = toString config.after; }
-        // optionalAttrs (config.before != [])
-          { Before = toString config.before; }
-        // optionalAttrs (config.bindsTo != [])
-          { BindsTo = toString config.bindsTo; }
-        // optionalAttrs (config.partOf != [])
-          { PartOf = toString config.partOf; }
-        // optionalAttrs (config.conflicts != [])
-          { Conflicts = toString config.conflicts; }
-        // optionalAttrs (config.requisite != [])
-          { Requisite = toString config.requisite; }
-        // optionalAttrs (config.restartTriggers != [])
-          { X-Restart-Triggers = toString config.restartTriggers; }
-        // optionalAttrs (config.description != "") {
-          Description = config.description; }
-        // optionalAttrs (config.documentation != []) {
-          Documentation = toString config.documentation; }
-        // optionalAttrs (config.onFailure != []) {
-          OnFailure = toString config.onFailure; }
-        // optionalAttrs (options.startLimitIntervalSec.isDefined) {
-          StartLimitIntervalSec = toString config.startLimitIntervalSec;
-        } // optionalAttrs (options.startLimitBurst.isDefined) {
-          StartLimitBurst = toString config.startLimitBurst;
-        };
-    };
+    config = mkMerge [
+      {
+        unitConfig =
+          optionalAttrs (config.requires != [])
+            { Requires = toString config.requires; }
+          // optionalAttrs (config.wants != [])
+            { Wants = toString config.wants; }
+          // optionalAttrs (config.after != [])
+            { After = toString config.after; }
+          // optionalAttrs (config.before != [])
+            { Before = toString config.before; }
+          // optionalAttrs (config.bindsTo != [])
+            { BindsTo = toString config.bindsTo; }
+          // optionalAttrs (config.partOf != [])
+            { PartOf = toString config.partOf; }
+          // optionalAttrs (config.conflicts != [])
+            { Conflicts = toString config.conflicts; }
+          // optionalAttrs (config.requisite != [])
+            { Requisite = toString config.requisite; }
+          // optionalAttrs (config.restartTriggers != [])
+            { X-Restart-Triggers = toString config.restartTriggers; }
+          // optionalAttrs (config.description != "") {
+            Description = config.description; }
+          // optionalAttrs (config.documentation != []) {
+            Documentation = toString config.documentation; }
+          // optionalAttrs (config.onFailure != []) {
+            OnFailure = toString config.onFailure; }
+          // optionalAttrs (options.startLimitIntervalSec.isDefined) {
+            StartLimitIntervalSec = toString config.startLimitIntervalSec;
+          } // optionalAttrs (options.startLimitBurst.isDefined) {
+            StartLimitBurst = toString config.startLimitBurst;
+          };
+      }
+      (mkIf (config.serviceConfig.DynamicUser or false) {
+        wants = [ "nscd.service" ];
+        after = [ "nscd.service" ];
+      })
+    ];
   };
 
   serviceConfig = { name, config, ... }: {

--- a/nixos/tests/sslh.nix
+++ b/nixos/tests/sslh.nix
@@ -65,6 +65,11 @@ import ./make-test-python.nix {
     server.wait_for_open_port(443)
     server.wait_for_open_port(22)
 
+    # check that sslh depends on nscd because it runs as a DynamicUser but
+    # iptables require the username to resolve
+    server.succeed("systemctl show -p Wants sslh.service | grep nscd.service")
+    server.succeed("systemctl show -p After sslh.service | grep nscd.service")
+
     for arg in ["-6", "-4"]:
         client.wait_until_succeeds(f"ping {arg} -c1 server")
 


### PR DESCRIPTION
otherwise their username does not resolve to their uid
Fixes #105353

###### Things done

Tested with the sslh nixos test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
