### PR TITLE
[staging-20.09] libass: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/development/libraries/libass/default.nix
+++ b/pkgs/development/libraries/libass/default.nix
@@ -1,8 +1,7 @@
 { stdenv, fetchurl, pkgconfig, yasm
-, freetype, fribidi
+, freetype, fribidi, harfbuzz
 , encaSupport ? true, enca ? null # enca support
 , fontconfigSupport ? true, fontconfig ? null # fontconfig support
-, harfbuzzSupport ? true, harfbuzz ? null # harfbuzz support
 , rasterizerSupport ? false # Internal rasterizer
 , largeTilesSupport ? false # Use larger tiles in the rasterizer
 , libiconv
@@ -10,7 +9,6 @@
 
 assert encaSupport -> enca != null;
 assert fontconfigSupport -> fontconfig != null;
-assert harfbuzzSupport -> harfbuzz != null;
 
 let
   mkFlag = optSet: flag: if optSet then "--enable-${flag}" else "--disable-${flag}";
@@ -19,27 +17,25 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "libass";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchurl {
     url = "https://github.com/libass/libass/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "18iqznl4mabhj9ywfsz4kwvbsplcv1jjxq50nxssvbj8my1267w8";
+    sha256 = "0cz8v6kh3f2j5rdjrra2z0h715fa16vjm7kambvqx9hak86262cz";
   };
 
   configureFlags = [
     (mkFlag encaSupport "enca")
     (mkFlag fontconfigSupport "fontconfig")
-    (mkFlag harfbuzzSupport "harfbuzz")
     (mkFlag rasterizerSupport "rasterizer")
     (mkFlag largeTilesSupport "large-tiles")
   ];
 
   nativeBuildInputs = [ pkgconfig yasm ];
 
-  buildInputs = [ freetype fribidi ]
+  buildInputs = [ freetype fribidi harfbuzz ]
     ++ optional encaSupport enca
     ++ optional fontconfigSupport fontconfig
-    ++ optional harfbuzzSupport harfbuzz
     ++ optional stdenv.isDarwin libiconv;
 
   meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix CVE-2020-26682 on 20.09. Unfortunately the version of libass in stable is 3y old and the patch has multiple failing hunks, so I think its the better choice to backport 0.15.0. https://github.com/libass/libass/releases/tag/0.15.0

```
Harfbuzz is now being required unconditionally as per
https://github.com/libass/libass/releases/tag/0.15.0

Fixes: CVE-2020-26682
(cherry picked from commit 8b8130f26ad043ac9721b3fafab500ce8bb39d06)
```

Closes: #102801

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
