### PR TITLE
nixos/nixpkgs/docs: fix typo in assertOneOf example

### DIFF
--- a/doc/functions/library/asserts.xml
+++ b/doc/functions/library/asserts.xml
@@ -103,7 +103,7 @@ stderr> assert failed
    <title>Ensuring a user provided a possible value</title>
 <programlisting><![CDATA[
 let sslLibrary = "bearssl";
-in lib.asserts.assertOneOf "sslLibrary" sslLibrary [ "openssl" "bearssl" ];
+in lib.asserts.assertOneOf "sslLibrary" sslLibrary [ "openssl" "libressl" ];
 => false
 stderr> trace: sslLibrary must be one of "openssl", "libressl", but is: "bearssl"
         ]]></programlisting>


### PR DESCRIPTION
This example was confusing at first because the element the message
indicated wasn't in the list of possible values was but the possible
values didn't match up either.  This ensures the example is consistent
with the logic being presented.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixing a typo in the NixOS manual where an example is slightly confusing due to the wrong entry.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
