### PR TITLE
subtitleeditor: add more gst-plugins

### DIFF
--- a/pkgs/applications/video/subtitleeditor/default.nix
+++ b/pkgs/applications/video/subtitleeditor/default.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation {
     gst_all_1.gstreamermm
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
     hicolor-icon-theme
     libsigcxx
     libxmlxx


### PR DESCRIPTION
If there is a reason for leaving these out, I would like to learn it.