### PR TITLE
lib/trivial: Move pipe note into pipe documentation.

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -57,15 +57,15 @@ rec {
      The output type of each function has to be the input type
      of the next function, and the last function returns the
      final value.
-  */
-  pipe = val: functions:
-    let reverseApply = x: f: f x;
-    in builtins.foldl' reverseApply val functions;
-  /* note please don’t add a function like `compose = flip pipe`.
+
+     note please don’t add a function like `compose = flip pipe`.
      This would confuse users, because the order of the functions
      in the list is not clear. With pipe, it’s obvious that it
      goes first-to-last. With `compose`, not so much.
   */
+  pipe = val: functions:
+    let reverseApply = x: f: f x;
+    in builtins.foldl' reverseApply val functions;
 
   ## Named versions corresponding to some builtin operators.
 


### PR DESCRIPTION
This one is a little weird.  The note at the end of the pipe function is
being picked up by the documentation generator and being used as the
documentation for the concat function (see the 20.09 manual for a cross
reference).  By moving this note into the documentation comment for
pipe, we solve two issues:

1. the note being listed under concat where it doesn't belong
2. the documentation for concat actually being exposed in the manual

If this isn't the desired solution we'll have to look into how
documentation is generated and see if there is a bug in that system
instead, but I like the clarity of this solution.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
