### PR TITLE
hdl-dump: init at 20202807

### DIFF
--- a/pkgs/tools/misc/hdl-dump/default.nix
+++ b/pkgs/tools/misc/hdl-dump/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, upx
+}:
+
+let
+  version = "20202807";
+  pname = "hdl-dump";
+in stdenv.mkDerivation {
+  inherit pname version;
+
+  # Using AkuHAK's repo because playstation2's repo is outdated
+  src = fetchFromGitHub {
+    owner = "AKuHAK";
+    repo = pname;
+    rev = "be37e112a44772a1341c867dc3dfee7381ce9e59";
+    sha256 = "0akxak6hm11h8z6jczxgr795s4a8czspwnhl3swqxp803dvjdx41";
+  };
+
+  buildInputs = [ upx ];
+
+  makeFlags = [ "RELEASE=yes" ];
+
+  installPhase = ''
+    install -Dm755 hdl_dump -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/AKuHAK/hdl-dump";
+    description = "PlayStation 2 HDLoader image dump/install utility";
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21664,6 +21664,8 @@ in
 
   howl = callPackage ../applications/editors/howl { };
 
+  hdl-dump = callPackage ../tools/misc/hdl-dump { };
+
   hpcg = callPackage ../tools/misc/hpcg/default.nix { };
 
   hpl = callPackage ../tools/misc/hpl { mpi = openmpi; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
