### PR TITLE
Update idevicerestore to 1.0.0 (+ required libraries to latest stable releases)

### DIFF
--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchurl, gettext, perlPackages, intltool, pkgconfig, glib,
-  libxml2, sqlite, zlib, sg3_utils, gdk-pixbuf, taglib,
+{ stdenv, lib, fetchurl, perlPackages, intltool, autoreconfHook,
+  pkg-config, glib, libxml2, sqlite, zlib, sg3_utils, gdk-pixbuf, taglib,
   libimobiledevice,
   monoSupport ? false, mono, gtk-sharp-2_0
 }:
@@ -15,11 +15,15 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  preConfigure = "configureFlagsArray=( --with-udev-dir=$out/lib/udev )";
+  postPatch = ''
+    # support libplist 2.2
+    substituteInPlace configure.ac --replace 'libplist >= 1.0' 'libplist-2.0 >= 2.2'
+  '';
 
   configureFlags = [
     "--without-hal"
     "--enable-udev"
+    "--with-udev-dir=${placeholder "out"}/lib/udev"
   ] ++ lib.optionals monoSupport [ "--with-mono" ];
 
   dontStrip = true;
@@ -27,7 +31,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ glib libxml2 sqlite zlib sg3_utils
     gdk-pixbuf taglib libimobiledevice ];
 
-  nativeBuildInputs = [ gettext intltool pkgconfig ]
+  nativeBuildInputs = [ autoreconfHook intltool pkg-config ]
     ++ (with perlPackages; [ perl XMLParser ])
     ++ lib.optionals monoSupport [ mono gtk-sharp-2_0 ];
 

--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "2020-01-20";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "61babf5f54e7734ebf3044af4c6294524d4b29b5";
-    sha256 = "02dnq6xza72li52kk4p2ak0gq2js3ssfp2fpjlgsv0bbn5mkg2hi";
+    rev = version;
+    sha256 = "1jkq3hpg4n5a6s1k618ib0s80pwf00nlfcby7xckysq8mnd2pp39";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libirecovery";
-  version = "2020-01-14";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "10a1f8dd11a11a0b8980fbf26f11e3ce74e7a923";
-    sha256 = "1v5c9dbbkrsplj1zkcczzm0i31ar3wcx6fpxb0pi4dsgj8846aic";
+    rev = version;
+    sha256 = "0p9ncqnz5kb7qisw00ynvasw1hax5qx241h9nwppi2g544i9lbnr";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libplist";
-  version = "2019-04-04";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "42bb64ba966082b440cb68cbdadf317f44710017";
-    sha256 = "19yw80yblq29i2jx9yb7bx0lfychy9dncri3fk4as35kq5bf26i8";
+    rev = version;
+    sha256 = "1vxhpjxniybqsg5wcygmdmr5dv7p2zb34dqnd3bi813rnnzsdjm6";
   };
 
   outputs = ["bin" "dev" "out" ] ++ stdenv.lib.optional enablePython "py";

--- a/pkgs/development/libraries/libusbmuxd/default.nix
+++ b/pkgs/development/libraries/libusbmuxd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libusbmuxd";
-  version = "2019-03-23";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "873252dc8b4e469c7dc692064ac616104fca5f65";
-    sha256 = "0qx3q0n1f2ajfm3vnairikayzln6iyb2y0i7sqfl8mj45ahl6wyj";
+    rev = version;
+    sha256 = "139pzsnixkck6ly1q6p0diqr0hgd0mx0pr4xx1jamm3f3656kpf9";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/filesystems/ifuse/default.nix
+++ b/pkgs/tools/filesystems/ifuse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ifuse";
-  version = "2018-10-08";
+  version = "1.1.4";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "e75d32c34d0e8b80320f0a007d5ecbb3f55ef7f0";
-    sha256 = "1b9w2i0sliswlkkb890l9i0rxrf631xywxf8ihygfmjdsfw47h1m";
+    rev = version;
+    sha256 = "1r12y3h1j7ikkwk874h9969kr4ksyamvrwywx19ml6rsr01arw84";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig fuse usbmuxd libimobiledevice ];

