### PR TITLE
ibus-engines.rime: init at 1.4.0

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, pkg-config, ibus, cmake, libnotify, librime, brise }:
+
+let rime-data = "${brise}/share/rime-data";
+in stdenv.mkDerivation rec {
+  pname = "ibus-rime";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "ibus-rime";
+    rev = version;
+    sha256 = "0zbajz7i18vrqwdyclzywvsjg6qzaih64jhi3pkxp7mbw8jc5vhy";
+  };
+
+  patches = [ ./fix-paths.patch ];
+
+  nativeBuildInputs = [ pkg-config cmake ];
+
+  buildInputs = [ ibus libnotify librime ];
+
+  postPatch = ''
+    # set compiled-in DATA_DIR so resources can be found
+    substituteInPlace rime_config.h \
+      --replace '#define IBUS_RIME_SHARED_DATA_DIR IBUS_RIME_INSTALL_PREFIX "/share/rime-data"' \
+                '#define IBUS_RIME_SHARED_DATA_DIR "${rime-data}"' \
+      --replace '#define IBUS_RIME_ICONS_DIR IBUS_RIME_INSTALL_PREFIX "/share/ibus-rime/icons"' \
+                '#define IBUS_RIME_ICONS_DIR "${placeholder "out"}/share/ibus-rime/icons"'
+  '';
+
+  cmakeFlags = [ "-DRIME_DATA_DIR=${rime-data}" ];
+
+  installPhase = ''
+    runHook preInstall
+    make --directory .. install PREFIX=$out builddir=$PWD
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/share/ibus/component/rime.xml \
+      --replace '/usr/lib/ibus-rime' "$out/libexec" \
+      --replace '/usr/share' "$out/share"
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description = "Rime Input Method Engine for Linux/IBus";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mschuwalow ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/fix-paths.patch
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/fix-paths.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile b/Makefile
+index 1fd0c25..0859399 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,7 @@ ifeq (${PREFIX},)
+ 	PREFIX=/usr
+ endif
+ sharedir = $(DESTDIR)$(PREFIX)/share
+-libexecdir = $(DESTDIR)$(PREFIX)/lib
++libexecdir = $(DESTDIR)$(PREFIX)/libexec
+
+ ifeq (${builddir},)
+ 	builddir=build
+@@ -23,8 +23,8 @@ ibus-engine-rime-static:
+ install:
+ 	install -m 755 -d $(sharedir)/ibus/component
+ 	install -m 644 -t $(sharedir)/ibus/component/ rime.xml
+-	install -m 755 -d $(libexecdir)/ibus-rime
+-	install -m 755 -t $(libexecdir)/ibus-rime/ $(builddir)/ibus-engine-rime
++	install -m 755 -d $(libexecdir)
++	install -m 755 -t $(libexecdir) $(builddir)/ibus-engine-rime
+ 	install -m 755 -d $(sharedir)/ibus-rime
+ 	install -m 755 -d $(sharedir)/ibus-rime/icons
+ 	install -m 644 -t $(sharedir)/ibus-rime/icons/ icons/*.png

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3033,6 +3033,8 @@ in
       protobuf = pkgs.protobuf3_8.overrideDerivation (oldAttrs: { stdenv = clangStdenv; });
     };
 
+    rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };
+
     table = callPackage ../tools/inputmethods/ibus-engines/ibus-table { };
 
     table-chinese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-chinese {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds an additional ibus engine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
