### PR TITLE
rust-synapse-compress-state: init at 0.1.0

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -1,12 +1,14 @@
 { lib, stdenv, python3, openssl
 , enableSystemd ? stdenv.isLinux, nixosTests
 , enableRedis ? false
+, callPackage
 }:
 
 with python3.pkgs;
 
 let
   plugins = python3.pkgs.callPackage ./plugins { };
+  tools = callPackage ./tools { };
 in
 buildPythonApplication rec {
   pname = "matrix-synapse";
@@ -68,6 +70,7 @@ buildPythonApplication rec {
 
   passthru.tests = { inherit (nixosTests) matrix-synapse; };
   passthru.plugins = plugins;
+  passthru.tools = tools;
   passthru.python = python3;
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/matrix-synapse/tools/default.nix
+++ b/pkgs/servers/matrix-synapse/tools/default.nix
@@ -1,0 +1,4 @@
+{ callPackage }:
+{
+  rust-synapse-compress-state = callPackage ./rust-synapse-compress-state.nix { };
+}

--- a/pkgs/servers/matrix-synapse/tools/rust-synapse-compress-state.nix
+++ b/pkgs/servers/matrix-synapse/tools/rust-synapse-compress-state.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rust-synapse-compress-state";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15jvkpbq6pgdc91wnni8fj435yqlwqgx3bb0vqjgsdyxs5lzalfh";
+  };
+
+  cargoSha256 = "1zdf091s0wyribsqp8l6arkablchqxmdyg2xdc57hh06p4fjiw48";
+
+  meta = with lib; {
+    description = "A tool to compress some state in a Synapse instance's database";
+    homepage = "https://github.com/matrix-org/rust-synapse-compress-state";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa maralorn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5222,6 +5222,8 @@ in
 
   matrix-synapse-plugins = recurseIntoAttrs matrix-synapse.plugins;
 
+  matrix-synapse-tools = recurseIntoAttrs matrix-synapse.tools;
+
   matrix-appservice-slack = callPackage ../servers/matrix-synapse/matrix-appservice-slack {};
 
   matrix-appservice-discord = callPackage ../servers/matrix-appservice-discord { };


### PR DESCRIPTION

###### Motivation for this change

"A tool to compress some state in a Synapse instance's database"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
