### PR TITLE
python3Packages.milc: init at 1.0.10

### DIFF
--- a/pkgs/development/python-modules/milc/default.nix
+++ b/pkgs/development/python-modules/milc/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, appdirs
+, argcomplete
+, colorama
+, gnugrep
+}:
+
+buildPythonPackage rec {
+  pname = "milc";
+  version = "1.0.10";
+
+  src = fetchFromGitHub {
+    owner = "clueboard";
+    repo = "milc";
+    rev = version;
+    sha256 = "04mk057b6jh0k4maqkg80kpilxak9r7vlr9xqwzczh2gs3g2x573";
+  };
+
+  checkInputs = [ gnugrep ];
+  propagatedBuildInputs = [ appdirs argcomplete colorama ];
+
+  # Upstream has a nose2 test suite that runs this hello script in a handful of
+  # ways, but it's not in setup.py and makes assumptions about relative paths in
+  # the src repo, so just sanity-check basic functionality.
+  checkPhase = ''
+    patchShebangs ./hello
+    ./hello | grep "Hello, World"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An Opinionated Batteries-Included Python 3 CLI Framework";
+    homepage = "https://milc.clueboard.co";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3781,6 +3781,8 @@ in {
 
   mido = callPackage ../development/python-modules/mido { };
 
+  milc = callPackage ../development/python-modules/milc { };
+
   milksnake = callPackage ../development/python-modules/milksnake { };
 
   minidb = callPackage ../development/python-modules/minidb { };


### PR DESCRIPTION
This is a dependency of [qmk](https://github.com/qmk/qmk_cli), which I would
like to package next.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).