### PR TITLE
dolphinEmu: install udev rules on linux

### DIFF
--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -109,8 +109,7 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-    mkdir -p $out/etc/udev/rules.d/
-    cp $src/Data/51-usb-device.rules $out/etc/udev/rules.d/
+    install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
   '';
 
   meta = with lib; {

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -108,6 +108,11 @@ stdenv.mkDerivation rec {
     sfml
   ];
 
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/etc/udev/rules.d/
+    cp $src/Data/51-usb-device.rules $out/etc/udev/rules.d/
+  '';
+
   meta = with lib; {
     homepage = "https://dolphin-emu.org/";
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -71,6 +71,9 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     cp -r ${desktopItem}/share/applications $out/share
     ln -sf $out/bin/dolphin-emu $out/bin/dolphin-emu-master
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/etc/udev/rules.d/
+    cp $src/Data/51-usb-device.rules $out/etc/udev/rules.d/
   '';
 
   meta = with lib; {

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -72,8 +72,7 @@ in stdenv.mkDerivation rec {
     cp -r ${desktopItem}/share/applications $out/share
     ln -sf $out/bin/dolphin-emu $out/bin/dolphin-emu-master
   '' + lib.optionalString stdenv.hostPlatform.isLinux ''
-    mkdir -p $out/etc/udev/rules.d/
-    cp $src/Data/51-usb-device.rules $out/etc/udev/rules.d/
+    install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules
   '';
 
   meta = with lib; {


### PR DESCRIPTION
This allows use of GameCube controllers via NixOS udev rules,
e.g. by setting

```nix
services.udev.packages = [ pkgs.dolphinEmu ];
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
