### PR TITLE
mpv: umpv desktop file

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -196,6 +196,8 @@ in stdenv.mkDerivation rec {
 
     cp TOOLS/mpv_identify.sh $out/bin
     cp TOOLS/umpv $out/bin
+    cp $out/share/applications/mpv.desktop $out/share/applications/umpv.desktop
+    sed -i '/Icon=/ ! s/mpv/umpv/g' $out/share/applications/umpv.desktop
   '' + optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     cp -r build/mpv.app $out/Applications


### PR DESCRIPTION
###### Motivation for this change
Desktop file for the unique instance wrapper script `umpv`. E.g. useful for some application launchers, file managers (nautilus) and other tools if the user wants to enqueue to single instance using those.

@AndersonTorres @fpletz @globin @Ma27 @tadeokondrak 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
