### PR TITLE
ffmpeg-full: re-enable encoders on macOS

### DIFF
--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -164,9 +164,8 @@
  *   utvideo vo-aacenc vo-amrwbenc xvmc zvbi blackmagic-design-desktop-video
  *
  * Need fixes to support Darwin:
- *   frei0r game-music-emu gsm libjack2 libmfx(intel-media-sdk) libssh
- *   libvpx(stable 1.3.0) openal openjpeg pulseaudio rtmpdump samba vid-stab
- *   wavpack x265 xavs
+ *   gsm libjack2 libmodplug libmfx(intel-media-sdk) nvenc pulseaudio samba
+ *   vid-stab
  *
  * Need fixes to support AArch64:
  *   libmfx(intel-media-sdk) nvenc

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12786,18 +12786,12 @@ in
 
   ffmpeg-full = callPackage ../development/libraries/ffmpeg-full {
     # The following need to be fixed on Darwin
-    frei0r = if stdenv.isDarwin then null else frei0r;
-    game-music-emu = if stdenv.isDarwin then null else game-music-emu;
     libjack2 = if stdenv.isDarwin then null else libjack2;
     libmodplug = if stdenv.isDarwin then null else libmodplug;
-    openal = if stdenv.isDarwin then null else openal;
     libmfx = if stdenv.isDarwin then null else intel-media-sdk;
     libpulseaudio = if stdenv.isDarwin then null else libpulseaudio;
-    rav1e = if stdenv.isDarwin then null else rav1e;
     samba = if stdenv.isDarwin then null else samba;
     vid-stab = if stdenv.isDarwin then null else vid-stab;
-    x265 = if stdenv.isDarwin then null else x265;
-    xavs = if stdenv.isDarwin then null else xavs;
     inherit (darwin.apple_sdk.frameworks)
       Cocoa CoreServices CoreAudio AVFoundation MediaToolbox
       VideoDecodeAcceleration;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A number of encoders for ffmpeg are currently disabled on macOS. Since many of them were disabled back in 2015, I checked if we can re-add some them back. This PR re-adds encoders that successfully compiled with ffmpeg.

```
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12787)   ffmpeg-full = callPackage ../development/libraries/ffmpeg-full {
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12788)     # The following need to be fixed on Darwin
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12789)     frei0r = if stdenv.isDarwin then null else frei0r;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12790)     game-music-emu = if stdenv.isDarwin then null else game-music-emu;
430c8520b2c1 (Nicolas Dudebout          2015-06-27 13:20:56 -0400 12791)     libjack2 = if stdenv.isDarwin then null else libjack2;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12792)     libmodplug = if stdenv.isDarwin then null else libmodplug;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12793)     openal = if stdenv.isDarwin then null else openal;
410c30077c01 (midchildan                2019-03-11 16:10:56 +0900 12794)     libmfx = if stdenv.isDarwin then null else intel-media-sdk;
b07929b0a389 (William A. Kennington III 2015-05-27 12:42:15 -0700 12795)     libpulseaudio = if stdenv.isDarwin then null else libpulseaudio;
2aff61f6092b (Okina Matara              2020-11-18 20:42:50 -0600 12796)     rav1e = if stdenv.isDarwin then null else rav1e;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12797)     samba = if stdenv.isDarwin then null else samba;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12798)     vid-stab = if stdenv.isDarwin then null else vid-stab;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12799)     x265 = if stdenv.isDarwin then null else x265;
033472c136ee (codyopel                  2015-04-07 03:34:27 -0400 12800)     xavs = if stdenv.isDarwin then null else xavs;
```

I also did a quick check with the resulting ffmpeg binary and was successfully able to transcode a video using the x265 encoder.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Package closure size
```console
❯   nix path-info -S /nix/store/x4xnib86wvlhjq1lsxsqh644mh4cmd8a-ffmpeg-full-4.3.1  # before
/nix/store/x4xnib86wvlhjq1lsxsqh644mh4cmd8a-ffmpeg-full-4.3.1	  198358600
❯ nix path-info -S "$(nix-build --no-out-link -A ffmpeg-full)"                      # after
/nix/store/bhz2qf4ngbjv4f8xh4yacvbaqch9nhn4-ffmpeg-full-4.3.1	  246738648
```