### PR TITLE
gnome-podcasts: add dependency gst-plugins-good

### DIFF
--- a/pkgs/applications/audio/gnome-podcasts/default.nix
+++ b/pkgs/applications/audio/gnome-podcasts/default.nix
@@ -55,6 +55,7 @@ rustPlatform.buildRustPackage rec {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-good
   ];
 
   # use Meson/Ninja phases


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I get this error currently when playing a podcast with the app:
```
podcasts_gtk::widgets::player: gst warning: Warning from element /GstPlayBin:playbin/GstURIDecodeBin:uridecodebin0: There is no codec present that can handle the stream's type.
No decoder available for type 'application/x-id3'.
../gst/playback/gsturidecodebin.c(957): unknown_type_cb (): /GstPlayBin:playbin/GstURIDecodeBin:uridecodebin0
```
Adding gst-plugins-good to buildInputs fixes this problem.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
