### PR TITLE
pythonPackages.nix-prefetch-github: 4.0.2 -> 4.0.3

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -1,41 +1,38 @@
-{ fetchPypi
+{ fetchFromGitHub
 , lib
 , buildPythonPackage
-, pythonOlder
 , attrs
 , click
 , effect
-, jinja2
 , git
 , pytestCheckHook
 , pytestcov
-, pytest-isort
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "nix-prefetch-github";
-  version = "4.0.2";
+  version = "4.0.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "ZdaWIkpJk8AvTZmA76VMTXeOUTrWLe+W3vh/e0zwWB4=";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "seppeljordan";
+    repo = "nix-prefetch-github";
+    rev = "v${version}";
+    sha256 = "CLcmwobPrL6NiI/nw+/Dwho/r15owV16Jmt5OcfFqvo=";
   };
 
   propagatedBuildInputs = [
     attrs
     click
     effect
-    jinja2
   ];
 
-  checkInputs = [ pytestCheckHook pytestcov pytest-isort git ];
-  checkPhase = ''
-    pytest -m 'not network'
-  '';
+  checkInputs = [ pytestCheckHook pytestcov git ];
 
-  # latest version of isort will cause tests to fail
   # ignore tests which are impure
-  disabledTests = [ "isort" "life" "outputs" "fetch_submodules" ];
+  disabledTests = [ "network" "requires_nix_build" ];
 
   meta = with lib; {
     description = "Prefetch sources from github";


### PR DESCRIPTION
###### Motivation for this change
`nix-prefetch-github` got an update upstream. This is addressed by this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
