### PR TITLE
readme: update reference to number of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ channels](https://nixos.org/nix/manual/#sec-channels).
 Nixpkgs is among the most active projects on GitHub. While thousands
 of open issues and pull requests might seem a lot at first, it helps
 consider it in the context of the scope of the project. Nixpkgs
-describes how to build over 40,000 pieces of software and implements a
+describes how to build tens of thousands of pieces of software and implements a
 Linux distribution. The [GitHub Insights](https://github.com/NixOS/nixpkgs/pulse)
 page gives a sense of the project activity.
 


### PR DESCRIPTION
We updated the top of the readme to reference 60,000, but we forgot to
update this reference. This changes it so it won't become invalid for
a bit.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jonringer 