### PR TITLE
r2mod_cli: init at 1.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7301,6 +7301,12 @@
     githubId = 816465;
     name = "Redvers Davies";
   };
+  reedrw = {
+    email = "reedrw5601@gmail.com";
+    github = "reedrw";
+    githubId = 21069876;
+    name = "Reed Williams";
+  };
   refnil = {
     email = "broemartino@gmail.com";
     github = "refnil";

--- a/pkgs/games/r2mod_cli/default.nix
+++ b/pkgs/games/r2mod_cli/default.nix
@@ -1,0 +1,34 @@
+{ fetchFromGitHub
+, jq
+, makeWrapper
+, p7zip
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "r2mod_cli";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "Foldex";
+    repo = "r2mod_cli";
+    rev = "v${version}";
+    sha256 = "1g64f8ms7yz4rzm6xb93agc08kh9sbwkhvq35dpfhvi6v59j3n5m";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/r2mod --prefix PATH : "${stdenv.lib.makeBinPath [ jq p7zip ]}";
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Risk of Rain 2 Mod Manager in Bash";
+    homepage = "https://github.com/foldex/r2mod_cli";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.reedrw ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25777,6 +25777,8 @@ in
 
   quantumminigolf = callPackage ../games/quantumminigolf {};
 
+  r2mod_cli = callPackage ../games/r2mod_cli { };
+
   racer = callPackage ../games/racer { };
 
   redeclipse = callPackage ../games/redeclipse { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
add [r2mod_cli](https://github.com/foldex/r2mod_cli), a Risk of Rain 2 mod manager written in Bash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
