### PR TITLE
Update Haskell package set to Stackage Nightly 2020-12-04 (plus other fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -327,6 +327,7 @@ self: super: {
   http-link-header = dontCheck super.http-link-header; # non deterministic failure https://hydra.nixos.org/build/75041105
   ihaskell = dontCheck super.ihaskell;
   influxdb = dontCheck super.influxdb;
+  integer-roots = dontCheck super.integer-roots; # requires an old version of smallcheck, will be fixed in > 1.0
   itanium-abi = dontCheck super.itanium-abi;
   katt = dontCheck super.katt;
   language-nix = if (pkgs.stdenv.hostPlatform.isAarch64 || pkgs.stdenv.hostPlatform.isi686) then dontCheck super.language-nix else super.language-nix; # aarch64: https://ghc.haskell.org/trac/ghc/ticket/15275

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -442,9 +442,6 @@ self: super: {
   rematch = dontCheck super.rematch;            # https://github.com/tcrayford/rematch/issues/5
   rematch-text = dontCheck super.rematch-text;  # https://github.com/tcrayford/rematch/issues/6
 
-  # Should not appear in nixpkgs yet (broken anyway)
-  yarn2nix = throw "yarn2nix is not yet packaged for nixpkgs. See https://github.com/Profpatsch/yarn2nix#yarn2nix";
-
   # no haddock since this is an umbrella package.
   cloud-haskell = dontHaddock super.cloud-haskell;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -38,11 +38,6 @@ self: super: {
   ghcjs-base = null;
   ghcjs-prim = null;
 
-  # Some packages add this (non-existent) dependency to express that they
-  # cannot compile in a given configuration. Win32 does this, for example, when
-  # compiled on Linux. We provide the name to avoid evaluation errors.
-  unbuildable = throw "package depends on meta package 'unbuildable'";
-
   # enable using a local hoogle with extra packagages in the database
   # nix-shell -p "haskellPackages.hoogleLocal { packages = with haskellPackages; [ mtl lens ]; }"
   # $ hoogle server

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4349,7 +4349,6 @@ broken-packages:
   - custom-prelude
   - CV
   - cv-combinators
-  - cyclotomic
   - cypher
   - d-bus
   - d3js

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6980,7 +6980,6 @@ broken-packages:
   - int-multimap
   - intcode
   - integer-pure
-  - integer-roots
   - integreat
   - intel-aes
   - intensional-datatys

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3379,8 +3379,8 @@ broken-packages:
   - base64-conduit
   - baserock-schema
   - basex-client
-  - basic
   - BASIC
+  - basic
   - baskell
   - batchd
   - battlenet
@@ -3528,6 +3528,7 @@ broken-packages:
   - BirdPP
   - birds-of-paradise
   - bisect-binary
+  - bishbosh
   - bit-array
   - bit-stream
   - bitcoin-address
@@ -3900,8 +3901,8 @@ broken-packages:
   - chatwork
   - cheapskate-terminal
   - check-pvp
-  - checked
   - Checked
+  - checked
   - checkmate
   - chell-quickcheck
   - chessIO
@@ -3995,6 +3996,7 @@ broken-packages:
   - cli-extras
   - cli-git
   - cli-nix
+  - clickhouse-haskell
   - clif
   - clifford
   - clifm
@@ -4359,8 +4361,8 @@ broken-packages:
   - damnpacket
   - Dangerous
   - danibot
-  - dao
   - Dao
+  - dao
   - dapi
   - darcs-benchmark
   - darcs-beta
@@ -4538,6 +4540,7 @@ broken-packages:
   - derive-gadt
   - derive-IG
   - derive-monoid
+  - derive-storable-plugin
   - derive-trie
   - derp-lib
   - describe
@@ -4806,11 +4809,13 @@ broken-packages:
   - ecma262
   - ecu
   - eddie
+  - ede
   - edenmodules
   - edenskel
   - edentv
   - edge
   - edges
+  - edis
   - edit
   - edit-lenses
   - editable
@@ -4891,6 +4896,7 @@ broken-packages:
   - enumfun
   - EnumMap
   - enummapmap
+  - env-extra
   - env-parser
   - envstatus
   - epanet-haskell
@@ -5011,8 +5017,9 @@ broken-packages:
   - f-ree-hack-cheats-free-v-bucks-generator
   - Facebook-Password-Hacker-Online-Latest-Version
   - faceted
-  - facts
+  - factory
   - Facts
+  - facts
   - factual-api
   - fadno
   - fadno-braids
@@ -5137,6 +5144,7 @@ broken-packages:
   - first-class-instances
   - firstify
   - FirstOrderTheory
+  - fishfood
   - fit
   - fits-parse
   - fitsio
@@ -5164,6 +5172,7 @@ broken-packages:
   - flamethrower
   - flamingra
   - flashblast
+  - flat
   - flat-maybe
   - flatbuffers
   - flay
@@ -5569,6 +5578,7 @@ broken-packages:
   - gloss-export
   - gloss-game
   - gloss-sodium
+  - glpk-headers
   - glpk-hs
   - gltf-codec
   - glue
@@ -6158,8 +6168,8 @@ broken-packages:
   - hdaemonize-buildfix
   - hdbc-aeson
   - HDBC-mysql
-  - hdbc-postgresql-hstore
   - HDBC-postgresql-hstore
+  - hdbc-postgresql-hstore
   - hdbi
   - hdbi-conduit
   - hdbi-postgresql
@@ -6203,6 +6213,7 @@ broken-packages:
   - hedgehog-servant
   - Hedi
   - hedis-config
+  - hedis-namespace
   - hedis-pile
   - hedis-simple
   - hedis-tags
@@ -6380,9 +6391,11 @@ broken-packages:
   - hlibfam
   - HList
   - hlivy
-  - hlogger
   - HLogger
+  - hlogger
   - hlongurl
+  - hlrdb
+  - hlrdb-core
   - hls
   - hls-brittany
   - hlwm
@@ -7221,6 +7234,7 @@ broken-packages:
   - keera-hails-reactive-yampa
   - keera-hails-reactivelenses
   - keera-hails-reactivevalues
+  - kempe
   - kerry
   - Ketchup
   - keter
@@ -7793,8 +7807,8 @@ broken-packages:
   - mecab
   - mech
   - Mecha
-  - mechs
   - Mechs
+  - mechs
   - mediabus
   - mediabus-fdk-aac
   - mediabus-rtp
@@ -8324,6 +8338,7 @@ broken-packages:
   - numeric-ranges
   - numerical
   - numhask-array
+  - numhask-free
   - numhask-hedgehog
   - numhask-histogram
   - numhask-prelude
@@ -8500,6 +8515,7 @@ broken-packages:
   - pandoc-crossref
   - pandoc-csv2table
   - pandoc-filter-graphviz
+  - pandoc-filter-indent
   - pandoc-include
   - pandoc-include-code
   - pandoc-japanese-filters
@@ -8667,6 +8683,7 @@ broken-packages:
   - peyotls
   - peyotls-codec
   - pez
+  - pg-extras
   - pg-harness
   - pg-harness-server
   - pg-recorder
@@ -8802,6 +8819,7 @@ broken-packages:
   - polysemy-methodology
   - polysemy-methodology-composite
   - polysemy-optics
+  - polysemy-path
   - polysemy-RandomFu
   - polysemy-resume
   - polysemy-test
@@ -8974,6 +8992,7 @@ broken-packages:
   - prosidy
   - prosidyc
   - prosper
+  - proteaaudio
   - proteome
   - proto-lens-combinators
   - proto-lens-descriptors
@@ -9437,7 +9456,11 @@ broken-packages:
   - rocksdb-haskell
   - roku-api
   - rollbar
+  - rollbar-cli
+  - rollbar-client
   - rollbar-hs
+  - rollbar-wai
+  - rollbar-yesod
   - roller
   - RollingDirectory
   - ron-rdt
@@ -9702,6 +9725,7 @@ broken-packages:
   - servant-openapi3
   - servant-pagination
   - servant-pandoc
+  - servant-polysemy
   - servant-pool
   - servant-postgresql
   - servant-proto-lens
@@ -9926,6 +9950,7 @@ broken-packages:
   - Smooth
   - smsaero
   - smt-lib
+  - smt2-parser
   - SmtLib
   - smtlib2
   - smtlib2-debug
@@ -10094,6 +10119,7 @@ broken-packages:
   - sqlvalue-list
   - sqsd-local
   - squeal-postgresql
+  - squeeze
   - sr-extra
   - srcinst
   - sscan
@@ -10181,6 +10207,7 @@ broken-packages:
   - stmcontrol
   - stochastic
   - StockholmAlignment
+  - stocks
   - Stomp
   - storable
   - storable-static-array
@@ -10362,8 +10389,8 @@ broken-packages:
   - table
   - table-tennis
   - tableaux
-  - tables
   - Tables
+  - tables
   - tablestorage
   - Tablify
   - tabloid
@@ -10633,8 +10660,8 @@ broken-packages:
   - tonatona-servant
   - too-many-cells
   - toodles
-  - top
   - Top
+  - top
   - topkata
   - torch
   - TORCS
@@ -10888,6 +10915,7 @@ broken-packages:
   - uploadcare
   - upskirt
   - urbit-airlock
+  - urbit-api
   - ureader
   - urembed
   - uri
@@ -11155,6 +11183,7 @@ broken-packages:
   - WEditor
   - WEditorBrick
   - WEditorHyphen
+  - weekdaze
   - weighted
   - weighted-regexp
   - welshy
@@ -11343,6 +11372,7 @@ broken-packages:
   - yam-datasource
   - yam-logger
   - yam-redis
+  - yam-servant
   - yam-transaction
   - yam-transaction-odbc
   - yam-web
@@ -11363,6 +11393,7 @@ broken-packages:
   - yaop
   - yap
   - yarn-lock
+  - yarn2nix
   - yarr
   - yarr-image-io
   - yavie

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -76,7 +76,7 @@ default-package-overrides:
   # haskell-language-server 0.5.0.0 doesn't accept newer versions
   - fourmolu ==0.2.*
   - refinery ==0.2.*
-  # Stackage Nightly 2020-11-23
+  # Stackage Nightly 2020-12-04
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -215,18 +215,18 @@ default-package-overrides:
   - ansi-terminal ==0.10.3
   - ansi-wl-pprint ==0.6.9
   - ANum ==0.2.0.2
-  - ap-normalize ==0.1.0.0
   - apecs ==0.9.2
   - apecs-gloss ==0.2.4
   - apecs-physics ==0.4.4
   - api-field-json-th ==0.1.0.2
-  - app-settings ==0.2.0.12
+  - ap-normalize ==0.1.0.0
   - appar ==0.1.8
   - appendmap ==0.1.5
   - apply-refact ==0.8.2.1
   - apportionment ==0.0.0.3
   - approximate ==0.3.2
   - approximate-equality ==1.1.0.2
+  - app-settings ==0.2.0.12
   - arbor-lru-cache ==0.1.1.1
   - arbor-postgres ==0.0.5
   - arithmoi ==0.11.0.1
@@ -235,12 +235,12 @@ default-package-overrides:
   - ascii ==1.0.0.2
   - ascii-case ==1.0.0.2
   - ascii-char ==1.0.0.2
+  - asciidiagram ==1.3.3.3
   - ascii-group ==1.0.0.2
   - ascii-predicates ==1.0.0.2
   - ascii-progress ==0.3.3.0
   - ascii-superset ==1.0.0.2
   - ascii-th ==1.0.0.2
-  - asciidiagram ==1.3.3.3
   - asif ==6.0.4
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
@@ -268,19 +268,14 @@ default-package-overrides:
   - authenticate ==1.3.5
   - authenticate-oauth ==1.6.0.1
   - auto ==0.4.3.1
-  - auto-update ==0.1.6
   - autoexporter ==1.1.19
+  - auto-update ==0.1.6
   - avers ==0.0.17.1
   - avro ==0.5.2.0
   - aws-cloudfront-signed-cookies ==0.2.0.6
   - backtracking ==0.1.0
   - bank-holidays-england ==0.2.0.6
   - barbies ==2.0.2.0
-  - base-compat ==0.11.2
-  - base-compat-batteries ==0.11.2
-  - base-orphans ==0.8.3
-  - base-prelude ==1.4
-  - base-unicode-symbols ==0.2.4.2
   - base16 ==0.3.0.1
   - base16-bytestring ==0.1.1.7
   - base16-lens ==0.1.3.0
@@ -294,7 +289,12 @@ default-package-overrides:
   - base64-bytestring-type ==1.0.1
   - base64-lens ==0.3.0
   - base64-string ==0.2
+  - base-compat ==0.11.2
+  - base-compat-batteries ==0.11.2
   - basement ==0.0.11
+  - base-orphans ==0.8.3
+  - base-prelude ==1.4
+  - base-unicode-symbols ==0.2.4.2
   - basic-prelude ==0.7.0
   - bazel-runfiles ==0.12
   - bbdb ==0.8
@@ -307,10 +307,11 @@ default-package-overrides:
   - bibtex ==0.1.0.6
   - bifunctors ==5.5.8
   - bimap ==0.4.0
-  - bimap-server ==0.1.0.1
   - bimaps ==0.1.0.2
+  - bimap-server ==0.1.0.1
   - bin ==0.1
   - binary-conduit ==1.3.1
+  - binaryen ==0.0.5.0
   - binary-ext ==2.0.4
   - binary-ieee754 ==0.1.0.0
   - binary-instances ==1.0.0.1
@@ -321,7 +322,6 @@ default-package-overrides:
   - binary-search ==1.0.0.3
   - binary-shared ==0.8.3
   - binary-tagged ==0.3
-  - binaryen ==0.0.5.0
   - bindings-DSL ==1.0.25
   - bindings-GLFW ==3.3.2.0
   - bindings-libzip ==1.0.1
@@ -329,8 +329,8 @@ default-package-overrides:
   - bins ==0.1.2.0
   - bitarray ==0.0.1.1
   - bits ==0.5.2
-  - bits-extra ==0.0.2.0
   - bitset-word8 ==0.1.1.2
+  - bits-extra ==0.0.2.0
   - bitvec ==1.0.3.0
   - blake2 ==0.3.0
   - blanks ==0.5.0
@@ -355,8 +355,8 @@ default-package-overrides:
   - boring ==0.1.3
   - both ==0.1.1.1
   - bound ==2.0.2
-  - bounded-queue ==1.0.0
   - BoundedChan ==1.0.3.0
+  - bounded-queue ==1.0.0
   - boundingboxes ==0.2.3
   - bower-json ==1.0.0.1
   - boxes ==0.1.5
@@ -373,10 +373,10 @@ default-package-overrides:
   - butcher ==1.3.3.2
   - bv ==0.5
   - bv-little ==1.1.1
-  - byte-count-reader ==0.10.1.2
-  - byte-order ==0.1.2.0
   - byteable ==0.1.1
+  - byte-count-reader ==0.10.1.2
   - bytedump ==1.0
+  - byte-order ==0.1.2.0
   - byteorder ==1.0.4
   - bytes ==0.17
   - byteset ==0.1.1.0
@@ -386,13 +386,12 @@ default-package-overrides:
   - bytestring-mmap ==0.2.2
   - bytestring-strict-builder ==0.4.5.3
   - bytestring-to-vector ==0.3.0.1
-  - bytestring-tree-builder ==0.2.7.5
+  - bytestring-tree-builder ==0.2.7.7
   - bz2 ==1.0.1.0
   - bzlib ==0.5.1.0
   - bzlib-conduit ==0.3.0.2
   - c14n ==0.1.0.1
   - c2hs ==0.28.6
-  - ca-province-codes ==1.0.0.0
   - cabal-debian ==5.1
   - cabal-doctest ==1.0.8
   - cabal-file ==0.1.1
@@ -404,12 +403,13 @@ default-package-overrides:
   - calendar-recycling ==0.0.0.1
   - call-stack ==0.2.0
   - can-i-haz ==0.3.1.0
+  - ca-province-codes ==1.0.0.0
   - cardano-coin-selection ==1.0.1
   - carray ==0.1.6.8
   - casa-client ==0.0.1
   - casa-types ==0.0.1
-  - case-insensitive ==1.2.1.0
   - cased ==0.1.0.0
+  - case-insensitive ==1.2.1.0
   - cases ==0.1.4
   - casing ==0.1.4.1
   - cassava ==0.5.2.0
@@ -468,12 +468,12 @@ default-package-overrides:
   - cmark-gfm ==0.2.2
   - cmark-lucid ==0.1.0.0
   - cmdargs ==0.10.20
+  - codec-beam ==0.2.0
+  - codec-rpm ==0.2.2
+  - code-page ==0.2
   - co-log ==0.4.0.1
   - co-log-concurrent ==0.5.0.0
   - co-log-core ==0.2.1.1
-  - code-page ==0.2
-  - codec-beam ==0.2.0
-  - codec-rpm ==0.2.2
   - Color ==0.3.0
   - colorful-monoids ==0.2.1.3
   - colorize-haskell ==1.0.1
@@ -508,7 +508,7 @@ default-package-overrides:
   - concurrent-split ==0.0.1.1
   - concurrent-supply ==0.1.8
   - cond ==0.4.1.1
-  - conduit ==1.3.3
+  - conduit ==1.3.4
   - conduit-algorithms ==0.0.11.0
   - conduit-combinators ==1.3.0
   - conduit-concurrent-map ==0.1.1
@@ -519,8 +519,8 @@ default-package-overrides:
   - conferer-hspec ==0.4.0.1
   - conferer-source-json ==0.4.0.1
   - conferer-warp ==0.4.0.1
-  - config-ini ==0.2.4.0
   - ConfigFile ==1.1.4
+  - config-ini ==0.2.4.0
   - configurator ==0.3.0.0
   - configurator-export ==0.1.0.1
   - configurator-pg ==0.2.5
@@ -528,8 +528,8 @@ default-package-overrides:
   - connection-pool ==0.2.2
   - console-style ==0.0.2.1
   - constraint ==0.1.4.0
-  - constraint-tuples ==0.1.2
   - constraints ==0.12
+  - constraint-tuples ==0.1.2
   - construct ==0.3
   - contravariant ==1.5.2
   - contravariant-extras ==0.3.5.2
@@ -556,13 +556,8 @@ default-package-overrides:
   - cron ==0.7.0
   - crypto-api ==0.13.3
   - crypto-cipher-types ==0.0.9
-  - crypto-enigma ==0.1.1.6
-  - crypto-numbers ==0.2.7
-  - crypto-pubkey ==0.2.8
-  - crypto-pubkey-types ==0.4.3
-  - crypto-random ==0.0.9
-  - crypto-random-api ==0.2.0
   - cryptocompare ==0.1.2
+  - crypto-enigma ==0.1.1.6
   - cryptohash ==0.11.9
   - cryptohash-cryptoapi ==0.1.4
   - cryptohash-md5 ==0.11.100.1
@@ -571,6 +566,11 @@ default-package-overrides:
   - cryptonite ==0.27
   - cryptonite-conduit ==0.2.2
   - cryptonite-openssl ==0.7
+  - crypto-numbers ==0.2.7
+  - crypto-pubkey ==0.2.8
+  - crypto-pubkey-types ==0.4.3
+  - crypto-random ==0.0.9
+  - crypto-random-api ==0.2.0
   - csp ==1.4.0
   - css-syntax ==0.1.0.0
   - css-text ==0.1.3.0
@@ -607,11 +607,12 @@ default-package-overrides:
   - data-default-instances-dlist ==0.0.1
   - data-default-instances-old-locale ==0.0.1
   - data-diverse ==4.7.0.0
+  - datadog ==0.2.5.0
   - data-dword ==0.3.2
   - data-endian ==0.1.1
   - data-fix ==0.3.0
   - data-forest ==0.1.0.8
-  - data-has ==0.3.0.0
+  - data-has ==0.4.0.0
   - data-hash ==0.2.0.1
   - data-interval ==2.0.1
   - data-inttrie ==0.1.4
@@ -625,7 +626,6 @@ default-package-overrides:
   - data-reify ==0.6.3
   - data-serializer ==0.3.4.1
   - data-textual ==0.3.0.3
-  - datadog ==0.2.5.0
   - dataurl ==0.1.0.0
   - DAV ==1.3.4
   - DBFunctor ==0.1.1.1
@@ -639,13 +639,13 @@ default-package-overrides:
   - declarative ==0.5.3
   - deepseq-generics ==0.2.0.0
   - deepseq-instances ==0.1.0.1
-  - deferred-folds ==0.9.11
+  - deferred-folds ==0.9.15
   - dejafu ==2.4.0.0
   - dense-linear-algebra ==0.1.0.0
   - depq ==0.4.1.0
   - deque ==0.4.3
-  - derive-topdown ==0.0.2.2
   - deriveJsonNoPrefix ==0.1.0.1
+  - derive-topdown ==0.0.2.2
   - deriving-aeson ==0.2.6
   - deriving-compat ==0.5.10
   - derulo ==1.0.9
@@ -654,17 +654,17 @@ default-package-overrides:
   - dhall-json ==1.7.3
   - dhall-lsp-server ==1.0.11
   - dhall-yaml ==1.2.3
-  - di-core ==1.0.4
-  - di-monad ==1.3.1
   - diagrams-solve ==0.1.2
   - dialogflow-fulfillment ==0.1.1.3
+  - di-core ==1.0.4
   - dictionary-sharing ==0.1.0.0
   - Diff ==0.4.0
   - digest ==0.0.1.2
   - digits ==0.3.1
   - dimensional ==1.3
-  - direct-sqlite ==2.3.26
+  - di-monad ==1.3.1
   - directory-tree ==0.12.1
+  - direct-sqlite ==2.3.26
   - dirichlet ==0.1.0.0
   - discount ==0.1.1
   - disk-free-space ==0.1.0.1
@@ -676,16 +676,16 @@ default-package-overrides:
   - dlist-instances ==0.1.1.1
   - dlist-nonempty ==0.1.1
   - dns ==4.0.1
-  - do-list ==1.0.1
-  - do-notation ==0.1.0.2
   - dockerfile ==0.2.0
   - doclayout ==0.3
-  - doctemplates ==0.8.2
+  - doctemplates ==0.8.3
   - doctest ==0.16.3
   - doctest-discover ==0.2.0.0
   - doctest-exitcode-stdio ==0.0
   - doctest-lib ==0.1
   - doldol ==0.4.1.2
+  - do-list ==1.0.1
+  - do-notation ==0.1.0.2
   - dotenv ==0.8.0.7
   - dotgen ==0.4.3
   - dotnet-timespan ==0.0.1.0
@@ -724,10 +724,10 @@ default-package-overrides:
   - elerea ==2.9.0
   - elf ==0.30
   - eliminators ==0.7
+  - elm2nix ==0.2.1
   - elm-bridge ==0.6.1
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
-  - elm2nix ==0.2.1
   - elynx ==0.5.0
   - elynx-markov ==0.5.0
   - elynx-nexus ==0.5.0
@@ -739,9 +739,9 @@ default-package-overrides:
   - enclosed-exceptions ==1.0.3
   - ENIG ==0.0.1.0
   - entropy ==0.4.1.6
-  - enum-subset-generate ==0.1.0.0
   - enummapset ==0.6.0.3
   - enumset ==0.0.5
+  - enum-subset-generate ==0.1.0.0
   - envelope ==0.2.2.0
   - envy ==2.1.0.0
   - epub-metadata ==4.5
@@ -760,24 +760,24 @@ default-package-overrides:
   - essence-of-live-coding-quickcheck ==0.2.4
   - etc ==0.4.1.0
   - eve ==0.1.9.0
-  - event-list ==0.1.2
   - eventful-core ==0.2.0
   - eventful-test-helpers ==0.2.0
+  - event-list ==0.1.2
   - eventstore ==1.4.1
   - every ==0.0.1
   - exact-combinatorics ==0.2.0.9
   - exact-pi ==0.5.0.1
   - exception-hierarchy ==0.1.0.4
   - exception-mtl ==0.4.0.1
+  - exceptions ==0.10.4
   - exception-transformers ==0.4.0.9
   - exception-via ==0.1.0.0
-  - exceptions ==0.10.4
   - executable-path ==0.0.3.1
   - exit-codes ==1.0.0
   - exomizer ==1.0.0
-  - exp-pairs ==0.2.1.0
   - expiring-cache-map ==0.0.6.1
   - explicit-exception ==0.1.10
+  - exp-pairs ==0.2.1.0
   - express ==0.1.3
   - extended-reals ==0.2.4.0
   - extensible-effects ==5.0.0.1
@@ -804,10 +804,10 @@ default-package-overrides:
   - fgl ==5.7.0.3
   - file-embed ==0.0.13.0
   - file-embed-lzma ==0
-  - file-modules ==0.1.2.4
-  - file-path-th ==0.1.0.0
   - filelock ==0.1.1.5
   - filemanip ==0.3.6.3
+  - file-modules ==0.1.2.4
+  - file-path-th ==0.1.0.0
   - filepattern ==0.1.2
   - fileplow ==0.1.0.0
   - filtrable ==0.1.4.0
@@ -837,8 +837,8 @@ default-package-overrides:
   - fn ==0.3.0.2
   - focus ==1.0.1.4
   - focuslist ==0.1.0.2
-  - fold-debounce ==0.2.0.9
   - foldable1 ==0.1.0.0
+  - fold-debounce ==0.2.0.9
   - foldl ==1.4.10
   - folds ==0.7.5
   - follow-file ==0.0.3
@@ -852,10 +852,10 @@ default-package-overrides:
   - foundation ==0.0.25
   - free ==5.1.4
   - free-categories ==0.2.0.2
-  - free-vl ==0.1.4
   - freenect ==1.2.1
   - freer-simple ==1.2.1.1
   - freetype2 ==0.2.0
+  - free-vl ==0.1.4
   - friendly-time ==0.4.1
   - from-sum ==0.2.3.0
   - frontmatter ==0.1.0.2
@@ -871,8 +871,8 @@ default-package-overrides:
   - fuzzcheck ==0.1.1
   - fuzzy ==0.1.0.0
   - fuzzy-dates ==0.1.1.2
-  - fuzzy-time ==0.1.0.0
   - fuzzyset ==0.2.0
+  - fuzzy-time ==0.1.0.0
   - gauge ==0.2.5
   - gd ==3000.7.3
   - gdp ==0.0.3.0
@@ -887,8 +887,8 @@ default-package-overrides:
   - generic-lens-core ==2.0.0.0
   - generic-monoid ==0.1.0.1
   - generic-optics ==2.0.0.0
-  - generic-random ==1.3.0.1
   - GenericPretty ==1.2.2
+  - generic-random ==1.3.0.1
   - generics-sop ==0.5.1.0
   - generics-sop-lens ==0.2.0.1
   - geniplate-mirror ==0.7.7
@@ -922,6 +922,9 @@ default-package-overrides:
   - ghc-core ==0.5.6
   - ghc-events ==0.14.0
   - ghc-exactprint ==0.6.3.3
+  - ghcid ==0.8.7
+  - ghci-hexcalc ==0.1.1.0
+  - ghcjs-codemirror ==0.0.0.2
   - ghc-lib ==8.10.2.20200916
   - ghc-lib-parser ==8.10.2.20200916
   - ghc-lib-parser-ex ==8.10.0.16
@@ -936,9 +939,6 @@ default-package-overrides:
   - ghc-typelits-knownnat ==0.7.3
   - ghc-typelits-natnormalise ==0.7.2
   - ghc-typelits-presburger ==0.3.0.1
-  - ghci-hexcalc ==0.1.1.0
-  - ghcid ==0.8.7
-  - ghcjs-codemirror ==0.0.0.2
   - ghost-buster ==0.1.1.0
   - gi-atk ==2.0.22
   - gi-cairo ==1.0.24
@@ -951,15 +951,14 @@ default-package-overrides:
   - gi-gdkx11 ==3.0.10
   - gi-gio ==2.0.27
   - gi-glib ==2.0.24
-  - gi-gobject ==2.0.24
+  - gi-gobject ==2.0.25
   - gi-graphene ==1.0.2
   - gi-gtk ==3.0.36
   - gi-gtk-hs ==0.3.9
   - gi-harfbuzz ==0.0.3
-  - gi-pango ==1.0.23
-  - gi-xlib ==2.0.9
   - ginger ==0.10.1.0
   - gingersnap ==0.3.1.0
+  - gi-pango ==1.0.23
   - githash ==0.1.5.0
   - github ==0.26
   - github-release ==1.3.5
@@ -968,6 +967,7 @@ default-package-overrides:
   - github-webhooks ==0.15.0
   - gitlab-haskell ==0.2.3
   - gitrev ==1.3.1
+  - gi-xlib ==2.0.9
   - gl ==0.9
   - glabrous ==2.0.2
   - GLFW-b ==3.3.0.0
@@ -982,11 +982,11 @@ default-package-overrides:
   - gothic ==0.1.5
   - gpolyline ==0.1.0.1
   - graph-core ==0.3.0.0
-  - graph-wrapper ==0.2.6.0
   - graphite ==0.10.0.1
   - graphql-client ==1.1.0
   - graphs ==0.7.1
   - graphviz ==2999.20.1.0
+  - graph-wrapper ==0.2.6.0
   - gravatar ==0.8.0
   - groom ==0.1.2.1
   - group-by-date ==0.1.0.3
@@ -1014,8 +1014,8 @@ default-package-overrides:
   - hashmap ==1.3.3
   - hashtables ==1.2.4.1
   - haskeline ==0.8.1.0
-  - haskell-gi ==0.24.5
-  - haskell-gi-base ==0.24.4
+  - haskell-gi ==0.24.7
+  - haskell-gi-base ==0.24.5
   - haskell-gi-overloading ==1.0
   - haskell-import-graph ==1.0.4
   - haskell-lexer ==1.1
@@ -1040,7 +1040,7 @@ default-package-overrides:
   - hdaemonize ==0.5.6
   - HDBC ==2.4.0.3
   - HDBC-session ==0.1.2.0
-  - headroom ==0.3.1.0
+  - headroom ==0.3.2.0
   - heap ==1.0.4
   - heaps ==0.3.6.1
   - hebrew-time ==0.1.2
@@ -1050,7 +1050,7 @@ default-package-overrides:
   - hedgehog-fakedata ==0.0.1.3
   - hedgehog-fn ==1.0
   - hedgehog-quickcheck ==0.1.1
-  - hedis ==0.12.15
+  - hedis ==0.13.1
   - hedn ==0.3.0.2
   - here ==1.2.13
   - heredoc ==0.2.0.0
@@ -1064,9 +1064,9 @@ default-package-overrides:
   - hgeometry ==0.11.0.0
   - hgeometry-combinatorial ==0.11.0.0
   - hgrev ==0.2.6
-  - hi-file-parser ==0.1.0.0
   - hidapi ==0.1.5
   - hie-bios ==0.7.1
+  - hi-file-parser ==0.1.0.0
   - higher-leveldb ==0.6.0.0
   - highlighting-kate ==0.6.4
   - hinfo ==0.0.3.0
@@ -1088,6 +1088,7 @@ default-package-overrides:
   - hnix-store-core ==0.2.0.0
   - hnock ==0.4.0
   - hoauth2 ==1.16.0
+  - hocon ==0.1.0.4
   - hOpenPGP ==2.9.5
   - hopenpgp-tools ==0.23.3
   - hopfli ==0.2.2.1
@@ -1103,16 +1104,15 @@ default-package-overrides:
   - hpc-lcov ==1.0.1
   - hprotoc ==2.4.17
   - hruby ==0.3.8
-  - hs-bibutils ==6.10.0.0
-  - hs-functors ==0.1.7.1
-  - hs-GeoIP ==0.3
-  - hs-php-session ==0.0.9.3
   - hsass ==0.8.0
+  - hs-bibutils ==6.10.0.0
   - hsc2hs ==0.68.7
   - hscolour ==1.24.4
   - hsdns ==1.8
   - hsebaysdk ==0.4.1.0
   - hsemail ==2.2.1
+  - hs-functors ==0.1.7.1
+  - hs-GeoIP ==0.3
   - hsini ==0.5.1.2
   - hsinstall ==2.6
   - HSlippyMap ==3.0.1
@@ -1145,6 +1145,7 @@ default-package-overrides:
   - hspec-tables ==0.0.1
   - hspec-wai ==0.10.1
   - hspec-wai-json ==0.10.1
+  - hs-php-session ==0.0.9.3
   - hsshellscript ==3.4.5
   - HStringTemplate ==0.8.7
   - HSvm ==0.1.1.3.22
@@ -1157,6 +1158,7 @@ default-package-overrides:
   - html-entities ==1.1.4.3
   - html-entity-map ==0.1.0.0
   - htoml ==1.0.0.3
+  - http2 ==2.0.5
   - HTTP ==4000.3.15
   - http-api-data ==0.4.1.1
   - http-client ==0.6.4.1
@@ -1168,14 +1170,13 @@ default-package-overrides:
   - http-date ==0.0.10
   - http-directory ==0.1.8
   - http-download ==0.2.0.0
+  - httpd-shed ==0.4.1.1
   - http-link-header ==1.0.3.1
   - http-media ==0.8.0.0
   - http-query ==0.1.0
   - http-reverse-proxy ==0.6.0
   - http-streams ==0.8.7.2
   - http-types ==0.12.3
-  - http2 ==2.0.5
-  - httpd-shed ==0.4.1.1
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.1.0
   - HUnit-approx ==1.1.1.1
@@ -1188,6 +1189,7 @@ default-package-overrides:
   - hw-conduit-merges ==0.2.1.0
   - hw-diagnostics ==0.0.1.0
   - hw-dsv ==0.4.1.0
+  - hweblib ==0.6.3
   - hw-eliasfano ==0.1.2.0
   - hw-excess ==0.2.3.0
   - hw-fingertree ==0.1.2.0
@@ -1200,7 +1202,7 @@ default-package-overrides:
   - hw-json-simd ==0.1.1.0
   - hw-json-simple-cursor ==0.1.1.0
   - hw-json-standard-cursor ==0.2.3.1
-  - hw-kafka-client ==3.1.2
+  - hw-kafka-client ==4.0.0
   - hw-mquery ==0.2.1.0
   - hw-packed-vector ==0.2.1.0
   - hw-parser ==0.1.1.0
@@ -1212,7 +1214,6 @@ default-package-overrides:
   - hw-string-parse ==0.0.0.4
   - hw-succinct ==0.1.0.1
   - hw-xml ==0.5.1.0
-  - hweblib ==0.6.3
   - hxt ==9.3.1.18
   - hxt-charproperties ==9.4.0.0
   - hxt-css ==0.1.0.3
@@ -1293,13 +1294,13 @@ default-package-overrides:
   - iso3166-country-codes ==0.20140203.8
   - iso639 ==0.1.0.3
   - iso8601-time ==0.1.5
-  - it-has ==0.2.0.0
   - iterable ==3.0
-  - ix-shapable ==0.1.0
+  - it-has ==0.2.0.0
   - ixset-typed ==0.5
   - ixset-typed-binary-instance ==0.1.0.2
   - ixset-typed-conversions ==0.1.2.0
   - ixset-typed-hashable-instance ==0.1.0.2
+  - ix-shapable ==0.1.0
   - jack ==0.7.1.4
   - jalaali ==1.0.0.0
   - jira-wiki-markup ==1.3.2
@@ -1310,9 +1311,9 @@ default-package-overrides:
   - js-flot ==0.8.3
   - js-jquery ==3.3.1
   - json-feed ==1.0.11
+  - jsonpath ==0.2.0.0
   - json-rpc ==1.0.3
   - json-rpc-generic ==0.2.1.5
-  - jsonpath ==0.2.0.0
   - JuicyPixels ==3.3.5
   - JuicyPixels-blurhash ==0.1.0.3
   - JuicyPixels-extra ==0.4.1
@@ -1388,9 +1389,9 @@ default-package-overrides:
   - libyaml ==0.1.2
   - LibZip ==1.0.1
   - life-sync ==1.1.1.0
-  - lift-generics ==0.2
   - lifted-async ==0.10.1.2
   - lifted-base ==0.2.3.12
+  - lift-generics ==0.2
   - line ==4.0.1
   - linear ==1.21.3
   - linear-circuit ==0.1.0.2
@@ -1399,11 +1400,11 @@ default-package-overrides:
   - linux-namespaces ==0.1.3.0
   - liquid-fixpoint ==0.8.10.2
   - List ==0.6.2
+  - ListLike ==4.7.2
   - list-predicate ==0.1.0.1
+  - listsafe ==0.1.0.1
   - list-singleton ==1.0.0.4
   - list-t ==1.0.4
-  - ListLike ==4.7.2
-  - listsafe ==0.1.0.1
   - ListTree ==0.2.3
   - little-logger ==0.3.1
   - little-rio ==0.2.2
@@ -1435,20 +1436,20 @@ default-package-overrides:
   - machines ==0.7.1
   - magic ==1.1
   - magico ==0.0.2.1
-  - main-tester ==0.2.0.1
   - mainland-pretty ==0.7.0.1
+  - main-tester ==0.2.0.1
   - makefile ==1.1.0.0
   - managed ==1.0.8
   - MapWith ==0.2.0.0
   - markdown ==0.1.17.4
   - markdown-unlit ==0.5.0
   - markov-chain ==0.0.3.4
-  - massiv ==0.5.6.0
+  - massiv ==0.5.7.0
   - massiv-io ==0.4.0.0
   - massiv-test ==0.1.5
+  - mathexpr ==0.3.0.0
   - math-extras ==0.1.1.0
   - math-functions ==0.3.4.1
-  - mathexpr ==0.3.0.0
   - matplotlib ==0.7.5
   - matrices ==0.5.0
   - matrix ==0.3.6.1
@@ -1460,9 +1461,9 @@ default-package-overrides:
   - mbox-utility ==0.0.3.1
   - mcmc ==0.3.0
   - mcmc-types ==1.0.3
-  - med-module ==0.1.2.1
   - medea ==1.2.0
   - median-stream ==0.7.0.0
+  - med-module ==0.1.2.1
   - megaparsec ==9.0.1
   - megaparsec-tests ==9.0.1
   - membrain ==0.0.0.2
@@ -1491,12 +1492,12 @@ default-package-overrides:
   - mime-mail ==0.5.0
   - mime-mail-ses ==0.4.3
   - mime-types ==0.1.0.9
-  - min-max-pqueue ==0.1.0.2
   - mini-egison ==1.0.0
   - minimal-configuration ==0.1.4
   - minimorph ==0.3.0.0
   - minio-hs ==1.5.3
   - miniutter ==0.5.1.1
+  - min-max-pqueue ==0.1.0.2
   - mintty ==0.1.2
   - missing-foreign ==0.1.1
   - MissingH ==1.4.3.0
@@ -1518,36 +1519,36 @@ default-package-overrides:
   - monad-control-aligned ==0.0.1.1
   - monad-coroutine ==0.9.0.4
   - monad-extras ==0.6.0
+  - monadic-arrays ==0.2.2
   - monad-journal ==0.8.1
-  - monad-logger ==0.3.35
+  - monadlist ==0.0.2
+  - monad-logger ==0.3.36
   - monad-logger-json ==0.1.0.0
   - monad-logger-prefix ==0.1.11
   - monad-loops ==0.4.3
   - monad-memo ==0.5.3
   - monad-metrics ==0.2.1.4
   - monad-par ==0.3.5
-  - monad-par-extras ==0.3.3
   - monad-parallel ==0.7.2.3
+  - monad-par-extras ==0.3.3
   - monad-peel ==0.2.1.2
   - monad-primitive ==0.1
   - monad-products ==4.0.1
+  - MonadPrompt ==1.0.0.5
+  - MonadRandom ==0.5.2
   - monad-resumption ==0.1.4.0
   - monad-skeleton ==0.1.5
   - monad-st ==0.2.4.1
+  - monads-tf ==0.1.0.3
   - monad-time ==0.3.1.0
   - monad-unlift ==0.2.0
   - monad-unlift-ref ==0.2.1
-  - monadic-arrays ==0.2.2
-  - monadlist ==0.0.2
-  - MonadPrompt ==1.0.0.5
-  - MonadRandom ==0.5.2
-  - monads-tf ==0.1.0.3
   - mongoDB ==2.7.0.0
+  - monoid-subclasses ==1.0.1
+  - monoid-transformer ==0.0.4
   - mono-traversable ==1.0.15.1
   - mono-traversable-instances ==0.1.1.0
   - mono-traversable-keys ==0.1.0
-  - monoid-subclasses ==1.0.1
-  - monoid-transformer ==0.0.4
   - more-containers ==0.2.2.0
   - morpheus-graphql ==0.16.0
   - morpheus-graphql-client ==0.16.0
@@ -1560,14 +1561,14 @@ default-package-overrides:
   - mpi-hs-cereal ==0.1.0.0
   - mtl-compat ==0.2.2
   - mtl-prelude ==2.0.3.1
-  - multi-containers ==0.1.1
   - multiarg ==0.30.0.10
+  - multi-containers ==0.1.1
   - multimap ==1.2.1
   - multipart ==0.2.1
   - multiset ==0.3.4.3
   - multistate ==0.8.0.3
-  - murmur-hash ==0.1.0.9
   - murmur3 ==1.0.4
+  - murmur-hash ==0.1.0.9
   - MusicBrainz ==0.4.1
   - mustache ==2.3.1
   - mutable-containers ==0.3.4
@@ -1615,16 +1616,16 @@ default-package-overrides:
   - nicify-lib ==1.0.1
   - NineP ==0.0.2.1
   - nix-paths ==1.0.1
-  - no-value ==1.0.0.0
-  - non-empty ==0.3.2
-  - non-empty-sequence ==0.2.0.4
-  - non-negative ==0.1.2
   - nonce ==1.0.7
   - nondeterminism ==1.4
+  - non-empty ==0.3.2
   - nonempty-containers ==0.3.4.1
-  - nonempty-vector ==0.2.1.0
   - nonemptymap ==0.0.6.0
+  - non-empty-sequence ==0.2.0.4
+  - nonempty-vector ==0.2.1.0
+  - non-negative ==0.1.2
   - not-gloss ==0.7.7.0
+  - no-value ==1.0.0.0
   - nowdoc ==0.1.1.0
   - nqe ==0.6.3
   - nri-env-parser ==0.1.0.2
@@ -1640,9 +1641,9 @@ default-package-overrides:
   - nvim-hs ==2.1.0.4
   - nvim-hs-contrib ==2.0.0.0
   - nvim-hs-ghcid ==2.0.0.0
-  - o-clock ==1.2.0
   - oauthenticated ==0.2.1.0
   - ObjectName ==1.1.0.1
+  - o-clock ==1.2.0
   - odbc ==0.2.2
   - oeis2 ==1.0.4
   - ofx ==0.4.4.0
@@ -1655,9 +1656,9 @@ default-package-overrides:
   - Only ==0.1
   - oo-prototypes ==0.1.0.0
   - opaleye ==0.7.1.0
-  - open-browser ==0.2.1.0
   - OpenAL ==1.7.0.5
   - openapi3 ==3.0.0.1
+  - open-browser ==0.2.1.0
   - openexr-write ==0.1.0.2
   - OpenGL ==3.0.3.0
   - OpenGLRaw ==3.3.4.0
@@ -1736,15 +1737,15 @@ default-package-overrides:
   - persistent ==2.10.5.3
   - persistent-documentation ==0.1.0.2
   - persistent-mysql ==2.10.2.3
-  - persistent-pagination ==0.1.1.1
+  - persistent-pagination ==0.1.1.2
   - persistent-postgresql ==2.10.1.2
-  - persistent-qq ==2.9.2
+  - persistent-qq ==2.9.2.1
   - persistent-sqlite ==2.10.6.2
   - persistent-template ==2.8.2.3
   - persistent-typed-db ==0.1.0.1
   - pg-harness-client ==0.6.0
-  - pg-transact ==0.3.1.1
   - pgp-wordlist ==0.1.0.3
+  - pg-transact ==0.3.1.1
   - phantom-state ==0.2.1.2
   - pid1 ==0.1.2.0
   - pipes ==4.3.14
@@ -1782,36 +1783,36 @@ default-package-overrides:
   - port-utils ==0.2.1.0
   - posix-paths ==0.2.1.6
   - possibly ==1.0.0.0
-  - post-mess-age ==0.2.1.0
   - postgres-options ==0.2.0.0
-  - postgresql-binary ==0.12.3.1
+  - postgresql-binary ==0.12.3.3
   - postgresql-libpq ==0.9.4.3
   - postgresql-libpq-notify ==0.2.0.0
   - postgresql-orm ==0.5.1
   - postgresql-simple ==0.6.3
   - postgresql-typed ==0.6.1.2
   - postgrest ==7.0.1
+  - post-mess-age ==0.2.1.0
   - pptable ==0.3.0.0
   - pqueue ==1.4.1.3
   - prairie ==0.0.1.0
   - prefix-units ==0.2.0
   - prelude-compat ==0.0.0.2
   - prelude-safeenum ==0.1.1.2
+  - prettyclass ==1.0.0.0
   - pretty-class ==1.0.1.1
   - pretty-diff ==0.2.0.3
   - pretty-hex ==1.1
-  - pretty-relative-time ==0.2.0.0
-  - pretty-show ==1.10
-  - pretty-simple ==3.3.0.0
-  - pretty-sop ==0.2.0.3
-  - pretty-terminal ==0.1.0.0
-  - prettyclass ==1.0.0.0
   - prettyprinter ==1.6.2
   - prettyprinter-ansi-terminal ==1.1.2
   - prettyprinter-compat-annotated-wl-pprint ==1
   - prettyprinter-compat-ansi-wl-pprint ==1.0.1
   - prettyprinter-compat-wl-pprint ==1.0.0.1
   - prettyprinter-convert-ansi-wl-pprint ==1.1.1
+  - pretty-relative-time ==0.2.0.0
+  - pretty-show ==1.10
+  - pretty-simple ==3.3.0.0
+  - pretty-sop ==0.2.0.3
+  - pretty-terminal ==0.1.0.0
   - primes ==0.2.1.0
   - primitive ==0.7.1.0
   - primitive-addr ==0.1.0.2
@@ -1825,21 +1826,14 @@ default-package-overrides:
   - product-profunctors ==0.11.0.1
   - profiterole ==0.1
   - profunctors ==5.5.2
-  - project-template ==0.2.1.0
   - projectroot ==0.2.0.1
+  - project-template ==0.2.1.0
   - prometheus ==2.2.2
   - prometheus-client ==1.0.1
   - prometheus-wai-middleware ==1.0.1.0
   - promises ==0.3
   - prompt ==0.1.1.2
   - prospect ==0.1.0.0
-  - proto-lens ==0.7.0.0
-  - proto-lens-arbitrary ==0.1.2.9
-  - proto-lens-optparse ==0.1.1.7
-  - proto-lens-protobuf-types ==0.7.0.0
-  - proto-lens-protoc ==0.7.0.0
-  - proto-lens-runtime ==0.7.0.0
-  - proto-lens-setup ==0.4.0.4
   - proto3-wire ==1.1.0
   - protobuf ==0.2.1.3
   - protobuf-simple ==0.1.1.0
@@ -1847,6 +1841,13 @@ default-package-overrides:
   - protocol-buffers-descriptor ==2.4.17
   - protocol-radius ==0.0.1.1
   - protocol-radius-test ==0.1.0.1
+  - proto-lens ==0.7.0.0
+  - proto-lens-arbitrary ==0.1.2.9
+  - proto-lens-optparse ==0.1.1.7
+  - proto-lens-protobuf-types ==0.7.0.0
+  - proto-lens-protoc ==0.7.0.0
+  - proto-lens-runtime ==0.7.0.0
+  - proto-lens-setup ==0.4.0.4
   - protolude ==0.3.0
   - proxied ==0.3.1
   - psqueues ==0.2.7.2
@@ -1892,38 +1893,37 @@ default-package-overrides:
   - random-source ==0.3.0.8
   - random-tree ==0.6.0.5
   - range ==0.3.0.2
-  - range-set-list ==0.1.3.1
   - Ranged-sets ==0.4.0
+  - range-set-list ==0.1.3.1
   - rank1dynamic ==0.4.1
   - rank2classes ==1.4.1
   - Rasterific ==0.7.5.3
   - rasterific-svg ==0.3.3.2
-  - rate-limit ==1.4.2
   - ratel ==1.0.12
+  - rate-limit ==1.4.2
   - ratel-wai ==1.1.3
   - rattle ==0.2
-  - raw-strings-qq ==1.1
   - rawfilepath ==0.2.4
   - rawstring-qm ==0.2.3.0
+  - raw-strings-qq ==1.1
   - rcu ==0.2.4
   - rdf ==0.1.0.4
   - rdtsc ==1.3.0.1
   - re2 ==0.3
+  - readable ==0.3.1
   - read-editor ==0.1.0.2
   - read-env-var ==1.0.0.0
-  - readable ==0.3.1
   - reanimate ==1.1.2.1
   - reanimate-svg ==0.13.0.0
   - rebase ==1.6.1
   - record-dot-preprocessor ==0.2.7
   - record-hasfield ==1.0
-  - record-wrangler ==0.1.1.0
   - records-sop ==0.1.0.3
+  - record-wrangler ==0.1.1.0
   - recursion-schemes ==5.2.1
   - reducers ==3.12.3
-  - ref-fd ==0.4.0.2
-  - ref-tf ==0.4.0.2
   - refact ==0.3.0.2
+  - ref-fd ==0.4.0.2
   - refined ==0.6.1
   - reflection ==2.1.6
   - reform ==0.2.7.4
@@ -1931,6 +1931,7 @@ default-package-overrides:
   - reform-hamlet ==0.0.5.3
   - reform-happstack ==0.2.5.4
   - RefSerialize ==0.4.0
+  - ref-tf ==0.4.0.2
   - regex ==1.1.0.0
   - regex-applicative ==0.3.4
   - regex-applicative-text ==0.1.0.1
@@ -1955,13 +1956,14 @@ default-package-overrides:
   - replace-attoparsec ==1.4.2.0
   - replace-megaparsec ==1.4.3.0
   - repline ==0.4.0.0
-  - req ==3.7.0
+  - req ==3.8.0
   - req-conduit ==1.0.0
   - rerebase ==1.6.1
   - resistor-cube ==0.0.1.2
   - resolv ==0.1.2.0
   - resource-pool ==0.2.3.2
   - resourcet ==1.2.4.2
+  - resourcet-pool ==0.1.0.0
   - result ==0.2.6.0
   - rethinkdb-client-driver ==0.0.25
   - retry ==0.8.1.2
@@ -1987,15 +1989,15 @@ default-package-overrides:
   - runmemo ==1.0.0.1
   - rvar ==0.2.0.6
   - safe ==0.3.19
+  - safecopy ==0.10.3
   - safe-decimal ==0.2.0.0
   - safe-exceptions ==0.1.7.1
   - safe-foldable ==0.1.0.0
+  - safeio ==0.0.5.0
   - safe-json ==1.1.1
   - safe-money ==0.9
-  - safe-tensor ==0.2.1.0
-  - safecopy ==0.10.3
-  - safeio ==0.0.5.0
   - SafeSemaphore ==0.10.1
+  - safe-tensor ==0.2.1.0
   - salak ==0.3.6
   - salak-yaml ==0.3.5.3
   - saltine ==0.1.1.0
@@ -2033,8 +2035,8 @@ default-package-overrides:
   - semigroupoid-extras ==5
   - semigroupoids ==5.3.4
   - semigroups ==0.19.1
-  - semiring-simple ==1.0.0.1
   - semirings ==0.5.4
+  - semiring-simple ==1.0.0.1
   - semver ==0.4.0.1
   - sendfile ==0.7.11.1
   - seqalign ==0.2.0.4
@@ -2051,18 +2053,20 @@ default-package-overrides:
   - servant-conduit ==0.15.1
   - servant-docs ==0.11.8
   - servant-errors ==0.1.6.0
+  - servant-exceptions ==0.2.1
+  - servant-exceptions-server ==0.2.1
   - servant-foreign ==0.15.3
   - servant-github-webhook ==0.4.2.0
   - servant-http-streams ==0.18.2
   - servant-machines ==0.15.1
   - servant-multipart ==0.12
-  - servant-openapi3 ==2.0.1.0
+  - servant-openapi3 ==2.0.1.1
   - servant-pipes ==0.15.2
   - servant-rawm ==1.0.0.0
   - servant-server ==0.18.2
   - servant-swagger ==1.1.10
-  - servant-swagger-ui ==0.3.4.3.36.1
-  - servant-swagger-ui-core ==0.3.3
+  - servant-swagger-ui ==0.3.4.3.37.2
+  - servant-swagger-ui-core ==0.3.4
   - serverless-haskell ==0.12.4
   - serversession ==1.0.1
   - serversession-frontend-wai ==1.0
@@ -2078,9 +2082,9 @@ default-package-overrides:
   - shared-memory ==0.2.0.0
   - shell-conduit ==5.0.0
   - shell-escape ==0.2.0
-  - shell-utility ==0.1
   - shellmet ==0.0.3.1
   - shelltestrunner ==1.9
+  - shell-utility ==0.1
   - shelly ==1.9.0
   - shikensu ==0.3.11
   - should-not-typecheck ==2.1.0
@@ -2109,8 +2113,8 @@ default-package-overrides:
   - skein ==1.0.9.4
   - skews ==0.1.0.3
   - skip-var ==0.1.1.0
-  - skylighting ==0.10.0.3
-  - skylighting-core ==0.10.0.3
+  - skylighting ==0.10.1
+  - skylighting-core ==0.10.1
   - slack-api ==0.12
   - slack-progressbar ==0.1.0.1
   - slist ==0.1.1.0
@@ -2150,16 +2154,16 @@ default-package-overrides:
   - splitmix ==0.0.5
   - spoon ==0.3.1
   - spreadsheet ==0.1.3.8
-  - sql-words ==0.1.6.4
   - sqlcli ==0.2.2.0
   - sqlcli-odbc ==0.2.0.1
   - sqlite-simple ==0.4.18.0
+  - sql-words ==0.1.6.4
   - squeal-postgresql ==0.7.0.1
   - squeather ==0.4.0.0
   - srcloc ==0.5.1.2
   - stache ==2.2.0
-  - stack-templatizer ==0.1.0.2
   - stackcollapse-ghc ==0.0.1.3
+  - stack-templatizer ==0.1.0.2
   - stateref ==0.3
   - StateVar ==1.2
   - static-text ==0.2.0.6
@@ -2174,16 +2178,16 @@ default-package-overrides:
   - stm-extras ==0.1.0.3
   - stm-hamt ==1.2.0.4
   - stm-lifted ==2.5.0.0
-  - stm-split ==0.0.2.1
   - STMonadTrans ==0.4.4
+  - stm-split ==0.0.2.1
   - stopwatch ==0.1.0.6
   - storable-complex ==0.2.3.0
   - storable-endian ==0.2.6
   - storable-record ==0.0.5
   - storable-tuple ==0.0.3.3
   - storablevector ==0.2.13.1
-  - store ==0.7.7
-  - store-core ==0.4.4.3
+  - store ==0.7.8
+  - store-core ==0.4.4.4
   - store-streaming ==0.2.0.3
   - stratosphere ==0.59.1
   - streaming ==0.2.3.0
@@ -2196,6 +2200,7 @@ default-package-overrides:
   - strict-list ==0.1.5
   - strict-tuple ==0.1.4
   - strict-tuple-lens ==0.1.0.1
+  - stringbuilder ==0.5.1
   - string-class ==0.1.7.0
   - string-combinators ==0.6.0.5
   - string-conv ==0.1.2
@@ -2203,9 +2208,8 @@ default-package-overrides:
   - string-interpolate ==0.3.0.2
   - string-qq ==0.0.4
   - string-random ==0.1.3.0
-  - string-transform ==1.1.1
-  - stringbuilder ==0.5.1
   - stringsearch ==0.3.6.6
+  - string-transform ==1.1.1
   - stripe-concepts ==1.0.2.4
   - stripe-core ==2.6.2
   - stripe-haskell ==2.6.2
@@ -2230,10 +2234,10 @@ default-package-overrides:
   - symmetry-operations-symbols ==0.0.2.1
   - sysinfo ==0.1.1
   - system-argv0 ==0.1.1
+  - systemd ==2.3.0
   - system-fileio ==0.3.16.4
   - system-filepath ==0.4.14
   - system-info ==0.5.1
-  - systemd ==2.3.0
   - tabular ==0.2.2.8
   - tagchup ==0.4.1.1
   - tagged ==0.8.6
@@ -2256,6 +2260,7 @@ default-package-overrides:
   - tasty-hedgehog ==1.0.0.2
   - tasty-hspec ==1.1.6
   - tasty-hunit ==0.10.0.2
+  - tasty-hunit-compat ==0.2
   - tasty-kat ==0.0.3
   - tasty-leancheck ==0.0.1
   - tasty-lua ==0.2.3.1
@@ -2296,6 +2301,7 @@ default-package-overrides:
   - text-icu ==0.7.0.1
   - text-latin1 ==0.3.1
   - text-ldap ==0.1.1.13
+  - textlocal ==0.1.0.5
   - text-manipulate ==0.2.0.1
   - text-metrics ==0.3.0
   - text-postgresql ==0.0.3.1
@@ -2306,9 +2312,8 @@ default-package-overrides:
   - text-show ==3.9
   - text-show-instances ==3.8.4
   - text-zipper ==0.10.1
-  - textlocal ==0.1.0.5
-  - tf-random ==0.5
   - tfp ==1.0.1.1
+  - tf-random ==0.5
   - th-abstraction ==0.4.0.0
   - th-bang-compat ==0.0.1.0
   - th-compat ==0.1
@@ -2316,6 +2321,10 @@ default-package-overrides:
   - th-data-compat ==0.1.0.0
   - th-desugar ==1.11
   - th-env ==0.1.0.2
+  - these ==1.1.1.1
+  - these-lens ==1.0.1.1
+  - these-optics ==1.0.1.1
+  - these-skinny ==0.7.4
   - th-expand-syns ==0.4.6.0
   - th-extras ==0.0.0.4
   - th-lift ==0.8.2
@@ -2323,37 +2332,33 @@ default-package-overrides:
   - th-nowq ==0.1.0.5
   - th-orphans ==0.13.11
   - th-printf ==0.7
-  - th-reify-compat ==0.0.1.5
-  - th-reify-many ==0.1.9
-  - th-strict-compat ==0.1.0.1
-  - th-test-utils ==1.1.0
-  - th-utilities ==0.2.4.0
-  - these ==1.1.1.1
-  - these-lens ==1.0.1.1
-  - these-optics ==1.0.1.1
-  - these-skinny ==0.7.4
   - thread-hierarchy ==0.3.0.2
   - thread-local-storage ==0.2
-  - thread-supervisor ==0.2.0.0
   - threads ==0.5.1.6
+  - thread-supervisor ==0.2.0.0
   - threepenny-gui ==0.9.0.0
+  - th-reify-compat ==0.0.1.5
+  - th-reify-many ==0.1.9
   - throttle-io-stream ==0.2.0.1
   - through-text ==0.1.0.0
   - throwable-exceptions ==0.1.0.9
+  - th-strict-compat ==0.1.0.1
+  - th-test-utils ==1.1.0
+  - th-utilities ==0.2.4.1
   - thyme ==0.3.5.5
   - tidal ==1.6.1
   - tile ==0.3.0.0
   - time-compat ==1.9.4
+  - timeit ==2.0
+  - timelens ==0.2.0.2
   - time-lens ==0.4.0.2
   - time-locale-compat ==0.1.1.5
   - time-locale-vietnamese ==1.0.0.0
   - time-manager ==0.0.0
   - time-parsers ==0.1.2.1
-  - time-units ==1.0.0
-  - timeit ==2.0
-  - timelens ==0.2.0.2
-  - timer-wheel ==0.3.0
   - timerep ==2.0.1.0
+  - timer-wheel ==0.3.0
+  - time-units ==1.0.0
   - timezone-olson ==0.2.0
   - timezone-series ==0.1.9
   - tinylog ==0.15.0
@@ -2388,10 +2393,13 @@ default-package-overrides:
   - ttl-hashtables ==1.4.1.0
   - ttrie ==0.1.2.1
   - tuple ==0.3.0.2
+  - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
-  - tuples-homogenous-h98 ==0.1.1.0
   - turtle ==1.5.20
+  - TypeCompose ==0.9.14
+  - typed-process ==0.2.6.0
+  - typed-uuid ==0.0.0.2
   - type-equality ==1
   - type-errors ==0.2.0.0
   - type-errors-pretty ==0.0.1.1
@@ -2405,17 +2413,14 @@ default-package-overrides:
   - type-of-html ==1.6.1.2
   - type-of-html-static ==0.1.0.2
   - type-operators ==0.2.0.0
-  - type-spec ==0.4.0.0
-  - TypeCompose ==0.9.14
-  - typed-process ==0.2.6.0
-  - typed-uuid ==0.0.0.2
   - typerep-map ==0.3.3.0
+  - type-spec ==0.4.0.0
   - tzdata ==0.2.20201021.0
   - ua-parser ==0.7.5.1
   - uglymemo ==0.1.0.1
   - ulid ==0.3.0.0
   - unagi-chan ==0.4.1.3
-  - unbounded-delays ==0.1.1.0
+  - unbounded-delays ==0.1.1.1
   - unboxed-ref ==0.4.0.0
   - unboxing-vector ==0.2.0.0
   - uncaught-exception ==0.1.0
@@ -2511,7 +2516,7 @@ default-package-overrides:
   - wai-cors ==0.2.7
   - wai-enforce-https ==0.0.2.1
   - wai-eventsource ==3.0.0
-  - wai-extra ==3.1.2
+  - wai-extra ==3.1.3
   - wai-feature-flags ==0.1.0.1
   - wai-handler-launch ==3.0.3.1
   - wai-logger ==2.3.6
@@ -2547,18 +2552,18 @@ default-package-overrides:
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
   - witch ==0.0.0.3
-  - with-location ==0.1.0
-  - with-utf8 ==1.0.2.1
   - witherable-class ==0
   - within ==0.2.0.1
+  - with-location ==0.1.0
+  - with-utf8 ==1.0.2.1
   - wizards ==1.0.3
   - wl-pprint-annotated ==0.1.0.1
   - wl-pprint-console ==0.1.0.2
   - wl-pprint-text ==1.2.0.1
-  - word-trie ==0.3.0
-  - word-wrap ==0.4.1
   - word24 ==2.0.1
   - word8 ==0.1.3
+  - word-trie ==0.3.0
+  - word-wrap ==0.4.1
   - world-peace ==1.0.2.0
   - wrap ==0.0.0
   - wreq ==0.5.3.2
@@ -2586,6 +2591,7 @@ default-package-overrides:
   - xml-basic ==0.1.3.1
   - xml-conduit ==1.9.0.0
   - xml-conduit-writer ==0.1.1.2
+  - xmlgen ==0.6.2.2
   - xml-hamlet ==0.5.0.1
   - xml-helpers ==1.0.0
   - xml-indexed-cursor ==0.1.1.0
@@ -2594,7 +2600,6 @@ default-package-overrides:
   - xml-to-json ==2.0.1
   - xml-to-json-fast ==2.0.0
   - xml-types ==0.3.8
-  - xmlgen ==0.6.2.2
   - xmonad ==0.15
   - xmonad-contrib ==0.16
   - xmonad-extras ==0.15.2
@@ -2602,7 +2607,6 @@ default-package-overrides:
   - xxhash-ffi ==0.2.0.0
   - yaml ==0.11.5.0
   - yamlparse-applicative ==0.1.0.2
-  - yes-precure5-command ==5.5.3
   - yesod ==1.6.1.0
   - yesod-auth ==1.6.10.1
   - yesod-auth-hashdb ==1.7.1.5
@@ -2615,8 +2619,9 @@ default-package-overrides:
   - yesod-persistent ==1.6.0.5
   - yesod-sitemap ==1.6.0
   - yesod-static ==1.6.1.0
-  - yesod-test ==1.6.10
+  - yesod-test ==1.6.11
   - yesod-websockets ==0.3.0.2
+  - yes-precure5-command ==5.5.3
   - yi-rope ==0.11
   - yjsvg ==0.2.0.1
   - yjtools ==0.9.18
@@ -2631,9 +2636,9 @@ default-package-overrides:
   - zio ==0.1.0.2
   - zip ==1.6.0
   - zip-archive ==0.4.1
-  - zip-stream ==0.2.0.1
   - zipper-extra ==0.1.3.2
   - zippers ==0.3
+  - zip-stream ==0.2.0.1
   - zlib ==0.6.2.2
   - zlib-bindings ==0.1.1.5
   - zlib-lens ==0.1.2.1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4887,7 +4887,6 @@ broken-packages:
   - EnumContainers
   - enumerate
   - enumerate-function
-  - enumeration
   - enumerator
   - enumerator-fd
   - enumerator-tf

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9067,7 +9067,6 @@ broken-packages:
   - qtah-generator
   - qtah-qt5
   - QuadEdge
-  - quadratic-irrational
   - QuadTree
   - quantfin
   - quantification

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3199,7 +3199,6 @@ broken-packages:
   - arion
   - arith-encode
   - arithmetic-circuits
-  - arithmoi
   - armada
   - armor
   - arpa

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6015,7 +6015,6 @@ broken-packages:
   - haskell-type-exts
   - haskell-typescript
   - haskell-tyrant
-  - haskell-xmpp
   - haskell2010
   - haskell2020
   - haskell98

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3197,7 +3197,6 @@ broken-packages:
   - arguedit
   - ariadne
   - arion
-  - arith-encode
   - arithmetic-circuits
   - armada
   - armor

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3795,7 +3795,6 @@ broken-packages:
   - canteven-log
   - canteven-parsedate
   - cantor
-  - cantor-pairing
   - cao
   - cap
   - Capabilities

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6251,7 +6251,6 @@ broken-packages:
   - heterolist
   - hetris
   - heukarya
-  - hevm
   - hevolisa
   - hevolisa-dph
   - hex-text

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -830,4 +830,7 @@ self: super: builtins.intersectAttrs super {
       export HOME=$TMPDIR
     '';
   });
+
+  # tests depend on a specific version of solc
+  hevm = dontCheck (doJailbreak super.hevm);
 }

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -7,9 +7,6 @@
 # files.
 self: super: {
 
-  multi-ghc-travis = throw ("haskellPackages.multi-ghc-travis has been renamed"
-    + " to haskell-ci, which is now on hackage");
-
   dconf2nix = self.callPackage ../tools/haskell/dconf2nix/dconf2nix.nix { };
 
   # https://github.com/channable/vaultenv/issues/1


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-12-04 20:00 +01:00. You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.