### PR TITLE
[WIP] Add package wayfire.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3777,6 +3777,12 @@
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
     }];
   };
+  ishan = {
+    name = "Ishan Agarwal";
+    email = "ishan365.ia@gmail.com";
+    github = "ishan9299";
+    githubId = 47824004;
+  };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 pythonPackages.buildPythonPackage {
   pname = "hydrus";
-  version = "413";
+  version = "420";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
-    rev = "9fbed11bef499e01a6799b298bea7d0967d30430";
-    sha256 = "1dl7qpzmlxl376lzm0chmwvf4nl55wz6fwcsw0ikb33rm8r33gq4";
+    rev = "067c4862a0ed8dd9264b464c69975b520139809f";
+    sha256 = "12x0rv2yxsczdaxvpb5ggf4jwzjd1vd7ml0r61s4342zwvjrhji9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub
+, meson, pkg-config, ninja
+, wayland, wayland-protocols
+, cairo, glm, wlroots
+, libevdev, freetype, libinput
+, pixman, libxkbcommon, libdrm
+, libjpeg, libpng, libav
+, libGL, mesa, wf-config
+, libcap, xcbutilerrors, xcbutilwm, libxml2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wayfire";
+  version = "ee9c9d708065f6b17df4fa454e6741bed10899d4";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wayfire";
+    rev = version;
+    sha256 = "sha256-zKaZr/tBTeMUeqgxSLKe+/rW+JGon+MzBzP3mnZh96E=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [
+    wayland wayland-protocols
+    cairo glm libav wlroots
+    libevdev freetype libinput
+    pixman libxkbcommon libdrm
+    libjpeg libpng
+    libGL mesa wf-config
+    libcap xcbutilerrors xcbutilwm libxml2
+  ];
+  mesonFlags = [
+    "-Duse_system_wlroots=enabled"
+    "-Duse_system_wfconfig=enabled"
+    "-Dwlroots:logind-provider=systemd"
+    "-Dwlroots:libseat=disabled"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "3D wayland compositor";
+    homepage    = "https://wayfire.org/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ishan ];
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wcm/default.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, meson, ninja
+, fetchFromGitHub, wayfire
+, wf-shell, pkg-config
+, libevdev, wayland
+, wayland-protocols
+, libxml2, gtk3, glm
+, wf-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wcm";
+  version = "5d935e0727ab976c85690669083addc9c21ee298";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Nrz/Em80+C8uTUf0+Ny/WLcMKFVRKAzXaeIp3m7NsnU=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [
+    wayfire wf-shell
+    libevdev wayland
+    wayland-protocols
+    libxml2 gtk3 glm
+    wf-config
+  ];
+
+  mesonFlags = [
+    "-Dwf_shell=enabled"
+    "-Dwayfire_config_file_path=~/.config/wayfire.ini"
+    "-Dwf_shell_config_file_path=~/.config/wf-shell.ini"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Wayfire Config Manager";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ishan ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wfshell/default.nix
+++ b/pkgs/applications/window-managers/wayfire/wfshell/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig
+, wayland, wayland-protocols
+, gtkmm3, wayfire, alsaLib
+, gtk-layer-shell, librsvg
+, libpulseaudio, glm, wf-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wf-shell";
+  version = "3fed0524897f297bc4e7c49049c6b4221a2ff417";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Ci66TOTyWZZ14VPJz3pvi+mI9EtCPMveDm5NS97l+Y4=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [
+    alsaLib glm gtkmm3
+    gtk-layer-shell
+    libpulseaudio
+    wayland librsvg
+    wayland-protocols
+    wayfire wf-config
+  ];
+
+  mesonFlags = [
+    "-Dpulse=enabled"
+    "-Dwayland-logout=true"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A GTK3-based panel for wayfire";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ishan ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/wfconfig/default.nix
+++ b/pkgs/development/libraries/wfconfig/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub
+, glm, libxml2, libevdev
+, meson, pkg-config, ninja
+}:
+
+
+stdenv.mkDerivation rec {
+  pname = "wf-config";
+  version = "ec865db3cf932f530adbdd1ea8d1e5b00d25f7a9";
+
+  src = fetchFromGitHub {
+    owner = "ammen99";
+    repo = "wf-config";
+    rev = version;
+    sha256 = "sha256-JSWdr+Q7kNByKMd6nB3ep/7U87hMSWqgbhYRFGP7Lqw=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+
+  buildInputs = [
+    glm
+    libxml2
+    libevdev
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A library for managing configuration files, written for wayfire";
+    homepage    = "https://wayfire.org/";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ishan ];
+  };
+}

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -79,6 +79,7 @@
 , "expo-cli"
 , {"fast-cli": "1.x"}
 , "fauna-shell"
+, "fixjson"
 , "fkill-cli"
 , "flood"
 , "forever"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -22,13 +22,13 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.1100.2" = {
+    "@angular-devkit/architect-0.1100.3" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.1100.2";
+      version = "0.1100.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.2.tgz";
-        sha512 = "wSMMM8eBPol48OtvIyrIq2H9rOIiJmrPEtPbH0BSuPX0B8BckVImeTPzloqxSrpul4tY7Iwx0zwISDEgb59Vbw==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1100.3.tgz";
+        sha512 = "PF4PlGOIVW8eYAObP7B/vfk8TaHBEWzr2NOb+kHsIJJmx11iivkHRWzzQmTUlhwnRslCcg5ngwx0IBPDzNVeTg==";
       };
     };
     "@angular-devkit/core-11.0.0" = {
@@ -49,13 +49,13 @@ let
         sha512 = "ui3g7w/0SpU9oq8uwN9upR8Y1eOXZ+P2p3NyDydBrR7ZEfEkRLS1mhozN/ib8farrwK5N3kIIJxMb5t3187Hng==";
       };
     };
-    "@angular-devkit/core-11.0.2" = {
+    "@angular-devkit/core-11.0.3" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "11.0.2";
+      version = "11.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.2.tgz";
-        sha512 = "vUmmUNmNM9oRcDmt0PunU/ayglo0apq4pGL9Z5jj6alf2WwEiTcGHjyuZSDIO9MOLi41519jp3mDx79qXvvyww==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-11.0.3.tgz";
+        sha512 = "gJRiBj0gWDR2VtIvLvwwc/GM2MZvg1xw69ZbBJ1VuUgDqPBHdC8q3UMW3B82wdhxK+RBYa7ZOJxtIVggaHkm9g==";
       };
     };
     "@angular-devkit/schematics-11.0.0" = {
@@ -76,13 +76,13 @@ let
         sha512 = "rAOnAndcybEH398xf5wzmcUPCoCi0dKiOo/+1dkKU5aTxynw1OUnANt5K6A+ZZTGnJmfjtP0ovkZGYun9IUDxQ==";
       };
     };
-    "@angular-devkit/schematics-11.0.2" = {
+    "@angular-devkit/schematics-11.0.3" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "11.0.2";
+      version = "11.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.2.tgz";
-        sha512 = "unNewc+Y9ofrdKxXNoSHKUL6wvV8Vgh2nJMTLI1VAw8nfqgWphI+s5XwbVzog65nhZ10xJeaUm9u5R8pxLDpQg==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-11.0.3.tgz";
+        sha512 = "VZnqgnnfyzyMluIDvGp+ZlDU2P9BnjrhacBOdqBS/jNQ7oxyE0AWrUApGXcejOJ13Z7pEf31E64P3bImcjwP+A==";
       };
     };
     "@angular-devkit/schematics-cli-0.1100.1" = {
@@ -335,15 +335,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz";
         sha512 = "kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==";
-      };
-    };
-    "@babel/generator-7.12.1" = {
-      name = "_at_babel_slash_generator";
-      packageName = "@babel/generator";
-      version = "7.12.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz";
-        sha512 = "DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==";
       };
     };
     "@babel/generator-7.12.5" = {
@@ -1633,13 +1624,13 @@ let
         sha512 = "ZHkXKq2XFFmAUdmSZrmqUSIrRM4O9gtkdpxMmV+LQl7kScUnbo6pMnXu6+FTDgZ12aW6SDoZoOJfS56WD+Eu6A==";
       };
     };
-    "@eslint/eslintrc-0.2.1" = {
+    "@eslint/eslintrc-0.2.2" = {
       name = "_at_eslint_slash_eslintrc";
       packageName = "@eslint/eslintrc";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz";
-        sha512 = "XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==";
+        url = "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz";
+        sha512 = "EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==";
       };
     };
     "@evocateur/libnpmaccess-3.1.2" = {
@@ -1714,13 +1705,13 @@ let
         sha512 = "R78HOWnLcxdip3FBrfbxti+85jdoRNpXV0Eihb6dl+sBRNo4+uzBNEQQ1P7ICoTzrehdkhdXkQYflvQFuQXyAA==";
       };
     };
-    "@expo/config-plugins-1.0.5" = {
+    "@expo/config-plugins-1.0.7" = {
       name = "_at_expo_slash_config-plugins";
       packageName = "@expo/config-plugins";
-      version = "1.0.5";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.5.tgz";
-        sha512 = "ykEHIZu7Xjnq7wgauXw0cSbo9C2SVvDmCRwyAJoReJ88R0xXOt+4GQJ6BYdmGv9Gmdt6DTrWqwMQOJK6GmoMew==";
+        url = "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.7.tgz";
+        sha512 = "Do7xH8kCnsFa4Rl/Z8Ja2i71N+OpQARUoJHCQTHzyttL9j1eYeLDBOB6Hrl1vf8jcFfBtuqf8QWvMQkwJ17uqA==";
       };
     };
     "@expo/config-types-40.0.0-beta.1" = {
@@ -1750,13 +1741,13 @@ let
         sha512 = "FYLMoI7c1Myw5vCyx7nMEW6Oos40wx28TuHcticKPU+zZiYrzyIa4aJzEv4bWnw1if6417lKXjncYvQEZRyxFw==";
       };
     };
-    "@expo/dev-tools-0.13.65" = {
+    "@expo/dev-tools-0.13.66" = {
       name = "_at_expo_slash_dev-tools";
       packageName = "@expo/dev-tools";
-      version = "0.13.65";
+      version = "0.13.66";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.65.tgz";
-        sha512 = "LhfxPzJuKPi3WlK5C5o9ejJOkscU6pCqHKRWI97zN8Xh6XJ6FMNfqgh+hJ94vqWAMmDpEBjY3e7MxZXqQaNaAQ==";
+        url = "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.66.tgz";
+        sha512 = "eg1KoEUXWLFF0a+whWDj1hdu/XGdAbUtx3pqI053/0cCI0g3GHAQvNA8gJ3NEeSHYQaLb7irK2rNE6lJTcUo8Q==";
       };
     };
     "@expo/eas-build-job-0.1.2" = {
@@ -2002,13 +1993,13 @@ let
         sha512 = "uUmr+z9gpMNw6yUGinQkkN/GDPypLvySs/0pwUBF9w7xfaGeRKoEGYhNS8JaIXgmR3621eKi3F2pBlSoSFfiew==";
       };
     };
-    "@expo/xdl-59.0.5" = {
+    "@expo/xdl-59.0.6" = {
       name = "_at_expo_slash_xdl";
       packageName = "@expo/xdl";
-      version = "59.0.5";
+      version = "59.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@expo/xdl/-/xdl-59.0.5.tgz";
-        sha512 = "JWQDKG+Eymgwm3xd2OAkTSpb3fgNetQFJHGZt4/2GUfqjQuyFWZMtmtKwJ2ZDaW+V8tNW0hgR5czWI/lsZSZnA==";
+        url = "https://registry.npmjs.org/@expo/xdl/-/xdl-59.0.6.tgz";
+        sha512 = "6YHUcVDF62L7IxdCzOasIv9mG/KiXnMofvAuCkAYUQZYNF6vAIQJxj+/JjWAYRfTj1JHdY0OFkVpICun0qJ2FA==";
       };
     };
     "@fast-csv/format-4.3.5" = {
@@ -2056,13 +2047,13 @@ let
         sha512 = "t3yIbbPKJubb22vQ/FIWwS9vFAzaPYzFxKWPHVWLtxs/P+5yL+LD3B16DRtYreWAdl9CZvEbos58ChLZ0KHwSQ==";
       };
     };
-    "@fluentui/react-7.153.2" = {
+    "@fluentui/react-7.153.4" = {
       name = "_at_fluentui_slash_react";
       packageName = "@fluentui/react";
-      version = "7.153.2";
+      version = "7.153.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.153.2.tgz";
-        sha512 = "8D/zFzv9WaHqX5qu5oT20rjxkKf3GMhc40AOK+wloIfqzGe/OOXpg2zr0Hz+OXEijkGU7UPsjZ6uys/UAcXERQ==";
+        url = "https://registry.npmjs.org/@fluentui/react/-/react-7.153.4.tgz";
+        sha512 = "ksglyptT/nkjChmIZ2OiushPJMMBfYgJHclMYqfp8Z4TGeXWPaYT6l5HfKeEZJTsMz3WtJpy+6MB48Yh4PYOLA==";
       };
     };
     "@fluentui/react-compose-0.19.12" = {
@@ -2209,13 +2200,13 @@ let
         sha512 = "GabNT51ErVHE2riDH4EQdRusUsI+nMElT8LdFHyuP53v8gwtleAj+LePQ9jif4NYUe/JQVqO8V28vPcHrA7gfQ==";
       };
     };
-    "@graphql-tools/url-loader-6.4.0" = {
+    "@graphql-tools/url-loader-6.5.0" = {
       name = "_at_graphql-tools_slash_url-loader";
       packageName = "@graphql-tools/url-loader";
-      version = "6.4.0";
+      version = "6.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.4.0.tgz";
-        sha512 = "M3mS/VH6vpnai3b3Fa33kYcdCgZvhFh7RqFE1R3NMfhYjphQ10EWwgf31P+VQcBNB2zz+ubxttI6UcJLiGqwuQ==";
+        url = "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-6.5.0.tgz";
+        sha512 = "lwjg5vhZ2VvuWAXuzPwvLJfLmVN+cXoFmV0UeBethgP0Zvy8nkm1V+3aFGoyGkhxnlQUfBg/PMidw/t+7vhfAg==";
       };
     };
     "@graphql-tools/utils-6.2.4" = {
@@ -2227,22 +2218,22 @@ let
         sha512 = "ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==";
       };
     };
-    "@graphql-tools/utils-7.1.2" = {
+    "@graphql-tools/utils-7.1.4" = {
       name = "_at_graphql-tools_slash_utils";
       packageName = "@graphql-tools/utils";
-      version = "7.1.2";
+      version = "7.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.2.tgz";
-        sha512 = "xFuhDyGMhaXTQpq48vjjCLA1VWc3fEo4n+zBcvQnbBSqhVPwAVa0ANcpb0NHmU9c3ypch26kK85TmC/HoK3YRg==";
+        url = "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.1.4.tgz";
+        sha512 = "4lxmstMpgHSM1ULD+1X5AcPFaizkdBubB7H9Rqr7Wh6L9bxUHBHFB3bhaFXT7FI0xE01Pt0IMsZadOIlhVTXrg==";
       };
     };
-    "@graphql-tools/wrap-7.0.3" = {
+    "@graphql-tools/wrap-7.0.4" = {
       name = "_at_graphql-tools_slash_wrap";
       packageName = "@graphql-tools/wrap";
-      version = "7.0.3";
+      version = "7.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.3.tgz";
-        sha512 = "co+ELAwZwMut7qGZow8ATMQlYOU2G3/gsEqz/SUAt7XizXWOOguSFjQKk1/OwHzgCFBbEjvwfoERcv6QC1EUxA==";
+        url = "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-7.0.4.tgz";
+        sha512 = "txBs0W4k3WR86aEzBYXtKdGeeUXCNdRNxjQA/95T6ywNYoM8pw2mvpoXrWOvzbeaH3zwhbHY7kwii4atrC9irg==";
       };
     };
     "@gulp-sourcemaps/identity-map-1.0.2" = {
@@ -3406,13 +3397,13 @@ let
         sha512 = "/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==";
       };
     };
-    "@microsoft/load-themed-styles-1.10.138" = {
+    "@microsoft/load-themed-styles-1.10.139" = {
       name = "_at_microsoft_slash_load-themed-styles";
       packageName = "@microsoft/load-themed-styles";
-      version = "1.10.138";
+      version = "1.10.139";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.138.tgz";
-        sha512 = "TDY8c3CnIbysFIQ8Lj/ZujLkvDB/jrnVOx6FDJICFfo1Jbcyia+nIbUkOJtXtTGK/sx/zfyYJxgFgKQEAtKLHQ==";
+        url = "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.139.tgz";
+        sha512 = "nqKpS5lfFaJGDATrwT+T2hM4WSMlBDwfh9W7+xgqfOQkV6h8y7uZq8Exro9C276Y3qd7M6jZ3pavSmsWgLk79w==";
       };
     };
     "@mozilla/readability-0.3.0" = {
@@ -3460,13 +3451,13 @@ let
         sha512 = "b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==";
       };
     };
-    "@netlify/build-5.5.2" = {
+    "@netlify/build-5.5.5" = {
       name = "_at_netlify_slash_build";
       packageName = "@netlify/build";
-      version = "5.5.2";
+      version = "5.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/build/-/build-5.5.2.tgz";
-        sha512 = "599fcS/FVJUMjnF5NS0QGwZ6B8uw7ROL50z6VfrHbdgpcHgoSCo3HNHeeIA6bfA4pO/IdnmRFOX4fDJgKPsbLw==";
+        url = "https://registry.npmjs.org/@netlify/build/-/build-5.5.5.tgz";
+        sha512 = "uzQH5y8mzipgrIWpVDJSdHRY6pav9KOXfx4OVj64SdQbA6DZB834LjXjJBI3TNf2qSz/wRoP5iY1NVLXZ8zivA==";
       };
     };
     "@netlify/cache-utils-1.0.6" = {
@@ -3532,13 +3523,13 @@ let
         sha512 = "ZgabL4Q+DfB5lqq36QYvGIhLifoiVz5oDfqLp1w7hRsJYwUhUPqeJx/0zph17ZaJB4CvHRadFOeyJeDSkzrERg==";
       };
     };
-    "@netlify/plugins-list-2.0.0" = {
+    "@netlify/plugins-list-2.0.1" = {
       name = "_at_netlify_slash_plugins-list";
       packageName = "@netlify/plugins-list";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.0.0.tgz";
-        sha512 = "GU0u0fnVqNTU32hVr7ig7bGG3/851a0SNjC9nl+iu4Eadax/hfCVSRoSffU0+d05UtXlLhkcgmuYnLySkTR8DA==";
+        url = "https://registry.npmjs.org/@netlify/plugins-list/-/plugins-list-2.0.1.tgz";
+        sha512 = "QSEtEfitpoFBcn+PKp+FnbhF6buEIAbTMzgUNgwCJCqEg0am6NZ0CLvqUDEw6mDzy4WyoX/3jPqHw4TMihg8aw==";
       };
     };
     "@netlify/run-utils-1.0.5" = {
@@ -3775,15 +3766,6 @@ let
         sha512 = "Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==";
       };
     };
-    "@oclif/errors-1.3.3" = {
-      name = "_at_oclif_slash_errors";
-      packageName = "@oclif/errors";
-      version = "1.3.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz";
-        sha512 = "EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==";
-      };
-    };
     "@oclif/errors-1.3.4" = {
       name = "_at_oclif_slash_errors";
       packageName = "@oclif/errors";
@@ -3865,13 +3847,13 @@ let
         sha512 = "G440PCuMi/OT8b71aWkR+kCWikngGtyRjOR24sPMDbpUFV4+B3r51fz1fcqeUiiEOYqUpr0Uy/sneUe1O/NfBg==";
       };
     };
-    "@oclif/plugin-plugins-1.9.1" = {
+    "@oclif/plugin-plugins-1.9.3" = {
       name = "_at_oclif_slash_plugin-plugins";
       packageName = "@oclif/plugin-plugins";
-      version = "1.9.1";
+      version = "1.9.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.9.1.tgz";
-        sha512 = "/lE644CeLZ9ZNpDzHTKSadUtHjo86CbKZBazJiBEeH3LAzf90AeiX447slVByGIAHOglvPgWLKaTUGuWdF/iwQ==";
+        url = "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.9.3.tgz";
+        sha512 = "DyrSP3sRPWOiQI0ae4OuUpjdYpCr5YS1cSzXNGL9uDVwKM4YVXvk9v0tzNzd1008oaNNXO/XDedPkAaoX110Mg==";
       };
     };
     "@oclif/plugin-plugins-1.9.4" = {
@@ -3919,13 +3901,13 @@ let
         sha512 = "9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==";
       };
     };
-    "@octokit/openapi-types-1.2.2" = {
+    "@octokit/openapi-types-2.0.0" = {
       name = "_at_octokit_slash_openapi-types";
       packageName = "@octokit/openapi-types";
-      version = "1.2.2";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-1.2.2.tgz";
-        sha512 = "vrKDLd/Rq4IE16oT+jJkDBx0r29NFkdkU8GwqVSP4RajsAvP23CMGtFhVK0pedUhAiMvG1bGnFcTC/xCKaKgmw==";
+        url = "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.0.0.tgz";
+        sha512 = "J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==";
       };
     };
     "@octokit/plugin-enterprise-rest-6.0.1" = {
@@ -3964,13 +3946,13 @@ let
         sha512 = "EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==";
       };
     };
-    "@octokit/request-5.4.11" = {
+    "@octokit/request-5.4.12" = {
       name = "_at_octokit_slash_request";
       packageName = "@octokit/request";
-      version = "5.4.11";
+      version = "5.4.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/request/-/request-5.4.11.tgz";
-        sha512 = "vskebNjuz4oTdPIv+9cQjHvjk8vjrMv2fOmSo6zr7IIaFHeVsJlG/C07MXiSS/+g/qU1GHjkPG1XW3faz57EoQ==";
+        url = "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz";
+        sha512 = "MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==";
       };
     };
     "@octokit/request-error-1.2.1" = {
@@ -4009,13 +3991,13 @@ let
         sha512 = "O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==";
       };
     };
-    "@octokit/types-6.0.1" = {
+    "@octokit/types-6.1.1" = {
       name = "_at_octokit_slash_types";
       packageName = "@octokit/types";
-      version = "6.0.1";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/types/-/types-6.0.1.tgz";
-        sha512 = "H/DnTKC+U09en2GFLH/MfAPNDaYb1isieD4Hx4NLpEt/I1PgtZP/8a+Ehc/j9GHuVF/UvGtOVD8AF9XXvws53w==";
+        url = "https://registry.npmjs.org/@octokit/types/-/types-6.1.1.tgz";
+        sha512 = "btm3D6S7VkRrgyYF31etUtVY/eQ1KzrNRqhFt25KSe2mKlXuLXJilglRC6eDA2P6ou94BUnk/Kz5MPEolXgoiw==";
       };
     };
     "@opencensus/core-0.0.8" = {
@@ -4450,13 +4432,13 @@ let
         sha512 = "uc6FmPEegAZawSHjUMFQwU7EjaDn7zy1iD/KD/wBROL9F4378OES8MKMYHoRAKT61Fk7LxVKZSDR5VespMQiqw==";
       };
     };
-    "@primer/octicons-11.0.0" = {
+    "@primer/octicons-11.1.0" = {
       name = "_at_primer_slash_octicons";
       packageName = "@primer/octicons";
-      version = "11.0.0";
+      version = "11.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@primer/octicons/-/octicons-11.0.0.tgz";
-        sha512 = "aMM2n7dl4ToEqQH9ZWQ8M8alGCoGsRk2k5hT5h3KXd54YFKte1twhJDvyQjIjjxqggNh5NUfyuqTOv6MPCVSKQ==";
+        url = "https://registry.npmjs.org/@primer/octicons/-/octicons-11.1.0.tgz";
+        sha512 = "qeW4Hu82V0eTKza54nIqud572lrZicy2R6PBX2SVfWlrfRUotpsRi6m/Dvxz/YKL/8xdwBSWgJl8hJXM4V5woA==";
       };
     };
     "@protobufjs/aspromise-1.1.2" = {
@@ -4693,13 +4675,13 @@ let
         sha512 = "c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==";
       };
     };
-    "@schematics/angular-11.0.2" = {
+    "@schematics/angular-11.0.3" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "11.0.2";
+      version = "11.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.2.tgz";
-        sha512 = "tUIuCYJUzHYuiXGJ2KCuwxMocS56kPHaM8+neVYWwWbOxKzLZXv80gMm/pIWxrqUDCkIUi3yb4ienudFhgQLYg==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-11.0.3.tgz";
+        sha512 = "H+rWJOafl8OXrC/GMJihWYTFsR2K49tWM6AyJLBxja6qyZwwL184SLPvvkPsz3+LDs+fxfOzQ1K+sIpuZLqizw==";
       };
     };
     "@schematics/schematics-0.1100.1" = {
@@ -4711,13 +4693,13 @@ let
         sha512 = "Y5J/qafyZtsu6spEFywGLjYMqEgONSDx9m8c8KL4c45+KqqerQeh2QQHims3G0brKUFIK3nCw95zqw+RMsGcsA==";
       };
     };
-    "@schematics/update-0.1100.2" = {
+    "@schematics/update-0.1100.3" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.1100.2";
+      version = "0.1100.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1100.2.tgz";
-        sha512 = "pETCmQylIQ7RM+8uqDkI3KfOaX5H7nuzmMXby28zdLPMZniYti0gJxieiVFhvdz2Ot2Axj0hznfmraFgC9mQMw==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.1100.3.tgz";
+        sha512 = "Hp+RVuVLYkJhGYzLY3kwSqk8nh9zC9F9AAR4QuwSXQv+pQxRbv48fdU3iVuKu/mVhz17RZJhTNoA/2uNMeGH2g==";
       };
     };
     "@segment/loosely-validate-event-2.0.0" = {
@@ -4747,13 +4729,13 @@ let
         sha512 = "lOUyRopNTKJYVEU9T6stp2irwlTDsYMmUKBOUjnMcwGveuUfIJqrCOtFLtIPPj3XJlbZy5F68l4KP9rZ8Ipang==";
       };
     };
-    "@serverless/components-3.4.2" = {
+    "@serverless/components-3.4.3" = {
       name = "_at_serverless_slash_components";
       packageName = "@serverless/components";
-      version = "3.4.2";
+      version = "3.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/components/-/components-3.4.2.tgz";
-        sha512 = "yBQwN4Z0LqsYzA+SCTh6/LaGEPAu6lNAr32j2pjjZWCnDwpV1TKaSCNDTAPNSVk5L2/8exRpiEQUNM0NyTGWqA==";
+        url = "https://registry.npmjs.org/@serverless/components/-/components-3.4.3.tgz";
+        sha512 = "buKvUPDeS54bUG9c56bmX5WcL3hBCHASKamHpUGmSa1ArSem8BE76LzPjiNcreOJGSFf9VGMgpsW1d1WKy2fAA==";
       };
     };
     "@serverless/core-1.1.2" = {
@@ -4765,13 +4747,13 @@ let
         sha512 = "PY7gH+7aQ+MltcUD7SRDuQODJ9Sav9HhFJsgOiyf8IVo7XVD6FxZIsSnpMI6paSkptOB7n+0Jz03gNlEkKetQQ==";
       };
     };
