### PR TITLE
ocamlPackages.odate: init at 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/odate/default.nix
+++ b/pkgs/development/ocaml-modules/odate/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, menhir
+}:
+
+buildDunePackage rec {
+  pname = "odate";
+  version = "0.6";
+
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchFromGitHub {
+    owner = "hhugo";
+    repo = pname;
+    rev = version;
+    sha256 = "1dk33lr0g2jnia2gqsm6nnc7nf256qgkm3v30w477gm6y2ppfm3h";
+  };
+
+  buildInputs = [ menhir ];
+
+  meta = {
+    description = "Date and duration in OCaml";
+    inherit (src.meta) homepage;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -736,6 +736,8 @@ let
 
     octavius = callPackage ../development/ocaml-modules/octavius { };
 
+    odate = callPackage ../development/ocaml-modules/odate { };
+
     odoc = callPackage ../development/ocaml-modules/odoc { };
 
     omd = callPackage ../development/ocaml-modules/omd { };


### PR DESCRIPTION
###### Motivation for this change

Simple date and duration manipulation in OCaml: https://github.com/hhugo/odate

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
