### PR TITLE
bolt: Disable atime tests

### DIFF
--- a/pkgs/os-specific/linux/bolt/default.nix
+++ b/pkgs/os-specific/linux/bolt/default.nix
@@ -3,6 +3,7 @@
 , ninja
 , pkgconfig
 , fetchFromGitLab
+, fetchpatch
 , python3
 , umockdev
 , gobject-introspection
@@ -60,8 +61,18 @@ stdenv.mkDerivation rec {
       (p: [ p.pygobject3 p.dbus-python p.python-dbusmock ]))
   ];
 
-  # meson install tries to create /var/lib/boltd
-  patches = [ ./0001-skip-mkdir.patch ];
+  patches = [
+    # meson install tries to create /var/lib/boltd
+    ./0001-skip-mkdir.patch
+
+    # https://github.com/NixOS/nixpkgs/issues/104429
+    # Upstream issue: https://gitlab.freedesktop.org/bolt/bolt/-/issues/167
+    (fetchpatch {
+      name = "disable-atime-tests.diff";
+      url = "https://gitlab.freedesktop.org/roberth/bolt/-/commit/1f672a7de2ebc4dd51590bb90f3b873a8ac0f4e6.diff";
+      sha256 = "134f5s6kjqs6612pwq5pm1miy58crn1kxbyyqhzjnzmf9m57fnc8";
+    })
+    ];
 
   postPatch = ''
     patchShebangs scripts tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unblock nixos-unstable.

Fixes #104429 

Upstream PR https://gitlab.freedesktop.org/bolt/bolt/-/merge_requests/239

> Access time is not always supported, so support for it is best-effort.
We disable such assertions so bolt can be unit tested on systems that have
"noatime" configured to speed up the filesystem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