-    "@serverless/enterprise-plugin-4.1.2" = {
+    "@serverless/enterprise-plugin-4.2.0" = {
       name = "_at_serverless_slash_enterprise-plugin";
       packageName = "@serverless/enterprise-plugin";
-      version = "4.1.2";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-4.1.2.tgz";
-        sha512 = "aAHF9ElWr0eaAEVXy6M9DvokiyVV/y5xokiBnAhQisMT2faTVlCX1B8D1nJef0NdJ6pXJVOd3JrXC4rIxjz0zg==";
+        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-4.2.0.tgz";
+        sha512 = "b7kVdcE+nLi9kWOu4lqvbYBeK0ChIPX9gbqMecs3fEAdPVMleZyC0CywdWnpOrV9xXij9tj4LxFv6NRRcFCXZg==";
       };
     };
     "@serverless/event-mocks-1.1.1" = {
@@ -4783,13 +4765,13 @@ let
         sha512 = "YAV5V/y+XIOfd+HEVeXfPWZb8C6QLruFk9tBivoX2roQLWVq145s4uxf8D0QioCueuRzkukHUS4JIj+KVoS34A==";
       };
     };
-    "@serverless/platform-client-3.1.2" = {
+    "@serverless/platform-client-3.1.4" = {
       name = "_at_serverless_slash_platform-client";
       packageName = "@serverless/platform-client";
-      version = "3.1.2";
+      version = "3.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-3.1.2.tgz";
-        sha512 = "zTJBhzjWtDBogLFnzoz6NYiQ6CThsxuvHQxSbBLcNK4+VQPIkrZOxaQ+dNCNLeLN1Tb3NnZDPNGkoThvgGwq3Q==";
+        url = "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-3.1.4.tgz";
+        sha512 = "oc65L9Dl1Xe+T5qv/fkmjYREtPzrQMdje0fC5ntvsfR3luxvSfQIinHYKbt30Qpyy2sJCBPG4IPEip7b3y0WwA==";
       };
     };
     "@serverless/platform-client-china-2.0.9" = {
@@ -4999,13 +4981,13 @@ let
         sha512 = "tJF+dY/wTfexwYuCgFB3RpWl4RGcf2H9RT9yurkTVi5wwKfvcNwZMUMwSlTDEFOqwmAsJ7e0uNVRlkPQHekCcQ==";
       };
     };
-    "@snyk/java-call-graph-builder-1.16.5" = {
+    "@snyk/java-call-graph-builder-1.17.0" = {
       name = "_at_snyk_slash_java-call-graph-builder";
       packageName = "@snyk/java-call-graph-builder";
-      version = "1.16.5";
+      version = "1.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.16.5.tgz";
-        sha512 = "6H4hkq/qYljJoH1QnZsTRPMqp9Kt5AOEZYGJAeSHkhJdfUYSLtqwN4WsU6yVR3vWAaDQ8Lllp3m6EL7nstMPZA==";
+        url = "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.17.0.tgz";
+        sha512 = "uO1b6UtT6QGz7F5ZgNdOSyMXBvykUhOcuHBRc//xUnBWsyJwdlAFp/d646zIeaBCe87Fcn5hXuWUGjj+N8rBzA==";
       };
     };
     "@snyk/rpm-parser-2.2.1" = {
@@ -5575,13 +5557,13 @@ let
         sha512 = "98rXVukLD6/ozrQ2O80NAlWDGA4INg+tqsEReWJldqyi2fulC9V7Use/n28SWgROXKm6003ycWV4gZHoF8GA6w==";
       };
     };
-    "@types/eslint-7.2.5" = {
+    "@types/eslint-7.2.6" = {
       name = "_at_types_slash_eslint";
       packageName = "@types/eslint";
-      version = "7.2.5";
+      version = "7.2.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.5.tgz";
-        sha512 = "Dc6ar9x16BdaR3NSxSF7T4IjL9gxxViJq8RmFd+2UAyA+K6ck2W+gUwfgpG/y9TPyUuBL35109bbULpEynvltA==";
+        url = "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz";
+        sha512 = "I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==";
       };
     };
     "@types/eslint-scope-3.7.0" = {
@@ -6502,13 +6484,13 @@ let
         sha512 = "cr6kZ+4m9lp86ytQc1jPOJXgINQyz3kLLunZ57jznW+WIAL0JqZbGubQk4GlD42MuQL5JGOABrxdpqqWeovlVQ==";
       };
     };
-    "@types/webpack-sources-2.0.0" = {
+    "@types/webpack-sources-2.1.0" = {
       name = "_at_types_slash_webpack-sources";
       packageName = "@types/webpack-sources";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz";
-        sha512 = "a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==";
+        url = "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.0.tgz";
+        sha512 = "LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==";
       };
     };
     "@types/websocket-1.0.1" = {
@@ -6538,13 +6520,13 @@ let
         sha512 = "NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==";
       };
     };
-    "@types/yargs-15.0.10" = {
+    "@types/yargs-15.0.11" = {
       name = "_at_types_slash_yargs";
       packageName = "@types/yargs";
-      version = "15.0.10";
+      version = "15.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.10.tgz";
-        sha512 = "z8PNtlhrj7eJNLmrAivM7rjBESG6JwC5xP3RVk12i/8HVP7Xnx/sEmERnRImyEuUaJfO942X0qMOYsoupaJbZQ==";
+        url = "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz";
+        sha512 = "jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==";
       };
     };
     "@types/yargs-parser-15.0.0" = {
@@ -6781,76 +6763,76 @@ let
         sha512 = "mFdUlfDGxoyreCQWO/SX4DvM/6epn37AimVGzLJLpSPJdWUerCnvxwzB6zL83SiYC6O6++cWEdzgz7EtKViFlA==";
       };
     };
-    "@vue/compiler-core-3.0.3" = {
+    "@vue/compiler-core-3.0.4" = {
       name = "_at_vue_slash_compiler-core";
       packageName = "@vue/compiler-core";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.3.tgz";
-        sha512 = "iWlRT8RYLmz7zkg84pTOriNUzjH7XACWN++ImFkskWXWeev29IKi7p76T9jKDaMZoPiGcUZ0k9wayuASWVxOwg==";
+        url = "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.4.tgz";
+        sha512 = "snpMICsbWTZqBFnPB03qr4DtiSxVYfDF3DvbDSkN9Z9NTM8Chl8E/lYhKBSsvauq91DAWAh8PU3lr9vrLyQsug==";
       };
     };
-    "@vue/compiler-dom-3.0.3" = {
+    "@vue/compiler-dom-3.0.4" = {
       name = "_at_vue_slash_compiler-dom";
       packageName = "@vue/compiler-dom";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.3.tgz";
-        sha512 = "6GdUbDPjsc0MDZGAgpi4lox+d+aW9/brscwBOLOFfy9wcI9b6yLPmBbjdIsJq3pYdJWbdvACdJ77avBBdHEP8A==";
+        url = "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.4.tgz";
+        sha512 = "FOxbHBIkkGjYQeTz1DlXQjS1Ms8EPXQWsdTdTPeohoS0KzCz6RiOjiAG+jLtMi6Nr5GX2h0TlCvcnI8mcsicFQ==";
       };
     };
-    "@vue/compiler-sfc-3.0.3" = {
+    "@vue/compiler-sfc-3.0.4" = {
       name = "_at_vue_slash_compiler-sfc";
       packageName = "@vue/compiler-sfc";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.3.tgz";
-        sha512 = "YocHSirye85kRVC4lU0+SE6uhrwGJzbhwkrqG4g6kmsAUopZ0qUjbICMlej5bYx2+AUz9yBIM7hpK8nIKFVFjg==";
+        url = "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.4.tgz";
+        sha512 = "brDn6HTuK6R3oBCjtMPPsIpyJEZFinlnxjtBXww/goFJOJBAU9CrsdegwyZItNnixCFUIg4CLv4Nj1Eg/eKlfg==";
       };
     };
-    "@vue/compiler-ssr-3.0.3" = {
+    "@vue/compiler-ssr-3.0.4" = {
       name = "_at_vue_slash_compiler-ssr";
       packageName = "@vue/compiler-ssr";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.3.tgz";
-        sha512 = "IjJMoHCiDk939Ix7Q5wrex59TVJr6JFQ95gf36f4G4UrVau0GGY/3HudnWT/6eyWJ7267+odqQs1uCZgDfL/Ww==";
+        url = "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.4.tgz";
+        sha512 = "4aYWQEL4+LS4+D44K9Z7xMOWMEjBsz4Li9nMcj2rxRQ35ewK6uFPodvs6ORP60iBDSkwUFZoldFlNemQlu1BFw==";
       };
     };
-    "@vue/reactivity-3.0.3" = {
+    "@vue/reactivity-3.0.4" = {
       name = "_at_vue_slash_reactivity";
       packageName = "@vue/reactivity";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.3.tgz";
-        sha512 = "t39Qmc42MX7wJtf8L6tHlu17eP9Rc5w4aRnxpLHNWoaRxddv/7FBhWqusJ2Bwkk8ixFHOQeejcLMt5G469WYJw==";
+        url = "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.4.tgz";
+        sha512 = "AFTABrLhUYZY2on3ea9FxeXal7w3f6qIp9gT+/oG93H7dFTL5LvVnxygCopv7tvkIl/GSGQb/yK1D1gmXx1Pww==";
       };
     };
-    "@vue/runtime-core-3.0.3" = {
+    "@vue/runtime-core-3.0.4" = {
       name = "_at_vue_slash_runtime-core";
       packageName = "@vue/runtime-core";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.3.tgz";
-        sha512 = "Fd1JVnYI6at0W/2ERwJuTSq4S22gNt8bKEbICcvCAac7hJUZ1rylThlrhsvrgA+DVkWU01r0niNZQ4UddlNw7g==";
+        url = "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.4.tgz";
+        sha512 = "qH9e4kqU7b3u1JewvLmGmoAGY+mnuBqz7aEKb2mhpEgwa1yFv496BRuUfMXXMCix3+TndUVMJ8jt41FSdNppwg==";
       };
     };
-    "@vue/runtime-dom-3.0.3" = {
+    "@vue/runtime-dom-3.0.4" = {
       name = "_at_vue_slash_runtime-dom";
       packageName = "@vue/runtime-dom";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.3.tgz";
-        sha512 = "ytTvSlRaEYvLQUkkpruIBizWIwuIeHER0Ch/evO6kUaPLjZjX3NerVxA40cqJx8rRjb9keQso21U2Jcpk8GsTg==";
+        url = "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.4.tgz";
+        sha512 = "BGIoiTSESzWUhN0Ofi2X/q+HN8f6IUFmUEyyBGKbmx7DTAJNZhFfjqsepfXQrM5IGeTfJLB1ZEVyroDQJNXq3g==";
       };
     };
-    "@vue/shared-3.0.3" = {
+    "@vue/shared-3.0.4" = {
       name = "_at_vue_slash_shared";
       packageName = "@vue/shared";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/shared/-/shared-3.0.3.tgz";
-        sha512 = "yGgkF7u4W0Dmwri9XdeY50kOowN4UIX7aBQ///jbxx37itpzVjK7QzvD3ltQtPfWaJDGBfssGL0wpAgwX9OJpQ==";
+        url = "https://registry.npmjs.org/@vue/shared/-/shared-3.0.4.tgz";
+        sha512 = "Swfbz31AaMX48CpFl+YmIrqOH9MgJMTrltG9e26A4ZxYx9LjGuMV+41WnxFzS3Bc9nbrc6sDPM37G6nIT8NJSg==";
       };
     };
     "@webassemblyjs/ast-1.8.1" = {
@@ -8491,13 +8473,13 @@ let
         sha512 = "sbLEIMQrkV7RkIruqTPXxeCMkAAycv4yzTkBzRgOR1BrR5UB7qZtupqxkersTJSf0HZ3sbaNRrNV80TnnM7cUw==";
       };
     };
-    "apollo-2.31.1" = {
+    "apollo-2.31.2" = {
       name = "apollo";
       packageName = "apollo";
-      version = "2.31.1";
+      version = "2.31.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo/-/apollo-2.31.1.tgz";
-        sha512 = "qx64LGc09GSwpEIUbRJX90zq6ixVsgo6ZPGuCsDTY83Lz5ITMeXIs7+CF/1oAU1IzEI+YRMVsFTkK2aIBZzSYA==";
+        url = "https://registry.npmjs.org/apollo/-/apollo-2.31.2.tgz";
+        sha512 = "LzN1DplRDBZf+5+UIEnINU62iEZx9kX16MbFNOZWj4LeGRRNHacv+QzdcNLRdWvtySCrFdS0MA4NyDQ48kRELw==";
       };
     };
     "apollo-cache-1.3.5" = {
@@ -8536,49 +8518,49 @@ let
         sha512 = "jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==";
       };
     };
-    "apollo-codegen-core-0.38.1" = {
+    "apollo-codegen-core-0.38.2" = {
       name = "apollo-codegen-core";
       packageName = "apollo-codegen-core";
-      version = "0.38.1";
+      version = "0.38.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.38.1.tgz";
-        sha512 = "LOeLQdSeKnHJBYxjhrJ/4b8RR9V4f9QhUAB/wYyJ7g8eCT4ZcjdGdwQ/KnijI0GmrWaz+t4Z5zn3wpXaudn7bA==";
+        url = "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.38.2.tgz";
+        sha512 = "tg9HUW9q2b4B+u6Ea6HMjHQsarSLlXRc/AVOoB0X2hRd21OZPqwf7CQYcuur6YQEOAM95JO7E3ExtNwReEkhJw==";
       };
     };
-    "apollo-codegen-flow-0.36.1" = {
+    "apollo-codegen-flow-0.36.2" = {
       name = "apollo-codegen-flow";
       packageName = "apollo-codegen-flow";
-      version = "0.36.1";
+      version = "0.36.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.36.1.tgz";
-        sha512 = "+986zLn9gA44fKF+7iKrPrtSN0cCtlgXeqBHZFujcyGaWWzra8+/lj23L+toFCT+FI93KYGZLqslrlwoMbcD3g==";
+        url = "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.36.2.tgz";
+        sha512 = "7/vlCOZl3mS+A59W4Lcgb5jHv0SwyhDekQeFr5Gf1MEHf/+n5xCdV7dlXmKtGmBhuynQz/pnZk/kKqIbHhGpAw==";
       };
     };
-    "apollo-codegen-scala-0.37.1" = {
+    "apollo-codegen-scala-0.37.2" = {
       name = "apollo-codegen-scala";
       packageName = "apollo-codegen-scala";
-      version = "0.37.1";
+      version = "0.37.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.37.1.tgz";
-        sha512 = "+pSDQ4MbGZNbQ1VgfHK0P+w+iDoIHDQ2Bq7WhjX8ZayKTpLb/X9eWYMzrfQRtr0uDrXbbPkM0YGj1kcdGehINw==";
+        url = "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.37.2.tgz";
+        sha512 = "iE1W07GLFMR23qqmCG/+iawwcV1dprX9S/xGKn3ylruPhMBVdkImv3jFuLgvsm69tUc7KGKW+42CiEMZOmsK6g==";
       };
     };
-    "apollo-codegen-swift-0.38.1" = {
+    "apollo-codegen-swift-0.38.2" = {
       name = "apollo-codegen-swift";
       packageName = "apollo-codegen-swift";
-      version = "0.38.1";
+      version = "0.38.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.38.1.tgz";
-        sha512 = "VJROl4GQzDJn8EnFX6IEP/G1KMeHZblD/Mrbweza+3Kel4wH6SpD533Jc/W4pd4pxdzbhbmfXkJSzkL/xPIvbg==";
+        url = "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.38.2.tgz";
+        sha512 = "rc6bBvBSOmV5NEk3T3/QDG7ThEbkKJ8/yILOWu1/YolOCgJgngZdzBOQ8EQOYbBX5gwEMRFV1HekAVQ8PLWpJg==";
       };
     };
-    "apollo-codegen-typescript-0.38.1" = {
+    "apollo-codegen-typescript-0.38.2" = {
       name = "apollo-codegen-typescript";
       packageName = "apollo-codegen-typescript";
-      version = "0.38.1";
+      version = "0.38.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.38.1.tgz";
-        sha512 = "UAHh1HliM8ahraF7csRYrbhrYhDcgqlE0PEu1WwqFISE1r7wRtLZXg+ic25iyRpTIZqkB8mfkym20Z5nZgmNbw==";
+        url = "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.38.2.tgz";
+        sha512 = "cK2PAoI7tZV9jsaP8gxVzv9fQiJAeNcRq62mDA12uD9yO0/wUHgetdISILPfPAgVCIwHGmBpke+ApJRBrK5i4w==";
       };
     };
     "apollo-datasource-0.7.2" = {
@@ -10048,13 +10030,13 @@ let
         sha512 = "+KBkqH7t/XE91Fqn8eyJeNIWsnhSWL8bSUqFD7TfE3FN07MTlC0nprGYp+2WfcYNz5i8Bus1vY2DHNVhtTImnw==";
       };
     };
-    "aws-sdk-2.800.0" = {
+    "aws-sdk-2.804.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.800.0";
+      version = "2.804.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.800.0.tgz";
-        sha512 = "1vxT8h2iFFaxfn+onMIdL/L+OcIG6G4BUzRt4wuvQzwbKArRy0fUN2d6E7aoM74wl8VlNIMTxBLCqxDnfVeVxQ==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.804.0.tgz";
+        sha512 = "a02pZdjL06MunElAZPPEjpghOp/ZA+16f+t4imh1k9FCDpsNVQrT23HRq/PMvRADA5uZZRkYwX8r9o6oH/1RlA==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -10172,15 +10154,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz";
         sha512 = "z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==";
-      };
-    };
-    "babel-eslint-10.1.0" = {
-      name = "babel-eslint";
-      packageName = "babel-eslint";
-      version = "10.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz";
-        sha512 = "ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==";
       };
     };
     "babel-extract-comments-1.0.0" = {
@@ -12181,13 +12154,13 @@ let
         sha512 = "HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==";
       };
     };
-    "browserslist-4.14.7" = {
+    "browserslist-4.15.0" = {
       name = "browserslist";
       packageName = "browserslist";
-      version = "4.14.7";
+      version = "4.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz";
-        sha512 = "BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz";
+        sha512 = "IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==";
       };
     };
     "brq-0.1.8" = {
@@ -13009,6 +12982,15 @@ let
         sha512 = "7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==";
       };
     };
+    "camel-case-4.1.2" = {
+      name = "camel-case";
+      packageName = "camel-case";
+      version = "4.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz";
+        sha512 = "gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==";
+      };
+    };
     "camelcase-1.2.1" = {
       name = "camelcase";
       packageName = "camelcase";
@@ -13117,13 +13099,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30001164" = {
+    "caniuse-lite-1.0.30001165" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30001164";
+      version = "1.0.30001165";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz";
-        sha512 = "G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz";
+        sha512 = "8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==";
       };
     };
     "canvas-2.6.1" = {
@@ -13135,13 +13117,13 @@ let
         sha512 = "S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==";
       };
     };
-    "capital-case-1.0.3" = {
+    "capital-case-1.0.4" = {
       name = "capital-case";
       packageName = "capital-case";
-      version = "1.0.3";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz";
-        sha512 = "OlUSJpUr7SY0uZFOxcwnDOU7/MpHlKTZx2mqnDYQFrDudXLFm0JJ9wr/l4csB+rh2Ug0OPuoSO53PqiZBqno9A==";
+        url = "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz";
+        sha512 = "ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==";
       };
     };
     "capture-exit-2.0.0" = {
@@ -13360,13 +13342,13 @@ let
         sha512 = "g9YLQVHVZS/3F+zIicfB58vjcxopvYQRp7xHzvyDFDhXH1aRZI/JhwSAO0X5qYiQluoGnaNAU6wByD2KTxJN1A==";
       };
     };
-    "change-case-4.1.1" = {
+    "change-case-4.1.2" = {
       name = "change-case";
       packageName = "change-case";
-      version = "4.1.1";
+      version = "4.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/change-case/-/change-case-4.1.1.tgz";
-        sha512 = "qRlUWn/hXnX1R1LBDF/RelJLiqNjKjUqlmuBVSEIyye8kq49CXqkZWKmi8XeUAdDXWFOcGLUMZ+aHn3Q5lzUXw==";
+        url = "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz";
+        sha512 = "bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==";
       };
     };
     "character-entities-1.2.4" = {
@@ -15556,13 +15538,13 @@ let
         sha512 = "Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==";
       };
     };
-    "constant-case-3.0.3" = {
+    "constant-case-3.0.4" = {
       name = "constant-case";
       packageName = "constant-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/constant-case/-/constant-case-3.0.3.tgz";
-        sha512 = "FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==";
+        url = "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz";
+        sha512 = "I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==";
       };
     };
     "constantinople-3.1.2" = {
@@ -16979,13 +16961,13 @@ let
         sha512 = "KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==";
       };
     };
-    "d3-array-2.8.0" = {
+    "d3-array-2.9.0" = {
       name = "d3-array";
       packageName = "d3-array";
-      version = "2.8.0";
+      version = "2.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz";
-        sha512 = "6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==";
+        url = "https://registry.npmjs.org/d3-array/-/d3-array-2.9.0.tgz";
+        sha512 = "yOokB8GozB6GAubW9n7phLdRugC8TgEjF6V1cX/q78L80d2tLirUnc0jvDSSF622JJJTmtnJOe9+WKs+yS5GFQ==";
       };
     };
     "d3-axis-1.0.12" = {
@@ -17717,13 +17699,13 @@ let
         sha512 = "3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw==";
       };
     };
-    "dayjs-1.9.6" = {
+    "dayjs-1.9.7" = {
       name = "dayjs";
       packageName = "dayjs";
-      version = "1.9.6";
+      version = "1.9.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz";
-        sha512 = "HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==";
+        url = "https://registry.npmjs.org/dayjs/-/dayjs-1.9.7.tgz";
+        sha512 = "IC877KBdMhBrCfBfJXHQlo0G8keZ0Opy7YIIq5QKtUbCuHMzim8S4PyiVK4YmihI3iOF9lhfUBW4AQWHTR5WHA==";
       };
     };
     "deasync-0.1.20" = {
@@ -18095,13 +18077,13 @@ let
         sha512 = "yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==";
       };
     };
-    "deep-equal-2.0.4" = {
+    "deep-equal-2.0.5" = {
       name = "deep-equal";
       packageName = "deep-equal";
-      version = "2.0.4";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.4.tgz";
-        sha512 = "BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==";
+        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz";
+        sha512 = "nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==";
       };
     };
     "deep-extend-0.2.11" = {
@@ -19346,13 +19328,13 @@ let
         sha512 = "BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==";
       };
     };
-    "domelementtype-2.0.2" = {
+    "domelementtype-2.1.0" = {
       name = "domelementtype";
       packageName = "domelementtype";
-      version = "2.0.2";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz";
-        sha512 = "wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==";
+        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz";
+        sha512 = "LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==";
       };
     };
     "domexception-1.0.1" = {
@@ -19409,6 +19391,15 @@ let
         sha512 = "J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==";
       };
     };
+    "domhandler-4.0.0" = {
+      name = "domhandler";
+      packageName = "domhandler";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz";
+        sha512 = "KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==";
+      };
+    };
     "domino-2.1.6" = {
       name = "domino";
       packageName = "domino";
@@ -19454,22 +19445,22 @@ let
         sha512 = "Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==";
       };
     };
-    "domutils-2.4.2" = {
+    "domutils-2.4.3" = {
       name = "domutils";
       packageName = "domutils";
-      version = "2.4.2";
+      version = "2.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz";
-        sha512 = "NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==";
+        url = "https://registry.npmjs.org/domutils/-/domutils-2.4.3.tgz";
+        sha512 = "MDMfEjgtzHvRX7i21XQfkk/vfZbLOe0VJk8dDETkTTo3BTeH3NXz3Xvs94UQ+GzTw/GjRYKsfVKIIOheYX63fw==";
       };
     };
-    "dot-case-3.0.3" = {
+    "dot-case-3.0.4" = {
       name = "dot-case";
       packageName = "dot-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz";
-        sha512 = "7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==";
+        url = "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz";
+        sha512 = "Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==";
       };
     };
     "dot-prop-4.2.1" = {
@@ -19895,13 +19886,13 @@ let
         sha512 = "dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==";
       };
     };
-    "electron-to-chromium-1.3.612" = {
+    "electron-to-chromium-1.3.616" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.612";
+      version = "1.3.616";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.612.tgz";
-        sha512 = "CdrdX1B6mQqxfw+51MPWB5qA6TKWjza9f5voBtUlRfEZEwZiFaxJLrhFI8zHE9SBAuGt4h84rQU6Ho9Bauo1LA==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.616.tgz";
+        sha512 = "CI8L38UN2BEnqXw3/oRIQTmde0LiSeqWSRlPA42ZTYgJQ8fYenzAM2Z3ni+jtILTcrs5aiXZCGJ96Pm+3/yGyQ==";
       };
     };
     "electrum-client-git://github.com/janoside/electrum-client" = {
@@ -20293,13 +20284,13 @@ let
         sha512 = "3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==";
       };
     };
-    "enhanced-resolve-5.3.2" = {
+    "enhanced-resolve-5.4.0" = {
       name = "enhanced-resolve";
       packageName = "enhanced-resolve";
-      version = "5.3.2";
+      version = "5.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.3.2.tgz";
-        sha512 = "G28GCrglCAH6+EqMN2D+Q2wCUS1O1vVQJBn8ME2I/Api41YBe4vLWWRBOUbwDH7vwzSZdljxwTRVqnf+sm6XqQ==";
+        url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz";
+        sha512 = "ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==";
       };
     };
     "enquirer-2.3.6" = {
@@ -20887,13 +20878,13 @@ let
         sha512 = "uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==";
       };
     };
-    "eslint-7.14.0" = {
+    "eslint-7.15.0" = {
       name = "eslint";
       packageName = "eslint";
-      version = "7.14.0";
+      version = "7.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz";
-        sha512 = "5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==";
+        url = "https://registry.npmjs.org/eslint/-/eslint-7.15.0.tgz";
+        sha512 = "Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==";
       };
     };
     "eslint-plugin-no-unsanitized-3.1.4" = {
@@ -20914,13 +20905,13 @@ let
         sha512 = "Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==";
       };
     };
-    "eslint-plugin-vue-7.1.0" = {
+    "eslint-plugin-vue-7.2.0" = {
       name = "eslint-plugin-vue";
       packageName = "eslint-plugin-vue";
-      version = "7.1.0";
+      version = "7.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.1.0.tgz";
-        sha512 = "9dW7kj8/d2IkDdgNpvIhJdJ3XzU3x4PThXYMzWt49taktYnGyrTY6/bXCYZ/VtQKU9kXPntPrZ41+8Pw0Nxblg==";
+        url = "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.2.0.tgz";
+        sha512 = "4mt0yIv6rBDNtvis/g22a0ozJ12GfcdEzX77u0ICYjKlxOVtGrKGEvo0cbOObHaKDg9a9kJcoaNodqE4TPfS2A==";
       };
     };
     "eslint-scope-3.7.3" = {
@@ -21047,6 +21038,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz";
         sha512 = "dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==";
+      };
+    };
+    "espree-7.3.1" = {
+      name = "espree";
+      packageName = "espree";
+      version = "7.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz";
+        sha512 = "v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==";
       };
     };
     "esprima-1.1.1" = {
@@ -21956,6 +21956,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extract-files/-/extract-files-5.0.1.tgz";
         sha512 = "qRW6y9eKF0VbCyOoOEtFhzJ3uykAw8GKwQVXyAIqwocyEWW4m+v+evec34RwtUkkxxHh7NKBLJ6AnXM8W4dH5w==";
+      };
+    };
+    "extract-files-9.0.0" = {
+      name = "extract-files";
+      packageName = "extract-files";
+      version = "9.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz";
+        sha512 = "CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==";
       };
     };
     "extract-stack-1.0.0" = {
@@ -22985,13 +22994,13 @@ let
         sha512 = "dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==";
       };
     };
