### PR TITLE
python2Packages.ecpy: unbreak due to invalid code

### DIFF
--- a/pkgs/development/python-modules/ecpy/default.nix
+++ b/pkgs/development/python-modules/ecpy/default.nix
@@ -9,10 +9,16 @@ buildPythonPackage rec {
     sha256 = "9635cffb9b6ecf7fd7f72aea1665829ac74a1d272006d0057d45a621aae20228";
   };
 
+  prePatch = ''
+    sed -i "s|reqs.append('future')|pass|" setup.py
+  '';
+
   propagatedBuildInputs = lib.optional (!isPy3k) future;
 
   # No tests implemented
   doCheck = false;
+
+  pythonImportsCheck = [ "ecpy" ];
 
   meta = with lib; {
     description = "Pure Pyhton Elliptic Curve Library";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

setup.py contains a broken code related to a "reqs" variable to add an optional dependency. This patch remove it.

I also added an import check as no other tests are active

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
