### PR TITLE
tinyobjloader: init at 1.0.6

### DIFF
--- a/pkgs/development/libraries/tinyobjloader/default.nix
+++ b/pkgs/development/libraries/tinyobjloader/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tinyobjloader";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "tinyobjloader";
+    repo = "tinyobjloader";
+    rev = "v${version}";
+    sha256 = "162168995f4xch7hm3iy6m57r8iqkpzi5x9qh1gsghlxwdxxqbis";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/tinyobjloader/tinyobjloader";
+    description = "Tiny but powerful single file wavefront obj loader";
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/tinyobjloader-py/default.nix
+++ b/pkgs/development/python-modules/tinyobjloader-py/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, pybind11, tinyobjloader }:
+
+buildPythonPackage rec {
+  pname = "tinyobjloader-py";
+  inherit (tinyobjloader) version src;
+
+  # Build needs headers from ${src}, setting sourceRoot or fetching from pypi won't work.
+  preConfigure = ''
+    cd python
+  '';
+
+  buildInputs = [ pybind11 ];
+
+  # No tests are included upstream
+  doCheck = false;
+  pythonImportsCheck = [ "tinyobjloader" ];
+
+  meta = with lib; tinyobjloader.meta // {
+    description = "Python wrapper for the C++ wavefront .obj loader tinyobjloader";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7671,6 +7671,8 @@ in
 
   tinyfecvpn = callPackage ../tools/networking/tinyfecvpn {};
 
+  tinyobjloader = callPackage ../development/libraries/tinyobjloader { };
+
   tinyprog = callPackage ../development/tools/misc/tinyprog { };
 
   tinyproxy = callPackage ../tools/networking/tinyproxy {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7276,6 +7276,8 @@ in {
 
   tinydb = callPackage ../development/python-modules/tinydb { };
 
+  tinyobjloader-py = callPackage ../development/python-modules/tinyobjloader-py { };
+
   tiros = callPackage ../development/python-modules/tiros { };
 
   tissue = callPackage ../development/python-modules/tissue { };


### PR DESCRIPTION

###### Motivation for this change
I've also added the python bindings, which were a bit of a pain to package. 

They require some headers from the tinyobj source, but simply adding this as a `buildInput` [won't work](https://gist.github.com/IvarWithoutBones/c0960f2816a0e63385c29d879970f43a).

Not sure if my solution is proper, very much open for feedback.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
