### PR TITLE
pythonPackages.poetry: Apply patch to fix failing tests

### DIFF
--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -88,6 +88,16 @@ buildPythonPackage rec {
     "test_builder_should_execute_build_scripts"
   ];
 
+  patches = [
+    # The following patch addresses a minor incompatibility with
+    # pytest-mock.  This is addressed upstream in
+    # https://github.com/python-poetry/poetry/pull/3457
+    (fetchpatch {
+      url = "https://github.com/python-poetry/poetry/commit/8ddceb7c52b3b1f35412479707fa790e5d60e691.diff";
+      sha256 = "yHjFb9xJBLFOqkOZaJolKviTdtST9PMFwH9n8ud2Y+U=";
+    })
+  ];
+
   meta = with lib; {
     homepage = "https://python-poetry.org/";
     description = "Python dependency management and packaging made easy";


### PR DESCRIPTION
###### Motivation for this change
The poetry package does not build currently since it is incompatible with our current version of `pytest-mock`. This incompatibility is addressed upstream in https://github.com/python-poetry/poetry/pull/3457

To fix the issue temporarily in nixpkgs I applied the patch from this PR to the current version in nixpkgs an left a comment with regards to the purpose of the patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
