### PR TITLE
v2ray: 4.32.1 -> 4.33.0

### DIFF
--- a/pkgs/tools/networking/v2ray/default.nix
+++ b/pkgs/tools/networking/v2ray/default.nix
@@ -3,22 +3,22 @@
 }:
 
 let
-  version = "4.32.1";
+  version = "4.33.0";
 
   src = fetchFromGitHub {
     owner = "v2fly";
     repo = "v2ray-core";
     rev = "v${version}";
-    sha256 = "1mlrl5fz1v3bcb83pczqp859d8w9mi7jj600a2yw7xm372w2irk8";
+    sha256 = "05w714i56nipp7m985g6zqq6ljz0w5ihxrgs93j10llfdd089iig";
   };
 
-  vendorSha256 = "1mz1acdj8ailgyqrr1v47n36qc24ggzw5rmj4p2awfwz3gp2yz6z";
+  vendorSha256 = "0ix5kxldgbcb10jh0l64lrh8qzla4qvsxi6vanb73y7lbsix120w";
 
   assets = {
     # MIT licensed
     "geoip.dat" = let
-      geoipRev = "202011050012";
-      geoipSha256 = "1d2n3hskgdmcfk1nl7a8lxxz325p84i7gz44cs77z1m9r7c2vsjy";
+      geoipRev = "202012030015";
+      geoipSha256 = "1qy9h0721y5kjcp0s859lhj253jfi3d3i658gpc4kmij2l5dxm5w";
     in fetchurl {
       url = "https://github.com/v2fly/geoip/releases/download/${geoipRev}/geoip.dat";
       sha256 = geoipSha256;
@@ -26,8 +26,8 @@ let
 
     # MIT licensed
     "geosite.dat" = let
-      geositeRev = "20201102141726";
-      geositeSha256 = "0sn2f5vd6w94ryh845mnbfyjzycg7cvb66rkzh37pg9l7fvgs4jh";
+      geositeRev = "20201207123222";
+      geositeSha256 = "03xckk39rrda42cam2awbsh0gib6rhmz28asc8vx29lsp9g2bj6n";
     in fetchurl {
       url = "https://github.com/v2fly/domain-list-community/releases/download/${geositeRev}/dlc.dat";
       sha256 = geositeSha256;
@@ -61,11 +61,9 @@ let
     '';
 
     meta = {
-      homepage = "https://www.v2ray.com/en/index.html";
+      homepage = "https://www.v2fly.org/en_US/";
       description = "A platform for building proxies to bypass network restrictions";
-      # The license of the dependency `https://github.com/XTLS/Go` doesn't allowed user to modify its source code,
-      # which made it unfree.
-      license = with lib.licenses; [ mit unfree ];
+      license = with lib.licenses; [ mit ];
       maintainers = with lib.maintainers; [ servalcatty ];
     };
   };
@@ -77,6 +75,7 @@ in runCommand "v2ray-${version}" {
   nativeBuildInputs = [ makeWrapper ];
 
   passthru = {
+    inherit core;
     updateScript = ./update.sh;
     tests = {
       simple-vmess-proxy-test = nixosTests.v2ray;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump version.

The unfree `XTLS` is removed in 4.33.0 (https://github.com/v2fly/v2ray-core/releases/tag/v4.33.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
