### PR TITLE
Use unstableGitUpdater on my unstable packages

### DIFF
--- a/pkgs/applications/audio/littlegptracker/default.nix
+++ b/pkgs/applications/audio/littlegptracker/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, unstableGitUpdater
 , SDL
 , jack2
 , Foundation
@@ -41,6 +42,8 @@ stdenv.mkDerivation rec {
 
   installPhase = let extension = if stdenv.isDarwin then "app" else "deb-exe";
     in "install -Dm555 lgpt.${extension} $out/bin/lgpt";
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with stdenv.lib; {
     description = "A music tracker similar to lsdj optimised to run on portable game consoles";

--- a/pkgs/applications/graphics/meme/default.nix
+++ b/pkgs/applications/graphics/meme/default.nix
@@ -1,8 +1,12 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv
+, buildGoPackage
+, unstableGitUpdater
+, fetchFromGitHub
+}:
 
 buildGoPackage rec {
-  pname = "meme-unstable";
-  version = "2017-09-10";
+  pname = "meme";
+  version = "unstable-2017-09-10";
 
   owner = "nomad-software";
   repo = "meme";
@@ -13,6 +17,8 @@ buildGoPackage rec {
     rev = "a6521f2eecb0aac22937b0013747ed9cb40b81ea";
     sha256 = "1gbsv1d58ck6mj89q31s5b0ppw51ab76yqgz39jgwqnkidvzdfly";
   };
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with stdenv.lib; {
     description = "A command line utility for creating image macro style memes";

--- a/pkgs/development/compilers/lobster/default.nix
+++ b/pkgs/development/compilers/lobster/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, unstableGitUpdater
 , cmake
 , callPackage
 
@@ -46,8 +47,9 @@ stdenv.mkDerivation rec {
   preConfigure = "cd dev";
   enableParallelBuilding = true;
 
-  passthru.tests = {
-    can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};
+  passthru = {
+    tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};
+    updateScript = unstableGitUpdater { };
   };
 
   meta = with stdenv.lib; {
@@ -63,4 +65,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -25,4 +25,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/tools/misc/cht.sh/default.nix
+++ b/pkgs/tools/misc/cht.sh/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, unstableGitUpdater
 , makeWrapper
 , curl
 , ncurses
@@ -35,6 +36,8 @@ stdenv.mkDerivation {
       --prefix PATH : "${stdenv.lib.makeBinPath [ curl rlwrap ncurses xsel ]}"
   '';
 
+  passthru.updateScript = unstableGitUpdater { };
+
   meta = with stdenv.lib; {
     description = "CLI client for cheat.sh, a community driven cheat sheet";
     license = licenses.mit;
@@ -42,4 +45,3 @@ stdenv.mkDerivation {
     homepage = "https://github.com/chubin/cheat.sh";
   };
 }
-

--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -1,8 +1,14 @@
-{ stdenv, fetchFromGitHub, makeWrapper, openssl, coreutils, gnugrep }:
+{ stdenv
+, fetchFromGitHub
+, unstableGitUpdater
+, makeWrapper
+, openssl
+, coreutils
+, gnugrep }:
 
 stdenv.mkDerivation {
-  pname = "bash-supergenpass-unstable";
-  version = "2018-04-18";
+  pname = "bash-supergenpass";
+  version = "unstable-2018-04-18";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -17,6 +23,8 @@ stdenv.mkDerivation {
     install -m755 -D supergenpass.sh "$out/bin/supergenpass"
     wrapProgram "$out/bin/supergenpass" --prefix PATH : "${stdenv.lib.makeBinPath [ openssl coreutils gnugrep ]}"
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with stdenv.lib; {
     description = "Bash shell-script implementation of SuperGenPass password generation";
@@ -36,4 +44,3 @@ stdenv.mkDerivation {
     homepage = "https://github.com/lanzz/bash-supergenpass";
   };
 }
-


### PR DESCRIPTION
##### Motivation for this change

#101083 was merged, so now I can use unstableGitUpdater for my unstable packages.

(I also removed some stray newlines)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