-    "flat-tree-1.7.0" = {
+    "flat-tree-1.8.0" = {
       name = "flat-tree";
       packageName = "flat-tree";
-      version = "1.7.0";
+      version = "1.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flat-tree/-/flat-tree-1.7.0.tgz";
-        sha512 = "dh9Dnlb5NLKDnJEtU6zP57FCDwusVoGhFAq3Uz1p/szjiuSlPdb3A3aoV31v4tlQMb3c8aDEUbqOpi+8DLDy7Q==";
+        url = "https://registry.npmjs.org/flat-tree/-/flat-tree-1.8.0.tgz";
+        sha512 = "VIdjqvARJGq1V+EhT18prwhrR4McbY2M6iH1vyKTgewfQtpyd1jhLXcnQJFZZDKBhpJM8zCB2kLQEiy51bhcOw==";
       };
     };
     "flatiron-0.4.3" = {
@@ -23498,13 +23507,13 @@ let
         sha512 = "wJaE62fLaB3jCYvY2ZHjZvmKK2iiLiiehX38rz5QZxtdN8fVPJDeZUiVvJrHStdTc+23LHlyZuSEKgFc0pxi2g==";
       };
     };
-    "fp-ts-2.9.0" = {
+    "fp-ts-2.9.1" = {
       name = "fp-ts";
       packageName = "fp-ts";
-      version = "2.9.0";
+      version = "2.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.0.tgz";
-        sha512 = "zYPaS+3BWy+hRhkCMJXLTHxdy7oshyKOfHge/S/n+LcLL5VIhctR9Xucxi3GwJbjwDZaz9IIbU1o+YjK0LsgYg==";
+        url = "https://registry.npmjs.org/fp-ts/-/fp-ts-2.9.1.tgz";
+        sha512 = "9++IpEtF2blK7tfSV+iHxO3KXdAGO/bPPQtUYqzC6XKzGOWNctqvlf13SpXxcu2mYaibOvneh/m9vAPLAHdoRQ==";
       };
     };
     "fragment-cache-0.2.1" = {
@@ -23595,6 +23604,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz";
         sha512 = "8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==";
+      };
+    };
+    "fs-capacitor-6.2.0" = {
+      name = "fs-capacitor";
+      packageName = "fs-capacitor";
+      version = "6.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz";
+        sha512 = "nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw==";
       };
     };
     "fs-chunk-store-1.7.0" = {
@@ -24092,13 +24110,13 @@ let
         sha512 = "3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
       };
     };
-    "geoip-country-4.0.44" = {
+    "geoip-country-4.0.45" = {
       name = "geoip-country";
       packageName = "geoip-country";
-      version = "4.0.44";
+      version = "4.0.45";
       src = fetchurl {
-        url = "https://registry.npmjs.org/geoip-country/-/geoip-country-4.0.44.tgz";
-        sha512 = "nC8TqPY7k6ig956peHrNJdjc5bWcIlURKQJKUwq1HdSlgxa4UvGTbbI+9NqxsUZ5Ozgp6NPa5qSU5GMa502kmg==";
+        url = "https://registry.npmjs.org/geoip-country/-/geoip-country-4.0.45.tgz";
+        sha512 = "K9wWTy1NAW08vnWB/SKLTeknlI3DTigtu404ItlwdUR/IC2DnACvD/kj1ZzfyC5Zc+iIoJdilErSQcFd/W63FA==";
       };
     };
     "get-amd-module-type-3.0.0" = {
@@ -25335,6 +25353,15 @@ let
         sha512 = "J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==";
       };
     };
+    "graphql-upload-11.0.0" = {
+      name = "graphql-upload";
+      packageName = "graphql-upload";
+      version = "11.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz";
+        sha512 = "zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==";
+      };
+    };
     "graphql-upload-8.1.0" = {
       name = "graphql-upload";
       packageName = "graphql-upload";
@@ -25342,6 +25369,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz";
         sha512 = "U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==";
+      };
+    };
+    "graphql-ws-2.0.0" = {
+      name = "graphql-ws";
+      packageName = "graphql-ws";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graphql-ws/-/graphql-ws-2.0.0.tgz";
+        sha512 = "8mueXeT7PswGeh/LObzKSYij+uD0FMGrvanHNaHuuUaiCfzqzc1ReflhEhzpS6bo4rxzK8L4aZtJ9Ci3hFQnIw==";
       };
     };
     "gray-matter-2.1.1" = {
@@ -25938,13 +25974,13 @@ let
         sha512 = "0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==";
       };
     };
-    "hast-util-embedded-1.0.5" = {
+    "hast-util-embedded-1.0.6" = {
       name = "hast-util-embedded";
       packageName = "hast-util-embedded";
-      version = "1.0.5";
+      version = "1.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.5.tgz";
-        sha512 = "0FfLHmfArWOizbdwjL+Rc9QIBzqP80juicNl4S4NEPq5OYWBCgYrtYDPUDoSyQQ9IQlBn9W7++fpYQNzZSq/wQ==";
+        url = "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.6.tgz";
+        sha512 = "JQMW+TJe0UAIXZMjCJ4Wf6ayDV9Yv3PBDPsHD4ExBpAspJ6MOcCX+nzVF+UJVv7OqPcg852WEMSHQPoRA+FVSw==";
       };
     };
     "hast-util-from-parse5-6.0.1" = {
@@ -26091,13 +26127,13 @@ let
         sha512 = "F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==";
       };
     };
-    "header-case-2.0.3" = {
+    "header-case-2.0.4" = {
       name = "header-case";
       packageName = "header-case";
-      version = "2.0.3";
+      version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/header-case/-/header-case-2.0.3.tgz";
-        sha512 = "LChe/V32mnUQnTwTxd3aAlNMk8ia9tjCDb/LjYtoMrdAPApxLB+azejUk5ERZIZdIqvinwv6BAUuFXH/tQPdZA==";
+        url = "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz";
+        sha512 = "H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==";
       };
     };
     "headless-0.1.7" = {
@@ -26181,13 +26217,13 @@ let
         sha1 = "b86ce808598e8a9d1892c571f3cedd86fc9f0653";
       };
     };
-    "highlight.js-10.4.0" = {
+    "highlight.js-10.4.1" = {
       name = "highlight.js";
       packageName = "highlight.js";
-      version = "10.4.0";
+      version = "10.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz";
-        sha512 = "EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA==";
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz";
+        sha512 = "yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==";
       };
     };
     "highlight.js-8.2.0" = {
@@ -28108,13 +28144,13 @@ let
         sha512 = "UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==";
       };
     };
-    "is-arguments-1.0.4" = {
+    "is-arguments-1.1.0" = {
       name = "is-arguments";
       packageName = "is-arguments";
-      version = "1.0.4";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz";
-        sha512 = "xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==";
+        url = "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz";
+        sha512 = "1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==";
       };
     };
     "is-arrayish-0.2.1" = {
@@ -28495,13 +28531,13 @@ let
         sha512 = "lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==";
       };
     };
-    "is-generator-function-1.0.7" = {
+    "is-generator-function-1.0.8" = {
       name = "is-generator-function";
       packageName = "is-generator-function";
-      version = "1.0.7";
+      version = "1.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz";
-        sha512 = "YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==";
+        url = "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz";
+        sha512 = "2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ==";
       };
     };
     "is-glob-2.0.1" = {
@@ -28675,13 +28711,13 @@ let
         sha1 = "6910bca5da8c95e784b5751b976cf5a10fee36d2";
       };
     };
-    "is-negative-zero-2.0.0" = {
+    "is-negative-zero-2.0.1" = {
       name = "is-negative-zero";
       packageName = "is-negative-zero";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz";
-        sha1 = "9553b121b0fac28869da9ed459e20c7543788461";
+        url = "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz";
+        sha512 = "2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==";
       };
     };
     "is-npm-1.0.0" = {
@@ -28792,13 +28828,13 @@ let
         sha1 = "00efbc08816c33cfc4ac8251d132e10dc65098d7";
       };
     };
-    "is-object-1.0.1" = {
+    "is-object-1.0.2" = {
       name = "is-object";
       packageName = "is-object";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz";
-        sha1 = "8952688c5ec2ffd6b03ecc85e769e02903083470";
+        url = "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz";
+        sha512 = "2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==";
       };
     };
     "is-observable-1.1.0" = {
@@ -29474,6 +29510,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz";
         sha512 = "S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==";
+      };
+    };
+    "isomorphic-form-data-2.0.0" = {
+      name = "isomorphic-form-data";
+      packageName = "isomorphic-form-data";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz";
+        sha512 = "TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==";
       };
     };
     "isomorphic-git-0.78.5" = {
@@ -30383,6 +30428,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz";
         sha512 = "KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==";
+      };
+    };
+    "json5-relaxed-0.5.4" = {
+      name = "json5-relaxed";
+      packageName = "json5-relaxed";
+      version = "0.5.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json5-relaxed/-/json5-relaxed-0.5.4.tgz";
+        sha512 = "oDPf7b6nFDKcX2qt5OLI/ZwGwH43qS/g2Z98UWo8ChoNtVMYdGa3Y48WHvjPqvNKnTUa2fOanvHFeE7ZxkiboQ==";
       };
     };
     "jsonata-1.8.4" = {
@@ -31736,13 +31790,13 @@ let
         sha1 = "bf967ba0dd31faaf09ab5bdb3676ad7f2aa18493";
       };
     };
-    "link-check-4.5.2" = {
+    "link-check-4.5.3" = {
       name = "link-check";
       packageName = "link-check";
-      version = "4.5.2";
+      version = "4.5.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/link-check/-/link-check-4.5.2.tgz";
-        sha512 = "I5dWK5rl2wq7nYRBrx8kDjp2roXqa6jdHcKTPBkh9/UlhwToAgCMIRdeUGKxichESo9BpHafF1ao+B8Ek6ErJg==";
+        url = "https://registry.npmjs.org/link-check/-/link-check-4.5.3.tgz";
+        sha512 = "fEUmR+DVqNq0HZAurR5+8v5ulrsRKN/nfNYA02GHvreceEI0S5LiE19Ggf8XHCDRfVbc/4BYZaldBUG7lwNmIQ==";
       };
     };
     "linkify-it-2.2.0" = {
@@ -33509,13 +33563,13 @@ let
         sha1 = "9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac";
       };
     };
-    "lower-case-2.0.1" = {
+    "lower-case-2.0.2" = {
       name = "lower-case";
       packageName = "lower-case";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz";
-        sha512 = "LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==";
+        url = "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz";
+        sha512 = "7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==";
       };
     };
     "lowercase-keys-1.0.0" = {
@@ -34931,13 +34985,13 @@ let
         sha1 = "f8a064760d37e7978ad5f9f6d3c119a494f57081";
       };
     };
-    "mermaid-8.8.3" = {
+    "mermaid-8.8.4" = {
       name = "mermaid";
       packageName = "mermaid";
-      version = "8.8.3";
+      version = "8.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mermaid/-/mermaid-8.8.3.tgz";
-        sha512 = "+SK/kofUw9Y4u08hU5KhLuoMy3If6DMdZEmaWeNnq368FUHQBBZbe+Pr0hjuGbz81rbOkFqar1O1DJjXopjM+g==";
+        url = "https://registry.npmjs.org/mermaid/-/mermaid-8.8.4.tgz";
+        sha512 = "YPn35uEAIrOcsDPjCiKNXXBdO1Aoazsv2zTZjG4+oXa7+tTVUb5sI81NqaTYa47RnoH9Vl4waLlEEJfB8KM9VA==";
       };
     };
     "mersenne-0.0.4" = {
@@ -35984,13 +36038,13 @@ let
         sha512 = "GpxVObyOzL0CGPBqo6B04GinN8JLk12NRYAIkYvARd9ZCoJKevvOyCaWK6bdK/kFSDj3LPDnCsJbezzNlsi87Q==";
       };
     };
-    "mqtt-packet-6.6.0" = {
+    "mqtt-packet-6.7.0" = {
       name = "mqtt-packet";
       packageName = "mqtt-packet";
-      version = "6.6.0";
+      version = "6.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.6.0.tgz";
-        sha512 = "LvghnKMFC70hKWMVykmhJarlO5e7lT3t9s9A2qPCUx+lazL3Mq55U+eCV0eLi7/nRRQYvEUWo/2tTo89EjnCJQ==";
+        url = "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz";
+        sha512 = "GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==";
       };
     };
     "mrmr-0.1.10" = {
@@ -36740,13 +36794,13 @@ let
         sha1 = "ae603b36b134bcec347b452422b0bf98d5832ec8";
       };
     };
-    "nearley-2.19.9" = {
+    "nearley-2.20.0" = {
       name = "nearley";
       packageName = "nearley";
-      version = "2.19.9";
+      version = "2.20.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nearley/-/nearley-2.19.9.tgz";
-        sha512 = "KpCXvcVWPmZrEs95tIkqWi+CgL48O8CJDVDgY/AQGWXR1O8KQPHt5iQrTLior0k0v3PGKIV2xPi879wR1sawwg==";
+        url = "https://registry.npmjs.org/nearley/-/nearley-2.20.0.tgz";
+        sha512 = "Ufhpu2Lrhbh7/InRnQmlgol/L4inT0ZCIh84xKb84zGZyw6PH/VeST3A7vRQTHuHmJHRBj4bw4ujEfJ4bprOig==";
       };
     };
     "neat-csv-2.1.0" = {
@@ -37092,13 +37146,13 @@ let
         sha512 = "rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==";
       };
     };
-    "no-case-3.0.3" = {
+    "no-case-3.0.4" = {
       name = "no-case";
       packageName = "no-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz";
-        sha512 = "ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==";
+        url = "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz";
+        sha512 = "fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==";
       };
     };
     "no-cliches-0.1.1" = {
@@ -38642,13 +38696,13 @@ let
         sha512 = "fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==";
       };
     };
-    "office-ui-fabric-react-7.153.2" = {
+    "office-ui-fabric-react-7.153.4" = {
       name = "office-ui-fabric-react";
       packageName = "office-ui-fabric-react";
-      version = "7.153.2";
+      version = "7.153.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.153.2.tgz";
-        sha512 = "IIGn6k5698tq8mAWNq1SfJjgTh6Aa1S/8jmR1rRlxJ1fwdAtzW09RxVc1f6R3akkE7sPEb3r3q+POSGGAZNXaQ==";
+        url = "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.153.4.tgz";
+        sha512 = "BF4eDxilcW2I6vboXECPqcz2nPYjFZtnHR7lSSY67xRWX0B1+g5xccxqUiDNO/vFmRzvTpD4j53JN70TIzJm1Q==";
       };
     };
     "omggif-1.0.10" = {
@@ -40064,13 +40118,13 @@ let
         sha1 = "df94fd8cf6531ecf75e6bef9a0858fbc72be2247";
       };
     };
-    "param-case-3.0.3" = {
+    "param-case-3.0.4" = {
       name = "param-case";
       packageName = "param-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz";
-        sha512 = "VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==";
+        url = "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz";
+        sha512 = "RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==";
       };
     };
     "paredit.js-0.3.6" = {
@@ -40559,13 +40613,13 @@ let
         sha1 = "2d578d3455f660da65eca18ef95b4e0de912761e";
       };
     };
-    "pascal-case-3.1.1" = {
+    "pascal-case-3.1.2" = {
       name = "pascal-case";
       packageName = "pascal-case";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz";
-        sha512 = "XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==";
+        url = "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz";
+        sha512 = "uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==";
       };
     };
     "pascalcase-0.1.1" = {
@@ -40721,13 +40775,13 @@ let
         sha512 = "b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==";
       };
     };
-    "path-case-3.0.3" = {
+    "path-case-3.0.4" = {
       name = "path-case";
       packageName = "path-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/path-case/-/path-case-3.0.3.tgz";
-        sha512 = "UMFU6UETFpCNWbIWNczshPrnK/7JAXBP2NYw80ojElbQ2+JYxdqWDBkvvqM93u4u6oLmuJ/tPOf2tM8KtXv4eg==";
+        url = "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz";
+        sha512 = "qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==";
       };
     };
     "path-dirname-1.0.2" = {
@@ -41349,6 +41403,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz";
         sha512 = "HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==";
+      };
+    };
+    "pkg-dir-5.0.0" = {
+      name = "pkg-dir";
+      packageName = "pkg-dir";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz";
+        sha512 = "NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==";
       };
     };
     "pkg-up-2.0.0" = {
@@ -44511,13 +44574,13 @@ let
         sha512 = "rlgpCupaW6qQqvu0hvv2FDv40QG427fjghV56XyPcP5aKtOAPzNAhQ7bHqk1YdS2vpW1W7aSV3JobedxuPlBAA==";
       };
     };
-    "react-devtools-core-4.10.0" = {
+    "react-devtools-core-4.10.1" = {
       name = "react-devtools-core";
       packageName = "react-devtools-core";
-      version = "4.10.0";
+      version = "4.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.10.0.tgz";
-        sha512 = "5m5VBtpjuHI7odyk3GAR3BJq3/IHQ0fVZ0+h8zUvoHulSj7Z9hp9d9n4Y1HmSZZxv7NUKfBtsnH+NfLNFDtfog==";
+        url = "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.10.1.tgz";
+        sha512 = "sXbBjGAWcf9HAblTP/zMtFhGHqxAfIR+GPxONZsSGN9FHnF4635dx1s2LdQWG9rJ+Ehr3nWg+BUAB6P78my5PA==";
       };
     };
     "react-dom-16.14.0" = {
@@ -46428,13 +46491,13 @@ let
         sha512 = "/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==";
       };
     };
-    "rollup-2.34.0" = {
+    "rollup-2.34.1" = {
       name = "rollup";
       packageName = "rollup";
-      version = "2.34.0";
+      version = "2.34.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rollup/-/rollup-2.34.0.tgz";
-        sha512 = "dW5iLvttZzdVehjEuNJ1bWvuMEJjOWGmnuFS82WeKHTGXDkRHQeq/ExdifkSyJv9dLcR86ysKRmrIDyR6O0X8g==";
+        url = "https://registry.npmjs.org/rollup/-/rollup-2.34.1.tgz";
+        sha512 = "tGveB6NU5x4MS/iXaIsjfUkEv4hxzJJ4o0FRy5LO62Ndx3R2cmE1qsLYlSfRkvHUUPqWiFoxEm8pRftzh1a5HA==";
       };
     };
     "rollup-plugin-babel-4.4.0" = {
@@ -46896,13 +46959,13 @@ let
         sha512 = "y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==";
       };
     };
-    "sass-1.29.0" = {
+    "sass-1.30.0" = {
       name = "sass";
       packageName = "sass";
-      version = "1.29.0";
+      version = "1.30.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sass/-/sass-1.29.0.tgz";
-        sha512 = "ZpwAUFgnvAUCdkjwPREny+17BpUj8nh5Yr6zKPGtLNTLrmtoRYIjm7njP24COhjJldjwW1dcv52Lpf4tNZVVRA==";
+        url = "https://registry.npmjs.org/sass/-/sass-1.30.0.tgz";
+        sha512 = "26EUhOXRLaUY7+mWuRFqGeGGNmhB1vblpTENO1Z7mAzzIZeVxZr9EZoaY1kyGLFWdSOZxRMAufiN2mkbO6dAlw==";
       };
     };
     "sax-0.5.8" = {
@@ -47274,6 +47337,15 @@ let
         sha512 = "OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==";
       };
     };
+    "semver-7.3.4" = {
+      name = "semver";
+      packageName = "semver";
+      version = "7.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz";
+        sha512 = "tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==";
+      };
+    };
     "semver-compare-1.0.0" = {
       name = "semver-compare";
       packageName = "semver-compare";
@@ -47382,13 +47454,13 @@ let
         sha512 = "BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==";
       };
     };
-    "sentence-case-3.0.3" = {
+    "sentence-case-3.0.4" = {
       name = "sentence-case";
       packageName = "sentence-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.3.tgz";
-        sha512 = "ZPr4dgTcNkEfcGOMFQyDdJrTU9uQO1nb1cjf+nuzb6FxgMDgKddZOM29qEsB7jvsZSMruLRcL2KfM4ypKpa0LA==";
+        url = "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz";
+        sha512 = "8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==";
       };
     };
     "sentence-splitter-2.3.2" = {
@@ -48327,13 +48399,13 @@ let
         sha512 = "g0w2Ft4RJl+F/1/tQvA4BUsH09s+RNd0RRa+So24Inv5yzce5xUnPzxlEWNUBG5TwQjfKDZSFWrf2rXz+e1Q2g==";
       };
     };
-    "snake-case-3.0.3" = {
+    "snake-case-3.0.4" = {
       name = "snake-case";
       packageName = "snake-case";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz";
-        sha512 = "WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==";
+        url = "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz";
+        sha512 = "LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==";
       };
     };
     "snapdragon-0.8.2" = {
@@ -48480,13 +48552,13 @@ let
         sha512 = "HHuOYEAACpUpkFgU8HT57mmxmonaJ4O3YADoSkVhnhkmJ+AowqZyJOau703dYHNrq2DvQ7qYw81H7yyxS1Nfjw==";
       };
     };
-    "snyk-mvn-plugin-2.23.4" = {
+    "snyk-mvn-plugin-2.25.0" = {
       name = "snyk-mvn-plugin";
       packageName = "snyk-mvn-plugin";
-      version = "2.23.4";
+      version = "2.25.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.23.4.tgz";
-        sha512 = "1dWqvFu6eo2KsXFDqRF28JFwrdzpc0k+GwpIqv7vF2kHarsMxnLnT/akhjbKzs+xlRTNFvqdKhEQxjdq2nSD1Q==";
+        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.25.0.tgz";
+        sha512 = "2NDWrMWi9K32i9CdWUy2Pce8D9myR0dxPDJJpamVt/DD3fDxH4ia701i2HdDgOjMq8PI6yIgI+vRaAW3X2GrbA==";
       };
     };
     "snyk-nodejs-lockfile-parser-1.30.1" = {
@@ -48615,6 +48687,15 @@ let
         sha512 = "2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==";
       };
     };
+    "socket.io-3.0.3" = {
+      name = "socket.io";
+      packageName = "socket.io";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socket.io/-/socket.io-3.0.3.tgz";
+        sha512 = "TC1GnSXhDVmd3bHji5aG7AgWB8UL7E6quACbKra8uFXBqlMwEDbrJFK+tjuIY5Pe9N0L+MAPPDv3pycnn0000A==";
+      };
+    };
     "socket.io-adapter-0.2.0" = {
       name = "socket.io-adapter";
       packageName = "socket.io-adapter";
@@ -48741,13 +48822,13 @@ let
         sha512 = "o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==";
       };
     };
-    "socks-2.5.0" = {
+    "socks-2.5.1" = {
       name = "socks";
       packageName = "socks";
-      version = "2.5.0";
+      version = "2.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/socks/-/socks-2.5.0.tgz";
-        sha512 = "00OqQHp5SCbwm9ecOMJj9aQtMSjwi1uVuGQoxnpKCS50VKZcOZ8z11CTKypmR8sEy7nZimy/qXY7rYJYbRlXmA==";
+        url = "https://registry.npmjs.org/socks/-/socks-2.5.1.tgz";
+        sha512 = "oZCsJJxapULAYJaEYBSzMcz8m3jqgGrHaGhkmU/o/PQfFWYWxkAaA0UMGImb6s6tEXfKi959X6VJjMMQ3P6TTQ==";
       };
     };
     "socks-proxy-agent-4.0.2" = {
@@ -51540,13 +51621,13 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
-    "systeminformation-4.30.10" = {
+    "systeminformation-4.30.11" = {
       name = "systeminformation";
       packageName = "systeminformation";
-      version = "4.30.10";
+      version = "4.30.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.30.10.tgz";
-        sha512 = "BndDV7hjRomUGkHK6MO661KUUWcDRbr5SlepDvREidYnR2QJIyHln0iSysH9GPOT7YJgwtswdyg/up/ZFYxHrQ==";
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.30.11.tgz";
+        sha512 = "dR2OJMvyBeF+VZ36851O7oQEUFdNtux3xFI+xAFbWg5J/mh5lQOBiceHTkYOyvGf++mMIKgpeAmYnKy+cyWIdw==";
       };
     };
     "syswide-cas-5.3.0" = {
@@ -51703,13 +51784,13 @@ let
         sha512 = "4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==";
       };
     };
-    "tapable-2.1.1" = {
+    "tapable-2.2.0" = {
       name = "tapable";
       packageName = "tapable";
-      version = "2.1.1";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tapable/-/tapable-2.1.1.tgz";
-        sha512 = "Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==";
+        url = "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz";
+        sha512 = "FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==";
       };
     };
     "tape-2.3.3" = {
@@ -52216,6 +52297,15 @@ let
         sha512 = "4YZvR4DPEI41n4Opwr4jmrLGG4hndxr7387kzRFIIzxHQjarPusH4lGXrugvgb7TtPrfZVTpZCVe44/xUxowEw==";
       };
     };
+    "throat-5.0.0" = {
+      name = "throat";
+      packageName = "throat";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz";
+        sha512 = "fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==";
+      };
+    };
     "throttle-1.0.3" = {
       name = "throttle";
       packageName = "throttle";
@@ -52495,13 +52585,13 @@ let
         sha512 = "pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==";
       };
     };
-    "tiny-secp256k1-1.1.5" = {
+    "tiny-secp256k1-1.1.6" = {
       name = "tiny-secp256k1";
       packageName = "tiny-secp256k1";
-      version = "1.1.5";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz";
-        sha512 = "duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==";
+        url = "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz";
+        sha512 = "FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==";
       };
     };
     "tinycolor-0.0.1" = {
@@ -52963,13 +53053,13 @@ let
         sha512 = "H/Z/yCuvZJj1vl1IQHI8dvF2QrUuXRJoptT5DW5967/dsLpXlCg+uyhFR5lfNj5mNaYePUbKtnL+qKWZGXv4Nw==";
       };
     };
-    "torrent-stream-1.2.0" = {
+    "torrent-stream-1.2.1" = {
       name = "torrent-stream";
       packageName = "torrent-stream";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.2.0.tgz";
-        sha512 = "piQP9/wrXRYvEUAsmdu+fy2D2WPwU7BcsflTnKLsZsrUDBT/Y1INhuYU7Fw9PqEm+RF7QAa2gD8nMmvfb7QomA==";
+        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.2.1.tgz";
+        sha512 = "F+3tYmXnpO2gyhZQ7o8yakELJH3FtKISI/FU0iWvchOWFUXiFnjbEBoumSzfcK1P71Qxzx2az4lVK4Dkq4KSew==";
       };
     };
     "tosource-1.0.0" = {
@@ -55024,13 +55114,13 @@ let
         sha1 = "f6b4501c2ec4cdd26ba78be7222961de77621598";
       };
     };
