### PR TITLE
[WIP] Wayfire package.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10106,4 +10106,9 @@
     github = "zupo";
     githubId = 311580;
   };
+  ishan = {
+    name = "Ishan Agarwal";
+    email = "ishan365.ia@gmail.com";
+    github = "ishan9299";
+    githubId = 47824004;
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3777,6 +3777,12 @@
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
     }];
   };
+  ishan = {
+    name = "Ishan Agarwal";
+    github = "ishan9299";
+    githubId = "47824004";
+    email = "ishan365.ia@gmail.com";
+  };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -11,15 +11,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "wayfire";
-  version = "0.6.0";
+  version = "8aa8260972edaba6d237e1a61217a4d2303edc3e";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire";
     rev = version;
-    sha256 = "0000000000000000000000000000000000000000000000000000";
+    sha256 = "sha256-r9k8e0LCDxr8tEZvcBbkvZ2RqcKXYX+/fxalKoqT15U=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub
+, meson, pkgconfig, ninja
+, wayland, wayland-protocols
+, cairo, glm
+, libevdev, freetype, libinput
+, pixman, libxkbcommon, libdrm
+, libjpeg, libpng
+, libGL, mesa
+, libcap, xcbutilerrors, xcbutilwm, libxml2
+, buildDocs ? true
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "wayfire";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wayfire";
+    rev = version;
+    sha256 = "0000000000000000000000000000000000000000000000000000";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig meson ninja ];
+  buildInputs = [
+    # egl glesv2
+    wayland wayland-protocols
+    cairo glm
+    libevdev freetype libinput
+    pixman libxkbcommon libdrm
+    libjpeg libpng
+    libGL mesa
+    libcap xcbutilerrors xcbutilwm libxml2
+  ];
+  mesonFlags = [
+    "-Duse_system_wlroots=disabled"
+    "-Duse_system_wfconfig=disabled"
+    "-Dwlroots:logind-provider=systemd"
+    "-Dwlroots:libseat=disabled"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "3D wayland compositor";
+    homepage    = "https://wayfire.org/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ishan9299 ];
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub
+, meson, pkg-config, ninja
+, wayland, wayland-protocols
+, cairo, glm
+, libevdev, freetype, libinput
+, pixman, libxkbcommon, libdrm
+, libjpeg, libpng
+, libGL, mesa, wf-config
+, libcap, xcbutilerrors, xcbutilwm, libxml2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wayfire";
+  version = "ee9c9d708065f6b17df4fa454e6741bed10899d4";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wayfire";
+    rev = version;
+    sha256 = "sha256-zKaZr/tBTeMUeqgxSLKe+/rW+JGon+MzBzP3mnZh96E=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [
+    wayland wayland-protocols
+    cairo glm
+    libevdev freetype libinput
+    pixman libxkbcommon libdrm
+    libjpeg libpng
+    libGL mesa wf-config
+    libcap xcbutilerrors xcbutilwm libxml2
+  ];
+  mesonFlags = [
+    "-Duse_system_wlroots=disabled"
+    "-Duse_system_wfconfig=enabled"
+    "-Dwlroots:logind-provider=systemd"
+    "-Dwlroots:libseat=disabled"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "3D wayland compositor";
+    homepage    = "https://wayfire.org/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ishan9299 ];
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,46 +1,42 @@
 { stdenv, fetchFromGitHub
-, meson, pkgconfig, ninja
+, meson, pkg-config, ninja
 , wayland, wayland-protocols
 , cairo, glm
 , libevdev, freetype, libinput
 , pixman, libxkbcommon, libdrm
 , libjpeg, libpng
-, libGL, mesa
+, libGL, mesa, wf-config
 , libcap, xcbutilerrors, xcbutilwm, libxml2
-, buildDocs ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "wayfire";
-  version = "8aa8260972edaba6d237e1a61217a4d2303edc3e";
+  version = "ee9c9d708065f6b17df4fa454e6741bed10899d4";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire";
     rev = version;
-    sha256 = "sha256-r9k8e0LCDxr8tEZvcBbkvZ2RqcKXYX+/fxalKoqT15U=";
+    sha256 = "sha256-zKaZr/tBTeMUeqgxSLKe+/rW+JGon+MzBzP3mnZh96E=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [
-    # egl glesv2
     wayland wayland-protocols
     cairo glm
     libevdev freetype libinput
     pixman libxkbcommon libdrm
     libjpeg libpng
-    libGL mesa
+    libGL mesa wf-config
     libcap xcbutilerrors xcbutilwm libxml2
   ];
   mesonFlags = [
     "-Duse_system_wlroots=disabled"
-    "-Duse_system_wfconfig=disabled"
+    "-Duse_system_wfconfig=enabled"
     "-Dwlroots:logind-provider=systemd"
     "-Dwlroots:libseat=disabled"
   ];
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "3D wayland compositor";

--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -1,0 +1,55 @@
+{ stdenv, meson, ninja
+, fetchFromGitHub, wayfire, pkgconfig
+, wlroots, wayland, wayland-protocols
+, cairo, glibmm, iio-sensor-proxy
+, libxkbcommon, glm, librsvg
+, boost, gtkmm3, udev
+, libinput
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wayfire-plugins-extra";
+  version = "b2036fc4e5935bf459b1779b89b59a73be92da9f";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wayfire-plugins-extra";
+    rev = version;
+    sha256 = "sha256-u1gOd6Sp2hDgOA+gln6C+ADyzrI0HrGQFu5L0zFpZuE=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig meson ninja ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wayfire
+    wlroots
+    cairo
+    glibmm
+    iio-sensor-proxy
+    libxkbcommon
+    glm
+    librsvg
+    boost
+    gtkmm3
+    udev
+    libinput
+  ];
+
+  mesonFlags = [
+    "-Denable_nk=true"
+    "-Denable_dbus=true"
+    "-Denable_windecor=true"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "3D wayland compositor";
+    homepage    = "https://wayfire.org/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ishan9299 ];
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/shell.nix
+++ b/pkgs/applications/window-managers/wayfire/shell.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig
+, wayland, wayland-protocols
+, gtkmm3, wayfire, alsaLib
+, gtk-layer-shell, librsvg
+, libpulseaudio, glm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wf-shell";
+  version = "3fed0524897f297bc4e7c49049c6b4221a2ff417";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Ci66TOTyWZZ14VPJz3pvi+mI9EtCPMveDm5NS97l+Y4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [
+    alsaLib glm gtkmm3
+    gtk-layer-shell
+    libpulseaudio
+    wayland librsvg
+    wayland-protocols
+    wayfire
+  ];
+
+  enableParallelBuilding = true;
+
+  mesonFlags = [
+    "-Dpulse=enabled" "-Dwayland-logout=true"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A GTK3-based panel for wayfire";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ishan9299 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wcm.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm.nix
@@ -1,0 +1,36 @@
+{ stdenv, meson, ninja
+, fetchFromGitHub, wayfire
+, wf-shell, pkgconfig
+, libevdev, wayland
+, wayland-protocols
+, libxml2, gtk3, glm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wcm";
+  version = "5d935e0727ab976c85690669083addc9c21ee298";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Nrz/Em80+C8uTUf0+Ny/WLcMKFVRKAzXaeIp3m7NsnU=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [
+    wayfire wf-shell
+    libevdev wayland
+    wayland-protocols
+    libxml2 gtk3 glm
+  ];
+
+
+  meta = with stdenv.lib; {
+    description = "Wayfire Config Manager";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ishan9299 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wcm/default.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, meson, ninja
+, fetchFromGitHub, wayfire
+, wf-shell, pkg-config
+, libevdev, wayland
+, wayland-protocols
+, libxml2, gtk3, glm
+, wf-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wcm";
+  version = "5d935e0727ab976c85690669083addc9c21ee298";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Nrz/Em80+C8uTUf0+Ny/WLcMKFVRKAzXaeIp3m7NsnU=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [
+    wayfire wf-shell
+    libevdev wayland
+    wayland-protocols
+    libxml2 gtk3 glm
+    wf-config
+  ];
+
+  mesonFlags = [
+    "-Dwf_shell=enabled"
+    "-Dwayfire_config_file_path=~/.config/wayfire.ini"
+    "-Dwf_shell_config_file_path=~/.config/wf-shell.ini"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Wayfire Config Manager";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ishan9299 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wfshell/default.nix
+++ b/pkgs/applications/window-managers/wayfire/wfshell/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig
+, wayland, wayland-protocols
+, gtkmm3, wayfire, alsaLib
+, gtk-layer-shell, librsvg
+, libpulseaudio, glm, wf-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wf-shell";
+  version = "3fed0524897f297bc4e7c49049c6b4221a2ff417";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Ci66TOTyWZZ14VPJz3pvi+mI9EtCPMveDm5NS97l+Y4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [
+    alsaLib glm gtkmm3
+    gtk-layer-shell
+    libpulseaudio
+    wayland librsvg
+    wayland-protocols
+    wayfire wf-config
+  ];
+
+  mesonFlags = [
+    "-Dpulse=enabled"
+    "-Dwayland-logout=true"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A GTK3-based panel for wayfire";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ishan9299 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/wfconfig/default.nix
+++ b/pkgs/development/libraries/wfconfig/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub
+, glm, libxml2, libevdev
+, meson, pkg-config, ninja
+}:
+
+
+stdenv.mkDerivation rec {
+  pname = "wf-config";
+  version = "ec865db3cf932f530adbdd1ea8d1e5b00d25f7a9";
+
+  src = fetchFromGitHub {
+    owner = "ammen99";
+    repo = "wf-config";
+    rev = version;
+    sha256 = "sha256-JSWdr+Q7kNByKMd6nB3ep/7U87hMSWqgbhYRFGP7Lqw=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+
+  buildInputs = [
+    glm
+    libxml2
+    libevdev
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A library for managing configuration files, written for wayfire";
+    homepage    = "https://wayfire.org/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ishan9299 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28752,4 +28752,10 @@ in
   psftools = callPackage ../os-specific/linux/psftools {};
 
   lc3tools = callPackage ../development/tools/lc3tools {};
+
+  wayfire = callPackage ../applications/window-managers/wayfire {};
+  wf-shell = callPackage ../applications/window-managers/wayfire/shell.nix {};
+  wcm = callPackage ../applications/window-managers/wayfire/wcm.nix {};
+  # wayfire-plugins-extra = callPackage ../applications/window-managers/wayfire/plugins.nix {};
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15471,6 +15471,8 @@ in
 
   mkLibsForQt5 = self: with self; {
 
+  wf-config = callPackage ../development/libraries/wfconfig {};
+
     ### KDE FRAMEWORKS
 
     inherit (kdeFrameworks.override { libsForQt5 = self; })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24893,6 +24893,10 @@ in
 
   xkbmon = callPackage ../applications/misc/xkbmon { };
 
+  wayfire = callPackage ../applications/window-managers/wayfire {};
+  wcm = callPackage ../applications/window-managers/wayfire/wcm {};
+  wf-shell = callPackage ../applications/window-managers/wayfire/wfshell {};
+
   win-spice = callPackage ../applications/virtualization/driver/win-spice { };
   win-virtio = callPackage ../applications/virtualization/driver/win-virtio { };
   win-qemu = callPackage ../applications/virtualization/driver/win-qemu { };
@@ -28754,4 +28758,5 @@ in
   psftools = callPackage ../os-specific/linux/psftools {};
 
   lc3tools = callPackage ../development/tools/lc3tools {};
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15471,6 +15471,8 @@ in
 
   mkLibsForQt5 = self: with self; {
 
+  wf-config = callPackage ../development/libraries/wfconfig {};
+
     ### KDE FRAMEWORKS
 
     inherit (kdeFrameworks.override { libsForQt5 = self; })
@@ -24891,6 +24893,10 @@ in
 
   xkbmon = callPackage ../applications/misc/xkbmon { };
 
+  wayfire = callPackage ../applications/window-managers/wayfire {};
+  wcm = callPackage ../applications/window-managers/wayfire/wcm {};
+  wf-shell = callPackage ../applications/window-managers/wayfire/wfshell {};
+
   win-spice = callPackage ../applications/virtualization/driver/win-spice { };
   win-virtio = callPackage ../applications/virtualization/driver/win-virtio { };
   win-qemu = callPackage ../applications/virtualization/driver/win-qemu { };
@@ -28752,10 +28758,5 @@ in
   psftools = callPackage ../os-specific/linux/psftools {};
 
   lc3tools = callPackage ../development/tools/lc3tools {};
-
-  wayfire = callPackage ../applications/window-managers/wayfire {};
-  wf-shell = callPackage ../applications/window-managers/wayfire/shell.nix {};
-  wcm = callPackage ../applications/window-managers/wayfire/wcm.nix {};
-  # wayfire-plugins-extra = callPackage ../applications/window-managers/wayfire/plugins.nix {};
 
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
It adds a wayfire package. The nixpkgs-wayland overlay only adds the compositor so it needs some more packages like.
- wf-shell.
- wayfire-plugins-extra.
- wcm.
To provide a desktop experience with wayfire. 
We can also add modules for wayfire.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Right now icons are missing but everything else seems to run fine. ~~Also I used the lastest commits because the wcm package needed the wf-config submodule to be at 0.6 but the latest release had 0.5 and the build was failing.~~ (Using the stable release now). 

~~The build for wayfire-plugins-extra build is failing with this warning~~ (Not including the wayfire-plugins-extra)

```
glibPreInstallPhase
installing
install flags: install
[0/1] Installing files. ersion: 0.56.0
Installing subprojects/dbus/libdbus_interface.so to /nix/store/1s0krsi0bpv42xk4w04851rmz6shnwfh-wayfire-8aa8260972edaba6d237e1a61217a4d2303edc3e/lib/wayfire
Traceback (most recent call last):
  File "/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/lib/python3.8/site-packages/mesonbuild/mesonmain.py", line 140, in run
    return options.run_func(options)
  File "/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/lib/python3.8/site-packages/mesonbuild/minstall.py", line 554, in run
    installer.do_install(datafilename)
  File "/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/lib/python3.8/site-packages/mesonbuild/minstall.py", line 372, in do_install
    self.install_targets(d)
  File "/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/lib/python3.8/site-packages/mesonbuild/minstall.py", line 482, in install_targets
    file_copied = self.do_copyfile(fname, outname, makedirs=(d.dirmaker, outdir))
  File "/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/lib/python3.8/site-packages/mesonbuild/minstall.py", line 278, in do_copyfile
    shutil.copy2(from_file, to_file)
  File "/nix/store/fzgk230riagc58n8w1fa41ngs723pzpb-python3-3.8.6/lib/python3.8/shutil.py", line 432, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/nix/store/fzgk230riagc58n8w1fa41ngs723pzpb-python3-3.8.6/lib/python3.8/shutil.py", line 261, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
PermissionError: [Errno 13] Permission denied: '/nix/store/1s0krsi0bpv42xk4w04851rmz6shnwfh-wayfire-8aa8260972edaba6d237e1a61217a4d2303edc3e/lib/wayfire/libdbus_interface.so'
FAILED: meson-install 
/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/bin/meson install --no-rebuild
ninja: build stopped: subcommand failed.
error: --- Error --------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix-build
builder for '/nix/store/246s2knhdwlkyq13mhwm11xkbnw3iplm-wayfire-plugins-extra-b2036fc4e5935bf459b1779b89b59a73be92da9f.drv' failed with exit code 1; last 10 log lines:
    File "/nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/lib/python3.8/site-packages/mesonbuild/minstall.py", line 278, in do_copyfile
      shutil.copy2(from_file, to_file)
    File "/nix/store/fzgk230riagc58n8w1fa41ngs723pzpb-python3-3.8.6/lib/python3.8/shutil.py", line 432, in copy2
      copyfile(src, dst, follow_symlinks=follow_symlinks)
    File "/nix/store/fzgk230riagc58n8w1fa41ngs723pzpb-python3-3.8.6/lib/python3.8/shutil.py", line 261, in copyfile
      with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
  PermissionError: [Errno 13] Permission denied: '/nix/store/1s0krsi0bpv42xk4w04851rmz6shnwfh-wayfire-8aa8260972edaba6d237e1a61217a4d2303edc3e/lib/wayfire/libdbus_interface.so'
  FAILED: meson-install 
  /nix/store/p5v5i9zyaysw9ncvsrqjks92j2j4bcly-meson-0.56.0/bin/meson install --no-rebuild
  ninja: build stopped: subcommand failed.

```
