### PR TITLE
parted: switch to python3

### DIFF
--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.hostPlatform.isMusl; /* translation test */
   checkInputs = [ check dosfstools e2fsprogs perl python3 util-linux ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Create, destroy, resize, check, and copy partitions";
 
     longDescription = ''
@@ -59,13 +59,13 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://www.gnu.org/software/parted/";
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
 
-    maintainers = [
-      # Add your name here!
+    maintainers = with maintainers; [
+      lukegb
     ];
 
     # GNU Parted requires libuuid, which is part of util-linux-ng.
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/parted/default.nix
+++ b/pkgs/tools/misc/parted/default.nix
@@ -8,7 +8,7 @@
 , dosfstools
 , e2fsprogs
 , perl
-, python2
+, python3
 , util-linux
 , check
 , enableStatic ? false
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   # Tests were previously failing due to Hydra running builds as uid 0.
   # That should hopefully be fixed now.
   doCheck = !stdenv.hostPlatform.isMusl; /* translation test */
-  checkInputs = [ check dosfstools e2fsprogs perl python2 util-linux ];
+  checkInputs = [ check dosfstools e2fsprogs perl python3 util-linux ];
 
   meta = {
     description = "Create, destroy, resize, check, and copy partitions";


### PR DESCRIPTION
###### Motivation for this change

Trying to remove things from the minimal ISO that still rely on Python 2. #105392

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
