### PR TITLE
pythonPackages.pyfuse3: init at 3.1.1

### DIFF
--- a/pkgs/development/python-modules/pyfuse3/default.nix
+++ b/pkgs/development/python-modules/pyfuse3/default.nix
@@ -1,0 +1,42 @@
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, pkg-config, fuse3, trio, pytestCheckHook, pytest-trio, which }:
+
+buildPythonPackage rec {
+  pname = "pyfuse3";
+  version = "3.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9feb42a8639dc4815522ee6af6f7221552cfd2df1c7a7e9df96767be65e18667";
+  };
+
+  patches = [
+    # Fixes tests with pytest 6, to be removed in next stable version
+    (fetchpatch {
+      url = "https://github.com/libfuse/pyfuse3/commit/0070eddfc33fc2fba8eb4fe9353a2d2fa1ae575b.patch";
+      sha256 = "0lb4x1j31ihs3qkn61x41k2vqwcjl2fp1c2qx2jg9br6yqhjmg3b";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ fuse3 ];
+
+  propagatedBuildInputs = [ trio ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-trio
+    which
+    fuse3
+  ];
+
+  # Checks if a /usr/bin directory exists, can't work on NixOS
+  disabledTests = [ "test_listdir" ];
+
+  meta = with lib; {
+    description = "Python 3 bindings for libfuse 3 with async I/O support";
+    homepage = "https://github.com/libfuse/pyfuse3";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5115,6 +5115,8 @@ in {
 
   pyfttt = callPackage ../development/python-modules/pyfttt { };
 
+  pyfuse3 = callPackage ../development/python-modules/pyfuse3 { };
+
   pyfxa = callPackage ../development/python-modules/pyfxa { };
 
   pygal = callPackage ../development/python-modules/pygal { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This library will be recommended in the next version of borgbackup as a replacement for llfuse

I tested it by compiling latest borg beta against it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
