### PR TITLE
dconf2nix: 0.0.6 -> 0.0.7

### DIFF
--- a/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
+++ b/pkgs/development/tools/haskell/dconf2nix/dconf2nix.nix
@@ -3,11 +3,11 @@
 }:
 mkDerivation {
   pname = "dconf2nix";
-  version = "0.0.6";
+  version = "0.0.7";
   src = fetchgit {
     url = "https://github.com/gvolpe/dconf2nix.git";
-    sha256 = "0ql3xrr05kg1xrfxq86mhzh5ky33sngx57sahzck3rb8fv2g6amv";
-    rev = "cf976e033c1a89f897924baa219c3b227fe68489";
+    sha256 = "04p8di1ckv5fkfa61pjg5xp8vcw091lz1kw39lh4w8ks2zjwaha1";
+    rev = "34c523e920b79208c3b4c0ad371900b0948799f7";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

NOTE: I built the binary as usual by running `nix-build -A dconf2nix` but the update is not picked up. If I run `result/bin/dconf2nix -v`, I still get the previous version. The [previous update](https://github.com/NixOS/nixpkgs/pull/98382) went well.

Did something change in how Haskell packages that are not on Hackage are built on `nixpkgs`?