### PR TITLE
kodi: 18.9 -> 19.0

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,9 +1,10 @@
 { stdenv, lib, fetchurl, fetchFromGitHub, autoconf, automake, libtool, makeWrapper, linuxHeaders
-, pkg-config, cmake, gnumake, yasm, python2Packages
+, pkg-config, cmake, gnumake, yasm, python3Packages
 , libgcrypt, libgpgerror, libunistring
 , boost, avahi, lame
 , gettext, pcre-cpp, yajl, fribidi, which
 , openssl, gperf, tinyxml2, taglib, libssh, swig, jre_headless
+, gtest, ncurses, spdlog
 , libxml2, systemd
 , alsaLib, libGLU, libGL, fontconfig, freetype, ftgl
 , libjpeg, libpng, libtiff
@@ -42,17 +43,18 @@ assert udevSupport  -> udev != null;
 assert usbSupport   -> libusb-compat-0_1 != null && ! udevSupport; # libusb-compat-0_1 won't be used if udev is avaliable
 assert vdpauSupport -> libvdpau != null;
 assert useWayland -> wayland != null && wayland-protocols != null && waylandpp != null && libxkbcommon != null;
+assert useGbm || useWayland || x11Support;
 
 let
-  kodiReleaseDate = "20200728";
-  kodiVersion = "18.9";
-  rel = "Leia";
+  kodiReleaseDate = "20210219";
+  kodiVersion = "19.0";
+  rel = "Matrix";
 
   kodi_src = fetchFromGitHub {
     owner  = "xbmc";
     repo   = "xbmc";
     rev    = "${kodiVersion}-${rel}";
-    sha256 = "0nnf7823pixj6n2fkjc8rbdjwayvhlbglij2by4rnjzzfgmqmw20";
+    sha256 = "097dg6a7v4ia85jx1pmlpwzdpqcqxlrmniqd005q73zvgj67zc2p";
   };
 
   cmakeProto = fetchurl {
@@ -87,9 +89,9 @@ let
 
   ffmpeg = kodiDependency rec {
     name    = "FFmpeg";
-    version = "4.0.3";
-    rev     = "${version}-${rel}-18.2";
-    sha256  = "1krsjlr949iy5l6ljxancza1yi6w1annxc5s6k283i9mb15qy8cy";
+    version = "4.3.1";
+    rev     = "${version}-${rel}-Beta1";
+    sha256  = "1c5rwlxn6xj501iw7masdv2p6wb9rkmd299lmlkx97sw1kvxvg2w";
     preConfigure = ''
       cp ${kodi_src}/tools/depends/target/ffmpeg/{CMakeLists.txt,*.cmake} .
       sed -i 's/ --cpu=''${CPU}//' CMakeLists.txt
@@ -151,6 +153,12 @@ let
     postPatch         = cmakeProtoPatch;
   };
 
+  kodi_platforms =
+    lib.optional useGbm "gbm" ++
+    lib.optional useWayland "wayland" ++
+    lib.optional x11Support "x11"
+  ;
+
 in stdenv.mkDerivation {
     name = "kodi-${lib.optionalString useWayland "wayland-"}${kodiVersion}";
 
@@ -158,10 +166,11 @@ in stdenv.mkDerivation {
 
     buildInputs = [
       gnutls libidn libtasn1 nasm p11-kit
-      libxml2 python2Packages.python
+      libxml2 python3Packages.python
       boost libmicrohttpd
       gettext pcre-cpp yajl fribidi libva libdrm
       openssl gperf tinyxml2 taglib libssh
+      gtest ncurses spdlog
       alsaLib libGL libGLU fontconfig freetype ftgl
       libjpeg libpng libtiff
       libmpeg2 libsamplerate libmad
@@ -210,7 +219,7 @@ in stdenv.mkDerivation {
       which
       pkg-config gnumake
       autoconf automake libtool # still needed for some components. Check if that is the case with 19.0
-      jre_headless yasm gettext python2Packages.python flatbuffers
+      jre_headless yasm gettext python3Packages.python flatbuffers
 
       # for TexturePacker
       giflib zlib libpng libjpeg lzo
@@ -221,6 +230,8 @@ in stdenv.mkDerivation {
     ];
 
     cmakeFlags = [
+      "-DAPP_RENDER_SYSTEM=${if useGbm then "gles" else "gl"}"
+      "-DCORE_PLATFORM_NAME=${lib.concatStringsSep " " kodi_platforms}"
       "-Dlibdvdcss_URL=${libdvdcss.src}"
       "-Dlibdvdnav_URL=${libdvdnav.src}"
       "-Dlibdvdread_URL=${libdvdread.src}"
@@ -231,14 +242,9 @@ in stdenv.mkDerivation {
       "-DLIRC_DEVICE=/run/lirc/lircd"
       "-DSWIG_EXECUTABLE=${buildPackages.swig}/bin/swig"
       "-DFLATBUFFERS_FLATC_EXECUTABLE=${buildPackages.flatbuffers}/bin/flatc"
-      "-DPYTHON_EXECUTABLE=${buildPackages.python2Packages.python}/bin/python"
+      "-DPYTHON_EXECUTABLE=${buildPackages.python3Packages.python}/bin/python"
     ] ++ lib.optional useWayland [
-      "-DCORE_PLATFORM_NAME=wayland"
-      "-DWAYLAND_RENDER_SYSTEM=gl"
       "-DWAYLANDPP_SCANNER=${buildPackages.waylandpp}/bin/wayland-scanner++"
-    ] ++ lib.optional useGbm [
-      "-DCORE_PLATFORM_NAME=gbm"
-      "-DGBM_RENDER_SYSTEM=gles"
     ];
 
     # 14 tests fail but the biggest issue is that every test takes 30 seconds -
@@ -256,14 +262,14 @@ in stdenv.mkDerivation {
     '';
 
     postPatch = ''
-      substituteInPlace xbmc/platform/linux/LinuxTimezone.cpp \
+      substituteInPlace xbmc/platform/posix/PosixTimezone.cpp \
         --replace 'usr/share/zoneinfo' 'etc/zoneinfo'
     '';
 
     postInstall = ''
       for p in $(ls $out/bin/) ; do
         wrapProgram $out/bin/$p \
-          --prefix PATH            ":" "${lib.makeBinPath ([ python2Packages.python glxinfo ] ++ lib.optional x11Support xdpyinfo)}" \
+          --prefix PATH            ":" "${lib.makeBinPath ([ python3Packages.python glxinfo ] ++ lib.optional x11Support xdpyinfo)}" \
           --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath
               ([ curl systemd libmad libvdpau libcec libcec_platform libass ]
                  ++ lib.optional nfsSupport libnfs
@@ -279,7 +285,7 @@ in stdenv.mkDerivation {
     installCheckPhase = "$out/bin/kodi --version";
 
     passthru = {
-      pythonPackages = python2Packages;
+      pythonPackages = python3Packages;
     };
 
     meta = with lib; {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -391,13 +391,13 @@ let self = rec {
 
     plugin = "pvr-hdhomerun";
     namespace = "pvr.hdhomerun";
-    version = "3.5.0";
+    version = "7.1.0";
 
     src = fetchFromGitHub {
       owner = "kodi-pvr";
       repo = "pvr.hdhomerun";
       rev = "${version}-${rel}";
-      sha256 = "1zrkvfn0im2qmvqm93pa3cg8xkxv61sxlj8nsz4r5z9v9nhqadf6";
+      sha256 = "0gbwjssnd319csq2kwlyjj1rskg19m1dxac5dl2dymvx5hn3zrgm";
     };
 
     meta = {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -122,6 +122,7 @@ let self = rec {
       '';
       platforms = platforms.all;
       maintainers = with maintainers; [ edwtjo ];
+      broken = true; # requires port to python3
     };
 
   };
@@ -151,6 +152,7 @@ let self = rec {
       '';
       platforms = platforms.all;
       maintainers = with maintainers; [ edwtjo ];
+      broken = true; # requires port to python3
     };
 
   };
@@ -204,6 +206,7 @@ let self = rec {
       homepage = "https://forum.kodi.tv/showthread.php?tid=258159";
       description = "A ROM launcher for Kodi that uses HyperSpin assets.";
       maintainers = with maintainers; [ edwtjo ];
+      broken = true; # requires port to python3
     };
   in {
     service = mkKodiPlugin {
@@ -256,6 +259,7 @@ let self = rec {
       homepage = src.meta.homepage;
       description = "Simpleplugin API";
       license = licenses.gpl3;
+      broken = true; # requires port to python3
     };
   };
 
@@ -284,6 +288,7 @@ let self = rec {
       '';
       platforms = platforms.all;
       maintainers = with maintainers; [ edwtjo ];
+      broken = true; # requires port to python3
     };
 
   };
@@ -356,6 +361,7 @@ let self = rec {
       homepage = "https://forum.kodi.tv/showthread.php?tid=187421";
       description = "A comic book reader";
       maintainers = with maintainers; [ edwtjo ];
+      broken = true; # requires port to python3
     };
   };
 
@@ -475,6 +481,7 @@ let self = rec {
       homepage = src.meta.homepage;
       description = "Yet Another Torrent Player: libtorrent-based torrent streaming for Kodi";
       license = licenses.gpl3;
+      broken = true; # requires port to python3
     };
   });
 

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -319,13 +319,13 @@ let self = rec {
 
     plugin = "steam-launcher";
     namespace = "script.steam.launcher";
-    version = "3.1.4";
+    version = "3.5.1";
 
     src = fetchFromGitHub rec {
       owner = "teeedubb";
       repo = owner + "-xbmc-repo";
-      rev = "db67704c3e16bdcdd3bdfe2926c609f1f6bdc4fb";
-      sha256 = "001a7zs3a4jfzj8ylxv2klc33mipmqsd5aqax7q81fbgwdlndvbm";
+      rev = "8260bf9b464846a1f1965da495d2f2b7ceb81d55";
+      sha256 = "1fj3ry5s44nf1jzxk4bmnpa4b9p23nrpmpj2a4i6xf94h7jl7p5k";
     };
 
     propagatedBuildInputs = [ steam ];

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, callPackage, fetchFromGitHub
-, cmake, kodiPlain, libcec_platform, tinyxml, rapidxml
+, cmake, kodiPlain, libcec_platform, tinyxml, pugixml
 , steam, udev, libusb1, jsoncpp, libhdhomerun, zlib
 , python3Packages, expat, glib, nspr, nss, openssl
 , libssh, libarchive, lzma, bzip2, lz4, lzo }:
@@ -415,13 +415,13 @@ let self = rec {
 
     plugin = "pvr-iptvsimple";
     namespace = "pvr.iptvsimple";
-    version = "3.5.7";
+    version = "7.4.2";
 
     src = fetchFromGitHub {
       owner = "kodi-pvr";
       repo = "pvr.iptvsimple";
       rev = "${version}-${rel}";
-      sha256 = "17znib7c491h2ii4gagxradh0jyvgga0d548gbk4yjj2nc9qqc6d";
+      sha256 = "062i922qi0izkvn7v47yhyy2cf3fa7xc3k95b1gm9abfdwkk8ywr";
     };
 
     meta = {
@@ -432,7 +432,7 @@ let self = rec {
       license = licenses.gpl2Plus;
     };
 
-    extraBuildInputs = [ zlib rapidxml ];
+    extraBuildInputs = [ zlib pugixml ];
   };
 
   osmc-skin = mkKodiPlugin rec {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -489,13 +489,13 @@ let self = rec {
 
     plugin = "inputstream-adaptive";
     namespace = "inputstream.adaptive";
-    version = "2.4.6";
+    version = "2.6.7";
 
     src = fetchFromGitHub {
       owner = "peak3d";
       repo = "inputstream.adaptive";
       rev = "${version}-${rel}";
-      sha256 = "09d9b35mpaf3g5m51viyan9hv7d2i8ndvb9wm0j7rs5gwsf0k71z";
+      sha256 = "1pwqmbr78wp12jn6rwv63npdfc456adwz0amlxf6gvgg43li6p7s";
     };
 
     extraBuildInputs = [ expat ];

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -224,14 +224,14 @@ let self = rec {
 
   joystick = mkKodiABIPlugin rec {
     namespace = "peripheral.joystick";
-    version = "1.4.7";
+    version = "1.7.1";
     plugin = namespace;
 
     src = fetchFromGitHub {
       owner = "xbmc";
       repo = namespace;
-      rev = "v${version}";
-      sha256 = "03gsp4kg41s3n4ib4wsv7m3krfipgwc2z07i4mnd5zvg0c4xrmap";
+      rev = "${version}-${rel}";
+      sha256 = "1dhj4afr9kj938xx70fq5r409mz6lbw4n581ljvdjj9lq7akc914";
     };
 
     meta = {
@@ -240,7 +240,7 @@ let self = rec {
       maintainers = with maintainers; [ edwtjo ];
     };
 
-    extraBuildInputs = [ udev ];
+    extraBuildInputs = [ tinyxml udev ];
   };
 
   simpleplugin = mkKodiPlugin rec {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -267,14 +267,14 @@ let self = rec {
 
     plugin = "svtplay";
     namespace = "plugin.video.svtplay";
-    version = "4.0.48";
+    version = "5.1.12";
 
     src = fetchFromGitHub {
       name = plugin + "-" + version + ".tar.gz";
       owner = "nilzen";
       repo = "xbmc-" + plugin;
-      rev = "dc18ad002cd69257611d0032fba91f57bb199165";
-      sha256 = "0klk1jpjc243ak306k94mag4b4s17w68v69yb8lzzydszqkaqa7x";
+      rev = "v${version}";
+      sha256 = "04j1nhm7mh9chs995lz6bv1vsq5xzk7a7c0lmk4bnfv8jrfpj0w6";
     };
 
     meta = {
@@ -288,7 +288,6 @@ let self = rec {
       '';
       platforms = platforms.all;
       maintainers = with maintainers; [ edwtjo ];
-      broken = true; # requires port to python3
     };
 
   };

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -538,14 +538,14 @@ let self = rec {
 
   vfs-libarchive = mkKodiABIPlugin rec {
     namespace = "vfs.libarchive";
-    version = "1.0.7";
+    version = "2.0.0";
     plugin = namespace;
 
     src = fetchFromGitHub {
       owner = "xbmc";
       repo = namespace;
       rev = "${version}-${rel}";
-      sha256 = "01qhv095h5j67ispm4iw18pd3kl7a0mnjkgm92al9qqiyif8lzgh";
+      sha256 = "1q62p1i6rvqk2zv6f1cpffkh95lgclys2xl4dwyhj3acmqdxd9i5";
     };
 
     meta = with lib; {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -369,13 +369,13 @@ let self = rec {
 
     plugin = "pvr-hts";
     namespace = "pvr.hts";
-    version = "4.4.14";
+    version = "8.2.2";
 
     src = fetchFromGitHub {
       owner = "kodi-pvr";
       repo = "pvr.hts";
       rev = "${version}-${rel}";
-      sha256 = "1bcwcwd2yjhw85yk6lyhf0iqiclrsz7r7vpbxgc650fwqbb146gr";
+      sha256 = "0jnn9gfjl556acqjf92wzzn371gxymhbbi665nqgg2gjcan0a49q";
     };
 
     meta = {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -295,14 +295,14 @@ let self = rec {
 
   steam-controller = mkKodiABIPlugin rec {
     namespace = "peripheral.steamcontroller";
-    version = "0.10.0";
+    version = "0.11.0";
     plugin = namespace;
 
     src = fetchFromGitHub {
       owner = "kodi-game";
       repo = namespace;
-      rev = "ea345392ab5aa4485f3a48d2037fa8a8e8ab82de";
-      sha256 = "1hbd8fdvn7xkr9csz1g9wah78nhnq1rkazl4zwa31y70830k3279";
+      rev = "f68140ca44f163a03d3a625d1f2005a6edef96cb";
+      sha256 = "09lm8i119xlsxxk0c64rnp8iw0crr90v7m8iwi9r31qdmxrdxpmg";
     };
 
     extraBuildInputs = [ libusb1 ];

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -516,14 +516,14 @@ let self = rec {
 
   vfs-sftp = mkKodiABIPlugin rec {
     namespace = "vfs.sftp";
-    version = "1.0.6";
+    version = "2.0.0";
     plugin = namespace;
 
     src = fetchFromGitHub {
       owner = "xbmc";
       repo = namespace;
       rev = "${version}-${rel}";
-      sha256 = "044kkzcpzvbyih4vys33r4hqw38xa82snmvl4qj1r80wnszc8af1";
+      sha256 = "06w74sh8yagrrp7a7rjaz3xrh1j3wdqald9c4b72c33gpk5997dk";
     };
 
     meta = with lib; {

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, callPackage, fetchFromGitHub
 , cmake, kodiPlain, libcec_platform, tinyxml, rapidxml
 , steam, udev, libusb1, jsoncpp, libhdhomerun, zlib
-, python2Packages, expat, glib, nspr, nss, openssl
+, python3Packages, expat, glib, nspr, nss, openssl
 , libssh, libarchive, lzma, bzip2, lz4, lzo }:
 
 with lib;
@@ -9,7 +9,7 @@ with lib;
 let self = rec {
 
   pluginDir = "/share/kodi/addons";
-  rel = "Leia";
+  rel = "Matrix";
 
   kodi = kodiPlain;
 
@@ -451,7 +451,7 @@ let self = rec {
     };
   };
 
-  yatp = python2Packages.toPythonModule (mkKodiPlugin rec {
+  yatp = python3Packages.toPythonModule (mkKodiPlugin rec {
     plugin = "yatp";
     namespace = "plugin.video.yatp";
     version = "3.3.2";
@@ -467,8 +467,8 @@ let self = rec {
 
     propagatedBuildInputs = [
       simpleplugin
-      python2Packages.requests
-      python2Packages.libtorrent-rasterbar
+      python3Packages.requests
+      python3Packages.libtorrent-rasterbar
     ];
 
     meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The newest version of `kodi` (`19.x`) has enough changes that I'm guessing we should start testing this sooner rather than later.

This is **heavily** work in progress. I'm hoping other contributors will work with me on this one :heart:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
