### PR TITLE
mmh: fix static build

### DIFF
--- a/pkgs/applications/networking/mailreaders/mmh/default.nix
+++ b/pkgs/applications/networking/mailreaders/mmh/default.nix
@@ -10,6 +10,11 @@ in stdenv.mkDerivation rec {
     sha256 = "1q97p4g3f1q2m567i2dbx7mm7ixw3g91ww2rymwj42cxk9iyizhv";
   };
 
+  postPatch = ''
+    substituteInPlace sbr/Makefile.in \
+      --replace "ar " "${stdenv.cc.targetPrefix}ar "
+ '';
+
   buildInputs = [ ncurses ];
   nativeBuildInputs = [ autoreconfHook flex ];
 


### PR DESCRIPTION

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
