### PR TITLE
openrgb: 0.4 -> 0.5

### DIFF
--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -17,6 +17,9 @@ mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp openrgb $out/bin
+
+    mkdir -p $out/etc/udev/rules.d
+    cp 60-openrgb.rules $out/etc/udev/rules.d
   '';
 
   doInstallCheck = true;

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -1,35 +1,32 @@
-{ mkDerivation, lib, fetchFromGitHub, qmake, libusb1, hidapi, pkg-config, fetchpatch }:
+{ lib, mkDerivation, fetchFromGitLab, qmake, libusb1, hidapi, pkg-config }:
 
 mkDerivation rec {
   pname = "openrgb";
-  version = "0.4";
+  version = "0.5";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "CalcProgrammer1";
     repo = "OpenRGB";
     rev = "release_${version}";
-    sha256 = "sha256-tHrRG2Zx7NYqn+WPiRpAlWA/QmxuAYidENanTkC1XVw";
+    sha256 = "001x2ycfmlb9s21sp91aw5gxizcn6kzm8x7bvkps4b1iq0ap5fzv";
   };
 
   nativeBuildInputs = [ qmake pkg-config ];
   buildInputs = [ libusb1 hidapi ];
 
-  patches = [
-    # Make build SOURCE_DATE_EPOCH aware, merged in master
-    (fetchpatch {
-      url = "https://gitlab.com/CalcProgrammer1/OpenRGB/-/commit/f1b7b8ba900db58a1119d8d3e21c1c79de5666aa.patch";
-      sha256 = "17m1hn1kjxfcmd4p3zjhmr5ar9ng0zfbllq78qxrfcq1a0xrkybx";
-    })
-  ];
-
   installPhase = ''
     mkdir -p $out/bin
-    cp OpenRGB $out/bin
+    cp openrgb $out/bin
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/OpenRGB --help > /dev/null
+    $out/bin/openrgb --help > /dev/null
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    HOME=$TMPDIR $out/bin/openrgb --help > /dev/null
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/openrgb/default.nix
+++ b/pkgs/applications/misc/openrgb/default.nix
@@ -24,11 +24,6 @@ mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/openrgb --help > /dev/null
-  '';
-
-  doInstallCheck = true;
-  installCheckPhase = ''
     HOME=$TMPDIR $out/bin/openrgb --help > /dev/null
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
0.5 was just released

###### Things done
 - fetch from GitLab (project was moved there)
- added `udev` rules
- ~~remove `installCheck` because it now always fails~~
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
