### PR TITLE
openresty: 1.17.8 -> 1.19.3

### DIFF
--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -8,15 +8,19 @@
 
 callPackage ../nginx/generic.nix args rec {
   pname = "openresty";
-  nginxVersion = "1.17.8";
-  version = "${nginxVersion}.2";
+  nginxVersion = "1.19.3";
+  version = "${nginxVersion}.1";
 
   src = fetchurl {
     url = "https://openresty.org/download/openresty-${version}.tar.gz";
-    sha256 = "1813w33hjm1hcqvl3b3f67qgi5zfjiqg6s01hiy12a5j3jqilcig";
+    sha256 = "0p9xn0xgbk6nmjfb25a3d6bwxm8q23igkixqma5fpygla6fcsvzk";
   };
 
-  fixPatch = patch: let name = patch.name or (builtins.baseNameOf patch); in
+  # generic.nix applies fixPatch on top of every patch defined there.  This
+  # allows updating the patch destination, as openresty has nginx source code
+  # in a different folder.
+  fixPatch = patch:
+    let name = patch.name or (builtins.baseNameOf patch); in
     runCommand "openresty-${name}" { src = patch; } ''
       substitute $src $out \
         --replace "a/" "a/bundle/nginx-${nginxVersion}/" \
@@ -40,9 +44,9 @@ callPackage ../nginx/generic.nix args rec {
 
   meta = {
     description = "A fast web application server built on Nginx";
-    homepage    = "http://openresty.org";
-    license     = lib.licenses.bsd2;
-    platforms   = lib.platforms.all;
+    homepage = "http://openresty.org";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ thoughtpolice lblasc emily ];
   };
 }


### PR DESCRIPTION
Also, add a quick comment about what fixPatch does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
