### PR TITLE
ocaml-ng.ocamlPackages_4_12.ocaml: 4.12.0~α1 → 4.12.0~α2

### DIFF
--- a/pkgs/development/compilers/ocaml/4.12.nix
+++ b/pkgs/development/compilers/ocaml/4.12.nix
@@ -1,9 +1,9 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "12";
-  patch_version = "0-alpha1";
+  patch_version = "0-alpha2";
   src = fetchTarball {
-    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~alpha1.tar.xz";
-    sha256 = "1p9nnj7l43b697b6bm767znbf1h0s2lyc1qb8izr1vfpsmnm11ws";
+    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~alpha2.tar.xz";
+    sha256 = "148vgjcfajjvrvh0q9kb2y7fszqd02cikb5wyznz7kjxka6xxyn9";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Prepare upcoming release: https://inbox.ocaml.org/caml-list/1918117305.106893276.1606818845424.JavaMail.zimbra@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
