### PR TITLE
dasel: Set version in ldflags

### DIFF
--- a/pkgs/applications/misc/dasel/default.nix
+++ b/pkgs/applications/misc/dasel/default.nix
@@ -16,6 +16,10 @@ buildGoModule rec {
 
   vendorSha256 = "1552k85z4s6gv7sss7dccv3h8x22j2sr12icp6s7s0a3i4iwyksw";
 
+  buildFlagsArray = ''
+    -ldflags=-s -w -X github.com/tomwright/dasel/internal.Version=${version}
+  '';
+
   meta = with stdenv.lib; {
     description = "Query and update data structures from the command line";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change


before:
```
$ dasel --version
dasel version development
```
after:
```
$ dasel --version
dasel version 1.8.0
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
