### PR TITLE
sd-image-*: Use F2FS instead of ext4 for root FS

### DIFF
--- a/nixos/lib/make-f2fs-fs.nix
+++ b/nixos/lib/make-f2fs-fs.nix
@@ -16,7 +16,6 @@
 , uuid ? "44444444-4444-4444-8888-888888888888"
 , f2fs-tools
 , perl
-, fakeroot
 }:
 
 let
@@ -25,7 +24,7 @@ in
 pkgs.stdenv.mkDerivation {
   name = "f2fs-fs.img${lib.optionalString compressImage ".zst"}";
 
-  nativeBuildInputs = [ f2fs-tools perl fakeroot ]
+  nativeBuildInputs = [ f2fs-tools perl ]
   ++ lib.optional compressImage zstd;
 
   buildCommand =
@@ -64,7 +63,7 @@ pkgs.stdenv.mkDerivation {
       truncate -s $bytes $img
 
       mkfs.f2fs -l ${volumeLabel} -U ${uuid} -T 1 $img
-      fakeroot sload.f2fs -T 1 -f ./rootImage $img
+      sload.f2fs -T 1 -f ./rootImage $img
 
       # I have ended up with corrupted images sometimes, I suspect that happens when the build machine's disk gets full during the build.
       if ! fsck.f2fs $img; then

--- a/nixos/lib/make-f2fs-fs.nix
+++ b/nixos/lib/make-f2fs-fs.nix
@@ -15,7 +15,6 @@
 , volumeLabel
 , uuid ? "44444444-4444-4444-8888-888888888888"
 , f2fs-tools
-, libfaketime
 , perl
 , fakeroot
 }:
@@ -26,7 +25,7 @@ in
 pkgs.stdenv.mkDerivation {
   name = "f2fs-fs.img${lib.optionalString compressImage ".zst"}";
 
-  nativeBuildInputs = [ f2fs-tools libfaketime perl fakeroot ]
+  nativeBuildInputs = [ f2fs-tools perl fakeroot ]
   ++ lib.optional compressImage zstd;
 
   buildCommand =
@@ -64,8 +63,8 @@ pkgs.stdenv.mkDerivation {
 
       truncate -s $bytes $img
 
-      faketime -f "1970-01-01 00:00:01" mkfs.f2fs -l ${volumeLabel} -U ${uuid} $img
-      faketime -f "1970-01-01 00:00:01" fakeroot sload.f2fs -f ./rootImage $img
+      mkfs.f2fs -l ${volumeLabel} -U ${uuid} -T 1 $img
+      fakeroot sload.f2fs -T 1 -f ./rootImage $img
 
       # I have ended up with corrupted images sometimes, I suspect that happens when the build machine's disk gets full during the build.
       if ! fsck.f2fs $img; then

--- a/nixos/lib/make-f2fs-fs.nix
+++ b/nixos/lib/make-f2fs-fs.nix
@@ -1,0 +1,82 @@
+# Builds an f2fs image containing a populated /nix/store with the closure
+# of store paths passed in the storePaths parameter, in addition to the
+# contents of a directory that can be populated with commands. The
+# generated image is sized to only fit its contents, with the expectation
+# that a script resizes the filesystem at boot time.
+{ pkgs
+, lib
+# List of derivations to be included
+, storePaths
+# Whether or not to compress the resulting image with zstd
+, compressImage ? false, zstd
+# Shell commands to populate the ./files directory.
+# All files in that directory are copied to the root of the FS.
+, populateImageCommands ? ""
+, volumeLabel
+, uuid ? "44444444-4444-4444-8888-888888888888"
+, f2fs-tools
+, libfaketime
+, perl
+, fakeroot
+}:
+
+let
+  sdClosureInfo = pkgs.buildPackages.closureInfo { rootPaths = storePaths; };
+in
+pkgs.stdenv.mkDerivation {
+  name = "f2fs-fs.img${lib.optionalString compressImage ".zst"}";
+
+  nativeBuildInputs = [ f2fs-tools libfaketime perl fakeroot ]
+  ++ lib.optional compressImage zstd;
+
+  buildCommand =
+    ''
+      ${if compressImage then "img=temp.img" else "img=$out"}
+      (
+      mkdir -p ./files
+      ${populateImageCommands}
+      )
+
+      echo "Preparing store paths for image..."
+
+      # Create nix/store before copying path
+      mkdir -p ./rootImage/nix/store
+
+      xargs -I % cp -a --reflink=auto % -t ./rootImage/nix/store/ < ${sdClosureInfo}/store-paths
+      (
+        GLOBIGNORE=".:.."
+        shopt -u dotglob
+
+        for f in ./files/*; do
+            cp -a --reflink=auto -t ./rootImage/ "$f"
+        done
+      )
+
+      # Also include a manifest of the closures in a format suitable for nix-store --load-db
+      cp ${sdClosureInfo}/registration ./rootImage/nix-path-registration
+
+      # Make a crude approximation of the size of the target image.
+      # If the script starts failing, increase the fudge factors here.
+      numInodes=$(find ./rootImage | wc -l)
+      numDataBlocks=$(du -s -c -B 4096 --apparent-size ./rootImage | tail -1 | awk '{ print int($1 * 1.10) }')
+      bytes=$((2 * 4096 * $numInodes + 4096 * $numDataBlocks))
+      echo "Creating an f2fs image of $bytes bytes (numInodes=$numInodes, numDataBlocks=$numDataBlocks)"
+
+      truncate -s $bytes $img
+
+      faketime -f "1970-01-01 00:00:01" mkfs.f2fs -l ${volumeLabel} -U ${uuid} $img
+      faketime -f "1970-01-01 00:00:01" fakeroot sload.f2fs -f ./rootImage $img
+
+      # I have ended up with corrupted images sometimes, I suspect that happens when the build machine's disk gets full during the build.
+      if ! fsck.f2fs $img; then
+        echo "--- Fsck failed for f2fs image of $bytes bytes (numInodes=$numInodes, numDataBlocks=$numDataBlocks) ---"
+        cat errorlog
+        return 1
+      fi
+
+      if [ ${builtins.toString compressImage} ]; then
+        echo "Compressing image"
+        zstd -v --no-progress ./$img -o $out
+      fi
+    '';
+}

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -19,7 +19,6 @@
   # - ttyAMA0: for QEMU's -machine virt
   # Also increase the amount of CMA to ensure the virtual console on the RPi3 works.
   boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
-  boot.kernelPackages = pkgs.linuxPackages_4_19;
 
   boot.initrd.availableKernelModules = [
     # Allows early (earlier) modesetting for the Raspberry Pi

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -19,6 +19,7 @@
   # - ttyAMA0: for QEMU's -machine virt
   # Also increase the amount of CMA to ensure the virtual console on the RPi3 works.
   boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
+  boot.kernelPackages = pkgs.linuxPackages_4_19;
 
   boot.initrd.availableKernelModules = [
     # Allows early (earlier) modesetting for the Raspberry Pi

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -29,7 +29,7 @@
   ];
 
   sdImage = {
-    populateFirmwareCommands = let
+    populateBootCommands = let
       configTxt = pkgs.writeText "config.txt" ''
         kernel=u-boot-rpi3.bin
 
@@ -45,14 +45,11 @@
         avoid_warnings=1
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
-        cp ${configTxt} firmware/config.txt
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
+        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin boot/u-boot-rpi3.bin
+        cp ${configTxt} boot/config.txt
+        ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./boot
       '';
-    populateRootCommands = ''
-      mkdir -p ./files/boot
-      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
-    '';
   };
 
   # the installation media is also the installation target,

--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -23,7 +23,7 @@
   boot.kernelParams = ["console=ttyS0,115200n8" "console=ttymxc0,115200n8" "console=ttyAMA0,115200n8" "console=ttyO0,115200n8" "console=ttySAC2,115200n8" "console=tty0"];
 
   sdImage = {
-    populateFirmwareCommands = let
+    populateBootCommands = let
       configTxt = pkgs.writeText "config.txt" ''
         # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
         # when attempting to show low-voltage or overtemperature warnings.
@@ -40,15 +40,12 @@
         enable_uart=1
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPi2}/u-boot.bin firmware/u-boot-rpi2.bin
-        cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin firmware/u-boot-rpi3.bin
-        cp ${configTxt} firmware/config.txt
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
+        cp ${pkgs.ubootRaspberryPi2}/u-boot.bin boot/u-boot-rpi2.bin
+        cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin boot/u-boot-rpi3.bin
+        cp ${configTxt} boot/config.txt
+        ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./boot
       '';
-    populateRootCommands = ''
-      mkdir -p ./files/boot
-      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
-    '';
   };
 
   # the installation media is also the installation target,

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
@@ -16,7 +16,7 @@
   boot.kernelPackages = pkgs.linuxPackages_rpi1;
 
   sdImage = {
-    populateFirmwareCommands = let
+    populateBootCommands = let
       configTxt = pkgs.writeText "config.txt" ''
         # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
         # when attempting to show low-voltage or overtemperature warnings.
@@ -29,15 +29,12 @@
         kernel=u-boot-rpi1.bin
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin firmware/u-boot-rpi0.bin
-        cp ${pkgs.ubootRaspberryPi}/u-boot.bin firmware/u-boot-rpi1.bin
-        cp ${configTxt} firmware/config.txt
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
+        cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin boot/u-boot-rpi0.bin
+        cp ${pkgs.ubootRaspberryPi}/u-boot.bin boot/u-boot-rpi1.bin
+        cp ${configTxt} boot/config.txt
+        ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./boot
       '';
-    populateRootCommands = ''
-      mkdir -p ./files/boot
-      ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
-    '';
   };
 
   # the installation media is also the installation target,

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
@@ -17,19 +17,11 @@
   boot.consoleLogLevel = lib.mkDefault 7;
 
   sdImage = {
-    firmwareSize = 128;
-    firmwarePartitionName = "NIXOS_BOOT";
     # This is a hack to avoid replicating config.txt from boot.loader.raspberryPi
-    populateFirmwareCommands =
-      "${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./firmware";
+    populateBootCommands =
+      "${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./boot";
     # As the boot process is done entirely in the firmware partition.
     populateRootCommands = "";
-  };
-
-  fileSystems."/boot/firmware" = {
-    # This effectively "renames" the attrsOf entry set in sd-image.nix
-    mountPoint = "/boot";
-    neededForBoot = true;
   };
 
   # the installation media is also the installation target,

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
@@ -20,8 +20,6 @@
     # This is a hack to avoid replicating config.txt from boot.loader.raspberryPi
     populateBootCommands =
       "${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./boot";
-    # As the boot process is done entirely in the firmware partition.
-    populateRootCommands = "";
   };
 
   # the installation media is also the installation target,

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -91,14 +91,12 @@ in
     };
 
     populateRootCommands = mkOption {
-      default = ''
-        mkdir -p files/boot
-      '';
+      default = "";
       description = ''
         Shell commands to populate the ./files directory.
         All files in that directory are copied to the
-        root (/) partition on the SD image. Use this to
-        populate the ./files/boot (/boot) directory.
+        root (/) partition on the SD image. This can be used
+        to inject files into the rootfs.
       '';
     };
 

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -74,7 +74,8 @@ in
     bootSize = mkOption {
       type = types.int;
       # As of 2019-08-18 the Raspberry pi firmware + u-boot takes ~18MiB
-      default = 120;
+      # A kernel, initrd, and dtbs are about 60MiB, and we want room for at least 2
+      default = 248;
       description = ''
         Size of the /boot partition, in megabytes.
       '';

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -46,7 +46,7 @@ in
           Contains the builder command used to populate an image,
           honoring all options except the <literal>-c &lt;path-to-default-configuration&gt;</literal>
           argument.
-          Useful to have for sdImage.populateRootCommands
+          Useful to have for sdImage.populateBootCommands
         '';
       };
 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -355,7 +355,7 @@ mountFS() {
 
     checkFS "$device" "$fsType"
 
-    # Optionally expand the filesystem.
+    # Optionally expand the partition.
     case $options in
         *x-nixos.autoexpand*)
             # Given a device of /dev/disk/by-label/NIXOS_SD

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -109,6 +109,11 @@ let
 
       # Copy some util-linux stuff.
       copy_bin_and_libs ${pkgs.util-linux}/sbin/blkid
+      copy_bin_and_libs ${pkgs.util-linux}/bin/lsblk
+      copy_bin_and_libs ${pkgs.util-linux}/bin/sfdisk
+
+      # Copy partprobe
+      copy_bin_and_libs ${pkgs.parted}/bin/partprobe
 
       # Copy dmsetup and lvm.
       copy_bin_and_libs ${getBin pkgs.lvm2}/bin/dmsetup

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -107,6 +107,17 @@ let
         '';
       };
 
+      autoExpand = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          If set, the partition is grown to the largest contiguous
+          extend possible. This is typically used when writing a
+          disk image to an SD card and growing the root partition
+          on first boot.
+        '';
+      };
+
       noCheck = mkOption {
         default = false;
         type = types.bool;
@@ -124,8 +135,11 @@ let
         # (same here)
         else if config.fsType == "reiserfs" then "-q"
         else null;
+      extraOptions = 
+        optional config.autoResize "x-nixos.autoresize" ++
+        optional config.autoExpand "x-nixos.autoexpand";
     in {
-      options = mkIf config.autoResize [ "x-nixos.autoresize" ];
+      options = mkIf (extraOptions != []) extraOptions;
       formatOptions = mkIf (defaultFormatOptions != null) (mkDefault defaultFormatOptions);
     };
 

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -135,7 +135,7 @@ let
         # (same here)
         else if config.fsType == "reiserfs" then "-q"
         else null;
-      extraOptions = 
+      extraOptions =
         optional config.autoResize "x-nixos.autoresize" ++
         optional config.autoExpand "x-nixos.autoexpand";
     in {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
F2FS has better behavior on SD cards and can improve performance and endurance over ext4. Closes #42242

###### Things done

- Added a partition expansion option to filesystems that expands the extent of the partition during stage-1, alongside filesystem resizing. This is needed because an F2FS partition cannot be resized after mounting it r/w.
- Added a `make-f2fs-fs.nix` module.
- Changed all `sd-image-*` modules to use F2FS.
  - This involved reverting the `/boot/firmware`/`/boot` split. `/boot` is now on FAT since u-boot doesn't support F2FS
  - The size of the `/boot` partition was increased to 256 MB (248, really, so the end of the partition is at the 256 MB boundary of the image)

###### Things to note:

- This change uses `sload.f2fs` to populate the root FS which seems to be a lot slower than the equivalent for ext4. Expect image builds to take about 5 minutes longer than before.
  - It's possible there's a better option here. Unsure
- Likewise, resizing an F2FS parition is fairly slow, so the first boot where the root partition gets resized can take a while. I'm not sure if this is dependent on SD card size or if it's related to the number of blocks that are allocated.
  - If it's related to # of blocks allocated, maybe it would make sense to enable file compression at the FS level for these images.
- F2FS partitions cannot be shrunk, so users who have more complex partitioning needs may not want this change.
  - It may be possible to add an option to the partition expanding feature that expands to all but the top N Bytes of the disk. It's always possible to expand more later if desired.

The images can be downloaded here, built on top of nixos-unstable:
- [Generic aarch64 image](https://f000.backblazeb2.com/file/nixos-f2fs/nixos-sd-image-21.03pre-aarch64.img.zst)
- [Raspberry pi 4 image](https://f000.backblazeb2.com/file/nixos-f2fs/nixos-sd-image-21.03pre-raspberrypi4.img.zst)
- Generic armv7l image (Currently building)
- Raspberry pi 0/1 image (Currently building)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
