### PR TITLE
kube3d: 3.4.0 -> 4.0.0

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -1,11 +1,8 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, k3sVersion ? "1.20.0-k3s2" }:
 
-let
-  k3sVersion = "1.20.0-k3s2";
-in
 buildGoModule rec {
   pname = "kube3d";
-  version = "3.4.0";
+  version = "4.0.0";
 
   excludedPackages = "tools";
 
@@ -13,7 +10,7 @@ buildGoModule rec {
     owner = "rancher";
     repo = "k3d";
     rev = "v${version}";
-    sha256 = "1fisbzv786n841pagy7zbanll7k1g5ib805j9azs2s30cfhvi08b";
+    sha256 = "sha256-sHtPW9EaTycHh9d/vp28BvzhmbLUQYsu6yMfJlJYH+k=";
   };
 
   vendorSha256 = null;
@@ -24,8 +21,8 @@ buildGoModule rec {
     "-ldflags="
     "-w"
     "-s"
-    "-X github.com/rancher/k3d/v3/version.Version=v${version}"
-    "-X github.com/rancher/k3d/v3/version.K3sVersion=v${k3sVersion}"
+    "-X github.com/rancher/k3d/v4/version.Version=v${version}"
+    "-X github.com/rancher/k3d/v4/version.K3sVersion=v${k3sVersion}"
   ];
 
   doCheck = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump kube3d/k3d to `4.0.0`

~Since this is a major version bump and still in-progress I've created this as a draft PR to try things out as it's being developed.~

Released: https://github.com/rancher/k3d/releases/tag/v4.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
