### PR TITLE
ruffle: init at nightly-2020-11-30

### DIFF
--- a/pkgs/misc/emulators/ruffle/default.nix
+++ b/pkgs/misc/emulators/ruffle/default.nix
@@ -1,0 +1,49 @@
+{ alsaLib
+, fetchFromGitHub
+, openssl
+, pkg-config
+, python3
+, rustPlatform
+, stdenv
+, wayland
+, xorg
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ruffle";
+  version = "nightly-2020-11-30";
+
+  src = fetchFromGitHub {
+    owner = "ruffle-rs";
+    repo = pname;
+    rev = version;
+    sha256 = "0z54swzy47laq3smficd3dyrs2zdi3cj2kb0b4hppjxpkkhiw4x0";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    alsaLib
+    openssl
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXi
+    xorg.libxcb
+    xorg.libXrender
+  ];
+
+  cargoSha256 = "05kwfcbzjyyfhiqklhhlv06pinzw9bry4j8l9lk3k04c1q30gzkw";
+
+  meta = with stdenv.lib; {
+    description = "An Adobe Flash Player emulator written in the Rust programming language.";
+    homepage = "https://ruffle.rs/";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ govanify ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6995,6 +6995,8 @@ in
 
   rubocop = callPackage ../development/tools/rubocop { };
 
+  ruffle = callPackage ../misc/emulators/ruffle { };
+
   runelite = callPackage ../games/runelite { };
 
   runningx = callPackage ../tools/X11/runningx { };


### PR DESCRIPTION
###### Motivation for this change

Initial addition of ruffle, the flash player emulator. While it isn't feature complete in the future this could lead to a drop-in replacement for flashplayer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
