### PR TITLE
pythonPackages.libusb1: 1.8.1 -> 1.9

### DIFF
--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "libusb1";
-  version = "1.8.1";
+  version = "1.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a8301a7e11ae44a03a46efc740022f8598ed55b6448b14ba68a63954ef18a240";
+    sha256 = "sha256:0l7vj04xm0i5ikxjdqrr5939q7amh0hfp0fqifkcvyjv9fvhyz65";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [ ] Tested compilation of all pkgs that depend on this change (`steamcontroller`)
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
