### PR TITLE
kicad-unstable: 2020-11-07 -> 2020-12-01

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,25 +27,25 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-11-07";
+      version =			"2020-12-01";
       src = {
-        rev =			"9454f9df9245aea037d1ad5baf050c2d9101159c";
-        sha256 =		"03bd0dk234ihqnwrv4n40gi856xcjqgxplfwjzlwcq521gwykv30";
+        rev =			"3c521942ed52e83482c82d426170b4fbf327f846";
+        sha256 =		"sha256:09qab69sy3n44kjlzxxx7gbksyr1kg8n14kz0zf8n71zfcqagci4";
       };
     };
     libVersion = {
-      version =			"2020-11-07";
+      version =			"2020-12-01";
       libSources = {
         i18n.rev =		"e89d9a89bec59199c1ade56ee2556591412ab7b0";
-        i18n.sha256 =		"04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
-        symbols.rev =		"9c50f4333bafc5a1abf7786436db5ffb6a66758d";
-        symbols.sha256 =	"06ic59svz0256isy93863i5ay4k8wshvp1kspnqrc776wmq03l3k";
-        templates.rev =		"41eae4ccd3ac02fdb969e3aa272c07ab51dcf5af";
-        templates.sha256 =	"0xxfkpsgbnafmpaxpz1747zn7fhqp0kfl32rzjrx4vzxyp25q805";
-        footprints.rev =	"50015af7e603cc499199c7e1c6daa7c85dd732ae";
-        footprints.sha256 =	"16bic67klbj7sgj7cab8ha2fg3ypp9ap82gxkn6ijvpl7dka8bhb";
-        packages3d.rev =	"df0dc0074491bb665b2c3ce569cbd4aa16118ad6";
-        packages3d.sha256 =	"027jlcp9fpryldjkcxhb1b5bpwqna9kl6r0lnkd86x238kj3rd8v";
+        i18n.sha256 =		"sha256:04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
+        symbols.rev =		"e538abb015b4f289910a6f26b2f1b9cb8bf2efdb";
+        symbols.sha256 =	"sha256:117y4cm46anlrnw6y6mdjgl1a5gab6h6m7cwx3q7qb284m9bs5gi";
+        templates.rev =		"32a4f6fab863976fdcfa232e3e08fdcf3323a954";
+        templates.sha256 =	"sha256:13r94dghrh9slpj7nkzv0zqv5hk49s6pxm4q5ndqx0y8037ivmhk";
+        footprints.rev =	"15ffd67e01257d4d8134dbd6708cb58977eeccbe";
+        footprints.sha256 =	"sha256:1ad5k3wh2zqfibrar7pd3g363jk2q51dvraxnq3zlxa2x4znh7mw";
+        packages3d.rev =	"d8b7e8c56d535f4d7e46373bf24c754a8403da1f";
+        packages3d.sha256 =	"sha256:0dh8ixg0w43wzj5h3164dz6l1vl4llwxhi3qcdgj1lgvrs28aywd";
       };
     };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bring the unstable Kicad derivation up-to-date with `master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
