### PR TITLE
libopenaptx: 0.1.0 → 0.2.0

### DIFF
--- a/pkgs/development/libraries/libopenaptx/default.nix
+++ b/pkgs/development/libraries/libopenaptx/default.nix
@@ -2,16 +2,22 @@
 
 stdenv.mkDerivation rec {
   pname = "libopenaptx";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "pali";
     repo = "libopenaptx";
     rev = version;
-    sha256 = "0996qmkmbax7ccknxrd3bx8xibs79a1ffms69scsj59f3kgj6854";
+    sha256 = "nTpw4vWgJ765FM6Es3SzaaaZr0YDydXglb0RWLbiigI=";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    # disable static builds
+    "ANAME="
+    "AOBJECTS="
+    "STATIC_UTILITIES="
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/pali/libopenaptx/releases/tag/0.2.0

Will be used by upcoming pipewire release.

cc @orivej @gebner @jansol

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
