### PR TITLE
snowmachine: init at 1.0.1

### DIFF
--- a/pkgs/applications/snowmachine/default.nix
+++ b/pkgs/applications/snowmachine/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage, lib, click, colorama, fetchPypi, setuptools-git }:
+
+buildPythonPackage rec {
+  pname = "snowmachine";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1v385hhxy2a8vx5p0fhn0di8l4qfpb0a86j6nwsg0aw6ngb09qf1";
+  };
+
+  buildInputs = [ setuptools-git ];
+  propagatedBuildInputs = [ click colorama ];
+
+  meta = with lib; {
+    description = "A python script that will make your terminal snow";
+    homepage = "http://github.com/sontek/snowmachine";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/applications/snowmachine/default.nix
+++ b/pkgs/applications/snowmachine/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ click colorama ];
 
   doCheck = false;
-  pythonImportsCheck = [ "click" "colorama" ];
+  pythonImportsCheck = [ "snowmachine" ];
 
   meta = with lib; {
     description = "A python script that will make your terminal snow";

--- a/pkgs/applications/snowmachine/default.nix
+++ b/pkgs/applications/snowmachine/default.nix
@@ -12,6 +12,9 @@ buildPythonPackage rec {
   buildInputs = [ setuptools-git ];
   propagatedBuildInputs = [ click colorama ];
 
+  doCheck = false;
+  pythonImportsCheck = [ "click" "colorama" ];
+
   meta = with lib; {
     description = "A python script that will make your terminal snow";
     homepage = "http://github.com/sontek/snowmachine";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28527,6 +28527,8 @@ in
 
   snowsql = callPackage ../applications/misc/snowsql {};
 
+  snowmachine = python3Packages.callPackage ../applications/snowmachine {};
+
   sidequest = callPackage ../applications/misc/sidequest {};
 
   maphosts = callPackage ../tools/networking/maphosts {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Getting into the winter spirit with some snowflakes!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

When looking for the license, I saw that it was created as BSD, but it didn't mention which BSD license:
```
$ rg 'BSD' -C 2 setup.py
21-    description=("A python script that will make your terminal "
22-                 "snow"),
23:    license = "BSD",
24-    setup_requires=['setuptools-git'],
25-    install_requires=requires,
--
34-        "Environment :: Console",
35-        "Environment :: Console :: Curses",
36:        "License :: OSI Approved :: BSD License",
37-    ],
38-    entry_points = {

```

I marked this as `unfree`. I'm opening an issue to ask the author to describe which BSD license to use.