### PR TITLE
zile: 2.4.14 -> 2.6.0.90

### DIFF
--- a/pkgs/applications/editors/zile/default.nix
+++ b/pkgs/applications/editors/zile/default.nix
@@ -1,15 +1,15 @@
-{ fetchurl, stdenv, pkgconfig, ncurses, boehmgc, perl, help2man }:
+{ fetchurl, stdenv, glib, libgee, pkg-config, ncurses, boehmgc, perl, help2man, vala }:
 
 stdenv.mkDerivation rec {
-  name = "zile-2.4.14";
+  name = "zile-2.6.0.90";
 
   src = fetchurl {
     url = "mirror://gnu/zile/${name}.tar.gz";
-    sha256 = "0x3byaddms8l3g7igx6njycqsq98wgapysdb5c7lhcnajlkp8y3s";
+    sha256 = "1bhdwnasmqhy0hi3fqmpzr8xkw5zlqjpmf1cj42h4cg3fnamp6r3";
   };
 
-  buildInputs = [ ncurses boehmgc ];
-  nativeBuildInputs = [ perl pkgconfig ]
+  buildInputs = [ glib libgee ncurses boehmgc vala ];
+  nativeBuildInputs = [ perl pkg-config ]
     # `help2man' wants to run Zile, which won't work when the
     # newly-produced binary can't be run at build-time.
     ++ stdenv.lib.optional


### PR DESCRIPTION
###### Motivation for this change

Upgrade package, possibly solve [this request](https://discourse.nixos.org/t/fixing-a-hydra-build-of-a-gnu-project/10389) from the maintainer.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).