### PR TITLE
kodi: accept plugins without extraRuntimeDependencies

### DIFF
--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -19,7 +19,7 @@ in buildEnv {
         --prefix KODI_HOME : $out/share/kodi \
         --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath
           (stdenv.lib.concatMap
-            (plugin: plugin.extraRuntimeDependencies) plugins)}"
+            (plugin: plugin.extraRuntimeDependencies or []) plugins)}"
     done
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Certain `kodi` plugins that you can install imperatively from within `kodi` itself have `python` dependencies which must be in `PYTHONPATH`. For example, the [plugin.video.netflix](https://github.com/CastagnaIT/plugin.video.netflix) plugin requires `pycryptodomex`. Sure, this PR may be considered a tiny bit hacky, but I thought pushing these `python` dependencies into `kodi` via the `plugins` directive seemed reasonable :man_shrugging: 
```
kodi.override { plugins = with kodiPlugins; [ python2Packages.pycryptodomex ]; }'
```

Without this PR I have to hack in the `extraRuntimeDependencies` like so:
```
kodi.override { plugins = with kodiPlugins; [ (python2Packages.pycryptodomex // { extraRuntimeDependencies = []; }) ]; }'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
