### PR TITLE
peach: init at 0.9.8

### DIFF
--- a/pkgs/servers/peach/default.nix
+++ b/pkgs/servers/peach/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "peach";
+  version = "0.9.8";
+
+  src = fetchFromGitHub {
+    owner = "peachdocs";
+    repo = "peach";
+    rev = "v${version}";
+    sha256 = "1pzk3sah39hz8n1kswxl35djh6wm0qcfcwrbfi50nd4k3bdgz7xl";
+  };
+
+  vendorSha256 = "0f215hd5a9d4fyvdirp2j14ghap5vwv12i28jmzm6wxjihj8nn1g";
+
+  meta = with lib; {
+    description = "Web server for multi-language, real-time synchronization and searchable documentation";
+    homepage = "https://peachdocs.org/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23161,6 +23161,8 @@ in
     inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-libav;
   };
 
+  peach = callPackage ../servers/peach { };
+
   peaclock = callPackage ../applications/misc/peaclock {
     stdenv = gccStdenv;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
