### PR TITLE
hsphfpd: 2020-10-25 -> 2020-11-27

### DIFF
--- a/pkgs/servers/pulseaudio/hsphfpd.nix
+++ b/pkgs/servers/pulseaudio/hsphfpd.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "hsphfpd";
-  version = "2020-10-25";
+  version = "2020-11-27";
 
   src = fetchFromGitHub {
     owner = "pali";
     repo = "hsphfpd-prototype";
-    rev = "601bf8f7bf2da97257aa6f786ec4cbb69b0ecbc8";
-    sha256 = "06hh0xmp143334x8dg5nmp5727g38q2m5kqsvlrfia6vw2hcq0v0";
+    rev = "58ffbf8f1b457e46801039d572cd344472828714";
+    sha256 = "1hyg3cz6s58k6a7a3hcbs6wfk14cflnikd9psi7sirq6cn1z0ggb";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