--- a/pkgs/tools/misc/ideviceinstaller/default.nix
+++ b/pkgs/tools/misc/ideviceinstaller/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ideviceinstaller";
-  version = "2018-10-01";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "f14def7cd9303a0fe622732fae9830ae702fdd7c";
-    sha256 = "1biwhbldvgdhn8ygp7w79ca0rivzdjpykr76pyhy7r2fa56mrwq8";
+    rev = version;
+    sha256 = "1xp0sjgfx2z19x9mxihn18ybsmrnrcfc55zbh5a44g3vrmagmlzz";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig usbmuxd libimobiledevice libzip ];
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       and enumerate installed or archived apps.
     '';
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ aristid infinisil ];
   };
 }

--- a/pkgs/tools/misc/idevicerestore/default.nix
+++ b/pkgs/tools/misc/idevicerestore/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "idevicerestore";
-  version = "2019-12-26";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "8207daaa2ac3cb3a5107aae6aefee8ecbe39b6d4";
-    sha256 = "1jz72bzk1fh12bs65pv06l85135hgfz1aqnbb084bvqcpj4gl40h";
+    rev = version;
+    sha256 = "1w7ywp77xc6v4hifi3j9ywrj447vv7fkwg2w26w0lq95f3bkblqr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/usbmuxd/default.nix
+++ b/pkgs/tools/misc/usbmuxd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "usbmuxd";
-  version = "2019-11-11";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "9af2b12552693a47601347e1eafc1e94132d727e";
-    sha256 = "0w8mf2wfpqijg882vhb8xarlp6zja23xf0b59z5zi774pnpjbqvj";
+    rev = version;
+    sha256 = "0a2xgrb4b3ndam448z74wh1267nmrz1wcbpx4xz86pwbdc93snab";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       in parallel. The higher-level layers are handled by libimobiledevice.
     '';
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ infinisil ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

It's been a few months and there is a new stable upstream release (1.0.0).
Since idevicerestore depends on the libraries, I wasn't sure if I should split this into multiple commits or leave it as a single one. Feedback very welcome!

```
nixpkgs % result/bin/idevicerestore
Usage: idevicerestore [OPTIONS] PATH

Restore IPSW firmware at PATH to an iOS device.

PATH can be a compressed .ipsw file or a directory containing all files
extracted from an IPSW.

OPTIONS:
  -i, --ecid ECID       Target specific device by its ECID
                        e.g. 0xaabb123456 (hex) or 1234567890 (decimal)
  -u, --udid UDID       Target specific device by its device UDID
                        NOTE: only works with devices in normal mode.
  -l, --latest          Use latest available firmware (with download on demand).
                        Before performing any action it will interactively ask
                        to select one of the currently signed firmware versions,
                        unless -y has been given too.
                        The PATH argument is ignored when using this option.
                        DO NOT USE if you need to preserve the baseband/unlock!
                        USE WITH CARE if you want to keep a jailbreakable
                        firmware!
  -e, --erase           Perform full restore instead of update, erasing all data
                        DO NOT USE if you want to preserve user data on the device!
  -y, --no-input        Non-interactive mode, do not ask for any input.
                        WARNING: This will disable certain checks/prompts that
                        are supposed to prevent DATA LOSS. Use with caution.
  -n, --no-action       Do not perform any restore action. If combined with -l
                        option the on-demand ipsw download is performed before
                        exiting.
  -h, --help            Prints this usage information
  -C, --cache-path DIR  Use specified directory for caching extracted or other
                        reused files.
  -d, --debug           Enable communication debugging
  -v, --version         Print version information

Advanced/experimental options:
  -c, --custom          Restore with a custom firmware (requires bootrom exploit)
  -s, --cydia           Use Cydia's signature service instead of Apple's
  -x, --exclude         Exclude nor/baseband upgrade
  -t, --shsh            Fetch TSS record and save to .shsh file, then exit
  -z, --no-restore      Do not restore and end after booting to the ramdisk
  -k, --keep-pers       Write personalized components to files for debugging
  -p, --pwn             Put device in pwned DFU mode and exit (limera1n devices)
  -P, --plain-progress  Print progress as plain step and progress
  -R, --restore-mode    Allow restoring from Restore mode
  -T, --ticket PATH     Use file at PATH to send as AP ticket

Homepage:    <https://libimobiledevice.org>
Bug Reports: <https://github.com/libimobiledevice/idevicerestore/issues>

% result/bin/idevicerestore -v
idevicerestore 1.0.0
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
