### PR TITLE
starboard-octant-plugin: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
+++ b/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "starboard-octant-plugin";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1rgfk8l3yz7xwghr06vcgpi6zzjynxxvyg2r78fgp7wpw7bh3rmd";
+    sha256 = "140m7mnpqhfbp2qqpr3jjsc770xdph98mm5zpgwzg0jwgpsrcxsm";
   };
 
-  vendorSha256 = "1f6x66zgrmm7x661d0d0qqharrpyb2bsi10swlgx68y5yz285296";
+  vendorSha256 = "0aphx2rpnvzmfyfs11hf8j5b7s5lgw4kcq4jpdrkjwx7zhl6qx2g";
 
   meta = with lib; {
     description = "Octant plugin for viewing Starboard security information";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

bump starboard-octant-plugin to `0.7.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
