### PR TITLE
systemd: fix pc files

### DIFF
--- a/pkgs/os-specific/linux/systemd/0019-Revert-pkg-config-prefix-is-not-really-configurable-.patch
+++ b/pkgs/os-specific/linux/systemd/0019-Revert-pkg-config-prefix-is-not-really-configurable-.patch
@@ -1,0 +1,72 @@
+From cd5b1075499b8498d9c700a317ad11a3199c447a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Sun, 6 Dec 2020 08:34:19 +0100
+Subject: [PATCH 19/19] Revert "pkg-config: prefix is not really configurable,
+ don't pretend it was"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit 6e65df89c348242dbd10036abc7dd5e8181cf733.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ src/core/systemd.pc.in | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/core/systemd.pc.in b/src/core/systemd.pc.in
+index ccb382e421..8a35e53a4a 100644
+--- a/src/core/systemd.pc.in
++++ b/src/core/systemd.pc.in
+@@ -11,7 +11,7 @@
+ # considered deprecated (though there is no plan to remove them). New names
+ # shall have underscores.
+ 
+-prefix=/usr
++prefix=@prefix@
+ root_prefix=@rootprefix_noslash@
+ rootprefix=${root_prefix}
+ sysconf_dir=@sysconfdir@
+@@ -26,10 +26,10 @@ systemdsystemunitdir=${systemd_system_unit_dir}
+ systemd_system_preset_dir=${rootprefix}/lib/systemd/system-preset
+ systemdsystempresetdir=${systemd_system_preset_dir}
+ 
+-systemd_user_unit_dir=/usr/lib/systemd/user
++systemd_user_unit_dir=${prefix}/lib/systemd/user
+ systemduserunitdir=${systemd_user_unit_dir}
+ 
+-systemd_user_preset_dir=/usr/lib/systemd/user-preset
++systemd_user_preset_dir=${prefix}/lib/systemd/user-preset
+ systemduserpresetdir=${systemd_user_preset_dir}
+ 
+ systemd_system_conf_dir=${sysconfdir}/systemd/system
+@@ -48,7 +48,7 @@ systemduserunitpath=${systemd_user_unit_path}
+ systemd_system_generator_dir=${root_prefix}/lib/systemd/system-generators
+ systemdsystemgeneratordir=${systemd_system_generator_dir}
+ 
+-systemd_user_generator_dir=/usr/lib/systemd/user-generators
++systemd_user_generator_dir=${prefix}/lib/systemd/user-generators
+ systemdusergeneratordir=${systemd_user_generator_dir}
+ 
+ systemd_system_generator_path=/run/systemd/system-generators:/etc/systemd/system-generators:/usr/local/lib/systemd/system-generators:${systemd_system_generator_dir}
+@@ -63,7 +63,7 @@ systemdsleepdir=${systemd_sleep_dir}
+ systemd_shutdown_dir=${root_prefix}/lib/systemd/system-shutdown
+ systemdshutdowndir=${systemd_shutdown_dir}
+ 
+-tmpfiles_dir=/usr/lib/tmpfiles.d
++tmpfiles_dir=${prefix}/lib/tmpfiles.d
+ tmpfilesdir=${tmpfiles_dir}
+ 
+ sysusers_dir=${rootprefix}/lib/sysusers.d
+@@ -78,7 +78,7 @@ binfmtdir=${binfmt_dir}
+ modules_load_dir=${rootprefix}/lib/modules-load.d
+ modulesloaddir=${modules_load_dir}
+ 
+-catalog_dir=/usr/lib/systemd/catalog
++catalog_dir=${prefix}/lib/systemd/catalog
+ catalogdir=${catalog_dir}
+ 
+ system_uid_max=@SYSTEM_UID_MAX@
+-- 
+2.29.2
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -148,6 +148,7 @@ stdenv.mkDerivation {
     ./0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
     ./0017-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
     ./0018-logind-seat-debus-show-CanMultiSession-again.patch
+    ./0019-Revert-pkg-config-prefix-is-not-really-configurable-.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
upstream decided to make this non-configurable... Lets' revert to the
version before.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/102355#issuecomment-739258115
https://github.com/NixOS/nixpkgs/pull/105850#issuecomment-739226257

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
