### PR TITLE
bwa: expand supported platforms

### DIFF
--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ];
 
+  # Avoid hardcoding gcc to allow environments with a different
+  # C compiler to build
+  preConfigure = ''
+    sed -i '/^CC/d' Makefile
+  '';
+
   # it's unclear which headers are intended to be part of the public interface
   # so we may find ourselves having to add more here over time
   installPhase = ''
@@ -27,6 +33,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl3;
     homepage    = "http://bio-bwa.sourceforge.net/";
     maintainers = with maintainers; [ luispedro ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.x86_64;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

BWA works across more platforms than just GCC on linux. This patch removes the enforced gcc line of the Makefile, allowing other stdenvs with non-gcc compilers to build, expanding support to other platforms.

@luispedro 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
