### PR TITLE
boost: fix cross-compile support

### DIFF
--- a/pkgs/development/libraries/boost/cross.patch
+++ b/pkgs/development/libraries/boost/cross.patch
@@ -1,0 +1,13 @@
+diff --git a/bootstrap.sh b/bootstrap.sh
+index ca0b08d58..5d4105ffe 100755
+--- a/bootstrap.sh
++++ b/bootstrap.sh
+@@ -223,7 +223,7 @@ rm -f config.log
+ if test "x$BJAM" = x; then
+   $ECHO -n "Building Boost.Build engine with toolset $TOOLSET... "
+   pwd=`pwd`
+-  (cd "$my_dir/tools/build/src/engine" && ./build.sh "$TOOLSET") > bootstrap.log 2>&1
++  (cd "$my_dir/tools/build/src/engine" && CXX="$CXX_FOR_BUILD" ./build.sh "$TOOLSET") > bootstrap.log 2>&1
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build Boost.Build build engine" 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -114,7 +114,8 @@ stdenv.mkDerivation {
     then ./darwin-1.55-no-system-python.patch
     else ./darwin-no-system-python.patch)
   ++ optional (and (versionAtLeast version "1.70") (!versionAtLeast version "1.73")) ./cmake-paths.patch
-  ++ optional (versionAtLeast version "1.73") ./cmake-paths-173.patch;
+  ++ optional (versionAtLeast version "1.73") ./cmake-paths-173.patch
+  ++ optional (stdenv.hostPlatform != stdenv.buildPlatform) ./cross.patch;
 
   meta = {
     homepage = "http://boost.org/";


### PR DESCRIPTION
###### Motivation for this change
boost fails to cross-compile, for example when targeting mingw. This is a simple fix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
