### PR TITLE
tests.buildRustCrate: Fix after hashing method change

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -146,12 +146,18 @@ let
         };
       in
       runCommand "assert-outputs-${name}" {
-      } ''
+      } (''
       local actualFiles=$(mktemp)
 
       cd "${crateOutput}"
-      find . -type f | sort >$actualFiles
-      diff -q ${expectedFilesFile} $actualFiles >/dev/null || {
+      find . -type f \
+        | sort \
+      ''
+      # sed out the hash because it differs per platform
+      + ''
+        | sed -E -e 's/-[0-9a-fA-F]{10}\.rlib/-HASH.rlib/g' \
+        > "$actualFiles"
+      diff -q ${expectedFilesFile} "$actualFiles" > /dev/null || {
         echo -e "\033[0;1;31mERROR: Difference in expected output files in ${crateOutput} \033[0m" >&2
         echo === Got:
         sed -e 's/^/  /' $actualFiles
@@ -164,7 +170,7 @@ let
         exit 1
       }
       touch $out
-      ''
+      '')
       ;
 
   in rec {
@@ -594,7 +600,7 @@ let
       };
       expectedFiles = [
         "./nix-support/propagated-build-inputs"
-        "./lib/libtest_lib-042a1fdbef.rlib"
+        "./lib/libtest_lib-HASH.rlib"
         "./lib/link"
       ];
     };
@@ -611,7 +617,7 @@ let
       };
       expectedFiles = [
         "./nix-support/propagated-build-inputs"
-        "./lib/libtest_lib-042a1fdbef.rlib"
+        "./lib/libtest_lib-HASH.rlib"
         "./lib/link"
       ];
     };

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -39,6 +39,7 @@ with pkgs;
   cross = callPackage ./cross {};
 
   rustCustomSysroot = callPackage ./rust-sysroot {};
+  buildRustCrate = callPackage ../build-support/rust/build-rust-crate/test { };
 
   nixos-functions = callPackage ./nixos-functions {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10071,7 +10071,6 @@ in
 
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate { };
   buildRustCrateHelpers = callPackage ../build-support/rust/build-rust-crate/helpers.nix { };
-  buildRustCrateTests = recurseIntoAttrs (callPackage ../build-support/rust/build-rust-crate/test { });
   cratesIO = callPackage ../build-support/rust/crates-io.nix { };
 
   cargo-web = callPackage ../development/tools/cargo-web {


### PR DESCRIPTION
###### Motivation for this change

As @lopsided98 points out in #105305, we're probably better off not asserting exact hashes, but that is a more involved fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
