### PR TITLE
mmtc: init at 0.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2939,6 +2939,12 @@
     githubId = 8182846;
     name = "Francesco Gazzetta";
   };
+  figsoda = {
+    email = "figsoda@pm.me";
+    github = "figsoda";
+    githubId = 40620903;
+    name = "figsoda";
+  };
   fionera = {
     email = "nix@fionera.de";
     github = "fionera";

--- a/pkgs/applications/audio/mmtc/default.nix
+++ b/pkgs/applications/audio/mmtc/default.nix
@@ -33,6 +33,6 @@ in rustPlatform.buildRustPackage.override {
       "Minimal mpd terminal client that aims to be simple yet highly configurable";
     homepage = "https://github.com/figsoda/mmtc";
     license = licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with maintainers; [ figsoda ];
   };
 }

--- a/pkgs/applications/audio/mmtc/default.nix
+++ b/pkgs/applications/audio/mmtc/default.nix
@@ -1,0 +1,38 @@
+{ callPackage, fetchFromGitHub, rustPlatform, stdenv }:
+
+let
+  rust = (let
+    mozilla = fetchFromGitHub {
+      owner = "mozilla";
+      repo = "nixpkgs-mozilla";
+      rev = "8c007b60731c07dd7a052cce508de3bb1ae849b4";
+      sha256 = "1zybp62zz0h077zm2zmqs2wcg3whg6jqaah9hcl1gv4x8af4zhs6";
+    };
+  in callPackage "${mozilla.out}/package-set.nix"
+  { }).latest.rustChannels.nightly.rust;
+in rustPlatform.buildRustPackage.override {
+  cargo = rust;
+  rustc = rust;
+} rec {
+  pname = "mmtc";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "figsoda";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "136ixb6d2dnz5rl9grxb49nq1qkilczbfyfbgi0xzkkzz2119dlm";
+  };
+
+  RUSTFLAGS = "";
+
+  cargoSha256 = "1g3512gi4z3hykr9f04rslm6aymk8lph6g851qwq0aip8jjqgz5h";
+
+  meta = with stdenv.lib; {
+    description =
+      "Minimal mpd terminal client that aims to be simple yet highly configurable";
+    homepage = "https://github.com/figsoda/mmtc";
+    license = licenses.mpl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/applications/audio/mmtc/default.nix
+++ b/pkgs/applications/audio/mmtc/default.nix
@@ -32,7 +32,9 @@ in rustPlatform.buildRustPackage.override {
     description =
       "Minimal mpd terminal client that aims to be simple yet highly configurable";
     homepage = "https://github.com/figsoda/mmtc";
+    changelog = "https://github.com/figsoda/mmtc/blob/v${version}/CHANGELOG.md";
     license = licenses.mpl20;
     maintainers = with maintainers; [ figsoda ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22539,6 +22539,8 @@ in
 
   MMA = callPackage ../applications/audio/MMA { };
 
+  mmtc = callPackage ../applications/audio/mmtc { };
+
   mmex = callPackage ../applications/office/mmex {
     wxGTK30 = wxGTK30.override {
       withWebKit = true;


### PR DESCRIPTION
###### Motivation for this change
mmtc is a minimal mpd terminal client that aims to be simple yet highly configurable 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
