### PR TITLE
crow-translate: init at 2.6.2

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, substituteAll
+, cmake
+, extra-cmake-modules
+, qttools
+, leptonica
+, tesseract4
+, qtmultimedia
+, qtx11extras
+, qttranslations
+}:
+let
+  singleapplication = fetchFromGitHub {
+    owner = "itay-grudev";
+    repo = "SingleApplication";
+    rev = "v3.2.0";
+    sha256 = "0w3z97dcqcz3bf7w6fja4smkafmx9kvhzb9px4k2nfmmyxh4yfma";
+  };
+  qtaskbarcontrol = fetchFromGitHub {
+    owner = "Skycoder42";
+    repo = "QTaskbarControl";
+    rev = "2.0.2";
+    sha256 = "0iymcvq3pv07fs9l4kh6hi1igqr7957iqndhsmg9fqkalf8nqyad";
+  };
+  qhotkey = fetchFromGitHub {
+    owner = "Skycoder42";
+    repo = "QHotkey";
+    rev = "1.4.2";
+    sha256 = "0391fkqrxqmzpvms4rk06aq05l308k6sadp6y3czq0gx2kng8mn9";
+  };
+  qonlinetranslator = fetchFromGitHub {
+    owner = "crow-translate";
+    repo = "QOnlineTranslator";
+    rev = "1.4.1";
+    sha256 = "1c6a8mdxms5vh8l7shi2kqdhafbzm50pbz6g1hhgg6qslla0vfn0";
+  };
+in
+mkDerivation rec {
+  pname = "crow-translate";
+  version = "2.6.2";
+
+  src = fetchFromGitHub {
+    owner = "crow-translate";
+    repo = "crow-translate";
+    rev = version;
+    sha256 = "1jgpqynmxmh6mrknpk5fh96lbdg799axp4cyn5rvalg3sdxajmqc";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./dont-fetch-external-libs.patch;
+      inherit singleapplication qtaskbarcontrol qhotkey qonlinetranslator;
+    })
+    (substituteAll {
+      # See https://github.com/NixOS/nixpkgs/issues/86054
+      src = ./fix-qttranslations-path.patch;
+      inherit qttranslations;
+    })
+  ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules qttools ];
+
+  buildInputs = [ leptonica tesseract4 qtmultimedia qtx11extras ];
+
+  meta = with stdenv.lib; {
+    description = "A simple and lightweight translator that allows to translate and speak text using Google, Yandex and Bing";
+    homepage = "https://crow-translate.github.io/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
+++ b/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
@@ -1,0 +1,33 @@
+diff --git i/cmake/ExternalLibraries.cmake w/cmake/ExternalLibraries.cmake
+index d8c88ae..47a12c0 100644
+--- i/cmake/ExternalLibraries.cmake
++++ w/cmake/ExternalLibraries.cmake
+@@ -2,24 +2,20 @@ include(FetchContent)
+ 
+ set(QAPPLICATION_CLASS QApplication)
+ FetchContent_Declare(SingleApplication
+-    GIT_REPOSITORY https://github.com/itay-grudev/SingleApplication
+-    GIT_TAG v3.2.0
++    SOURCE_DIR @singleapplication@
+ )
+ 
+ FetchContent_Declare(QTaskbarControl
+-    GIT_REPOSITORY https://github.com/Skycoder42/QTaskbarControl
+-    GIT_TAG 2.0.2
++    SOURCE_DIR @qtaskbarcontrol@
+ )
+ 
+ option(QHOTKEY_INSTALL OFF)
+ FetchContent_Declare(QHotkey
+-    GIT_REPOSITORY https://github.com/Skycoder42/QHotkey
+-    GIT_TAG 1.4.2
++    SOURCE_DIR @qhotkey@
+ )
+ 
+ FetchContent_Declare(QOnlineTranslator
+-    GIT_REPOSITORY https://github.com/crow-translate/QOnlineTranslator
+-    GIT_TAG 1.4.1
++    SOURCE_DIR @qonlinetranslator@
+ )
+ 
+ FetchContent_MakeAvailable(SingleApplication QTaskbarControl QHotkey QOnlineTranslator)

--- a/pkgs/applications/misc/crow-translate/fix-qttranslations-path.patch
+++ b/pkgs/applications/misc/crow-translate/fix-qttranslations-path.patch
@@ -1,0 +1,13 @@
+diff --git i/src/settings/appsettings.cpp w/src/settings/appsettings.cpp
+index 7be4573..e65994e 100644
+--- i/src/settings/appsettings.cpp
++++ w/src/settings/appsettings.cpp
+@@ -82,7 +82,7 @@ void AppSettings::applyLanguage(QLocale::Language lang)
+         QLocale::setDefault(QLocale(lang));
+ 
+     s_appTranslator.load(QLocale(), QStringLiteral(PROJECT_NAME), QStringLiteral("_"), QStandardPaths::locate(QStandardPaths::AppDataLocation, QStringLiteral("translations"), QStandardPaths::LocateDirectory));
+-    s_qtTranslator.load(QLocale(), QStringLiteral("qt"), QStringLiteral("_"), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
++    s_qtTranslator.load(QLocale(), QStringLiteral("qt"), QStringLiteral("_"), QLatin1String("@qttranslations@/translations"));
+ }
+ 
+ QLocale::Language AppSettings::defaultLanguage()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -198,6 +198,8 @@ in
 
   cpu-x = callPackage ../applications/misc/cpu-x { };
 
+  crow-translate = libsForQt5.callPackage ../applications/misc/crow-translate { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit dhall-nix;
   };


### PR DESCRIPTION
###### Motivation for this change

> **[Crow Translate](https://crow-translate.github.io/)** is a simple and lightweight translator programmed in C++ / Qt that allows to translate and speak text using Google, Yandex and Bing translate API.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
