### PR TITLE
WIP: treewide: splice more nested package sets

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -231,6 +231,7 @@ rec {
       } // keep self;
       self = f self // {
         newScope = scope: newScope (spliced // scope);
+        makeScopeWithSplicing = makeScopeWithSplicing splicePackages self.newScope;
         callPackage = newScope spliced; # == self.newScope {};
         # N.B. the other stages of the package set spliced in are *not*
         # overridden.

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -69,9 +69,7 @@ with pkgs;
               recursivePthLoader
             ;
           };
-        in lib.makeScopeWithSplicing
-          pkgs.splicePackages
-          pkgs.newScope
+        in pkgs.makeScopeWithSplicing
           otherSplices
           keep
           (lib.extends overrides pythonPackagesFun))

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -131,6 +131,17 @@ in
 
   newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
 
+  makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
+
+  topProjectedSpliced = attr: {
+    selfBuildBuild   = pkgs.pkgsBuildBuild.${attr};
+    selfBuildHost    = pkgs.pkgsBuildHost.${attr};
+    selfBuildTarget  = pkgs.pkgsBuildTarget.${attr};
+    selfHostHost     = pkgs.pkgsHostHost.${attr};
+    selfHostTarget   = pkgs.pkgsHostTarget.${attr};
+    selfTargetTarget = pkgs.pkgsTargetTarget.${attr} or {};
+  };
+
   # Haskell package sets need this because they reimplement their own
   # `newScope`.
   __splicedPackages = splicedPackages // { recurseForDerivations = false; };


### PR DESCRIPTION
###### Motivation for this change

So far this just has some functions that might come in handy. Next step
is to find package sets that provide things used as non-buildInputs
(most of them seem to not fit that?).

I've always hated this splicing monster. Maybe others can tell me where
this might be worth it.

CC @FRidh @globin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