-    "upper-case-2.0.1" = {
+    "upper-case-2.0.2" = {
       name = "upper-case";
       packageName = "upper-case";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz";
-        sha512 = "laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==";
+        url = "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz";
+        sha512 = "KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==";
       };
     };
     "upper-case-first-1.1.2" = {
@@ -55042,13 +55132,13 @@ let
         sha1 = "5d79bedcff14419518fd2edb0a0507c9b6859115";
       };
     };
-    "upper-case-first-2.0.1" = {
+    "upper-case-first-2.0.2" = {
       name = "upper-case-first";
       packageName = "upper-case-first";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.1.tgz";
-        sha512 = "105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==";
+        url = "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz";
+        sha512 = "514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==";
       };
     };
     "uri-js-3.0.2" = {
@@ -55484,13 +55574,13 @@ let
         sha512 = "vRAKaS8WcYNgzbxyH2LdheqgL4sQLis8LXl7r/mN+O4mpWlUpoCsTtietxepLrft2q0TFA2gaIvSWN1iRkzW/w==";
       };
     };
-    "utp-native-2.2.1" = {
+    "utp-native-2.2.2" = {
       name = "utp-native";
       packageName = "utp-native";
-      version = "2.2.1";
+      version = "2.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/utp-native/-/utp-native-2.2.1.tgz";
-        sha512 = "7GvD4gjGyL1GaNtZAaBVHn8SeWgx9/xIVE1LufMR0m2pWUs1EVx5WiOCXrCHyt7e15+5SquBMoQfj888pJySxA==";
+        url = "https://registry.npmjs.org/utp-native/-/utp-native-2.2.2.tgz";
+        sha512 = "xwn5neM3aKgRCNYaiENRf2pwPa2G79O7r+OCZJDiy92x2q58Ez9hFUPeAW0IQcv0Ii5l1ytDIFWWyaiYVOtlng==";
       };
     };
     "uuid-2.0.3" = {
@@ -56078,13 +56168,13 @@ let
         sha512 = "/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==";
       };
     };
-    "verda-1.1.2" = {
+    "verda-1.2.0" = {
       name = "verda";
       packageName = "verda";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/verda/-/verda-1.1.2.tgz";
-        sha512 = "c91aFgK+UQBqWoixDP8MRvyAN5hfVVaXT3nuk6uFiEb3NXu5UwtK7qCBIZP08talrYDn9ifIpcl+h0JGcH7IlQ==";
+        url = "https://registry.npmjs.org/verda/-/verda-1.2.0.tgz";
+        sha512 = "6xCi3IqMbT/H9PFBBmVB2foC3GBVpTm/doRCr3Is5RAdcpZHlkhfDto6WpoF0Sei1Dz60/lXGoaqOYM2op9Ftw==";
       };
     };
     "verror-1.1.0" = {
@@ -56447,22 +56537,22 @@ let
         sha512 = "jWi+297PJUUWTHwlcrZz0zIuEXuHOBJIQMapXmEzbosWGv/gMnNSAMV4hTKnl5wzxvZKZzV6j+WFdrSlKQ5qnw==";
       };
     };
-    "vscode-debugadapter-testsupport-1.42.0" = {
+    "vscode-debugadapter-testsupport-1.43.0" = {
       name = "vscode-debugadapter-testsupport";
       packageName = "vscode-debugadapter-testsupport";
-      version = "1.42.0";
+      version = "1.43.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.42.0.tgz";
-        sha512 = "5miGnlsT1VLeXcu04AR+LvD4lwTRlEMAj0nyLgVlMdHzH4RDbX2M2/nXSpRbcsdEHcXoRQlfkAXhM4ZQQ4BUBw==";
+        url = "https://registry.npmjs.org/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.43.0.tgz";
+        sha512 = "dxTu7xgNDipoIKf7H2mrVBhp9Vxx2czrnn1N7eIvmg3CYOLPOq3AGrzHoCwMOZNJX1rVttdYZet1f0bEjrDyjg==";
       };
     };
-    "vscode-debugprotocol-1.42.0" = {
+    "vscode-debugprotocol-1.43.0" = {
       name = "vscode-debugprotocol";
       packageName = "vscode-debugprotocol";
-      version = "1.42.0";
+      version = "1.43.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.42.0.tgz";
-        sha512 = "nVsfVCat9FZlOso5SYB1LQQiFGifTyOALpkpJdudDlRXGTpI3mSFiDYXWaoFm7UcfqTOzn1SC7Hqw4d89btT0w==";
+        url = "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.43.0.tgz";
+        sha512 = "pnj+9wVS3yPYz/RXoYSN1tCv+D4139ueaY2WC7V6fUd9QZU8IE5s4r/lZUMJ9gAEGz2km/Iv4qcI7Fdlz5xS9w==";
       };
     };
     "vscode-emmet-helper-1.2.17" = {
@@ -56906,13 +56996,13 @@ let
         sha512 = "uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==";
       };
     };
-    "vue-3.0.3" = {
+    "vue-3.0.4" = {
       name = "vue";
       packageName = "vue";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vue/-/vue-3.0.3.tgz";
-        sha512 = "BZG5meD5vLWdvfnRL5WqfDy+cnXO1X/SweModGUna78bdFPZW6+ZO1tU9p0acrskX3DKFcfSp2s4SZnMjABx6w==";
+        url = "https://registry.npmjs.org/vue/-/vue-3.0.4.tgz";
+        sha512 = "2o+AiQF8sAupyhbyl3oxVCl3WCwC/n5NI7VMM+gVQ231qvSB8eI7sCBloloqDJK6yA367EEtmRSeSCf4sxCC+A==";
       };
     };
     "vue-cli-plugin-apollo-0.21.3" = {
@@ -56958,6 +57048,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.1.tgz";
         sha512 = "8FdXi0gieEwh1IprIBafpiJWcApwrU+l2FEj8c1HtHFdNXMd0+2jUSjBVmcQYohf/E72irwAXEXLga6TQcB3FA==";
+      };
+    };
+    "vue-eslint-parser-7.2.0" = {
+      name = "vue-eslint-parser";
+      packageName = "vue-eslint-parser";
+      version = "7.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.2.0.tgz";
+        sha512 = "uVcQqe8sUNzdHGcRHMd2Z/hl6qEaWrAmglTKP92Fnq9TYU9un8xsyFgEdFJaXh/1rd7h8Aic1GaiQow5nVneow==";
       };
     };
     "vue-onsenui-helper-json-1.0.2" = {
@@ -57336,15 +57435,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/webpackbar/-/webpackbar-4.0.0.tgz";
         sha512 = "k1qRoSL/3BVuINzngj09nIwreD8wxV4grcuhHTD8VJgUbGcy8lQSPqv+bM00B7F+PffwIsQ8ISd4mIwRbr23eQ==";
-      };
-    };
-    "websocket-1.0.32" = {
-      name = "websocket";
-      packageName = "websocket";
-      version = "1.0.32";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz";
-        sha512 = "i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==";
       };
     };
     "websocket-driver-0.6.5" = {
@@ -58274,6 +58364,15 @@ let
         sha512 = "kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==";
       };
     };
+    "ws-7.4.1" = {
+      name = "ws";
+      packageName = "ws";
+      version = "7.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz";
+        sha512 = "pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==";
+      };
+    };
     "x-default-browser-0.3.1" = {
       name = "x-default-browser";
       packageName = "x-default-browser";
@@ -58804,15 +58903,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz";
         sha512 = "hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==";
-      };
-    };
-    "yaeti-0.0.6" = {
-      name = "yaeti";
-      packageName = "yaeti";
-      version = "0.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz";
-        sha1 = "f26f484d72684cf42bedfb76970aa1608fbf9577";
       };
     };
     "yallist-2.1.2" = {
@@ -59388,17 +59478,17 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "11.0.2";
+    version = "11.0.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.0.2.tgz";
-      sha512 = "mebt4ikwXD3gsbHRxKCpn83yW3UVnhiVDEpSXljs1YxscZ1X1dXrxb2g6LdAJwVp9xY5ERqRQeZM7eChqLTrvg==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-11.0.3.tgz";
+      sha512 = "ytYVvALJ1YRDZYoqNoUcE4SLyNcMyt2V+Youaasj+C43V0h1GzHZ4J6G4X9sKaaiNAGV4GKjB9r7jzCymaiq+A==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.1100.2"
-      sources."@angular-devkit/core-11.0.2"
-      sources."@angular-devkit/schematics-11.0.2"
-      sources."@schematics/angular-11.0.2"
-      sources."@schematics/update-0.1100.2"
+      sources."@angular-devkit/architect-0.1100.3"
+      sources."@angular-devkit/core-11.0.3"
+      sources."@angular-devkit/schematics-11.0.3"
+      sources."@schematics/angular-11.0.3"
+      sources."@schematics/update-0.1100.3"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
@@ -60070,10 +60160,10 @@ in
   "@bitwarden/cli" = nodeEnv.buildNodePackage {
     name = "_at_bitwarden_slash_cli";
     packageName = "@bitwarden/cli";
-    version = "1.13.2";
+    version = "1.13.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@bitwarden/cli/-/cli-1.13.2.tgz";
-      sha512 = "DqNFJ3OgwJweYGc8pxYUW6mJGLSAMN3QH8mtXOwiy3I/SR5QY+ebbEd5XhCdibjHk5nIyLAiP8Erkdevhjuozw==";
+      url = "https://registry.npmjs.org/@bitwarden/cli/-/cli-1.13.3.tgz";
+      sha512 = "N6eUF/1JBENunuXcpt0d2t5fRLuZndobKMxKTMyqguEH3Fy9cRhEopirxbXskEDCf7Dh2jUdlL/b+4e3fpG7rw==";
     };
     dependencies = [
       sources."abab-2.0.5"
@@ -60265,7 +60355,7 @@ in
       })
       sources."@schematics/schematics-0.1100.1"
       sources."@types/anymatch-1.3.1"
-      sources."@types/eslint-7.2.5"
+      sources."@types/eslint-7.2.6"
       sources."@types/eslint-scope-3.7.0"
       sources."@types/estree-0.0.45"
       sources."@types/json-schema-7.0.6"
@@ -60284,7 +60374,7 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      sources."@types/webpack-sources-2.0.0"
+      sources."@types/webpack-sources-2.1.0"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
       sources."@webassemblyjs/helper-api-error-1.9.0"
@@ -60318,10 +60408,10 @@ in
       sources."binary-extensions-2.1.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."buffer-from-1.1.1"
       sources."callsites-3.1.0"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."chalk-3.0.0"
       sources."chardet-0.7.0"
       sources."chokidar-3.4.3"
@@ -60342,7 +60432,7 @@ in
       sources."cross-spawn-7.0.3"
       sources."deepmerge-4.2.2"
       sources."defaults-1.0.3"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."enhanced-resolve-4.3.0"
@@ -60429,6 +60519,7 @@ in
           sources."chalk-4.1.0"
         ];
       })
+      sources."lru-cache-6.0.0"
       sources."macos-release-2.4.1"
       sources."magic-string-0.25.7"
       sources."memfs-3.2.0"
@@ -60487,7 +60578,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."schema-utils-2.7.0"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."serialize-javascript-5.0.1"
       sources."shebang-command-2.0.0"
       sources."shebang-regex-3.0.0"
@@ -60546,9 +60637,9 @@ in
       sources."wcwidth-1.0.1"
       (sources."webpack-5.4.0" // {
         dependencies = [
-          sources."enhanced-resolve-5.3.2"
+          sources."enhanced-resolve-5.4.0"
           sources."schema-utils-3.0.0"
-          sources."tapable-2.1.1"
+          sources."tapable-2.2.0"
         ];
       })
       sources."webpack-node-externals-2.5.2"
@@ -60560,6 +60651,7 @@ in
       sources."which-2.0.2"
       sources."windows-release-4.0.0"
       sources."wrappy-1.0.2"
+      sources."yallist-4.0.0"
       sources."yaml-1.10.0"
       sources."yocto-queue-0.1.0"
     ];
@@ -60599,12 +60691,11 @@ in
       sources."@babel/compat-data-7.12.7"
       (sources."@babel/core-7.12.9" // {
         dependencies = [
-          sources."@babel/generator-7.12.5"
           sources."@babel/types-7.12.7"
           sources."semver-5.7.1"
         ];
       })
-      (sources."@babel/generator-7.12.1" // {
+      (sources."@babel/generator-7.12.5" // {
         dependencies = [
           sources."@babel/types-7.12.7"
         ];
@@ -60772,7 +60863,6 @@ in
       })
       (sources."@babel/traverse-7.12.9" // {
         dependencies = [
-          sources."@babel/generator-7.12.5"
           sources."@babel/types-7.12.7"
         ];
       })
@@ -60804,7 +60894,9 @@ in
       (sources."@oclif/command-1.8.0" // {
         dependencies = [
           sources."@oclif/plugin-help-3.2.0"
-          sources."semver-7.3.2"
+          sources."lru-cache-6.0.0"
+          sources."semver-7.3.4"
+          sources."yallist-4.0.0"
         ];
       })
       (sources."@oclif/config-1.17.0" // {
@@ -60814,14 +60906,14 @@ in
           sources."tslib-2.0.3"
         ];
       })
-      (sources."@oclif/errors-1.3.3" // {
+      (sources."@oclif/errors-1.3.4" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
           sources."clean-stack-3.0.1"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."escape-string-regexp-4.0.0"
-          sources."fs-extra-9.0.1"
+          sources."fs-extra-8.1.0"
           sources."wrap-ansi-7.0.0"
         ];
       })
@@ -60851,13 +60943,15 @@ in
           sources."strip-ansi-5.2.0"
         ];
       })
-      (sources."@oclif/plugin-plugins-1.9.1" // {
+      (sources."@oclif/plugin-plugins-1.9.3" // {
         dependencies = [
-          sources."fs-extra-9.0.1"
+          sources."fs-extra-8.1.0"
+          sources."lru-cache-6.0.0"
           sources."npm-run-path-4.0.1"
           sources."path-key-3.1.1"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."tslib-2.0.3"
+          sources."yallist-4.0.0"
         ];
       })
       (sources."@oclif/plugin-warn-if-update-available-1.7.0" // {
@@ -60931,24 +61025,24 @@ in
       })
       sources."@vue/cli-ui-addon-webpack-4.5.9"
       sources."@vue/cli-ui-addon-widgets-4.5.9"
-      (sources."@vue/compiler-core-3.0.3" // {
+      (sources."@vue/compiler-core-3.0.4" // {
         dependencies = [
           sources."@babel/types-7.12.7"
           sources."source-map-0.6.1"
         ];
       })
-      sources."@vue/compiler-dom-3.0.3"
-      (sources."@vue/compiler-sfc-3.0.3" // {
+      sources."@vue/compiler-dom-3.0.4"
+      (sources."@vue/compiler-sfc-3.0.4" // {
         dependencies = [
           sources."@babel/types-7.12.7"
           sources."source-map-0.6.1"
         ];
       })
-      sources."@vue/compiler-ssr-3.0.3"
-      sources."@vue/reactivity-3.0.3"
-      sources."@vue/runtime-core-3.0.3"
-      sources."@vue/runtime-dom-3.0.3"
-      sources."@vue/shared-3.0.3"
+      sources."@vue/compiler-ssr-3.0.4"
+      sources."@vue/reactivity-3.0.4"
+      sources."@vue/runtime-core-3.0.4"
+      sources."@vue/runtime-dom-3.0.4"
+      sources."@vue/shared-3.0.4"
       sources."@wry/context-0.4.4"
       sources."@wry/equality-0.1.11"
       sources."abbrev-1.1.1"
@@ -60992,7 +61086,7 @@ in
           sources."to-regex-range-2.1.1"
         ];
       })
-      (sources."apollo-2.31.1" // {
+      (sources."apollo-2.31.2" // {
         dependencies = [
           sources."mkdirp-1.0.4"
           sources."strip-ansi-5.2.0"
@@ -61002,17 +61096,17 @@ in
       sources."apollo-cache-control-0.11.4"
       sources."apollo-cache-inmemory-1.6.6"
       sources."apollo-client-2.6.10"
-      (sources."apollo-codegen-core-0.38.1" // {
+      (sources."apollo-codegen-core-0.38.2" // {
         dependencies = [
           sources."recast-0.20.4"
           sources."source-map-0.6.1"
           sources."tslib-2.0.3"
         ];
       })
-      sources."apollo-codegen-flow-0.36.1"
-      sources."apollo-codegen-scala-0.37.1"
-      sources."apollo-codegen-swift-0.38.1"
-      sources."apollo-codegen-typescript-0.38.1"
+      sources."apollo-codegen-flow-0.36.2"
+      sources."apollo-codegen-scala-0.37.2"
+      sources."apollo-codegen-swift-0.38.2"
+      sources."apollo-codegen-typescript-0.38.2"
       sources."apollo-datasource-0.7.2"
       sources."apollo-env-0.6.5"
       sources."apollo-graphql-0.6.0"
@@ -61123,7 +61217,7 @@ in
       })
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -61149,16 +61243,28 @@ in
       sources."caller-callsite-2.0.0"
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
-      sources."camel-case-4.1.1"
+      (sources."camel-case-4.1.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30001164"
-      sources."capital-case-1.0.3"
+      sources."caniuse-lite-1.0.30001165"
+      (sources."capital-case-1.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."capture-stack-trace-1.0.1"
       sources."cardinal-2.1.1"
       sources."caseless-0.12.0"
       sources."caw-2.0.1"
       sources."chalk-2.4.2"
-      sources."change-case-4.1.1"
+      (sources."change-case-4.1.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."chardet-0.7.0"
       (sources."chokidar-2.1.8" // {
         dependencies = [
@@ -61218,11 +61324,19 @@ in
           sources."fs-extra-9.0.1"
           sources."has-flag-4.0.0"
           sources."is-wsl-2.2.0"
-          sources."semver-7.3.2"
+          (sources."jsonfile-6.1.0" // {
+            dependencies = [
+              sources."universalify-2.0.0"
+            ];
+          })
+          sources."lru-cache-6.0.0"
+          sources."semver-7.3.4"
           sources."supports-color-7.2.0"
           sources."supports-hyperlinks-2.1.0"
           sources."tslib-2.0.3"
           sources."type-fest-0.11.0"
+          sources."universalify-1.0.0"
+          sources."yallist-4.0.0"
         ];
       })
       sources."cli-width-3.0.0"
@@ -61253,7 +61367,11 @@ in
       sources."config-chain-1.1.12"
       sources."configstore-3.1.5"
       sources."consolidate-0.16.0"
-      sources."constant-case-3.0.3"
+      (sources."constant-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       (sources."content-disposition-0.5.3" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -61342,7 +61460,11 @@ in
       sources."dicer-0.3.0"
       sources."diff-4.0.2"
       sources."dir-glob-3.0.1"
-      sources."dot-case-3.0.3"
+      (sources."dot-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."dot-prop-4.2.1"
       sources."dotenv-8.2.0"
       (sources."download-7.1.0" // {
@@ -61360,7 +61482,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.4"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       sources."elegant-spinner-1.0.1"
       sources."emoji-regex-8.0.0"
       sources."emojis-list-3.0.0"
@@ -61462,12 +61584,7 @@ in
       sources."fs-capacitor-2.0.4"
       sources."fs-constants-1.0.0"
       sources."fs-exists-sync-0.1.0"
-      (sources."fs-extra-7.0.1" // {
-        dependencies = [
-          sources."jsonfile-4.0.0"
-          sources."universalify-0.1.2"
-        ];
-      })
+      sources."fs-extra-7.0.1"
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.13"
       sources."fswin-2.17.1227"
@@ -61578,7 +61695,11 @@ in
       })
       sources."hash-sum-2.0.0"
       sources."hash.js-1.1.7"
-      sources."header-case-2.0.3"
+      (sources."header-case-2.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."homedir-polyfill-1.0.3"
       sources."hosted-git-info-2.8.8"
       sources."http-cache-semantics-3.8.1"
@@ -61646,11 +61767,11 @@ in
       sources."is-glob-4.0.1"
       sources."is-installed-globally-0.1.0"
       sources."is-natural-number-4.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-npm-1.0.0"
       sources."is-number-7.0.0"
       sources."is-obj-1.0.1"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-observable-1.1.0"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
@@ -61708,11 +61829,7 @@ in
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."json5-2.1.3"
-      (sources."jsonfile-6.1.0" // {
-        dependencies = [
-          sources."universalify-2.0.0"
-        ];
-      })
+      sources."jsonfile-4.0.0"
       sources."jsprim-1.4.1"
       sources."keyv-3.0.0"
       sources."kind-of-6.0.3"
@@ -61777,7 +61894,11 @@ in
       sources."loglevel-1.7.1"
       sources."long-4.0.0"
       sources."lowdb-1.0.0"
-      sources."lower-case-2.0.1"
+      (sources."lower-case-2.0.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."lowercase-keys-1.0.1"
       (sources."lru-cache-5.1.1" // {
         dependencies = [
@@ -61836,7 +61957,11 @@ in
       sources."negotiator-0.6.2"
       sources."neo-async-2.6.2"
       sources."nice-try-1.0.5"
-      sources."no-case-3.0.3"
+      (sources."no-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."node-dir-0.1.17"
       sources."node-fetch-2.6.1"
       sources."node-ipc-9.1.3"
@@ -61917,17 +62042,29 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."param-case-3.0.3"
+      (sources."param-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."parse-git-config-2.0.3"
       sources."parse-json-5.1.0"
       sources."parse-passwd-1.0.0"
       sources."parse-path-4.0.2"
       sources."parse-url-5.0.2"
       sources."parseurl-1.3.3"
-      sources."pascal-case-3.1.1"
+      (sources."pascal-case-3.1.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."pascalcase-0.1.1"
       sources."password-prompt-1.1.2"
-      sources."path-case-3.0.3"
+      (sources."path-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."path-dirname-1.0.2"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
@@ -62094,7 +62231,11 @@ in
           sources."setprototypeof-1.1.1"
         ];
       })
-      sources."sentence-case-3.0.3"
+      (sources."sentence-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."serve-static-1.14.1"
       sources."set-blocking-2.0.0"
       sources."set-value-2.0.1"
@@ -62109,7 +62250,11 @@ in
       sources."signal-exit-3.0.3"
       sources."slash-3.0.0"
       sources."slice-ansi-0.0.4"
-      sources."snake-case-3.0.3"
+      (sources."snake-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -62305,7 +62450,7 @@ in
       sources."union-value-1.0.1"
       sources."uniq-1.0.1"
       sources."unique-string-1.0.0"
-      sources."universalify-1.0.0"
+      sources."universalify-0.1.2"
       sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -62329,8 +62474,16 @@ in
           sources."widest-line-2.0.1"
         ];
       })
-      sources."upper-case-2.0.1"
-      sources."upper-case-first-2.0.1"
+      (sources."upper-case-2.0.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
+      (sources."upper-case-first-2.0.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."uri-js-4.4.0"
       sources."urix-0.1.0"
       sources."url-parse-lax-1.0.0"
@@ -62357,7 +62510,6 @@ in
           sources."fs-extra-8.1.0"
           sources."get-stream-5.2.0"
           sources."is-stream-2.0.0"
-          sources."jsonfile-4.0.0"
           sources."mimic-fn-2.1.0"
           sources."npm-run-path-4.0.1"
           sources."onetime-5.1.2"
@@ -62365,14 +62517,13 @@ in
           sources."path-key-3.1.1"
           sources."shebang-command-2.0.0"
           sources."shebang-regex-3.0.0"
-          sources."universalify-0.1.2"
           sources."which-2.0.2"
         ];
       })
       (sources."vue-codemod-0.0.4" // {
         dependencies = [
           sources."globby-10.0.2"
-          sources."vue-3.0.3"
+          sources."vue-3.0.4"
         ];
       })
       sources."watch-1.0.2"
@@ -63200,12 +63351,12 @@ in
       sources."inherits-2.0.4"
       sources."inline-source-map-0.6.2"
       sources."insert-module-globals-7.2.1"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.2.2"
       sources."is-core-module-2.2.0"
       sources."is-date-object-1.0.2"
-      sources."is-generator-function-1.0.7"
+      sources."is-generator-function-1.0.8"
       sources."is-regex-1.1.1"
       sources."is-symbol-1.0.3"
       sources."is-typed-array-1.1.3"
@@ -63662,7 +63813,12 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-json-stringify-1.2.0"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      (sources."semver-7.3.4" // {
+        dependencies = [
+          sources."lru-cache-6.0.0"
+          sources."yallist-4.0.0"
+        ];
+      })
       (sources."send-0.17.1" // {
         dependencies = [
           (sources."debug-2.6.9" // {
@@ -63703,7 +63859,7 @@ in
       sources."strip-ansi-5.2.0"
       sources."strip-bom-3.0.0"
       sources."strip-indent-2.0.0"
-      sources."tiny-secp256k1-1.1.5"
+      sources."tiny-secp256k1-1.1.6"
       sources."to-fast-properties-1.0.3"
       sources."toidentifier-1.0.0"
       sources."token-stream-0.0.1"
@@ -64125,7 +64281,7 @@ in
       sources."time-line-1.0.1"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
-      (sources."torrent-stream-1.2.0" // {
+      (sources."torrent-stream-1.2.1" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."magnet-uri-4.2.3"
@@ -64614,7 +64770,7 @@ in
       sources."fb-watchman-2.0.1"
       sources."flatted-2.0.2"
       sources."follow-redirects-1.13.0"
-      sources."fp-ts-2.9.0"
+      sources."fp-ts-2.9.1"
       sources."fs-extra-8.1.0"
       sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
@@ -64658,6 +64814,7 @@ in
       })
       sources."lodash-4.17.20"
       sources."log4js-6.3.0"
+      sources."lru-cache-6.0.0"
       sources."metals-languageclient-0.3.3"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
@@ -64695,7 +64852,7 @@ in
       sources."rfdc-1.1.4"
       sources."rimraf-3.0.2"
       sources."safe-buffer-5.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."setimmediate-1.0.5"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
@@ -64837,7 +64994,7 @@ in
       sources."callsites-3.1.0"
       sources."camelcase-2.1.1"
       sources."camelcase-keys-2.1.0"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."capture-stack-trace-1.0.1"
       sources."ccount-1.1.0"
       sources."chalk-2.4.2"
@@ -64925,7 +65082,7 @@ in
       sources."doctrine-3.0.0"
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
-          sources."domelementtype-2.0.2"
+          sources."domelementtype-2.1.0"
           sources."entities-2.1.0"
         ];
       })
@@ -64934,7 +65091,7 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-5.3.0"
       sources."duplexer3-0.1.4"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
@@ -64966,6 +65123,8 @@ in
       (sources."execa-0.7.0" // {
         dependencies = [
           sources."cross-spawn-5.1.0"
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
         ];
       })
       sources."execall-1.0.0"
