### PR TITLE
arduino-mk: wrap python scripts

### DIFF
--- a/pkgs/development/arduino/arduino-mk/default.nix
+++ b/pkgs/development/arduino/arduino-mk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, python3Packages, installShellFiles }:
 
 stdenv.mkDerivation rec {
   version = "1.6.0";
@@ -11,8 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "0flpl97d2231gp51n3y4qvf3y1l8xzafi1sgpwc305vwc2h4dl2x";
   };
 
-  phases = ["installPhase"];
-  installPhase = "ln -s $src $out";
+  nativeBuildInputs = [ python3Packages.wrapPython installShellFiles ];
+  propagatedBuildInputs = with python3Packages; [ pyserial ];
+  installPhase = ''
+    mkdir $out
+    cp -rT $src $out
+    installManPage *.1
+  '';
+  postFixupPhase = ''
+    wrapPythonPrograms
+  '';
 
   meta = {
     description = "Makefile for Arduino sketches";


### PR DESCRIPTION
###### Motivation for this change
`arduino-mk` brings the python script `ard-reset-arduino` and requires it in `Arduino.mk`, but this script is not able to use `pyserial`.

###### Things done
- [X] Add `wrapPythonPrograms` in `postFixupPhase`.
- [X] Add pyserial in `propagatedBuildInputs`.
- [X] Move manpages to `$out/share/man/`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
