### PR TITLE
nixos/mailman: make Postfix support optional (provided you configure the MTA yourself)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -252,6 +252,19 @@
   <itemizedlist>
    <listitem>
     <para>
+     The Mailman NixOS module (<literal>services.mailman</literal>) has a new
+     option <xref linkend="opt-services.mailman.enablePostfix" />, defaulting
+     to true, that controls integration with Postfix.
+    </para>
+    <para>
+     If this option is disabled, default MTA config becomes not set and you
+     should set the options in <literal>services.mailman.settings.mta</literal>
+     according to the desired configuration as described in
+     <link xlink:href="https://mailman.readthedocs.io/en/latest/src/mailman/docs/mta.html">Mailman documentation</link>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The default-version of <literal>nextcloud</literal> is <package>nextcloud20</package>.
      Please note that it's <emphasis>not</emphasis> possible to upgrade <literal>nextcloud</literal>
      across multiple major versions! This means that it's e.g. not possible to upgrade

--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -38,7 +38,7 @@ let
   webSettingsJSON = pkgs.writeText "settings.json" (builtins.toJSON webSettings);
 
   # TODO: Should this be RFC42-ised so that users can set additional options without modifying the module?
-  mtaConfig = pkgs.writeText "mailman-postfix.cfg" ''
+  postfixMtaConfig = pkgs.writeText "mailman-postfix.cfg" ''
     [postfix]
     postmap_command: ${pkgs.postfix}/bin/postmap
     transport_file_type: hash
