### PR TITLE
pax: init at 20201030

### DIFF
--- a/pkgs/tools/archivers/pax/default.nix
+++ b/pkgs/tools/archivers/pax/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "pax";
+  version = "20201030";
+
+  src = fetchurl {
+    url = "http://www.mirbsd.org/MirOS/dist/mir/cpio/paxmirabilis-${version}.tgz";
+    sha256 = "1p18nxijh323f4i1s2pg7pcr0557xljl5avv8ll5s9nfr34r5j0w";
+  };
+
+  buildPhase = ''
+    sh Build.sh -r -tpax
+  '';
+
+  installPhase = ''
+    install -Dm555 pax $out/bin/pax
+    ln -s $out/bin/pax $out/bin/paxcpio
+    ln -s $out/bin/pax $out/bin/paxtar
+    install -Dm444 mans/pax{,cpio,tar}.1 -t $out/share/man/man1/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "POSIX standard archive tool from MirBSD";
+    homepage = "https://www.mirbsd.org/pax.htm";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3542,6 +3542,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  pax = callPackage ../tools/archivers/pax { };
+
   rage = callPackage ../tools/security/rage { };
 
   rar2fs = callPackage ../tools/filesystems/rar2fs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Provides the `pax` command for creating and unpacking pax archives (similar to `tar`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
