### PR TITLE
gatling: 0.15 -> 0.16

### DIFF
--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -11,6 +11,15 @@ stdenv.mkDerivation {
 
   buildInputs = [ libowfat zlib ];
 
+  postPatch = ''
+    substituteInPlace Makefile --replace \
+      'LIBOWFAT_HEADERS=$(PREFIX)/libowfat' \
+      'LIBOWFAT_HEADERS=${libowfat}/include/libowfat'
+    substituteInPlace Makefile --replace \
+      'LIBOWFAT_LIBRARY=$(PREFIX)/libowfat' \
+      'LIBOWFAT_LIBRARY=${libowfat}/lib'
+  '';
+
   installPhase = ''
     runHook preInstall
     install -D opentracker $out/bin/opentracker

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -12,12 +12,9 @@ stdenv.mkDerivation {
   buildInputs = [ libowfat zlib ];
 
   postPatch = ''
-    substituteInPlace Makefile --replace \
-      'LIBOWFAT_HEADERS=$(PREFIX)/libowfat' \
-      'LIBOWFAT_HEADERS=${libowfat}/include/libowfat'
-    substituteInPlace Makefile --replace \
-      'LIBOWFAT_LIBRARY=$(PREFIX)/libowfat' \
-      'LIBOWFAT_LIBRARY=${libowfat}/lib'
+    substituteInPlace Makefile \
+      --replace 'LIBOWFAT_HEADERS=$(PREFIX)/libowfat' 'LIBOWFAT_HEADERS=${libowfat}/include/libowfat' \
+      --replace 'LIBOWFAT_LIBRARY=$(PREFIX)/libowfat' 'LIBOWFAT_LIBRARY=${libowfat}/lib'
   '';
 
   installPhase = ''

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -11,11 +11,10 @@ stdenv.mkDerivation {
 
   buildInputs = [ libowfat zlib ];
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace 'LIBOWFAT_HEADERS=$(PREFIX)/libowfat' 'LIBOWFAT_HEADERS=${libowfat}/include/libowfat' \
-      --replace 'LIBOWFAT_LIBRARY=$(PREFIX)/libowfat' 'LIBOWFAT_LIBRARY=${libowfat}/lib'
-  '';
+  makeFlags = [
+    "LIBOWFAT_HEADERS=${libowfat}/include/libowfat"
+    "LIBOWFAT_LIBRARY=${libowfat}/lib"
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/libraries/libowfat/default.nix
+++ b/pkgs/development/libraries/libowfat/default.nix
@@ -8,17 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "1hcqg7pvy093bxx8wk7i4gvbmgnxz2grxpyy7b4mphidjbcv7fgl";
   };
 
-  # Dirty patch because 0.32 "moved headers to <libowfat/> upon install"
-  # but it breaks gatling-0.15 and opentracker-2018-05-26 ...
-  postPatch = ''
-    substituteInPlace GNUmakefile --replace \
-      'install -d $(DESTDIR)$(INCLUDEDIR)/libowfat' \
-      'install -d $(DESTDIR)$(INCLUDEDIR)'
-    substituteInPlace GNUmakefile --replace \
-      'install -m 644 $(INCLUDES) $(DESTDIR)$(INCLUDEDIR)/libowfat' \
-      'install -m 644 $(INCLUDES) $(DESTDIR)$(INCLUDEDIR)'
-  '';
-
   makeFlags = [ "prefix=$(out)" ];
   enableParallelBuilding = true;
 

--- a/pkgs/servers/http/gatling/default.nix
+++ b/pkgs/servers/http/gatling/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, libowfat, zlib, openssl }:
+{ stdenv, fetchurl, libowfat, libcap, zlib, openssl }:
 
 let
-  version = "0.15";
+  version = "0.16";
 in
 stdenv.mkDerivation rec {
   pname = "gatling";
@@ -9,10 +9,10 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.fefe.de/gatling/${pname}-${version}.tar.xz";
-    sha256 = "194srqyja3pczpbl6l169zlvx179v7ln0m6yipmhvj6hrv82k8vg";
+    sha256 = "0nrnws5qrl4frqcsfa9z973vv5mifgr9z170qbvg3mq1wa7475jz";
   };
 
-  buildInputs = [  libowfat zlib openssl.dev ];
+  buildInputs = [ libowfat libcap zlib openssl.dev ];
 
   configurePhase = ''
     substituteInPlace Makefile --replace "/usr/local" "$out"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump. Fixes compatibility with current libowfat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
