### PR TITLE
ocamlPackages.js_of_ocaml*: 3.7.0 -> 3.8.0

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/camlp4.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/camlp4.nix
@@ -3,17 +3,17 @@
 }:
 
 buildDunePackage rec {
-	version = "3.2.1";
-	pname = "js_of_ocaml-camlp4"; 
+  version = "3.2.1";
+  pname = "js_of_ocaml-camlp4";
 
-	src = fetchFromGitHub {
-		owner = "ocsigen";
-		repo = "js_of_ocaml";
-		rev = version;
-		sha256 = "1v2hfq0ra9j07yz6pj6m03hrvgys4vmx0gclchv94yywpb2wc7ik";
-	};
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = "js_of_ocaml";
+    rev = version;
+    sha256 = "1v2hfq0ra9j07yz6pj6m03hrvgys4vmx0gclchv94yywpb2wc7ik";
+  };
 
-	inherit (js_of_ocaml-compiler) meta;
+  inherit (js_of_ocaml-compiler) meta;
 
   buildInputs = [ camlp4 ocsigen_deriving ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/camlp4.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/camlp4.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, js_of_ocaml-compiler
+{ buildDunePackage, fetchFromGitHub, ocaml, findlib, dune, js_of_ocaml-compiler
 , camlp4, ocsigen_deriving
 }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
 	version = "3.2.1";
 	pname = "js_of_ocaml-camlp4"; 
 
@@ -13,9 +13,7 @@ stdenv.mkDerivation rec {
 		sha256 = "1v2hfq0ra9j07yz6pj6m03hrvgys4vmx0gclchv94yywpb2wc7ik";
 	};
 
-	inherit (js_of_ocaml-compiler) installPhase meta;
+	inherit (js_of_ocaml-compiler) meta;
 
-	buildInputs = [ ocaml findlib dune camlp4 ocsigen_deriving ];
-
-	buildPhase = "dune build -p js_of_ocaml-camlp4";
+  buildInputs = [ camlp4 ocsigen_deriving ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -4,25 +4,25 @@
 }:
 
 buildDunePackage rec {
-	pname = "js_of_ocaml-compiler";
-	version = "3.7.1";
-	useDune2 = true;
+  pname = "js_of_ocaml-compiler";
+  version = "3.7.0";
+  useDune2 = true;
 
-	src = fetchurl {
-		url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-		sha256 = "0i0smhvsfx2ydmbyg5ai5cgqsfnng8rkcvys4i3fa55cw24aknrn";
-	};
+  src = fetchurl {
+    url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
+    sha256 = "0rw6cfkl3zlyav8q2w7grxxqjmg35mz5rgvmkiqb58nl4gmgzx6w";
+  };
 
-	nativeBuildInputs = [ cppo menhir ];
+  nativeBuildInputs = [ cppo menhir ];
   buildInputs = [ cmdliner ];
 
   configurePlatforms = [];
-	propagatedBuildInputs = [ yojson ocaml-migrate-parsetree ];
+  propagatedBuildInputs = [ yojson ocaml-migrate-parsetree ];
 
-	meta = {
-		description = "Compiler from OCaml bytecode to Javascript";
-		license = lib.licenses.gpl2;
-		maintainers = [ lib.maintainers.vbgl ];
-		homepage = "https://ocsigen.org/js_of_ocaml/";
-	};
+  meta = {
+    description = "Compiler from OCaml bytecode to Javascript";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.vbgl ];
+    homepage = "https://ocsigen.org/js_of_ocaml/";
+  };
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,23 +1,23 @@
 { lib, fetchurl, buildDunePackage
-, cmdliner, cppo, yojson, ocaml-migrate-parsetree
+, cmdliner, cppo, yojson, ppxlib
 , menhir
 }:
 
 buildDunePackage rec {
   pname = "js_of_ocaml-compiler";
-  version = "3.7.0";
+  version = "3.8.0";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-    sha256 = "0rw6cfkl3zlyav8q2w7grxxqjmg35mz5rgvmkiqb58nl4gmgzx6w";
+    sha256 = "069jyiayxcgwnips3adxb3d53mzd4rrq2783b9fgmsiyzm545lcy";
   };
 
   nativeBuildInputs = [ cppo menhir ];
   buildInputs = [ cmdliner ];
 
   configurePlatforms = [];
-  propagatedBuildInputs = [ yojson ocaml-migrate-parsetree ];
+  propagatedBuildInputs = [ yojson ppxlib ];
 
   meta = {
     description = "Compiler from OCaml bytecode to Javascript";

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, buildDunePackage
-, ocaml, findlib, cmdliner, dune_2, cppo, yojson, ocaml-migrate-parsetree
+, cmdliner, cppo, yojson, ocaml-migrate-parsetree
 , menhir
 }:
 
@@ -13,7 +13,7 @@ buildDunePackage rec {
 		sha256 = "0i0smhvsfx2ydmbyg5ai5cgqsfnng8rkcvys4i3fa55cw24aknrn";
 	};
 
-	nativeBuildInputs = [ ocaml findlib dune_2 cppo menhir ];
+	nativeBuildInputs = [ cppo menhir ];
   buildInputs = [ cmdliner ];
 
   configurePlatforms = [];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -1,16 +1,13 @@
-{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
+{ buildDunePackage, js_of_ocaml-compiler
 , ocaml-migrate-parsetree, ppx_tools_versioned, uchar
 }:
 
-stdenv.mkDerivation {
+buildDunePackage {
   pname = "js_of_ocaml"; 
 
-  inherit (js_of_ocaml-compiler) version src installPhase meta;
+  inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-  buildInputs = [ findlib ocaml-migrate-parsetree ppx_tools_versioned ];
-  nativeBuildInputs = [ ocaml findlib dune_2 ];
+  buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned ];
 
 	propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
-
-	buildPhase = "dune build -p js_of_ocaml";
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, js_of_ocaml-compiler
-, ocaml-migrate-parsetree, ppx_tools_versioned, uchar
+, ppxlib, uchar
 }:
 
 buildDunePackage {
@@ -7,7 +7,7 @@ buildDunePackage {
 
   inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-  buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned ];
+  buildInputs = [ ppxlib ];
 
   propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -3,11 +3,11 @@
 }:
 
 buildDunePackage {
-  pname = "js_of_ocaml"; 
+  pname = "js_of_ocaml";
 
   inherit (js_of_ocaml-compiler) version src meta useDune2;
 
   buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned ];
 
-	propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
+  propagatedBuildInputs = [ js_of_ocaml-compiler uchar ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -4,11 +4,11 @@
 }:
 
 buildDunePackage {
-	pname = "js_of_ocaml-lwt"; 
+  pname = "js_of_ocaml-lwt";
 
-	inherit (js_of_ocaml-compiler) version src meta useDune2;
+  inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+  buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
-	propagatedBuildInputs = [ js_of_ocaml ocaml_lwt lwt_log ];
+  propagatedBuildInputs = [ js_of_ocaml ocaml_lwt lwt_log ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -1,16 +1,14 @@
-{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler, js_of_ocaml-ppx
+{ buildDunePackage, js_of_ocaml-compiler, js_of_ocaml-ppx
 , ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml, ocaml_lwt, lwt_log
 }:
 
-stdenv.mkDerivation {
+buildDunePackage {
 	pname = "js_of_ocaml-lwt"; 
 
-	inherit (js_of_ocaml-compiler) version src installPhase meta;
+	inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	buildInputs = [ ocaml findlib dune_2 js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+	buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
 	propagatedBuildInputs = [ js_of_ocaml ocaml_lwt lwt_log ];
-
-	buildPhase = "dune build -p js_of_ocaml-lwt";
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -1,5 +1,4 @@
 { buildDunePackage, js_of_ocaml-compiler, js_of_ocaml-ppx
-, ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml, ocaml_lwt, lwt_log
 }:
 
@@ -8,7 +7,7 @@ buildDunePackage {
 
   inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-  buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+  buildInputs = [ js_of_ocaml-ppx ];
 
   propagatedBuildInputs = [ js_of_ocaml ocaml_lwt lwt_log ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
@@ -3,9 +3,9 @@
 }:
 
 buildDunePackage {
-	pname = "js_of_ocaml-ocamlbuild"; 
+  pname = "js_of_ocaml-ocamlbuild";
 
-	inherit (js_of_ocaml-compiler) version src meta useDune2;
+  inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	propagatedBuildInputs = [ ocamlbuild ];
+  propagatedBuildInputs = [ ocamlbuild ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
@@ -1,15 +1,11 @@
-{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
+{ buildDunePackage, js_of_ocaml-compiler
 , ocamlbuild
 }:
 
-stdenv.mkDerivation {
+buildDunePackage {
 	pname = "js_of_ocaml-ocamlbuild"; 
 
-	inherit (js_of_ocaml-compiler) version src installPhase meta;
-
-	buildInputs = [ ocaml findlib dune_2 ];
+	inherit (js_of_ocaml-compiler) version src meta useDune2;
 
 	propagatedBuildInputs = [ ocamlbuild ];
-
-	buildPhase = "dune build -p js_of_ocaml-ocamlbuild";
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -1,14 +1,12 @@
-{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
+{ buildDunePackage, js_of_ocaml-compiler
 , ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml
 }:
 
-stdenv.mkDerivation {
+buildDunePackage {
 	pname = "js_of_ocaml-ppx"; 
 
-	inherit (js_of_ocaml-compiler) version src installPhase meta;
+	inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	buildInputs = [ ocaml findlib dune_2 ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
-
-	buildPhase = "dune build -p js_of_ocaml-ppx";
+	buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -4,9 +4,9 @@
 }:
 
 buildDunePackage {
-	pname = "js_of_ocaml-ppx"; 
+  pname = "js_of_ocaml-ppx";
 
-	inherit (js_of_ocaml-compiler) version src meta useDune2;
+  inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
+  buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, js_of_ocaml-compiler
-, ocaml-migrate-parsetree, ppx_tools_versioned
+, ppxlib
 , js_of_ocaml
 }:
 
@@ -8,5 +8,5 @@ buildDunePackage {
 
   inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-  buildInputs = [ ocaml-migrate-parsetree ppx_tools_versioned js_of_ocaml ];
+  buildInputs = [ ppxlib js_of_ocaml ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -3,9 +3,9 @@
 }:
 
 buildDunePackage {
-	pname = "js_of_ocaml-ppx_deriving_json";
+  pname = "js_of_ocaml-ppx_deriving_json";
 
-	inherit (js_of_ocaml-compiler) version src meta useDune2;
+  inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	propagatedBuildInputs = [ js_of_ocaml ppxlib ];
+  propagatedBuildInputs = [ js_of_ocaml ppxlib ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -1,19 +1,11 @@
-{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
+{ buildDunePackage, js_of_ocaml-compiler
 , js_of_ocaml, ppxlib
 }:
 
-if !stdenv.lib.versionAtLeast ppxlib.version "0.14"
-then throw "js_of_ocaml-ppx_deriving_json is not compatible with ppxlib ${ppxlib.version}"
-else
-
-stdenv.mkDerivation {
+buildDunePackage {
 	pname = "js_of_ocaml-ppx_deriving_json";
 
-	inherit (js_of_ocaml-compiler) version src installPhase meta;
-
-	buildInputs = [ ocaml findlib dune_2 ];
+	inherit (js_of_ocaml-compiler) version src meta useDune2;
 
 	propagatedBuildInputs = [ js_of_ocaml ppxlib ];
-
-	buildPhase = "dune build -p js_of_ocaml-ppx_deriving_json";
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -1,5 +1,5 @@
 { buildDunePackage, js_of_ocaml-compiler
-, js_of_ocaml-ppx, ocaml-migrate-parsetree, ppx_tools_versioned
+, js_of_ocaml-ppx
 , js_of_ocaml, reactivedata, tyxml
 }:
 
@@ -8,7 +8,7 @@ buildDunePackage {
 
   inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-  buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+  buildInputs = [ js_of_ocaml-ppx ];
 
   propagatedBuildInputs = [ js_of_ocaml reactivedata tyxml ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -4,11 +4,11 @@
 }:
 
 buildDunePackage {
-	pname = "js_of_ocaml-tyxml";
+  pname = "js_of_ocaml-tyxml";
 
-	inherit (js_of_ocaml-compiler) version src meta useDune2;
+  inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+  buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
-	propagatedBuildInputs = [ js_of_ocaml reactivedata tyxml ];
+  propagatedBuildInputs = [ js_of_ocaml reactivedata tyxml ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -1,16 +1,14 @@
-{ stdenv, ocaml, findlib, dune_2, js_of_ocaml-compiler
+{ buildDunePackage, js_of_ocaml-compiler
 , js_of_ocaml-ppx, ocaml-migrate-parsetree, ppx_tools_versioned
 , js_of_ocaml, reactivedata, tyxml
 }:
 
-stdenv.mkDerivation {
+buildDunePackage {
 	pname = "js_of_ocaml-tyxml";
 
-	inherit (js_of_ocaml-compiler) version src installPhase meta;
+	inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-	buildInputs = [ ocaml findlib dune_2 js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
+	buildInputs = [ js_of_ocaml-ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
 	propagatedBuildInputs = [ js_of_ocaml reactivedata tyxml ];
-
-	buildPhase = "dune build -p js_of_ocaml-tyxml";
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -427,19 +427,27 @@ let
 
     jingoo = callPackage ../development/ocaml-modules/jingoo { };
 
-    js_of_ocaml = callPackage ../development/tools/ocaml/js_of_ocaml { };
+    js_of_ocaml = callPackage ../development/tools/ocaml/js_of_ocaml {
+      ppxlib = ppxlib.override { version = "0.15.0"; };
+    };
 
     js_of_ocaml-camlp4 = callPackage ../development/tools/ocaml/js_of_ocaml/camlp4.nix {};
 
-    js_of_ocaml-compiler = callPackage ../development/tools/ocaml/js_of_ocaml/compiler.nix {};
+    js_of_ocaml-compiler = callPackage ../development/tools/ocaml/js_of_ocaml/compiler.nix {
+      ppxlib = ppxlib.override { version = "0.15.0"; };
+    };
 
     js_of_ocaml-lwt = callPackage ../development/tools/ocaml/js_of_ocaml/lwt.nix {};
 
     js_of_ocaml-ocamlbuild = callPackage ../development/tools/ocaml/js_of_ocaml/ocamlbuild.nix {};
 
-    js_of_ocaml-ppx = callPackage ../development/tools/ocaml/js_of_ocaml/ppx.nix {};
+    js_of_ocaml-ppx = callPackage ../development/tools/ocaml/js_of_ocaml/ppx.nix {
+      ppxlib = ppxlib.override { version = "0.15.0"; };
+    };
 
-    js_of_ocaml-ppx_deriving_json = callPackage ../development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix { };
+    js_of_ocaml-ppx_deriving_json = callPackage ../development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix {
+      ppxlib = ppxlib.override { version = "0.15.0"; };
+    };
 
     js_of_ocaml-tyxml = callPackage ../development/tools/ocaml/js_of_ocaml/tyxml.nix {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Tried to see if I could do the broken auto-update properly. Unfortunately it seems that this update currently breaks
`eliom` which should be fixed as soon as they support ocaml-migrate-parsetree 2.1.0 or we have a patch for it:

```
+ ocamlfind ocamlc -c -g -keep-locs -w +A-4-6-7-9-40-42-44-48 -package 'ppx_tools_versioned, ppx_tools_versioned.metaquot_408' -I src/ppx -o src/ppx/ppx_eliom_client.cmi src/ppx/ppx_eliom_client.mli
findlib: [WARNING] Package ocaml-migrate-parsetree has multiple definitions in /nix/store/4fpj30ah88j7zcpc3mgrgwc4y4qmdkyl-ocaml4.10.0-ocaml-migrate-parsetree-2.1.0/lib/ocaml/4.10.0/site-lib/ocaml-migrate-parsetree/META, /nix/store/c0sga3bi7dbbh40lsfg9i91w9s9aj542-ocaml4.10.0-ocaml-migrate-parsetree-1.8.0/lib/ocaml/4.10.0/site-lib/ocaml-migrate-parsetree/META
findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /nix/store/lqgcqn9nh1bknq3dj7qnh1k7fcapsdag-ocaml-4.10.0/lib/ocaml, /nix/store/lqgcqn9nh1bknq3dj7qnh1k7fcapsdag-ocaml-4.10.0/lib/ocaml/compiler-libs
File "src/ppx/ppx_eliom_client.mli", line 2, characters 45-78:
2 |   Migrate_parsetree.Versions.OCaml_408.types Migrate_parsetree.Driver.rewriter
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Migrate_parsetree.Driver
Command exited with code 2.
Compilation unsuccessful after building 11 targets (4 cached) in 00:00:00.
make: *** [Makefile:14: native] Error 10
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
