### PR TITLE
pikopixel: init at 1.0-b9e

### DIFF
--- a/pkgs/applications/graphics/pikopixel/default.nix
+++ b/pkgs/applications/graphics/pikopixel/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchurl
+, gnustep
+, gcc
+, llvmPackages_9
+}:
+
+let
+  # Earlier llvm than 9 segfaults
+  gnustep' = gnustep.override { llvmPackages = llvmPackages_9; };
+
+in gnustep'.gsmakeDerivation rec {
+  pname = "pikopixel";
+  version = "1.0-b9e";
+
+  src = fetchurl {
+    url = "http://twilightedge.com/downloads/PikoPixel.Sources.${version}.tar.gz";
+    sha256 = "1gmgb5ch7s6fwvg85l6pl6fsx0maqwd8yvg7sz3r9lj32g2pz5wn";
+  };
+
+  sourceRoot = "PikoPixel.Sources.${version}/PikoPixel";
+
+  buildInputs = [
+    gnustep'.base
+    gnustep'.gui
+    gnustep'.back
+  ];
+
+  # Fix the Exec and Icon paths in the .desktop file, and save the file in the
+  # correct place.
+  # postInstall gets redefined in gnustep.make's builder.sh, so we use preFixup
+  preFixup = ''
+    mkdir -p $out/share/applications
+    sed \
+      -e "s@^Exec=.*\$@Exec=$out/bin/PikoPixel %F@" \
+      -e "s@^Icon=.*/local@Icon=$out@" \
+      PikoPixel.app/Resources/PikoPixel.desktop > $out/share/applications/PikoPixel.desktop
+  '';
+
+  meta = with lib; {
+    description = "Application for drawing and editing pixel-art images";
+    homepage = "http://twilightedge.com/mac/pikopixel/";
+    downloadPage = "http://twilightedge.com/mac/pikopixel/";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/desktops/gnustep/default.nix
+++ b/pkgs/desktops/gnustep/default.nix
@@ -1,21 +1,22 @@
-{ pkgs, newScope, llvmPackages_6 }:
+{ newScope
+, llvmPackages
+, giflib_4_1
+}:
 
 let
   callPackage = newScope self;
 
   self = rec {
-    stdenv = pkgs.clangStdenv;
+    stdenv = llvmPackages.stdenv;
 
     gsmakeDerivation = callPackage ./make/gsmakeDerivation.nix {};
     gorm = callPackage ./gorm {};
     projectcenter = callPackage ./projectcenter {};
     system_preferences = callPackage ./systempreferences {};
-    libobjc = callPackage ./libobjc2 {
-      stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
-    };
+    libobjc = callPackage ./libobjc2 {};
     make = callPackage ./make {};
     back = callPackage ./back {};
-    base = callPackage ./base { giflib = pkgs.giflib_4_1; };
+    base = callPackage ./base { giflib = giflib_4_1; };
     gui = callPackage ./gui {};
     gworkspace = callPackage ./gworkspace {};
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23289,6 +23289,8 @@ in
 
   purple-facebook = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-facebook { };
 
+  pikopixel = callPackage ../applications/graphics/pikopixel { };
+
   pithos = callPackage ../applications/audio/pithos {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm having some problems with the application: the auxiliary windows constantly appear and disappear when clicking. I'm not sure if that's due to my window manager setup, so it'd be nice if someone with gnome/kde/something else tested it.
EDIT: I tested it on GNOME, and there are no issues, so it's just my setup.

Finally, I have no idea how to build this for darwin, and ofborg is down, so any help for that platform is appreciated. Is it just a matter of adding `xcbuild` to `nativeBuildInputs`?