### PR TITLE
Add Symbiflow + prjxray for OSS Xilinx FPGA development

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5684,6 +5684,12 @@
     githubId = 2971615;
     name = "Marius Bergmann";
   };
+  mcaju = {
+    email = "cajum.bugs@yandex.com";
+    github = "CajuM";
+    githubId = 10420834;
+    name = "Mihai-Drosi Caju";
+  };
   mcbeth = {
     email = "mcbeth@broggs.org";
     github = "mcbeth";

--- a/pkgs/data/misc/prjxray-db/default.nix
+++ b/pkgs/data/misc/prjxray-db/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "prjxray-db";
+  version = "0.0-0232-g303a61d";
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "prjxray-db";
+    rev    = "303a61d8bc552f7a533b91b17448c59e908aa391";
+    sha256 = "0r75xig16dbgh3nfygggir0a160x52y766h7hd9xcib9m88jixb2";
+  };
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    DBDIR="$out/share/symbiflow/prjxray-db/"
+    DB_CONFIG="$out/bin/prjxray-config"
+
+    mkdir -p $DBDIR $out/bin
+
+    for device in artix7 kintex7 zynq7; do
+      cp -r $src/$device $DBDIR
+    done
+
+    echo -e "#!/bin/sh\n\necho $DBDIR" > $DB_CONFIG
+    chmod +x $DB_CONFIG
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Project X-Ray - Xilinx Series 7 Bitstream Documentation";
+    homepage    = "https://github.com/SymbiFlow/prjxray-db";
+    license     = licenses.cc0;
+    maintainers = with maintainers; [ mcaju ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/data/misc/symbiflow-arch-defs/default.nix
+++ b/pkgs/data/misc/symbiflow-arch-defs/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, fetchurl
+, autoPatchelfHook
+, python3Packages
+, archs ? [ "xc7a100t" "xc7a50t" "xc7z010" "xc7z020" ]
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "symbiflow-arch-defs";
+  version = "20200914-111752-g05d68df0";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/66/20200914-111752/symbiflow-arch-defs-install-05d68df0.tar.xz";
+    sha256 = "1gmynybh8n33ag521w17c2kd16n834hqc6d8hi2pfs5kg1jl1a74";
+  };
+
+  sourceRoot = ".";
+
+  propagatedBuildInputs = [
+    python3Packages.lxml
+    python3Packages.python-constraint
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r bin/{symbiflow_*,vpr_common,python} $out/bin
+    for script in $out/bin/symbiflow_*; do
+        substituteInPlace $script --replace '/env' '/symbiflow_env'
+    done
+    cp bin/env $out/bin/symbiflow_env
+
+    mkdir -p $out/share/symbiflow/arch
+    cp -r share/symbiflow/{scripts,techmaps} $out/share/symbiflow/
+
+    for arch in ${builtins.concatStringsSep " " archs}; do
+        cp -r share/symbiflow/arch/"$arch"_test* $out/share/symbiflow/arch/
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Project X-Ray - Xilinx Series 7 Bitstream Documentation";
+    homepage    = "https://github.com/SymbiFlow/symbiflow-arch-defs";
+    hydraPlatforms = [];
+    license     = licenses.isc;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/prjxray-tools/default.nix
+++ b/pkgs/development/compilers/prjxray-tools/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "prjxray-tools";
+  version = "0.1-2676-gac8d30e3";
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "prjxray";
+    fetchSubmodules = true;
+    rev    = "ac8d30e3fe2029122408888d2313844b3e0c265b";
+    sha256 = "1ag7dk12hdhip821crwinncp8vgyzs0r85l1h2vbgn61lnxc7f4h";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Documenting the Xilinx 7-series bit-stream format";
+    homepage    = "https://github.com/SymbiFlow/prjxray";
+    license     = licenses.isc;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/compilers/symbiflow-vtr/default.nix
+++ b/pkgs/development/compilers/symbiflow-vtr/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitHub
+, bison
+, cmake
+, flex
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "symbiflow-vtr";
+  version = "8.0.0.rc2-4003-g8980e4621";
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "vtr-verilog-to-routing";
+    rev    = "8980e46218542888fac879961b13aa7b0fba8432";
+    sha256 = "1sq7f1f3dzfm48a9vq5nvp0zllby0nasm3pvqab70f4jaq0m1aaa";
+  };
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    flex
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DWITH_ODIN=OFF"
+    "-DWITH_ABC=OFF"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "SymbiFlow WIP changes for Verilog to Routing (VTR)";
+    homepage    = "https://github.com/SymbiFlow/vtr-verilog-to-routing";
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/compilers/symbiflow-yosys-plugins/default.nix
+++ b/pkgs/development/compilers/symbiflow-yosys-plugins/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchFromGitHub
+, symbiflow-yosys
+, zlib
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "symbiflow-yosys-plugins";
+  version = "1.0.0.7-0060-g7454cd6b";
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "yosys-symbiflow-plugins";
+    rev    = "7454cd6b5e4fd22854e2ada219a5e3c3a06e0717";
+    sha256 = "0r9r31p7fy4ylfrwvwlbivq5a03xrph34blxbxzx2c8bc02mbv0s";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ symbiflow-yosys ];
+
+  buildInputs = [
+    readline
+    zlib
+  ];
+
+  makeFlags = [ "PLUGINS_DIR=${placeholder "out"}/share/yosys/plugins" ];
+
+  meta = with stdenv.lib; {
+    description = "Yosys SymbiFlow Plugins";
+    homepage    = "https://github.com/SymbiFlow/yosys-symbiflow-plugins";
+    license     = licenses.isc;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/compilers/symbiflow-yosys/default.nix
+++ b/pkgs/development/compilers/symbiflow-yosys/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, abc-verifier
+, fetchFromGitHub
+, yosys
+, plugins ? []
+}:
+
+let
+  localAbc-verifier = abc-verifier.overrideAttrs (_: rec {
+    pname = "abc-verifier";
+    version = "2020.06.22";
+
+    src = fetchFromGitHub {
+      owner  = "YosysHQ";
+      repo   = "abc";
+      rev    = "341db25668f3054c87aa3372c794e180f629af5d";
+      sha256 = "14cgv34vz5ljkcms6nrv19vqws2hs8bgjgffk5q03cbxnm2jxv5s";
+    };
+
+    passthru.rev = src.rev;
+  });
+in
+
+(yosys.overrideAttrs (oldAttrs: rec {
+  pname   = "symbiflow-yosys";
+  version = "0.9+2406";
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "yosys";
+    rev    = "d8b2d1a2b1a93057678cf49bb8f0329f191faba1";
+    sha256 = "1w8jnqzabvzixjllhb6ak2n2gmjvsn6qd996i7z70bsq5rgdkq9g";
+  };
+})).override {
+  abc-verifier = localAbc-verifier;
+  plugins = plugins;
+}

