### PR TITLE
mycli: fix build with sqlparse 0.4.x

### DIFF
--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -37,6 +37,7 @@ buildPythonApplication rec {
       excludes = [ "changelog.md" "mycli/AUTHORS" ];
     })
   ];
+
   postPatch = ''
     substituteInPlace setup.py \
       --replace "sqlparse>=0.3.0,<0.4.0" "sqlparse"

--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python3
 , glibcLocales
+, fetchpatch
 }:
 
 with python3.pkgs;
@@ -28,7 +29,20 @@ buildPythonApplication rec {
       --ignore=mycli/packages/paramiko_stub/__init__.py
   '';
 
-  meta = {
+  patches = [
+    # TODO: remove with next release (v1.22.3 or v1.23)
+    (fetchpatch {
+      url = "https://github.com/dbcli/mycli/commit/17f093d7b70ab2d9f3c6eababa041bf76f029aac.patch";
+      sha256 = "sha256-VwfbtzUtElV+ErH+NJb+3pRtSaF0yVK8gEWCvlzZNHI=";
+      excludes = [ "changelog.md" "mycli/AUTHORS" ];
+    })
+  ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "sqlparse>=0.3.0,<0.4.0" "sqlparse"
+  '';
+
+  meta = with lib; {
     inherit version;
     description = "Command-line interface for MySQL";
     longDescription = ''
@@ -36,7 +50,7 @@ buildPythonApplication rec {
       syntax highlighting.
     '';
     homepage = "http://mycli.net";
-    license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.jojosch ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jojosch ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

mycli did not build anymore (https://nix-cache.s3.amazonaws.com/log/p6izraw64rxqgak4zx6vcrmv0wcrf6cv-mycli-1.22.2.drv):

```
ERROR: Could not find a version that satisfies the requirement sqlparse<0.4.0,>=0.3.0 (from mycli)
ERROR: No matching distribution found for sqlparse<0.4.0,>=0.3.0
```

and then the following is fixed by https://github.com/dbcli/mycli/commit/17f093d7b70ab2d9f3c6eababa041bf76f029aac

```
ImportError while loading conftest '/build/mycli-1.22.2/test/conftest.py'.
test/conftest.py:2: in <module>
    from .utils import (HOST, USER, PASSWORD, PORT, CHARSET, create_db,
test/utils.py:10: in <module>
    from mycli.main import special
mycli/main.py:42: in <module>
    from .sqlcompleter import SQLCompleter
mycli/sqlcompleter.py:7: in <module>
    from .packages.completion_engine import suggest_type
mycli/packages/completion_engine.py:5: in <module>
    from sqlparse.compat import text_type
E   ModuleNotFoundError: No module named 'sqlparse.compat'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
