### PR TITLE
ocamlPackages.uri: 3.1.0 → 4.0.0

### DIFF
--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  patches = [ ./install.patch ];
+  patches = [ ./install.patch ./uri.patch ];
 
   meta = with stdenv.lib; {
     description = "XML documents and web site compiler";

--- a/pkgs/applications/misc/stog/uri.patch
+++ b/pkgs/applications/misc/stog/uri.patch
@@ -1,0 +1,13 @@
+diff --git a/src/stog_url.ml b/src/stog_url.ml
+index 5d30a43f..c67bfc36 100644
+--- a/src/stog_url.ml
++++ b/src/stog_url.ml
+@@ -40,7 +40,7 @@ let of_string s =
+   with _ ->
+     failwith (Printf.sprintf "Malformed URL %S" s)
+ ;;
+-let to_string = Uri.to_string ;;
++let to_string u = Uri.to_string u;;
+ 
+ let path url =
+   let l =

--- a/pkgs/development/ocaml-modules/ocplib-json-typed/bson.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/bson.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage {
   pname = "ocplib-json-typed-bson";
-  inherit (ocplib-json-typed) version src;
+  inherit (ocplib-json-typed) version useDune2 src;
 
   propagatedBuildInputs = [ ocplib-json-typed ocplib-endian ];
 

--- a/pkgs/development/ocaml-modules/ocplib-json-typed/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
 	pname = "ocplib-json-typed";
 	version = "0.7.1";
+	useDune2 = true;
 	src = fetchFromGitHub {
 		owner = "OCamlPro";
 		repo = "ocplib-json-typed";

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -1,19 +1,21 @@
 { lib, fetchurl, buildDunePackage, ounit
-, re, stringext
+, angstrom, stringext
 }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.03";
   pname = "uri";
-  version = "3.1.0";
+  version = "4.0.0";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0hxc2mshmqxz2qmjya47dzf858s6lsf3xvqswpzprkvhv0zq4ln4";
+    sha256 = "13r9nkgym9z3dqxkyf0yyaqlrk5r3pjdw0kfzvrc90bmhwl9j380";
   };
 
-  buildInputs = [ ounit ];
-  propagatedBuildInputs = [ re stringext ];
+  checkInputs = [ ounit ];
+  propagatedBuildInputs = [ angstrom stringext ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/uri/sexp.nix
+++ b/pkgs/development/ocaml-modules/uri/sexp.nix
@@ -6,8 +6,9 @@ else
 
 buildDunePackage {
   pname = "uri-sexp";
-  inherit (uri) version src doCheck meta;
+  inherit (uri) version useDune2 src meta;
 
-  buildInputs = [ ounit ];
+  checkInputs = [ ounit ];
   propagatedBuildInputs = [ ppx_sexp_conv sexplib0 uri ];
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
 }


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

cc maintainer of `stog` @regnat

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
