### PR TITLE
python3Packages.google_cloud_secret_manager: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/google_cloud_secret_manager/default.nix
+++ b/pkgs/development/python-modules/google_cloud_secret_manager/default.nix
@@ -1,20 +1,22 @@
 { lib, buildPythonPackage, fetchPypi
-, grpc_google_iam_v1, google_api_core
+, grpc_google_iam_v1, google_api_core, libcst, proto-plus
 , pytest, mock
 }:
 
 buildPythonPackage rec {
   pname = "google-cloud-secret-manager";
-  version = "1.0.0";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cm3xqacxnbpv2706bd2jl86mvcsphpjlvhzngz2k2p48a0jjx8r";
+    sha256 = "1w2q602ww8s3n714l2gnaklqzbczshrspxvmvjr6wfwwalxwkc62";
   };
 
   propagatedBuildInputs = [
     google_api_core
     grpc_google_iam_v1
+    libcst
+    proto-plus
   ];
 
   checkInputs = [


### PR DESCRIPTION
Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
