### PR TITLE
lc3tools: fix errors due to incorrect hardcoded paths

### DIFF
--- a/pkgs/development/tools/lc3tools/0002-lc3os-path.patch
+++ b/pkgs/development/tools/lc3tools/0002-lc3os-path.patch
@@ -1,0 +1,21 @@
+diff --git a/lc3sim.c b/lc3sim.c
+index dac7f7a..736fd7c 100644
+--- a/lc3sim.c
++++ b/lc3sim.c
+@@ -665,14 +665,14 @@ init_machine ()
+     bzero (lc3_sym_hash, sizeof (lc3_sym_hash));
+     clear_all_breakpoints ();
+ 
+-    if (read_obj_file (INSTALL_DIR "/lc3os.obj", &os_start, &os_end) == -1) {
++    if (read_obj_file (INSTALL_DIR "/share/lc3tools/lc3os.obj", &os_start, &os_end) == -1) {
+ 	if (gui_mode)
+ 	    puts ("ERR {Failed to read LC-3 OS code.}");
+ 	else
+ 	    puts ("Failed to read LC-3 OS code.");
+ 	show_state_if_stop_visible ();
+     } else {
+-	if (read_sym_file (INSTALL_DIR "/lc3os.sym") == -1) {
++	if (read_sym_file (INSTALL_DIR "/share/lc3tools/lc3os.sym") == -1) {
+ 	    if (gui_mode)
+ 		puts ("ERR {Failed to read LC-3 OS symbols.}");
+ 	    else

--- a/pkgs/development/tools/lc3tools/0003-lc3sim-tk-path.patch
+++ b/pkgs/development/tools/lc3tools/0003-lc3sim-tk-path.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.def b/Makefile.def
+index 34f7df3..05dc86c 100644
+--- a/Makefile.def
++++ b/Makefile.def
+@@ -155,7 +155,7 @@ dist_lc3sim-tk: lc3sim-tk
+ 
+ lc3sim-tk: lc3sim-tk.def
+ 	${SED} -e 's @@WISH@@ ${WISH} g' \
+-		-e 's*@@LC3_SIM@@*"${INSTALL_DIR}/lc3sim"*g' \
++		-e 's*@@LC3_SIM@@*"${INSTALL_DIR}/bin/lc3sim"*g' \
+ 		-e 's!@@CODE_FONT@@!${CODE_FONT}!g' \
+ 		-e 's!@@BUTTON_FONT@@!${BUTTON_FONT}!g' \
+ 		-e 's!@@CONSOLE_FONT@@!${CONSOLE_FONT}!g' \

--- a/pkgs/development/tools/lc3tools/default.nix
+++ b/pkgs/development/tools/lc3tools/default.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation {
     # the original configure looks for things in the FHS path
     # I have modified it to take environment vars
     ./0001-mangle-configure.patch
+
+    # lc3sim looks for the LC3 OS in $out/share/lc3tools instead of $out
+    ./0002-lc3os-path.patch
+
+    # lc3sim-tk looks for lc3sim in $out/bin instead of $out
+    ./0003-lc3sim-tk-path.patch
   ];
 
   nativeBuildInputs = [ unzip ];
@@ -27,10 +33,9 @@ stdenv.mkDerivation {
   prefixKey = "--installdir ";
 
   postInstall = ''
-    rm $out/{COPYING,NO_WARRANTY,README}
     mkdir -p $out/{bin,share/lc3tools}
 
-    mv -t $out/share/lc3tools $out/lc3os*
+    mv -t $out/share/lc3tools $out/{COPYING,NO_WARRANTY,README} $out/lc3os*
     mv -t $out/bin $out/lc3*
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

My previous PR for lc3tools had some breakage due to the upstream install scripts hardcoding executable and library paths. I have fixed the references to these paths so lc3sim and lc3sim-tk now run. (the previous PR, lc3convert and lc3as ran but I did not test the other executables)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
