### PR TITLE
pythonPackages.goobook: Switch to importsCheck

### DIFF
--- a/pkgs/development/python-modules/goobook/default.nix
+++ b/pkgs/development/python-modules/goobook/default.nix
@@ -23,6 +23,10 @@ buildPythonPackage rec {
     installManPage goobook.1
   '';
 
+  doCheck = false;
+
+  pythonImportsCheck = [ "goobook" ];
+
   meta = with stdenv.lib; {
     description = "Access your Google contacts from the command line";
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#105657

```
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing goobook.egg-info/PKG-INFO
writing dependency_links to goobook.egg-info/dependency_links.txt
writing entry points to goobook.egg-info/entry_points.txt
writing requirements to goobook.egg-info/requires.txt
writing top-level names to goobook.egg-info/top_level.txt
reading manifest file 'goobook.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'goobook/*.json'
writing manifest file 'goobook.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Finished executing setuptoolsCheckPhase
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
