### PR TITLE
[20.09] libproxy: fix CVE-2020-25219, CVE-2020-26154

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -71,6 +71,17 @@ stdenv.mkDerivation rec {
       url = "https://github.com/libproxy/libproxy/pull/95.patch";
       sha256 = "18vyr6wlis9zfwml86606jpgb9mss01l9aj31iiciml8p857aixi";
     })
+    (fetchpatch {
+      name = "CVE-2020-25219.patch";
+      url = "https://github.com/libproxy/libproxy/commit/a83dae404feac517695c23ff43ce1e116e2bfbe0.patch";
+      sha256 = "0wdh9qjq99aw0jnf2840237i3hagqzy42s09hz9chfgrw8pyr72k";
+    })
+    (fetchpatch {
+      name = "CVE-2020-26154.patch";
+      url = "https://github.com/libproxy/libproxy/commit/4411b523545b22022b4be7d0cac25aa170ae1d3e.patch";
+      sha256 = "0pdy9sw49lxpaiwq073cisk0npir5bkch70nimdmpszxwp3fv1d8";
+    })
+
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     (fetchpatch {
       url = "https://github.com/libproxy/libproxy/commit/44158f03f8522116758d335688ed840dfcb50ac8.patch";


### PR DESCRIPTION
###### Motivation for this change

CVE-2020-25219:
url::recvline in url.cpp in libproxy 0.4.x through 0.4.15 allows a
remote HTTP server to trigger uncontrolled recursion via a response
composed of an infinite stream that lacks a newline character. This
leads to stack exhaustion.

CVE-2020-26154:
url.cpp in libproxy through 0.4.15 is prone to a buffer overflow when
PAC is enabled, as demonstrated by a large PAC file that is delivered
without a Content-length header.

Fixes: CVE-2020-25219, CVE-2020-26154
(cherry picked from commit c0e0a6876f8377096223c39d035924f77c9dcff1)


Backport of #105287

cc @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] ran `dino` which depends on `libproxy`
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
