### PR TITLE
pass-import: 2.6 -> 3.1

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -34,11 +34,15 @@ let
 
       postBuild = ''
         files=$(find $out/bin/ -type f -exec readlink -f {} \;)
-        rm $out/bin
-        mkdir $out/bin
+        if [ -L $out/bin ]; then
+          rm $out/bin
+          mkdir $out/bin
+        fi
 
         for i in $files; do
-          ln -sf $i $out/bin/$(basename $i)
+          if ! [ "$(readlink -f "$out/bin/$(basename $i)")" = "$i" ]; then
+            ln -sf $i $out/bin/$(basename $i)
+          fi
         done
 
         wrapProgram $out/bin/pass \

--- a/pkgs/tools/security/pass/extensions/0001-Fix-installation-with-Nix.patch
+++ b/pkgs/tools/security/pass/extensions/0001-Fix-installation-with-Nix.patch
@@ -1,0 +1,41 @@
+From 611cb2de31a460789c44615d3a52b8d24dbd6fdd Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Fri, 4 Dec 2020 21:53:52 +0100
+Subject: [PATCH] Fix installation with Nix
+
+---
+ Makefile | 2 +-
+ setup.py | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 2febf4e..8feab91 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,7 +7,7 @@ all:
+ 	@echo
+ 
+ install:
+-	@python3 setup.py install --root="$(DESTDIR)" --optimize=1 --skip-build
++	@python3 setup.py install --root="$(DESTDIR)" --optimize=1 --skip-build --prefix=
+ 	@echo
+ 	@echo "pass-import is installed succesfully"
+ 	@echo
+diff --git a/setup.py b/setup.py
+index b30870c..d9fedbc 100644
+--- a/setup.py
++++ b/setup.py
+@@ -15,8 +15,8 @@ with Path('pass_import', '__about__.py').open() as file:
+ with open('README.md') as file:
+     long_description = file.read()
+ 
+-share = Path(sys.prefix, 'share')
+-lib = Path('/usr', 'lib', 'password-store', 'extensions')
++share = Path('/share')
++lib = Path('/lib', 'password-store', 'extensions')
+ if '--user' in sys.argv:
+     lib = Path.home() / '.password-store' / 'extensions'
+     if 'XDG_DATA_HOME' in os.environ:
+-- 
+2.28.0
+

--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -5,48 +5,38 @@ let
     p.defusedxml
     p.setuptools
     p.pyaml
+    p.pykeepass
+    p.filemagic
+    p.cryptography
+    p.secretstorage
   ]);
 
 in stdenv.mkDerivation rec {
   pname = "pass-import";
-  version = "2.6";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner = "roddhjav";
     repo = "pass-import";
     rev = "v${version}";
-    sha256 = "1q8rln4djh2z8j2ycm654df5y6anm5iv2r19spgy07c3fnisxlac";
+    sha256 = "sha256-nH2xAqWfMT+Brv3z9Aw6nbvYqArEZjpM28rKsRPihqA=";
   };
+
+  patches = [ ./0001-Fix-installation-with-Nix.patch ];
 
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ pythonEnv ];
 
-  patches = [
-    # https://github.com/roddhjav/pass-import/pull/91
-    (fetchpatch {
-      url = "https://github.com/roddhjav/pass-import/commit/6ccaf639e92df45bd400503757ae4aa2c5c030d7.patch";
-      sha256 = "0lw9vqvbqcy96s7v7nz0i1bdx93x7qr13azymqypcdhjwmq9i63h";
-    })
-  ];
+  makeFlags = [ "DESTDIR=${placeholder "out"}" ];
 
-  postPatch = ''
-    sed -i -e 's|$0|${pass}/bin/pass|' import.bash
-  '';
-
-  dontBuild = true;
-
-  installFlags = [
-    "PREFIX=$(out)"
-    "BASHCOMPDIR=$(out)/share/bash-completion/completions"
-  ];
-
-  postFixup = ''
-    install -D pass_import.py $out/${pythonPackages.python.sitePackages}/pass_import.py
+  postInstall = ''
+    wrapProgram $out/bin/pimport \
+      --prefix PATH : "${pythonEnv}/bin" \
+      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}"
     wrapProgram $out/lib/password-store/extensions/import.bash \
       --prefix PATH : "${pythonEnv}/bin" \
-      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}" \
-      --run "export PREFIX"
+      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION

###### Motivation for this change

ChangeLog in https://github.com/roddhjav/pass-import/blob/v3.1/CHANGELOG.rst#31---2020-10-25

For further details, please read the commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
