### PR TITLE
radicle-upstream: init at 0.1.5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, appimageTools, gsettings-desktop-schemas, gtk3, autoPatchelfHook, zlib, fetchurl }:
+
+let
+  pname = "radicle-upstream";
+  version = "0.1.5";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://releases.radicle.xyz/radicle-upstream-${version}.AppImage";
+    sha256 =  "1q5p6bvzi5awxd9a3xvvdhy26bz0dx8drb1z0zzqdvqqcxxyydq7";
+  };
+
+  contents = appimageTools.extractType2 { inherit name src; };
+
+  git-remote-rad = stdenv.mkDerivation rec {
+    pname = "git-remote-rad";
+    inherit version;
+    src = contents;
+
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [ zlib ];
+
+    installPhase = ''
+      mkdir -p $out/bin/
+      cp ${contents}/resources/git-remote-rad $out/bin/git-remote-rad
+    '';
+  };
+in
+
+# FIXME: a dependency of the `proxy` component of radicle-upstream (radicle-macros
+# v0.1.0) uses unstable rust features, making a from source build impossible at
+# this time. See this PR for discussion: https://github.com/NixOS/nixpkgs/pull/105674
+appimageTools.wrapType2 {
+  inherit name src;
+
+  profile = ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+
+    # this automatically adds the git-remote-rad binary to the users `PATH` so
+    # they don't need to mess around with shell profiles...
+    ln -s ${git-remote-rad}/bin/git-remote-rad $out/bin/git-remote-rad
+
+    # desktop item
+    install -m 444 -D ${contents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+
+    # icon
+    install -m 444 -D ${contents}/${pname}.png \
+      $out/share/icons/hicolor/512x512/apps/${pname}.png
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A decentralized app for code collaboration";
+    homepage = "https://radicle.xyz/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ xwvvvvwx ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17628,6 +17628,8 @@ in
 
   radicale = radicale3;
 
+  radicle-upstream = callPackage ../applications/version-management/git-and-tools/radicle-upstream {};
+
   rake = callPackage ../development/tools/build-managers/rake { };
 
   redis = callPackage ../servers/nosql/redis { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds a package for the `radicle-upstream` p2p code collaboration client ([homepage](https://radicle.xyz/)).

Some notes:

- This is an electron app bundled as an appimage. I just downloaded the appimage directly from the releases site. My understanding is that the infra for from source builds of electron apps doesn't really exist in nixpkgs atm, so this is an acceptable practice. Happy to put together a from source build if there are some nice examples I can copy.

- The package here is a little dirty because `radicle-upstream` drops a git helper `git-remote-rad` into the users home directory. This is a dynamically linked binary, so I needed to open up the appimage and `patchelf` it before bulding the final wrapped appimage. In the future it might make sense to add a seperate package for the `git-remote-rad` helper and allow interaction with the radicle network without the UI. I kept them together for now as it allows the simplest installation experience (a single package), and the git helper can't publish to the network without the UI running at the moment anyway, so it's currently not very useful by itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
