### PR TITLE
thermald: 2.3 -> 2.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -652,6 +652,12 @@
     githubId = 56009;
     name = "Arcadio Rubio García";
   };
+  archseer = {
+    email = "blaz@mxxn.io";
+    github = "archseer";
+    githubId = 1372918;
+    name = "Blaž Hrastnik";
+  };
   arcnmx = {
     email = "arcnmx@users.noreply.github.com";
     github = "arcnmx";

--- a/nixos/modules/services/hardware/thermald.nix
+++ b/nixos/modules/services/hardware/thermald.nix
@@ -23,15 +23,6 @@ in {
         default = null;
         description = "the thermald manual configuration file.";
       };
-
-      adaptive = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable adaptive mode, only working on kernel versions greater than 5.8.
-          Thermald will detect this itself, safe to enable on kernel versions below 5.8.
-        '';
-      };
     };
   };
 
@@ -48,8 +39,8 @@ in {
             --no-daemon \
             ${optionalString cfg.debug "--loglevel=debug"} \
             ${optionalString (cfg.configFile != null) "--config-file ${cfg.configFile}"} \
-            ${optionalString cfg.adaptive "--adaptive"} \
             --dbus-enable
+            --adaptive
         '';
       };
     };

--- a/pkgs/tools/system/thermald/default.nix
+++ b/pkgs/tools/system/thermald/default.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "thermald";
-  version = "2.3";
+  version = "2.4.1";
 
   outputs = [ "out" "devdoc" ];
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "intel";
     repo = "thermal_daemon";
     rev = "v${version}";
-    sha256 = "0cisaca2c2z1x9xvxc4lr6nl6yqx5bww6brh73m0p1n643jgq1dl";
+    sha256 = "0rlac7v1b59m7gh767hkd8a0r4p001nd24786fnmryygbxynd2s6";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION


###### Motivation for this change

2.4 comes with massive improvements to adaptive mode.

Note: I've removed the `adaptive` option that was added in the last package update and set it to always on to match the change upstream.

thermald will automatically switch to passive mode if needed (some fixes for that landed in 2.4), and [upstream sets it to always on](
https://github.com/intel/thermal_daemon/blob/a6e68a65b53a3d7a023c9b45db31ceffbd7e5dfb/data/thermald.service.in#L9).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
