### PR TITLE
libff: init at 1.0.0

### DIFF
--- a/pkgs/development/libraries/libff/default.nix
+++ b/pkgs/development/libraries/libff/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, boost, gmp, openssl, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "libff";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "scipr-lab";
+    repo = "libff";
+    rev = "v${version}";
+    sha256 = "0dczi829497vqlmn6n4fgi89bc2h9f13gx30av5z2h6ikik7crgn";
+    fetchSubmodules = true;
+  };
+
+  cmakeFlags = [ "-DWITH_PROCPS=Off" ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ boost gmp openssl ];
+
+  meta = with stdenv.lib; {
+    description = "C++ library for Finite Fields and Elliptic Curves";
+    changelog = "https://github.com/scipr-lab/libff/blob/develop/CHANGELOG.md";
+    homepage = "https://github.com/scipr-lab/libff";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ arturcygan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14010,6 +14010,8 @@ in
 
   libfixposix = callPackage ../development/libraries/libfixposix {};
 
+  libff = callPackage ../development/libraries/libff { };
+
   libffcall = callPackage ../development/libraries/libffcall { };
 
   libffi = callPackage ../development/libraries/libffi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Split out from https://github.com/NixOS/nixpkgs/pull/105298

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
