### PR TITLE
python3Packages.mypy: compile with mypyc

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,16 +1,22 @@
-{ stdenv, fetchPypi, buildPythonPackage, typed-ast, psutil, isPy3k
+{ stdenv, fetchFromGitHub, buildPythonPackage, typed-ast, psutil, isPy3k
 , mypy-extensions
 , typing-extensions
+, fetchpatch
 }:
-
 buildPythonPackage rec {
   pname = "mypy";
   version = "0.790";
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-KyG6Ra2e8uLriM5K6t0BEtD1AmQYMkF2/UlKaCS3SXU=";
+  # Fetch 0.790 from GitHub temporarily because mypyc.analysis is missing from
+  # the Pip package (see also https://github.com/python/mypy/issues/9584). It
+  # should be possible to move back to Pypi for the next release.
+  src = fetchFromGitHub {
+    owner = "python";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zq3lpdf9hphcklk40wz444h8w3dkhwa12mqba5j9lmg11klnhz7";
+    fetchSubmodules = true;
   };
 
   propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
@@ -24,7 +30,30 @@ buildPythonPackage rec {
     "mypy.api"
     "mypy.fastparse"
     "mypy.report"
+    "mypyc"
+    "mypyc.analysis"
   ];
+
+  # These three patches are required to make compilation with mypyc work for
+  # 0.790, see also https://github.com/python/mypy/issues/9584.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/python/mypy/commit/f6522ae646a8d87ce10549f29fcf961dc014f154.patch";
+      sha256 = "0d3jp4d0b7vdc0prk07grhajsy7x3wcynn2xysnszawiww93bfrh";
+    })
+    (fetchpatch {
+      url = "https://github.com/python/mypy/commit/acd603496237a78b109ca9d89991539633cbbb99.patch";
+      sha256 = "0ry1rxpz2ws7zzrmq09pra9dlzxb84zhs8kxwf5xii1k1bgmrljr";
+    })
+    (fetchpatch {
+      url = "https://github.com/python/mypy/commit/81818b23b5d53f31caf3515d6f0b54e3c018d790.patch";
+      sha256 = "002y24kfscywkw4mz9lndsps543j4xhr2kcnfbrqr4i0yxlvdbca";
+    })
+  ];
+
+  # Compile mypy with mypyc, which makes mypy about 4 times faster. The compiled
+  # version is also the default in the wheels on Pypi that include binaries.
+  MYPY_USE_MYPYC = "1";
 
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";


### PR DESCRIPTION
###### Motivation for this change

Mypy includes `mypyc`, a compiler that translates annotated Python to C, which can be compiled into a Python module. When `mypy` itself is compiled with `mypyc`, it is about 4 times faster than the interpreted `mypy`, so using the compiled version is especially useful on large codebases where typechecking can take a long time.

[The wheels distributed on Pypi have included a mypyc-compiled mypy by default since version 0.700](http://mypy-lang.blogspot.com/2019/04/mypy-0700-released-up-to-4x-faster.html), but because those wheels are platform-specific, we can't take advantage of them. With this change, we build `mypy` with `mypyc` from source, so it should work across all supported platforms.

Ideally taking advantage of `mypyc` would be as simple as setting [`MYPY_USE_MYPYC=1`](https://github.com/python/mypy/blob/88f76ee0e95674cc1ff4c723a86156823fb06291/setup.py#L84), but due to a few issues that have since been fixed upstream, this is not possible for v0.790. I expect that in a future version that will work, but for now, take the source from GitHub (because the package on Pypi is missing some files), and apply a few patches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Running the bare `mypyc` binary fails with this message:

```
Traceback (most recent call last):
  File "build/setup.py", line 2, in <module>
    from mypyc.build import mypycify
ModuleNotFoundError: No module named 'mypyc'
```

But it also does that on master, so that is not a change introduced by this PR.

You can tell that `mypyc` did its work because `lib/python3.8/site-packages/mypy` is now full of `.cpython-38-x86_64-linux-gnu.so`-files for every module. These are the compiled modules.