@@ -65221,7 +65380,7 @@ in
       sources."longest-streak-2.0.4"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-6.0.0"
       sources."make-dir-1.3.0"
       sources."map-age-cleaner-0.1.3"
       sources."map-cache-0.2.2"
@@ -65457,7 +65616,7 @@ in
       sources."safe-buffer-5.2.1"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
           sources."semver-5.7.1"
@@ -65687,7 +65846,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
-      sources."yallist-2.1.2"
+      sources."yallist-4.0.0"
       (sources."yargs-11.1.1" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
@@ -65773,10 +65932,10 @@ in
   coc-rust-analyzer = nodeEnv.buildNodePackage {
     name = "coc-rust-analyzer";
     packageName = "coc-rust-analyzer";
-    version = "0.18.0";
+    version = "0.19.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.18.0.tgz";
-      sha512 = "26wqJFlLsKj2BWaFUfjuu7pIBob36HeUH131IPlxAvluxcd/uhIZZEm22DzBJFhiX6alP+6nHfKsjpI+ntyAtA==";
+      url = "https://registry.npmjs.org/coc-rust-analyzer/-/coc-rust-analyzer-0.19.0.tgz";
+      sha512 = "HeoHspOK0pg9UGUV6jYX5IlJhWIslA34Yg99QqJU2xCJxE93YAlyhJ0S/TVtkQdCYpn6D7UiHjKDazUQKkDMOQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -65893,11 +66052,11 @@ in
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       (sources."chalk-4.1.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
@@ -65928,14 +66087,14 @@ in
       sources."dir-glob-3.0.1"
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
-          sources."domelementtype-2.0.2"
+          sources."domelementtype-2.1.0"
           sources."entities-2.1.0"
         ];
       })
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -66038,7 +66197,7 @@ in
       sources."node-releases-1.1.67"
       (sources."normalize-package-data-3.0.0" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."normalize-range-0.1.2"
@@ -66327,7 +66486,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@eslint/eslintrc-0.2.1"
+      sources."@eslint/eslintrc-0.2.2"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.6"
@@ -66361,8 +66520,8 @@ in
       sources."emoji-regex-7.0.3"
       sources."enquirer-2.3.6"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-7.14.0"
-      sources."eslint-plugin-vue-7.1.0"
+      sources."eslint-7.15.0"
+      sources."eslint-plugin-vue-7.2.0"
       sources."eslint-scope-5.1.1"
       (sources."eslint-utils-2.1.0" // {
         dependencies = [
@@ -66370,7 +66529,7 @@ in
         ];
       })
       sources."eslint-visitor-keys-2.0.0"
-      (sources."espree-7.3.0" // {
+      (sources."espree-7.3.1" // {
         dependencies = [
           sources."eslint-visitor-keys-1.3.0"
         ];
@@ -66391,9 +66550,9 @@ in
       sources."fast-deep-equal-3.1.3"
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
-      sources."file-entry-cache-5.0.1"
-      sources."flat-cache-2.0.1"
-      sources."flatted-2.0.2"
+      sources."file-entry-cache-6.0.0"
+      sources."flat-cache-3.0.4"
+      sources."flatted-3.1.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
@@ -66418,6 +66577,7 @@ in
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."levn-0.4.1"
       sources."lodash-4.17.20"
+      sources."lru-cache-6.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
       sources."mkdirp-0.5.5"
@@ -66436,8 +66596,8 @@ in
       sources."regexpp-3.1.0"
       sources."resolve-1.19.0"
       sources."resolve-from-4.0.0"
-      sources."rimraf-2.6.3"
-      sources."semver-7.3.2"
+      sources."rimraf-3.0.2"
+      sources."semver-7.3.4"
       sources."shebang-command-2.0.0"
       sources."shebang-regex-3.0.0"
       sources."slice-ansi-2.1.0"
@@ -66467,7 +66627,7 @@ in
       sources."uri-js-4.4.0"
       sources."v8-compile-cache-2.2.0"
       sources."vls-0.5.10"
-      (sources."vue-eslint-parser-7.1.1" // {
+      (sources."vue-eslint-parser-7.2.0" // {
         dependencies = [
           sources."eslint-visitor-keys-1.3.0"
           sources."espree-6.2.1"
@@ -66476,7 +66636,7 @@ in
       sources."which-2.0.2"
       sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
-      sources."write-1.0.3"
+      sources."yallist-4.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -67144,7 +67304,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.1.4"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."semver-diff-3.1.1" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -67183,7 +67343,7 @@ in
       sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-7.2.0"
-      sources."systeminformation-4.30.10"
+      sources."systeminformation-4.30.11"
       sources."term-size-2.2.1"
       sources."through-2.3.8"
       sources."tmp-0.2.1"
@@ -68149,7 +68309,7 @@ in
           sources."extend-shallow-2.0.1"
         ];
       })
-      sources."flat-tree-1.7.0"
+      sources."flat-tree-1.8.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -68538,7 +68698,7 @@ in
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
       sources."utile-0.3.0"
-      (sources."utp-native-2.2.1" // {
+      (sources."utp-native-2.2.2" // {
         dependencies = [
           sources."node-gyp-build-4.2.3"
           sources."readable-stream-3.6.0"
@@ -68966,7 +69126,7 @@ in
       sources."concat-map-0.0.1"
       (sources."conf-7.1.2" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."convert-source-map-1.7.0"
@@ -69060,6 +69220,7 @@ in
       sources."lodash-4.17.20"
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-2.0.0"
+      sources."lru-cache-6.0.0"
       (sources."make-dir-3.1.0" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -69117,7 +69278,7 @@ in
       sources."punycode-2.1.1"
       sources."quick-lru-5.1.1"
       sources."react-16.14.0"
-      sources."react-devtools-core-4.10.0"
+      sources."react-devtools-core-4.10.1"
       sources."react-is-16.13.1"
       sources."react-reconciler-0.24.0"
       (sources."read-pkg-5.2.0" // {
@@ -69194,7 +69355,8 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
+      sources."yallist-4.0.0"
       sources."yargs-parser-18.1.3"
       sources."yoga-layout-prebuilt-1.10.0"
     ];
@@ -69243,7 +69405,7 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.12"
-      sources."@fluentui/react-7.153.2"
+      sources."@fluentui/react-7.153.4"
       sources."@fluentui/react-compose-0.19.12"
       sources."@fluentui/react-focus-7.16.19"
       sources."@fluentui/react-stylesheets-0.2.4"
@@ -69260,7 +69422,7 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."@microsoft/load-themed-styles-1.10.138"
+      sources."@microsoft/load-themed-styles-1.10.139"
       sources."@nodelib/fs.scandir-2.1.3"
       sources."@nodelib/fs.stat-2.0.3"
       sources."@nodelib/fs.walk-1.2.4"
@@ -69500,7 +69662,6 @@ in
           sources."p-map-4.0.0"
           sources."rimraf-3.0.2"
           sources."tar-6.0.5"
-          sources."yallist-4.0.0"
         ];
       })
       sources."cache-base-1.0.1"
@@ -70064,11 +70225,7 @@ in
       })
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-1.0.1"
-      (sources."lru-cache-6.0.0" // {
-        dependencies = [
-          sources."yallist-4.0.0"
-        ];
-      })
+      sources."lru-cache-6.0.0"
       sources."lru-queue-0.1.0"
       (sources."make-dir-3.1.0" // {
         dependencies = [
@@ -70123,23 +70280,24 @@ in
       sources."minimalistic-crypto-utils-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      sources."minipass-2.9.0"
+      (sources."minipass-2.9.0" // {
+        dependencies = [
+          sources."yallist-3.1.1"
+        ];
+      })
       (sources."minipass-collect-1.0.2" // {
         dependencies = [
           sources."minipass-3.1.3"
-          sources."yallist-4.0.0"
         ];
       })
       (sources."minipass-flush-1.0.5" // {
         dependencies = [
           sources."minipass-3.1.3"
-          sources."yallist-4.0.0"
         ];
       })
       (sources."minipass-pipeline-1.2.4" // {
         dependencies = [
           sources."minipass-3.1.3"
-          sources."yallist-4.0.0"
         ];
       })
       sources."minizlib-1.3.3"
@@ -70280,7 +70438,7 @@ in
       sources."object.map-1.0.1"
       sources."object.pick-1.3.0"
       sources."object.reduce-1.0.1"
-      sources."office-ui-fabric-react-7.153.2"
+      sources."office-ui-fabric-react-7.153.4"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -70474,11 +70632,11 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."sass-1.29.0"
+      sources."sass-1.30.0"
       sources."sax-1.2.4"
       sources."scheduler-0.19.1"
       sources."schema-utils-2.7.1"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."semver-greatest-satisfied-range-1.1.0"
       (sources."send-0.17.1" // {
         dependencies = [
@@ -70576,7 +70734,6 @@ in
       (sources."ssri-8.0.0" // {
         dependencies = [
           sources."minipass-3.1.3"
-          sources."yallist-4.0.0"
         ];
       })
       sources."stack-trace-0.0.10"
@@ -70648,6 +70805,7 @@ in
       (sources."tar-4.4.13" // {
         dependencies = [
           sources."mkdirp-0.5.5"
+          sources."yallist-3.1.1"
         ];
       })
       (sources."terser-5.5.1" // {
@@ -70814,6 +70972,7 @@ in
           sources."terser-webpack-plugin-1.4.5"
           sources."to-regex-range-2.1.1"
           sources."y18n-4.0.1"
+          sources."yallist-3.1.1"
         ];
       })
       sources."webpack-sources-1.4.3"
@@ -70834,11 +70993,11 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
-      sources."yallist-3.1.1"
+      sources."yallist-4.0.0"
       (sources."yargs-7.1.1" // {
         dependencies = [
           sources."is-fullwidth-code-point-1.0.0"
@@ -70880,10 +71039,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "7.14.0";
+    version = "7.15.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz";
-      sha512 = "5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-7.15.0.tgz";
+      sha512 = "Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -70893,7 +71052,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@eslint/eslintrc-0.2.1"
+      sources."@eslint/eslintrc-0.2.2"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.6"
@@ -70931,7 +71090,7 @@ in
         ];
       })
       sources."eslint-visitor-keys-2.0.0"
-      (sources."espree-7.3.0" // {
+      (sources."espree-7.3.1" // {
         dependencies = [
           sources."eslint-visitor-keys-1.3.0"
         ];
@@ -70952,9 +71111,9 @@ in
       sources."fast-deep-equal-3.1.3"
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
-      sources."file-entry-cache-5.0.1"
-      sources."flat-cache-2.0.1"
-      sources."flatted-2.0.2"
+      sources."file-entry-cache-6.0.0"
+      sources."flat-cache-3.0.4"
+      sources."flatted-3.1.0"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.6"
@@ -70976,9 +71135,8 @@ in
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."levn-0.4.1"
       sources."lodash-4.17.20"
+      sources."lru-cache-6.0.0"
       sources."minimatch-3.0.4"
-      sources."minimist-1.2.5"
-      sources."mkdirp-0.5.5"
       sources."ms-2.1.2"
       sources."natural-compare-1.4.0"
       sources."once-1.4.0"
@@ -70991,8 +71149,8 @@ in
       sources."punycode-2.1.1"
       sources."regexpp-3.1.0"
       sources."resolve-from-4.0.0"
-      sources."rimraf-2.6.3"
-      sources."semver-7.3.2"
+      sources."rimraf-3.0.2"
+      sources."semver-7.3.4"
       sources."shebang-command-2.0.0"
       sources."shebang-regex-3.0.0"
       sources."slice-ansi-2.1.0"
@@ -71015,7 +71173,7 @@ in
       sources."which-2.0.2"
       sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
-      sources."write-1.0.3"
+      sources."yallist-4.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -71043,7 +71201,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@eslint/eslintrc-0.2.1"
+      sources."@eslint/eslintrc-0.2.2"
       sources."acorn-7.4.1"
       sources."acorn-jsx-5.3.1"
       sources."ajv-6.12.6"
@@ -71075,7 +71233,7 @@ in
       sources."emoji-regex-7.0.3"
       sources."enquirer-2.3.6"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-7.14.0"
+      sources."eslint-7.15.0"
       sources."eslint-scope-5.1.1"
       (sources."eslint-utils-2.1.0" // {
         dependencies = [
@@ -71083,7 +71241,7 @@ in
         ];
       })
       sources."eslint-visitor-keys-2.0.0"
-      (sources."espree-7.3.0" // {
+      (sources."espree-7.3.1" // {
         dependencies = [
           sources."eslint-visitor-keys-1.3.0"
         ];
@@ -71104,9 +71262,9 @@ in
       sources."fast-deep-equal-3.1.3"
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
-      sources."file-entry-cache-5.0.1"
-      sources."flat-cache-2.0.1"
-      sources."flatted-2.0.2"
+      sources."file-entry-cache-6.0.0"
+      sources."flat-cache-3.0.4"
+      sources."flatted-3.1.0"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.6"
@@ -71128,9 +71286,8 @@ in
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."levn-0.4.1"
       sources."lodash-4.17.20"
+      sources."lru-cache-6.0.0"
       sources."minimatch-3.0.4"
-      sources."minimist-1.2.5"
-      sources."mkdirp-0.5.5"
       sources."ms-2.1.2"
       sources."nanolru-1.0.0"
       sources."natural-compare-1.4.0"
@@ -71144,8 +71301,8 @@ in
       sources."punycode-2.1.1"
       sources."regexpp-3.1.0"
       sources."resolve-from-4.0.0"
-      sources."rimraf-2.6.3"
-      sources."semver-7.3.2"
+      sources."rimraf-3.0.2"
+      sources."semver-7.3.4"
       sources."shebang-command-2.0.0"
       sources."shebang-regex-3.0.0"
       sources."slice-ansi-2.1.0"
@@ -71168,7 +71325,7 @@ in
       sources."which-2.0.2"
       sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
-      sources."write-1.0.3"
+      sources."yallist-4.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -71183,10 +71340,10 @@ in
   expo-cli = nodeEnv.buildNodePackage {
     name = "expo-cli";
     packageName = "expo-cli";
-    version = "4.0.6";
+    version = "4.0.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/expo-cli/-/expo-cli-4.0.6.tgz";
-      sha512 = "dpNpZMddzA3WUQQyT7VVUOg9UlQiRSjlFWOqXIqZyDSSc/XPWwC1DNrtOCMYvVwDm4sfIUnmiSA7LSM5MJWnGw==";
+      url = "https://registry.npmjs.org/expo-cli/-/expo-cli-4.0.8.tgz";
+      sha512 = "PcJqWSu2mHSEX/O/Vt5Wrui6ZIOE3mwUN4NL2xxmvVUAzIp08SzkAnWJOSThOxcTfHh9kd9fFK1GP6BZItvQOA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -71325,10 +71482,10 @@ in
       sources."@expo/bunyan-4.0.0"
       (sources."@expo/config-3.3.18" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
-      (sources."@expo/config-plugins-1.0.5" // {
+      (sources."@expo/config-plugins-1.0.7" // {
         dependencies = [
           sources."slash-3.0.0"
           sources."uuid-3.4.0"
@@ -71359,7 +71516,7 @@ in
           sources."type-fest-0.12.0"
         ];
       })
-      sources."@expo/dev-tools-0.13.65"
+      sources."@expo/dev-tools-0.13.66"
       sources."@expo/eas-build-job-0.1.2"
       (sources."@expo/image-utils-0.3.9" // {
         dependencies = [
@@ -71426,7 +71583,7 @@ in
           sources."react-refresh-0.8.3"
         ];
       })
-      (sources."@expo/xdl-59.0.5" // {
+      (sources."@expo/xdl-59.0.6" // {
         dependencies = [
           sources."chownr-1.1.4"
           (sources."fs-minipass-1.2.7" // {
@@ -71444,13 +71601,19 @@ in
           sources."mkdirp-1.0.4"
           (sources."npm-package-arg-8.1.0" // {
             dependencies = [
-              sources."semver-7.3.2"
+              sources."lru-cache-6.0.0"
+              sources."semver-7.3.4"
+              sources."yallist-4.0.0"
             ];
           })
           (sources."pacote-11.1.0" // {
             dependencies = [
               sources."minipass-3.1.3"
-              sources."semver-7.3.2"
+              (sources."semver-7.3.4" // {
+                dependencies = [
+                  sources."lru-cache-6.0.0"
+                ];
+              })
               (sources."tar-6.0.5" // {
                 dependencies = [
                   sources."chownr-2.0.0"
@@ -71526,7 +71689,7 @@ in
       (sources."@npmcli/git-2.0.4" // {
         dependencies = [
           sources."mkdirp-1.0.4"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."which-2.0.2"
         ];
       })
@@ -71621,12 +71784,12 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      (sources."@types/webpack-sources-2.0.0" // {
+      (sources."@types/webpack-sources-2.1.0" // {
         dependencies = [
           sources."source-map-0.7.3"
         ];
       })
-      sources."@types/yargs-15.0.10"
+      sources."@types/yargs-15.0.11"
       sources."@types/yargs-parser-15.0.0"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
@@ -71813,7 +71976,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."buffer-5.7.1"
       sources."buffer-equal-0.0.1"
       sources."buffer-from-1.1.1"
@@ -71844,14 +72007,15 @@ in
       sources."caller-path-2.0.0"
       sources."callsite-1.0.0"
       sources."callsites-2.0.0"
-      (sources."camel-case-4.1.1" // {
+      (sources."camel-case-4.1.2" // {
         dependencies = [
-          sources."pascal-case-3.1.1"
+          sources."pascal-case-3.1.2"
+          sources."tslib-2.0.3"
         ];
       })
       sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       (sources."chalk-4.1.0" // {
@@ -72005,7 +72169,7 @@ in
         dependencies = [
           (sources."dom-serializer-0.2.2" // {
             dependencies = [
-              sources."domelementtype-2.0.2"
+              sources."domelementtype-2.1.0"
             ];
           })
           sources."domelementtype-1.3.1"
@@ -72037,14 +72201,14 @@ in
       sources."dag-map-1.0.2"
       sources."dashdash-1.14.1"
       sources."dateformat-3.0.3"
-      sources."dayjs-1.9.6"
+      sources."dayjs-1.9.7"
       sources."debug-4.3.1"
       sources."debuglog-1.0.1"
       sources."decache-4.4.0"
       sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
       sources."decompress-response-3.3.0"
-      sources."deep-equal-2.0.4"
+      sources."deep-equal-2.0.5"
       sources."deep-extend-0.6.0"
       sources."deep-scope-analyser-1.7.0"
       sources."deepmerge-1.5.2"
@@ -72100,17 +72264,25 @@ in
       sources."dom-serializer-1.1.0"
       sources."dom-walk-0.1.2"
       sources."domain-browser-1.2.0"
-      sources."domelementtype-2.0.2"
+      sources."domelementtype-2.1.0"
       sources."domhandler-3.3.0"
-      sources."domutils-2.4.2"
-      sources."dot-case-3.0.3"
+      (sources."domutils-2.4.3" // {
+        dependencies = [
+          sources."domhandler-4.0.0"
+        ];
+      })
+      (sources."dot-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."dot-prop-5.3.0"
       sources."duplexer-0.1.2"
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -72144,7 +72316,7 @@ in
       })
       sources."error-stack-parser-2.0.6"
       sources."errorhandler-1.5.1"
-      sources."es-abstract-1.18.0-next.1"
+      sources."es-abstract-1.17.7"
       sources."es-get-iterator-1.1.1"
       sources."es-to-primitive-1.2.1"
       sources."escalade-3.1.1"
@@ -72446,7 +72618,7 @@ in
       sources."ipaddr.js-1.9.1"
       sources."is-absolute-url-2.1.0"
       sources."is-accessor-descriptor-1.0.0"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-arrayish-0.3.2"
       sources."is-bigint-1.0.1"
       sources."is-binary-path-2.1.0"
@@ -72473,7 +72645,7 @@ in
       })
       sources."is-lambda-1.0.1"
       sources."is-map-2.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-number-7.0.0"
       sources."is-number-object-1.0.4"
       sources."is-obj-2.0.0"
@@ -72505,11 +72677,7 @@ in
       sources."is-string-1.0.5"
       sources."is-svg-3.0.0"
       sources."is-symbol-1.0.3"
-      (sources."is-typed-array-1.1.3" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."is-typed-array-1.1.3"
       sources."is-typedarray-1.0.0"
       sources."is-valid-path-0.1.1"
       sources."is-weakmap-2.0.1"
@@ -72599,7 +72767,11 @@ in
       sources."logkitty-0.7.1"
       sources."loglevel-1.7.1"
       sources."loose-envify-1.4.0"
-      sources."lower-case-2.0.1"
+      (sources."lower-case-2.0.2" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-6.0.0"
       (sources."make-dir-2.1.0" // {
@@ -72718,13 +72890,17 @@ in
       sources."neo-async-2.6.2"
       sources."next-tick-1.1.0"
       sources."nice-try-1.0.5"
-      sources."no-case-3.0.3"
+      (sources."no-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."node-fetch-2.6.1"
       sources."node-forge-0.7.6"
       (sources."node-gyp-7.1.2" // {
         dependencies = [
           sources."rimraf-3.0.2"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."which-2.0.2"
         ];
       })
@@ -72743,7 +72919,7 @@ in
       sources."npm-bundled-1.1.1"
       (sources."npm-install-checks-4.0.0" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."npm-normalize-package-bin-1.0.1"
@@ -72756,14 +72932,14 @@ in
       (sources."npm-pick-manifest-6.1.0" // {
         dependencies = [
           sources."npm-package-arg-8.1.0"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       (sources."npm-registry-fetch-8.1.5" // {
         dependencies = [
           sources."minipass-3.1.3"
           sources."npm-package-arg-8.1.0"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."npm-run-path-2.0.2"
@@ -72791,10 +72967,22 @@ in
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
       sources."object.assign-4.1.2"
-      sources."object.entries-1.1.3"
-      sources."object.getownpropertydescriptors-2.1.1"
+      (sources."object.entries-1.1.3" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+        ];
+      })
+      (sources."object.getownpropertydescriptors-2.1.1" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+        ];
+      })
       sources."object.pick-1.3.0"
-      sources."object.values-1.1.2"
+      (sources."object.values-1.1.2" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+        ];
+      })
       sources."obuf-1.1.2"
       sources."omggif-1.0.10"
       sources."on-finished-2.3.0"
@@ -72851,12 +73039,16 @@ in
           sources."npm-package-arg-8.1.0"
           sources."npm-registry-fetch-9.0.0"
           sources."rimraf-3.0.2"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."pako-1.0.11"
       sources."parallel-transform-1.2.0"
-      sources."param-case-3.0.3"
+      (sources."param-case-3.0.4" // {
+        dependencies = [
+          sources."tslib-2.0.3"
+        ];
+      })
       sources."parse-asn1-5.1.6"
       sources."parse-bmfont-ascii-1.0.6"
       sources."parse-bmfont-binary-1.0.6"
@@ -73149,11 +73341,7 @@ in
       sources."regenerator-runtime-0.13.7"
       sources."regenerator-transform-0.14.5"
       sources."regex-not-1.0.2"
-      (sources."regexp.prototype.flags-1.3.0" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."regexp.prototype.flags-1.3.0"
       sources."regexpu-core-4.7.1"
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
@@ -73171,7 +73359,7 @@ in
           sources."ansi-regex-2.1.1"
           (sources."dom-serializer-0.2.2" // {
             dependencies = [
-              sources."domelementtype-2.0.2"
+              sources."domelementtype-2.1.0"
               sources."entities-2.1.0"
             ];
           })
@@ -73267,7 +73455,11 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shell-quote-1.6.1"
-      sources."side-channel-1.0.3"
+      (sources."side-channel-1.0.3" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+        ];
+      })
       sources."signal-exit-3.0.3"
       sources."simple-plist-1.1.1"
       sources."simple-swizzle-0.2.2"
@@ -73322,7 +73514,7 @@ in
           sources."faye-websocket-0.11.3"
         ];
       })
-      sources."socks-2.5.0"
+      sources."socks-2.5.1"
       sources."socks-proxy-agent-5.0.0"
       sources."source-list-map-2.0.1"
       sources."source-map-0.5.7"
@@ -73424,7 +73616,7 @@ in
           sources."css-what-3.4.2"
           (sources."dom-serializer-0.2.2" // {
             dependencies = [
-              sources."domelementtype-2.0.2"
+              sources."domelementtype-2.1.0"
             ];
           })
           sources."domelementtype-1.3.1"
@@ -73754,11 +73946,7 @@ in
       sources."which-boxed-primitive-1.0.1"
       sources."which-collection-1.0.1"
       sources."which-module-2.0.0"
-      (sources."which-typed-array-1.1.2" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."which-typed-array-1.1.2"
       (sources."wide-align-1.1.3" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
@@ -74339,7 +74527,7 @@ in
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
       sources."is-number-7.0.0"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-plain-obj-1.1.0"
       sources."is-plain-object-2.0.4"
       sources."is-retry-allowed-1.2.0"
@@ -74367,6 +74555,7 @@ in
       sources."lodash.template-4.5.0"
       sources."lodash.templatesettings-4.2.0"
       sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       sources."merge2-1.4.1"
@@ -74455,7 +74644,7 @@ in
       sources."safe-buffer-5.2.1"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -74575,12 +74764,62 @@ in
       sources."word-wrap-1.2.3"
       sources."wrap-ansi-7.0.0"
       sources."wrappy-1.0.2"
+      sources."yallist-4.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "faunadb shell";
       homepage = https://github.com/fauna/fauna-shell;
       license = "MPL-2.0";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  fixjson = nodeEnv.buildNodePackage {
+    name = "fixjson";
+    packageName = "fixjson";
+    version = "1.1.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/fixjson/-/fixjson-1.1.1.tgz";
+      sha512 = "cKclzjy4yv7Byu/v7hW4a4hwNgrINI/g2K/d3dtcMScdtY8BwBApb1gGBTLppuRaQpfdM/z0xj+5l8xcVKCm8w==";
+    };
+    dependencies = [
+      sources."ansi-regex-5.0.0"
+      sources."ansi-styles-4.3.0"
+      sources."balanced-match-1.0.0"
+      sources."brace-expansion-1.1.11"
+      sources."cliui-7.0.4"
+      sources."color-convert-2.0.1"
+      sources."color-name-1.1.4"
+      sources."concat-map-0.0.1"
+      sources."detect-indent-6.0.0"
+      sources."emoji-regex-8.0.0"
+      sources."escalade-3.1.1"
+      sources."fs.realpath-1.0.0"
+      sources."get-caller-file-2.0.5"
+      sources."glob-7.1.6"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."is-fullwidth-code-point-3.0.0"
+      sources."json5-relaxed-0.5.4"
+      sources."minimatch-3.0.4"
+      sources."once-1.4.0"
+      sources."path-is-absolute-1.0.1"
+      sources."require-directory-2.1.1"
+      sources."string-width-4.2.0"
+      sources."strip-ansi-6.0.0"
+      sources."wrap-ansi-7.0.0"
+      sources."wrappy-1.0.2"
+      sources."y18n-5.0.5"
+      sources."yargs-16.1.1"
+      sources."yargs-parser-20.2.4"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "JSON fixer for humans using (relaxed) JSON5";
+      homepage = "https://github.com/rhysd/fixjson#readme";
+      license = "MIT";
     };
     production = true;
     bypassCache = true;
@@ -74786,10 +75025,10 @@ in
   flood = nodeEnv.buildNodePackage {
     name = "flood";
     packageName = "flood";
-    version = "4.2.0";
+    version = "4.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/flood/-/flood-4.2.0.tgz";
-      sha512 = "xdfiYucaiUEmaScEDZr24vq5qkBe7cC51YeFG9gSFZF0ccGtoVG1RMw55vA06VyMxLUlYVqR9uYxyKVmk/xDBg==";
+      url = "https://registry.npmjs.org/flood/-/flood-4.3.0.tgz";
+      sha512 = "+SgygDdGTnKaZA2N0VzaUKVqAV8S4KrisdL9+DtIWweJwP/mYQ7WIhIJVMiJWbyYjtPTGoUqvxYqEP/QiFgfNw==";
     };
     dependencies = [
       sources."async-2.6.3"
@@ -74800,7 +75039,7 @@ in
       sources."concat-map-0.0.1"
       sources."fd-slicer-1.1.0"
       sources."fs.realpath-1.0.0"
-      sources."geoip-country-4.0.44"
+      sources."geoip-country-4.0.45"
       sources."glob-7.1.6"
       sources."iconv-lite-0.5.2"
       sources."inflight-1.0.6"
@@ -74997,7 +75236,7 @@ in
       sources."ini-1.3.5"
       sources."invert-kv-1.0.0"
       sources."is-accessor-descriptor-1.0.0"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.2.2"
@@ -75380,7 +75619,7 @@ in
       sources."multiserver-address-1.0.1"
       sources."multiserver-scopes-1.0.0"
       sources."muxrpc-6.5.1"
-      sources."nearley-2.19.9"
+      sources."nearley-2.20.0"
       sources."node-gyp-build-4.2.3"
       sources."node-polyglot-1.0.0"
       sources."non-private-ip-1.4.4"
@@ -75447,7 +75686,7 @@ in
       sources."separator-escape-0.0.0"
       sources."sha.js-2.4.5"
       sources."smart-buffer-4.1.0"
-      sources."socks-2.5.0"
+      sources."socks-2.5.1"
       sources."sodium-browserify-1.3.0"
       (sources."sodium-browserify-tweetnacl-0.2.6" // {
         dependencies = [
@@ -75673,6 +75912,7 @@ in
       sources."lodash-4.17.20"
       sources."log-symbols-4.0.0"
       sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
       (sources."make-dir-3.1.0" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -75749,7 +75989,7 @@ in
       sources."run-async-2.4.1"
       sources."rxjs-6.6.3"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."semver-diff-3.1.1" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -75791,6 +76031,7 @@ in
       sources."wrappy-1.0.2"
       sources."write-file-atomic-3.0.3"
       sources."xdg-basedir-4.0.0"
+      sources."yallist-4.0.0"
       sources."yargs-parser-18.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -75830,45 +76071,53 @@ in
       sources."@graphql-cli/init-4.1.0"
       (sources."@graphql-tools/batch-execute-7.0.0" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
       (sources."@graphql-tools/delegate-7.0.7" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
       (sources."@graphql-tools/graphql-file-loader-6.2.6" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
       sources."@graphql-tools/import-6.2.5"
       (sources."@graphql-tools/json-file-loader-6.2.6" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
       sources."@graphql-tools/load-6.2.4"
       (sources."@graphql-tools/merge-6.2.6" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
       (sources."@graphql-tools/schema-7.1.2" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
-      (sources."@graphql-tools/url-loader-6.4.0" // {
+      (sources."@graphql-tools/url-loader-6.5.0" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
-      sources."@graphql-tools/utils-6.2.4"
-      (sources."@graphql-tools/wrap-7.0.3" // {
+      (sources."@graphql-tools/utils-6.2.4" // {
         dependencies = [
-          sources."@graphql-tools/utils-7.1.2"
+          (sources."camel-case-4.1.1" // {
+            dependencies = [
+              sources."tslib-1.14.1"
+            ];
+          })
+        ];
+      })
+      (sources."@graphql-tools/wrap-7.0.4" // {
+        dependencies = [
+          sources."@graphql-tools/utils-7.1.4"
         ];
       })
       sources."@kwsites/file-exists-1.1.1"
@@ -75895,20 +76144,18 @@ in
       sources."array-union-2.1.0"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."at-least-node-1.0.0"
       sources."available-typed-arrays-1.0.2"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
-      sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       sources."base64-js-1.5.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
       sources."buffer-5.7.1"
-      sources."bufferutil-4.0.2"
+      sources."busboy-0.3.1"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
           sources."get-stream-5.2.0"
@@ -75918,9 +76165,9 @@ in
       sources."call-bind-1.0.0"
       sources."call-me-maybe-1.0.1"
       sources."callsites-3.1.0"
-      (sources."camel-case-4.1.1" // {
+      (sources."camel-case-4.1.2" // {
         dependencies = [
-          sources."tslib-1.14.1"
+          sources."tslib-2.0.3"
         ];
       })
       sources."caseless-0.12.0"
@@ -75958,46 +76205,39 @@ in
       })
       sources."cross-fetch-3.0.6"
       sources."cross-spawn-6.0.5"
-      sources."d-1.0.1"
       sources."dashdash-1.14.1"
       sources."dataloader-2.0.0"
       sources."debug-4.3.1"
       sources."decompress-response-3.3.0"
-      sources."deep-equal-2.0.4"
+      sources."deep-equal-2.0.5"
       sources."deep-extend-0.6.0"
       sources."defaults-1.0.3"
       sources."defer-to-connect-1.1.3"
       sources."define-properties-1.1.3"
       sources."delayed-stream-1.0.0"
+      sources."depd-1.1.2"
+      sources."dicer-0.3.0"
       sources."dir-glob-3.0.1"
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.18.0-next.1"
+      sources."es-abstract-1.17.7"
       sources."es-get-iterator-1.1.1"
       sources."es-to-primitive-1.2.1"
-      sources."es5-ext-0.10.53"
-      sources."es6-iterator-2.0.3"
       sources."es6-promise-3.3.1"
-      sources."es6-symbol-3.1.3"
       sources."escalade-3.1.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
-      sources."eventemitter3-3.1.2"
       sources."execa-1.0.0"
-      (sources."ext-1.4.0" // {
-        dependencies = [
-          sources."type-2.1.0"
-        ];
-      })
       sources."extend-3.0.2"
       (sources."external-editor-3.1.0" // {
         dependencies = [
           sources."tmp-0.0.33"
         ];
       })
+      sources."extract-files-9.0.0"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-3.1.3"
       sources."fast-glob-3.2.4"
@@ -76012,6 +76252,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."form-urlencoded-4.2.1"
+      sources."fs-capacitor-6.2.0"
       sources."fs-extra-9.0.1"
       sources."fs-minipass-2.1.0"
       sources."fs.realpath-1.0.0"
@@ -76038,12 +76279,15 @@ in
       })
       sources."graphql-subscriptions-1.1.0"
       sources."graphql-type-json-0.3.2"
+      sources."graphql-upload-11.0.0"
+      sources."graphql-ws-2.0.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
       sources."has-1.0.3"
       sources."has-flag-4.0.0"
       sources."has-symbols-1.0.1"
       sources."http-cache-semantics-4.1.0"
+      sources."http-errors-1.8.0"
       sources."http-signature-1.2.0"
       sources."http2-client-1.3.3"
       sources."iconv-lite-0.4.24"
@@ -76069,7 +76313,7 @@ in
           sources."strip-ansi-6.0.0"
         ];
       })
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-arrayish-0.2.1"
       sources."is-bigint-1.0.1"
       sources."is-boolean-object-1.0.1"
@@ -76081,7 +76325,7 @@ in
       sources."is-glob-4.0.1"
       sources."is-interactive-1.0.0"
       sources."is-map-2.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-number-7.0.0"
       sources."is-number-object-1.0.4"
       sources."is-promise-4.0.0"
@@ -76090,17 +76334,16 @@ in
       sources."is-stream-1.1.0"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
-      (sources."is-typed-array-1.1.3" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."is-typed-array-1.1.3"
       sources."is-typedarray-1.0.0"
       sources."is-weakmap-2.0.1"
       sources."is-weakset-2.0.1"
       sources."is-wsl-2.2.0"
       sources."isarray-2.0.5"
       sources."isexe-2.0.0"
+      sources."isobject-4.0.0"
+      sources."isomorphic-form-data-2.0.0"
+      sources."isomorphic-ws-4.0.1"
       sources."isstream-0.1.2"
       sources."iterall-1.3.0"
       sources."js-tokens-4.0.0"
@@ -76134,9 +76377,9 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      (sources."lower-case-2.0.1" // {
+      (sources."lower-case-2.0.2" // {
         dependencies = [
-          sources."tslib-1.14.1"
+          sources."tslib-2.0.3"
         ];
       })
       sources."lowercase-keys-1.0.1"
@@ -76159,17 +76402,15 @@ in
       sources."mkdirp-1.0.4"
       sources."ms-2.1.2"
       sources."mute-stream-0.0.8"
-      sources."next-tick-1.0.0"
       sources."nice-try-1.0.5"
-      (sources."no-case-3.0.3" // {
+      (sources."no-case-3.0.4" // {
         dependencies = [
-          sources."tslib-1.14.1"
+          sources."tslib-2.0.3"
         ];
       })
       sources."node-emoji-1.10.0"
       sources."node-fetch-2.6.1"
       sources."node-fetch-h2-2.3.0"
-      sources."node-gyp-build-4.2.3"
       sources."node-readfiles-0.2.0"
       sources."normalize-path-2.1.1"
       sources."normalize-url-4.5.0"
@@ -76187,6 +76428,7 @@ in
       sources."object-inspect-1.9.0"
       sources."object-is-1.1.4"
       sources."object-keys-1.1.1"
+      sources."object-path-0.11.5"
       sources."object.assign-4.1.2"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
@@ -76220,9 +76462,9 @@ in
       sources."parent-module-1.0.1"
       sources."parse-github-url-1.0.2"
       sources."parse-json-5.1.0"
-      (sources."pascal-case-3.1.1" // {
+      (sources."pascal-case-3.1.2" // {
         dependencies = [
-          sources."tslib-1.14.1"
+          sources."tslib-2.0.3"
         ];
       })
       sources."passwd-user-3.0.0"
@@ -76239,11 +76481,7 @@ in
       sources."qs-6.5.2"
       sources."rc-1.2.8"
       sources."reftools-1.1.7"
-      (sources."regexp.prototype.flags-1.3.0" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."regexp.prototype.flags-1.3.0"
       sources."registry-auth-token-4.2.1"
       sources."registry-url-5.1.0"
       sources."remove-trailing-separator-1.1.0"
@@ -76264,6 +76502,7 @@ in
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
       sources."semver-5.7.1"
+      sources."setprototypeof-1.2.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."should-13.2.3"
@@ -76272,12 +76511,18 @@ in
       sources."should-type-1.4.0"
       sources."should-type-adaptors-1.1.0"
       sources."should-util-1.0.1"
-      sources."side-channel-1.0.3"
+      (sources."side-channel-1.0.3" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+        ];
+      })
       sources."signal-exit-3.0.3"
       sources."simple-git-2.21.0"
       sources."slash-3.0.0"
       sources."sprintf-js-1.0.3"
       sources."sshpk-1.16.1"
+      sources."statuses-1.5.0"
+      sources."streamsearch-0.1.2"
       sources."string-env-interpolation-1.0.1"
       (sources."string-width-4.2.0" // {
         dependencies = [
@@ -76290,50 +76535,36 @@ in
       sources."strip-ansi-5.2.0"
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
-      sources."subscriptions-transport-ws-0.9.18"
       sources."supports-color-7.2.0"
       (sources."swagger2openapi-7.0.4" // {
         dependencies = [
           sources."yargs-16.1.1"
         ];
       })
-      sources."symbol-observable-1.2.0"
       sources."sync-fetch-0.3.0"
       sources."tar-6.0.5"
       sources."through-2.3.8"
       sources."tmp-0.2.1"
       sources."to-readable-stream-1.0.0"
       sources."to-regex-range-5.0.1"
+      sources."toidentifier-1.0.0"
       sources."tough-cookie-2.5.0"
       sources."tslib-2.0.2"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."type-1.2.0"
       sources."type-fest-0.3.1"
-      sources."typedarray-to-buffer-3.1.5"
       sources."universalify-1.0.0"
       sources."unixify-1.0.0"
       sources."uri-js-4.4.0"
       sources."url-parse-lax-3.0.0"
-      sources."utf-8-validate-5.0.3"
       sources."uuid-3.4.0"
       sources."valid-url-1.0.9"
       sources."verror-1.10.0"
       sources."wcwidth-1.0.1"
-      (sources."websocket-1.0.32" // {
-        dependencies = [
-          sources."debug-2.6.9"
-          sources."ms-2.0.0"
-        ];
-      })
       sources."which-1.3.1"
       sources."which-boxed-primitive-1.0.1"
       sources."which-collection-1.0.1"
-      (sources."which-typed-array-1.1.2" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."which-typed-array-1.1.2"
       (sources."wrap-ansi-7.0.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
@@ -76341,9 +76572,8 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-5.2.2"
+      sources."ws-7.4.0"
       sources."y18n-5.0.5"
-      sources."yaeti-0.0.6"
       sources."yallist-4.0.0"
       sources."yaml-1.10.0"
       sources."yargs-16.0.3"
@@ -76762,7 +76992,7 @@ in
           sources."supports-color-7.2.0"
         ];
       })
-      sources."systeminformation-4.30.10"
+      sources."systeminformation-4.30.11"
       sources."term-canvas-0.0.5"
       sources."type-fest-0.11.0"
       sources."wordwrap-0.0.3"
@@ -78555,7 +78785,7 @@ in
         ];
       })
       sources."smart-buffer-4.1.0"
