### PR TITLE
ssh-copy-id: init at 8.4p1

### DIFF
--- a/pkgs/tools/networking/openssh/copyid.nix
+++ b/pkgs/tools/networking/openssh/copyid.nix
@@ -8,5 +8,5 @@ runCommandNoCC "ssh-copy-id-${openssh.version}" {
   };
 } ''
   install -Dm 755 {${openssh},$out}/bin/ssh-copy-id
-  installManPage ${openssh}/share/man/man1/ssh-copy-id.1.gz
+  install -Dm 644 {${openssh},$out}/share/man/man1/ssh-copy-id.1.gz
 ''

--- a/pkgs/tools/networking/openssh/copyid.nix
+++ b/pkgs/tools/networking/openssh/copyid.nix
@@ -1,0 +1,12 @@
+{ runCommandNoCC, installShellFiles, openssh }:
+
+runCommandNoCC "ssh-copy-id-${openssh.version}" {
+  nativeBuildInputs = [ installShellFiles ];
+  meta = openssh.meta // {
+    description = "A tool to copy SSH public keys to a remote machine";
+    priority = (openssh.meta.priority or 0) - 1;
+  };
+} ''
+  install -Dm 755 {${openssh},$out}/bin/ssh-copy-id
+  installManPage ${openssh}/share/man/man1/ssh-copy-id.1.gz
+''

--- a/pkgs/tools/networking/openssh/copyid.nix
+++ b/pkgs/tools/networking/openssh/copyid.nix
@@ -1,7 +1,6 @@
-{ runCommandNoCC, installShellFiles, openssh }:
+{ runCommandNoCC, openssh }:
 
 runCommandNoCC "ssh-copy-id-${openssh.version}" {
-  nativeBuildInputs = [ installShellFiles ];
   meta = openssh.meta // {
     description = "A tool to copy SSH public keys to a remote machine";
     priority = (openssh.meta.priority or 0) - 1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6919,6 +6919,8 @@ in
     withGssapiPatches = true;
   });
 
+  ssh-copy-id = callPackage ../tools/networking/openssh/copyid.nix { };
+
   opensp = callPackage ../tools/text/sgml/opensp { };
 
   opentracker = callPackage ../applications/networking/p2p/opentracker { };


### PR DESCRIPTION
Split the ssh-copy-id tool from the openssh package into a separate output. This mainly benefits macOS users because the version of openssh that is preintalled in macOS doesn't provide ssh-copy-id.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
