### PR TITLE
fedora-backgrounds: use stdenvNoCC

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenvNoCC
 , coreutils
 }:
 
@@ -7,10 +7,10 @@
 , patches ? [ ]
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   inherit patches src version;
 
-  pname = "fedora${stdenv.lib.versions.major version}-backgrounds";
+  pname = "fedora${stdenvNoCC.lib.versions.major version}-backgrounds";
 
   dontBuild = true;
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     "DESTDIR=$(out)"
   ];
 
-  meta = with stdenv.lib; {
+  meta = with stdenvNoCC.lib; {
     homepage = "https://github.com/fedoradesign/backgrounds";
     description = "A set of default and supplemental wallpapers for Fedora";
     license = licenses.cc-by-sa-40;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

No need for a C build environment when copying some backgrounds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
