### PR TITLE
nixos/wooting: add xinput support

### DIFF
--- a/nixos/modules/hardware/wooting.nix
+++ b/nixos/modules/hardware/wooting.nix
@@ -1,12 +1,33 @@
 { config, lib, pkgs, ... }:
 
 with lib;
+let
+  cfg = config.hardware.wooting;
+in
 {
-  options.hardware.wooting.enable =
-    mkEnableOption "Enable support for Wooting keyboards";
+  options.hardware.wooting = {
+    enable = mkEnableOption "support for Wooting keyboards";
+    xinput.enable = mkEnableOption "xinput support for Wooting keyboards";
+  };
 
-  config = mkIf config.hardware.wooting.enable {
+  config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.wootility ];
-    services.udev.packages = [ pkgs.wooting-udev-rules ];
+
+    services.udev.packages =
+      [ pkgs.wooting-udev-rules ]
+      ++ (optional cfg.xinput.enable pkgs.wooting-xinput-udev-rules);
+
+    systemd.services = mkIf cfg.xinput.enable {
+      "wooting-xinput@" = {
+        description = "xboxdrv userspace driver for native Xbox 360 interface of Wooting keyboards";
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = ''
+            ${pkgs.xboxdrv}/bin/xboxdrv --type xbox360 --device-by-id 03eb:%I --silent --quiet \
+              --detach-kernel-driver --mimic-xpad
+          '';
+        };
+      };
+    };
   };
 }

--- a/pkgs/os-specific/linux/wooting-xinput-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/wooting-xinput-udev-rules/default.nix
@@ -1,0 +1,25 @@
+{ stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "wooting-xinput-udev-rules";
+  version = "20210525";
+
+  # Source: https://wooting.helpscoutdocs.com/article/83-guide-configuring-xinput-support-for-the-wootings-under-linux
+  src = [ ./wooting-xinput.rules ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    install -Dpm644 $src $out/lib/udev/rules.d/71-wooting.rules
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://wooting.helpscoutdocs.com/article/83-guide-configuring-xinput-support-for-the-wootings-under-linux";
+    description = ''
+      udev rules that give NixOS permission to communicate with Wooting keyboards in xinput mode
+    '';
+    platforms = platforms.linux;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/os-specific/linux/wooting-xinput-udev-rules/wooting-xinput.rules
+++ b/pkgs/os-specific/linux/wooting-xinput-udev-rules/wooting-xinput.rules
@@ -1,0 +1,11 @@
+# Wooting One
+SUBSYSTEM=="usb", ENV{PRODUCT}=="3eb/ff01/*", ENV{INTERFACE}=="255/93/1", TAG+="systemd", ENV{SYSTEMD_WANTS}="wooting-xinput@ff01"
+
+# Wooting Two
+SUBSYSTEM=="usb", ENV{PRODUCT}=="3eb/ff02/*", ENV{INTERFACE}=="255/93/1", TAG+="systemd", ENV{SYSTEMD_WANTS}="wooting-xinput@ff02"
+
+# Wooting Two Lekker Edition
+SUBSYSTEM=="usb", ENV{PRODUCT}=="31e3/1210/*", ENV{INTERFACE}=="255/93/1", TAG+="systemd", ENV{SYSTEMD_WANTS}="wooting-xinput@31e3:1210"
+
+# Wooting Two HE
+SUBSYSTEM=="usb", ENV{PRODUCT}=="31e3/1220/*", ENV{INTERFACE}=="255/93/1", TAG+="systemd", ENV{SYSTEMD_WANTS}="wooting-xinput@31e3:1220"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21435,6 +21435,8 @@ in
 
   wooting-udev-rules = callPackage ../os-specific/linux/wooting-udev-rules { };
 
+  wooting-xinput-udev-rules = callPackage ../os-specific/linux/wooting-xinput-udev-rules { };
+
   wpa_supplicant = callPackage ../os-specific/linux/wpa_supplicant { };
 
   wpa_supplicant_ro_ssids = wpa_supplicant.override {


### PR DESCRIPTION
###### Motivation for this change
This PR adds xinput support for Wooting keyboards to the `hardware.wooting` NixOS module, enabled by setting the `hardware.wooting.xinput.enable` option, see [upstream documentation](https://wooting.helpscoutdocs.com/article/83-guide-configuring-xinput-support-for-the-wootings-under-linux).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
