### PR TITLE
gcadapter-oc-kmod: init at 1.4

### DIFF
--- a/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
+++ b/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, kernel
+, kmod
+}:
+
+let
+  kerneldir = "lib/modules/${kernel.modDirVersion}";
+in stdenv.mkDerivation rec {
+  pname = "gcadapter-oc-kmod";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "HannesMann";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1nqhj3vqq9rnj37cnm2c4867mnxkr8di3i036shcz44h9qmy9d40";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KERNEL_SOURCE_DIR=${kernel.dev}/${kerneldir}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  installPhase = ''
+    install -D {,$out/${kerneldir}/extra/}gcadapter_oc.ko
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter";
+    homepage = "https://github.com/HannesMann/gcadapter-oc-kmod";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ r-burns ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18398,6 +18398,8 @@ in
 
     fwts-efi-runtime = callPackage ../os-specific/linux/fwts/module.nix { };
 
+    gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
+
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
     e1000e = if stdenv.lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;


### PR DESCRIPTION
This is a simple kernel module which "overclocks" the polling rate for certain GameCube-controller-to-USB adapters.

Tested locally using 4-port Mayflash adapter (requires https://github.com/NixOS/nixpkgs/pull/105749), was able to overclock adapter to 1kHz (up from default 125Hz) via

```nix
  boot.extraModulePackages = [
    pkgs.linuxPackages.gcadapter-oc-kmod
  ];
```
and `sudo modprobe gcadapter_oc`.

dmesg output:

```
[  117.494116] gcadapter_oc: Adapter connected
[  117.494119] gcadapter_oc: bInterval value of endpoint 0x81 set to 1.
[  117.494120] gcadapter_oc: bInterval value of endpoint 0x02 set to 1.
```

###### Motivation for this change

"Overclocking your GCC to USB Adapter"
https://docs.google.com/document/d/1cQ3pbKZm_yUtcLK9ZIXyPzVbTJkvnfxKIyvuFMwzWe0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
