### PR TITLE
spotifyd: workaround panic with older rust version

### DIFF
--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
+{ stdenv, fetchFromGitHub, rustPackages_1_45, pkgconfig, openssl
 , withALSA ? true, alsaLib ? null
 , withPulseAudio ? false, libpulseaudio ? null
 , withPortAudio ? false, portaudio ? null
@@ -7,7 +7,10 @@
 , dbus ? null
 }:
 
-rustPlatform.buildRustPackage rec {
+# rust >= 1.48 causes a panic within spotifyd on music playback. as long as
+# there is no upstream fix for the issue we use an older version of rust.
+# Upstream issue: https://github.com/Spotifyd/spotifyd/issues/719
+rustPackages_1_45.rustPlatform.buildRustPackage rec {
   pname = "spotifyd";
   version = "0.2.24";
 


### PR DESCRIPTION
###### Motivation for this change

rust >= 1.48 causes a panic within spotifyd on music playback. As long
as there is no upstream fix for the issue we use an older version of
rust.

Upstream issue: https://github.com/Spotifyd/spotifyd/issues/719


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested on NixOS on aarch64-linux