-      sources."socks-2.5.0"
+      sources."socks-2.5.1"
       sources."socks-proxy-agent-5.0.0"
       sources."source-map-0.6.1"
       sources."split2-3.2.2"
@@ -78615,7 +78845,7 @@ in
       })
       sources."wrappy-1.0.2"
       sources."write-file-atomic-3.0.3"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xregexp-2.0.0"
       sources."yallist-3.1.1"
     ];
@@ -78842,7 +79072,11 @@ in
       sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      sources."minipass-2.9.0"
+      (sources."minipass-2.9.0" // {
+        dependencies = [
+          sources."yallist-3.1.1"
+        ];
+      })
       sources."minizlib-1.3.3"
       sources."mkdirp-1.0.4"
       sources."ms-2.0.0"
@@ -78920,7 +79154,11 @@ in
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."semaphore-async-await-1.5.1"
-      sources."semver-7.3.2"
+      (sources."semver-7.3.4" // {
+        dependencies = [
+          sources."lru-cache-6.0.0"
+        ];
+      })
       sources."seq-0.3.5"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.3"
@@ -78954,6 +79192,7 @@ in
       (sources."tar-4.4.13" // {
         dependencies = [
           sources."mkdirp-0.5.5"
+          sources."yallist-3.1.1"
         ];
       })
       sources."through-2.3.8"
@@ -78975,7 +79214,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."uuid-3.4.0"
       sources."validate-npm-package-license-3.0.4"
-      (sources."verda-1.1.2" // {
+      (sources."verda-1.2.0" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."ansi-styles-4.3.0"
@@ -79011,7 +79250,7 @@ in
       sources."xmldom-0.3.0"
       sources."xpath-0.0.27"
       sources."y18n-3.2.1"
-      sources."yallist-3.1.1"
+      sources."yallist-4.0.0"
       sources."yargs-6.6.0"
       sources."yargs-parser-4.2.1"
     ];
@@ -79150,29 +79389,6 @@ in
       sha512 = "4JjZOpv5WyJ3VbtcxrOf5FYQBYPjbBsrIGLG+DoYNFPLsOWEOJeZH24XO2UnNKb5YopcsCzR+iaTXVCPNQ2tAw==";
     };
     dependencies = [
-      sources."@babel/code-frame-7.10.4"
-      (sources."@babel/generator-7.12.5" // {
-        dependencies = [
-          sources."source-map-0.5.7"
-        ];
-      })
-      sources."@babel/helper-function-name-7.10.4"
-      sources."@babel/helper-get-function-arity-7.10.4"
-      sources."@babel/helper-split-export-declaration-7.11.0"
-      sources."@babel/helper-validator-identifier-7.10.4"
-      (sources."@babel/highlight-7.10.4" // {
-        dependencies = [
-          sources."chalk-2.4.2"
-        ];
-      })
-      sources."@babel/parser-7.12.7"
-      sources."@babel/template-7.12.7"
-      (sources."@babel/traverse-7.12.9" // {
-        dependencies = [
-          sources."debug-4.3.1"
-        ];
-      })
-      sources."@babel/types-7.12.7"
       sources."@braintree/sanitize-url-3.1.0"
       sources."@cronvel/get-pixels-3.4.0"
       sources."@joplinapp/fork-htmlparser2-4.1.8"
@@ -79201,7 +79417,12 @@ in
         ];
       })
       sources."ansi-regex-2.1.1"
-      sources."ansi-styles-3.2.1"
+      (sources."ansi-styles-4.3.0" // {
+        dependencies = [
+          sources."color-convert-2.0.1"
+          sources."color-name-1.1.4"
+        ];
+      })
       sources."anymatch-3.1.1"
       sources."aproba-1.2.0"
       sources."are-we-there-yet-1.1.5"
@@ -79219,7 +79440,7 @@ in
       sources."async-mutex-0.1.4"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.800.0" // {
+      (sources."aws-sdk-2.804.0" // {
         dependencies = [
           sources."sax-1.2.1"
           sources."uuid-3.3.2"
@@ -79229,7 +79450,6 @@ in
       })
       sources."aws-sign2-0.7.0"
       sources."aws4-1.11.0"
-      sources."babel-eslint-10.1.0"
       sources."balanced-match-1.0.0"
       sources."base-64-0.1.0"
       sources."base64-js-1.5.1"
@@ -79251,15 +79471,7 @@ in
       sources."camel-case-3.0.0"
       sources."camelcase-4.1.0"
       sources."caseless-0.12.0"
-      (sources."chalk-4.1.0" // {
-        dependencies = [
-          sources."ansi-styles-4.3.0"
-          sources."color-convert-2.0.1"
-          sources."color-name-1.1.4"
-          sources."has-flag-4.0.0"
-          sources."supports-color-7.2.0"
-        ];
-      })
+      sources."chalk-4.1.0"
       sources."charenc-0.0.2"
       sources."chokidar-3.4.3"
       sources."chownr-1.1.4"
@@ -79340,10 +79552,14 @@ in
       sources."diacritics-1.3.0"
       sources."diff-match-patch-1.0.5"
       sources."dom-serializer-1.1.0"
-      sources."domelementtype-2.0.2"
+      sources."domelementtype-2.1.0"
       sources."domexception-1.0.1"
       sources."domhandler-3.3.0"
-      sources."domutils-2.4.2"
+      (sources."domutils-2.4.3" // {
+        dependencies = [
+          sources."domhandler-4.0.0"
+        ];
+      })
       sources."ecc-jsbn-0.1.2"
       (sources."emphasize-1.5.0" // {
         dependencies = [
@@ -79365,7 +79581,6 @@ in
       sources."es6-promise-pool-2.5.0"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.14.3"
-      sources."eslint-visitor-keys-1.3.0"
       sources."esprima-4.0.1"
       sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
@@ -79397,7 +79612,6 @@ in
       sources."fs-minipass-1.2.7"
       sources."fs.realpath-1.0.0"
       sources."fsevents-2.1.3"
-      sources."function-bind-1.1.1"
       (sources."gauge-2.7.4" // {
         dependencies = [
           sources."strip-ansi-3.0.1"
@@ -79409,18 +79623,16 @@ in
       sources."github-from-package-0.0.0"
       sources."glob-7.1.6"
       sources."glob-parent-5.1.1"
-      sources."globals-11.12.0"
       sources."graceful-fs-4.2.4"
       sources."graphlib-2.1.8"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.5"
-      sources."has-1.0.3"
       sources."has-ansi-2.0.0"
-      sources."has-flag-3.0.0"
+      sources."has-flag-4.0.0"
       sources."has-unicode-2.0.1"
       sources."he-1.2.0"
-      sources."highlight.js-10.4.0"
+      sources."highlight.js-10.4.1"
       sources."html-encoding-sniffer-1.0.2"
       sources."html-entities-1.3.1"
       sources."html-minifier-3.5.21"
@@ -79428,7 +79640,7 @@ in
         dependencies = [
           (sources."dom-serializer-0.2.2" // {
             dependencies = [
-              sources."domelementtype-2.0.2"
+              sources."domelementtype-2.1.0"
               sources."entities-2.1.0"
             ];
           })
@@ -79486,7 +79698,6 @@ in
       sources."is-arrayish-0.3.2"
       sources."is-binary-path-2.1.0"
       sources."is-buffer-1.1.6"
-      sources."is-core-module-2.2.0"
       sources."is-docker-2.1.1"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-1.0.0"
@@ -79518,7 +79729,6 @@ in
           sources."tough-cookie-3.0.1"
         ];
       })
-      sources."jsesc-2.5.2"
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
@@ -79550,6 +79760,7 @@ in
           sources."highlight.js-9.12.0"
         ];
       })
+      sources."lru-cache-6.0.0"
       sources."magicli-0.0.8"
       (sources."markdown-it-10.0.0" // {
         dependencies = [
@@ -79577,7 +79788,7 @@ in
       sources."md5-2.3.0"
       sources."md5-file-4.0.0"
       sources."mdurl-1.0.1"
-      sources."mermaid-8.8.3"
+      sources."mermaid-8.8.4"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."mimic-response-2.1.0"
@@ -79591,7 +79802,11 @@ in
       })
       sources."minimatch-3.0.4"
       sources."minimist-1.2.5"
-      sources."minipass-2.9.0"
+      (sources."minipass-2.9.0" // {
+        dependencies = [
+          sources."yallist-3.1.1"
+        ];
+      })
       sources."minizlib-1.3.3"
       sources."mkdirp-0.5.5"
       sources."mkdirp-classic-0.5.3"
@@ -79660,7 +79875,6 @@ in
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-key-3.1.1"
-      sources."path-parse-1.0.6"
       sources."performance-now-2.1.0"
       sources."picomatch-2.2.2"
       sources."pify-3.0.0"
@@ -79703,7 +79917,6 @@ in
       sources."request-promise-native-1.0.9"
       sources."requires-port-1.0.0"
       sources."reselect-4.0.0"
-      sources."resolve-1.19.0"
       sources."resolve-url-0.2.1"
       sources."retry-0.10.1"
       sources."rimraf-2.7.1"
@@ -79712,7 +79925,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."saxes-3.1.11"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."server-destroy-1.0.1"
       sources."set-blocking-2.0.0"
       sources."setimmediate-1.0.5"
@@ -79774,12 +79987,16 @@ in
       })
       sources."strip-json-comments-2.0.1"
       sources."stylis-3.5.4"
-      sources."supports-color-5.5.0"
+      sources."supports-color-7.2.0"
       sources."symbol-observable-1.2.0"
       sources."symbol-tree-3.2.4"
       sources."syswide-cas-5.3.0"
       sources."table-layout-0.4.5"
-      sources."tar-4.4.13"
+      (sources."tar-4.4.13" // {
+        dependencies = [
+          sources."yallist-3.1.1"
+        ];
+      })
       sources."tar-fs-2.1.1"
       (sources."tar-stream-2.1.4" // {
         dependencies = [
@@ -79800,13 +80017,15 @@ in
       })
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
+          sources."ansi-styles-3.2.1"
           sources."chalk-2.4.2"
+          sources."has-flag-3.0.0"
           sources."is-fullwidth-code-point-2.0.0"
           sources."node-emoji-git+https://github.com/laurent22/node-emoji.git"
           sources."string-width-2.1.1"
+          sources."supports-color-5.5.0"
         ];
       })
-      sources."to-fast-properties-2.0.0"
       sources."to-regex-range-5.0.1"
       sources."toidentifier-1.0.0"
       sources."tough-cookie-2.5.0"
@@ -79863,12 +80082,12 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xml-name-validator-3.0.0"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"
       sources."xmlchars-2.2.0"
-      sources."yallist-3.1.1"
+      sources."yallist-4.0.0"
       sources."yargs-parser-7.0.0"
     ];
     buildInputs = globalBuildInputs;
@@ -80009,7 +80228,7 @@ in
       sources."date-now-0.1.4"
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
-          sources."domelementtype-2.0.2"
+          sources."domelementtype-2.1.0"
           sources."entities-2.1.0"
         ];
       })
@@ -80263,6 +80482,7 @@ in
       sources."lodash-id-0.14.0"
       sources."lowdb-1.0.0"
       sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
       (sources."make-dir-3.1.0" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -80319,7 +80539,7 @@ in
       sources."responselike-1.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."semver-compare-1.0.0"
       (sources."semver-diff-3.1.1" // {
         dependencies = [
@@ -80371,6 +80591,7 @@ in
       sources."write-file-atomic-3.0.3"
       sources."xdg-basedir-4.0.0"
       sources."y18n-5.0.5"
+      sources."yallist-4.0.0"
       sources."yargs-16.1.1"
       sources."yargs-parser-20.2.4"
     ];
@@ -80601,7 +80822,7 @@ in
       sources."which-module-2.0.0"
       sources."wrap-ansi-6.2.0"
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."y18n-4.0.1"
       sources."yargs-15.4.1"
@@ -81085,7 +81306,7 @@ in
           sources."universal-user-agent-6.0.0"
         ];
       })
-      sources."@octokit/openapi-types-1.2.2"
+      sources."@octokit/openapi-types-2.0.0"
       sources."@octokit/plugin-enterprise-rest-6.0.1"
       (sources."@octokit/plugin-paginate-rest-1.1.2" // {
         dependencies = [
@@ -81098,7 +81319,7 @@ in
           sources."@octokit/types-2.16.2"
         ];
       })
-      (sources."@octokit/request-5.4.11" // {
+      (sources."@octokit/request-5.4.12" // {
         dependencies = [
           sources."@octokit/request-error-2.0.4"
           sources."is-plain-object-5.0.0"
@@ -81111,7 +81332,7 @@ in
         ];
       })
       sources."@octokit/rest-16.43.2"
-      sources."@octokit/types-6.0.1"
+      sources."@octokit/types-6.1.1"
       sources."@types/glob-7.1.3"
       sources."@types/minimatch-3.0.3"
       sources."@types/minimist-1.2.1"
@@ -81535,7 +81756,7 @@ in
       sources."is-finite-1.1.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       (sources."is-number-3.0.0" // {
         dependencies = [
           sources."kind-of-3.2.2"
@@ -81616,7 +81837,7 @@ in
               sources."type-fest-0.8.1"
             ];
           })
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."type-fest-0.18.1"
           sources."yallist-4.0.0"
           sources."yargs-parser-20.2.4"
@@ -82896,7 +83117,7 @@ in
       sources."uuid-3.4.0"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yeast-0.1.2"
     ];
@@ -83041,7 +83262,7 @@ in
       sources."@types/node-14.14.10"
       sources."@types/normalize-package-data-2.4.0"
       sources."@types/resolve-0.0.8"
