### PR TITLE
tlclient: init at 4.12.0

### DIFF
--- a/pkgs/applications/networking/remote/tlclient/default.nix
+++ b/pkgs/applications/networking/remote/tlclient/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, copyDesktopItems
+, makeDesktopItem
+, alsa-lib
+, libX11
+, pcsclite
+}:
+let
+  tlclient-png = fetchurl {
+    url = "https://aur.archlinux.org/cgit/aur.git/plain/tlclient.png?h=tlclient&id=fd126edd54a012caa8c9ce47ab8d7fb25e982e74";
+    sha256 = "12i0wc4a8r69kwcdj0kjidwvmwhpb8jcwsqxw9dl5vm1gdqxyz5v";
+    name = "tlclient-png";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "tlclient";
+  version = "4.13.0-2172";
+
+  src = fetchurl {
+    # x86_64 arch tarball
+    url = "https://www.cendio.com/downloads/clients/tl-${version}-client-linux-dynamic-x86_64.tar.gz";
+    sha256 = "1mpigdd3abcypwjiwql2lrvpw3r6074czsxyanndnvfzy7xhc8ac";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook copyDesktopItems ];
+  propagatedBuildInputs = [ alsa-lib libX11 pcsclite ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 "lib/tlclient/EULA.txt" "$out/share/licenses/tlclient/EULA.txt"
+    install -m644 "lib/tlclient/open_source_licenses.txt" "$out/share/licenses/tlclient/open_source_licenses.txt"
+    cp -R lib "$out/"
+
+    install -Dm644 "etc/tlclient.conf" "$out/etc/tlclient.conf"
+    install -Dm755 "bin/tlclient" "$out/bin/tlclient"
+    install -Dm755 "bin/tlclient-openconf" "$out/bin/tlclient-openconf"
+
+    install -Dm644 "${tlclient-png}" "$out/share/tlclient/tlclient.png"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "ThinLinc Client";
+      name = "tlclient";
+      exec = "tlclient";
+      icon = "tlclient";
+      comment = meta.description;
+      type = "Application";
+      categories = "Network;RemoteAccess;";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Linux remote desktop client built on open source technology";
+    license = {
+      fullName = "Cendio End User License Agreement 3.2";
+      url = "https://www.cendio.com/thinlinc/docs/legal/eula";
+      free = false;
+    };
+    homepage = "https://www.cendio.com/";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2963,6 +2963,8 @@ with pkgs;
 
   inherit (nodePackages) fx;
 
+  tlclient = callPackage ../applications/networking/remote/tlclient { };
+
   tllist = callPackage ../development/libraries/tllist { };
 
   fcft = callPackage ../development/libraries/fcft { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/105399

###### Things done
Packaged non-free thin linc client for linux x86_64

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
