### PR TITLE
python: pip: 20.2.4 -> 20.3

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -11,7 +11,7 @@ pipInstallPhase() {
     export PYTHONPATH="$out/@pythonSitePackages@:$PYTHONPATH"
 
     pushd dist || return 1
-    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags --build tmpbuild
+    @pythonInterpreter@ -m pip install ./*.whl --no-index --no-warn-script-location --prefix="$out" --no-cache $pipInstallFlags
     popd || return 1
 
     runHook postInstall

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -23,14 +23,6 @@ stdenv.mkDerivation rec {
     (setuptoolsBuildHook.override{setuptools=null; wheel=null;})
   ];
 
-  postPatch = ''
-    mkdir -p $out/bin
-  '' + stdenv.lib.optionalString isPy27 ''
-    pushd "${pip.src.name}"
-    patch -p1 < ${builtins.elemAt pip.patches 0}
-    popd
-  '';
-
   nativeBuildInputs = [ makeWrapper unzip ];
   buildInputs = [ python ];
 
@@ -49,17 +41,17 @@ stdenv.mkDerivation rec {
 
     echo "Building setuptools wheel..."
     pushd setuptools
-    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache --build tmpbuild .
+    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
     popd
 
     echo "Building wheel wheel..."
     pushd wheel
-    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache --build tmpbuild .
+    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
     popd
 
     echo "Building pip wheel..."
     pushd pip
-    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache --build tmpbuild .
+    ${python.pythonForBuild.interpreter} -m pip install --no-build-isolation --no-index --prefix=$out  --ignore-installed --no-dependencies --no-cache .
     popd
   '';
 

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -1,8 +1,12 @@
-{ stdenv, python, fetchPypi, makeWrapper, unzip, makeSetupHook
+{ stdenv
+, python
+, makeWrapper
+, unzip
 , pipInstallHook
 , setuptoolsBuildHook
-, wheel, pip, setuptools
-, isPy27
+, wheel
+, pip
+, setuptools
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
 
     # install "." instead of "*.whl"
-    ${python.pythonForBuild.pkgs.bootstrapped-pip}/bin/pip install --no-index --prefix=$out --no-cache --build=tmpdir .
+    ${python.pythonForBuild.pkgs.bootstrapped-pip}/bin/pip install --no-index --prefix=$out --no-cache
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -2,7 +2,7 @@
 , python
 , buildPythonPackage
 , bootstrapped-pip
-, fetchFromGitHub
+, fetchPypi
 , mock
 , scripttest
 , virtualenv
@@ -16,25 +16,15 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "20.2.4";
+  version = "20.3";
   format = "other";
 
-  src = fetchFromGitHub {
-    owner = "pypa";
-    repo = pname;
-    rev = version;
-    sha256 = "eMVV4ftgV71HLQsSeaOchYlfaJVgzNrwUynn3SA1/Do=";
-    name = "${pname}-${version}-source";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03kfx8ymqllv5lyngnylqks6h3z04ky29l29kcm2vhpaarkcmrws";
   };
 
   nativeBuildInputs = [ bootstrapped-pip ];
-
-  patches = lib.optionals isPy27 [
-    (fetchpatch {
-      url = "https://github.com/pypa/pip/commit/94fbb6cf78c267bf7cdf83eeeb2536ad56cfe639.patch";
-      sha256 = "Z6x5yxBp8QkU/GOfb1ltI0dVt//MaI09XK3cdY42kFs=";
-    })
-  ];
 
   # pip detects that we already have bootstrapped_pip "installed", so we need
   # to force it a little.

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -1,5 +1,4 @@
 { lib
-, python
 , buildPythonPackage
 , bootstrapped-pip
 , fetchPypi
@@ -8,10 +7,6 @@
 , virtualenv
 , pretend
 , pytest
-, setuptools
-, wheel
-, isPy27
-, fetchpatch
 }:
 
 buildPythonPackage rec {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates to the latest version of pip. I imagine this is a fairly large thing to test. I just thought that I'd throw up a PR in any case to get things started.

The `--build` argument has been deprecated in pip 20.3. See: https://github.com/pypa/pip/pull/9049


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
