### PR TITLE
ocamlPackages.bigstringaf: 0.6.0 → 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom-async/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-async/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "angstrom-async";
 
-  inherit (angstrom) version src;
+  inherit (angstrom) version useDune2 src;
 
   minimumOCamlVersion = "4.04.1";
 

--- a/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "angstrom-lwt-unix";
 
-  inherit (angstrom) version src;
+  inherit (angstrom) version useDune2 src;
 
   minimumOCamlVersion = "4.03";
 

--- a/pkgs/development/ocaml-modules/angstrom-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-unix/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "angstrom-unix";
 
-  inherit (angstrom) version src;
+  inherit (angstrom) version useDune2 src;
 
   minimumOCamlVersion = "4.03";
 

--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -1,8 +1,9 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, alcotest, result, bigstringaf, ppx_let }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, ocaml-syntax-shims, alcotest, result, bigstringaf, ppx_let }:
 
 buildDunePackage rec {
   pname = "angstrom";
   version = "0.15.0";
+  useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 
@@ -14,6 +15,7 @@ buildDunePackage rec {
   };
 
   checkInputs = [ alcotest ppx_let ];
+  buildInputs = [ ocaml-syntax-shims ];
   propagatedBuildInputs = [ bigstringaf result ];
   doCheck = lib.versionAtLeast ocaml.version "4.05";
 

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -2,7 +2,9 @@
 
 buildDunePackage rec {
   pname = "bigstringaf";
-  version = "0.6.0";
+  version = "0.7.0";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.03";
 
@@ -10,7 +12,7 @@ buildDunePackage rec {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    sha256 = "04b088vrqzmxsyan9f9nr8721bxip4b930cgvb5zkbbmrw3ylmwc";
+    sha256 = "1q1sqxzdnlrpl95ccrhl7lwy3zswgd9rbn19ildclh0lyi2vazbj";
   };
 
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -10,6 +10,8 @@ buildDunePackage rec {
   pname = "earlybird";
   version = "0.1.5";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/ke/default.nix
+++ b/pkgs/development/ocaml-modules/ke/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
   pname = "ke";
   version = "0.4";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/ke/releases/download/v${version}/ke-v${version}.tbz";
     sha256 = "13c9xy60vmq29mnwpg3h3zgl6gjbjfwbx1s0crfc6xwvark0zxnx";
@@ -14,7 +16,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ bigarray-compat fmt ];
 
-  checkInputs = lib.optionals doCheck [ alcotest bigstringaf ];
+  checkInputs = [ alcotest bigstringaf ];
   doCheck = true;
 
   minimumOCamlVersion = "4.03";


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

cc maintainers @romildo (`earlybird`) @sternenseemann (`angstrom`).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
