### PR TITLE
razergenie: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/applications/misc/razergenie/default.nix
+++ b/pkgs/applications/misc/razergenie/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "0.8.1";
+  version = "0.9.0";
   pname = "razergenie";
 
 in stdenv.mkDerivation {
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
     owner = "z3ntu";
     repo = "RazerGenie";
     rev = "v${version}";
-    sha256 = "1ggxnaidxbbpkv1h3zwwyci6886sssgslk5adbikbhz9kc9qg239";
+    sha256 = "17xlv26q8sdbav00wdm043449pg2424l3yaf8fvkc9rrlqkv13a4";
   };
 
   nativeBuildInputs = [
@@ -35,7 +35,7 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/z3ntu/RazerGenie";
     description = "Qt application for configuring your Razer devices under GNU/Linux";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ f4814n ];
+    maintainers = with maintainers; [ f4814n Mogria ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The Developer released version 0.9 https://github.com/z3ntu/RazerGenie/releases/tag/v0.9.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
