### PR TITLE
linux_zen: 5.9.10 -> 5.9.12

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchFromGitHub, buildLinux, ... } @ args:
 
 let
-  version = "5.9.11";
+  version = "5.9.12";
 in
 
 buildLinux (args // {
-  modDirVersion = "${version}-zen2";
+  modDirVersion = "${version}-zen1";
   inherit version;
   isZen = true;
 
   src = fetchFromGitHub {
     owner = "zen-kernel";
     repo = "zen-kernel";
-    rev = "v${version}-zen2";
-    sha256 = "1qipxicd8a094y28nv6cb4kzcc29hz7yg39fz4faly2rwivirv81";
+    rev = "v${version}-zen1";
+    sha256 = "07cmcw8ib9wc4im08pbmxhj187lhsfxh2asn4jdxadxxq3f60h6w";
   };
 
   extraMeta = {

--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchFromGitHub, buildLinux, ... } @ args:
 
 let
-  version = "5.9.10";
+  version = "5.9.11";
 in
 
 buildLinux (args // {
-  modDirVersion = "${version}-zen1";
+  modDirVersion = "${version}-zen2";
   inherit version;
   isZen = true;
 
   src = fetchFromGitHub {
     owner = "zen-kernel";
     repo = "zen-kernel";
-    rev = "v${version}-zen1";
-    sha256 = "0836mclwr3r4hm4pn8hp21sk14avrfwiv2s8lqx3cjasgdbyi826";
+    rev = "v${version}-zen2";
+    sha256 = "1qipxicd8a094y28nv6cb4kzcc29hz7yg39fz4faly2rwivirv81";
   };
 
   extraMeta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxPackages_zen.ixgbevf</li>
    <li>linuxPackages_zen.lttng-modules</li>
    <li>linuxPackages_zen.ndiswrapper</li>
    <li>linuxPackages_zen.nvidia_x11_legacy304</li>
    <li>linuxPackages_zen.phc-intel</li>
    <li>linuxPackages_zen.rtl8723bs</li>
    <li>linuxPackages_zen.sch_cake</li>
    <li>linuxPackages_zen.tbs</li>
  </ul>
</details>
<details>
  <summary>19 packages failed to build:</summary>
  <ul>
    <li>linuxPackages_zen.amdgpu-pro</li>
    <li>linuxPackages_zen.anbox</li>
    <li>linuxPackages_zen.ati_drivers_x11</li>
    <li>linuxPackages_zen.broadcom_sta</li>
    <li>linuxPackages_zen.chipsec</li>
    <li>linuxPackages_zen.cryptodev</li>
    <li>linuxPackages_zen.dpdk</li>
    <li>linuxPackages_zen.ena</li>
    <li>linuxPackages_zen.evdi</li>
    <li>linuxPackages_zen.mwprocapture</li>
    <li>linuxPackages_zen.mxu11x0</li>
    <li>linuxPackages_zen.nvidia_x11_legacy340</li>
    <li>linuxPackages_zen.nvidia_x11_legacy390</li>
    <li>linuxPackages_zen.nvidia_x11_vulkan_beta</li>
    <li>linuxPackages_zen.oci-seccomp-bpf-hook</li>
    <li>linuxPackages_zen.rtl8814au</li>
    <li>linuxPackages_zen.rtl8821au</li>
    <li>linuxPackages_zen.rtl88xxau-aircrack</li>
    <li>linuxPackages_zen.rtlwifi_new</li>
  </ul>
</details>
<details>
  <summary>54 packages built:</summary>
  <ul>
    <li>linuxPackages_zen.acpi_call</li>
    <li>linuxPackages_zen.akvcam</li>
    <li>linuxPackages_zen.asus-wmi-sensors</li>
    <li>linuxPackages_zen.batman_adv</li>
    <li>linuxPackages_zen.bbswitch</li>
    <li>linuxPackages_zen.bcc</li>
    <li>linuxPackages_zen.bpftrace</li>
    <li>linuxPackages_zen.can-isotp</li>
    <li>linuxPackages_zen.cpupower</li>
    <li>linuxPackages_zen.ddcci-driver</li>
    <li>linuxPackages_zen.digimend</li>
    <li>linuxPackages_zen.facetimehd</li>
    <li>linuxPackages_zen.fwts-efi-runtime</li>
    <li>linuxPackages_zen.hyperv-daemons</li>
    <li>linuxPackages_zen.intel-speed-select</li>
    <li>linuxPackages_zen.it87</li>
    <li>linuxPackages_zen.jool</li>
    <li>linuxPackages_zen.kernel</li>
    <li>linuxPackages_zen.mba6x_bl</li>
    <li>linuxPackages_zen.netatop</li>
    <li>linuxPackages_zen.nvidia_x11</li>
    <li>linuxPackages_zen.nvidiabl</li>
    <li>linuxPackages_zen.openafs</li>
    <li>linuxPackages_zen.openafs_1_9</li>
    <li>linuxPackages_zen.openrazer</li>
    <li>linuxPackages_zen.perf</li>
    <li>linuxPackages_zen.ply</li>
    <li>linuxPackages_zen.r8125</li>
    <li>linuxPackages_zen.r8168</li>
    <li>linuxPackages_zen.rtl8192eu</li>
    <li>linuxPackages_zen.rtl8812au</li>
    <li>linuxPackages_zen.rtl8821ce</li>
    <li>linuxPackages_zen.rtl8821cu</li>
    <li>linuxPackages_zen.rtl88x2bu</li>
    <li>linuxPackages_zen.sysdig</li>
    <li>linuxPackages_zen.system76</li>
    <li>linuxPackages_zen.system76-acpi</li>
    <li>linuxPackages_zen.system76-io</li>
    <li>linuxPackages_zen.systemtap</li>
    <li>linuxPackages_zen.tmon</li>
    <li>linuxPackages_zen.tp_smapi</li>
    <li>linuxPackages_zen.turbostat</li>
    <li>linuxPackages_zen.tuxedo-keyboard</li>
    <li>linuxPackages_zen.usbip</li>
    <li>linuxPackages_zen.v4l2loopback</li>
    <li>linuxPackages_zen.v86d</li>
    <li>linuxPackages_zen.vhba</li>
    <li>linuxPackages_zen.virtualbox</li>
    <li>linuxPackages_zen.virtualboxGuestAdditions</li>
    <li>linuxPackages_zen.x86_energy_perf_policy</li>
    <li>linuxPackages_zen.xpadneo</li>
    <li>linuxPackages_zen.zenpower</li>
    <li>linuxPackages_zen.zfs</li>
    <li>linuxPackages_zen.zfsUnstable</li>
  </ul>
</details>
