### PR TITLE
Firefox wrapper preserve addon settings

### DIFF
--- a/doc/builders/packages/firefox.section.md
+++ b/doc/builders/packages/firefox.section.md
@@ -9,7 +9,7 @@ The `wrapFirefox` function allows to pass policies, preferences and extension th
   myFirefox = wrapFirefox firefox-unwrapped {
     nixExtensions = [
       (fetchFirefoxAddon {
-        name = "ublock";
+        name = "ublock"; # Has to be unique!
         url = "https://addons.mozilla.org/firefox/downloads/file/3679754/ublock_origin-1.31.0-an+fx.xpi";
         sha256 = "1h768ljlh3pi23l27qp961v1hd0nbj2vasgy11bmcrlqp40zgvnr";
       })
@@ -42,7 +42,7 @@ The `wrapFirefox` function allows to pass policies, preferences and extension th
 If `nixExtensions != null` then all manually installed addons will be uninstalled from your browser profile.
 To view available enterprise policies visit [enterprise policies](https://github.com/mozilla/policy-templates#enterprisepoliciesenabled)
 or type into the Firefox url bar: `about:policies#documentation`.
-Nix installed addons do not have a valid signature, which is why signature verification is disabled. This does not compromise security because downloaded addons are checksumed and manual addons can't be installed.
+Nix installed addons do not have a valid signature, which is why signature verification is disabled. This does not compromise security because downloaded addons are checksumed and manual addons can't be installed. Also make sure that the `name` field of fetchFirefoxAddon is unique.
 
 ## Troubleshooting {#sec-firefox-troubleshooting}
 If addons do not appear installed although they have been defined in your nix configuration file reset the local addon state of your Firefox profile by clicking `help -> restart with addons disabled -> restart -> refresh firefox`. This can happen if you switch from manual addon mode to nix addon mode and then back to manual mode and then again to nix addon mode.

--- a/pkgs/build-support/fetchfirefoxaddon/default.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/default.nix
@@ -1,15 +1,20 @@
 {stdenv, lib, coreutils, unzip, jq, zip, fetchurl,writeScript,  ...}:
-{ name
+let
+
+in
+  {
+  name
 , url
 , md5 ? ""
 , sha1 ? ""
 , sha256 ? ""
 , sha512 ? ""
 }:
+
 stdenv.mkDerivation rec {
 
   inherit name;
-  extid = "${src.outputHash}@${name}";
+  extid = "12345@${name}";
   passthru = {
     exitd=extid;
   };


### PR DESCRIPTION
###### Motivation for this change
In the current firefox wrapper every addon update discards the addon settings, like mentioned here https://github.com/NixOS/nixpkgs/issues/105783#issuecomment-739212366.

###### Things done
This change makes the extid static and user defined. However now it has to be made sure that every addon gets assigned an unique name by  the user. I do not know how to do that in the nix language so if someone knows how please comment how ^^.

I would like to do something like this:
![1607180523_grim](https://user-images.githubusercontent.com/22085373/101246386-4ebf5380-3713-11eb-9fd6-ac7965ab9486.png)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
