### PR TITLE
nixos/tests/cloud-init: fix the erroring out

### DIFF
--- a/nixos/tests/cloud-init.nix
+++ b/nixos/tests/cloud-init.nix
@@ -51,29 +51,31 @@ in makeTest {
     networking.hostName = "";
   };
   testScript = ''
-    machine.wait_for_unit("cloud-init.service")
-    machine.succeed("cat /tmp/cloudinit-write-file | grep -q 'cloudinit'")
+    # To wait until cloud-init terminates its run
+    unnamed.wait_for_unit("cloud-final.service")
+
+    unnamed.succeed("cat /tmp/cloudinit-write-file | grep -q 'cloudinit'")
 
     # install snakeoil ssh key and provision .ssh/config file
-    machine.succeed("mkdir -p ~/.ssh")
-    machine.succeed(
+    unnamed.succeed("mkdir -p ~/.ssh")
+    unnamed.succeed(
         "cat ${snakeOilPrivateKey} > ~/.ssh/id_snakeoil"
     )
-    machine.succeed("chmod 600 ~/.ssh/id_snakeoil")
+    unnamed.succeed("chmod 600 ~/.ssh/id_snakeoil")
 
-    machine.wait_for_unit("sshd.service")
+    unnamed.wait_for_unit("sshd.service")
 
     # we should be able to log in as the root user, as well as the created nixos user
-    machine.succeed(
+    unnamed.succeed(
         "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentityFile=~/.ssh/id_snakeoil root@localhost 'true'"
     )
-    machine.succeed(
+    unnamed.succeed(
         "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentityFile=~/.ssh/id_snakeoil nixos@localhost 'true'"
     )
 
     # test changing hostname via cloud-init worked
     assert (
-        machine.succeed(
+        unnamed.succeed(
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentityFile=~/.ssh/id_snakeoil nixos@localhost 'hostname'"
         ).strip()
         == "test"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The test was broken for a 1.5 months apparently? Well, now it passes. I wonder how this happened...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
