### PR TITLE
ocamlPackages.astring: 0.8.3 -> 0.8.5

### DIFF
--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -1,12 +1,25 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
 
-stdenv.mkDerivation rec {
-  version = "0.8.3";
-  name = "ocaml${ocaml.version}-astring-${version}";
+let
+  # Use astring 0.8.3 for OCaml < 4.05
+  param =
+    if stdenv.lib.versionAtLeast ocaml.version "4.05"
+    then {
+      version = "0.8.5";
+      sha256 = "1ykhg9gd3iy7zsgyiy2p9b1wkpqg9irw5pvcqs3sphq71iir4ml6";
+    } else {
+      version = "0.8.3";
+      sha256 = "0ixjwc3plrljvj24za3l9gy0w30lsbggp8yh02lwrzw61ls4cri0";
+    };
+in
+
+stdenv.mkDerivation {
+  name = "ocaml${ocaml.version}-astring-${param.version}";
+  inherit (param) version;
 
   src = fetchurl {
-    url = "https://erratique.ch/software/astring/releases/astring-${version}.tbz";
-    sha256 = "0ixjwc3plrljvj24za3l9gy0w30lsbggp8yh02lwrzw61ls4cri0";
+    url = "https://erratique.ch/software/astring/releases/astring-${param.version}.tbz";
+    inherit (param) sha256;
   };
 
   buildInputs = [ ocaml findlib ocamlbuild topkg ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Support for OCaml 4.12.

Since astring is a common dependency and the maintainance effort is
minimal (package dependencies and build system didn't change) we keep
the old 0.8.3 version around for OCaml < 4.05, since 0.8.4 requires a
minimum of OCaml 4.05.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
