### PR TITLE
pytest_xdist: make version conditional on python interpreter

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5823,11 +5823,10 @@ in {
 
   pytest-watch = callPackage ../development/python-modules/pytest-watch { };
 
-  pytest_xdist_1 = callPackage ../development/python-modules/pytest-xdist { };
-
-  pytest_xdist_2 = callPackage ../development/python-modules/pytest-xdist/2.nix { };
-
-  pytest_xdist = self.pytest_xdist_2;
+  pytest_xdist = if isPy3k then
+    callPackage ../development/python-modules/pytest-xdist/2.nix { }
+  else
+    callPackage ../development/python-modules/pytest-xdist { };
 
   pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
 


### PR DESCRIPTION
###### Motivation for this change

Fix for #106058

Like a number of other modules, the newer version of `pytest_xdist`
simply does not work on a python 2.x interpreter, resulting in
instantiation errors for tools using the 2.x interpreter like:

```
error: pytest-xdist-2.1.0 not supported for interpreter python2.7
(use '--show-trace' to show detailed location information)
```

This change uses the same strategy as those other modules to
conditionalize the version that is selected on the version of the
python interpreter.

I would like to keep this working for a while, at least, since the
DeDRM plugin for Calibre only works under python2 for the moment.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
