### PR TITLE
mcomix3: manpage location, app icon

### DIFF
--- a/pkgs/applications/graphics/mcomix3/default.nix
+++ b/pkgs/applications/graphics/mcomix3/default.nix
@@ -1,13 +1,15 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, python3
 , wrapGAppsHook
+, installShellFiles
+, python3
 , gobject-introspection
 , gtk3
 , gdk-pixbuf
+
 # Recommended Dependencies:
-, unrarSupport ? false
+, unrarSupport ? false  # unfree software
 , unrar
 , p7zip
 , lhasa
@@ -18,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
   pname = "mcomix3";
   version = "unstable-2020-11-23";
 
-  # fetch from github because no official release on pypi/github and no build system
+  # no official release on pypi/github and no build system
   src = fetchFromGitHub {
     repo   = "${pname}";
     owner  = "multiSnow";
@@ -27,7 +29,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   buildInputs = [ gobject-introspection gtk3 gdk-pixbuf ];
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook installShellFiles ];
   propagatedBuildInputs = (with python3.pkgs; [ pillow pygobject3 pycairo ]);
 
   format = "other";
@@ -55,7 +57,8 @@ python3.pkgs.buildPythonApplication rec {
 
   postInstall = ''
     rmdir $libdir/mcomix/mcomix
-    cp man/* $out/share/man/man1/
+    installManPage man/*
+    mv $out/share/man/man1/mcomix.1 $out/share/man/man1/${pname}.1
     cp -r mime/icons/* $out/share/icons/hicolor/
     cp mime/*.desktop $out/share/applications/
     cp mime/*.appdata.xml $out/share/metainfo/
@@ -63,12 +66,13 @@ python3.pkgs.buildPythonApplication rec {
     for folder in $out/share/icons/hicolor/*; do
         mkdir $folder/{apps,mimetypes}
         mv $folder/*.png $folder/mimetypes
+        cp $libdir/mcomix/images/$(basename $folder)/mcomix.png $folder/apps/${pname}.png
         cp $folder/mimetypes/application-x-cbt.png $folder/mimetypes/application-x-cbr.png
         cp $folder/mimetypes/application-x-cbt.png $folder/mimetypes/application-x-cbz.png
     done
   '';
 
-  # to prevent double wrapping
+  # prevent double wrapping
   dontWrapGApps = true;
   preFixup = ''
     makeWrapperArgs+=(
@@ -77,7 +81,7 @@ python3.pkgs.buildPythonApplication rec {
     )
   '';
 
-  # real pytests seem to be broken upstream
+  # real pytests broken upstream
   checkPhase = ''
     $out/bin/comicthumb --help > /dev/null
     $out/bin/${pname} --help > /dev/null

--- a/pkgs/applications/graphics/mcomix3/default.nix
+++ b/pkgs/applications/graphics/mcomix3/default.nix
@@ -57,8 +57,8 @@ python3.pkgs.buildPythonApplication rec {
 
   postInstall = ''
     rmdir $libdir/mcomix/mcomix
+    mv man/mcomix.1 man/${pname}.1
     installManPage man/*
-    mv $out/share/man/man1/mcomix.1 $out/share/man/man1/${pname}.1
     cp -r mime/icons/* $out/share/icons/hicolor/
     cp mime/*.desktop $out/share/applications/
     cp mime/*.appdata.xml $out/share/metainfo/


### PR DESCRIPTION
###### Motivation for this change
Application icon is currently missing in `mcomix3`. Additionally, `man mcomix3` is failing, because the corresponding manpage is named `mcomix` instead of `mcomix3`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
