### PR TITLE
osx-cpu-temp: Init at 1.0

### DIFF
--- a/pkgs/os-specific/darwin/osx-cpu-temp/default.nix
+++ b/pkgs/os-specific/darwin/osx-cpu-temp/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub
+, IOKit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "osx-cpu-temp";
+  version = "unstable-2020-12-04";
+
+  src = fetchFromGitHub rec {
+    name = "osx-cpu-temp-source";
+    owner = "lavoiesl";
+    repo = pname;
+    rev = "6ec951be449badcb7fb84676bbc2c521e600e844";
+    sha256 = "1nlibgr55bpln6jbdf8vqcp0fj9zv9343vflb7s9w0yh33fsbg9d";
+  };
+
+  buildInputs = [ IOKit ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp osx-cpu-temp $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Outputs current CPU temperature for OSX.";
+    homepage = "https://github.com/lavoiesl/osx-cpu-temp";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ virusdave ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18118,6 +18118,10 @@ in
 
   openisns = callPackage ../os-specific/linux/open-isns { };
 
+  osx-cpu-temp = callPackage ../os-specific/darwin/osx-cpu-temp {
+    inherit (pkgs.darwin.apple_sdk.frameworks) IOKit;
+  };
+
   osxfuse = callPackage ../os-specific/darwin/osxfuse { };
 
   osxsnarf = callPackage ../os-specific/darwin/osxsnarf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
