### PR TITLE
tmuxPlugins.jump: init at 2020-06-26

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -180,6 +180,26 @@ in rec {
     };
   };
 
+  jump = mkDerivation {
+    pluginName = "jump";
+    version = "2020-06-26";
+    rtpFilePath = "tmux-jump.tmux";
+    src = fetchFromGitHub {
+      owner = "schasse";
+      repo = "tmux-jump";
+      rev = "416f613d3eaadbe1f6f9eda77c49430527ebaffb";
+      sha256 = "1xbzdyhsgaq2in0f8f491gwjmx6cxpkf2c35d2dk0kg4jfs505sz";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/schasse/tmux-jump";
+      description = "Vimium/Easymotion like navigation for tmux";
+      license = licenses.gpl3;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ arnarg ];
+    };
+  };
+
   logging = mkDerivation {
     pluginName = "logging";
     version = "unstable-2019-04-19";


### PR DESCRIPTION
###### Motivation for this change
Adding tmux plugin jump. Useful plugin for jumping to text, similar to vimium and easymotion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
