### PR TITLE
gmqcc: init at unstable-2020-10-27

### DIFF
--- a/pkgs/development/compilers/gmqcc/default.nix
+++ b/pkgs/development/compilers/gmqcc/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "gmqcc";
+  version = "unstable-2020-10-27";
+
+  src = fetchFromGitHub {
+    owner = "graphitemaster";
+    repo = "gmqcc";
+    rev = "237722c0b2065f3abf32f479fffaf59105dff150";
+    sha256 = "0awmrj1s9j04vwzjv28jqdpwfzlazwkdllfg0hqj8bms5pjpqld1";
+  };
+
+  doCheck = true;
+
+  installPhase = ''
+    # Install Binaries
+    mkdir -pv $out/bin
+    cp -v {gmqcc,qcvm} $out/bin/
+
+    # Install man pages
+    mkdir -pv $out/share/man/man1
+    cp -v doc/{gmqcc,qcvm}.1 $out/share/man/man1/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://graphitemaster.github.io/gmqcc/index.html";
+    description = "An improved QuakeC compiler";
+    license = with licenses; [ mit ];
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ illiusdope ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2183,6 +2183,8 @@ in
 
   gdrive = callPackage ../applications/networking/gdrive { };
 
+  gmqcc = callPackage ../development/compilers/gmqcc { };
+
   go-chromecast = callPackage ../applications/video/go-chromecast { };
 
   go-rice = callPackage ../tools/misc/go.rice {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A modern QuakeC compiler.  I decided to put it in `development/compilers` rather than `games` because it's only a compiler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
