### PR TITLE
weechatScripts.colorize_nicks: init at 27

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/colorize_nicks/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/colorize_nicks/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchurl, weechat }:
+
+stdenv.mkDerivation {
+  pname = "weechat-colorize_nicks";
+  version = "27";
+
+  src = fetchurl {
+    url = "https://github.com/weechat/scripts/raw/bc8a9051800779a036ba11689a277cd5f03657b2/python/colorize_nicks.py";
+    sha256 = "0hiay88vvy171jiq6ahflm0ipb7sslfxwhmmm8psv6qk19rv2sxs";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp $src $out/share/colorize_nicks.py
+  '';
+
+  passthru = {
+    scripts = [ "colorize_nicks.py" ];
+  };
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "Use the weechat nick colors in the chat area";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -1,6 +1,8 @@
 { callPackage, luaPackages, python3Packages }:
 
 {
+  colorize_nicks = callPackage ./colorize_nicks { };
+
   weechat-matrix-bridge = callPackage ./weechat-matrix-bridge {
     inherit (luaPackages) cjson luaffi;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
