### PR TITLE
ETH2 Validator node support

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -275,6 +275,7 @@
   ./services/backup/zfs-replication.nix
   ./services/backup/znapzend.nix
   ./services/blockchain/ethereum/geth.nix
+  ./services/blockchain/ethereum/lighthouse.nix
   ./services/backup/zrepl.nix
   ./services/cluster/hadoop/default.nix
   ./services/cluster/k3s/default.nix

--- a/nixos/modules/services/blockchain/ethereum/lighthouse.nix
+++ b/nixos/modules/services/blockchain/ethereum/lighthouse.nix
@@ -1,0 +1,283 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  eachLighthouse = config.services.lighthouse;
+
+  lighthouseOpts = { config, lib, name, ...}: {
+
+    options = {
+
+      beacon = mkOption {
+        description = "Beacon node";
+        type = types.submodule {
+          options = {
+            enable = lib.mkEnableOption  "Lightouse Beacon node";
+
+            address = mkOption {
+              type = types.str;
+              default = "0.0.0.0";
+              description = ''
+                Listen address of Beacon node.
+              '';
+            };
+
+            port = mkOption {
+              type = types.port;
+              default = 9000;
+              description = ''
+                Port number the Beacon node will be listening on.
+              '';
+            };
+
+            http = {
+              port = mkOption {
+                type = types.port;
+                default = 5052;
+                description = ''
+                  Port number of Beacon node RPC service.
+                '';
+              };
+
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = ''
+                  Listen address of Beacon node RPC service.
+                '';
+              };
+            };
+
+            metrics = {
+              enable = lib.mkEnableOption "Beacon node prometheus metrics";
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = ''
+                  Listen address of Beacon node metrics service.
+                '';
+              };
+
+              port = mkOption {
+                type = types.port;
+                default = 5054;
+                description = ''
+                  Port number of Beacon node metrics service.
+                '';
+              };
+            };
+
+            eth1Endpoints = mkOption {
+              type = types.listOf types.str;
+              default = ["http://localhost:8545"];
+              description = ''
+                List of ETH1 nodes to connect to.
+              '';
+            };
+
+            extraArgs = mkOption {
+              type = types.str;
+              description = ''
+                Additional arguments passed to the lighthouse beacon command.
+              '';
+              default = "";
+              example = "";
+            };
+          };
+        };
+      };
+
+      validator = mkOption {
+        description = "Validator node";
+        type = types.submodule {
+          options = {
+            enable = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Enable Lightouse Validator node.";
+            };
+
+            beaconNodes = mkOption {
+              type = types.listOf types.str;
+              default = ["http://localhost:5052"];
+              description = ''
+                Beacon nodes to connect to.
+              '';
+            };
+
+            metrics = {
+              enable = lib.mkEnableOption "Validator node prometheus metrics";
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = ''
+                  Listen address of Validator node metrics service.
+                '';
+              };
+
+              port = mkOption {
+                type = types.port;
+                default = 5056;
+                description = ''
+                  Port number of Validator node metrics service.
+                '';
+              };
+            };
+
+            extraArgs = mkOption {
+              type = types.str;
+              description = ''
+                Additional arguments passed to the lighthouse validator command.
+              '';
+              default = "";
+              example = "";
+            };
+          };
+        };
+      };
+
+      network = mkOption {
+        type = types.enum [ "pyrmont" "mainnet" ];
+        default = "mainnet";
+        description = ''
+          The network to connect to. Mainnet is the default ethereum network.
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = types.str;
+        description = ''
+          Additional arguments passed to every lighthouse command.
+        '';
+        default = "";
+        example = "";
+      };
+
+      package = mkOption {
+        default = pkgs.lighthouse-ethereum;
+        type = types.package;
+        description = ''
+          Package to use as Lighthouse node.
+        '';
+      };
+    };
+  };
+
+  lighthouse-wrapper = (lighthouseName: cfg:
+    pkgs.writeScriptBin "lh-${lighthouseName}" ''
+      #! ${pkgs.runtimeShell}
+      cd ${cfg.package}
+      sudo=exec
+      if [[ "$USER" != lighthouse-${lighthouseName}-validator ]]; then
+        sudo='exec /run/wrappers/bin/sudo -u lighthouse-${lighthouseName}-validator'
+      fi
+      $sudo \
+        ${cfg.package}/bin/lighthouse --network ${cfg.network} --datadir /var/lib/lighthouse-validator/${lighthouseName}/${cfg.network} $*
+    ''
+  );
+
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+    services.lighthouse = mkOption {
+      type = types.attrsOf (types.submodule lighthouseOpts);
+      default = {};
+      description = "Specification of one or more lighthouse instances.";
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf (eachLighthouse != {}) {
+
+    # Create a real user for the validator so we can interact with it
+    users.users = mapAttrs' (lighthouseName: cfg: (
+      nameValuePair "lighthouse-${lighthouseName}-validator" {
+      group = "lighthouse";
+      createHome = false;
+      description = "Lighthouse Validator User (${lighthouseName})";
+      home = "/var/lib/lighthouse-validator/${lighthouseName}";
+      isSystemUser = true;
+      packages = [ cfg.package ];
+    })) eachLighthouse;
+
+    users.groups.lighthouse = {};
+
+    # Create a wrapper script for each instance that has the proper data directory set
+    environment.systemPackages = flatten (mapAttrsToList lighthouse-wrapper eachLighthouse);
+
+    systemd.tmpfiles.rules = [
+       "d '/var/lib/lighthouse-validator' 0770 root lighthouse - -"
+    ] ++ flatten (mapAttrsToList (lighthouseName: cfg: [
+       "d '/var/lib/lighthouse-validator/${lighthouseName}' 0700 lighthouse-${lighthouseName}-validator lighthouse - -"
+    ]) eachLighthouse);
+
+    systemd.services = mapAttrs' (lighthouseName: cfg: (
+      nameValuePair "lighthouse-${lighthouseName}-beacon" (mkIf cfg.beacon.enable {
+        description = "Lighthouse Beacon node (${lighthouseName})";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          DynamicUser = true;
+          Restart = "always";
+          StateDirectory = "lighthouse-beacon/${lighthouseName}/${cfg.network}";
+
+          # Hardening measures
+          PrivateTmp = "true";
+          ProtectSystem = "full";
+          NoNewPrivileges = "true";
+          PrivateDevices = "true";
+          MemoryDenyWriteExecute = "true";
+        };
+
+        script = ''
+          ${cfg.package}/bin/lighthouse beacon \
+            --disable-upnp \
+            --http --http-address ${cfg.beacon.http.address} --http-port ${toString cfg.beacon.http.port} \
+            --network ${cfg.network} \
+            --eth1-endpoints ${lib.concatStringsSep "," cfg.beacon.eth1Endpoints} \
+            --port ${toString cfg.beacon.port} --listen-address ${cfg.beacon.address} \
+            ${optionalString cfg.beacon.metrics.enable ''--metrics --metrics-address ${cfg.beacon.metrics.address} --metrics-port ${toString cfg.beacon.metrics.port}''} \
+            ${cfg.extraArgs} ${cfg.beacon.extraArgs} \
+            --datadir /var/lib/lighthouse-beacon/${lighthouseName}/${cfg.network}
+        '';
+      }))) eachLighthouse // mapAttrs' (lighthouseName: cfg: (
+      nameValuePair "lighthouse-${lighthouseName}-validator" (mkIf cfg.validator.enable {
+        description = "Lighthouse Validator node (${lighthouseName})";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        serviceConfig = {
+          User = "lighthouse-${lighthouseName}-validator";
+          Group = "lighthouse";
+          Restart = "always";
+          StateDirectory = "lighthouse-validator/${lighthouseName}/${cfg.network}";
+
+          # Hardening measures
+          PrivateTmp = "true";
+          ProtectSystem = "full";
+          NoNewPrivileges = "true";
+          PrivateDevices = "true";
+          MemoryDenyWriteExecute = "true";
+        };
+
+        script = ''
+          ${cfg.package}/bin/lighthouse validator \
+            --network ${cfg.network} \
+            --beacon-nodes ${lib.concatStringsSep "," cfg.validator.beaconNodes} \
+            ${optionalString cfg.validator.metrics.enable ''--metrics --metrics-address ${cfg.validator.metrics.address} --metrics-port ${toString cfg.validator.metrics.port}''} \
+            ${cfg.extraArgs} ${cfg.validator.extraArgs} \
+            --datadir /var/lib/lighthouse-validator/${lighthouseName}/${cfg.network}
+        '';
+      }))) eachLighthouse;
+
+  };
+
+}

