### PR TITLE
ocamlPackages.alcotest: 1.0.1 → 1.2.3

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/default.nix
+++ b/pkgs/development/ocaml-modules/alcotest/default.nix
@@ -1,17 +1,21 @@
 { lib, buildDunePackage, fetchurl
-, astring, cmdliner, fmt, uuidm, re, stdlib-shims
+, astring, cmdliner, fmt, uuidm, re, stdlib-shims, uutf
 }:
 
 buildDunePackage rec {
   pname = "alcotest";
-  version = "1.0.1";
+  version = "1.2.3";
+
+  useDune2 = true;
 
   src = fetchurl {
-    url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-${version}.tbz";
-    sha256 = "1xlklxb83gamqbg8j5dzm5jk4mvcwkspxajh93p6vpw9ia1li1qc";
+    url = "https://github.com/mirage/alcotest/releases/download/${version}/alcotest-mirage-${version}.tbz";
+    sha256 = "1bmjcivbmd4vib15v4chycgd1gl8js9dk94vzxkdg06zxqd4hp08";
   };
 
-  propagatedBuildInputs = [ astring cmdliner fmt uuidm re stdlib-shims ];
+  propagatedBuildInputs = [ astring cmdliner fmt uuidm re stdlib-shims uutf ];
+
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/mirage/alcotest";

--- a/pkgs/development/ocaml-modules/alcotest/lwt.nix
+++ b/pkgs/development/ocaml-modules/alcotest/lwt.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "alcotest-lwt";
 
-  inherit (alcotest) version src;
+  inherit (alcotest) version src useDune2;
 
   propagatedBuildInputs = [ alcotest logs ocaml_lwt ];
 

--- a/pkgs/development/ocaml-modules/domain-name/default.nix
+++ b/pkgs/development/ocaml-modules/domain-name/default.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
   pname = "domain-name";
   version = "0.3.0";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/hannesm/domain-name/releases/download/v${version}/domain-name-v${version}.tbz";
     sha256 = "12kc9p2a2fi1ipc2hyhbzivxpph3npglxwdgvhd6v20rqqdyvnad";
@@ -14,7 +16,7 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.03";
 
-  buildInputs = [ alcotest ];
+  checkInputs = [ alcotest ];
 
   propagatedBuildInputs = [ astring fmt ];
 

--- a/pkgs/development/ocaml-modules/duration/default.nix
+++ b/pkgs/development/ocaml-modules/duration/default.nix
@@ -1,16 +1,18 @@
-{ lib, buildDunePackage, fetchurl, alcotest }:
+{ lib, buildDunePackage, ocaml, fetchurl, alcotest }:
 
 buildDunePackage rec {
   pname = "duration";
   version = "0.1.3";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/hannesm/duration/releases/download/${version}/duration-${version}.tbz";
     sha256 = "0m9r0ayhpl98g9vdxrbjdcllns274jilic5v8xj1x7dphw21p95h";
   };
 
-  doCheck = true;
-  checkInputs = lib.optional doCheck alcotest;
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ alcotest ];
 
   meta = {
     homepage = "https://github.com/hannesm/duration";

--- a/pkgs/development/ocaml-modules/gmap/default.nix
+++ b/pkgs/development/ocaml-modules/gmap/default.nix
@@ -1,8 +1,10 @@
-{ lib, buildDunePackage, fetchurl, alcotest }:
+{ lib, buildDunePackage, ocaml, fetchurl, alcotest }:
 
 buildDunePackage rec {
   pname = "gmap";
   version = "0.3.0";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/hannesm/gmap/releases/download/${version}/gmap-${version}.tbz";
@@ -11,9 +13,9 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.03";
 
-  buildInputs = [ alcotest ];
+  checkInputs = [ alcotest ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
 
   meta = {
     description = "Heterogenous maps over a GADT";

--- a/pkgs/development/ocaml-modules/graphql/default.nix
+++ b/pkgs/development/ocaml-modules/graphql/default.nix
@@ -1,13 +1,13 @@
-{ lib, buildDunePackage, alcotest, graphql_parser, rresult, yojson }:
+{ buildDunePackage, alcotest, graphql_parser, rresult, yojson }:
 
 buildDunePackage rec {
   pname = "graphql";
 
-  inherit (graphql_parser) version src;
+  inherit (graphql_parser) version useDune2 src;
 
   propagatedBuildInputs = [ graphql_parser rresult yojson ];
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/graphql/lwt.nix
+++ b/pkgs/development/ocaml-modules/graphql/lwt.nix
@@ -1,13 +1,13 @@
-{ lib, buildDunePackage, alcotest, graphql, ocaml_lwt }:
+{ buildDunePackage, alcotest, graphql, ocaml_lwt }:
 
 buildDunePackage rec {
   pname = "graphql-lwt";
 
-  inherit (graphql) version src;
+  inherit (graphql) version useDune2 src;
 
   propagatedBuildInputs = [ graphql ocaml_lwt ];
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/graphql/parser.nix
+++ b/pkgs/development/ocaml-modules/graphql/parser.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "graphql_parser";
   version = "0.13.0";
 
+  useDune2 = true;
+
   minimumOCamlVersion = "4.03";
 
   src = fetchurl {
@@ -14,7 +16,7 @@ buildDunePackage rec {
   nativeBuildInputs = [ menhir ];
   propagatedBuildInputs = [ fmt re ];
 
-  checkInputs = lib.optional doCheck alcotest;
+  checkInputs = [ alcotest ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/mirage-time/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-time/default.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "mirage-time";
   version = "2.0.1";
 
+  useDune2 = true;
+
   src = fetchurl {
     url = "https://github.com/mirage/mirage-time/releases/download/v${version}/mirage-time-v${version}.tbz";
     sha256 = "1w6mm4g7fc19cs0ncs0s9fsnb1k1s04qqzs9bsqvq8ngsb90cbh0";

--- a/pkgs/development/ocaml-modules/mirage-time/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-time/unix.nix
@@ -3,7 +3,7 @@
 buildDunePackage {
   pname = "mirage-time-unix";
 
-  inherit (mirage-time) src version minimumOCamlVersion;
+  inherit (mirage-time) src useDune2 version minimumOCamlVersion;
 
   propagatedBuildInputs = [ mirage-time ocaml_lwt duration ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/mirage/alcotest/releases

Use Dune 2.

cc maintainers @ericbmerritt (`alcotest`), @sternenseemann (`mirage-time`). 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
