### PR TITLE
mojave-gtk-theme: 2020-03-19 -> 2020-11-29

### DIFF
--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mojave-gtk-theme";
-  version = "2020-03-19";
+  version = "2020-11-29";
 
   srcs = [
     (fetchFromGitHub {
       owner = "vinceliuice";
       repo = pname;
       rev = version;
-      sha256 = "1f120sx092i56q4dx2b8d3nnn9pdw67656446nw702rix7zc5jpx";
+      sha256 = "07lcg28y0scpii29j85343kmcga4wyaayjpx9a118z838mnvb757";
     })
     (fetchurl {
       url = "https://github.com/vinceliuice/Mojave-gtk-theme/raw/11741a99d96953daf9c27e44c94ae50a7247c0ed/macOS_Mojave_Wallpapers.tar.xz";


### PR DESCRIPTION
###### Motivation for this change
Resolves a size and performance regression introduced when [libsass bumped 3.6.1 -> 3.6.3](https://github.com/NixOS/nixpkgs/pull/82377).  With this change, this package's size shrinks from 1.5G to 31M and GTK applications start quickly again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    **1,833,380,816 → 271,684,768**
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FYI: maintainer @romildo