-      sources."@types/yargs-15.0.10"
+      sources."@types/yargs-15.0.11"
       sources."@types/yargs-parser-15.0.0"
       sources."@webassemblyjs/ast-1.9.0"
       sources."@webassemblyjs/floating-point-hex-parser-1.9.0"
@@ -83192,7 +83413,7 @@ in
         ];
       })
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."bser-2.1.1"
       sources."buffer-5.2.1"
       sources."buffer-from-1.1.1"
@@ -83208,7 +83429,7 @@ in
       sources."cached-path-relative-1.0.2"
       sources."call-bind-1.0.0"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."capture-exit-2.0.0"
       sources."caseless-0.12.0"
       (sources."chalk-3.0.0" // {
@@ -83332,7 +83553,7 @@ in
       sources."duplexer2-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -84090,10 +84311,10 @@ in
   markdown-link-check = nodeEnv.buildNodePackage {
     name = "markdown-link-check";
     packageName = "markdown-link-check";
-    version = "3.8.3";
+    version = "3.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.8.3.tgz";
-      sha512 = "Q9LTCwBjWcQR9dd6LNMXg9GFewkRiVEaU/+Y2ZcCbOb0lVqIfeJworWYGakG7bFj8HJQILBTRnAnEK9DDKfdPA==";
+      url = "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.8.4.tgz";
+      sha512 = "7uIEdppB5S8A/Wla+lUm40HJUg2qvZD7UPx2bSWgChe/my487whvNMf19M1T/j9LQXzRvIIDTYrec7+diJyKqg==";
     };
     dependencies = [
       sources."ajv-6.12.6"
@@ -84136,7 +84357,7 @@ in
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
-      sources."link-check-4.5.2"
+      sources."link-check-4.5.3"
       sources."lodash-4.17.20"
       sources."markdown-link-extractor-1.2.6"
       sources."marked-1.2.5"
@@ -84589,7 +84810,7 @@ in
       sources."unbzip2-stream-1.4.3"
       sources."util-deprecate-1.0.2"
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."yauzl-2.10.0"
     ];
     buildInputs = globalBuildInputs;
@@ -84614,14 +84835,14 @@ in
       sources."@fluentui/date-time-utilities-7.9.0"
       sources."@fluentui/dom-utilities-1.1.1"
       sources."@fluentui/keyboard-key-0.2.12"
-      sources."@fluentui/react-7.153.2"
+      sources."@fluentui/react-7.153.4"
       sources."@fluentui/react-compose-0.19.12"
       sources."@fluentui/react-focus-7.16.19"
       sources."@fluentui/react-stylesheets-0.2.4"
       sources."@fluentui/react-theme-provider-0.18.0"
       sources."@fluentui/react-window-provider-1.0.1"
       sources."@fluentui/theme-1.7.0"
-      sources."@microsoft/load-themed-styles-1.10.138"
+      sources."@microsoft/load-themed-styles-1.10.139"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@types/classnames-2.2.11"
@@ -84736,6 +84957,7 @@ in
       sources."lodash.merge-4.6.2"
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
       sources."media-typer-0.3.0"
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
@@ -84758,7 +84980,7 @@ in
       sources."node-fetch-1.6.3"
       sources."normalize-url-4.5.0"
       sources."object-assign-4.1.1"
-      sources."office-ui-fabric-react-7.153.2"
+      sources."office-ui-fabric-react-7.153.4"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -84823,7 +85045,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."scheduler-0.19.1"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."send-0.17.1" // {
         dependencies = [
           sources."ms-2.1.1"
@@ -84874,6 +85096,7 @@ in
       sources."vary-1.1.2"
       sources."wrappy-1.0.2"
       sources."xtend-4.0.2"
+      sources."yallist-4.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -85111,12 +85334,13 @@ in
       sources."lodash.defaults-4.2.0"
       sources."lodash.omit-4.5.0"
       sources."logform-2.2.0"
+      sources."lru-cache-6.0.0"
       sources."ms-2.1.2"
       sources."one-time-0.0.4"
       sources."process-nextick-args-2.0.1"
       sources."readable-stream-3.6.0"
       sources."safe-buffer-5.2.1"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."simple-swizzle-0.2.2"
       sources."stack-trace-0.0.10"
       sources."string_decoder-1.3.0"
@@ -85131,6 +85355,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
+      sources."yallist-4.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -85145,10 +85370,10 @@ in
   netlify-cli = nodeEnv.buildNodePackage {
     name = "netlify-cli";
     packageName = "netlify-cli";
-    version = "2.69.0";
+    version = "2.69.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-2.69.0.tgz";
-      sha512 = "QFlOsS2wTEdAkFXMG5PWbR2SNALOv+n4z4+yQYFEt+TbAHn0NUwbpDT/UxR/NdQtwvzY0NpyjSZSQou5n4mpKg==";
+      url = "https://registry.npmjs.org/netlify-cli/-/netlify-cli-2.69.1.tgz";
+      sha512 = "e6C2UT0yt9RblWuLIQKZwR2xzwVcBX5PnDrYTsBnVaBNs6ddorpWjHm/qRx7No7CH5P7ITI8b3W4fQhOsQSo7g==";
     };
     dependencies = [
       sources."@babel/code-frame-7.10.4"
@@ -85265,7 +85490,7 @@ in
       sources."@dabh/diagnostics-2.0.2"
       sources."@jest/types-24.9.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
-      (sources."@netlify/build-5.5.2" // {
+      (sources."@netlify/build-5.5.5" // {
         dependencies = [
           sources."chalk-3.0.0"
           sources."resolve-2.0.0-next.2"
@@ -85289,7 +85514,7 @@ in
       })
       sources."@netlify/open-api-0.18.1"
       sources."@netlify/plugin-edge-handlers-1.10.0"
-      sources."@netlify/plugins-list-2.0.0"
+      sources."@netlify/plugins-list-2.0.1"
       sources."@netlify/run-utils-1.0.5"
       sources."@netlify/traffic-mesh-agent-0.27.0"
       sources."@netlify/traffic-mesh-agent-darwin-x64-0.27.0"
@@ -85410,7 +85635,7 @@ in
           sources."universal-user-agent-6.0.0"
         ];
       })
-      sources."@octokit/openapi-types-1.2.2"
+      sources."@octokit/openapi-types-2.0.0"
       (sources."@octokit/plugin-paginate-rest-1.1.2" // {
         dependencies = [
           sources."@octokit/types-2.16.2"
@@ -85422,7 +85647,7 @@ in
           sources."@octokit/types-2.16.2"
         ];
       })
-      (sources."@octokit/request-5.4.11" // {
+      (sources."@octokit/request-5.4.12" // {
         dependencies = [
           sources."@octokit/request-error-2.0.4"
           sources."is-plain-object-5.0.0"
@@ -85435,7 +85660,7 @@ in
         ];
       })
       sources."@octokit/rest-16.43.2"
-      sources."@octokit/types-6.0.1"
+      sources."@octokit/types-6.1.1"
       sources."@rollup/plugin-babel-5.2.2"
       (sources."@rollup/plugin-commonjs-15.1.0" // {
         dependencies = [
@@ -85536,7 +85761,7 @@ in
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
       sources."atob-lite-2.0.0"
-      (sources."aws-sdk-2.800.0" // {
+      (sources."aws-sdk-2.804.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -85591,7 +85816,7 @@ in
           sources."readable-stream-3.6.0"
         ];
       })
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."btoa-lite-1.0.0"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
@@ -85615,7 +85840,7 @@ in
       sources."call-bind-1.0.0"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."cardinal-2.1.1"
       sources."caw-2.0.1"
       sources."ccount-1.1.0"
@@ -85865,7 +86090,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       sources."elf-cam-0.1.1"
       (sources."elliptic-6.5.3" // {
         dependencies = [
@@ -86193,7 +86418,7 @@ in
       sources."is-interactive-1.0.0"
       sources."is-module-1.0.0"
       sources."is-natural-number-4.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-npm-4.0.0"
       (sources."is-number-3.0.0" // {
         dependencies = [
@@ -86223,7 +86448,7 @@ in
       sources."isobject-3.0.1"
       (sources."isurl-1.0.0" // {
         dependencies = [
-          sources."is-object-1.0.1"
+          sources."is-object-1.0.2"
         ];
       })
       sources."jest-get-type-24.9.0"
@@ -86335,6 +86560,7 @@ in
         ];
       })
       sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
       sources."ltgt-2.2.1"
       sources."macos-release-2.4.1"
       sources."magic-string-0.25.7"
@@ -86644,7 +86870,7 @@ in
       sources."reusify-1.0.4"
       sources."rimraf-3.0.2"
       sources."ripemd160-2.0.2"
-      sources."rollup-2.34.0"
+      sources."rollup-2.34.1"
       sources."rollup-plugin-node-builtins-2.1.2"
       sources."rollup-plugin-terser-7.0.2"
       sources."run-async-2.4.1"
@@ -86657,7 +86883,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.1"
       sources."seek-bzip-1.0.6"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."semver-diff-3.1.1" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -86970,6 +87196,7 @@ in
       sources."xmlbuilder-9.0.7"
       sources."xtend-4.0.2"
       sources."y18n-4.0.1"
+      sources."yallist-4.0.0"
       sources."yargs-15.4.1"
       sources."yargs-parser-18.1.3"
       sources."yarn-1.22.10"
@@ -87074,6 +87301,7 @@ in
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
+      sources."lru-cache-6.0.0"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."minimatch-3.0.4"
@@ -87097,7 +87325,7 @@ in
       sources."rimraf-3.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.3"
       sources."sshpk-1.16.1"
@@ -87827,10 +88055,10 @@ in
           sources."ms-2.1.2"
           sources."readable-stream-3.6.0"
           sources."string_decoder-1.3.0"
-          sources."ws-7.4.0"
+          sources."ws-7.4.1"
         ];
       })
-      (sources."mqtt-packet-6.6.0" // {
+      (sources."mqtt-packet-6.7.0" // {
         dependencies = [
           sources."debug-4.3.1"
           sources."ms-2.1.2"
@@ -88656,7 +88884,7 @@ in
       sources."rimraf-3.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       (sources."semver-diff-3.1.1" // {
         dependencies = [
           sources."semver-6.3.0"
@@ -88667,7 +88895,7 @@ in
       sources."signal-exit-3.0.3"
       sources."sisteransi-1.0.5"
       sources."smart-buffer-4.1.0"
-      sources."socks-2.5.0"
+      sources."socks-2.5.1"
       sources."socks-proxy-agent-5.0.0"
       sources."spawn-please-1.0.0"
       sources."sprintf-js-1.0.3"
@@ -89152,7 +89380,7 @@ in
           sources."pako-1.0.11"
         ];
       })
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       (sources."buffer-4.9.2" // {
         dependencies = [
           sources."isarray-1.0.0"
@@ -89169,7 +89397,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.8"
@@ -89289,7 +89517,7 @@ in
       })
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
-          sources."domelementtype-2.0.2"
+          sources."domelementtype-2.1.0"
           sources."entities-2.1.0"
         ];
       })
@@ -89304,7 +89532,7 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       (sources."elliptic-6.5.3" // {
         dependencies = [
           sources."bn.js-4.11.9"
@@ -89457,7 +89685,7 @@ in
       sources."is-extglob-2.1.1"
       sources."is-glob-4.0.1"
       sources."is-html-1.1.0"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-number-3.0.0"
       sources."is-obj-2.0.0"
       sources."is-plain-object-2.0.4"
@@ -90039,7 +90267,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ipaddr.js-1.9.1"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-typedarray-1.0.0"
       sources."isarray-1.0.0"
@@ -90062,6 +90290,7 @@ in
       sources."locate-path-3.0.0"
       sources."lodash-4.17.20"
       sources."lodash.clone-4.5.0"
+      sources."lru-cache-6.0.0"
       sources."media-typer-0.3.0"
       sources."mediawiki-title-0.6.5"
       sources."merge-1.2.1"
@@ -90142,7 +90371,7 @@ in
       sources."serve-static-1.14.1"
       (sources."service-runner-2.8.0" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."yargs-14.2.3"
         ];
       })
@@ -90180,6 +90409,7 @@ in
       sources."wrap-ansi-5.1.0"
       sources."wrappy-1.0.2"
       sources."y18n-4.0.1"
