### PR TITLE
Improve static Nix Darwin support

### DIFF
--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -281,8 +281,8 @@ in {
   python39 = super.python39.override { static = true; };
   python3Minimal = super.python3Minimal.override { static = true; };
 
-
-  libev = super.libev.override { static = true; };
+  # Note: -static doesn’t work on darwin
+  libev = super.libev.override { static = !super.stdenv.hostPlatform.isDarwin; };
 
   libexecinfo = super.libexecinfo.override { enableShared = false; };
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -34,13 +34,17 @@ self: super: let
     });
   };
 
-  staticAdapters = [ makeStaticLibraries propagateBuildInputs ]
+  staticAdapters =
+    # makeStaticDarwin must go first so that the extraBuildInputs
+    # override does not recreate mkDerivation, removing subsequent
+    # adapters.
+    optional super.stdenv.hostPlatform.isDarwin makeStaticDarwin
+
+    ++ [ makeStaticLibraries propagateBuildInputs ]
 
     # Apple does not provide a static version of libSystem or crt0.o
     # So we can’t build static binaries without extensive hacks.
     ++ optional (!super.stdenv.hostPlatform.isDarwin) makeStaticBinaries
-
-    ++ optional super.stdenv.hostPlatform.isDarwin makeStaticDarwin
 
     # Glibc doesn’t come with static runtimes by default.
     # ++ optional (super.stdenv.hostPlatform.libc == "glibc") ((flip overrideInStdenv) [ self.stdenv.glibc.static ])

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -163,6 +163,7 @@ in {
   };
   mkl = super.mkl.override { enableStatic = true; };
   nix = super.nix.override { enableStatic = true; };
+  nixUnstable = super.nixUnstable.override { enableStatic = true; };
   openssl = (super.openssl_1_1.override { static = true; }).overrideAttrs (o: {
     # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
     configureFlags = (removeUnknownConfigureFlags o.configureFlags);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

These changes are what's needed for `pkgsStatic.nix` to build on x86_64-darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
