### PR TITLE
dyndnsc: init at 0.5.1

### DIFF
--- a/pkgs/applications/networking/dyndns/dyndnsc/default.nix
+++ b/pkgs/applications/networking/dyndns/dyndnsc/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "dyndnsc";
+  version = "0.5.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    hash = "sha256-Sy6U0XhIQ9mPmznmWKqoyqE34vaE84fwlivouaF7Dd0=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "bottle==" "bottle>="
+  '';
+
+  nativeBuildInputs = with python3Packages; [ pytestrunner ];
+  propagatedBuildInputs = with python3Packages; [
+    daemonocle
+    dnspython
+    netifaces
+    requests
+    setuptools
+  ];
+  checkInputs = with python3Packages; [ bottle pytestCheckHook ];
+
+  disabledTests = [
+    # dnswanip connects to an external server to discover the
+    # machine's IP address.
+    "dnswanip"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # The tests that spawn a server using Bottle cannot be run on
+    # macOS or Windows as the default multiprocessing start method
+    # on those platforms is 'spawn', which requires the code to be
+    # run to be picklable, which this code isn't.
+    # Additionaly, other start methods are unsafe and prone to failure
+    # on macOS; see https://bugs.python.org/issue33725.
+    "BottleServer"
+  ];
+  # Allow tests that bind or connect to localhost on macOS.
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "Dynamic DNS update client with support for multiple protocols";
+    longDescription = ''
+      Dyndnsc is a command line client for sending updates to Dynamic
+      DNS (DDNS, DynDNS) services.  It supports multiple protocols and
+      services, and it has native support for IPv6.  The configuration
+      file allows using foreign, but compatible services.  Dyndnsc
+      ships many different IP detection mechanisms, support for
+      configuring multiple services in one place and it has a daemon
+      mode for running unattended.  It has a plugin system to provide
+      external notification services.
+    '';
+    homepage = "https://github.com/infothrill/python-dyndnsc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ AluisioASG ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/daemonocle/default.nix
+++ b/pkgs/development/python-modules/daemonocle/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, click
+, psutil
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "daemonocle";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "jnrbsn";
+    repo = "daemonocle";
+    rev = "v${version}";
+    hash = "sha256-kDCbosXTIffuCzHcReXhiW4YPbxDW3OPnTbMC/EGJrM=";
+  };
+
+  propagatedBuildInputs = [ click psutil ];
+  checkInputs = [ pytestCheckHook ];
+
+  # One third of the tests fail on the sandbox with
+  # "psutil.NoSuchProcess: no process found with pid 0".
+  doCheck = false;
+  disabledTests = [ "sudo" ];
+  pythonImportsCheck = [ "daemonocle" ];
+
+  meta = with lib; {
+    description = "A Python library for creating super fancy Unix daemons";
+    longDescription = ''
+      daemonocle is a library for creating your own Unix-style daemons
+      written in Python.  It solves many problems that other daemon
+      libraries have and provides some really useful features you don't
+      often see in other daemons.
+    '';
+    homepage = "https://github.com/jnrbsn/daemonocle";
+    license = licenses.mit;
+    maintainers = [ maintainers.AluisioASG ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2037,6 +2037,8 @@ in
 
   dyncall = callPackage ../development/libraries/dyncall { };
 
+  dyndnsc = callPackage ../applications/networking/dyndns/dyndnsc { };
+
   earlyoom = callPackage ../os-specific/linux/earlyoom { };
 
   EBTKS = callPackage ../development/libraries/science/biology/EBTKS { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1452,6 +1452,8 @@ in {
 
   daemonize = callPackage ../development/python-modules/daemonize { };
 
+  daemonocle = callPackage ../development/python-modules/daemonocle { };
+
   daphne = callPackage ../development/python-modules/daphne { };
 
   darcsver = callPackage ../development/python-modules/darcsver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Since #68663 got closed, I decided to PR my own take at it. I have a corresponding NixOS module but haven't used it in a while and I want to figure out how to write tests, so I'll leave it for later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
