### PR TITLE
qjackctl: add `jackSession` option

### DIFF
--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, mkDerivation, fetchurl, pkgconfig, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras }:
+{ stdenv, mkDerivation, fetchurl
+, pkg-config, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras
+# Enable jack session support
+, jackSession ? false
+}:
 
 mkDerivation rec {
   version = "0.6.3";
@@ -20,9 +24,12 @@ mkDerivation rec {
     dbus
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
 
-  configureFlags = [ "--enable-jack-version" ];
+  configureFlags = [
+    "--enable-jack-version"
+    (stdenv.lib.strings.enableFeature jackSession "jack-session")
+  ];
 
   meta = with stdenv.lib; {
     description = "A Qt application to control the JACK sound server daemon";


### PR DESCRIPTION
###### Motivation for this change

This adds `jackSession` option, which allows to enable or disable jack session support.

The option is disabled by default for the following reasons:

1. The JACK-Session API is deprecated: https://jackaudio.org/api/group__JackSessionManagerAPI.html
2. Disabling this feature allows to use qjackctl with PipeWire

See also: https://github.com/NixOS/nixpkgs/issues/102547

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@cillianderoiste