### PR TITLE
python3Packages.hjson: fix wrapper

### DIFF
--- a/pkgs/development/python-modules/hjson/default.nix
+++ b/pkgs/development/python-modules/hjson/default.nix
@@ -1,6 +1,8 @@
 { stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, pythonImportsCheckHook
+, makeWrapper
 }:
 
 buildPythonPackage rec {
@@ -14,6 +16,15 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1jc7j790rcqnhbrfj4lhnz3f6768dc55aij840wmx16jylfqpc2n";
   };
+
+  nativeBuildInputs = [ makeWrapper pythonImportsCheckHook ];
+
+  pythonImportsCheck = [ "hjson" ];
+
+  postInstall = ''
+    rm $out/bin/hjson.cmd
+    wrapProgram $out/bin/hjson --set PYTHONPATH "$PYTHONPATH"
+  '';
 
   meta = with stdenv.lib; {
     description = "A user interface for JSON";


### PR DESCRIPTION
And add a basic import test with the standard hook.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).