### PR TITLE
ink: init at 0.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7749,6 +7749,12 @@
     github = "s1341";
     githubId = 5682183;
   };
+  samb96 = {
+    email = "samb96@gmail.com";
+    github = "samb96";
+    githubId = 819426;
+    name = "Sam Bickley";
+  };
   samdoshi = {
     email = "sam@metal-fish.co.uk";
     github = "samdoshi";

--- a/pkgs/development/libraries/libinklevel/default.nix
+++ b/pkgs/development/libraries/libinklevel/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, pkg-config, libusb1 }:
+
+stdenv.mkDerivation rec {
+  pname = "libinklevel";
+  version = "0.9.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1zwkicjznkzw81ax745inv4n29y20vq82w8249vizaal76739n19";
+  };
+
+  buildInputs = [
+    pkg-config
+    libusb1
+  ];
+
+  outputs = [ "out" "dev" "doc" ];
+
+  meta = with stdenv.lib; {
+    description = "A library for checking the ink level of your printer";
+    longDescription = ''
+      Libinklevel is a library for checking the ink level of your printer on a
+      system which runs Linux or FreeBSD. It supports printers attached via
+      USB. Currently printers of the following brands are supported: HP, Epson
+      and Canon. Canon BJNP network printers are supported too. This is not
+      official software from the printer manufacturers. The goal of this
+      project is to create a vendor independent API for retrieving the ink
+      level of a printer connected to a Linux or FreeBSD box.
+    '';
+    homepage = "http://libinklevel.sourceforge.net/";
+    license = licenses.gpl2;
+    platforms = platforms.linux ++ platforms.freebsd;
+    maintainers = with maintainers; [ samb96 ];
+  };
+}

--- a/pkgs/tools/misc/ink/default.nix
+++ b/pkgs/tools/misc/ink/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, libinklevel }:
+
+stdenv.mkDerivation rec {
+  pname = "ink";
+  version = "0.5.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1fk0b8vic04a3i3vmq73hbk7mzbi57s8ks6ighn3mvr6m2v8yc9d";
+  };
+
+  buildInputs = [
+    libinklevel
+  ];
+
+  outputs = [ "out" "man" ];
+
+  meta = with stdenv.lib; {
+    description = "A command line tool for checking the ink level of your locally connected printer";
+    longDescription = ''
+      Ink is a command line tool for checking the ink level of your locally connected printer on a system which runs Linux or FreeBSD. Canon BJNP network printers are supported too.
+    '';
+    homepage = "http://ink.sourceforge.net/";
+    license = licenses.gpl2;
+    platforms = platforms.linux ++ platforms.freebsd;
+    maintainers = with maintainers; [ samb96 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14016,6 +14016,8 @@ in
 
   libinjection = callPackage ../development/libraries/libinjection { };
 
+  libinklevel = callPackage ../development/libraries/libinklevel { };
+
   libnats-c = callPackage ../development/libraries/libnats-c {
     openssl = openssl_1_0_2;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2306,6 +2306,8 @@ in
 
   ifm = callPackage ../tools/graphics/ifm {};
 
+  ink = callPackage ../tools/misc/ink { };
+
   interlock = callPackage ../servers/interlock {};
 
   jellyfin = callPackage ../servers/jellyfin { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A command line tool for checking the ink level of a locally connected printer.

I also added the associated library: libinklevel: init at 0.9.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
