### PR TITLE
pass: add find and grep as dependencies

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, pkgs, fetchurl, buildEnv
-, coreutils, gnused, getopt, git, tree, gnupg, openssl, which, procps
-, qrencode , makeWrapper, pass, symlinkJoin
+, coreutils, findutils, gnugrep, gnused, getopt, git, tree, gnupg, openssl
+, which, procps , qrencode , makeWrapper, pass, symlinkJoin
 
 , xclip ? null, xdotool ? null, dmenu ? null
 , x11Support ? !stdenv.isDarwin , dmenuSupport ? x11Support
@@ -80,8 +80,10 @@ stdenv.mkDerivation rec {
 
   wrapperPath = with stdenv.lib; makeBinPath ([
     coreutils
+    findutils
     getopt
     git
+    gnugrep
     gnupg
     gnused
     tree


### PR DESCRIPTION
When pass is called from passff it does not have grep and find in its
path.

PATH="" /home/beardhatcode/.nix-profile/bin/pass grep lol                                             ~
/nix/store/HASH-password-store-1.7.3/bin/.pass-wrapped: line 399: find: command not found

$ PATH="/nix/store/HASH-findutils-4.7.0/bin" /home/beardhatcode/.nix-profile/bin/pass grep lol
/nix/store/HASH-password-store-1.7.3/bin/.pass-wrapped: line 403: grep: command not found
/nix/store/HASH-password-store-1.7.3/bin/.pass-wrapped: line 403: grep: command not found

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

PassFF did not work properly 

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (10 packages built, see bottom)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<details>
<summary>`nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` output</summary>
<pre>
$ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"     ~/Documents/nixpkgs/pkgs/tools/security/pass
these paths will be fetched (2.73 MiB download, 12.96 MiB unpacked):
  /nix/store/1jcc4z7w736sg6va7vxp0aj4z6jicp4d-nixpkgs-review-2.5.0
  /nix/store/6bxr4dvrkl91kdq5p4yphhka9xwid84z-nix-2.4pre20201201_5a6ddb3
  /nix/store/lssm44v6r2b2zr0xsp13qzk2mgl1ibpl-nlohmann_json-3.7.3
  /nix/store/pa9wjfmfv6dchj6kij20vwkv6rpz4b29-nix-2.4pre20201201_5a6ddb3-man
copying path '/nix/store/pa9wjfmfv6dchj6kij20vwkv6rpz4b29-nix-2.4pre20201201_5a6ddb3-man' from 'https://cache.nixos.org'...
copying path '/nix/store/lssm44v6r2b2zr0xsp13qzk2mgl1ibpl-nlohmann_json-3.7.3' from 'https://cache.nixos.org'...
copying path '/nix/store/6bxr4dvrkl91kdq5p4yphhka9xwid84z-nix-2.4pre20201201_5a6ddb3' from 'https://cache.nixos.org'...
copying path '/nix/store/1jcc4z7w736sg6va7vxp0aj4z6jicp4d-nixpkgs-review-2.5.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 62, done.
remote: Counting objects: 100% (43/43), done.
remote: Compressing objects: 100% (13/13), done.
remote: Total 26 (delta 17), reused 17 (delta 11), pack-reused 0
Unpacking objects: 100% (26/26), 5.00 KiB | 243.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   5d30b8ad31f..263ddd73cd4  master     -> refs/nixpkgs-review/0
$ git worktree add /home/beardhatcode/.cache/nixpkgs-review/rev-a2cc15a0f4e04a66e6d2b941b0697548c4569a83-dirty/nixpkgs 263ddd73cd48820feba9a097311cbbf7424644ae
Preparing worktree (detached HEAD 263ddd73cd4)
Updating files: 100% (23415/23415), done.
HEAD is now at 263ddd73cd4 pythonPackages.class-registry: Add typing propagatedBuildInput when using python2
$ nix-env -f /home/beardhatcode/.cache/nixpkgs-review/rev-a2cc15a0f4e04a66e6d2b941b0697548c4569a83-dirty/nixpkgs -qaP --xml --out-path --show-trace
Applying `nixpkgs` diff...
$ nix-env -f /home/beardhatcode/.cache/nixpkgs-review/rev-a2cc15a0f4e04a66e6d2b941b0697548c4569a83-dirty/nixpkgs -qaP --xml --out-path --show-trace --meta
10 packages updated:
krunner-pass pass-audit pass-extensions-env pass-import passff-host password-store password-store password-store qtpass rofi-pass

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/beardhatcode/.cache/nixpkgs-review/rev-a2cc15a0f4e04a66e6d2b941b0697548c4569a83-dirty/build.nix
10 packages built:
krunner-pass pass pass-nodmenu pass-otp pass-wayland passExtensions.pass-audit passExtensions.pass-import passff-host qtpass rofi-pass

$ nix-shell /home/beardhatcode/.cache/nixpkgs-review/rev-a2cc15a0f4e04a66e6d2b941b0697548c4569a83-dirty/shell.nix
</pre>
</details>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>krunner-pass</li>
    <li>pass</li>
    <li>pass-nodmenu</li>
    <li>pass-otp</li>
    <li>pass-wayland</li>
    <li>passExtensions.pass-audit</li>
    <li>passExtensions.pass-import</li>
    <li>passff-host</li>
    <li>qtpass</li>
    <li>rofi-pass</li>
  </ul>
</details>