### PR TITLE
uncertainties: 3.1.4 -> 3.1.5

### DIFF
--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "uncertainties";
-  version = "3.1.4";
+  version = "3.1.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0s69kdhl8vhqazhxqdvb06l83x0iqdm0yr4vp3p52alzi6a8lm33";
+    sha256 = "00z9xl40czmqk0vmxjvmjvwb41r893l4dad7nj1nh6blw3kw28li";
   };
 
   propagatedBuildInputs = [ future ];


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one `nix-shell -p 'python3.withPackages (p: [ p.uncertainties ])' --run 'python'`
- [x] Tested compilation of all pkgs that depend on this change (`pythonPackages.uncertainties`)
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
