### PR TITLE
perlPackages.Mojolicious: 8.63 -> 8.67

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13312,10 +13312,10 @@ let
 
   Mojolicious = buildPerlPackage {
     pname = "Mojolicious";
-    version = "8.63";
+    version = "8.67";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-8.63.tar.gz";
-      sha256 = "1nw500wi6kdyawc2aq37lnx6zfkpby3sczflh5pjz623i8nw4b66";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-8.67.tar.gz";
+      sha256 = "0b1ajsfvpzcmy7qp1rjr2n1z263yk5bkzmal0kx72ajg1l1dd85v";
     };
     meta = {
       homepage = "https://mojolicious.org";


### PR DESCRIPTION
###### Motivation for this change

https://metacpan.org/source/SRI/Mojolicious-8.67/Changes

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>44 packages built:</summary>
  <ul>
    <li>abcde</li>
    <li>convos</li>
    <li>perl530Packages.JSONValidator</li>
    <li>perl530Packages.LinkEmbedder</li>
    <li>perl530Packages.Minion</li>
    <li>perl530Packages.MinionBackendSQLite</li>
    <li>perl530Packages.MinionBackendmysql</li>
    <li>perl530Packages.MojoIOLoopForkCall</li>
    <li>perl530Packages.MojoJWT</li>
    <li>perl530Packages.MojoPg</li>
    <li>perl530Packages.MojoRedis</li>
    <li>perl530Packages.MojoSQLite</li>
    <li>perl530Packages.Mojolicious</li>
    <li>perl530Packages.MojoliciousPluginAssetPack</li>
    <li>perl530Packages.MojoliciousPluginGravatar</li>
    <li>perl530Packages.MojoliciousPluginMail</li>
    <li>perl530Packages.MojoliciousPluginOpenAPI</li>
    <li>perl530Packages.MojoliciousPluginStatus</li>
    <li>perl530Packages.MojoliciousPluginTextExceptions</li>
    <li>perl530Packages.MojoliciousPluginWebpack</li>
    <li>perl530Packages.Mojomysql</li>
    <li>perl530Packages.MusicBrainz</li>
    <li>perl530Packages.OpenAPIClient</li>
    <li>perl532Packages.JSONValidator</li>
    <li>perl532Packages.LinkEmbedder</li>
    <li>perl532Packages.Minion</li>
    <li>perl532Packages.MinionBackendSQLite</li>
    <li>perl532Packages.MinionBackendmysql</li>
    <li>perl532Packages.MojoIOLoopForkCall</li>
    <li>perl532Packages.MojoJWT</li>
    <li>perl532Packages.MojoPg</li>
    <li>perl532Packages.MojoRedis</li>
    <li>perl532Packages.MojoSQLite</li>
    <li>perl532Packages.Mojolicious</li>
    <li>perl532Packages.MojoliciousPluginAssetPack</li>
    <li>perl532Packages.MojoliciousPluginGravatar</li>
    <li>perl532Packages.MojoliciousPluginMail</li>
    <li>perl532Packages.MojoliciousPluginOpenAPI</li>
    <li>perl532Packages.MojoliciousPluginStatus</li>
    <li>perl532Packages.MojoliciousPluginTextExceptions</li>
    <li>perl532Packages.MojoliciousPluginWebpack</li>
    <li>perl532Packages.Mojomysql</li>
    <li>perl532Packages.MusicBrainz</li>
    <li>perl532Packages.OpenAPIClient</li>
  </ul>
</details>
