### PR TITLE
criu: Switch to Python 3

### DIFF
--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, protobuf, protobufc, asciidoc, iptables
 , xmlto, docbook_xsl, libpaper, libnl, libcap, libnet, pkgconfig
-, which, python, makeWrapper, docbook_xml_dtd_45 }:
+, which, python3, makeWrapper, docbook_xml_dtd_45 }:
 
 stdenv.mkDerivation rec {
   pname = "criu";
@@ -12,8 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ pkgconfig docbook_xsl which makeWrapper docbook_xml_dtd_45 ];
-  buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap libnet python iptables ];
+  nativeBuildInputs = [ pkgconfig docbook_xsl which makeWrapper docbook_xml_dtd_45 python3 python3.pkgs.wrapPython ];
+  buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap libnet iptables ];
+  propagatedBuildInputs = with python3.pkgs; [ python python3.pkgs.protobuf ];
 
   postPatch = ''
     substituteInPlace ./Documentation/Makefile --replace "2>/dev/null" ""
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     wrapProgram $out/bin/criu \
       --prefix PATH : ${lib.makeBinPath [ iptables ]}
+    wrapPythonPrograms
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I'm currently trying to rid my system of Python 2. I verified that the build still works but unfortunately I cannot test this properly. 

`crit --version` or importing `pycriu` in an interactive Python shell fails but that also failed before.
cc @FRidh @jonringer: Any ideas how to package this correctly? It's basically a C program/library that also ships with a Python library (`pycriu` in `lib/python3.8/site-packages/pycriu/`).

I've also tried the following changes:
```
  nativeBuildInputs = [ python3 python3.pkgs.wrapPython ];
  propagatedBuildInputs = with python3.pkgs; [ python protobuf ];
  postFixup = ''
    wrapPythonPrograms # Need something like wrapPythonLibraries
  '';
```
But I'm not getting `$out/nix-support/propagated-build-inputs` and it still fails with:
```console
$ crit --version
Traceback (most recent call last):
  File "/nix/store/dif0rqr5vhspiwyz3i2mlddvrczrn97q-criu-3.15/bin/.crit-wrapped", line 4, in <module>
    from pycriu import cli
  File "/nix/store/dif0rqr5vhspiwyz3i2mlddvrczrn97q-criu-3.15/lib/python3.8/site-packages/pycriu/__init__.py", line 1, in <module>
    from . import rpc_pb2 as rpc
  File "/nix/store/dif0rqr5vhspiwyz3i2mlddvrczrn97q-criu-3.15/lib/python3.8/site-packages/pycriu/rpc_pb2.py", line 5, in <module>
    from google.protobuf.internal import enum_type_wrapper
ModuleNotFoundError: No module named 'google'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
