### PR TITLE
sauerbraten: 5492 -> 2020-12-04

### DIFF
--- a/pkgs/games/sauerbraten/default.nix
+++ b/pkgs/games/sauerbraten/default.nix
@@ -1,50 +1,43 @@
-{ stdenv, fetchsvn, SDL2, SDL2_image, SDL2_mixer
-, zlib, runtimeShell
+{ stdenv, fetchzip, SDL2, SDL2_image, SDL2_mixer
+, zlib, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
-  name = "sauerbraten-r${version}";
-  version = "5492";
+  pname = "sauerbraten";
+  version = "2020-12-04";
 
-  src = fetchsvn {
-    url = "https://svn.code.sf.net/p/sauerbraten/code";
-    sha256 = "0pin7ggy84fadjvran18db5v0l81qfv42faknpfaxx47xqz00l5s";
-    rev = version;
+  src = fetchzip {
+    url = "mirror://sourceforge/sauerbraten/sauerbraten_${builtins.replaceStrings [ "-" ] [ "_" ] version}_linux.tar.bz2";
+    sha256 = "1hknwpnvsakz6s7l7j1r5aqmgrzp4wcbn8yg8nxmvsddbhxdj1kc";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   buildInputs = [
     SDL2 SDL2_mixer SDL2_image
     zlib
   ];
 
-  preBuild = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -lX11"
-    pushd src
-  '';
+  sourceRoot = "source/src";
 
   installPhase = ''
-    popd
     mkdir -p $out/bin $out/share/sauerbraten $out/share/doc/sauerbraten
-    cp -rv "docs/"* $out/share/doc/sauerbraten/
-    cp -v src/sauer_client src/sauer_server $out/share/sauerbraten/
-    cp -rv packages $out/share/sauerbraten/
-    cp -rv data $out/share/sauerbraten/
-    cat > $out/bin/sauerbraten_server <<EOF
-    #!${runtimeShell}
-    cd $out/share/sauerbraten
-    ./sauer_server "\$@"
-    EOF
-    cat > $out/bin/sauerbraten_client <<EOF
-    #!${runtimeShell}
-    cd $out/share/sauerbraten
-    ./sauer_client "\$@"
-    EOF
-    chmod a+x $out/bin/sauerbraten_*
+    cp -rv "../docs/"* $out/share/doc/sauerbraten/
+    cp -v sauer_client sauer_server $out/share/sauerbraten/
+    cp -rv ../packages ../data $out/share/sauerbraten/
+
+    makeWrapper $out/share/sauerbraten/sauer_server $out/bin/sauerbraten_server \
+      --run "cd $out/share/sauerbraten"
+    makeWrapper $out/share/sauerbraten/sauer_client $out/bin/sauerbraten_client \
+      --run "cd $out/share/sauerbraten" \
+      --add-flags "-q\''${HOME}"
   '';
 
   meta = with stdenv.lib; {
-    description = "";
-    maintainers = [ maintainers.raskin ];
+    description = "A free multiplayer & singleplayer first person shooter, the successor of the Cube FPS";
+    maintainers = with maintainers; [ raskin ajs124 ];
     hydraPlatforms =
       # raskin: tested amd64-linux;
       # not setting platforms because it is 0.5+ GiB of game data


### PR DESCRIPTION
http://www.sauerworld.org/new-sauerbraten-2020-edition-released/

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Can't force push the commit message in #106033

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
