### PR TITLE
nixos:nixos-rebuild: allow switching to a specific generation number

### DIFF
--- a/nixos/doc/manual/administration/rollback.section.md
+++ b/nixos/doc/manual/administration/rollback.section.md
@@ -36,3 +36,28 @@ $ ls -l /nix/var/nix/profiles/system-*-link
 ...
 lrwxrwxrwx 1 root root 78 Aug 12 13:54 /nix/var/nix/profiles/system-268-link -> /nix/store/202b...-nixos-13.07pre4932_5a676e4-4be1055
 ```
+
+Third, you can switch to a specific configuration in a running system:
+```ShellSession
+# nixos-rebuild switch --generation N
+```
+
+This is equivalent to running:
+```ShellSession
+# /nix/var/nix/profiles/system-N-link/bin/switch-to-configuration switch
+```
+
+::: {.note}
+`nixos-rebuild-ng` does not support `--generation` yet. If
+`system.rebuild.enableNg` is set to `true` in your NixOS configuration, then
+you won’t be able to use `--generation`.
+:::
+
+To get a list of available generations, you can run
+```ShellSession
+$ nixos-rebuild list-generations
+Generation  Build-date           NixOS version           Kernel   Configuration Revision                    Specialisation
+3 current   2025-08-14 18:32:19  25.11.20250814.c0302e0  6.12.41  92ad34354fbe5df2cba094623cb027999b3c712f  *
+2           2025-08-14 18:29:46  25.11.20250814.c0302e0  6.12.41  098d5ec67e51391d6ea169e267b620839aa56b8e  *
+1           2025-08-14 18:22:18  25.11.20250814.c0302e0  6.12.41  7ee3edc32100cf7bb78030a24a146e802ccec7a7  *
+```

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -6,6 +6,8 @@
 
 - `nixos-rebuild-ng`, a full rewrite of `nixos-rebuild` in Python, is enabled by default from this release. You can disable it by setting [](#opt-system.rebuild.enableNg) to `false` in your configuration if you need, but please report any issues. It is expected that the next major version of NixOS (26.05) will remove the {option}`system.rebuild.enableNg` option.
 
+- The `nixos-rebuild switch` command can now roll back to a specific `--generation <number>`. See `man nixos-rebuild` for more details.
+
 - Secure boot support can now be enabled for the Limine bootloader through {option}`boot.loader.limine.secureBoot.enable`. Bootloader install script signs the bootloader, then kernels are hashed during system rebuild and written to a config. This allows Limine to boot only the kernels installed through NixOS system.
 
 - The default PostgreSQL version for new NixOS installations (i.e. with `system.stateVersion >= 25.11`) is v17.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1057,6 +1057,7 @@ in
     imports = [ ./nixos-rebuild-specialisations.nix ];
     _module.args.withNg = true;
   };
+  nixos-rebuild-switch = runTest ./nixos-rebuild-switch;
   nixos-rebuild-target-host = runTest {
     imports = [ ./nixos-rebuild-target-host.nix ];
     _module.args.withNg = false;

--- a/nixos/tests/nixos-rebuild-switch/configuration-to-switch-to.nix
+++ b/nixos/tests/nixos-rebuild-switch/configuration-to-switch-to.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  modulesPath,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ./hardware-configuration.nix
+    "${modulesPath}/testing/test-instrumentation.nix"
+  ];
+
+  system.rebuild.enableNg = false;
+
+  boot.loader.grub = {
+    enable = true;
+    device = "/dev/vda";
+    forceInstall = true;
+  };
+
+  documentation.enable = false;
+
+  environment.systemPackages = [
+    # make a different config, so that the nixos-rebuild has something to do
+    (pkgs.writeShellScriptBin "iAmGeneration" ''
+      echo -n ${lib.strings.escapeShellArg (lib.trivial.readFile ./generation.txt)}
+    '')
+    # for list-generations parsing
+    pkgs.jq
+  ];
+}

--- a/nixos/tests/nixos-rebuild-switch/default.nix
+++ b/nixos/tests/nixos-rebuild-switch/default.nix
@@ -1,0 +1,98 @@
+{
+  name = "nixos-rebuild-switch";
+
+  nodes = {
+    machine =
+      let
+        configFile = ./configuration-to-switch-to.nix;
+      in
+      { modulesPath, ... }:
+      {
+        imports = [
+          "${modulesPath}/installer/cd-dvd/channel.nix"
+        ];
+
+        system.includeBuildDependencies = true;
+
+        system.rebuild.enableNg = false;
+
+        virtualisation = {
+          cores = 2;
+          memorySize = 2048;
+        };
+
+        # Normally, nixos-rebuild will try to download any missing dependencies
+        # from the Internet. Normally, NixOS tests can’t access the Internet.
+        # This next part ensures that all the dependencies for building the
+        # configurations that we’ll be switching to are already in the VM’s Nix
+        # store so that the VM won’t need to access the Internet.
+        specialisation.configurationToSwitchTo.configuration.imports = [ configFile ];
+
+        environment.etc."configuration-to-switch-to.nix".source = configFile;
+      };
+  };
+
+  testScript = ''
+    from shlex import quote
+
+
+    def create_generation_txt(gen):
+        machine.succeed(f"echo {quote(gen)} > /etc/nixos/generation.txt")
+
+
+    def test_for_boot_generation(gen):
+        machine.succeed(f"""[ "$(nixos-rebuild list-generations --json | jq 'map(select(.current))[0].generation')" -eq {quote(gen)} ]""")
+
+
+    def test_for_active_generation(gen):
+        machine.succeed(f'[ "$(iAmGeneration)" -eq {quote(gen)} ]')
+
+
+    machine.start()
+    machine.succeed("nixos-generate-config")
+    machine.succeed("cp /etc/configuration-to-switch-to.nix /etc/nixos/configuration.nix")
+
+    with subtest("Does not have a system profile initially"):
+        machine.fail("nixos-rebuild list-generations");
+
+    with subtest("Create generation 1"):
+        create_generation_txt("1")
+        machine.succeed("nixos-rebuild switch")
+        test_for_boot_generation("1")
+        test_for_active_generation("1")
+
+    with subtest("Create generation 2"):
+        create_generation_txt("2")
+        machine.succeed("nixos-rebuild switch")
+        test_for_boot_generation("2")
+        test_for_active_generation("2")
+
+    with subtest("Create generation 3"):
+        create_generation_txt("3")
+        out = machine.succeed("nixos-rebuild switch 2>&1")
+        assert "building the system configuration..." in out
+        test_for_boot_generation("3")
+        test_for_active_generation("3")
+
+    with subtest("must switch to `--generation 1`"):
+        create_generation_txt("4")
+        out = machine.succeed("nixos-rebuild switch --generation 1 2>&1")
+        assert "building the system configuration..." not in out
+        test_for_boot_generation("1")
+        test_for_active_generation("1")
+
+    with subtest("`boot --generation 3` must not activate it"):
+        machine.succeed("nixos-rebuild boot --generation 3")
+        test_for_boot_generation("3")
+        test_for_active_generation("1")
+        # TODO: QEMU seems to have a tempfs and so after a reboot the content of the disk is lost
+        # This also requires adding the parameter `machine.start(allow_reboot = True)`
+        # machine.reboot()
+        # test_for_active_generation("3")
+
+    with subtest("`switch --rollback` must activate previous generation"):
+        machine.succeed("nixos-rebuild switch --rollback")
+        test_for_boot_generation("2")
+        test_for_active_generation("2")
+  '';
+}

--- a/nixos/tests/nixos-rebuild-switch/generation.txt
+++ b/nixos/tests/nixos-rebuild-switch/generation.txt
@@ -1,0 +1,1 @@
+Initial generation (no system profile yet)

--- a/nixos/tests/nixos-rebuild-switch/hardware-configuration.nix
+++ b/nixos/tests/nixos-rebuild-switch/hardware-configuration.nix
@@ -1,0 +1,9 @@
+/**
+  A stub module that does nothing.
+
+  This module only exists in order to prevent configuration-to-switch-to.nix from
+  failing to evaluate outside of the test VM. Once configuration-to-switch-to.nix
+  is copied into the test VM, there will be an actual hardware-configuration.nix.
+*/
+{
+}

--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -67,6 +67,7 @@ substitute {
     repl = callPackage ./test/repl.nix { };
     simple-installer = nixosTests.installer.simple;
     specialisations = nixosTests.nixos-rebuild-specialisations;
+    switch = nixosTests.nixos-rebuild-switch;
     target-host = nixosTests.nixos-rebuild-target-host;
   };
 

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -18,6 +18,7 @@
 .Op Fl -no-build-nix
 .Op Fl -fast
 .Op Fl -rollback
+.Op Fl -generation Ar number
 .br
 .Op Fl -file | f Ar path
 .Op Fl -attr | A Ar attrPath
@@ -241,7 +242,9 @@ $ nixos-rebuild build-image --image-variant proxmox
 .It Cm list-generations Op Fl -json
 List the available generations in a similar manner to the boot loader
 menu. It shows the generation number, build date and time, NixOS version,
-kernel version and the configuration revision.
+kernel version and the configuration revision. This is useful to get
+information e.g. for which generation to roll back to with
+.Ic nixos-rebuild switch Fl -generation Ar number .
 There is also a json version of output available.
 .El
 .
@@ -292,6 +295,15 @@ Instead of building a new configuration as specified by
 defined as the one before the “current” generation of the Nix profile
 .Pa /nix/var/nix/profiles/system Ns
 \&.)
+.
+.It Fl -generation Ar number
+Instead of building a new configuration as specified by
+.Pa /etc/nixos/configuration.nix Ns
+, switch to the generation who's number is
+.Ar number .
+You can use the
+.Cm list-generations
+subcommand to get a list of generations along with their numbers.
 .
 .It Fl -builders Ar builder-spec
 Allow ad-hoc remote builders for building the new system. This requires

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -25,6 +25,7 @@ action=
 buildNix=1
 fast=
 rollback=
+generation=
 upgrade=
 upgrade_all=
 profile=/nix/var/nix/profiles/system
@@ -93,6 +94,14 @@ while [ "$#" -gt 0 ]; do
         ;;
       --rollback)
         rollback=1
+        ;;
+      --generation)
+        if [ "$#" -eq 0 ]; then
+            log "Must provide a generation number"
+            log "Usage: \`$(basename "$0") ${action:-switch} --generation <NUMBER>'"
+            exit 1
+        fi
+        generation="$1"; shift 1
         ;;
       --upgrade)
         upgrade=1
@@ -527,7 +536,7 @@ fi
 
 # First build Nix, since NixOS may require a newer version than the
 # current one.
-if [[ -n "$rollback" || "$action" = dry-build ]]; then
+if [ "$action" = dry-build ]; then
     buildNix=
 fi
 
@@ -792,7 +801,7 @@ fi
 # Either upgrade the configuration in the system profile (for "switch"
 # or "boot"), or just build it and create a symlink "result" in the
 # current directory (for "build" and "test").
-if [ -z "$rollback" ]; then
+if [ -z "$rollback" ] && [ -z "$generation" ]; then
     log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
         if [[ -z $buildingAttribute ]]; then
@@ -896,7 +905,7 @@ if [ -z "$rollback" ]; then
     if ! [[ "$action" = switch || "$action" = boot ]]; then
         copyToTarget "$pathToConfig"
     fi
-else # [ -n "$rollback" ]
+elif [ -n "$rollback" ]; then
     if [[ "$action" = switch || "$action" = boot ]]; then
         targetHostSudoCmd nix-env --rollback -p "$profile"
         pathToConfig="$profile"
@@ -906,6 +915,22 @@ else # [ -n "$rollback" ]
             sed -n '/current/ {g; p;}; s/ *\([0-9]*\).*/\1/; h'
         )
         pathToConfig="$profile"-${systemNumber}-link
+        if [ -z "$targetHost" ]; then
+            ln -sT "$pathToConfig" ./result
+        fi
+    else
+        showSyntax
+    fi
+else # [ -n "$generation" ]
+    if [ ! -L "$profile-$generation-link" ]; then
+        log "Cannot find generation \`$generation'. Run 'nixos-rebuild list-generations' to find available generations."
+        exit 1
+    fi
+    if [ "$action" = switch ] || [ "$action" = boot ]; then
+        targetHostCmd nix-env --switch-generation "$generation" -p "$profile"
+        pathToConfig="$profile"
+    elif [ "$action" = test ] || [ "$action" = build ]; then
+        pathToConfig="$profile"-${generation}-link
         if [ -z "$targetHost" ]; then
             ln -sT "$pathToConfig" ./result
         fi


### PR DESCRIPTION
###### Motivation for this change
If the user wants to `rollback` to any of the system generations but the last, this is currently not easily doable (see #24374).
In order to unify the interface with `nix-env` a bit more, I propose to add a flag ``nixos-rebuild --generation` to easily go to a specific generation.

I had an issue, where I didn't notice a package breaking ~10 generations ago and while fixing it, I had to go back and forth multiple times. Since I didn't know about
```sh
sudo nix-env --switch-generation 12345 -p /nix/var/nix/profiles/system
sudo /nix/var/nix/profiles/system/bin/switch-to-configuration switch
```
I repeated the rollback `n` times.

This implementation would make it possible to run
```sh
sudo nixos-rebuild switch --generation 12345
```

###### Maintainers
@nbp added `--rollback`
@worldofpeace did the last edits
And I guess @edolstra ?

###### Things done

- [x] Tested manually on local system
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
