### PR TITLE
slurm/nixos: 20.02.5.1 -> 20.11.0.1, fix module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -278,6 +278,15 @@
       <xref linkend="opt-services.privoxy.enableTor" /> = true;
     </programlisting>
    </listitem>
+   <listitem>
+     <para>
+       The options <literal>services.slurm.dbdserver.storagePass</literal>
+       and <literal>services.slurm.dbdserver.configFile</literal> have been removed.
+       Use <literal>services.slurm.dbdserver.storagePassFile</literal> instead to provide the database password.
+       Extra config options can be given via the option <literal>services.slurm.dbdserver.extraConfig</literal>. The actual configuration file is created on the fly on startup of the service.
+       This avoids that the password gets exposed in the nix store.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -86,14 +86,16 @@ in {
 
     dbd =
       { pkgs, ... } :
-      {
+      let
+        passFile = pkgs.writeText "dbdpassword" "password123";
+      in {
         networking.firewall.enable = false;
         systemd.tmpfiles.rules = [
           "f /etc/munge/munge.key 0400 munge munge - mungeverryweakkeybuteasytointegratoinatest"
         ];
         services.slurm.dbdserver = {
           enable = true;
-          storagePass = "password123";
+          storagePassFile = "${passFile}";
         };
         services.mysql = {
           enable = true;

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   pname = "slurm";
-  version = "20.02.6.1";
+  version = "20.11.0.1";
 
   # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
   # because the latter does not keep older releases.
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     repo = "slurm";
     # The release tags use - instead of .
     rev = "${pname}-${builtins.replaceStrings ["."] ["-"] version}";
-    sha256 = "0vllyljsmv3y9hw4vfgnz9cnjqhlk55dy1bipssw872aldlxfcdk";
+    sha256 = "0f750wlvm48j5b2fkvhy47zyagxfl6kbn2m9lx0spxwyn9qgh6bn";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change
Since slurm-20.11.0.1 the dbd server requires slurmdbd.conf to be in mode 600 to protect the database password. This change creates slurmdbd.conf on-the-fly at service startup and thus avoids that the database password ends up in the nix store and improves security.

###### Things done
* updated slurm package
* fixed config options for dbdserver
* updated release notes
* update slurm test
 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
