### PR TITLE
monero 0.17.1.3 -> 0.17.1.5

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -1,6 +1,5 @@
 { stdenv, wrapQtAppsHook, makeDesktopItem
 , fetchFromGitHub
-, fetchpatch
 , cmake, qttools, pkgconfig
 , qtbase, qtdeclarative, qtgraphicaleffects
 , qtmultimedia, qtxmlpatterns
@@ -28,13 +27,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.17.1.4";
+  version = "0.17.1.5";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1ixjfdlvwr2an2s9jaql240bk7jpq5hhm5c4hww0bicyy3fp12ng";
+    sha256 = "0qlcqli0wvrjfy89mbgh1hpmk60dxgn5sws93h8lhgyfwx557iw0";
   };
 
   nativeBuildInputs = [
@@ -59,14 +58,7 @@ stdenv.mkDerivation rec {
     chmod -R +w source/monero
   '';
 
-  patches = [
-    ./move-log-file.patch
-    # fix build failure due to invalid use of CMAKE_PREFIX_PATH
-    (fetchpatch {
-      url = "https://github.com/monero-project/monero-gui/commit/ef2be82c21b0934522ad8e110805b66f5948da1f.patch";
-      sha256 = "1rhazk2xwa5dv1cmkrkq8yr08qxslg4k929cvlliabrx20kbr5z5";
-    })
-  ];
+  patches = [ ./move-log-file.patch ];
 
   postPatch = ''
     # set monero-gui version

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -17,13 +17,13 @@ assert trezorSupport -> all (x: x!=null) [ libusb1 protobuf python3 ];
 
 stdenv.mkDerivation rec {
   pname = "monero";
-  version = "0.17.1.3";
+  version = "0.17.1.5";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "1ddkdfd8i5q509qziwcx1f6nm8axs4a1ppzv2y5lgsqpq375if6j";
+    sha256 = "0yy9n2qng02j314h8fh5n0mcy6vpdks0yk4d8ifn8hj03f3g2c8b";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Notes: my client stopped synchronising to the remote node, maybe it's unrelated but it would be good if someone could confirm.
