### PR TITLE
python3Packages.jsonstreams: Init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/jsonstreams/default.nix
+++ b/pkgs/development/python-modules/jsonstreams/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, six, }:
+
+buildPythonPackage rec {
+  pname = "jsonstreams";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "dcbaker";
+    repo = pname;
+    rev = version;
+    sha256 = "0c85fdqkj5k4b0v0ngx2d9qbmzdsvglh4j9k9h7508bvn7l8fa4b";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "tests --doctest-modules jsonstreams" ];
+
+  meta = with lib; {
+    description = "A JSON streaming writer";
+    homepage = "https://github.com/dcbaker/jsonstreams";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chkno ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3186,6 +3186,8 @@ in {
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };
 
+  jsonstreams = callPackage ../development/python-modules/jsonstreams { };
+
   jsonwatch = callPackage ../development/python-modules/jsonwatch { };
 
   jug = callPackage ../development/python-modules/jug { };


### PR DESCRIPTION
###### Motivation for this change
Make this python library available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    0 → 110,903,680
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
