### PR TITLE
marl: init at 1.0.0

### DIFF
--- a/pkgs/development/libraries/marl/default.nix
+++ b/pkgs/development/libraries/marl/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, cmake, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "marl";
+  version = "1.0.0";  # Based on marl's CHANGES.md
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    sha256 = "0pnbarbyv82h05ckays2m3vgxzdhpcpg59bnzsddlb5v7rqhw51w";
+    rev = "40209e952f5c1f3bc883d2b7f53b274bd454ca53";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  # Turn on the flag to install after building the library.
+  cmakeFlags = ["-DMARL_INSTALL=ON"];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/google/marl";
+    description = "A hybrid thread / fiber task scheduler written in C++ 11";
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ breakds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2374,6 +2374,8 @@ in
 
   mapproxy = callPackage ../applications/misc/mapproxy { };
 
+  marl = callPackage ../development/libraries/marl {};
+
   marlin-calc = callPackage ../tools/misc/marlin-calc {};
 
   masscan = callPackage ../tools/security/masscan {


### PR DESCRIPTION
###### Motivation for this change

This pull request packages a modern fiber scheduler library for C++, called [marl](https://github.com/google/marl).
I have been using this package with `nix-shell` for a few projects which verifies that the package works as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
