### PR TITLE
python3Packages.jupytext: fix build by adding missing markdown-it-py dep; python3 only

### DIFF
--- a/pkgs/development/python-modules/jupytext/default.nix
+++ b/pkgs/development/python-modules/jupytext/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, isPy27
-, mock
+, markdown-it-py
 , nbformat
 , pytest
 , pyyaml
@@ -10,16 +10,19 @@ buildPythonPackage rec {
   pname = "jupytext";
   version = "1.7.1";
 
+  disabled = isPy27;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "23123b90c267c67716fe6a022dfae49b84fd3809370d83211f2920eb3106bf40";
   };
 
   propagatedBuildInputs = [
-    pyyaml
+    markdown-it-py
     nbformat
+    pyyaml
     toml
-  ] ++ lib.optionals isPy27 [ mock ]; # why they put it in install_requires, who knows
+  ];
 
   checkInputs = [
     pytest

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -1,0 +1,49 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook, pythonOlder
+, attrs
+, coverage
+, psutil
+, pytest
+, pytest-benchmark
+}:
+
+buildPythonPackage rec {
+  pname = "markdown-it-py";
+  version = "0.5.6";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "executablebooks";
+    repo = "markdown-it-py";
+    rev = "v${version}";
+    sha256 = "1m9g8xvd7jiz80x9hl8bw9x0ppndqq5nlcn5y8bjxnfj5s31vpbi";
+  };
+
+  propagatedBuildInputs = [ attrs ];
+
+  checkInputs = [
+    coverage
+    pytest-benchmark
+    psutil
+    pytest
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Requires the unpackaged pytest-regressions fixture plugin
+    "test_amsmath"
+    "test_container"
+    "test_deflist"
+    "test_dollarmath"
+    "test_spec"
+    "test_texmath"
+  ];
+
+  meta = with lib; {
+    description = "Markdown parser done right";
+    homepage = "https://markdown-it-py.readthedocs.io/en/latest";
+    changelog = "https://github.com/executablebooks/markdown-it-py/blob/master/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -2,7 +2,6 @@
 , attrs
 , coverage
 , psutil
-, pytest
 , pytest-benchmark
 }:
 
@@ -25,7 +24,6 @@ buildPythonPackage rec {
     coverage
     pytest-benchmark
     psutil
-    pytest
     pytestCheckHook
   ];
 
@@ -42,7 +40,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Markdown parser done right";
     homepage = "https://markdown-it-py.readthedocs.io/en/latest";
-    changelog = "https://github.com/executablebooks/markdown-it-py/blob/master/CHANGELOG.md";
+    changelog = "https://github.com/executablebooks/markdown-it-py/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ bhipple ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3703,6 +3703,8 @@ in {
   else
     callPackage ../development/python-modules/markdown/3_1.nix { };
 
+  markdown-it-py = callPackage ../development/python-modules/markdown-it-py { };
+
   markdown-macros = callPackage ../development/python-modules/markdown-macros { };
 
   markdownsuperscript = callPackage ../development/python-modules/markdownsuperscript { };


### PR DESCRIPTION
###### Motivation for this change
Jupytext stopped working after latest update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).