### PR TITLE
quickfix: init at 1.15.1

### DIFF
--- a/pkgs/development/libraries/quickfix/default.nix
+++ b/pkgs/development/libraries/quickfix/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  pname = "quickfix";
+  version = "1.15.1";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev =  "v${version}";
+    sha256 = "1fgpwgvyw992mbiawgza34427aakn5zrik3sjld0i924a9d17qwg";
+  };
+
+  patches = [
+    # Improved C++17 compatibility
+    (fetchpatch {
+      url = "https://github.com/quickfix/quickfix/commit/a46708090444826c5f46a5dbf2ba4b069b413c58.diff";
+      sha256 = "1wlk4j0wmck0zm6a70g3nrnq8fz0id7wnyxn81f7w048061ldhyd";
+    })
+    ./disableUnitTests.patch
+  ];
+
+  # autoreconfHook does not work
+  nativeBuildInputs = [ autoconf automake libtool ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  # More hacking out of the unittests
+  preBuild = ''
+    substituteInPlace Makefile --replace 'UnitTest++' ' '
+  '';
+
+  meta = with stdenv.lib; {
+    description = "QuickFIX C++ Fix Engine Library";
+    homepage = "http://www.quickfixengine.org";
+    license = licenses.free; # similar to BSD 4-clause
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/development/libraries/quickfix/disableUnitTests.patch
+++ b/pkgs/development/libraries/quickfix/disableUnitTests.patch
@@ -1,0 +1,65 @@
+diff -u -r source-baseline-patchPhase/configure.ac source/configure.ac
+--- source-baseline-patchPhase/configure.ac	1970-01-01 00:00:01.000000000 +0000
++++ source/configure.ac	2021-01-12 22:49:28.948861699 +0000
+@@ -43,7 +43,7 @@
+ 
+ AC_CANONICAL_HOST
+ 
+-build_no_unit_test = no
++build_no_unit_test = yes
+ 
+ # Detect the target system
+ case "${host_os}" in
+@@ -344,8 +344,6 @@
+     examples/Makefile
+     examples/executor/Makefile
+     examples/executor/C++/Makefile
+-    examples/ordermatch/Makefile
+-    examples/ordermatch/test/Makefile
+     examples/tradeclient/Makefile
+     examples/tradeclientgui/Makefile
+     examples/tradeclientgui/banzai/Makefile
+diff -u -r source-baseline-patchPhase/examples/Makefile.am source/examples/Makefile.am
+--- source-baseline-patchPhase/examples/Makefile.am	1970-01-01 00:00:01.000000000 +0000
++++ source/examples/Makefile.am	2021-01-12 22:51:55.782568550 +0000
+@@ -1,3 +1,3 @@
+-SUBDIRS = executor ordermatch tradeclient tradeclientgui
++SUBDIRS = executor tradeclient tradeclientgui
+ 
+-EXTRA_DIST = examples.dsw configure configure.in bootstrap Makefile.am
+\ No newline at end of file
++EXTRA_DIST = examples.dsw configure configure.in bootstrap Makefile.am
+diff -u -r source-baseline-patchPhase/src/Makefile.am source/src/Makefile.am
+--- source-baseline-patchPhase/src/Makefile.am	1970-01-01 00:00:01.000000000 +0000
++++ source/src/Makefile.am	2021-01-12 22:53:02.593432380 +0000
+@@ -15,27 +15,23 @@
+ if NO_UNIT_TEST
+ noinst_PROGRAMS =
+ else
+-noinst_PROGRAMS = at ut pt
++noinst_PROGRAMS = at pt
+ endif
+ 
+ at_SOURCES = at.cpp at_application.h
+-ut_SOURCES = ut.cpp
+ pt_SOURCES = pt.cpp
+ 
+ EXTRA_DIST = getopt.c getopt-repl.h
+ 
+ at_LDADD = C++/libquickfix.la
+-ut_LDADD = C++/test/libquickfixcpptest.la C++/libquickfix.la
+ pt_LDADD = C++/libquickfix.la
+ 
+ INCLUDES =-IC++ -IC++/test -I../UnitTest++/src
+-LDFLAGS =-L../UnitTest++ -lUnitTest++
++ 
+ 
+ all-local:
+-	rm -f ../test/ut ../test/pt ../test/at ../test/ut_debug
+-	ln -s ../src/ut ../test/ut
++	rm -rf ../test/pt ../test/at ../test/ut_debug
+ 	ln -s ../src/pt ../test/pt
+ 	ln -s ../src/at ../test/at
+-	ln -s ../src/.libs/ut ../test/ut_debug
+ 
+ clean-local:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6795,6 +6795,8 @@ in
 
   qtikz = libsForQt514.callPackage ../applications/graphics/ktikz { };
 
+  quickfix = callPackage ../development/libraries/quickfix { };
+
   quickjs = callPackage ../development/interpreters/quickjs { };
 
   quickserve = callPackage ../tools/networking/quickserve { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a common library used in the financial industry, used for processing securities trade data.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
