### PR TITLE
asciidoc: add minimal variant for Python 3

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/minimal.nix
+++ b/pkgs/tools/typesetting/asciidoc/minimal.nix
@@ -1,0 +1,52 @@
+{ fetchFromGitHub
+, stdenv
+, python
+, autoreconfHook
+
+, libxml2
+, libxslt
+, docbook_xml_dtd_45
+, docbook_xsl_ns
+, docbook_xsl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "asciidoc";
+  version = "9.0.3";
+
+  src = fetchFromGitHub {
+    owner = "asciidoc";
+    repo = "asciidoc-py3";
+    rev = version;
+    sha256 = "129wm790b7c86clwwcqjy2ri72lwq8fyxkxw4dfj9a2r50xhlfri";
+  };
+
+  nativeBuildInputs = [ python autoreconfHook libxml2 libxslt docbook_xml_dtd_45 docbook_xsl_ns docbook_xsl ];
+
+  preBuild = ''
+    patchShebangs asciidoc.py
+  '';
+
+  postInstall = ''
+    patchShebangs $out/bin/a2x.py
+    patchShebangs $out/bin/asciidoc.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Text-based document generation system";
+    longDescription = ''
+      AsciiDoc is a text document format for writing notes, documentation,
+      articles, books, ebooks, slideshows, web pages, man pages and blogs.
+      AsciiDoc files can be translated to many formats including HTML, PDF,
+      EPUB, man page.
+
+      AsciiDoc is highly configurable: both the AsciiDoc source file syntax and
+      the backend output markups (which can be almost any type of SGML/XML
+      markup) can be customized and extended by the user.
+    '';
+    homepage = "http://www.methods.co.nz/asciidoc/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.bjornfor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2664,22 +2664,18 @@ in
 
   arpoison = callPackage ../tools/networking/arpoison { };
 
-  asciidoc = callPackage ../tools/typesetting/asciidoc {
-    inherit (python2Packages) matplotlib numpy aafigure recursivePthLoader;
-    w3m = w3m-batch;
-    enableStandardFeatures = false;
+  asciidoc = callPackage ../tools/typesetting/asciidoc/minimal.nix {
+    python = python3;
   };
 
-  asciidoc-full = appendToName "full" (asciidoc.override {
-    inherit (python2Packages) pygments;
+  asciidoc-full = appendToName "full" (callPackage ../tools/typesetting/asciidoc {
+    inherit (python2Packages) pygments matplotlib numpy aafigure recursivePthLoader;
+    w3m = w3m-batch;
     texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
     enableStandardFeatures = true;
   });
 
-  asciidoc-full-with-plugins = appendToName "full-with-plugins" (asciidoc.override {
-    inherit (python2Packages) pygments;
-    texlive = texlive.combine { inherit (texlive) scheme-minimal dvipng; };
-    enableStandardFeatures = true;
+  asciidoc-full-with-plugins = appendToName "with-plugins" (asciidoc-full.override {
     enableExtraPlugins = true;
   });
 


### PR DESCRIPTION
###### Motivation for this change

Trying to remove things from the minimal ISO that still rely on Python 2. #105392

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
