### PR TITLE
pythonPackages.llfuse: downgrade pytest version

### DIFF
--- a/pkgs/development/python-modules/llfuse/default.nix
+++ b/pkgs/development/python-modules/llfuse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, buildPythonPackage, pkgconfig, pytest, fuse, attr, which
+{ stdenv, fetchurl, fetchpatch, buildPythonPackage, pkgconfig, pytest_5, fuse, attr, which
 , contextlib2, osxfuse
 }:
 
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   buildInputs =
     optionals stdenv.isLinux [ fuse ]
     ++ optionals stdenv.isDarwin [ osxfuse ];
-  checkInputs = [ pytest which ] ++
+  checkInputs = [ pytest_5 which ] ++
     optionals stdenv.isLinux [ attr ];
 
   propagatedBuildInputs = [ contextlib2 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fails to build with Pytest 6

This library is used by borgbackup and is not maintained anymore, the current beta version of borg can use pyfuse3 instead

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
