### PR TITLE
stlink: Correct comment about the use of services.udev.packages

### DIFF
--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -5,7 +5,7 @@ let
   libusb1' = if stdenv.isDarwin then libusb1.override { withStatic = true; } else libusb1;
 
 # IMPORTANT: You need permissions to access the stlink usb devices.
-# Add services.udev.pkgs = [ pkgs.stlink ] to your configuration.nix
+# Add services.udev.packages = [ pkgs.stlink ] to your configuration.nix
 
 in stdenv.mkDerivation rec {
   pname = "stlink";


### PR DESCRIPTION
services.udev.pkgs does not exists, but services.udev.packages does.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It's not possible to simply copy&paste the comment to configuration.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
