### PR TITLE
.github/workflow/reviewdog: Add shellcheck GitHub Action

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,17 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+
+          # Report findings on any changed lines (not just added).
+          filter_mode: diff_context


### PR DESCRIPTION
There's been some interest in running Shellcheck as part of the review workflow on discrete .sh scripts as a review aid. In particular, this would cover stage-1-init.sh and stage-2-init.sh.

The use of reviewdog here is to parse the output of Shellcheck and, crucially, *only report failures on lines modified by the PR author*, which allows for this to be introduced now and for Shellcheck lint failures to gradually be driven down over time (or through a separate concerted effort).

This is run in the default `github-pr-check` mode. If we used the `github-pr-review` mode instead then Shellcheck's suggestions would be in the form of review comments, but I don't think the tradeoff is worth it (and I don't really like the automatically generated commits that GitHub generates when you accept review comments...).

cc @SuperSandro2000 @grahamc 

[WIP, but deliberately not draft so codeowners see it]