### PR TITLE
buildRustPackage: support multiple `cargo` invocations

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -237,6 +237,27 @@ rustPlatform.buildRustPackage rec {
 }
 ```
 
+### Running `cargo build` multiple times with different build flags
+Using the `cargoBuildFlagsMultiple` attribute it's possible to run `cargo build` several times in the `buildPhase`.
+The argument takes a list of lists of strings. Each list of strings (2) represents the additional arguments passed to a distinct `cargo build` invocation.
+Every invocation still respects the `cargoBuildFlags` attribute. This effectively allows passing unique flags to each crate while also defining common flags.
+
+The following example shows how to build different crates that live in the same workspace:
+
+```nix
+buildRustPackage {
+    (...)
+
+    cargoBuildFlags = [ "--no-default-features" ]
+
+    cargoBuildFlagsMultiple = [
+      [ "--manifest-path=crates/a/Cargo.toml" "--features=a" ]
+      [ "--manifest-path=crates/b/Cargo.toml" "--features=b"]
+    ];
+
+    (...)
+```
+
 ## Compiling Rust crates using Nix instead of Cargo
 
 ### Simple operation


### PR DESCRIPTION
###### Motivation for this change
This change allows calling `cargo build` multiple times with distinct
flags. Please see the doc changes for more details.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
