### PR TITLE
mapmap: Fix startup issues and unbreak the derivation.

### DIFF
--- a/pkgs/applications/video/mapmap/default.nix
+++ b/pkgs/applications/video/mapmap/default.nix
@@ -1,11 +1,13 @@
-{ stdenv 
+{ stdenv
 , fetchFromGitHub
+, fetchpatch
 , qttools
 , qtmultimedia
 , liblo
 , gst_all_1
 , qmake
 , pkgconfig
+, wrapQtAppsHook
 }:
 
 with stdenv;
@@ -25,6 +27,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     pkgconfig
+    wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -35,6 +38,14 @@ mkDerivation rec {
     gst_all_1.gstreamermm
     gst_all_1.gst-libav
     gst_all_1.gst-vaapi
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "message-handler-segfault.patch";
+      url = "https://github.com/mapmapteam/mapmap/pull/519/commits/22eeee59ba7de6de7b73ecec3b0ea93bdc7f04e8.patch";
+      sha256 = "0is905a4lf9vvl5b1n4ky6shrnbs5kz9mlwfk78hrl4zabfmcl5l";
+    })
   ];
 
   installPhase = ''
@@ -57,8 +68,6 @@ mkDerivation rec {
     license = licenses.gpl3;
     maintainers = [ maintainers.erictapen ];
     platforms = platforms.linux;
-    # binary segfaults at the moment
-    broken = true;
   };
 
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

mapmap has been broken as far as I can see for two reasons:

1. It segfaulted on startup due to a too early initialization of it's message handler. See: https://github.com/mapmapteam/mapmap/pull/519
2. It did not use `wrapQtAppsHook` and therefor failed on startup with the usual error message.

I'm not familiar with mapmap right now, so I so far can only tell that it starts up again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
