### PR TITLE
Cross-compile configuration for reMarkable 2 tablet

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -39,6 +39,11 @@ rec {
     platform = platforms.zero-gravitas;
   };
 
+  remarkable2 = {
+    config = "armv7l-unknown-linux-gnueabihf";
+    platform = platforms.zero-sugar;
+  };
+
   armv7l-hf-multiplatform = {
     config = "armv7l-unknown-linux-gnueabihf";
     platform = platforms.armv7l-hf-multiplatform;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -217,6 +217,21 @@ rec {
     };
   };
 
+  zero-sugar = {
+    name = "zero-sugar";
+    kernelBaseConfig = "zero-sugar_defconfig";
+    kernelArch = "arm";
+    kernelDTB = true;
+    kernelAutoModules = false;
+    kernelPreferBuiltin = true;
+    kernelTarget = "zImage";
+    gcc = {
+      cpu = "cortex-a7";
+      fpu = "neon-vfpv4";
+      float-abi = "hard";
+    };
+  };
+
   scaleway-c1 = armv7l-hf-multiplatform // {
     gcc = {
       cpu = "cortex-a9";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Following in the footsteps of @siraben's work in https://github.com/NixOS/nixpkgs/pull/102503, add toolchain support for the reMarkable 2 tablet:

- `lib.systems.examples.remarkable2`
- `lib.systems.platforms.zero-sugar`

Where the platform differs from `zero-gravitas` is the target machine-specific options, which support the i.MX 7Dual in the reMarkable 2. In particular, imx7d gains the extra features of the `armv7ve` arch and an upgrade to the VFPv4 FPU. Otherwise, this is a copy-paste of the reMarkable 1 configuration.

This has been tested by installing Nix on the tablet and using `nix-copy-closure` to install cross-compiled packages. Packages tested so far: 

- hello
- nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
