### PR TITLE
[WIP] symcc: init at 1.0

### DIFF
--- a/pkgs/tools/security/symcc/default.nix
+++ b/pkgs/tools/security/symcc/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, llvm_9
+, clang_9
+, z3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "symcc";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "eurecom-s3";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "152b8p861rhdixh63qxk01xb1fpc500mi3sxrw0j5lsq974wbi6a";
+  };
+
+  nativeBuildInputs = [
+    cmake ninja llvm_9 clang_9
+  ];
+
+  buildInputs = [
+    z3
+  ];
+
+  meta = with stdenv.lib; {
+    description = "efficient compiler-based symbolic execution";
+    homepage = "http://www.s3.eurecom.fr/tools/symbolic_execution/symcc.html";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dump_stack ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