@@ -81,7 +81,7 @@ in {
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = "Enable Mailman on this host. Requires an active Postfix installation.";
+        description = "Enable Mailman on this host. Requires an active MTA on the host (e.g. Postfix).";
       };
 
       package = mkOption {
@@ -90,6 +90,20 @@ in {
         defaultText = "pkgs.mailman";
         example = literalExample "pkgs.mailman.override { archivers = []; }";
         description = "Mailman package to use";
+      };
+
+      enablePostfix = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Enable Postfix integration. Requires an active Postfix installation.
+
+          If you want to use another MTA, set this option to false and configure
+          settings in services.mailman.settings.mta.
+
+          Refer to the Mailman manual for more info.
+        '';
       };
 
       siteOwner = mkOption {
@@ -182,7 +196,7 @@ in {
         pid_file = "/run/mailman/master.pid";
       };
 
-      mta.configuration = lib.mkDefault "${mtaConfig}";
+      mta.configuration = lib.mkDefault (if cfg.enablePostfix then "${postfixMtaConfig}" else throw "When Mailman Postfix integration is disabled, set `services.mailman.settings.mta.configuration` to the path of the config file required to integrate with your MTA.");
 
       "archiver.hyperkitty" = lib.mkIf cfg.hyperkitty.enable {
         class = "mailman_hyperkitty.Archiver";
@@ -211,14 +225,22 @@ in {
               See <https://mailman.readthedocs.io/en/latest/src/mailman/docs/mta.html>.
             '';
           };
-    in [
+    in (lib.optionals cfg.enablePostfix [
       { assertion = postfix.enable;
-        message = "Mailman requires Postfix";
+        message = ''
+          Mailman's default NixOS configuration requires Postfix to be enabled.
+
+          If you want to use another MTA, set services.mailman.enablePostfix
+          to false and configure settings in services.mailman.settings.mta.
+
+          Refer to <https://mailman.readthedocs.io/en/latest/src/mailman/docs/mta.html>
+          for more info.
+        '';
       }
       (requirePostfixHash [ "relayDomains" ] "postfix_domains")
       (requirePostfixHash [ "config" "transport_maps" ] "postfix_lmtp")
       (requirePostfixHash [ "config" "local_recipient_maps" ] "postfix_lmtp")
-    ];
+    ]);
 
     users.users.mailman = {
       description = "GNU Mailman";
@@ -275,7 +297,7 @@ in {
       '';
     }) ];
 
-    services.postfix = {
+    services.postfix = lib.mkIf cfg.enablePostfix {
       recipientDelimiter = "+";         # bake recipient addresses in mail envelopes via VERP
       config = {
         owner_request_special = "no";   # Mailman handles -owner addresses on its own

--- a/nixos/modules/services/mail/mailman.xml
+++ b/nixos/modules/services/mail/mailman.xml
@@ -13,9 +13,9 @@
   </para>
 
   <section xml:id="module-services-mailman-basic-usage">
-    <title>Basic usage</title>
+    <title>Basic usage with Postfix</title>
     <para>
-      For a basic configuration, the following settings are suggested:
+      For a basic configuration with Postfix as the MTA, the following settings are suggested:
       <programlisting>{ config, ... }: {
   services.postfix = {
     enable = true;
@@ -54,6 +54,41 @@
       avoid spam -- a number of additional measures for authenticating
       incoming and outgoing mails, such as SPF, DMARC and DKIM are
       necessary, but outside the scope of the Mailman module.
+    </para>
+  </section>
+  <section xml:id="module-services-mailman-other-mtas">
+    <title>Using with other MTAs</title>
+    <para>
+      Mailman also supports other MTA, though with a little bit more configuration. For example, to use Mailman with Exim, you can use the following settings:
+      <programlisting>{ config, ... }: {
+  services = {
+    mailman = {
+      enable = true;
+      siteOwner = "mailman@example.org";
+      <link linkend="opt-services.mailman.enablePostfix">enablePostfix</link> = false;
+      settings.mta = {
+        incoming = "mailman.mta.exim4.LMTP";
+        outgoing = "mailman.mta.deliver.deliver";
+        lmtp_host = "localhost";
+        lmtp_port = "8024";
+        smtp_host = "localhost";
+        smtp_port = "25";
+        configuration = "python:mailman.config.exim4";
+      };
+    };
+    exim = {
+      enable = true;
+      # You can configure Exim in a separate file to reduce configuration.nix clutter
+      config = builtins.readFile ./exim.conf;
+    };
+  };
+}</programlisting>
+    </para>
+    <para>
+      The exim config needs some special additions to work with Mailman. Currently
+      NixOS can't manage Exim config with such granularity. Please refer to
+      <link xlink:href="https://mailman.readthedocs.io/en/latest/src/mailman/docs/mta.html">Mailman documentation</link>
+      for more info on configuring Mailman for working with Exim.
     </para>
   </section>
 </chapter>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #102641. Backward compatibility is provided: merging this PR will not result in any changes to the system besides the manual.

###### To Do
 - [x] Documentation
   - We need more awareness around `cfg.settings.mta` for this PR to be useful
   - The new `cfg.enablePostfix` option should clearly explain how to configure Mailman with other MTAs
 - [x] Error messages may need some refining
 - [ ] Tests for Mailman?
   - I think we need to cover Mailman with NixOS tests, including integration with other MTAs. It may be out of scope for this PR though.

###### How to test this
The following is a `configuration.nix` file that works the same with or without this PR being merged. You can build it using the tip of this branch as Nixpkgs or the master at the time of filing this PR - the derivation hash should stay EXACTLY the same.

```nix
# Build the test configuration from the base branch (pinned for convenience here)
nix-repl> old = ((builtins.getFlake "github:NixOS/nixpkgs/23a5371532aed94099834e46058a7e307c3dda87").lib.nixosSystem { modules = [ ./test-configuration.nix ]; }).config.system.build.vm
# Build from this PR
nix-repl> new = ((builtins.getFlake "github:kisik21/nixpkgs/mailman-other-mta-support").lib.nixosSystem { modules = [ ./test-configuration.nix ]; }).config.system.build.vm
# Ensure the produced output is the same
nix-repl> old == new
true
```

<details>
  <summary><code>configuration.nix</code> listing for testing backwards compatibility</summary>

```nix
{ config, pkgs, lib, ... }:
{
  imports = [
    # Unify flake and non-flake suffixes
    # Taken from https://github.com/NixOS/nixpkgs/issues/101622#issuecomment-716516561
    ({ config, lib, ... }: with lib; {
      system.nixos.revision = mkForce null;
      system.nixos.versionSuffix = mkForce "pre-git";
    })
    # Disable the manual to prevent it from breaking the comparison
    # We only need to compare the functional differences between systems
    # Not the range of available options
    ({ config, lib, ... }: with lib; {
      documentation.nixos.enable = false;
    })
  ];
  services = {
    postfix = {
      enable = true;
      relayDomains = [
        "hash:/var/lib/mailman/data/postfix_domains"
      ];
      config = {
        transport_maps = [
          "hash:/var/lib/mailman/data/postfix_lmtp"
        ];
        local_recipient_maps = [
          "hash:/var/lib/mailman/data/postfix_lmtp"
        ];
      };
    };
    mailman = {
      enable = true;
      siteOwner = "postmaster@fireburn.ru";
    };
  };
}
```

</details>

The following is a rough example of a minimal working Exim with Mailman config. Warning: this is untested, use at your own risk! :3 

<details>
  <summary><code>mailman-with-exim.nix</code></summary>

```nix
{ config, lib, pkgs, ... }:
{
  services = {
    mailman = {
      enable = true;
      siteOwner = "postmaster@fireburn.ru";
      enablePostfix = false;
      settings.mta = {
        incoming = "mailman.mta.exim4.LMTP";
        outgoing = "mailman.mta.deliver.deliver";
        lmtp_host = "localhost";
        lmtp_port = "8024";
        smtp_host = "localhost";
        smtp_port = "25";
        configuration = "python:mailman.config.exim4";
      };
    };
    exim = {
      enable = true;
      config = ''
        primary_hostname = mail.fireburn.ru
        domainlist local_domains = fireburn.ru : *.fireburn.ru
        domainlist relay_to_domains = :
        domainlist mm_domains = lists.fireburn.ru
        hostlist relay_from_hosts = <; localhost

        acl_smtp_rcpt = acl_check_rcpt
        .ifdef _HAVE_PRDR
        acl_smtp_data_prdr = acl_check_prdr
        .endif
        acl_smtp_data = acl_check_data

        never_users = root : nobody
        host_lookup = *
        dns_dnssec_ok = 1

        .ifdef _HAVE_PRDR
        prdr_enable = true
        .endif

        qualifyDomain = fireburn.ru
        log_selector = +smtp_protocol_error +smtp_syntax_error +tls_certificate_verified
        ignore_bounce_errors_after = 2d
        timeout_frozen_after = 7d
        check_rfc2047_length = false
        rfc1413_hosts =

        begin acl
        acl_check_rcpt:
          accept hosts = :
                 control = dkim_disable_verify

          deny message = Restricted chars in address
               domains = +local_domains
               local_parts = ^[.] : ^.*[@%!/|]

          deny message = Restricted chars in address
               domains = !+local_domains
               local_parts = ^[./|] : ^.*[@%!] : ^.*/\\.\\./

          accept local_parts = postmaster
                 domains = +local_domains
          require verify = sender

          accept hosts = +relay_from_hosts
                 control = submission
                 control = dkim_disable_verify

          require message = nice hosts say HELO first
                  condition = ''${if def:sender_helo_name}

          require message = relay not permitted
                  domains = +local_domains : +relay_to_domains

          require verify = recipient
          accept

        .ifdef _HAVE_PRDR
        acl_check_prdr:
          warn set acl_m_did_prdr = y
          accept
        .endif

        acl_check_data:
          deny message = max line length exceeded
               condition = ''${if > {$max_received_linelength}{998}}

          deny message = header syntax
               log_message = header syntax ($acl_verify_message)
               !verify = header_syntax

          accept

        begin routers
        dnslookup:
          driver = dnslookup
          domains ! +local_domains
          transport = remote_smtp
          ignore_target_hosts = <; 0.0.0.0 ; 127.0.0.0/8 ; ::1
          dnssec_request_domains = *
          no_more

        system_aliases:
          driver = redirect
          allow_fail
          allow_defer
          data = ''${lookup{$local_part}lsearch{/etc/aliases}}
          user = exim
          file_transport = address_file
          pipe_transport = address_pipe

        mailman3_router:
          driver = accept
          domains = +mm_domains
          require_files = /var/lib/mailman/lists/''${local_part}.''${domain}
          local_part_suffix_optional
          local_part_suffix = \
            -bounces   : -bounces+* : \
            -confirm   : -confirm+* : \
            -join      : -leave     : \
            -owner     : -request   : \
            -subscribe : -unsubscribe
          transport = mailman3_transport

        userforward:
          driver = redirect
          check_local_user
          local_part_suffix = +* : -*
          local_part_suffix_optional
          file = $home/.forward
          allow_filter
          no_verify
          no_expn
          check_ancestor
          file_transport = address_file
          pipe_transport = address_pipe
          reply_transport = address_reply

        localuser:
          driver = accept
          check_local_user
          local_part_suffix = +* : -*
          local_part_suffix_optional
          transport = local_delivery
          cannot_route_message = This user isn't known in these lands

          begin transports
          remote_smtp:
            driver = smtp
            message_size_limit = ''${if > {$max_received_linelength}{998} {1} {0}
          .ifdef _HAVE_DANE
            dnssec_request_domains = *
            hosts_try_dane = *
          .endif
          .ifdef _HAVE_PRDR
            hosts_try_prdr = *
          .endif

          local_delivery:
            driver = appendfile
            directory = $home/Maildir/
            delivery_date_add
            envelope_to_add
            return_path_add
            create_directory
            maildir_format

          address_pipe:
            driver = pipe
            return_fail_output

          address_file:
            driver = appendfile
            delivery_date_add
            envelope_to_add
            return_path_add

          address_reply:
            driver = autoreply

          mailman3_transport:
            driver = smtp
            protocol = lmtp
            allow_localhost
            hosts = localhost
            port = MM3_LMTP_PORT
            rcpt_include_affixes = true

          begin retry
          # Address or Domain    Error       Retries
          # -----------------    -----       -------
          *                      *           F,2h,15m; G,16h,1h,1.5; F,4d,6h
          begin rewrite
          begin authenticators
      '';
    };
  };
}
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (**evaluated only**, did not build nor test)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
