### PR TITLE
matomo: 3.14.1 -> 4.0.4

### DIFF
--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -14,16 +14,53 @@ let
 
   fqdn =
     let
-      join = hostName: domain: hostName + optionalString (domain != null) ".${domain}";
-     in join config.networking.hostName config.networking.domain;
+      join = hostName: domain:
+        hostName + optionalString (domain != null) ".${domain}";
+    in
+    join config.networking.hostName config.networking.domain;
 
-in {
+in
+{
   imports = [
-    (mkRenamedOptionModule [ "services" "piwik" "enable" ] [ "services" "matomo" "enable" ])
-    (mkRenamedOptionModule [ "services" "piwik" "webServerUser" ] [ "services" "matomo" "webServerUser" ])
-    (mkRemovedOptionModule [ "services" "piwik" "phpfpmProcessManagerConfig" ] "Use services.phpfpm.pools.<name>.settings")
-    (mkRemovedOptionModule [ "services" "matomo" "phpfpmProcessManagerConfig" ] "Use services.phpfpm.pools.<name>.settings")
-    (mkRenamedOptionModule [ "services" "piwik" "nginx" ] [ "services" "matomo" "nginx" ])
+    (mkRenamedOptionModule [
+      "services"
+      "piwik"
+      "enable"
+    ] [
+      "services"
+      "matomo"
+      "enable"
+    ])
+    (mkRenamedOptionModule [
+      "services"
+      "piwik"
+      "webServerUser"
+    ] [
+      "services"
+      "matomo"
+      "webServerUser"
+    ])
+    (mkRemovedOptionModule [
+      "services"
+      "piwik"
+      "phpfpmProcessManagerConfig"
+    ]
+      "Use services.phpfpm.pools.<name>.settings")
+    (mkRemovedOptionModule [
+      "services"
+      "matomo"
+      "phpfpmProcessManagerConfig"
+    ]
+      "Use services.phpfpm.pools.<name>.settings")
+    (mkRenamedOptionModule [
+      "services"
+      "piwik"
+      "nginx"
+    ] [
+      "services"
+      "matomo"
+      "nginx"
+    ])
   ];
 
   options = {
@@ -78,17 +115,16 @@ in {
       };
 
       nginx = mkOption {
-        type = types.nullOr (types.submodule (
-          recursiveUpdate
-            (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
-            {
-              # enable encryption by default,
-              # as sensitive login and Matomo data should not be transmitted in clear text.
-              options.forceSSL.default = true;
-              options.enableACME.default = true;
-            }
-        )
-        );
+        type = types.nullOr (types.submodule (recursiveUpdate
+          (import ../web-servers/nginx/vhost-options.nix {
+            inherit config lib;
+          })
+          {
+            # enable encryption by default,
+            # as sensitive login and Matomo data should not be transmitted in clear text.
+            options.forceSSL.default = true;
+            options.enableACME.default = true;
+          }));
         default = null;
         example = {
           serverAliases = [
@@ -98,13 +134,13 @@ in {
           enableACME = false;
         };
         description = ''
-            With this option, you can customize an nginx virtualHost which already has sensible defaults for Matomo.
-            Either this option or the webServerUser option is mandatory.
-            Set this to {} to just enable the virtualHost if you don't need any customization.
-            If enabled, then by default, the <option>serverName</option> is
-            <literal>''${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
-            SSL is active, and certificates are acquired via ACME.
-            If this is set to null (the default), no nginx virtualHost will be configured.
+          With this option, you can customize an nginx virtualHost which already has sensible defaults for Matomo.
+          Either this option or the webServerUser option is mandatory.
+          Set this to {} to just enable the virtualHost if you don't need any customization.
+          If enabled, then by default, the <option>serverName</option> is
+          <literal>''${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
+          SSL is active, and certificates are acquired via ACME.
+          If this is set to null (the default), no nginx virtualHost will be configured.
         '';
       };
     };
@@ -115,27 +151,38 @@ in {
       "If services.matomo.nginx is set, services.matomo.nginx.webServerUser is ignored and should be removed."
     ];
 
-    assertions = [ {
-        assertion = cfg.nginx != null || cfg.webServerUser != null;
-        message = "Either services.matomo.nginx or services.matomo.nginx.webServerUser is mandatory";
+    assertions = [{
+      assertion = cfg.nginx != null || cfg.webServerUser != null;
+      message =
+        "Either services.matomo.nginx or services.matomo.nginx.webServerUser is mandatory";
     }];
 
     users.users.${user} = {
       isSystemUser = true;
       createHome = true;
       home = dataDir;
-      group  = user;
+      group = user;
     };
-    users.groups.${user} = {};
+    users.groups.${user} = { };
 
     systemd.services.matomo-setup-update = {
       # everything needs to set up and up to date before Matomo php files are executed
-      requiredBy = [ "${phpExecutionUnit}.service" ];
-      before = [ "${phpExecutionUnit}.service" ];
+      requiredBy = [
+        "${phpExecutionUnit}.service"
+      ];
+      before = [
+        "${phpExecutionUnit}.service"
+      ];
       # the update part of the script can only work if the database is already up and running
-      requires = [ databaseService ];
-      after = [ databaseService ];
-      path = [ cfg.package ];
+      requires = [
+        databaseService
+      ];
+      after = [
+        databaseService
+      ];
+      path = [
+        cfg.package
+      ];
       environment.PIWIK_USER_PATH = dataDir;
       serviceConfig = {
         Type = "oneshot";
@@ -158,19 +205,19 @@ in {
         fi
         chown -R ${user}:${user} ${dataDir}
         chmod -R ug+rwX,o-rwx ${dataDir}
-        '';
+      '';
       script = ''
-            # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
-            # Copy config folder
-            chmod g+s "${dataDir}"
-            cp -r "${cfg.package}/share/config" "${dataDir}/"
-            chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
+        # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
+        # Copy config folder
+        chmod g+s "${dataDir}"
+        cp -r "${cfg.package}/share/config" "${dataDir}/"
+        chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
 
-            # check whether user setup has already been done
-            if test -f "${dataDir}/config/config.ini.php"; then
-              # then execute possibly pending database upgrade
-              matomo-console core:update --yes
-            fi
+        # check whether user setup has already been done
+        if test -f "${dataDir}/config/config.ini.php"; then
+          # then execute possibly pending database upgrade
+          matomo-console core:update --yes
+        fi
       '';
     };
 
@@ -179,8 +226,12 @@ in {
     systemd.services.matomo-archive-processing = {
       description = "Archive Matomo reports";
       # the archiving can only work if the database is already up and running
-      requires = [ databaseService ];
-      after = [ databaseService ];
+      requires = [
+        databaseService
+      ];
+      after = [
+        databaseService
+      ];
 
       # TODO: might get renamed to MATOMO_USER_PATH in future versions
       environment.PIWIK_USER_PATH = dataDir;
@@ -190,117 +241,133 @@ in {
         UMask = "0007";
         CPUSchedulingPolicy = "idle";
         IOSchedulingClass = "idle";
-        ExecStart = "${cfg.package}/bin/matomo-console core:archive --url=https://${user}.${fqdn}";
+        ExecStart =
+          "${cfg.package}/bin/matomo-console core:archive --url=https://${user}.${fqdn}";
       };
     };
 
-    systemd.timers.matomo-archive-processing = mkIf cfg.periodicArchiveProcessing {
-      description = "Automatically archive Matomo reports every hour";
+    systemd.timers.matomo-archive-processing =
+      mkIf cfg.periodicArchiveProcessing {
+        description = "Automatically archive Matomo reports every hour";
 
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = "hourly";
-        Persistent = "yes";
-        AccuracySec = "10m";
+        wantedBy = [
+          "timers.target"
+        ];
+        timerConfig = {
+          OnCalendar = "hourly";
+          Persistent = "yes";
+          AccuracySec = "10m";
+        };
       };
-    };
 
     systemd.services.${phpExecutionUnit} = {
       # stop phpfpm on package upgrade, do database upgrade via matomo-setup-update, and then restart
-      restartTriggers = [ cfg.package ];
+      restartTriggers = [
+        cfg.package
+      ];
       # stop config.ini.php from getting written with read permission for others
       serviceConfig.UMask = "0007";
     };
 
-    services.phpfpm.pools = let
-      # workaround for when both are null and need to generate a string,
-      # which is illegal, but as assertions apparently are being triggered *after* config generation,
-      # we have to avoid already throwing errors at this previous stage.
-      socketOwner = if (cfg.nginx != null) then config.services.nginx.user
-      else if (cfg.webServerUser != null) then cfg.webServerUser else "";
-    in {
-      ${pool} = {
-        inherit user;
-        phpOptions = ''
-          error_log = 'stderr'
-          log_errors = on
-        '';
-        settings = mapAttrs (name: mkDefault) {
-          "listen.owner" = socketOwner;
-          "listen.group" = "root";
-          "listen.mode" = "0660";
-          "pm" = "dynamic";
-          "pm.max_children" = 75;
-          "pm.start_servers" = 10;
-          "pm.min_spare_servers" = 5;
-          "pm.max_spare_servers" = 20;
-          "pm.max_requests" = 500;
-          "catch_workers_output" = true;
+    services.phpfpm.pools =
+      let
+        # workaround for when both are null and need to generate a string,
+        # which is illegal, but as assertions apparently are being triggered *after* config generation,
+        # we have to avoid already throwing errors at this previous stage.
+        socketOwner =
+          if (cfg.nginx != null) then
+            config.services.nginx.user
+          else if (cfg.webServerUser != null) then
+            cfg.webServerUser
+          else
+            "";
+      in
+      {
+        ${pool} = {
+          inherit user;
+          phpOptions = ''
+            error_log = 'stderr'
+            log_errors = on
+          '';
+          settings = mapAttrs (name: mkDefault) {
+            "catch_workers_output" = true;
+            "listen.group" = "root";
+            "listen.mode" = "0660";
+            "listen.owner" = socketOwner;
+            "pm" = "dynamic";
+            "pm.max_children" = 75;
+            "pm.max_requests" = 500;
+            "pm.max_spare_servers" = 20;
+            "pm.min_spare_servers" = 5;
+            "pm.start_servers" = 10;
+          };
+          phpEnv.PIWIK_USER_PATH = dataDir;
         };
-        phpEnv.PIWIK_USER_PATH = dataDir;
       };
-    };
-
 
     services.nginx.virtualHosts = mkIf (cfg.nginx != null) {
       # References:
       # https://fralef.me/piwik-hardening-with-nginx-and-php-fpm.html
       # https://github.com/perusio/piwik-nginx
-      "${user}.${fqdn}" = mkMerge [ cfg.nginx {
-        # don't allow to override the root easily, as it will almost certainly break Matomo.
-        # disadvantage: not shown as default in docs.
-        root = mkForce "${cfg.package}/share";
+      "${user}.${fqdn}" = mkMerge [
+        cfg.nginx
+        {
+          # don't allow to override the root easily, as it will almost certainly break Matomo.
+          # disadvantage: not shown as default in docs.
+          root = mkForce "${cfg.package}/share";
 
-        # define locations here instead of as the submodule option's default
-        # so that they can easily be extended with additional locations if required
-        # without needing to redefine the Matomo ones.
-        # disadvantage: not shown as default in docs.
-        locations."/" = {
-          index = "index.php";
-        };
-        # allow index.php for webinterface
-        locations."= /index.php".extraConfig = ''
-          fastcgi_pass unix:${fpm.socket};
-        '';
-        # allow matomo.php for tracking
-        locations."= /matomo.php".extraConfig = ''
-          fastcgi_pass unix:${fpm.socket};
-        '';
-        # allow piwik.php for tracking (deprecated name)
-        locations."= /piwik.php".extraConfig = ''
-          fastcgi_pass unix:${fpm.socket};
-        '';
-        # Any other attempt to access any php files is forbidden
-        locations."~* ^.+\\.php$".extraConfig = ''
-          return 403;
-        '';
-        # Disallow access to unneeded directories
-        # config and tmp are already removed
-        locations."~ ^/(?:core|lang|misc)/".extraConfig = ''
-          return 403;
-        '';
-        # Disallow access to several helper files
-        locations."~* \\.(?:bat|git|ini|sh|txt|tpl|xml|md)$".extraConfig = ''
-          return 403;
-        '';
-        # No crawling of this site for bots that obey robots.txt - no useful information here.
-        locations."= /robots.txt".extraConfig = ''
-          return 200 "User-agent: *\nDisallow: /\n";
-        '';
-        # let browsers cache matomo.js
-        locations."= /matomo.js".extraConfig = ''
-          expires 1M;
-        '';
-        # let browsers cache piwik.js (deprecated name)
-        locations."= /piwik.js".extraConfig = ''
-          expires 1M;
-        '';
-      }];
+          # define locations here instead of as the submodule option's default
+          # so that they can easily be extended with additional locations if required
+          # without needing to redefine the Matomo ones.
+          # disadvantage: not shown as default in docs.
+          locations."/" = { index = "index.php"; };
+          # allow index.php for webinterface
+          locations."= /index.php".extraConfig = ''
+            fastcgi_pass unix:${fpm.socket};
+          '';
+          # allow matomo.php for tracking
+          locations."= /matomo.php".extraConfig = ''
+            fastcgi_pass unix:${fpm.socket};
+          '';
+          # allow piwik.php for tracking (deprecated name)
+          locations."= /piwik.php".extraConfig = ''
+            fastcgi_pass unix:${fpm.socket};
+          '';
+          # Any other attempt to access any php files is forbidden
+          locations."~* ^.+\\.php$".extraConfig = ''
+            return 403;
+          '';
+          # Disallow access to unneeded directories
+          # config and tmp are already removed
+          locations."~ ^/(?:core|lang|misc)/".extraConfig = ''
+            return 403;
+          '';
+          # Disallow access to several helper files
+          locations."~* \\.(?:bat|git|ini|sh|txt|tpl|xml|md)$".extraConfig = ''
+            return 403;
+          '';
+          # No crawling of this site for bots that obey robots.txt - no useful information here.
+          locations."= /robots.txt".extraConfig = ''
+            return 200 "User-agent: *\nDisallow: /\n";
+          '';
+          # let browsers cache matomo.js
+          locations."= /matomo.js".extraConfig = ''
+            expires 1M;
+          '';
+          # let browsers cache piwik.js (deprecated name)
+          locations."= /piwik.js".extraConfig = ''
+            expires 1M;
+          '';
+        }
+      ];
     };
   };
 
   meta = {
     doc = ./matomo-doc.xml;
-    maintainers = with lib.maintainers; [ florianjacob ];
+    maintainers = with lib.maintainers; [
+      florianjacob
+      kiwi
+    ];
   };
 }

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -1,109 +1,120 @@
-{ stdenv, fetchurl, makeWrapper, php }:
-
+{ fetchurl
+, makeWrapper
+, php
+, stdenv
+}:
 let
   versions = {
     matomo = {
-      version = "3.14.1";
-      sha256 = "0gp6v797118z703nh0p77zvsizvdg0c2jkn26996d4sqw5pa78v3";
+      version = "4.0.4";
+      sha256 = "1331ah5q9n9w6l1z20v6bn6xiayjx3ay08i9l06220y729ri8nbx";
     };
 
     matomo-beta = {
-      version = "3.14.1";
+      version = "4.0.4";
       # `beta` examples: "b1", "rc1", null
       # TOOD when updating: use null if stable version is >= latest beta or release candidate
       beta = null;
-      sha256 = "0gp6v797118z703nh0p77zvsizvdg0c2jkn26996d4sqw5pa78v3";
+      sha256 = "1331ah5q9n9w6l1z20v6bn6xiayjx3ay08i9l06220y729ri8nbx";
     };
   };
-  common = pname: { version, sha256, beta ? null }:
+  common = pname:
+    { version, sha256, beta ? null }:
     let
-      fullVersion = version + stdenv.lib.optionalString (beta != null) "-${toString beta}";
+      fullVersion = version
+        + stdenv.lib.optionalString (beta != null) "-${toString beta}";
       name = "${pname}-${fullVersion}";
     in
+    stdenv.mkDerivation rec {
+      inherit name;
+      version = fullVersion;
 
-      stdenv.mkDerivation rec {
-        inherit name;
-        version = fullVersion;
-
-        src = fetchurl {
-          url = "https://builds.matomo.org/matomo-${version}.tar.gz";
-          inherit sha256;
-        };
-
-        nativeBuildInputs = [ makeWrapper ];
-
-        # make-localhost-default-database-server.patch:
-        #   This changes the default value of the database server field
-        #   from 127.0.0.1 to localhost.
-        #   unix socket authentication only works with localhost,
-        #   but password-based SQL authentication works with both.
-        # TODO: is upstream interested in this?
-        # -> discussion at https://github.com/matomo-org/matomo/issues/12646
-        patches = [ ./make-localhost-default-database-host.patch ];
-
-        # this bootstrap.php adds support for getting PIWIK_USER_PATH
-        # from an environment variable. Point it to a mutable location
-        # to be able to use matomo read-only from the nix store
-        postPatch = ''
-          cp ${./bootstrap.php} bootstrap.php
-        '';
-
-        # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
-        # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
-        #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
-        #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
-        installPhase = ''
-          runHook preInstall
-
-          # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
-          mkdir -p $out/share
-          cp -ra * $out/share/
-          # tmp/ is created by matomo in PIWIK_USER_PATH
-          rmdir $out/share/tmp
-          # config/ needs to be accessed by PIWIK_USER_PATH anyway
-          ln -s $out/share/config $out/
-
-          makeWrapper ${php}/bin/php $out/bin/matomo-console \
-            --add-flags "$out/share/console"
-
-          runHook postInstall
-        '';
-
-        filesToFix = [
-          "misc/composer/build-xhprof.sh"
-          "misc/composer/clean-xhprof.sh"
-          "misc/cron/archive.sh"
-          "plugins/Installation/FormDatabaseSetup.php"
-          "vendor/leafo/lessphp/package.sh"
-          "vendor/pear/archive_tar/sync-php4"
-          "vendor/szymach/c-pchart/coverage.sh"
-          # drupal_test.sh does not exist in 3.12.0-b3; added for 3.13.0
-          "vendor/twig/twig/drupal_test.sh"
-        ];
-
-        # This fixes the consistency check in the admin interface
-        #
-        # The filesToFix list may contain files that are exclusive to only one of the versions we build
-        # make sure to test for existence to avoid erroring on an incompatible version and failing
-        postFixup = ''
-          pushd $out/share > /dev/null
-          for f in $filesToFix; do
-            if [ -f "$f" ]; then
-              length="$(wc -c "$f" | cut -d' ' -f1)"
-              hash="$(md5sum "$f" | cut -d' ' -f1)"
-              sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
-            fi
-          done
-          popd > /dev/null
-        '';
-
-        meta = with stdenv.lib; {
-          description = "A real-time web analytics application";
-          license = licenses.gpl3Plus;
-          homepage = "https://matomo.org/";
-          platforms = platforms.all;
-          maintainers = with maintainers; [ florianjacob kiwi ];
-        };
+      src = fetchurl {
+        url = "https://builds.matomo.org/matomo-${version}.tar.gz";
+        inherit sha256;
       };
+
+      nativeBuildInputs = [
+        makeWrapper
+      ];
+
+      # make-localhost-default-database-server.patch:
+      #   This changes the default value of the database server field
+      #   from 127.0.0.1 to localhost.
+      #   unix socket authentication only works with localhost,
+      #   but password-based SQL authentication works with both.
+      # TODO: is upstream interested in this?
+      # -> discussion at https://github.com/matomo-org/matomo/issues/12646
+      patches = [ ./make-localhost-default-database-host.patch ];
+
+      # this bootstrap.php adds support for getting PIWIK_USER_PATH
+      # from an environment variable. Point it to a mutable location
+      # to be able to use matomo read-only from the nix store
+      postPatch = ''
+        cp ${./bootstrap.php} bootstrap.php
+      '';
+
+      # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
+      # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
+      #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
+      #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
+      installPhase = ''
+        runHook preInstall
+
+        # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
+        mkdir -p $out/share
+        cp -ra * $out/share/
+        # tmp/ is created by matomo in PIWIK_USER_PATH
+        rmdir $out/share/tmp
+        # config/ needs to be accessed by PIWIK_USER_PATH anyway
+        ln -s $out/share/config $out/
+
+        makeWrapper ${php}/bin/php $out/bin/matomo-console \
+          --add-flags "$out/share/console"
+
+        runHook postInstall
+      '';
+
+      filesToFix = [
+        "misc/composer/build-xhprof.sh"
+        "misc/composer/clean-xhprof.sh"
+        "misc/cron/archive.sh"
+        "plugins/Installation/FormDatabaseSetup.php"
+        "vendor/leafo/lessphp/package.sh"
+        "vendor/pear/archive_tar/sync-php4"
+        "vendor/szymach/c-pchart/coverage.sh"
+        # drupal_test.sh does not exist in 3.12.0-b3; added for 3.13.0
+        "vendor/twig/twig/drupal_test.sh"
+        # run_tests.sh is new in 4.*
+        "vendor/matomo/matomo-php-tracker/run_tests.sh"
+      ];
+
+      # This fixes the consistency check in the admin interface
+      #
+      # The filesToFix list may contain files that are exclusive to only one of the versions we build
+      # make sure to test for existence to avoid erroring on an incompatible version and failing
+      postFixup = ''
+        pushd $out/share > /dev/null
+        for f in $filesToFix; do
+          if [ -f "$f" ]; then
+            length="$(wc -c "$f" | cut -d' ' -f1)"
+            hash="$(md5sum "$f" | cut -d' ' -f1)"
+            sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
+          fi
+        done
+        popd > /dev/null
+      '';
+
+      meta = with stdenv.lib; {
+        description = "A real-time web analytics application";
+        license = licenses.gpl3Plus;
+        homepage = "https://matomo.org/";
+        platforms = platforms.all;
+        maintainers = with maintainers; [
+          florianjacob
+          kiwi
+        ];
+      };
+    };
 in
 stdenv.lib.mapAttrs common versions

--- a/pkgs/servers/web-apps/matomo/make-localhost-default-database-host.patch
+++ b/pkgs/servers/web-apps/matomo/make-localhost-default-database-host.patch
@@ -3,8 +3,8 @@ index 74de2535b4..bc172ad0eb 100644
 --- a/plugins/Installation/FormDatabaseSetup.php
 +++ b/plugins/Installation/FormDatabaseSetup.php
 @@ -82,7 +82,7 @@ class FormDatabaseSetup extends QuickForm2
- 
- 
+
+
          $defaults = array(
 -            'host'          => '127.0.0.1',
 +            'host'          => 'localhost',


### PR DESCRIPTION
i might have a problem with compulsive formatting (especially w.r.t. lists)

[there should probably be a note somewhere about a manual database upgrade step that should be done (this is the note)](https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/)
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

various versions of 4.0.x (beta versions too. currently this PR, 4.0.4) have been running on my server for a few weeks now. I tested upgrades and new installs (on... 4.0.1 i think) in a vm.

there may be a change to how it handles reverse proxies I'm not sure. also not sure if a module change is in order or not. (it doesn't like letting me log into matomo.$domain but stats.$domain is fine. it might not have liked matomo.$domain before either, I don't remember. too late for me to check now :smile: )

@florianjacob @aanderse 
