### PR TITLE
nim: expose testament test runner

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -255,6 +255,11 @@ let
         ln -s $out/bin/${targetPlatform.config}-nim $out/bin/nim
 
         makeWrapper \
+          ${nim'}/bin/testament $out/bin/${targetPlatform.config}-testament \
+          $wrapperArgs
+        ln -s $out/bin/${targetPlatform.config}-testament $out/bin/testament
+
+        makeWrapper \
           ${nimble'}/bin/nimble $out/bin/${targetPlatform.config}-nimble \
           --suffix PATH : $out/bin
         ln -s $out/bin/${targetPlatform.config}-nimble $out/bin/nimble


### PR DESCRIPTION
###### Motivation for this change

https://nim-lang.org/docs/testament.html

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
