### PR TITLE
 thunderbird, thunderbird-bin: 78.5.0 -> 78.5.1 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.5.0";
+  version = "78.5.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/af/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/af/thunderbird-78.5.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "011468ce085f2b5da8968b0622733d9fa25b47ec5e83b3bf4171323948aebb35";
+      sha256 = "87cb38398aaa5af68e562a5fc6d20d3d3477d871979bd4a635c94c440e66a482";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ar/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ar/thunderbird-78.5.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "661b0f1981b21df20b910f9d833d86c2812b189097ad7e1affc7338abb4f0c5c";
+      sha256 = "935efae7caa116e16c341d64634954d77cafbc5e28626b46f5385b8416060f51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ast/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ast/thunderbird-78.5.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "c1acc2b6d5dd22adeab3106c3c6925ce0c1a434e1d38b3f699fab4ca319eab14";
+      sha256 = "a5868dc7987529790910e638b64b15295a2d57e449fa515f4e17a4ab88a830e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/be/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/be/thunderbird-78.5.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "6f76341164c182dd8392d2d1abbb0408a3ab773a7389dbf1eb9bb4042d49f500";
+      sha256 = "af52b29567ce26159890f70fcdccd4cafd49c7fc75c620bb606727fd27b7049a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/bg/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/bg/thunderbird-78.5.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "4e97b38383d3a145645ca518449e37e42b5b25cbb98cb72f52657b4813f2b343";
+      sha256 = "91856a4745a8bdefac7c2b0193766a4f0009378dfe941dbbe1afcae2ffae2337";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/br/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/br/thunderbird-78.5.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1d5bcb706bf2eb589aa0c64589fc5b22021977947d6e1099f339a46c55a56f84";
+      sha256 = "d5ba5fe368c99377a264d8574607335fc4317dad447bb38fdc6a5b53d2e95b49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ca/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ca/thunderbird-78.5.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "3284b98707ee67977f148bd20d88750cc03799d9ba4aa5668c44901846fb8bcf";
+      sha256 = "396a1d7b668c7f47b56d7cb41e6e914f03e9e517a14b4698abedb501037ef2c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cak/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/cak/thunderbird-78.5.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "7998d66eaf3edc4ee156dff06a30de8abae08ff66b380ea93d7ec0b827a0ea29";
+      sha256 = "914b76ad8268db608be0595039a68189146ded384c23407ccbcd78a5e74e19ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cs/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/cs/thunderbird-78.5.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "5ba37c9dd7a1fc291bcc8b24ef025432dbd5f8a45ea2a4d1273177c6a7c8f6bd";
+      sha256 = "4b62702cabecfbb2567b19446f405936c9d948dad6f65a2e3f21809d4f2b1176";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/cy/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/cy/thunderbird-78.5.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "baaad2ef28f51b6f57fa6f0583e8e0125c50ea3b4c94dea5854faf9826aecad0";
+      sha256 = "736d245bd7766ac8c611a6801b3769a84baf4abae94818e0cfcadde8521850ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/da/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/da/thunderbird-78.5.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "6113ed3f5a36f16e64f0cc499eb683a0d7d377d0cce37882f46f203893b789d8";
+      sha256 = "53143b51b84ee74ee9131d3b3b80e2cf873e5a8c22478c87db34a9d2ac34607a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/de/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/de/thunderbird-78.5.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "81490e8cd8110285177c27f4057ff48ed1bdb55c94c83cc78e262b9cfcbd87ea";
+      sha256 = "2f3a4d8bf96e9653dd3883ac4399c650e87831d7df137358401966683d382e6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/dsb/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/dsb/thunderbird-78.5.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "4c6abc365842c902ff184b403a6c271760bd8e71da9efa90d30310e032b03729";
+      sha256 = "81a3674dd2495da673a2fe3e3d200d7cadf83f9c67ff92bf2d607f6546bc2f38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/el/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/el/thunderbird-78.5.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d492a83d3ddaf5beead77fd90a2334ca4ed90023d4c4ad478249a360f49cd5be";
+      sha256 = "651e8f535b2518bc4e56706cfb76da6d0e35d4fec031f8426cbefb404e4790d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-CA/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/en-CA/thunderbird-78.5.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "d7ddc5a22e89827067255726824e46d3355906441051c9faa04e6241cb833955";
+      sha256 = "775983115d98e3581db993f6202fdad1de6b23d38e5bb7edfd965ad6bc0ae425";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-GB/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/en-GB/thunderbird-78.5.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "10ff106bb933374661e3398ea4ce02c205242d1f7a647504161e295b5e3d1e11";
+      sha256 = "d0a3569c76b85fdca01e5098cf279b08a63d2d9023e92cadf3f8dc136d76c619";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/en-US/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/en-US/thunderbird-78.5.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "297429aff3f10ab7c2859a37ec351b6b0a478495b8a34e8b492ae3473f052c7f";
+      sha256 = "4363d8fd759ac4f4783eeb76726c8cf22e5afb3c171f26fe5cca5ab194ab6959";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/es-AR/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/es-AR/thunderbird-78.5.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "c8bafb3476d127d28f565ea5dd749b0c870087f395e0aabfb848a004846498e9";
+      sha256 = "3a04a2e42935c97c7ef003e4a690c0433783b57ce56700f07ad8b590e48b4ad0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/es-ES/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/es-ES/thunderbird-78.5.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d8c5350627e7e6f48fbfa863bed1971254104ee299d81d1f36b99d6c6ee54313";
+      sha256 = "f70a3feb09b79153d18e2a382017abbd6e015c78d4d55ff66f8b199b450172c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/et/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/et/thunderbird-78.5.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "f2a1001b0bb87965e40cd832102d2233b732273930d36715ff2db900b37c9ed2";
+      sha256 = "c739f5306a2526baf74e57a029371390d02f8c119681b0f154481ae32c67c18c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/eu/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/eu/thunderbird-78.5.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "30c6da377a8fc4596f6a67b189c1c9f7a9075df96ed3a59b4da7e0e77157d950";
+      sha256 = "9f95f4f1ec40e2732e053e68b31529b827f95876ad890d752f5380158f53b9e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fa/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fa/thunderbird-78.5.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8f98dd01764a5d244c25c3c409b8dbcaa1d3daf7b3a970c60d3d37fd5ffc4294";
+      sha256 = "e53dd458656ee9f39e996042016256949c974161c51b1bee63a401d90d59bace";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fi/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fi/thunderbird-78.5.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "be5f152b28ee21d916b184999023a1a5adddd1d2c7448e7eb37bd08948f6a14c";
+      sha256 = "b0a96b08e986e49ee6526ab098fb0d44700b3a2aa7f96205b318fdd4b938ef51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fr/thunderbird-78.5.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c1b2d725c43196dfe3f9bfd291dfae84ba392151222589d80e3921e627667d59";
+      sha256 = "872da741245da7466de58d766a0362983d59a111a65a333881d3636defe00eb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/fy-NL/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fy-NL/thunderbird-78.5.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "622c42950cc7d3889372b6e0c5833dc5c5f608ab23ca9962e0af67ce4b2f8ff5";
+      sha256 = "d57862f51ec01e63ab77916ab352276b7f4992b089508dee0c9c5d389ab88d95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ga-IE/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ga-IE/thunderbird-78.5.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "7293859380e07d362192cd9dcf88b8da04cde6e102f0b8d51a00021bf8fd9e98";
+      sha256 = "bda41b8eff5a5004f753944c49f15ddbd1f76c19b0310481251e04ff64309597";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/gd/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/gd/thunderbird-78.5.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "f54b892150bd49d028337a88d3a0b2df896a47a6904067b381d385281d2c681e";
+      sha256 = "0671af342859574cb96dbe119d76d7ffa92a8c3fef11eee2a03f662ea71fb84a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/gl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/gl/thunderbird-78.5.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "58c88bf739fde7e0f7e279106622abde617a0aa267f34f1c10f8d886800dc50b";
+      sha256 = "b458d6f79914fc4c551b3fa4444dc5ad4fa8d3310907a33a3480bf363bcdbfdb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/he/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/he/thunderbird-78.5.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "8278c7580356c360c74ad161a6ee052e9398e39a2a5b75217ac0239db28ee4cf";
+      sha256 = "146f2a8417827d2d6352f7cc20486ecca8fd1e0ad384d4eb2d8b2635edf2075f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hr/thunderbird-78.5.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "b20bef1b7fab8d63c5cc6336dd59264e7c62a9a4c6f2db4232ed27624b26a3cb";
+      sha256 = "5c510bd3a8f8015e5c8a7c0cff401e3557b0cdca83bff77d2384c8f75f287152";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hsb/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hsb/thunderbird-78.5.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "ad4797a36c713b5026a4da131fc46f341cb8b72e5ad2f07a677bfedca8401163";
+      sha256 = "605ae5746f0df98c7a561550da9cc938d0e06a222f422910ab118fa89d09e793";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hu/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hu/thunderbird-78.5.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1f3dea138c4f82f91b9aaf891b9959d1cdda273f20af811d967ed55058f69064";
+      sha256 = "7d42f5e242e04d06bb9abd9bde8fe21571fa13f91b027369a048447d4de8526c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/hy-AM/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hy-AM/thunderbird-78.5.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "836668531a555d9bd23fbb3c3b27cc647a327d02e6db1903248fc6b3d59c5dc1";
+      sha256 = "74b0b31089be36c0538eb24c98e57123f24599b4122aac5b08c4eb914f6a8f7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/id/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/id/thunderbird-78.5.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1d74cd88cddf7b22ef8b19ee6cfedaaade15cecf68712ec8568888d0708c9c81";
+      sha256 = "291ad6b1fcdc537e723ee76cf0a40a3084bdf1ebec68fc3c8c54714618f5d790";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/is/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/is/thunderbird-78.5.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a6e3320211b207e9a36c6197dbf97e746d2e9e9b7bda444a8511550b5846d329";
+      sha256 = "188e2cab8e00421b8a5f9c9a174e8a529ab404a0f4f3976797e41848eb0abc4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/it/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/it/thunderbird-78.5.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f0e659e6888590394a652033f3d15b29ff9318b4c88faae51d6347f1441201b3";
+      sha256 = "12daeb5314ae81a82ce95c35dc9e34d676fe8b666a84a38aea36367b52aa2c95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ja/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ja/thunderbird-78.5.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a2ffc461e6d942222bef4229a820bf8536ef41dce83efc458d82476d5f98f5a4";
+      sha256 = "cdd41967d60abff6053f1736375cbbdb521bbdf5aa25110ca8e08bb365c853ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ka/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ka/thunderbird-78.5.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "6a374b791fac25bfc3f10726d93497291163dd95b1372dc09db70c098822f4f9";
+      sha256 = "9548232d8df327e6282b5413d904d5742aadfa75574b1333a235df2097337032";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/kab/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/kab/thunderbird-78.5.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "a23dc5cfef7bcbe32c32363d0048813a24cfbb19f17c3041b23fc751936dcadc";
+      sha256 = "ca35aa36ed5794661372e76f24dd6c98d11d35da76aff5396215ebe9331aa881";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/kk/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/kk/thunderbird-78.5.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "2187f7d763d34787de0d9870f746548459bd0a2ef0676286d2f9ce9bc9092ef1";
+      sha256 = "dd90fff1a4ee8380e03e59ef324298d1591833a021d14a11fdb2829cd3a934f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ko/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ko/thunderbird-78.5.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "ff88da9f6c77e8f5c1bebab542abc51266ba03d97fc5d22b86cf52a26db75e63";
+      sha256 = "4dae3766bf420a0cfb5473fa95356f0061b657a7ebfdc808b69a8e639564893b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/lt/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/lt/thunderbird-78.5.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "77531cad8587aba9c4091bd22c79e40e45d3c57083b5af3e54af3576ed45134b";
+      sha256 = "de4b448d9651692bc4eb38447d94c94e37d93dae816edb5f3936d56a58aa41af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ms/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ms/thunderbird-78.5.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "aaa346d9bcc1cbd84beedb75c9949d4a2cd8bf80496a31e2018c2493fed68339";
+      sha256 = "08593e72643de8f79b6d90a0c41d6031f915097d3f28f1e7e901c21caa0ab037";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nb-NO/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/nb-NO/thunderbird-78.5.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "dac3f1eeef73c247f9c79a09b7ffab1498be6c96865b5f21ee28d398941430a1";
+      sha256 = "21caa07be03725788c41fa527e7656a0467194e8a498de87f2455b571c4e14b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/nl/thunderbird-78.5.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "e0b3df7064e08e34f85b9a83d2bef990f66ad0e1bc86f764139fc57d005d1aa3";
+      sha256 = "7c1c00a8e03d0a8e4fa9cdc3b4acce51215e9f273660e48ad76347e6003a1985";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/nn-NO/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/nn-NO/thunderbird-78.5.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "eb420586e8be191ffc41f4a920506336cc9dccbf229c260a7f193cbe169a6da4";
+      sha256 = "103bc1307f47c20102e14362fcd6da696eb122fe77f680e70cd0849c9c03c47a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pa-IN/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pa-IN/thunderbird-78.5.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "12f7c97b130ce40dd1dcd00a16a20000113b7be33c87ab9002848439ce626abd";
+      sha256 = "388d01d0881573164816d7ddf6a08c17ad966616f1c8e8e429f821d2bb179a62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pl/thunderbird-78.5.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "5ad96dee4b422c820da8a76ab64e62e919c21d99b01b92f346a55acada7cf8ac";
+      sha256 = "160651e72037bb89ac62534714ce9ecbebdec0cf1f8a6127396c68ab531745f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pt-BR/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pt-BR/thunderbird-78.5.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "7d6568c067796f21079a4f6bf3374a1b91807a9b30270587cf815892d86e1590";
+      sha256 = "6d2064a6ed4bb684384f7e79b61cfceb66a9a26900e9947b3666c36d6b8793cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/pt-PT/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pt-PT/thunderbird-78.5.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "22058d65e2ba94f39ca6ada6750beacf2bacac0f296a34542fde01e897e4a4e2";
+      sha256 = "2ccc7a3d9d845f1a3e2ad3869cbd4cefa10e44992c27444a599f6f1429070f32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/rm/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/rm/thunderbird-78.5.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "c61ff10e4260eb2650fc1a4e0ca8df6c4e4e2e9525168ceaef86a9b8b2ddba54";
+      sha256 = "05e45497c19d46292617de4f247f014f7b14a684f74bfd314caf408416dc5b19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ro/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ro/thunderbird-78.5.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "2ec34bfd9fe4a0f0cf17f132146ab2a589c986a8b4317124f3bfc34ac48f732a";
+      sha256 = "bf01cf8c987e46f03236dbaab14aa551464019f471aa111299b6c7538e995f80";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/ru/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ru/thunderbird-78.5.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "b835dd1757f5cdc580a2b91f01a8089c1396d9eacee665fe9976019f8523fdec";
+      sha256 = "a3cbdfa26ff487d0efdabfa9dc324b75ec1446964f1c0192afcd67565dfc4a51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/si/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/si/thunderbird-78.5.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "3722e47d39024c13dd799e0c89cf79a1302817605f7025388cd5f62fea15d168";
+      sha256 = "fb26eef7b0c5b233e41f8d4ad79f11aa7d0db21b155bf0d9284881cabb51f6e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sk/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sk/thunderbird-78.5.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4717620562c338f533053677d8956490d2d42abfd52beb6a0d41466ba3e72a36";
+      sha256 = "d462f2606bfd7f6e0e45334a68d266889f0f9f927f08d5b92c39329711a8c4cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sl/thunderbird-78.5.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d712c5b3dddfa181877353d28667d410bea3a1f3d85e92dc058a3f3ac5ff4824";
+      sha256 = "b6011aefaf1eb60c8849b4ecc7a7a6fa0a72def8ba690f5b7ca61de3e089c9a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sq/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sq/thunderbird-78.5.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "8443ae1161c6b3e807c9d4abc01824e894a11b6f6c9a52d3097b8301461ac0c3";
+      sha256 = "aeed36c0d6129dc58d496f8f6177a88950a4c4cfe2e4ac157fb389ea79488b11";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sr/thunderbird-78.5.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "13f093880d41748efa8f1566e5884d632f2fa80d4eb4f1a8dd1dc20ea626cee8";
+      sha256 = "f55cb398b3e6420acf6791d9ab5592b9915d299c5111ea917934b5729d22dd7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/sv-SE/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sv-SE/thunderbird-78.5.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "ee9d7262a8b6cd8460b2f1c4c0102b68f9a0983e1f021f2283ead172f07e3f37";
+      sha256 = "036b4f2b3d6cd24bcdcdbc1da1f44df2fba012f22ab96d0840a8c7ae0b945055";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/th/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/th/thunderbird-78.5.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "09cd7b862cb8caa511b6d550bb668f0fd51fdfee5b2f6a31814282785688e4de";
+      sha256 = "316ae39fb02b9ad1b28bbe7a21342e5e85dd7593978b4935b7be20253fe6b761";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/tr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/tr/thunderbird-78.5.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "0d9f63aa7b63d571d7414755bd4e8bc27b7c5fd093ee46ed0fc2db469940dcd5";
+      sha256 = "73811e185274d880abdb15503a928a537428460080245426a07cf1c01e38f1c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/uk/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/uk/thunderbird-78.5.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "0aa64449381edeed7c37d18e03f74dac2f5038a6c3c5de9fa6ad037b139bb5bb";
+      sha256 = "8ff9e333cf16a02e7888f297851b5a9316c5b57cf546f592f12d2aab6e3bed48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/uz/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/uz/thunderbird-78.5.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "eabd24b838a072cb1aa9bebf3c573b3a6e7a364b759aebd62d12b16911956a00";
+      sha256 = "899c0c8c886fbaa6a6609a500bb374797bd36272138a6fcdc6aca7c7b6a6fe66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/vi/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/vi/thunderbird-78.5.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "ce9b5afcb60fc0f17a384a9096b26626f3d3f570222910a46872688009aee262";
+      sha256 = "13afdad34f64a1c96f9612c10c8af880e9718ae10d8a1578bc397b238a936dbd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/zh-CN/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/zh-CN/thunderbird-78.5.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "9d69c7ef37282a7741d2392456c9ef5f5700fa1b718889e93bf7010fa99617db";
+      sha256 = "00a1d01acabd210ba70ed6d0842ab5e1674109c7f39f561e8295d1ffd5f80a0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-x86_64/zh-TW/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/zh-TW/thunderbird-78.5.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "6001d4e74212b72b2a3583438925d2431bb28994a661b4b47e77268e7790e526";
+      sha256 = "19b84b15a6bbf593a342c874822764bd73022d2c846fe20a6d7d91aceeb1ee15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/af/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/af/thunderbird-78.5.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e30adc9074f08e04a4477f59eff6af83bcdf22ccafa1aef5ace219a830c50f38";
+      sha256 = "4c1487a6b823a76d477085e66b377f536f2cfd95b4ddc6804b97c792af77c554";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ar/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ar/thunderbird-78.5.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "6d9456fd3f76de33a3f7c46d8197d83c36c832922b83de64cf4c2f5a56f7729d";
+      sha256 = "d33576a1d8c346195a20c8a222281d682d14f604654ff173eb28ca8a9343574b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ast/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ast/thunderbird-78.5.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "1427f7741ba5c5da163ecfce3053bdab7b14c8fc2e8c046c244f7eea6d015a2e";
+      sha256 = "09d68977bc121e562f3c697bd1d87b21250c8a0bcac013940e3806d4a69a749d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/be/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/be/thunderbird-78.5.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "97258efe6425869e4710c07e880df2a3f6c14d626e6512374043cff226f141fb";
+      sha256 = "bb58501c902788b2d1f8f308468aa57447a15979cab59dc89c27e3738748b6d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/bg/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/bg/thunderbird-78.5.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "a30496a969a954525dbcf1ec0e94d8533baea3809e61d6c1c6e299f883d9676d";
+      sha256 = "373bd3548f518a4ae56e8a103b64eb76c3139b984a5af8013de56b133a0d44c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/br/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/br/thunderbird-78.5.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "16dfc1b869bb10ce7c56f1b22981586678cd81a42e13c4075ebc1da76728258d";
+      sha256 = "40934c8ec7070ad29cb0111624de431a0cdeeff9c7c01d8781444e33f65acbca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ca/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ca/thunderbird-78.5.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "bd29d4b8376355090adca0185194d3c9b6124c336bec0dababaa4a214f9945fb";
+      sha256 = "fbce4213fe7564f2af3f980f5844961cac9a7ec2a30b23d7cdd4e5db6aa4ebaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cak/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/cak/thunderbird-78.5.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "b9723a8f8b8a61d01f09b18f1dff6529d22c89653586ad032831c87683da12b8";
+      sha256 = "2aaf7ea23606be03f5f7168aaa4286760f236d084babd1f81540f8b62b37962c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cs/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/cs/thunderbird-78.5.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "55ff98744b2f120a855c8a3bc435d39209504b7eda92560be40b8cb3fbe007f0";
+      sha256 = "880e36431f76161674fdb9f2902c9d5487bed528a198722458b7e6e76e80e9b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/cy/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/cy/thunderbird-78.5.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "818a93f5a4f02e8cf7b3373c31c435dffca3fc1f86d5acc3fd4355bca21f9cf0";
+      sha256 = "eddb4dcac8063e5b245eb1c095c4ff98cb03714bf5b07f0366b89d670a9d95dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/da/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/da/thunderbird-78.5.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7df66098805f276e1498fa28c00aa7eaa8a8993b561261c54f7091a808ff6766";
+      sha256 = "2425487caaab7979f504d37cf6b100c7cb030e8e5495b6723fa4f953348e4f40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/de/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/de/thunderbird-78.5.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "194831e85294b41a4c1bcec8a2f20f337786054525d50e2fd6dfd6134385d2d8";
+      sha256 = "81df3e5ba46fe5959f785c06bef0b70daa55e8f8721cfff0bf55a76f7343b32f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/dsb/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/dsb/thunderbird-78.5.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e7344c6b2c90bca56adfca1619e1bfdc0e473f7230d4c1059d6516cee8d51759";
+      sha256 = "995d3aaf3df22aa3166f161b98113fc25b813dc7cee2743b2bdd6913b4a620c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/el/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/el/thunderbird-78.5.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "e2d4680ced58f78699f7bdc2c3493d6157cf2c9261aa697cd6092ed0687a7bbe";
+      sha256 = "ad5162a76dba9c37e2542fa7ed08c63edce9955600e9b50889abb03e352ddf23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-CA/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/en-CA/thunderbird-78.5.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "6afd7bb703c62763b787d77b7467881f07d12e73d32d07c6461642307e3b9f5f";
+      sha256 = "c605520e5e65449855c355147f18b813f66d38dce52e8d3a23b90afbec5bcbf1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-GB/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/en-GB/thunderbird-78.5.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "78114f1a1dff6c5430b148fbb8707e03cd3ec1d05af48082755190ae45e94dd4";
+      sha256 = "63b0d984ee8296c5185ed1aab279a0ef065986d989edbd0a7683b9db6a6d94bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/en-US/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/en-US/thunderbird-78.5.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "beb328b15c7b981b10f26cad6325a04257be20e25e819fa771f88fe5e5c98aec";
+      sha256 = "b5404037f2678d36acbb225f43d426a86db9a4828a69b1beaf44dc3b5264ae7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/es-AR/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/es-AR/thunderbird-78.5.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3c096d5225f8fe273b6f0adc119ea419cf60e7a7723fb3a63a6dec1be6e4c3ef";
+      sha256 = "cefe0ff79bacc9c16fe649c0d7b4f932afca6ebb10c8426fac527485e92f4422";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/es-ES/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/es-ES/thunderbird-78.5.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "68796cda86944bfb70207b79c162c0b2fdb66b17511300c799204fce58d2c2b2";
+      sha256 = "de7c6685c4e73ee334faf83c809b2f45d55c971282ba99aecfd5d1c8b05577da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/et/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/et/thunderbird-78.5.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "6187058a289cb43e89916e484ac46c2359fc9c452d07dd4dab2e3ff8ae397c47";
+      sha256 = "e5174b12c61221436a5926224f61f218bfe762086f1d5bb814af5f7708592392";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/eu/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/eu/thunderbird-78.5.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "ad587a3b25de553b69ab9aa61b9d99c4f4d7dd37b05672540eda7907b21f2857";
+      sha256 = "66bfbb4edc775117a6f048f52084fff9828633166ac6234a7c1dc0d67311677f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fa/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fa/thunderbird-78.5.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "8c06bbd83b5485b113bf4d0ca69af9ca21c7854ff38b19831eadae0c586dc606";
+      sha256 = "072163a9d1a94b1f5c297c794791b4bd3e7f7e6897e7f7615df59a9dd2232a52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fi/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fi/thunderbird-78.5.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "bac6ecf3d22f6097f8cccb7da81866941426ee7bbb690937a2333b411a305fbd";
+      sha256 = "9c269f267251bee9828acfd78d04bf149767dfe5247ae4f53ec5b0bd65c410ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fr/thunderbird-78.5.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "859457a9c0bae23e4acf901d38de814858c60fe1a5e28ee897b2c2f4c86bc29a";
+      sha256 = "6ccfac2b5d96491c4d5dc7b00e4458617ca68fe07917941559534a31424c977c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/fy-NL/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fy-NL/thunderbird-78.5.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "d5a91d212e0c9c6c533bd7f05edca3dbea93eba0bf0d34eabd1e9ba7c7138e8b";
+      sha256 = "1b470c45c9d52a8a84c59dbb4ed0e6966d124ffdc3ea865e4d02289bd39b346f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ga-IE/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ga-IE/thunderbird-78.5.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "980e053f0bcd5096753213fd6cc252be388312980032132bf912af2d4249278a";
+      sha256 = "a1cbb9a4c1bf91f920da9e4e0e39e6ecff0a8c87413898c1930ce69dadad9a26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/gd/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/gd/thunderbird-78.5.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "7b61b433d2f55191f7ecc63e04ceabcebcc85ab211553b71de575bbf14db05ee";
+      sha256 = "909be2cc362ed839f373eb22d27c5f3c569b1c82fc2ba5aaf270d605029d336c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/gl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/gl/thunderbird-78.5.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "2dbb2021eacf17f5d42d0f8edc32a3f4d0ae3964cc8b44b0875fcee9bbd8ebbe";
+      sha256 = "8ffadcffd16aca8befd4b9c230b7da750e6a694add7ee465227a0c3f31a5c655";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/he/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/he/thunderbird-78.5.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "b64fdf97d7f3029ffe465bbe621735970c73682cbde03935c2ad94325a7a77cf";
+      sha256 = "a9242889345131a405d138d0ec8e470eb49c59ada18b1e8f78004f307ceb41b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hr/thunderbird-78.5.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "05606268efa91e8266a75f9f53dae8e8095fd70bc1095e2cc160171eb32e9a0a";
+      sha256 = "eb1f5496811677e28b2ed034da40ebf1fef324673e0f3acb2c21f0db5c71f592";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hsb/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hsb/thunderbird-78.5.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "8a2dd27b17cbfad0846a40b4863c72e0754137e4ae581998ff291b4428a069ef";
+      sha256 = "643a2b11a0775a71a8fa6c25097cfe297e6bc190fb29eee18ddd3d16fb61d989";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hu/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hu/thunderbird-78.5.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "01daa9ab4f5d096a9a5e138db4debeee302fb875f885e644eea88103c5c62111";
+      sha256 = "61d91bed542a7e014a8d11e46e1b3d97e8bef1303bba397b3d4da0585b1e68af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/hy-AM/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hy-AM/thunderbird-78.5.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "69159084189c5700e5c8c27bf4cc0345fcafe0879b7f7cca285246a41e411578";
+      sha256 = "2e6739d14a45529ed2a68abb8ed03ad901b4e7770efebd382f6e9626c86da036";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/id/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/id/thunderbird-78.5.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "798203a12f76cb3c698363da72b235fc9abfc5a68913f3265c9b17b14318eb73";
+      sha256 = "8753bc4c7292cd0c6ee382bb5572e432222e7c39ed739904d91ed1ece5a8197e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/is/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/is/thunderbird-78.5.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "19544548a0b0217f5f5256949d74897c784298dfe762174487ab2ba2557a55e7";
+      sha256 = "4f624262b72fce7d258b6f7c264f7d2266ebcfdd59fce895e4e85c72fa784637";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/it/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/it/thunderbird-78.5.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "b1ae17f3d4533db0107ab280ec4e8ecc610db9581d44ed52d8ca87c821c37c1b";
+      sha256 = "6298ce45c4a659e47877302d61a50dfc7e0634e7c3e7036aeec49da5a2839073";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ja/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ja/thunderbird-78.5.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "c16c27372c28063a06e31fc440294a655fb72bc033efbfd797d150e99e6ebaed";
+      sha256 = "85a7b01f65c79b0e13c4f8a18f3950f0a250f380fc8756b8fb1709680a148554";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ka/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ka/thunderbird-78.5.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "3057efd5078776f1690890d601153a73e2450051a0edb61e92d196318b644679";
+      sha256 = "f7b18243b9985b54eb8684b62bad47b7b021eb959f467fec9876c866d92b1727";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/kab/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/kab/thunderbird-78.5.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "ce8010b362b601819fac825ce27b9efd8af8f0965f8f1cabb21bfcddb2ec7315";
+      sha256 = "cc8eb77d0d0ea95a1e2b13db51da4f18a9500aeacee1cbe505da67f2b6a9b979";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/kk/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/kk/thunderbird-78.5.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "b73930d1508bdcaecfb9ce280f0d86fd5dc7a3d26160caa0eabbe47243956139";
+      sha256 = "6999faf34774806e1e4257a139dd97dd50a889a7729fef4f51a8b41bb4ad169e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ko/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ko/thunderbird-78.5.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "24d6e557b6419bb3a512646edb6e1e4d01ce1c0e134b9bb9cc54ad5acb6a0675";
+      sha256 = "42b0bf1ebfce252fdfca3ed8de9f227bbb054bf591e6155b716b18e9613a9cff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/lt/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/lt/thunderbird-78.5.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "c9dc7dc77a1c1acdc1e244e6b1201ecd3305b5c10ef946ceb880fb66d57c249a";
+      sha256 = "6ffe9b52189579bee34604499649901be5c8be2a026eb70a33ac9eb4e3b21880";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ms/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ms/thunderbird-78.5.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d3a0b9fc5b38de919515df9dc6ca696c7c70f629b192e8cae099a55432d466d3";
+      sha256 = "640942eb04d84d24bd28cf5e49e57497934810394b50693bad591cf3b783e1bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nb-NO/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/nb-NO/thunderbird-78.5.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "80f552a61288f1d1a6346d302919fd90f63c2d349a2d33921eac9a65c341a7d9";
+      sha256 = "c0d35274192ae664314e91fd9364609cbbf142f8177d37210c9c49fdf8d31086";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/nl/thunderbird-78.5.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "89007857be04b59bf724a2f6c295c0948a885c8da8c7a7060922e04f616baf30";
+      sha256 = "864ac834a0f44ce112deb107abce170802abaa63556f0aad88ee828bf3f8a98c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/nn-NO/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/nn-NO/thunderbird-78.5.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "b7a8060d3138a55a29374d890b326e77105f41e809053d34c24464a892c6bdbc";
+      sha256 = "e821eaf0388885e3b5e88001a2c4410cdf065059b79a3581c324f53d1cf59eb5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pa-IN/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pa-IN/thunderbird-78.5.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "69f803555cc9b3ba7fbf638e101b76bef10a234747cd0764e906e5d2adbb9a97";
+      sha256 = "5a0afbf815683afd24c258ac66a45dc300028b4d41a9950784355645874459ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pl/thunderbird-78.5.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "4cd4da857d9cbdc5d89e07529d30df28a758c3c105160d2217b50206147c21e5";
+      sha256 = "cebdc0a0188edc63fce0b4fe0a4a3f22ab792ad486bd1e10e635ac8f641f1b5d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pt-BR/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pt-BR/thunderbird-78.5.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "43fca4ac927932589b58e60f7b3b1cdcdc1d73b6f9073e0c1eb2993527afe9be";
+      sha256 = "7bbf9aa4d48bf84a7455dcebc6b7476e4c1ffa085c1771fbdf302f71d10e4825";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/pt-PT/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pt-PT/thunderbird-78.5.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "25591b73b7ae5d28441baeeae3fb3a5a47f36ea21db763b95782494fd8491122";
+      sha256 = "b84c28dfb5d677768a6e0f69c8ea63fcaf884839739789ac72f50e7b8884f8ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/rm/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/rm/thunderbird-78.5.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "14a0725f1083ab9c4baafe6944604cc5781cc9d3d44cbc406874b5ce01df785d";
+      sha256 = "f34eea430a9e929c25ad961b1c92724c5539a46cbbfb9a97a5c7edca4996115a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ro/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ro/thunderbird-78.5.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "f32af00602a13e262e6b34c8b5783b31a991dee72d82c841086d21e37d669dcd";
+      sha256 = "115cd666282822f35924d4de3b33fd0dd3d790d278bb35849ada579d43d5ac54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/ru/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ru/thunderbird-78.5.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "367e7865f1c5d10eb912fce96a34bf6ce25ca48e4ec9209bce8af06412be7781";
+      sha256 = "961eb62e639f8f7c7c5695bd39df50fe4b3401e7aeade8281600779bb8edd374";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/si/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/si/thunderbird-78.5.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "da0494be7a26f0a531d108ca20a0bc9763860e44adaa6149ea059f46daabbe0c";
+      sha256 = "0887999609e47839a0f7600215c3083ce939fe13abc0c38cf701449224dbc87a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sk/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sk/thunderbird-78.5.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "1c5078f413207049a35c69be32c6996cad169cadc009b3f079b3adc8a932ca22";
+      sha256 = "a3b9281efc4c0cd6cb454f2c5b97567b4d2c6567076cee188e85c30a45213f98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sl/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sl/thunderbird-78.5.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "d8a5edf78b5a87c0b3baf0199231e6e9224e1afdf4eff05780b6c9b98657c1ef";
+      sha256 = "141e9a41dba4c2a3eee4370d2db6e14f8805fee2d70c20ecbb9865b7a0dcaa77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sq/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sq/thunderbird-78.5.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "fefcb88c0c5f6ee62ba8224417a629d8a4f0c18b20fcb037c36af772b0d2b71c";
+      sha256 = "6a50fdac7993294937756a169b4b0ac7fe021611c5c6a730ea194ee7302c95dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sr/thunderbird-78.5.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c42818c409de6447c1aa00f8aa6422a9fbb6fa16f01d5076331937c1145a4b87";
+      sha256 = "2ec4c2f367bceb3f05c75e55366cc66fae6593fc35c79d7bea57f34f93d79dba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/sv-SE/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sv-SE/thunderbird-78.5.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "c27d87cde88f38f3611358b5fb3622611c38860ee37d1d90aaabcb4db614a031";
+      sha256 = "4a9027f9aa74bd9c6e3cbf02ac1918f1b9dfbda57ed0344a99fccad9fa271f79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/th/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/th/thunderbird-78.5.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "df9b827a723675e70131d147fa6f6325f6e6a14a6b95f6f5b6fae4552501c6b0";
+      sha256 = "f394b18a364fa84ff5eeeee00c841248ba4095285833ce625b700fd500b9c0cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/tr/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/tr/thunderbird-78.5.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "7a9d6e1b5927c7c54b73062a59d366cd5153896a89e95005177fdf4b789eda42";
+      sha256 = "9f180c1b6b604fc597bf1ecb10e3521c70953cb70d4292105cb3bc7cbeb806c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/uk/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/uk/thunderbird-78.5.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "c421df09d5bbb5e4de273258757df28e5a6eba291a4eabbf28db71a50cb11da7";
+      sha256 = "f828ac8f52bda71f913462e60fb7ea2221de4f824063b95b85709320a820db8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/uz/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/uz/thunderbird-78.5.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "296ca42b0c9f67ef0bb545f458334ec26e03be3327fd1e1b066d8324965704b2";
+      sha256 = "8d3dd4a1bbe008e4d346c22c01bafe988dde88fa6c9919c50194b9b155bc821f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/vi/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/vi/thunderbird-78.5.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "46579d9723f5ccc84700c2544f3d1235db338471306d87a1caa0ac4fb337c8bd";
+      sha256 = "4db40b3debca281c59e926bd0f9cb4e5cd2150bf27235f1178ed8e497616a031";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/zh-CN/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/zh-CN/thunderbird-78.5.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "9bf0df6568eadf611891f49591975166da95eb4e78e1191eb3354a81637907d2";
+      sha256 = "399707f970a01e2f3c2eacc81f2f3bb33b1f49433c3ba6c49f4615b499f0c246";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.0/linux-i686/zh-TW/thunderbird-78.5.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/zh-TW/thunderbird-78.5.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "8fee4fd8980d551317fc8f98f29938034f5ff90b765e73ef8cd09f8fe68f90c8";
+      sha256 = "27ad21908069582a4a7641dc9a7d9acc69d4842382499cef2cee2f84d0fc3856";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -71,13 +71,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.5.0";
+  version = "78.5.1";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "0c32dz8p7rrr0w13l2ynf9snj59ij1v2ld3s75vz1hvks4dikwgcbm44wmvmbisvgyfgzdsphafzlq3kz3j1ja30qjigl0dj709vr6s";
+      "202s2h9fsvg4chy93rgxdf4vlavf3wbp9vqgh0nrgk5wcdhz17144vhw1bmxia8hf99snq2a3ix6haidwl8d2n6l2nfsjzcnphhxd9z";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- High security fixes
- Other fixes and updates

https://www.thunderbird.net/en-US/thunderbird/78.5.1/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2020-53/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
