### PR TITLE
kernel: Switch to ZSTD compression & manual-config.nix improvements

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -512,7 +512,12 @@ in
 
     boot.initrd.compressor = mkOption {
       internal = true;
-      default = "gzip -9n";
+      default = (
+        if lib.versionAtLeast config.boot.kernelPackages.kernel.version "5.9" then
+          "${lib.getBin pkgs.zstd}/bin/zstd -10"
+        else
+          "gzip -9n"
+        );
       type = types.str;
       description = "The compressor to use on the initrd image.";
       example = "xz";

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -654,7 +654,10 @@ let
 
       MODULE_COMPRESS    = yes;
       MODULE_COMPRESS_XZ = yes;
-      KERNEL_XZ          = yes;
+
+      # use zstd for kernel compression if newer than 5.9, else xz.
+      KERNEL_XZ          = { optional = true; tristate = whenOlder "5.9" "y";};
+      KERNEL_ZSTD        = { optional = true; tristate = whenAtLeast "5.9" "y";};
 
       SYSVIPC            = yes;  # System-V IPC
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,5 @@
 { buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
-, libelf, cpio, elfutils, gawk
+, libelf, cpio, elfutils, zstd, gawk
 , writeTextFile
 }:
 
@@ -299,7 +299,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches
   enableParallelBuilding = true;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk ]
+  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk zstd ]
       ++ optional  (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
       ++ optional  (stdenv.lib.versionAtLeast version "4.14" && stdenv.lib.versionOlder version "5.8") libelf
       # Removed util-linuxMinimal since it should not be a dependency.

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,5 @@
 { buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
-, libelf, cpio, elfutils
+, libelf, cpio, elfutils, gawk
 , writeTextFile
 }:
 
@@ -113,7 +113,7 @@ let
             sed -i "$mf" -e 's|/usr/bin/||g ; s|/bin/||g ; s|/sbin/||g'
         done
         sed -i Makefile -e 's|= depmod|= ${buildPackages.kmod}/bin/depmod|'
-        sed -i scripts/ld-version.sh -e "s|/usr/bin/awk|${buildPackages.gawk}/bin/awk|"
+        patchShebangs scripts/ld-version.sh
       '';
 
       postPatch = ''
@@ -299,7 +299,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches
   enableParallelBuilding = true;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr ]
+  nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk ]
       ++ optional  (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
       ++ optional  (stdenv.lib.versionAtLeast version "4.14" && stdenv.lib.versionOlder version "5.8") libelf
       # Removed util-linuxMinimal since it should not be a dependency.


### PR DESCRIPTION
###### Motivation for this change

Switches the kernel and initrd compression to zstd on kernels 5.9 and newer.

Also addresses two issues I've had to patch when using `linuxManualConfig`:

1) Adds `zstd` to nativeBuildInputs, it's required if `KERNEL_ZSTD` is enabled. (I think [zstd should be a part of stdenv (refs #101108), just like `bzip2 gzip xz`](https://github.com/NixOS/nixpkgs/issues/101108#issuecomment-735636354) but it's a start.)

2) ~~Certain BPF config options use `bpf_helpers_doc.py` which references `python3` via FHS so it has to be fixed up.~~ 
Used `patchShebang` instead of `sed` to patch a FHS shebang referencing awk.

Closes #101108

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
