### PR TITLE
mindustry,mindustry-server: 104.6 -> 120

### DIFF
--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -2,10 +2,11 @@
 , makeWrapper
 , makeDesktopItem
 , fetchFromGitHub
-, gradle_5
+, gradleGen
+, jdk14
 , perl
 , jre
-, libpulseaudio
+, alsaLib
 
 # Make the build version easily overridable.
 # Server and client build versions must match, and an empty build version means
@@ -21,14 +22,14 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "104.6";
+  version = "120";
   buildVersion = makeBuildVersion version;
 
   src = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "1crdfiymaz57gnma6bmdcsnbl635nhjdndrjv467c4xfq9vvap2i";
+    sha256 = "08l5c53izh5vmgahsj0qhpfiva0vs5qhh77bb770hzpadxvysyc8";
   };
 
   desktopItem = makeDesktopItem {
@@ -49,11 +50,14 @@ let
     sed -i 's/com.github.anuken:packr:-SNAPSHOT/com.github.anuken:packr:034efe51781d2d8faa90370492133241bfb0283c/' build.gradle
   '';
 
+  # The default one still uses jdk8 (#89731)
+  gradle_6 = (gradleGen.override (old: { java = jdk14; })).gradle_6_7;
+
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {
     pname = "${pname}-deps";
     inherit version src postPatch;
-    nativeBuildInputs = [ gradle_5 perl ];
+    nativeBuildInputs = [ gradle_6 perl ];
     # Here we build both the server and the client so we only have to specify
     # one hash for 'deps'. Deps can be garbage collected after the build,
     # so this is not really an issue.
@@ -70,7 +74,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "08yrczz1qn78qy3x67gs7d0xvihbfbb8ggiczq2nj812745zcizw";
+    outputHash = "1yv9l8zdml6drmvlgv45w3qas9qmb654x4kja3an4d16k020khr7";
   };
 
   # Separate commands for building and installing the server and the client
@@ -84,7 +88,7 @@ let
     install -Dm644 desktop/build/libs/Mindustry.jar $out/share/mindustry.jar
     mkdir -p $out/bin
     makeWrapper ${jre}/bin/java $out/bin/mindustry \
-      --prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib \
+      ${stdenv.lib.optionalString stdenv.isLinux "--prefix LD_LIBRARY_PATH : ${alsaLib}/lib"} \
       --add-flags "-jar $out/share/mindustry.jar"
     install -Dm644 core/assets/icons/icon_64.png $out/share/icons/hicolor/64x64/apps/mindustry.png
     install -Dm644 ${desktopItem}/share/applications/Mindustry.desktop $out/share/applications/Mindustry.desktop
@@ -102,7 +106,7 @@ assert stdenv.lib.assertMsg (enableClient || enableServer)
 stdenv.mkDerivation rec {
   inherit pname version src postPatch;
 
-  nativeBuildInputs = [ gradle_5 makeWrapper ];
+  nativeBuildInputs = [ gradle_6 makeWrapper ];
 
   buildPhase = with stdenv.lib; ''
     export GRADLE_USER_HOME=$(mktemp -d)

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -130,4 +130,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

After a ton of betas, the "codename 6.0" release is finally stable: https://github.com/Anuken/Mindustry/releases/tag/v120

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
