### PR TITLE
Add patiencediff python library

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9452,6 +9452,16 @@
     githubId = 19174984;
     name = "Alex Whitt";
   };
+  wildsebastian = {
+    name = "Sebastian Wild";
+    email = "sebastian@wild-siena.com";
+    github = "wildsebastian";
+    githubId = 1215623;
+    keys = [{
+      longkeyid = "rsa4096/0x366A2940479A06FC";
+      fingerprint = "DA03 D6C6 3F58 E796 AD26  E99B 366A 2940 479A 06FC";
+    }];
+  };
   willibutz = {
     email = "willibutz@posteo.de";
     github = "willibutz";

--- a/pkgs/development/python-modules/breezy/default.nix
+++ b/pkgs/development/python-modules/breezy/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , configobj
+, patiencediff
 , six
 , fastimport
 , dulwich
@@ -18,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "1eff207403f48898fa3b3ffa7a4275197c6c58fec105ef267caf1f5fd5a6c7be";
   };
 
-  propagatedBuildInputs = [ configobj six fastimport dulwich launchpadlib ];
+  propagatedBuildInputs = [ configobj patiencediff six fastimport dulwich launchpadlib ];
 
   checkInputs = [ testtools ];
 

--- a/pkgs/development/python-modules/patiencediff/default.nix
+++ b/pkgs/development/python-modules/patiencediff/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "patiencediff";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nm2242xgg59l06m54rzxp41aly3lxjh0a1s7h6dk7ryxjh002lv";
+  };
+
+  meta = with lib; {
+    description = "C implementation of patiencediff algorithm for Python";
+    homepage = "https://github.com/breezy-team/patiencediff";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.wildsebastian ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4474,6 +4474,8 @@ in {
 
   pathtools = callPackage ../development/python-modules/pathtools { };
 
+  patiencediff = callPackage ../development/python-modules/patiencediff { };
+
   patool = callPackage ../development/python-modules/patool { };
 
   patsy = callPackage ../development/python-modules/patsy { };


### PR DESCRIPTION
Add external patiencediff library to python-modules and as a dependency
to breezy.

###### Motivation for this change
nix-prefetch-baz does not build with latest breezy version 3.1.0. This requires the external package `patiencediff`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
