### PR TITLE
sysdig: fix bash-completion location

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, kernel
+{ stdenv, fetchFromGitHub, cmake, kernel, installShellFiles
 , luajit, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils, tbb, c-ares, protobuf, grpc
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-lYjMvxMIReANNwMr62u881Nugrs9piOaN3EmrvGzRns=";
   };
 
-  nativeBuildInputs = [ cmake perl ];
+  nativeBuildInputs = [ cmake perl installShellFiles ];
   buildInputs = [
     zlib luajit ncurses jsoncpp libb64 openssl curl jq gcc elfutils tbb c-ares protobuf grpc
   ] ++ optionals (kernel != null) kernel.moduleBuildDependencies;
@@ -38,19 +38,28 @@ stdenv.mkDerivation rec {
     export KERNELDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   '';
 
-  postInstall = optionalString (kernel != null) ''
-    make install_driver
-    kernel_dev=${kernel.dev}
-    kernel_dev=''${kernel_dev#/nix/store/}
-    kernel_dev=''${kernel_dev%%-linux*dev*}
-    if test -f "$out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko"; then
-        sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
-    else
-        xz -d $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko.xz
-        sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
-        xz $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
-    fi
-  '';
+  postInstall =
+    ''
+      # Fix the bash completion location
+      installShellCompletion --bash $out/etc/bash_completion.d/sysdig
+      rm $out/etc/bash_completion.d/sysdig
+      rmdir $out/etc/bash_completion.d
+      rmdir $out/etc
+    ''
+    + optionalString (kernel != null) ''
+      make install_driver
+      kernel_dev=${kernel.dev}
+      kernel_dev=''${kernel_dev#/nix/store/}
+      kernel_dev=''${kernel_dev%%-linux*dev*}
+      if test -f "$out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko"; then
+          sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
+      else
+          xz -d $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko.xz
+          sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
+          xz $out/lib/modules/${kernel.modDirVersion}/extra/sysdig-probe.ko
+      fi
+    '';
+
 
   meta = {
     description = "A tracepoint-based system tracing tool for Linux (with clients for other OSes)";


### PR DESCRIPTION
###### Motivation for this change

In order to support auto-loading, the bash-completion scripts should
live in $out/share/bash-completion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
