### PR TITLE
libsForQt5.sonnet: Switch from hunspell to aspell

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/sonnet.nix
+++ b/pkgs/development/libraries/kde-frameworks/sonnet.nix
@@ -1,6 +1,6 @@
 { mkDerivation, lib
 , extra-cmake-modules
-, hunspell, qtbase, qttools
+, aspell, qtbase, qttools
 }:
 
 mkDerivation {
@@ -10,6 +10,6 @@ mkDerivation {
     broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ hunspell qttools ];
+  buildInputs = [ aspell qttools ];
   propagatedBuildInputs = [ qtbase ];
 }


### PR DESCRIPTION
###### Motivation for this change

Hunspell does not work, while aspell does. Closes #26654.

Also see https://github.com/NixOS/nixpkgs/issues/26654#issuecomment-626734025.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 105965"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
