### PR TITLE
nixos/navidrome: init module and test

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -224,6 +224,7 @@
   ./services/audio/liquidsoap.nix
   ./services/audio/mpd.nix
   ./services/audio/mopidy.nix
+  ./services/audio/navidrome.nix
   ./services/audio/roon-server.nix
   ./services/audio/slimserver.nix
   ./services/audio/snapserver.nix

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -4,12 +4,13 @@ with lib;
 
 let
   cfg = config.services.navidrome;
+  settingsFormat = pkgs.formats.json {};
 in {
   options = {
     services.navidrome = {
       enable = mkEnableOption pkgs.navidrome.meta.description;
       settings = mkOption rec {
-        type = types.attrs;
+        type = settingsFormat.type;
         apply = recursiveUpdate default;
         default = {
           Address = "127.0.0.1";
@@ -19,43 +20,35 @@ in {
           MusicFolder = "/mnt/music";
         };
         description = ''
-          Configuration for Navidrome, see <link xlink:href="https://www.navidrome.org/docs/usage/configuration-options/"/> for supported values
+          Configuration for Navidrome, see <link xlink:href="https://www.navidrome.org/docs/usage/configuration-options/"/> for supported values.
         '';
       };
     };
   };
 
   config = mkIf cfg.enable {
+    systemd.packages = [ pkgs.navidrome ];
+
     systemd.services.navidrome = {
-      description = "Navidrome Media Server";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = ''
-          ${pkgs.navidrome}/bin/navidrome --configfile ${pkgs.writeText "navidrome.json" (builtins.toJSON cfg.settings)}
-        '';
+        ExecStart = [
+          ""
+          "${pkgs.navidrome}/bin/navidrome --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}"
+        ];
         DynamicUser = true;
         StateDirectory = "navidrome";
-        WorkingDirectory = "/var/lib/navidrome";
         RuntimeDirectory = "navidrome";
         RootDirectory = "/run/navidrome";
+        ReadWritePaths = "";
         BindReadOnlyPaths = [
           builtins.storeDir
         ] ++ lib.optional (cfg.settings ? MusicFolder) cfg.settings.MusicFolder;
         CapabilityBoundingSet = "";
-        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
-        RestrictNamespaces = true;
         PrivateDevices = true;
-        PrivateUsers = true;
         ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
         ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
+        SystemCallFilter = [ "~@resources" "~@cpu-emulation" ];
         SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
-        RestrictRealtime = true;
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
         UMask = "0066";

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.navidrome;
+in {
+  options = {
+    services.navidrome = {
+      enable = mkEnableOption pkgs.navidrome.meta.description;
+      settings = mkOption rec {
+        type = types.attrs;
+        apply = recursiveUpdate default;
+        default = {
+          Address = "127.0.0.1";
+          Port = 4533;
+        };
+        example = {
+          MusicFolder = "/mnt/music";
+        };
+        description = ''
+          Configuration for Navidrome, see <link xlink:href="https://www.navidrome.org/docs/usage/configuration-options/"/> for supported values
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.navidrome = {
+      description = "Navidrome Media Server";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.navidrome}/bin/navidrome --configfile ${pkgs.writeText "navidrome.json" (builtins.toJSON cfg.settings)}
+        '';
+        DynamicUser = true;
+        StateDirectory = "navidrome";
+        WorkingDirectory = "/var/lib/navidrome";
+        RuntimeDirectory = "navidrome";
+        RootDirectory = "/run/navidrome";
+        BindReadOnlyPaths = [
+          builtins.storeDir
+        ] ++ lib.optional (cfg.settings ? MusicFolder) cfg.settings.MusicFolder;
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+        RestrictRealtime = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        UMask = "0066";
+        ProtectHostname = true;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -237,6 +237,7 @@ in
   nat.firewall = handleTest ./nat.nix { withFirewall = true; };
   nat.firewall-conntrack = handleTest ./nat.nix { withFirewall = true; withConntrackHelpers = true; };
   nat.standalone = handleTest ./nat.nix { withFirewall = false; };
+  navidrome = handleTest ./navidrome.nix {};
   ncdns = handleTest ./ncdns.nix {};
   ndppd = handleTest ./ndppd.nix {};
   neo4j = handleTest ./neo4j.nix {};

--- a/nixos/tests/navidrome.nix
+++ b/nixos/tests/navidrome.nix
@@ -1,0 +1,12 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "navidrome";
+
+  machine = { ... }: {
+    services.navidrome.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("navidrome")
+    machine.wait_for_open_port("4533")
+  '';
+})

--- a/pkgs/servers/misc/navidrome/default.nix
+++ b/pkgs/servers/misc/navidrome/default.nix
@@ -2,9 +2,15 @@
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
-  pname = "navidrome";
+let
   version = "0.39.0";
+  upstream-systemd-unit = fetchurl {
+    url = "https://raw.githubusercontent.com/deluan/navidrome/v${version}/contrib/navidrome.service";
+    sha256 = "065lcmv7carbi0vy08qh3q5rsii8hp8xrrnfk5dgqyvykpf97cz5";
+  };
+in stdenv.mkDerivation rec {
+  pname = "navidrome";
+  inherit version;
 
   src = fetchurl {
     url = "https://github.com/deluan/navidrome/releases/download/v${version}/navidrome_${version}_Linux_x86_64.tar.gz";
@@ -20,6 +26,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
      mkdir -p $out/bin
      cp navidrome $out/bin
+     mkdir -p $out/lib/systemd/system
+     cp ${upstream-systemd-unit} $out/lib/systemd/system/navidrome.service
   '';
 
   postFixup = ''

--- a/pkgs/servers/misc/navidrome/default.nix
+++ b/pkgs/servers/misc/navidrome/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ffmpeg, ffmpegSupport ? true, makeWrapper }:
+{ stdenv, fetchurl, ffmpeg, ffmpegSupport ? true, makeWrapper, nixosTests }:
 
 with stdenv.lib;
 
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/navidrome \
       --prefix PATH : ${makeBinPath (optional ffmpegSupport ffmpeg)}
   '';
+
+  passthru.tests.navidrome = nixosTests.navidrome;
 
   meta = {
     description = "Navidrome Music Server and Streamer compatible with Subsonic/Airsonic";


### PR DESCRIPTION
Co-authored-by: aciceri <andrea.ciceri@autistici.org>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Continuing work from #92621

Added systemd security options

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
