### PR TITLE
[20.09] pythonPackages.tmdb3: disable on python3

### DIFF
--- a/pkgs/development/python-modules/tmdb3/default.nix
+++ b/pkgs/development/python-modules/tmdb3/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
 
 buildPythonPackage rec {
   pname = "tmdb3";
   version = "0.7.2";
+  disabled = isPy3k; # Upstream has not received any updates since 2015, and importing from python3 does not work.
 
   src = fetchPypi {
     inherit pname version;
@@ -11,6 +12,8 @@ buildPythonPackage rec {
 
   # no tests implemented
   doCheck = false;
+
+  pythonImportsCheck = [ "tmdb3" ];
 
   meta = with lib; {
     description = "Python implementation of the v3 API for TheMovieDB.org, allowing access to movie and cast information";


### PR DESCRIPTION
(cherry picked from commit 235bf5ad7dd5554b101d97c5f4ee1e62169d0170)

###### Motivation for this change
Original PR: #101951
cc @SuperSandro2000 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
