### PR TITLE
kubernetes: misc fixes

### DIFF
--- a/pkgs/applications/networking/cluster/kubectl/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl/default.nix
@@ -1,27 +1,24 @@
-{ stdenv, kubernetes }:
+{ stdenv, kubernetes, installShellFiles }:
 
 stdenv.mkDerivation {
   name = "kubectl-${kubernetes.version}";
 
   # kubectl is currently part of the main distribution but will eventially be
   # split out (see homepage)
-  src = kubernetes;
+  dontUnpack = true;
+
+  nativeBuildInputs = [ installShellFiles ];
 
   outputs = [ "out" "man" ];
 
   installPhase = ''
-    mkdir -p \
-      "$out/bin" \
-      "$out/share/bash-completion/completions" \
-      "$out/share/zsh/site-functions" \
-      "$man/share/man/man1"
+    install -D ${kubernetes}/bin/kubectl -t $out/bin
 
-    cp bin/kubectl $out/bin/kubectl
+    installManPage "${kubernetes.man}/share/man/man1"/kubectl*
 
-    cp "${kubernetes.man}/share/man/man1"/kubectl* "$man/share/man/man1"
-
-    $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
-    $out/bin/kubectl completion zsh > $out/share/zsh/site-functions/_kubectl
+    installShellCompletion --cmd kubectl \
+      --bash <($out/bin/kubectl completion bash) \
+      --zsh <($out/bin/kubectl completion zsh)
   '';
 
   meta = kubernetes.meta // {

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -1,7 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go, go-bindata, makeWrapper, rsync
+{ stdenv
+, lib
+, fetchFromGitHub
+, removeReferencesTo
+, which
+, go
+, makeWrapper
+, rsync
+, installShellFiles
+
 , components ? [
-    "cmd/kubeadm"
-    "cmd/kubectl"
     "cmd/kubelet"
     "cmd/kube-apiserver"
     "cmd/kube-controller-manager"
@@ -10,8 +17,6 @@
     "test/e2e/e2e.test"
   ]
 }:
-
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "kubernetes";
@@ -24,9 +29,9 @@ stdenv.mkDerivation rec {
     sha256 = "05gisihrklkzsdsrrmvmqlfwfdx73jbwd5668n5wa5hp432qyvwi";
   };
 
-  nativeBuildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
+  nativeBuildInputs = [ removeReferencesTo makeWrapper which go rsync installShellFiles ];
 
-  outputs = ["out" "man" "pause"];
+  outputs = [ "out" "man" "pause" ];
 
   postPatch = ''
     # go env breaks the sandbox
@@ -41,7 +46,10 @@ stdenv.mkDerivation rec {
     patchShebangs ./hack
   '';
 
-  WHAT=concatStringsSep " " components;
+  WHAT = lib.concatStringsSep " " ([
+    "cmd/kubeadm"
+    "cmd/kubectl"
+  ] ++ components);
 
   postBuild = ''
     ./hack/update-generated-docs.sh
@@ -49,11 +57,12 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$out/share/zsh/site-functions" "$man/share/man" "$pause/bin"
+    for p in $WHAT; do
+      install -D _output/local/go/bin/''${p##*/} -t $out/bin
+    done
 
-    cp _output/local/go/bin/* "$out/bin/"
-    cp build/pause/pause "$pause/bin/pause"
-    cp -R docs/man/man1 "$man/share/man"
+    install -D build/pause/pause -t $pause/bin
+    installManPage docs/man/man1/*.[1-9]
 
     cp cluster/addons/addon-manager/kube-addons.sh $out/bin/kube-addons
     patchShebangs $out/bin/kube-addons
@@ -61,19 +70,22 @@ stdenv.mkDerivation rec {
 
     cp ${./mk-docker-opts.sh} $out/bin/mk-docker-opts.sh
 
-    $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
-    $out/bin/kubectl completion zsh > $out/share/zsh/site-functions/_kubectl
+    for tool in kubeadm kubectl; do
+      installShellCompletion --cmd $tool \
+        --bash <($out/bin/$tool completion bash) \
+        --zsh <($out/bin/$tool completion zsh)
+    done
   '';
 
   preFixup = ''
     find $out/bin $pause/bin -type f -exec remove-references-to -t ${go} '{}' +
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Production-Grade Container Scheduling and Management";
     license = licenses.asl20;
     homepage = "https://kubernetes.io";
-    maintainers = with maintainers; [johanot offline saschagrunert];
+    maintainers = with maintainers; [ johanot offline saschagrunert ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- don't install unnecessary binaries

~1100MB -> ~700MB

- ~~conversion-gen~~
- ~~deepcopy-gen~~
- ~~defaulter-gen~~
- e2e.test
- ~~gendocs~~
- ~~genkubedocs~~
- ~~genman~~
- ~~genyaml~~
- ~~go-bindata~~
- ~~go2make~~
- kube-addons
- kube-apiserver
- kube-controller-manager
- kube-proxy
- kube-scheduler
- kubeadm
- kubectl
- kubelet
- mk-docker-opts.sh
- ~~openapi-gen~~
- ~~prerelease-lifecycle-gen~~

Also:

- remove go-bindata, already vendored by upstream
- use installShellFiles, add kubeadm completion
- require kubeadm/kubectl so installPhase can't be broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
