### PR TITLE
idevicerestore: Add darwin build support.

### DIFF
--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       devices to the Linux Desktop.
     '';
     license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl21;
     # Upstream description says it works on more platforms, but packager hasn't tried that yet
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ nh2 ];
   };
 }

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/libimobiledevice/libplist";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ infinisil ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libusbmuxd/default.nix
+++ b/pkgs/development/libraries/libusbmuxd/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "A client library to multiplex connections from and to iOS devices";
     homepage    = "https://github.com/libimobiledevice/libusbmuxd";
     license     = licenses.lgpl21Plus;
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/tools/misc/idevicerestore/default.nix
+++ b/pkgs/tools/misc/idevicerestore/default.nix
@@ -4,6 +4,7 @@
 , libirecovery
 , libzip
 , libusbmuxd
+, IOKit
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
     # Not listing other dependencies specified in
     # https://github.com/libimobiledevice/idevicerestore/blob/8a882038b2b1e022fbd19eaf8bea51006a373c06/README#L20
     # because they are inherited `libimobiledevice`.
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/libimobiledevice/idevicerestore";
@@ -51,8 +52,8 @@ stdenv.mkDerivation rec {
       This will download and restore a device to the latest firmware available.
     '';
     license = licenses.lgpl21Plus;
-    # configure.ac suggests it should work for darwin and mingw as well but not tried yet
-    platforms = platforms.linux;
+    # configure.ac suggests it should work for mingw as well but not tried yet
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ nh2 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4750,7 +4750,9 @@ in
 
   ifuse = callPackage ../tools/filesystems/ifuse { };
   ideviceinstaller = callPackage ../tools/misc/ideviceinstaller { };
-  idevicerestore = callPackage ../tools/misc/idevicerestore { };
+  idevicerestore = callPackage ../tools/misc/idevicerestore {
+    inherit (darwin) IOKit;
+  };
 
   inherit (callPackages ../tools/filesystems/irods rec {
             stdenv = llvmPackages.libcxxStdenv;


### PR DESCRIPTION
###### Motivation for this change

I saw that in the original derivation the comment mentioned darwin should be theoretically supported but it wasn't tested.
I tested it and it compiles fine and can run a few basic CLI commands.

I had to add the darwin flag to a few of the dependencies as well. Not sure if that needs to go into a separate PR?

(This is my first nixpkg contribution, so a sanity check would be appreciated 😃  )

###### Things done

1. I cloned the nixpkgs repo
2. I made my changes
3. I built it using:

```
$ nix-build default.nix -A idevicerestore
```
4. Ran the resulting binary on macOS 10.15.7:

```
% /nix/store/zscw4bcgqrgaypjl1r0z7zh13rbl2fk5-idevicerestore-2019-12-26/bin/idevicerestore 
Usage: idevicerestore [OPTIONS] PATH
Restore IPSW firmware at PATH to an iOS device.

PATH can be a compressed .ipsw file or a directory containing all files
extracted from an IPSW.

Options:
 -i, --ecid ECID  Target specific device by its ECID
                  e.g. 0xaabb123456 (hex) or 1234567890 (decimal)
 -u, --udid UDID  Target specific device by its device UDID
                  NOTE: only works with devices in normal mode.
 -l, --latest     Use latest available firmware (with download on demand).
                  Before performing any action it will interactively ask to
                  select one of the currently signed firmware versions,
                  unless -y has been given too.
                  The PATH argument is ignored when using this option.
                  DO NOT USE if you need to preserve the baseband (unlock)!
                  USE WITH CARE if you want to keep a jailbreakable firmware!
 -e, --erase      Perform a full restore, erasing all data (defaults to update)
                  DO NOT USE if you want to preserve user data on the device!
 -y, --no-input   Non-interactive mode, do not ask for any input.
                  WARNING: This will disable certain checks/prompts that are
                  supposed to prevent DATA LOSS. Use with caution.
 -n, --no-action  Do not perform any restore action. If combined with -l option
                  the on-demand ipsw download is performed before exiting.
 -h, --help       Prints this usage information
 -C, --cache-path DIR  Use specified directory for caching extracted or other
                  reused files.
 -d, --debug      Enable communication debugging

Advanced/experimental options:
 -c, --custom     Restore with a custom firmware
 -s, --cydia      Use Cydia's signature service instead of Apple's
 -x, --exclude    Exclude nor/baseband upgrade
 -t, --shsh       Fetch TSS record and save to .shsh file, then exit
 -k, --keep-pers  Write personalized components to files for debugging
 -p, --pwn        Put device in pwned DFU mode and exit (limera1n devices only)

Homepage: <http://libimobiledevice.org>
mseeger@mseeger-mbp ~ % 
```

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [Not Applicable] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [Nothing depends on it] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
