### PR TITLE
kbs2: 0.1.6 -> 0.2.2

### DIFF
--- a/pkgs/tools/security/kbs2/default.nix
+++ b/pkgs/tools/security/kbs2/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "kbs2";
-  version = "0.1.6";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "woodruffw";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0n83d4zvy74rn38fqq84lm58l24c3r87m2di2sw4cdr1hkjg3nbl";
+    sha256 = "1qf17ga5k1shim6lk5lqp6my90gj6qldc36f6l4634kndiv2xflb";
   };
 
-  cargoSha256 = "0kafyljn3b87k5m0wdii0gfa4wj1yfys8jqx79inj82m0w1khprk";
+  cargoSha256 = "03nilfc0wvzhvx48m0qj05dqb18ypgkpkmbfj5nb96nridizwg0r";
 
   nativeBuildInputs = [ installShellFiles ]
     ++ stdenv.lib.optionals stdenv.isLinux [ python3 ];
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     export HOME=$TMPDIR
   '';
 
-  checkFlagsArray = [ "--skip=kbs2::config::tests::test_find_config_dir" ];
+  checkFlags = [ "--skip=kbs2::config::tests::test_find_config_dir" ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ "--skip=test_ragelib_rewrap_keyfile" ];
 
   postInstall = ''
     mkdir -p $out/share/kbs2
@@ -38,6 +39,7 @@ rustPlatform.buildRustPackage rec {
   meta = with stdenv.lib; {
     description = "A secret manager backed by age";
     homepage = "https://github.com/woodruffw/kbs2";
+    changelog = "https://github.com/woodruffw/kbs2/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = [ maintainers.marsam ];
   };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/woodruffw/kbs2/blob/v0.2.2/README.md


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
