### PR TITLE
ocamlPackages.cinaps: init at 0.14.0

### DIFF
--- a/pkgs/development/ocaml-modules/cinaps/default.nix
+++ b/pkgs/development/ocaml-modules/cinaps/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildDunePackage, fetchurl, re, ppx_jane }:
+
+let
+  major = "0.14";
+in
+
+buildDunePackage rec {
+  pname = "cinaps";
+  version = "${major}.0";
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://ocaml.janestreet.com/ocaml-core/v${major}/files/cinaps-v${version}.tar.gz";
+    sha256 = "1zacmcp97c75r03l1p9wpg81qj9g2r52dhiag7xqhn94q33zklcc";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [ re ];
+
+  doCheck = true;
+  checkInputs = [ ppx_jane ];
+
+  meta = with lib; {
+    description = "Trivial Metaprogramming tool using the OCaml toplevel";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/ocaml-ppx/cinaps";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -129,6 +129,8 @@ let
 
     cil = callPackage ../development/ocaml-modules/cil { };
 
+    cinaps = callPackage ../development/ocaml-modules/cinaps { };
+
     cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
 
     cohttp = callPackage ../development/ocaml-modules/cohttp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add non-janestreet cinaps.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
