### PR TITLE
patchelf: add patch: false alarm for non overlapping sections

### DIFF
--- a/pkgs/development/tools/misc/patchelf/PR230-fix-false-alarm-for-non-overlapping-sections.patch
+++ b/pkgs/development/tools/misc/patchelf/PR230-fix-false-alarm-for-non-overlapping-sections.patch
@@ -1,0 +1,42 @@
+From 6edec83653ce1b5fc201ff6db93b966394766814 Mon Sep 17 00:00:00 2001
+From: rmnull <rmnull@users.noreply.github.com>
+Date: Tue, 18 Aug 2020 20:22:52 +0530
+Subject: [PATCH] mark phdrs synced with sections, avoid rechecking it when
+ syncing note sections to segments.
+
+This also serves as a bug fix when a previously synced note segment
+overlaps with another section and creates a false alarm.
+---
+ src/patchelf.cc | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index 05ec793..622f0b6 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -669,6 +669,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
+             memset(contents + rdi(shdr.sh_offset), 'X', rdi(shdr.sh_size));
+     }
+ 
++    std::set<unsigned int> noted_phdrs = {};
+     for (auto & i : replacedSections) {
+         std::string sectionName = i.first;
+         auto & shdr = findSection(sectionName);
+@@ -721,7 +722,7 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
+                 shdr.sh_addralign = orig_shdr.sh_addralign;
+ 
+             for (unsigned int j = 0; j < phdrs.size(); ++j)
+-                if (rdi(phdrs[j].p_type) == PT_NOTE) {
++                if (rdi(phdrs[j].p_type) == PT_NOTE && noted_phdrs.find(j) == noted_phdrs.end()) {
+                     Elf_Off p_start = rdi(phdrs[j].p_offset);
+                     Elf_Off p_end = p_start + rdi(phdrs[j].p_filesz);
+                     Elf_Off s_start = rdi(orig_shdr.sh_offset);
+@@ -739,6 +740,8 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
+                     phdrs[j].p_offset = shdr.sh_offset;
+                     phdrs[j].p_vaddr = phdrs[j].p_paddr = shdr.sh_addr;
+                     phdrs[j].p_filesz = phdrs[j].p_memsz = shdr.sh_size;
++
++                    noted_phdrs.insert(j);
+                 }
+         }
+ 

--- a/pkgs/development/tools/misc/patchelf/default.nix
+++ b/pkgs/development/tools/misc/patchelf/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     sha256 = "14npmdxppmh0ci140w8i8cy7zg1pnqg81a1mdsnza711ab7k36k9";
   };
 
+  patches = [
+    ./PR230-fix-false-alarm-for-non-overlapping-sections.patch
+  ];
+
   setupHook = [ ./setup-hook.sh ];
 
   # fails 8 out of 24 tests, problems when loading libc.so.6


### PR DESCRIPTION
###### Motivation for this change

Starting with version 0.12, patchelf sometimes returns an error complaining about overlapping sections.  The build of tsm-client reports the following error message

> unsupported overlap of SHT_NOTE and PT_NOTE

see https://github.com/NixOS/nixpkgs/issues/106257

There is a patch available in this patchelf pull request: https://github.com/NixOS/patchelf/pull/230
The pull request at hand adds the patch to the nixpkgs patchelf build recipe.  This fixes the `tsm-client` package, maybe more.


###### Note on local tests

Due to lack of machine power, **I cannot fully test this commit**.  It tries to rebuild stdenv again, and would even try to build the whole world to obtain a NixOS system for testing.
However, I tested the patch by building the attached recipe with current nixos-unstable (`83cbad92d73`) and also with current nixos-20.09 (`3a02dc9edb2`).  This generates a working patchelf alone, then uses a modified autoPatchelfHook to inject the fixed patchelf into the `PATH` of the tsm-client build.  It makes tsm-client build correctly (on unstable and on 20.09).
Note that the attached recipe below can also be used as a workaround to build a working tsm-client.

[tsm-client-fix.nix.txt](https://github.com/NixOS/nixpkgs/files/5658338/tsm-client-fix.nix.txt)

Notifying patchelf maintainer: @edolstra


###### Things done

See the note on local tests above.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS: x86_64
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`: too much
- [x] Tested execution of all binary files (usually in `./result/bin/`): indirectly tested, by building `tsm-client`
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): 39,441,192 Bytes + 240 Bytes = 39,441,432 Bytes (this is the increase measured with the patchelf build by the attached recipe)
- [x] Ensured that relevant documentation is up to date: *no changes needed*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
