### PR TITLE
rofi-systemd: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/system/rofi-systemd/default.nix
+++ b/pkgs/tools/system/rofi-systemd/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, rofi, systemd, coreutils, util-linux, gawk, makeWrapper
+{ stdenv, fetchFromGitHub, rofi, systemd, coreutils, util-linux, gawk, makeWrapper, jq
 }:
 
 stdenv.mkDerivation rec {
   pname = "rofi-systemd";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "IvanMalison";
     repo = "rofi-systemd";
     rev = "v${version}";
-    sha256 = "1dbygq3qaj1f73hh3njdnmibq7vi6zbyzdc6c0j989c0r1ksv0zi";
+    sha256 = "0lgffb6rk1kf91j4j303lzpx8w2g9zy2gk99p8g8pk62a30c5asm";
   };
 
   buildInputs = [ makeWrapper ];
@@ -22,11 +22,12 @@ stdenv.mkDerivation rec {
   '';
 
   wrapperPath = with stdenv.lib; makeBinPath [
-    rofi
     coreutils
-    util-linux
     gawk
+    jq
+    rofi
     systemd
+    util-linux
   ];
 
   fixupPhase = ''


### PR DESCRIPTION
###### Motivation for this change
version 0.1.0 is no longer compatible with output from new versions of systemd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
