### PR TITLE
mucommander: Use jdk11 & gradle6

### DIFF
--- a/pkgs/applications/misc/mucommander/default.nix
+++ b/pkgs/applications/misc/mucommander/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gradle_4_10, perl, makeWrapper, jre, gsettings-desktop-schemas }:
+{ stdenv, fetchFromGitHub, gradle_6, perl, makeWrapper, jdk11, gsettings-desktop-schemas }:
 
 let
   version = "0.9.3-3";
@@ -36,7 +36,7 @@ let
   deps = stdenv.mkDerivation {
     name = "${name}-deps";
     inherit src postPatch;
-    nativeBuildInputs = [ gradle_4_10 perl ];
+    nativeBuildInputs = [ gradle_6 perl ];
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
       gradle --no-daemon build
@@ -54,7 +54,7 @@ let
 
 in stdenv.mkDerivation {
   inherit name src postPatch;
-  nativeBuildInputs = [ gradle_4_10 perl makeWrapper ];
+  nativeBuildInputs = [ gradle_6 perl makeWrapper ];
 
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)
@@ -73,7 +73,7 @@ in stdenv.mkDerivation {
     tar xvf build/distributions/mucommander-${version}.tar --directory=$out --strip=1
     wrapProgram $out/bin/mucommander \
       --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name} \
-      --set JAVA_HOME ${jre}
+      --set JAVA_HOME ${jdk11}
   '';
 
   meta = with stdenv.lib; {
@@ -81,6 +81,9 @@ in stdenv.mkDerivation {
     description = "Cross-platform file manager";
     license = licenses.gpl3;
     maintainers = with maintainers; [ volth ];
+    # build is broken on MacOS
+    # https://github.com/NixOS/nixpkgs/pull/105784
+    broken = stdenv.isDarwin;
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Remove second-last usage of gradle 4 in nixpkgs. Only one left is in `pkgs/development/compilers/openjdk/openjfx/11.nix`. Also use jdk11 for running mucommander instead of jre8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
