### PR TITLE
pythonPackages.ufonormalizer: 0.4.2 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/ufonormalizer/default.nix
+++ b/pkgs/development/python-modules/ufonormalizer/default.nix
@@ -1,14 +1,18 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, setuptools_scm }:
 
 buildPythonPackage rec {
   pname = "ufonormalizer";
-  version = "0.4.2";
+  version = "0.5.0";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1rn64a0i151qk6h5f9pijcmja195i2d6f8jbi5h4xkgkinm9wwzj";
+    sha256 = "1qc3389i2y16n1hjg4dzk821klzjipbh9c9yci70z51pp21mwwh5";
     extension = "zip";
   };
+
+  nativeBuildInputs = [ setuptools_scm ];
 
   meta = with lib; {
     description = "Script to normalize the XML and other data inside of a UFO";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/unified-font-object/ufoNormalizer/releases/tag/0.5.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
