### PR TITLE
oatpp: init at 1.2.0

### DIFF
--- a/pkgs/development/libraries/oatpp/default.nix
+++ b/pkgs/development/libraries/oatpp/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "oatpp";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "oatpp";
+    repo = "oatpp";
+    rev = version;
+    sha256 = "05rm0m5zf1b5ky8prf6yni2074bz6yjjbrc2qk96fb48fc1198gw";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  # Tests fail on darwin. See https://github.com/NixOS/nixpkgs/pull/105419#issuecomment-735826894
+  doCheck = !stdenv.isDarwin;
+
+  meta = with stdenv.lib; {
+    homepage = "https://oatpp.io/";
+    description = "Light and powerful C++ web framework for highly scalable and resource-efficient web applications";
+    license = licenses.asl20;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6110,6 +6110,8 @@ in
 
   oathToolkit = callPackage ../tools/security/oath-toolkit { };
 
+  oatpp = callPackage ../development/libraries/oatpp { };
+
   obex_data_server = callPackage ../tools/bluetooth/obex-data-server { };
 
   obexd = callPackage ../tools/bluetooth/obexd { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
