### PR TITLE
octoprint: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -25,12 +25,28 @@ let
       [
         # the following dependencies are non trivial to update since later versions introduce backwards incompatible
         # changes that might affect plugins, or due to other observed problems
-        (mkOverride "markupsafe" "1.1.1" "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b")
         (mkOverride "rsa" "4.0" "1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487")
         (mkOverride "markdown" "3.1.1" "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
         (mkOverride "tornado" "5.1.1" "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409")
         (mkOverride "unidecode" "0.04.21" "280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051")
         (mkOverride "sarge" "0.1.5.post0" "1c1ll7pys9vra5cfi8jxlgrgaql6c27l6inpy15aprgqhc4ck36s")
+
+        # Octoprint needs zeroconf >=0.24 <0.25. While this should be done in
+        # the mkOverride aboves, this package also has broken tests, so we need
+        # a proper override.
+        (
+          self: super: {
+            zeroconf = super.zeroconf.overrideAttrs (oldAttrs: rec {
+              version = "0.24.5";
+              src = oldAttrs.src.override {
+                inherit version;
+                sha256 = "0jpgd0rk91si93857mjrizan5gc42kj1q4fi4160qgk68la88fl9";
+              };
+              buildInputs = [ self.nose ];
+              checkPhase = "nosetests";
+            });
+          }
+        )
 
         # Built-in dependency
         (
@@ -55,13 +71,13 @@ let
           self: super: {
             octoprint-firmwarecheck = self.buildPythonPackage rec {
               pname = "OctoPrint-FirmwareCheck";
-              version = "2020.06.22";
+              version = "2020.09.23";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint-FirmwareCheck";
                 rev = version;
-                sha256 = "19y7hrgg9z8hl7cwqkvg8nc8bk0wwrsfvjd1wawy33wn60psqv1h";
+                sha256 = "1l1ajhnsc39prgk59mp93h90dgl9gh660cci00z5b5gj2h6dv1d1";
               };
               doCheck = false;
             };
@@ -72,13 +88,13 @@ let
           self: super: {
             octoprint = self.buildPythonPackage rec {
               pname = "OctoPrint";
-              version = "1.4.2";
+              version = "1.5.1";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint";
                 rev = version;
-                sha256 = "1bblrjwkccy1ifw7lf55g3k9lq1sqzwd49vj8bfzj2w07a7qda62";
+                sha256 = "04x58cjivslsrld341ip11c50d50p2q01090nsyji0j255v986j9";
               };
 
               propagatedBuildInputs = with super; [
@@ -119,6 +135,7 @@ let
                 filetype
                 unidecode
                 blinker
+                zeroconf
               ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
 
               checkInputs = with super; [ pytestCheckHook mock ddt ];

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -98,43 +98,43 @@ let
               };
 
               propagatedBuildInputs = with super; [
-                octoprint-firmwarecheck
-                octoprint-filecheck
-                markupsafe
-                tornado
-                markdown
-                rsa
-                regex
+                blinker
+                cachelib
+                click
+                emoji
+                feedparser
+                filetype
                 flask
-                jinja2
-                flask_login
                 flask-babel
                 flask_assets
-                werkzeug
-                itsdangerous
-                cachelib
-                pyyaml
-                pyserial
-                netaddr
-                watchdog
-                sarge
-                netifaces
-                pylru
-                pkginfo
-                requests
-                semantic-version
-                psutil
-                click
-                feedparser
-                future
-                websocket_client
-                wrapt
-                emoji
+                flask_login
                 frozendict
+                future
+                itsdangerous
+                jinja2
+                markdown
+                markupsafe
+                netaddr
+                netifaces
+                octoprint-filecheck
+                octoprint-firmwarecheck
+                pkginfo
+                psutil
+                pylru
+                pyserial
+                pyyaml
+                regex
+                requests
+                rsa
+                sarge
+                semantic-version
                 sentry-sdk
-                filetype
+                tornado
                 unidecode
-                blinker
+                watchdog
+                websocket_client
+                werkzeug
+                wrapt
                 zeroconf
               ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
 

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -25,6 +25,7 @@ let
       [
         # the following dependencies are non trivial to update since later versions introduce backwards incompatible
         # changes that might affect plugins, or due to other observed problems
+        (mkOverride "flask-babel" "1.0.0" "0gmb165vkwv5v7dxsxa2i3zhafns0fh938m2zdcrv4d8z5l099yn")
         (mkOverride "rsa" "4.0" "1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487")
         (mkOverride "markdown" "3.1.1" "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
         (mkOverride "tornado" "5.1.1" "4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409")

--- a/pkgs/development/python-modules/feedparser/default.nix
+++ b/pkgs/development/python-modules/feedparser/default.nix
@@ -1,19 +1,25 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
+, sgmllib3k
 }:
 
 buildPythonPackage rec {
   pname = "feedparser";
   version = "6.0.2";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1b00a105425f492f3954fd346e5b524ca9cef3a4bbf95b8809470e9857aa1074";
   };
 
-  # lots of networking failures
-  doCheck = false;
+  propagatedBuildInputs = [ sgmllib3k ];
+
+  checkPhase = ''
+    python -Wd tests/runtests.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/kurtmckee/feedparser";

--- a/pkgs/development/python-modules/sgmllib3k/default.nix
+++ b/pkgs/development/python-modules/sgmllib3k/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "sgmllib3k";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  # fetchFromGitHub instead of fetchPypi to run tests.
+  src = fetchFromGitHub {
+    owner = "hsoft";
+    repo = "sgmllib";
+    rev = "799964676f35349ca2dd04503e34c2b3ad522c0d";
+    sha256 = "0bzf6pv85dzfxfysm6zbj8m40hp0xzr9h8qlk4hp3nmy88rznqvr";
+  };
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/sgmllib3k/";
+    description = "Python 3 port of sgmllib";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6696,6 +6696,8 @@ in {
 
   sfepy = callPackage ../development/python-modules/sfepy { };
 
+  sgmllib3k = callPackage ../development/python-modules/sgmllib3k { };
+
   shamir-mnemonic = callPackage ../development/python-modules/shamir-mnemonic { };
 
   shap = callPackage ../development/python-modules/shap { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I noticed it was out of date, the update required me to shave some yaks as well

- python3Packages.sgmllib3k: init at 1.0.0
- python3Packages.feedparser: 5.2.1 -> 6.0.2
- octoprint: 1.4.2 -> 1.5.1
- octoprint: sort propagatedBuildInputs


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
