### PR TITLE
nixos/installation-device: replace wpa_supplicant by iwd

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -27,6 +27,8 @@ with lib;
   # Provide networkmanager for easy wireless configuration.
   networking.networkmanager.enable = true;
   networking.wireless.enable = mkImageMediaOverride false;
+  # Using networkmanager with iwd is still buggy at the moment
+  networking.wireless.iwd.enable = false;
 
   # KDE complains if power management is disabled (to be precise, if
   # there is no power management backend such as upower).

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -74,10 +74,8 @@ with lib;
       permitRootLogin = "yes";
     };
 
-    # Enable wpa_supplicant, but don't start it by default.
-    networking.wireless.enable = mkDefault true;
-    networking.wireless.userControlled.enable = true;
-    systemd.services.wpa_supplicant.wantedBy = mkOverride 50 [];
+    # Enable iwd by default for wireless networking
+    networking.wireless.iwd.enable = mkDefault true;
 
     # Tell the Nix evaluator to garbage collect more aggressively.
     # This is desirable in memory-constrained environments that don't


### PR DESCRIPTION
###### Motivation for this change
This a draft pr for https://github.com/NixOS/nixpkgs/issues/105560
~~Sill need to figure out how this interacts with other iso images, that build on top of `installation-device.nix`.~~
This will make all images, that do not build on top of `installation-cd-graphical-base` use `iwd`, since `installation-cd-graphical-base` is the only one referencing network-manager.

###### Things done

Built the minimal iso image with this and https://github.com/NixOS/nixpkgs/pull/105559 applied, closure size went down by 3M.