### PR TITLE
spigot: 20200101 -> 20200901

### DIFF
--- a/pkgs/tools/misc/spigot/default.nix
+++ b/pkgs/tools/misc/spigot/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "spigot";
-  version = "20200101";
+  version = "20200901";
   src = fetchgit {
     url = "https://git.tartarus.org/simon/spigot.git";
-    rev = "b1b0b202b3523b72f0638fb31fd49c47f4abb39c";
-    sha256 = "0lh5v42aia1hvhsqzs515q0anrjc6c2s9bjklfaap5gz0cg59wbv";
+    rev = "9910e5bdc203bae6b7bbe1ed4a93f13755c1cae";
+    sha256 = "1az6v9gk0g2k197lr288nmr9jv20bvgc508vn9ic3v7mav7hf5bf";
   };
 
   nativeBuildInputs = [ autoreconfHook halibut perl ];


### PR DESCRIPTION
###### Motivation for this change

Resync with upstream

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
