### PR TITLE
python3Packages.py-air-control-exporter: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/py-air-control-exporter/default.nix
+++ b/pkgs/development/python-modules/py-air-control-exporter/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage, fetchPypi, flask, isPy27, lib, prometheus_client
+, py-air-control, pytestCheckHook, pytestcov, pytestrunner, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "py-air-control-exporter";
+  version = "0.1.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1f13d3mlj6c3xvkclimahx7gpqqn8z56lh4kwy1d3gkjm7zs9zw9";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  checkInputs = [ pytestCheckHook pytestcov pytestrunner ];
+  propagatedBuildInputs = [ flask prometheus_client py-air-control ];
+
+  meta = with lib; {
+    description = "Exports Air Quality Metrics to Prometheus.";
+    homepage = "https://github.com/urbas/py-air-control-exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ urbas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4851,6 +4851,8 @@ in {
 
   py-air-control = callPackage ../development/python-modules/py-air-control { };
 
+  py-air-control-exporter = callPackage ../development/python-modules/py-air-control-exporter { };
+
   py2bit = callPackage ../development/python-modules/py2bit { };
 
   py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`py-air-control-exporter` is not yet packaged in nixpkgs.

This is a new leaf package. It's size is:
```
nix path-info -sh  $(nix-build --no-out-link -A pkgs.python3Packages.py-air-control-exporter)
/nix/store/7sa2yddlhf10y33k53a4zs19vnplclw9-python3.8-py-air-control-exporter-0.1.4       15.9K
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @SuperSandro2000 @lukegb 