### PR TITLE
pam -> use NixOS suid unix_chkpwd wrapper

### DIFF
--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, buildPackages, fetchurl, fetchpatch, flex, cracklib, db4 }:
+{ stdenv, buildPackages, fetchurl, fetchpatch, flex, cracklib, db4
+, ckpwdDir ? "/run/wrappers/bin" }:
 
 stdenv.mkDerivation rec {
   pname = "linux-pam";
@@ -44,7 +45,13 @@ stdenv.mkDerivation rec {
   # which is done by dlopening $out/lib/security/pam_foo.so
   # $out/etc was also missed: pam_env(login:session): Unable to open config file
 
-  preConfigure = stdenv.lib.optionalString (stdenv.hostPlatform.libc == "musl") ''
+  preConfigure = ''
+      # the unix_chkpwd binary needs to be suid to check /etc/shadow. NixOS
+      # builds a suid wrapper in /run/wrappers/bin/ for unix_chkpwd, use that
+      # instead of trying to use the one installed into the store.
+      sed -e 's%$(sbindir)/unix_chkpwd%${ckpwdDir}/unix_chkpwd%' -i modules/pam_unix/Makefile.am
+      sed -e 's%$(sbindir)/unix_chkpwd%${ckpwdDir}/unix_chkpwd%' -i modules/pam_unix/Makefile.in
+  '' + stdenv.lib.optionalString (stdenv.hostPlatform.libc == "musl") ''
       # export ac_cv_search_crypt=no
       # (taken from Alpine linux, apparently insecure but also doesn't build O:))
       # disable insecure modules


### PR DESCRIPTION
###### Motivation for this change

Non-root applications that use PAM to check auth credentials need a suid helper application to access `/etc/shadow`. 

NixOS creates this wrapper at `/run/wrappers/chkpwd`, this patch the `pam_unix` security module to use the suid wrapper. It provides a function argument to allow overriding the chkpwd to use.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
