### PR TITLE
ideamaker: init at 4.0.1

### DIFF
--- a/pkgs/applications/misc/ideamaker/default.nix
+++ b/pkgs/applications/misc/ideamaker/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, autoPatchelfHook
+, curl
+, dpkg
+, fetchurl
+, gcc
+, lib
+, libGLU
+, libcork
+, makeDesktopItem
+, qt5
+, quazip_qt4
+, zlib
+}:
+stdenv.mkDerivation rec {
+  pname = "ideamaker";
+  version = "4.0.1";
+
+  src = fetchurl {
+    # N.B. Unfortunately ideamaker adds a number after the patch number in
+    # their release scheme which is not referenced anywhere other than in
+    # the download URL. Because of this, I have chosen to not use ${version}
+    # and just handwrite the correct values in the following URL, hopefully
+    # avoiding surprises for the next person that comes to update this
+    # package.
+    url = "https://download.raise3d.com/ideamaker/release/4.0.1/ideaMaker_4.0.1.4802-ubuntu_amd64.deb";
+    sha256 = "0a1jcakdglcr4kz0kyq692dbjk6aq2yqcp3i6gzni91k791h49hp";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg qt5.wrapQtAppsHook ];
+  buildInputs = [
+    curl
+    gcc.cc.lib
+    libGLU
+    libcork
+    qt5.qtbase
+    qt5.qtserialport
+    quazip_qt4
+    zlib
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/pixmaps}
+
+    cp usr/lib/x86_64-linux-gnu/ideamaker/ideamaker $out/bin
+    ln -s "${desktopItem}/share/applications" $out/share/
+    cp usr/share/ideamaker/icons/ideamaker-icon.png $out/share/pixmaps/${pname}.png
+
+    runHook postInstall
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    desktopName = "Ideamaker";
+    genericName = meta.description;
+    categories = "Utility;Viewer;Engineering;";
+    mimeType = "application/sla";
+  };
+
+  meta = with lib; {
+    homepage = "https://www.raise3d.com/ideamaker/";
+    description = "Raise3D's 3D slicer software";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/development/libraries/libcork/default.nix
+++ b/pkgs/development/libraries/libcork/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, lib
+, pkg-config
+, check
+}:
+stdenv.mkDerivation rec {
+  pname = "libcork";
+  version = "1.0.0--rc3";
+
+  src = fetchFromGitHub {
+    owner = "dcreager";
+    repo = pname;
+    rev = version;
+    sha256 = "152gqnmr6wfmflf5l6447am4clmg3p69pvy3iw7yhaawjqa797sk";
+  };
+
+  # N.B. We need to create this file, otherwise it tries to use git to
+  # determine the package version, which we do not want.
+  #
+  # N.B. We disable tests by force, since their build is broken.
+  postPatch = ''
+    echo "${version}" > .version-stamp
+    echo "${version}" > .commit-stamp
+    sed -i '/add_subdirectory(tests)/d' ./CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ check ];
+
+  doCheck = false;
+
+  postInstall = ''
+    ln -s $out/lib/libcork.so $out/lib/libcork.so.1
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dcreager/libcork";
+    description = "A simple, easily embeddable cross-platform C library";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5360,6 +5360,8 @@ in
 
   libck = callPackage ../development/libraries/libck { };
 
+  libcork = callPackage ../development/libraries/libcork { };
+
   libconfig = callPackage ../development/libraries/libconfig { };
 
   libcmis = callPackage ../development/libraries/libcmis { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21839,6 +21839,8 @@ in
 
   id3v2 = callPackage ../applications/audio/id3v2 { };
 
+  ideamaker = callPackage ../applications/misc/ideamaker { };
+
   ifenslave = callPackage ../os-specific/linux/ifenslave { };
 
   ii = callPackage ../applications/networking/irc/ii {


### PR DESCRIPTION
###### Motivation for this change
I wanted to try ideamaker out and noticed it wasn't packaged. One of its
dependencies, libcork, was also missing so I packaged it.

- libcork: init at 1.0.0--rc3
- ideamaker: init at 4.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
