### PR TITLE
clucene_core*: Make multi output

### DIFF
--- a/pkgs/development/libraries/clucene-core/2.x.nix
+++ b/pkgs/development/libraries/clucene-core/2.x.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1arffdwivig88kkx685pldr784njm0249k0rb1f1plwavlrw9zfx";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost zlib ];

--- a/pkgs/development/libraries/clucene-core/default.nix
+++ b/pkgs/development/libraries/clucene-core/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "202ee45af747f18642ae0a088d7c4553521714a511a1a9ec99b8144cf9928317";
   };
 
+  outputs = [ "out" "dev" ];
+
   patches = [ ./gcc6.patch ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
This removes header files from the runtime closure of dependants.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