--- a/pkgs/applications/blockchains/lighthouse/0001-Use-same-version-of-discv5-everywhere.patch
+++ b/pkgs/applications/blockchains/lighthouse/0001-Use-same-version-of-discv5-everywhere.patch
@@ -1,0 +1,96 @@
+From 19b48346efa96952e38bc69b12c48f7faf88c68e Mon Sep 17 00:00:00 2001
+From: Pascal Bach <pascal.bach@nextrem.ch>
+Date: Sat, 5 Jun 2021 17:08:14 +0200
+Subject: [PATCH] Use only a single version do discv5
+
+---
+ Cargo.lock                     | 38 +++-------------------------------
+ beacon_node/network/Cargo.toml |  2 +-
+ 2 files changed, 4 insertions(+), 36 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 9f992430..10073977 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1639,38 +1639,6 @@ version = "1.0.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+ 
+-[[package]]
+-name = "discv5"
+-version = "0.1.0-beta.3"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f6f52d2228d51e8f868a37d5b5b25b82c13552b635d5b47c3a5d53855a6fc4f0"
+-dependencies = [
+- "aes-ctr",
+- "aes-gcm 0.8.0",
+- "arrayvec",
+- "digest 0.9.0",
+- "enr",
+- "fnv",
+- "futures 0.3.14",
+- "hex",
+- "hkdf",
+- "k256",
+- "lazy_static",
+- "lru_time_cache",
+- "parking_lot",
+- "rand 0.7.3",
+- "rlp 0.5.0",
+- "sha2 0.9.3",
+- "smallvec",
+- "tokio 1.5.0",
+- "tokio-stream",
+- "tokio-util 0.6.6",
+- "tracing",
+- "tracing-subscriber",
+- "uint",
+- "zeroize",
+-]
+-
+ [[package]]
+ name = "discv5"
+ version = "0.1.0-beta.3"
+@@ -2033,7 +2001,7 @@ dependencies = [
+  "base64 0.13.0",
+  "directory",
+  "dirs 3.0.2",
+- "discv5 0.1.0-beta.3 (git+https://github.com/sigp/discv5?rev=02d2c896c66f8dc2b848c3996fedcd98e1dfec69)",
++ "discv5",
+  "error-chain",
+  "eth2_ssz",
+  "eth2_ssz_derive",
+@@ -2856,7 +2824,7 @@ version = "0.1.0"
+ dependencies = [
+  "beacon_chain",
+  "bs58 0.4.0",
+- "discv5 0.1.0-beta.3 (git+https://github.com/sigp/discv5?rev=02d2c896c66f8dc2b848c3996fedcd98e1dfec69)",
++ "discv5",
+  "environment",
+  "eth1",
+  "eth2",
+@@ -4170,7 +4138,7 @@ name = "network"
+ version = "0.2.0"
+ dependencies = [
+  "beacon_chain",
+- "discv5 0.1.0-beta.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "discv5",
+  "environment",
+  "error-chain",
+  "eth2_libp2p",
+diff --git a/beacon_node/network/Cargo.toml b/beacon_node/network/Cargo.toml
+index 0f0fad35..4d802424 100644
+--- a/beacon_node/network/Cargo.toml
++++ b/beacon_node/network/Cargo.toml
+@@ -15,7 +15,7 @@ slog-term = "2.6.0"
+ slog-async = "2.5.0"
+ logging = { path = "../../common/logging" }
+ environment = { path = "../../lighthouse/environment" }
+-discv5 = { version = "0.1.0-beta.3" }
++discv5 = { git = "https://github.com/sigp/discv5 ", rev = "02d2c896c66f8dc2b848c3996fedcd98e1dfec69", features = ["libp2p"] }
+ 
+ [dependencies]
+ beacon_chain =  { path = "../beacon_chain" }
+-- 
+2.31.1
+

--- a/pkgs/applications/blockchains/lighthouse/0004-Ignore-tests-that-require-network-access.patch
+++ b/pkgs/applications/blockchains/lighthouse/0004-Ignore-tests-that-require-network-access.patch
@@ -1,0 +1,24 @@
+From 12fd701a9c92bff1c3b030b9dd70d29d01a0d8b6 Mon Sep 17 00:00:00 2001
+From: Pascal Bach <pascal.bach@nextrem.ch>
+Date: Thu, 18 Feb 2021 14:30:35 +0100
+Subject: [PATCH 4/4] Ignore tests that require network access
+
+---
+ validator_client/slashing_protection/tests/interop.rs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/validator_client/slashing_protection/tests/interop.rs b/validator_client/slashing_protection/tests/interop.rs
+index 62cd03e2..fd426e24 100644
+--- a/validator_client/slashing_protection/tests/interop.rs
++++ b/validator_client/slashing_protection/tests/interop.rs
+@@ -21,6 +21,7 @@ fn test_root_dir() -> PathBuf {
+ }
+ 
+ #[test]
++#[ignore]
+ fn generated() {
+     for entry in test_root_dir()
+         .join("generated")
+-- 
+2.30.1
+

--- a/pkgs/applications/blockchains/lighthouse/bin.nix
+++ b/pkgs/applications/blockchains/lighthouse/bin.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv
+, fetchurl
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lighthouse-bin";
+  version = "1.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/sigp/lighthouse/releases/download/v${version}/lighthouse-v${version}-x86_64-unknown-linux-gnu-portable.tar.gz";
+    sha256 = "054d792g7lyv6g40d2qgg47d20881m5xidifk0fiw2aa21zbv9lm";
+  };
+
+  # Work around the "unpacker appears to have produced no directories"
+  # case that happens when the archive doesn't have a subdirectory.
+  setSourceRoot = "sourceRoot=$(pwd)";
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 -D lighthouse $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "An open-source Ethereum 2.0 client, written in Rust.";
+    homepage = "https://github.com/sigp/lighthouse";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -1,0 +1,76 @@
+{ lib, stdenv
+, fetchFromGitHub, fetchgit
+, rustPlatform
+, pkg-config, cmake, protobuf
+, zlib, bzip2, openssl, leveldb
+, nodePackages, curl, gnumake, git
+, portable ? true
+}:
+
+let
+  # Contains the data required by the deposit_contract
+  # See `common/deposit_contract/build.rs` in the lighthous source for exact version
+  eth2specs = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "eth2.0-specs";
+    rev = "v0.12.1";
+    sha256 = "05irxnskcsdbp844hgk2hwkjmgfjxin99jr1fl5b5wg1v7v7gl4y";
+  };
+  eth2specs_unsafe = fetchFromGitHub {
+    owner = "sigp";
+    repo = "unsafe-eth2-deposit-contract";
+    # NOTE: the version of the unsafe contract lags the main tag, but the v0.9.2.1 code is compatible
+    # with the unmodified v0.12.1 contract. See `common/deposit_contract/build.rs` for details.
+    rev = "v0.9.2.1";
+    sha256 = "151ahdj5114xb5hbhzsx5rx4yyry832hhm0bkx36s2np3r8v883q";
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "lighthouse";
+  version = "1.4.0";
+
+  src = fetchgit {
+    url = "https://github.com/sigp/lighthouse.git";
+    rev = "v${version}";
+    sha256 = "05bp3qx79gkgrbl1mdz8khi16252xkzksll980f3bff2aka8sw04";
+    # Version detection requires git to be present
+    leaveDotGit = true;
+  };
+
+  # LevelDB can't be unvendored and it requires cmake to be built
+  nativeBuildInputs = [ pkg-config cmake protobuf git ];
+  buildInputs = [ openssl zlib bzip2 leveldb ];
+  checkInputs = [ nodePackages.ganache-cli curl gnumake ];
+
+  preConfigure = ''
+    # Needed to get openssl-sys to use pkg-config.
+    export OPENSSL_NO_VENDOR=1
+
+    # Prost build needs this
+    export PROTOC="${protobuf}/bin/protoc"
+    export PROTOC_INCLUDE="${protobuf}/include"
+
+    # Use the pre fetched files instead of downloading them during build
+    export LIGHTHOUSE_DEPOSIT_CONTRACT_SPEC_URL="file://${eth2specs}/deposit_contract/contracts/validator_registration.json"
+    export LIGHTHOUSE_DEPOSIT_CONTRACT_TESTNET_URL="file://${eth2specs_unsafe}/unsafe_validator_registration.json"
+  '';
+
+  cargoBuildFlags = [ "--features" "${lib.optionalString portable "portable,"}" ];
+
+  cargoSha256 = "00ck7if514mczkg2lfy3p60sf8g0l0yq007imjiy965sby414nhg";
+  cargoPatches = [
+    ./0001-Use-same-version-of-discv5-everywhere.patch
+  ];
+
+  patches = [
+    ./0004-Ignore-tests-that-require-network-access.patch
+  ];
+
+  meta = with lib; {
+    description = "An open-source Ethereum 2.0 client, written in Rust.";
+    homepage = "https://github.com/sigp/lighthouse";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28326,6 +28326,7 @@ in
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };
 
   lighthouse-ethereum = callPackage ../applications/blockchains/lighthouse { };
+  lighthouse-ethereum-bin = callPackage ../applications/blockchains/lighthouse/bin.nix { };
 
   lightning-loop = callPackage ../applications/blockchains/lightning-loop { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28325,6 +28325,8 @@ in
 
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };
 
+  lighthouse-ethereum = callPackage ../applications/blockchains/lighthouse { };
+
   lightning-loop = callPackage ../applications/blockchains/lightning-loop { };
 
   lightning-pool = callPackage ../applications/blockchains/lightning-pool { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

**This is still work in progress, I'm currently testing and tweaking the modules: Don't us it yet as a mainnet validator. (Unless you know what you are doing).**.

Provide all the necessary services to allow running an [ETH2 validator](https://ethereum.org/en/eth2/staking/) on NixOS.

- [x] Services for ETH1 nodes
  - [x] [openethereum](https://github.com/openethereum/openethereum)
  - [x] [geth](https://github.com/ethereum/go-ethereum)
- [x] Services for ETH2 beacon and validator nodes
   - [x] [lighthouse](https://github.com/sigp/lighthouse)
- [ ] Package validator software
  - [ ] [lighthouse-ethereum](https://github.com/sigp/lighthouse)
  - [x] [lighthouse-ethereum-bin](https://github.com/sigp/lighthouse)

Open Points:

- [x] Package lighthouse from source. Currently the binary is packaged as the depndencies fo lighthouse can't be vendored. Fixed with v1.1.1. I will still provide an additional binary package as a fallback in case packaging issues arise again in the future.
- [ ] Create documentation how to setup a ETH2 validator
- [ ] lighthouse 1.1.1 build requires rust 1.50 https://github.com/NixOS/nixpkgs/pull/112792

Related MRs:

- [ ] #106983
- [ ] https://github.com/NixOS/nixpkgs/pull/113649

The goal is to have this all ready on unstable for the 21.05 stable release so that everybody can run a validatr node on stable.
This probably also means we should define that we will backport new releases of the involved packages to stable branches.

In addition to the official documentation a lot of the best practice was taken from the following sources:
- https://github.com/eth2-educators/eth2-docker
- https://someresat.medium.com/guide-to-staking-on-ethereum-2-0-ubuntu-lighthouse-41de20513b12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