+      sources."yallist-4.0.0"
       (sources."yargs-13.3.2" // {
         dependencies = [
           sources."yargs-parser-13.1.2"
@@ -90599,7 +90829,7 @@ in
       sources."ip-1.1.5"
       sources."ip-set-1.0.2"
       sources."ipaddr.js-2.0.0"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-arrayish-0.2.1"
       sources."is-callable-1.2.2"
       sources."is-core-module-2.2.0"
@@ -90751,7 +90981,7 @@ in
       sources."tmp-0.0.33"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
-      (sources."torrent-stream-1.2.0" // {
+      (sources."torrent-stream-1.2.1" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."magnet-uri-4.2.3"
@@ -91128,7 +91358,7 @@ in
       sources."toidentifier-1.0.0"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
-      (sources."torrent-stream-1.2.0" // {
+      (sources."torrent-stream-1.2.1" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."mkdirp-0.3.5"
@@ -91152,7 +91382,7 @@ in
       sources."verror-1.10.0"
       sources."which-1.3.1"
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."xtend-4.0.2"
       sources."yeast-0.1.2"
@@ -91403,7 +91633,12 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-7.3.2"
+      (sources."semver-7.3.4" // {
+        dependencies = [
+          sources."lru-cache-6.0.0"
+          sources."yallist-4.0.0"
+        ];
+      })
       sources."setprototypeof-1.1.1"
       sources."shimmer-1.2.1"
       sources."signal-exit-3.0.3"
@@ -91420,7 +91655,7 @@ in
       sources."statuses-1.5.0"
       sources."string_decoder-0.10.31"
       sources."supports-color-7.2.0"
-      sources."systeminformation-4.30.10"
+      sources."systeminformation-4.30.11"
       sources."thunkify-2.1.2"
       sources."to-regex-range-5.0.1"
       sources."toidentifier-1.0.0"
@@ -92010,10 +92245,10 @@ in
   pyright = nodeEnv.buildNodePackage {
     name = "pyright";
     packageName = "pyright";
-    version = "1.1.90";
+    version = "1.1.92";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.90.tgz";
-      sha512 = "CNrTDpxd4vWcGpjxCPLg2fvKYlEhU8ksi7Fkdb+bFNfOb/1ENvZ8QoDYebtLFceoBlgWU9X+MluuFKudwHKKkw==";
+      url = "https://registry.npmjs.org/pyright/-/pyright-1.1.92.tgz";
+      sha512 = "kL6c2wafnJgbXmG2Svz9isAhAMWARnmMiUGBRytcdVsse11crLDzaWusegA4P6sTweoHMcT3+P8fmLv2Av1u/Q==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -92046,9 +92281,9 @@ in
       sources."colors-0.6.2"
       sources."concat-map-0.0.1"
       sources."cycle-1.0.3"
-      sources."deep-equal-2.0.4"
+      sources."deep-equal-2.0.5"
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.18.0-next.1"
+      sources."es-abstract-1.17.7"
       sources."es-get-iterator-1.1.1"
       sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
@@ -92064,23 +92299,19 @@ in
       sources."i-0.3.6"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-bigint-1.0.1"
       sources."is-boolean-object-1.0.1"
       sources."is-callable-1.2.2"
       sources."is-date-object-1.0.2"
       sources."is-map-2.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-number-object-1.0.4"
       sources."is-regex-1.1.1"
       sources."is-set-2.0.1"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
-      (sources."is-typed-array-1.1.3" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."is-typed-array-1.1.3"
       sources."is-weakmap-2.0.1"
       sources."is-weakset-2.0.1"
       sources."isarray-2.0.5"
@@ -92099,15 +92330,15 @@ in
       sources."pkginfo-0.4.1"
       sources."prompt-0.2.14"
       sources."read-1.0.7"
-      (sources."regexp.prototype.flags-1.3.0" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."regexp.prototype.flags-1.3.0"
       sources."revalidator-0.1.8"
       sources."rimraf-2.7.1"
       sources."semver-5.7.1"
-      sources."side-channel-1.0.3"
+      (sources."side-channel-1.0.3" // {
+        dependencies = [
+          sources."es-abstract-1.18.0-next.1"
+        ];
+      })
       sources."stack-trace-0.0.10"
       sources."string.prototype.trimend-1.0.3"
       sources."string.prototype.trimstart-1.0.3"
@@ -92116,11 +92347,7 @@ in
       sources."utile-0.2.1"
       sources."which-boxed-primitive-1.0.1"
       sources."which-collection-1.0.1"
-      (sources."which-typed-array-1.1.2" // {
-        dependencies = [
-          sources."es-abstract-1.17.7"
-        ];
-      })
+      sources."which-typed-array-1.1.2"
       (sources."winston-0.8.3" // {
         dependencies = [
           sources."pkginfo-0.3.1"
@@ -92309,7 +92536,7 @@ in
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-8.4.0"
       sources."word-wrap-1.2.3"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xml-name-validator-3.0.0"
       sources."xmlchars-2.2.0"
     ];
@@ -92685,10 +92912,10 @@ in
   rollup = nodeEnv.buildNodePackage {
     name = "rollup";
     packageName = "rollup";
-    version = "2.34.0";
+    version = "2.34.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/rollup/-/rollup-2.34.0.tgz";
-      sha512 = "dW5iLvttZzdVehjEuNJ1bWvuMEJjOWGmnuFS82WeKHTGXDkRHQeq/ExdifkSyJv9dLcR86ysKRmrIDyR6O0X8g==";
+      url = "https://registry.npmjs.org/rollup/-/rollup-2.34.1.tgz";
+      sha512 = "tGveB6NU5x4MS/iXaIsjfUkEv4hxzJJ4o0FRy5LO62Ndx3R2cmE1qsLYlSfRkvHUUPqWiFoxEm8pRftzh1a5HA==";
     };
     dependencies = [
       sources."fsevents-2.1.3"
@@ -92716,7 +92943,7 @@ in
           sources."chalk-2.4.2"
         ];
       })
-      sources."@eslint/eslintrc-0.2.1"
+      sources."@eslint/eslintrc-0.2.2"
       sources."@rollup/plugin-commonjs-13.0.2"
       sources."@rollup/plugin-node-resolve-8.4.0"
       sources."@rollup/pluginutils-3.1.0"
@@ -92732,7 +92959,7 @@ in
       sources."@types/vscode-1.51.0"
       (sources."@typescript-eslint/eslint-plugin-3.10.1" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."@typescript-eslint/experimental-utils-3.10.1"
@@ -92740,7 +92967,7 @@ in
       sources."@typescript-eslint/types-3.10.1"
       (sources."@typescript-eslint/typescript-estree-3.10.1" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."@typescript-eslint/visitor-keys-3.10.1"
@@ -92809,7 +93036,9 @@ in
       sources."domutils-1.5.1"
       (sources."editorconfig-0.15.3" // {
         dependencies = [
+          sources."lru-cache-4.1.5"
           sources."semver-5.7.1"
+          sources."yallist-2.1.2"
         ];
       })
       sources."emoji-regex-7.0.3"
@@ -92818,16 +93047,16 @@ in
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
-      (sources."eslint-7.14.0" // {
+      (sources."eslint-7.15.0" // {
         dependencies = [
           sources."eslint-visitor-keys-2.0.0"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."eslint-scope-5.1.1"
       sources."eslint-utils-2.1.0"
       sources."eslint-visitor-keys-1.3.0"
-      sources."espree-7.3.0"
+      sources."espree-7.3.1"
       sources."esprima-4.0.1"
       (sources."esquery-1.3.1" // {
         dependencies = [
@@ -92846,12 +93075,12 @@ in
       sources."fast-json-stable-stringify-2.1.0"
       sources."fast-levenshtein-2.0.6"
       sources."fd-slicer-1.1.0"
-      sources."file-entry-cache-5.0.1"
+      sources."file-entry-cache-6.0.0"
       sources."fill-range-7.0.1"
       sources."find-up-5.0.0"
       sources."flat-5.0.2"
-      sources."flat-cache-2.0.1"
-      sources."flatted-2.0.2"
+      sources."flat-cache-3.0.4"
+      sources."flatted-3.1.0"
       sources."form-data-3.0.0"
       sources."fs.realpath-1.0.0"
       sources."fsevents-2.1.3"
@@ -92902,7 +93131,7 @@ in
       sources."locate-path-6.0.0"
       sources."lodash-4.17.20"
       sources."log-symbols-4.0.0"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-6.0.0"
       sources."magic-string-0.25.7"
       (sources."markdown-it-10.0.0" // {
         dependencies = [
@@ -92914,8 +93143,6 @@ in
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."minimatch-3.0.4"
-      sources."minimist-1.2.5"
-      sources."mkdirp-0.5.5"
       (sources."mocha-8.2.1" // {
         dependencies = [
           sources."debug-4.2.0"
@@ -92966,8 +93193,8 @@ in
       sources."require-main-filename-2.0.0"
       sources."resolve-1.19.0"
       sources."resolve-from-4.0.0"
-      sources."rimraf-2.6.3"
-      sources."rollup-2.34.0"
+      sources."rimraf-3.0.2"
+      sources."rollup-2.34.1"
       sources."safe-buffer-5.2.1"
       sources."semver-6.3.0"
       sources."serialize-javascript-5.0.1"
@@ -93021,7 +93248,11 @@ in
       sources."vscode-languageclient-7.0.0-next.12"
       sources."vscode-languageserver-protocol-3.16.0-next.10"
       sources."vscode-languageserver-types-3.16.0-next.4"
-      sources."vscode-test-1.4.1"
+      (sources."vscode-test-1.4.1" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+        ];
+      })
       sources."which-2.0.2"
       sources."which-module-2.0.0"
       (sources."wide-align-1.1.3" // {
@@ -93040,9 +93271,8 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."write-1.0.3"
       sources."y18n-4.0.1"
-      sources."yallist-2.1.2"
+      sources."yallist-4.0.0"
       (sources."yargs-13.3.2" // {
         dependencies = [
           sources."find-up-3.0.0"
@@ -93205,10 +93435,10 @@ in
   sass = nodeEnv.buildNodePackage {
     name = "sass";
     packageName = "sass";
-    version = "1.29.0";
+    version = "1.30.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/sass/-/sass-1.29.0.tgz";
-      sha512 = "ZpwAUFgnvAUCdkjwPREny+17BpUj8nh5Yr6zKPGtLNTLrmtoRYIjm7njP24COhjJldjwW1dcv52Lpf4tNZVVRA==";
+      url = "https://registry.npmjs.org/sass/-/sass-1.30.0.tgz";
+      sha512 = "26EUhOXRLaUY7+mWuRFqGeGGNmhB1vblpTENO1Z7mAzzIZeVxZr9EZoaY1kyGLFWdSOZxRMAufiN2mkbO6dAlw==";
     };
     dependencies = [
       sources."anymatch-3.1.1"
@@ -93240,11 +93470,15 @@ in
   semver = nodeEnv.buildNodePackage {
     name = "semver";
     packageName = "semver";
-    version = "7.3.2";
+    version = "7.3.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz";
-      sha512 = "OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==";
+      url = "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz";
+      sha512 = "tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==";
     };
+    dependencies = [
+      sources."lru-cache-6.0.0"
+      sources."yallist-4.0.0"
+    ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "The semantic version parser used by npm.";
@@ -93364,10 +93598,10 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "2.14.0";
+    version = "2.15.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-2.14.0.tgz";
-      sha512 = "c3PRJPQqRmg2NRIcv3c0iD0XZbrJsEczWdSLXwi8AGdcokIbvjTM6fXOsq7i0nhL/BYyaib1O9WazEgmvpDGDw==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-2.15.0.tgz";
+      sha512 = "lgLFdmjcTJAP3v/BlZkE3EyE1ZkIfcoBcL/J/z9dF8er71w6UJ0pixbnJ4CYSOgqS5DK7MphaP+hTTY12Aw6OQ==";
     };
     dependencies = [
       sources."2-thenable-1.0.0"
@@ -93399,7 +93633,7 @@ in
         ];
       })
       sources."@serverless/component-metrics-1.0.8"
-      (sources."@serverless/components-3.4.2" // {
+      (sources."@serverless/components-3.4.3" // {
         dependencies = [
           sources."ansi-regex-5.0.0"
           sources."ramda-0.27.1"
@@ -93412,9 +93646,9 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."@serverless/enterprise-plugin-4.1.2"
+      sources."@serverless/enterprise-plugin-4.2.0"
       sources."@serverless/event-mocks-1.1.1"
-      sources."@serverless/platform-client-3.1.2"
+      sources."@serverless/platform-client-3.1.4"
       sources."@serverless/platform-client-china-2.0.9"
       (sources."@serverless/platform-sdk-2.3.2" // {
         dependencies = [
@@ -93501,7 +93735,7 @@ in
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."at-least-node-1.0.0"
-      (sources."aws-sdk-2.800.0" // {
+      (sources."aws-sdk-2.804.0" // {
         dependencies = [
           sources."buffer-4.9.2"
           sources."ieee754-1.1.13"
@@ -93634,7 +93868,7 @@ in
         ];
       })
       sources."dashdash-1.14.1"
-      sources."dayjs-1.9.6"
+      sources."dayjs-1.9.7"
       sources."debug-3.1.0"
       sources."decode-uri-component-0.2.0"
       sources."decompress-4.2.1"
@@ -93851,7 +94085,7 @@ in
       sources."is-glob-4.0.1"
       sources."is-natural-number-4.0.1"
       sources."is-number-7.0.0"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-plain-obj-1.1.0"
       sources."is-promise-2.2.2"
       sources."is-retry-allowed-1.2.0"
@@ -93920,6 +94154,7 @@ in
       })
       sources."long-1.1.2"
       sources."lowercase-keys-1.0.1"
+      sources."lru-cache-6.0.0"
       sources."lru-queue-0.1.0"
       (sources."make-dir-1.3.0" // {
         dependencies = [
@@ -94056,7 +94291,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.1"
       sources."seek-bzip-1.0.6"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."set-blocking-2.0.0"
       sources."set-immediate-shim-1.0.1"
       sources."shebang-command-1.2.0"
@@ -94154,6 +94389,7 @@ in
       })
       sources."term-size-2.2.1"
       sources."text-hex-1.0.0"
+      sources."throat-5.0.0"
       sources."through-2.3.8"
       sources."timed-out-4.0.1"
       sources."timers-ext-0.1.7"
@@ -94208,7 +94444,7 @@ in
       })
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.4.3"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
       sources."xmlhttprequest-ssl-1.5.5"
@@ -94859,10 +95095,10 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.432.1";
+    version = "1.434.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.432.1.tgz";
-      sha512 = "fyrxd921tgEkLx8XVUaWXu+0hqImQPQm9+EOWvVXcYUnw19TNUgAQsY02SY3f6AO35E9+JZbra1Okd56CrqYBg==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.434.2.tgz";
+      sha512 = "DPU3c0ixrefM7Rh7klUn9fTTTaiee3J3SKVn4zU7LxDREKlxPB+A+xiGkEbkRsLqIZK1xJtP6KopwWOSYjZ+Ow==";
     };
     dependencies = [
       sources."@sindresorhus/is-2.1.1"
@@ -95283,7 +95519,7 @@ in
         ];
       })
       sources."snyk-module-3.1.0"
-      (sources."snyk-mvn-plugin-2.23.4" // {
+      (sources."snyk-mvn-plugin-2.25.0" // {
         dependencies = [
           sources."@snyk/cli-interface-2.9.1"
           (sources."@snyk/dep-graph-1.19.4" // {
@@ -95291,7 +95527,7 @@ in
               sources."tslib-1.14.1"
             ];
           })
-          (sources."@snyk/java-call-graph-builder-1.16.5" // {
+          (sources."@snyk/java-call-graph-builder-1.17.0" // {
             dependencies = [
               sources."tmp-0.2.1"
             ];
@@ -95456,6 +95692,7 @@ in
       sources."wrappy-1.0.2"
       sources."write-file-atomic-3.0.3"
       sources."xdg-basedir-4.0.0"
+      sources."xml-js-1.6.11"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"
       sources."xregexp-2.0.0"
@@ -95510,7 +95747,7 @@ in
       sources."socket.io-adapter-2.0.3"
       sources."socket.io-parser-4.0.2"
       sources."vary-1.1.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -95876,8 +96113,7 @@ in
       sources."flumeview-level-3.0.14"
       (sources."flumeview-links-1.0.1" // {
         dependencies = [
-          sources."deep-equal-2.0.4"
-          sources."es-abstract-1.18.0-next.1"
+          sources."deep-equal-2.0.5"
           sources."isarray-2.0.5"
           sources."map-filter-reduce-3.2.2"
         ];
@@ -95958,7 +96194,7 @@ in
       })
       sources."is-alphabetical-1.0.4"
       sources."is-alphanumerical-1.0.4"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-bigint-1.0.1"
       sources."is-binary-path-1.0.1"
       sources."is-boolean-object-1.0.1"
@@ -95986,7 +96222,7 @@ in
       sources."is-glob-2.0.1"
       sources."is-hexadecimal-1.0.4"
       sources."is-map-2.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-number-2.1.0"
       sources."is-number-object-1.0.4"
       (sources."is-plain-object-2.0.4" // {
@@ -96087,7 +96323,7 @@ in
       })
       sources."napi-macros-2.0.0"
       sources."ncp-2.0.0"
-      sources."nearley-2.19.9"
+      sources."nearley-2.20.0"
       sources."nice-try-1.0.5"
       sources."node-gyp-build-4.2.3"
       sources."non-private-ip-1.4.4"
@@ -96348,7 +96584,7 @@ in
         ];
       })
       sources."snapdragon-util-3.0.1"
-      sources."socks-2.5.0"
+      sources."socks-2.5.1"
       sources."sodium-browserify-1.3.0"
       (sources."sodium-browserify-tweetnacl-0.2.6" // {
         dependencies = [
@@ -96601,7 +96837,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.800.0" // {
+      (sources."aws-sdk-2.804.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -96741,7 +96977,7 @@ in
         dependencies = [
           sources."cookie-0.3.1"
           sources."debug-4.1.1"
-          sources."ws-7.4.0"
+          sources."ws-7.4.1"
         ];
       })
       (sources."engine.io-client-3.4.4" // {
@@ -97428,11 +97664,11 @@ in
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."callsites-3.1.0"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.2.2"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       (sources."chalk-4.1.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
@@ -97463,14 +97699,14 @@ in
       sources."dir-glob-3.0.1"
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
-          sources."domelementtype-2.0.2"
+          sources."domelementtype-2.1.0"
           sources."entities-2.1.0"
         ];
       })
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.7.0"
-      sources."electron-to-chromium-1.3.612"
+      sources."electron-to-chromium-1.3.616"
       sources."emoji-regex-8.0.0"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -97572,7 +97808,7 @@ in
       sources."node-releases-1.1.67"
       (sources."normalize-package-data-3.0.0" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."normalize-range-0.1.2"
@@ -97733,7 +97969,7 @@ in
       sources."define-properties-1.1.3"
       (sources."dom-serializer-0.2.2" // {
         dependencies = [
-          sources."domelementtype-2.0.2"
+          sources."domelementtype-2.1.0"
         ];
       })
       sources."domelementtype-1.3.1"
@@ -97750,7 +97986,7 @@ in
       sources."has-symbols-1.0.1"
       sources."is-callable-1.2.2"
       sources."is-date-object-1.0.2"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-regex-1.1.1"
       sources."is-symbol-1.0.3"
       sources."js-yaml-3.14.0"
@@ -98673,7 +98909,7 @@ in
       sources."inherits-2.0.4"
       sources."is-alphabetical-1.0.4"
       sources."is-alphanumerical-1.0.4"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-arrayish-0.2.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.2.2"
@@ -99010,7 +99246,7 @@ in
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-yarn-2.1.0"
-      sources."hast-util-embedded-1.0.5"
+      sources."hast-util-embedded-1.0.6"
       sources."hast-util-from-parse5-6.0.1"
       sources."hast-util-has-property-1.0.4"
       sources."hast-util-is-body-ok-link-1.0.4"
@@ -99442,7 +99678,7 @@ in
       sources."inherits-2.0.4"
       sources."is-callable-1.2.2"
       sources."is-date-object-1.0.2"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-regex-1.1.1"
       sources."is-symbol-1.0.3"
       sources."object-assign-4.1.1"
@@ -99596,7 +99832,7 @@ in
       sources."is-callable-1.2.2"
       sources."is-capitalized-1.0.0"
       sources."is-date-object-1.0.2"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-regex-1.1.1"
       sources."is-string-1.0.5"
       sources."is-symbol-1.0.3"
@@ -100090,7 +100326,7 @@ in
       sources."wide-align-1.1.3"
       sources."with-open-file-0.1.7"
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yallist-3.1.1"
       sources."yarn-1.22.4"
@@ -100210,6 +100446,7 @@ in
       sources."jsprim-1.4.1"
       sources."keypress-0.2.1"
       sources."lodash-4.17.20"
+      sources."lru-cache-6.0.0"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."minimatch-3.0.4"
@@ -100234,7 +100471,7 @@ in
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.2.1"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      sources."semver-7.3.4"
       sources."sprintf-0.1.5"
       sources."sshpk-1.16.1"
       sources."stack-trace-0.0.10"
@@ -100254,6 +100491,7 @@ in
       })
       sources."wrappy-1.0.2"
       sources."xmldom-0.3.0"
+      sources."yallist-4.0.0"
       sources."yauzl-2.10.0"
     ];
     buildInputs = globalBuildInputs;
@@ -100629,20 +100867,30 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.5.13";
+    version = "1.5.14";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.5.13.tgz";
-      sha512 = "m+NczxQwrfo5Jle+QvgToZZAmgoiJoKGc0UT0e9YHQx288DBfNnrDUpaNBZB+L6i0NMqkp8c/CHAFaVpJS0v7Q==";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.5.14.tgz";
+      sha512 = "F8dtwD2lV3ey0zIZfZXqcBaOweZ/iEVx0RQxjDgGWEsKBnnbXLxNlTNqzrhUuFuskJNVv6Se2QzyBWVMn2mbuA==";
     };
     dependencies = [
       sources."@dabh/diagnostics-2.0.2"
-      sources."@primer/octicons-11.0.0"
+      sources."@primer/octicons-11.1.0"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
+      sources."@types/body-parser-1.19.0"
+      sources."@types/component-emitter-1.2.10"
+      sources."@types/connect-3.4.33"
+      sources."@types/cookie-0.4.0"
+      sources."@types/cors-2.8.8"
+      sources."@types/express-4.17.9"
+      sources."@types/express-serve-static-core-4.17.14"
+      sources."@types/mime-2.0.3"
       sources."@types/node-14.14.10"
+      sources."@types/qs-6.9.5"
+      sources."@types/range-parser-1.2.3"
+      sources."@types/serve-static-1.13.8"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
-      sources."after-0.8.2"
       sources."ansi-regex-5.0.0"
       (sources."ansi-styles-4.3.0" // {
         dependencies = [
@@ -100651,15 +100899,9 @@ in
         ];
       })
       sources."array-flatten-1.1.1"
-      sources."arraybuffer.slice-0.0.7"
       sources."async-3.2.0"
-      sources."async-limiter-1.0.1"
-      sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
-      sources."base64-arraybuffer-0.1.4"
       sources."base64id-2.0.0"
-      sources."better-assert-1.0.2"
-      sources."blob-0.0.5"
       sources."blueimp-md5-2.18.0"
       sources."body-parser-1.19.0"
       sources."bootstrap-3.4.1"
@@ -100671,7 +100913,6 @@ in
           sources."lowercase-keys-2.0.0"
         ];
       })
-      sources."callsite-1.0.0"
       sources."cliui-7.0.4"
       sources."clone-2.1.2"
       sources."clone-response-1.0.2"
@@ -100681,9 +100922,7 @@ in
       sources."color-string-1.5.4"
       sources."colors-1.4.0"
       sources."colorspace-1.1.2"
-      sources."component-bind-1.0.0"
-      sources."component-emitter-1.2.1"
-      sources."component-inherit-0.0.3"
+      sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."content-disposition-0.5.3"
       sources."content-type-1.0.4"
@@ -100691,6 +100930,7 @@ in
       sources."cookie-parser-1.4.5"
       sources."cookie-signature-1.0.6"
       sources."core-util-is-1.0.2"
+      sources."cors-2.8.5"
       sources."crossroads-0.12.2"
       sources."debug-2.6.9"
       sources."decompress-response-3.3.0"
@@ -100707,23 +100947,14 @@ in
       sources."enabled-2.0.0"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.4"
-      (sources."engine.io-3.4.2" // {
+      (sources."engine.io-4.0.4" // {
         dependencies = [
-          sources."cookie-0.3.1"
+          sources."cookie-0.4.1"
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
       })
-      (sources."engine.io-client-3.4.4" // {
-        dependencies = [
-          sources."component-emitter-1.3.0"
-          sources."debug-3.1.0"
-          sources."parseqs-0.0.6"
-          sources."parseuri-0.0.6"
-          sources."ws-6.1.4"
-        ];
-      })
-      sources."engine.io-parser-2.2.1"
+      sources."engine.io-parser-4.0.1"
       sources."escalade-3.1.1"
       sources."escape-html-1.0.3"
       sources."etag-1.8.1"
@@ -100747,8 +100978,6 @@ in
       sources."getmac-5.17.0"
       sources."glob-7.1.6"
       sources."got-9.6.0"
-      sources."has-binary2-1.0.3"
-      sources."has-cors-1.1.0"
       sources."hasher-1.2.0"
       (sources."hogan.js-3.0.2" // {
         dependencies = [
@@ -100759,7 +100988,6 @@ in
       sources."http-errors-1.7.2"
       sources."iconv-lite-0.4.24"
       sources."ignore-5.1.8"
-      sources."indexof-0.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
@@ -100769,7 +100997,7 @@ in
       sources."is-fullwidth-code-point-3.0.0"
       sources."is-stream-2.0.0"
       sources."is-wsl-2.2.0"
-      sources."isarray-2.0.1"
+      sources."isarray-1.0.0"
       sources."jquery-3.5.1"
       sources."jquery-ui-1.12.1"
       sources."json-buffer-3.0.0"
@@ -100811,7 +101039,6 @@ in
       sources."normalize-url-4.5.0"
       sources."nprogress-0.2.0"
       sources."object-assign-4.1.1"
-      sources."object-component-0.0.3"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -100823,8 +101050,6 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."parseqs-0.0.5"
-      sources."parseuri-0.0.5"
       sources."parseurl-1.3.3"
       sources."passport-0.4.1"
       sources."passport-local-1.0.0"
@@ -100851,7 +101076,12 @@ in
       sources."rimraf-3.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-7.3.2"
+      (sources."semver-7.3.4" // {
+        dependencies = [
+          sources."lru-cache-6.0.0"
+          sources."yallist-4.0.0"
+        ];
+      })
       (sources."send-0.17.1" // {
         dependencies = [
           sources."ms-2.1.1"
@@ -100862,28 +101092,14 @@ in
       sources."signals-1.0.0"
       sources."simple-swizzle-0.2.2"
       sources."snapsvg-0.5.1"
-      (sources."socket.io-2.3.0" // {
+      (sources."socket.io-3.0.3" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
       })
-      sources."socket.io-adapter-1.1.2"
-      (sources."socket.io-client-2.3.0" // {
-        dependencies = [
-          sources."base64-arraybuffer-0.1.5"
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-          (sources."socket.io-parser-3.3.1" // {
-            dependencies = [
-              sources."component-emitter-1.3.0"
-              sources."debug-3.1.0"
-              sources."ms-2.0.0"
-            ];
-          })
-        ];
-      })
-      (sources."socket.io-parser-3.4.1" // {
+      sources."socket.io-adapter-2.0.3"
+      (sources."socket.io-parser-4.0.2" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -100906,7 +101122,6 @@ in
         ];
       })
       sources."text-hex-1.0.0"
-      sources."to-array-0.1.4"
       sources."to-readable-stream-1.0.0"
       sources."toidentifier-1.0.0"
       sources."triple-beam-1.3.0"
@@ -100920,20 +101135,17 @@ in
       sources."winston-3.3.3"
       (sources."winston-transport-4.4.0" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.7"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."wrap-ansi-7.0.0"
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
-      sources."xmlhttprequest-ssl-1.5.5"
+      sources."ws-7.4.1"
       sources."y18n-5.0.5"
       sources."yallist-2.1.2"
       sources."yargs-16.1.1"
       sources."yargs-parser-20.2.4"
-      sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -100978,7 +101190,7 @@ in
       sources."concat-map-0.0.1"
       sources."console-control-strings-1.1.0"
       sources."core-util-is-1.0.2"
-      sources."d3-array-2.8.0"
+      sources."d3-array-2.9.0"
       sources."d3-color-2.0.0"
       sources."d3-delaunay-5.3.0"
       sources."d3-dispatch-2.0.0"
@@ -101718,7 +101930,7 @@ in
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
-      sources."is-negative-zero-2.0.0"
+      sources."is-negative-zero-2.0.1"
       sources."is-number-7.0.0"
       sources."is-plain-object-2.0.4"
       sources."is-regex-1.1.1"
@@ -102070,8 +102282,8 @@ in
       sources."v8-compile-cache-2.2.0"
       sources."vm-browserify-1.1.2"
       sources."vsce-1.81.1"
-      sources."vscode-debugadapter-testsupport-1.42.0"
-      sources."vscode-debugprotocol-1.42.0"
+      sources."vscode-debugadapter-testsupport-1.43.0"
+      sources."vscode-debugprotocol-1.43.0"
       (sources."watchpack-1.7.5" // {
         dependencies = [
           sources."chokidar-3.4.3"
@@ -102301,7 +102513,7 @@ in
       sources."is-extendable-0.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-natural-number-4.0.1"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-redirect-1.0.0"
       sources."is-retry-allowed-1.2.0"
       sources."is-stream-1.1.0"
@@ -102678,7 +102890,7 @@ in
           sources."debug-4.3.1"
           sources."eslint-scope-5.1.1"
           sources."espree-6.2.1"
-          sources."vue-eslint-parser-7.1.1"
+          sources."vue-eslint-parser-7.2.0"
         ];
       })
       sources."eslint-scope-4.0.3"
@@ -102791,7 +103003,7 @@ in
         ];
       })
       sources."has-yarn-2.1.0"
-      sources."hast-util-embedded-1.0.5"
+      sources."hast-util-embedded-1.0.6"
       sources."hast-util-has-property-1.0.4"
       sources."hast-util-is-body-ok-link-1.0.4"
       sources."hast-util-is-element-1.1.0"
@@ -102849,7 +103061,7 @@ in
         ];
       })
       sources."is-obj-1.0.1"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
       sources."is-plain-object-2.0.4"
@@ -103413,7 +103625,7 @@ in
       sources."@devicefarmer/adbkit-2.11.3"
       sources."@devicefarmer/adbkit-logcat-1.1.0"
       sources."@devicefarmer/adbkit-monkey-1.0.1"
-      (sources."@eslint/eslintrc-0.2.1" // {
+      (sources."@eslint/eslintrc-0.2.2" // {
         dependencies = [
           sources."debug-4.3.1"
           sources."ms-2.1.2"
@@ -103913,7 +104125,7 @@ in
       sources."ipaddr.js-1.9.1"
       sources."is-absolute-0.1.7"
       sources."is-accessor-descriptor-1.0.0"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-2.1.0"
       sources."is-buffer-1.1.6"
@@ -103933,7 +104145,7 @@ in
       sources."is-npm-5.0.0"
       sources."is-number-7.0.0"
       sources."is-obj-2.0.0"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-path-inside-3.0.2"
       sources."is-plain-obj-1.1.0"
       (sources."is-plain-object-2.0.4" // {
@@ -104513,13 +104725,13 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "5.9.0";
+    version = "5.10.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-5.9.0.tgz";
-      sha512 = "YnnqIV/uAS5ZrNpctSv378qV7HmbJ74DL+XfvMxzbX1bV9e7eeT6eEWU4wuUw33CNr/HspBh7R/xQlVjTEyAeA==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-5.10.0.tgz";
+      sha512 = "P0bHAXmIz0zsNcHNLqFmLY1ZtrT+jtBr7FqpuDtA2o7GiHC+zBsfhgK7SmJ1HG7BAEb3G9JoMdSVi7mEDvG3Zg==";
     };
     dependencies = [
-      sources."@types/eslint-7.2.5"
+      sources."@types/eslint-7.2.6"
       sources."@types/eslint-scope-3.7.0"
       sources."@types/estree-0.0.45"
       sources."@types/json-schema-7.0.6"
@@ -104547,14 +104759,14 @@ in
       sources."acorn-8.0.4"
       sources."ajv-6.12.6"
       sources."ajv-keywords-3.5.2"
-      sources."browserslist-4.14.7"
+      sources."browserslist-4.15.0"
       sources."buffer-from-1.1.1"
-      sources."caniuse-lite-1.0.30001164"
+      sources."caniuse-lite-1.0.30001165"
       sources."chrome-trace-event-1.0.2"
       sources."colorette-1.2.1"
       sources."commander-2.20.3"
-      sources."electron-to-chromium-1.3.612"
-      sources."enhanced-resolve-5.3.2"
+      sources."electron-to-chromium-1.3.616"
+      sources."enhanced-resolve-5.4.0"
       sources."escalade-3.1.1"
       sources."eslint-scope-5.1.1"
       (sources."esrecurse-4.3.0" // {
@@ -104566,7 +104778,7 @@ in
       sources."events-3.2.0"
       sources."fast-deep-equal-3.1.3"
       sources."fast-json-stable-stringify-2.1.0"
-      sources."find-up-4.1.0"
+      sources."find-up-5.0.0"
       sources."glob-to-regexp-0.4.1"
       sources."graceful-fs-4.2.4"
       sources."has-flag-4.0.0"
@@ -104574,17 +104786,16 @@ in
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-traverse-0.4.1"
       sources."loader-runner-4.1.0"
-      sources."locate-path-5.0.0"
+      sources."locate-path-6.0.0"
       sources."merge-stream-2.0.0"
       sources."mime-db-1.44.0"
       sources."mime-types-2.1.27"
       sources."neo-async-2.6.2"
       sources."node-releases-1.1.67"
-      sources."p-limit-2.3.0"
-      sources."p-locate-4.1.0"
-      sources."p-try-2.2.0"
+      sources."p-limit-3.1.0"
+      sources."p-locate-5.0.0"
       sources."path-exists-4.0.0"
-      sources."pkg-dir-4.2.0"
+      sources."pkg-dir-5.0.0"
       sources."punycode-2.1.1"
       sources."randombytes-2.1.0"
       sources."safe-buffer-5.2.1"
@@ -104594,17 +104805,13 @@ in
       sources."source-map-0.6.1"
       sources."source-map-support-0.5.19"
       sources."supports-color-7.2.0"
-      sources."tapable-2.1.1"
+      sources."tapable-2.2.0"
       (sources."terser-5.5.1" // {
         dependencies = [
           sources."source-map-0.7.3"
         ];
       })
-      (sources."terser-webpack-plugin-5.0.3" // {
-        dependencies = [
-          sources."p-limit-3.1.0"
-        ];
-      })
+      sources."terser-webpack-plugin-5.0.3"
       sources."tslib-1.14.1"
       sources."uri-js-4.4.0"
       sources."watchpack-2.0.1"
@@ -104955,7 +105162,7 @@ in
       sources."ipaddr.js-1.9.1"
       sources."is-absolute-url-3.0.3"
       sources."is-accessor-descriptor-1.0.0"
-      sources."is-arguments-1.0.4"
+      sources."is-arguments-1.1.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.2.2"
@@ -105692,7 +105899,7 @@ in
       sources."ut_pex-2.0.1"
       sources."utf-8-validate-5.0.3"
       sources."util-deprecate-1.0.2"
-      sources."utp-native-2.2.1"
+      sources."utp-native-2.2.2"
       sources."videostream-3.2.2"
       sources."vlc-command-1.2.0"
       (sources."webtorrent-0.112.0" // {
@@ -105709,7 +105916,7 @@ in
       })
       sources."winreg-1.2.4"
       sources."wrappy-1.0.2"
-      sources."ws-7.4.0"
+      sources."ws-7.4.1"
       sources."xml2js-0.4.23"
       sources."xmlbuilder-11.0.1"
       sources."xmldom-0.1.31"
@@ -105984,7 +106191,12 @@ in
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
-      sources."cross-spawn-async-2.2.5"
+      (sources."cross-spawn-async-2.2.5" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
       sources."dargs-6.1.0"
@@ -106114,7 +106326,7 @@ in
       sources."glob-to-regexp-0.3.0"
       (sources."global-agent-2.1.12" // {
         dependencies = [
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
         ];
       })
       sources."global-dirs-0.1.1"
@@ -106190,7 +106402,7 @@ in
         ];
       })
       sources."is-obj-1.0.1"
-      sources."is-object-1.0.1"
+      sources."is-object-1.0.2"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
       sources."is-plain-object-2.0.4"
@@ -106255,7 +106467,7 @@ in
       sources."log-symbols-2.2.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-6.0.0"
       sources."macos-release-2.4.1"
       sources."make-dir-1.3.0"
       sources."map-age-cleaner-0.1.3"
@@ -106612,6 +106824,8 @@ in
           sources."cross-spawn-5.1.0"
           sources."execa-0.7.0"
           sources."get-stream-3.0.0"
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
         ];
       })
       sources."text-table-0.2.0"
@@ -106689,7 +106903,7 @@ in
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.4.3"
       sources."xdg-basedir-3.0.0"
-      sources."yallist-2.1.2"
+      sources."yallist-4.0.0"
       (sources."yeoman-character-1.1.0" // {
         dependencies = [
           sources."has-flag-1.0.0"
@@ -106726,7 +106940,7 @@ in
           sources."onetime-5.1.2"
           sources."path-key-3.1.1"
           sources."restore-cursor-3.1.0"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."shebang-command-2.0.0"
           sources."shebang-regex-3.0.0"
           (sources."string-width-4.2.0" // {
@@ -106778,7 +106992,7 @@ in
           sources."pify-4.0.1"
           sources."read-pkg-5.2.0"
           sources."read-pkg-up-5.0.0"
-          sources."semver-7.3.2"
+          sources."semver-7.3.4"
           sources."slash-2.0.0"
           sources."type-fest-0.6.0"
         ];

--- a/pkgs/development/python-modules/pygobject/3.36.nix
+++ b/pkgs/development/python-modules/pygobject/3.36.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, buildPythonPackage, pkgconfig, glib, gobject-introspection,
+pycairo, cairo, which, ncurses, meson, ninja, isPy3k, gnome3 }:
+
+buildPythonPackage rec {
+  pname = "pygobject";
+  version = "3.36.1";
+
+  format = "other";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0b9CgC0c7BE7Wtqg579/N0W0RSHcIWNYjSdtXNYdcY8=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  mesonFlags = [
+    "-Dpython=python${if isPy3k then "3" else "2" }"
+  ];
+
+  nativeBuildInputs = [ pkgconfig meson ninja gobject-introspection ];
+  buildInputs = [ glib gobject-introspection ]
+                 ++ stdenv.lib.optionals stdenv.isDarwin [ which ncurses ];
+  propagatedBuildInputs = [ pycairo cairo ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "python3.pkgs.${pname}3";
+    };
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://pygobject.readthedocs.io/";
+    description = "Python bindings for Glib";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pylibacl/0.5.nix
+++ b/pkgs/development/python-modules/pylibacl/0.5.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "pylibacl";
+  version = "0.5.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0drvxb21y7p0aikcv3jx90vdcjk96kibf9x8qgxic2prxxd3f3q6";
+  };
+
+  # ERROR: testExtended (tests.test_acls.AclExtensions)
+  # IOError: [Errno 0] Error
+  doCheck = false;
+
+  buildInputs = with pkgs; [ acl ];
+
+  meta = {
+    description = "A Python extension module for POSIX ACLs, it can be used to query, list, add, and remove ACLs from files and directories under operating systems that support them";
+    license = lib.licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -55,7 +55,6 @@ buildPythonApplication rec {
   meta = with lib; {
     homepage    = "https://github.com/kozec/sc-controller";
     # donations: https://www.patreon.com/kozec
-    broken = true;
     description = "User-mode driver and GUI for Steam Controller and other controllers";
     license     = licenses.gpl2;
     platforms   = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15480,6 +15480,8 @@ in
 
   qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };
 
+  wf-config = callPackage ../development/libraries/wfconfig {};
+
   mkLibsForQt5 = self: with self; {
 
     ### KDE FRAMEWORKS
@@ -24632,6 +24634,10 @@ in
 
   way-cooler = throw ("way-cooler is abandoned by its author: " +
     "https://way-cooler.org/blog/2020/01/09/way-cooler-post-mortem.html");
+
+  wayfire = callPackage ../applications/window-managers/wayfire {};
+  wcm = callPackage ../applications/window-managers/wayfire/wcm {};
+  wf-shell = callPackage ../applications/window-managers/wayfire/wfshell {};
 
   waypipe = callPackage ../applications/networking/remote/waypipe { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5154,7 +5154,10 @@ in {
 
   pygobject2 = callPackage ../development/python-modules/pygobject { inherit (pkgs) pkgconfig; };
 
-  pygobject3 = callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; };
+  pygobject3 = if isPy3k then
+    callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; }
+  else
+    callPackage ../development/python-modules/pygobject/3.36.nix { inherit (pkgs) meson pkgconfig; };
 
   pygogo = callPackage ../development/python-modules/pygogo { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5245,7 +5245,10 @@ in {
 
   pylev = callPackage ../development/python-modules/pylev { };
 
-  pylibacl = callPackage ../development/python-modules/pylibacl { };
+  pylibacl = if isPy3k then
+    callPackage ../development/python-modules/pylibacl { }
+  else
+    callPackage ../development/python-modules/pylibacl/0.5.nix { };
 
   pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Wayfire is a wayland compositor. The wayfire package itself is available as package in nixpkgs-overlays repo but it doesn't have the packages required to give us the gui desktop. So this pull request was made. Also if possible we can have modules for wayfire like sway or gnome3.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
