### PR TITLE
ocamlPackages.qcheck: 0.15 → 0.16

### DIFF
--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -1,8 +1,12 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, mdx, qtest, result }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, dune-configurator
+, mdx, qtest, result
+}:
 
 buildDunePackage rec {
   pname = "iter";
   version = "1.2.1";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "c-cube";
@@ -11,10 +15,11 @@ buildDunePackage rec {
     sha256 = "0j2sg50byn0ppmf6l36ksip7zx1d3gv7sc4hbbxs2rmx39jr7vxh";
   };
 
-  buildInputs = lib.optionals doCheck [ mdx.bin qtest ];
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ result ];
 
   doCheck = lib.versionAtLeast ocaml.version "4.07";
+  checkInputs = [ mdx.bin qtest ];
 
   meta = {
     homepage = "https://github.com/c-cube/sequence";

--- a/pkgs/development/ocaml-modules/qcheck/alcotest.nix
+++ b/pkgs/development/ocaml-modules/qcheck/alcotest.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "qcheck-alcotest";
 
-  inherit (qcheck-core) version src;
+  inherit (qcheck-core) version useDune2 src;
 
   propagatedBuildInputs = [ qcheck-core alcotest ];
 

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -2,7 +2,9 @@
 
 buildDunePackage rec {
   pname = "qcheck-core";
-  version = "0.15";
+  version = "0.16";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.03";
 
@@ -10,7 +12,7 @@ buildDunePackage rec {
     owner = "c-cube";
     repo = "qcheck";
     rev = version;
-    sha256 = "1ywaklqm1agvxvzv7pwl8v4zlwc3ykw6l251w43f0gy9cfwqmh3j";
+    sha256 = "1s5dpqj8zvd3wr2w3fp4wb6yc57snjpxzzfv9fb6l9qgigswwjdr";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "qcheck";
 
-  inherit (qcheck-ounit) version src;
+  inherit (qcheck-ounit) version useDune2 src;
 
   propagatedBuildInputs = [ qcheck-ounit ];
 

--- a/pkgs/development/ocaml-modules/qcheck/ounit.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ounit.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "qcheck-ounit";
 
-  inherit (qcheck-core) version src;
+  inherit (qcheck-core) version useDune2 src;
 
   propagatedBuildInputs = [ qcheck-core ounit ];
 

--- a/pkgs/development/ocaml-modules/qtest/default.nix
+++ b/pkgs/development/ocaml-modules/qtest/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "qtest";
   version = "2.11.1";
 
+  useDune2 = true;
+
   src = fetchFromGitHub {
     owner = "vincent-hugot";
     repo = pname;

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -2,6 +2,7 @@
 , js_of_ocaml-ppx, re }:
 
 if stdenv.lib.versionOlder ocaml.version "4.03"
+|| stdenv.lib.versionAtLeast ocaml.version "4.11"
 then throw "xtmpl not supported for ocaml ${ocaml.version}"
 else
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://github.com/c-cube/qcheck/blob/0.16/CHANGELOG.md
Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
