### PR TITLE
libslirp: 4.3.1 -> 4.4.0

### DIFF
--- a/pkgs/development/libraries/libslirp/default.nix
+++ b/pkgs/development/libraries/libslirp/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchFromGitLab
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -9,24 +8,15 @@
 
 stdenv.mkDerivation rec {
   pname = "libslirp";
-  version = "4.3.1";
+  version = "4.4.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "slirp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0pzgjj2x2vrjshrzrl2x39xp5lgwg4b4y9vs8xvadh1ycl10v3fv";
+    sha256 = "0abh337jvij664w65zszjql42n720zzfap0ab0amr4qcvkzw7bjx";
   };
-
-  patches = [
-    # remove >4.3.1
-    (fetchpatch {
-      name = "CVE-2020-29129_CVE-2020-29130.patch";
-      url = "https://gitlab.freedesktop.org/slirp/libslirp/-/commit/2e1dcbc0c2af64fcb17009eaf2ceedd81be2b27f.patch";
-      sha256 = "01vbjqgnc0kp881l5p6b31cyyirhwhavm6x36hlgkymswvl3wh9w";
-    })
-  ];
 
   nativeBuildInputs = [ meson ninja pkg-config ];
 
@@ -41,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/slirp/libslirp";
     license = licenses.bsd3;
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
https://gitlab.freedesktop.org/slirp/libslirp/-/releases/v4.4.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
