### PR TITLE
iwd: don't include testing tools by default

### DIFF
--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -9,6 +9,8 @@
 , readline
 , openssl
 , python3Packages
+
+, withTestingTools ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -60,8 +62,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postInstall = ''
+  postInstall = stdenv.lib.optionalString withTestingTools ''
     cp -a test/* $out/bin/
+  '' + ''
     mkdir -p $out/share
     cp -a doc $out/share/
     cp -a README AUTHORS TODO $out/share/doc/


### PR DESCRIPTION
Hide the testing tools behind a flag. They blow up the closure
size by a huge factor.

###### Motivation for this change
Reduce closure size from ~250M to 40M 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
