### PR TITLE
botan2: 2.9.0 -> 2.17.2

### DIFF
--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -1,9 +1,9 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  baseVersion = "2.9";
-  revision = "0";
-  sha256 = "06fiyalvc68p11qqh953azx2vrbav5vr00yvcfp67p9l4csn8m9h";
+  baseVersion = "2.17";
+  revision = "2";
+  sha256 = "0v0yiq0qxcrsn5b34j6bz8i6pds8dih2ds90ylmy1msm5gz7vqpb";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -4,6 +4,7 @@ callPackage ./generic.nix (args // {
   baseVersion = "1.10";
   revision = "17";
   sha256 = "04rnha712dd3sdb2q7k2yw45sf405jyigk7yrjfr6bwd9fvgyiv8";
+  sourceExtension = "tgz";
   extraConfigureFlags = "--with-gnump";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, python, bzip2, zlib, gmp, openssl, boost
 # Passed by version specific builders
 , baseVersion, revision, sha256
+, sourceExtension ? "tar.xz"
 , extraConfigureFlags ? ""
 , postPatch ? null
 , darwin
@@ -12,10 +13,10 @@ stdenv.mkDerivation rec {
   version = "${baseVersion}.${revision}";
 
   src = fetchurl {
-    name = "Botan-${version}.tgz";
+    name = "Botan-${version}.${sourceExtension}";
     urls = [
-       "http://files.randombit.net/botan/v${baseVersion}/Botan-${version}.tgz"
-       "http://botan.randombit.net/releases/Botan-${version}.tgz"
+       "http://files.randombit.net/botan/v${baseVersion}/Botan-${version}.${sourceExtension}"
+       "http://botan.randombit.net/releases/Botan-${version}.${sourceExtension}"
     ];
     inherit sha256;
   };

--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation rec {
     '';
     maintainers = with maintainers; [ erictapen ];
     platforms = platforms.linux;
+    broken = true; # fails to build with recent versions of botan. https://github.com/das-labor/neopg/issues/98
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated botan2 by a bunch of versions. Thereby addressing the two advisories botan2 got in 2020.

https://botan.randombit.net/security.html

```
2020

    2020-07-05: Failure to enforce name constraints on alternative names

    The path validation algorithm enforced name constraints on the primary DN included in the certificate but failed to do so against alternative DNs which may be included in the subject alternative name. This would allow a corrupted sub-CA which was constrained by a name constraints extension in its own certificate to issue a certificate containing a prohibited DN. Until 2.15.0, there was no API to access these alternative name DNs so it is unlikely that any application would make incorrect access control decisions on the basis of the incorrect DN. Reported by Mario Korth of Ruhr-Universität Bochum.

    Introduced in 1.11.29, fixed in 2.15.0

    2020-03-24: Side channel during CBC padding

    The CBC padding operations were not constant time and as a result would leak the length of the plaintext values which were being padded to an attacker running a side channel attack via shared resources such as cache or branch predictor. No information about the contents was leaked, but the length alone might be used to make inferences about the contents. This issue affects TLS CBC ciphersuites as well as CBC encryption using PKCS7 or other similar padding mechanisms. In all cases, the unpadding operations were already constant time and are not affected. Reported by Maximilian Blochberger of Universität Hamburg.

    Fixed in 2.14.0, all prior versions affected.

```

I have not checked the release notes yet and the commit message could probably use some love after doing that.
I have made sure that botan and botan2 build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
