### PR TITLE
nixos/iwd: pull in upstream .link unit file

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -95,6 +95,15 @@
     </para>
    </listitem>
    <listitem>
+    <para>
+     The <varname>networking.wireless.iwd</varname> module now installs
+     the upstream-provided 80-iwd.link file, which sets the NamePolicy=
+     for all wlan devices to "keep kernel", to avoid race conditions
+     between iwd and networkd. If you don't want this, you can set
+     <literal>systemd.network.links."80-iwd" = lib.mkForce {}</literal>.
+    </para>
+   </listitem>
+   <listitem>
      <para>
        <literal>rubyMinimal</literal> was removed due to being unused and
        unusable. The default ruby interpreter includes JIT support, which makes

--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -22,6 +22,11 @@ in {
 
     systemd.packages = [ pkgs.iwd ];
 
+    systemd.network.links."80-iwd" = {
+      matchConfig.Type = "wlan";
+      linkConfig.NamePolicy = "keep kernel";
+    };
+
     systemd.services.iwd.wantedBy = [ "multi-user.target" ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

This is meant to fix the race condition between `iwd` and `udev` trying to
rename the interface.

Once `systemd.packages` [learns](https://github.com/NixOS/nixpkgs/issues/105689) to deal with `.link` unit files it probably won't be needed anymore.

###### Things done

Currently testing this on my system.
 
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