--- a/pkgs/development/python-modules/python-prjxray/default.nix
+++ b/pkgs/development/python-modules/python-prjxray/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, pkgs
+, buildPythonPackage
+, intervaltree
+, numpy
+, openpyxl
+, parse
+, progressbar
+, pyjson5
+, pyyaml
+, simplejson
+, symbiflow-fasm
+, textx
+}:
+
+buildPythonPackage rec {
+  pname = "python-prjxray";
+  version = pkgs.prjxray-tools.version;
+
+  src = pkgs.prjxray-tools.src;
+
+  propagatedBuildInputs = [
+    intervaltree
+    numpy
+    openpyxl
+    parse
+    progressbar
+    pyjson5
+    pyyaml
+    simplejson
+    symbiflow-fasm
+    textx
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Documenting the Xilinx 7-series bit-stream format";
+    homepage    = "https://github.com/SymbiFlow/prjxray";
+    license     = licenses.isc;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/python-modules/symbiflow-fasm/default.nix
+++ b/pkgs/development/python-modules/symbiflow-fasm/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, pkgs
+, fetchFromGitHub
+, buildPythonPackage
+, textx
+}:
+
+buildPythonPackage rec {
+  pname = "symbiflow-fasm";
+  version = "0.0.1-g4857dde";
+
+  src = fetchFromGitHub {
+    owner = "SymbiFlow";
+    repo = "fasm";
+    rev = "4857dde757edd88688c2faf808774d85bdbe3900";
+    sha256 = "1za7f8slf8wvp1mfbfc3vdv61115p49k0vwngs4db6ips1qg1435";
+  };
+
+  propagatedBuildInputs = [ textx ];
+
+  meta = with stdenv.lib; {
+    description = "FPGA Assembly (FASM) Parser and Generation library";
+    homepage = "https://github.com/SymbiFlow/fasm";
+    license = licenses.isc;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/python-modules/textx/default.nix
+++ b/pkgs/development/python-modules/textx/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, arpeggio
+, click
+, jinja2
+}:
+
+buildPythonPackage rec {
+  pname = "textX";
+  version = "2.2.0";
+
+  src = fetchPypi {
+    inherit pname;
+    inherit version;
+    sha256 = "00mwd588ms96qp27m5vpjkzk30wfw53hnmv8y77slxca8lw9vq82";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "tests/functional" ];
+
+  propagatedBuildInputs = [
+    arpeggio
+    click
+    jinja2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "textX is a meta-language for building Domain-Specific Languages (DSLs) in Python";
+    homepage = "https://textx.github.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/development/python-modules/xc-fasm/default.nix
+++ b/pkgs/development/python-modules/xc-fasm/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+, simplejson
+, intervaltree
+, python-prjxray
+, symbiflow-fasm
+, textx
+}:
+
+buildPythonPackage rec {
+  pname = "xc-fasm";
+  version = "0.0.1-g0ddd9516";
+
+  src = fetchFromGitHub {
+    owner = "SymbiFlow";
+    repo = "xc-fasm";
+    rev = "0ddd951602d47d5b95f2072f8aa751af5e81e577";
+    sha256 = "15bzw92sx99s0zldr48na4yhrnp7b90nxsd8ya6ag1pvvijp2al4";
+  };
+
+  propagatedBuildInputs = [
+    simplejson
+    intervaltree
+    python-prjxray
+    symbiflow-fasm
+    textx
+  ];
+
+  # Pip will check for and then install missing dependecies.
+  # Because some of them are installed from git, it will try
+  # to download them even if they're present in
+  # propagatedBuildInputs.
+  pipInstallFlags = [ "--no-deps" ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with stdenv.lib; {
+    description = "XC FASM libraries";
+    homepage = "https://github.com/SymbiFlow/xc-fasm";
+    license = licenses.isc;
+    maintainers = with maintainers; [ mcaju ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10417,6 +10417,8 @@ in
 
   swift = callPackage ../development/compilers/swift { };
 
+  symbiflow-vtr = callPackage ../development/compilers/symbiflow-vtr { };
+
   swiProlog = callPackage ../development/compilers/swi-prolog {
     inherit (darwin.apple_sdk.frameworks) Security;
     jdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20254,6 +20254,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  prjxray-db = callPackage ../data/misc/prjxray-db { };
+
   profont = callPackage ../data/fonts/profont
     { inherit (buildPackages.xorg) mkfontscale; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10419,6 +10419,8 @@ in
 
   symbiflow-vtr = callPackage ../development/compilers/symbiflow-vtr { };
 
+  symbiflow-yosys = callPackage ../development/compilers/symbiflow-yosys { };
+
   swiProlog = callPackage ../development/compilers/swi-prolog {
     inherit (darwin.apple_sdk.frameworks) Security;
     jdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10421,6 +10421,8 @@ in
 
   symbiflow-yosys = callPackage ../development/compilers/symbiflow-yosys { };
 
+  symbiflow-yosys-plugins = callPackage ../development/compilers/symbiflow-yosys-plugins { };
+
   swiProlog = callPackage ../development/compilers/swi-prolog {
     inherit (darwin.apple_sdk.frameworks) Security;
     jdk = openjdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20299,6 +20299,8 @@ in
 
   sweet = callPackage ../data/themes/sweet { };
 
+  symbiflow-arch-defs = callPackage ../data/misc/symbiflow-arch-defs { };
+
   mime-types = callPackage ../data/misc/mime-types { };
 
   shared-mime-info = callPackage ../data/misc/shared-mime-info { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10785,6 +10785,8 @@ in
   polyml56 = callPackage ../development/compilers/polyml/5.6.nix { };
   polyml57 = callPackage ../development/compilers/polyml/5.7.nix { };
 
+  prjxray-tools = callPackage ../development/compilers/prjxray-tools { };
+
   pure = callPackage ../development/interpreters/pure {
     /*llvm = llvm_35;*/
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7296,6 +7296,8 @@ in {
 
   sybil = callPackage ../development/python-modules/sybil { };
 
+  symbiflow-fasm = callPackage ../development/python-modules/symbiflow-fasm { };
+
   symengine = callPackage ../development/python-modules/symengine { symengine = pkgs.symengine; };
 
   sympy = if isPy3k then

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4753,6 +4753,8 @@ in {
 
   python-openems = callPackage ../development/python-modules/python-openems { };
 
+  python-prjxray = callPackage ../development/python-modules/python-prjxray { };
+
   python-tado = callPackage ../development/python-modules/python-tado { };
 
   pkutils = callPackage ../development/python-modules/pkutils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8065,6 +8065,8 @@ in {
 
   xattr = callPackage ../development/python-modules/xattr { };
 
+  xc-fasm = callPackage ../development/python-modules/xc-fasm { };
+
   xcaplib = callPackage ../development/python-modules/xcaplib { };
 
   xcffib = callPackage ../development/python-modules/xcffib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7429,6 +7429,8 @@ in {
 
   textfsm = callPackage ../development/python-modules/textfsm { };
 
+  textx = callPackage ../development/python-modules/textx { };
+
   testpath = callPackage ../development/python-modules/testpath { };
 
   testrepository = callPackage ../development/python-modules/testrepository { };


### PR DESCRIPTION
###### Motivation for this change
To integrate symbiflow and prjxray into nixpkgs, it is already available in Conda. Should make us competitive.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).