### PR TITLE
[python-unstable] libgit2: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, python3
+{ stdenv, fetchFromGitHub, cmake, pkg-config, python3
 , zlib, libssh2, openssl, pcre, http-parser
 , libiconv, Security
 }:
 
 stdenv.mkDerivation rec {
   pname = "libgit2";
-  version = "1.0.0";
+  version = "1.1.0";
   # keep the version in sync with python3.pkgs.pygit2 and libgit2-glib
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "06cwrw93ycpfb5kisnsa5nsy95pm11dbh0vvdjg1jn25h9q5d3vc";
+    sha256 = "1vj7q7b8j3smiyi1acbc5x86lqk00igdm2adjnqs9n011i13rykl";
   };
 
   cmakeFlags = [
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "-DUSE_HTTP_PARSER=system"
   ];
 
-  nativeBuildInputs = [ cmake python3 pkgconfig ];
+  nativeBuildInputs = [ cmake python3 pkg-config ];
 
   buildInputs = [ zlib libssh2 openssl pcre http-parser ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;


### PR DESCRIPTION
###### Motivation for this change
part of https://github.com/NixOS/nixpkgs/pull/105368

created a separate PR just to verify I wasn't introducing more regressions

libgit2-glib hasn't had any new releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
