### PR TITLE
nixos/manual: suggest wpa_supplicant command that doesn't fail with sudo

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -64,8 +64,8 @@
 
    <para>
     To manually configure the wifi on the minimal installer, run
-    <command>wpa_supplicant -B -i interface -c &lt;(wpa_passphrase 'SSID'
-    'key')</command>.
+    <command>wpa_passphrase '<replaceable>SSID</replaceable>' '<replaceable>key</replaceable>'
+     | sudo wpa_supplicant -B -i <replaceable>interface</replaceable> -c /dev/stdin</command>.
    </para>
 
    <para>


### PR DESCRIPTION
The install section of the manual currently suggests a command to get wpa_supplicant running, but it only works from a root shell. If one uses 'sudo' under a user shell, as is the first instinct of many users, one gets the error "/dev/fd/xx: No such file or directory". This new command works when run as root, user w/ sudo, and root w/ sudo.