### PR TITLE
keeweb: 1.15.7 → 1.16.0

### DIFF
--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -4,7 +4,7 @@ let
   throwSystem = throw "Unsupported system: ${system}";
 
   pname = "keeweb";
-  version = "1.15.7";
+  version = "1.16.0";
   name = "${pname}-${version}";
 
   suffix = {
@@ -15,8 +15,8 @@ let
   src = fetchurl {
     url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.${suffix}";
     sha256 = {
-      x86_64-linux = "0cy0avl0m07xs523xm0rzsmifl28sv4rjb2jj3x492qmr2v64ckk";
-      x86_64-darwin = "0r8c3zi0ibj0bb0gfc1axfn0y4qpjqfr0xpcxf810d65kaz6wic4";
+      x86_64-linux = "1pivic7n5nv00s8bb51i2jz2mxgjn92hkc8n0p8662ai1cdng47g";
+      x86_64-darwin = "0q6k0qgkgzid9yjbfsfpp8l9dr0n8xp25a4jf2bxwickm4irs9mz";
     }.${system} or throwSystem;
   };
 


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/keeweb/keeweb/releases/tag/v1.16.0)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
