### PR TITLE
factorio-experimental, factorio-headless-experimental: 1.1.3 -> 1.1.4

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.3.tar.xz",
+        "name": "factorio_alpha_x64-1.1.4.tar.xz",
         "needsAuth": true,
-        "sha256": "0lsgj7361bf9zhidp4hpdhb9jj7wgcw7s0q5bpqbigbnz848m3lm",
+        "sha256": "0gg10pk0qb44iizwvlzndjr2xkygqzaxmhp9bam7gz86b5cxs0cl",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.3/alpha/linux64",
-        "version": "1.1.3"
+        "url": "https://factorio.com/get-download/1.1.4/alpha/linux64",
+        "version": "1.1.4"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.0.0.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.3.tar.xz",
+        "name": "factorio_headless_x64-1.1.4.tar.xz",
         "needsAuth": false,
-        "sha256": "1164hbbd1b33hjnvjm079czjypj837gpjp2i4f23rkd4qmjpl0dj",
+        "sha256": "085lpblysh126y38z01f358xcpwmx1a6hcjlc66aw5ff6bp36yq8",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.3/headless/linux64",
-        "version": "1.1.3"
+        "url": "https://factorio.com/get-download/1.1.4/headless/linux64",
+        "version": "1.1.4"
       },
       "stable": {
         "name": "factorio_headless_x64-1.0.0.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://forums.factorio.com/viewtopic.php?f=3&p=525324

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
