### PR TITLE
libtapi: build the 'tapi' executable

### DIFF
--- a/pkgs/os-specific/darwin/libtapi/build-tapi-command.patch
+++ b/pkgs/os-specific/darwin/libtapi/build-tapi-command.patch
@@ -1,0 +1,114 @@
+diff --git a/src/llvm/projects/libtapi/CMakeLists.txt b/src/llvm/projects/libtapi/CMakeLists.txt
+index ecf9f24ca..a8edae638 100644
+--- a/src/llvm/projects/libtapi/CMakeLists.txt
++++ b/src/llvm/projects/libtapi/CMakeLists.txt
+@@ -176,6 +176,13 @@ option(TAPI_INCLUDE_TESTS "Generate build targets for the TAPI unit tests."
+ option(TAPI_INCLUDE_DOCS "Generate build targets for the TAPI docs."
+       ${LLVM_INCLUDE_DOCS})
+ 
++if (NOT DEFINED CLANG_VERSION)
++  set(CLANG_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
++endif ()
++if (NOT DEFINED CLANG_TABLEGEN_EXE)
++  set(CLANG_TABLEGEN_EXE "${LLVM_TOOLS_BINARY_DIR}/clang-tblgen")
++endif ()
++
+ # Include must go first.
+ add_subdirectory(include)
+ # All targets below may depend on all tablegen'd files.
+diff --git a/src/llvm/projects/libtapi/include/tapi/Diagnostics/CMakeLists.txt b/src/llvm/projects/libtapi/include/tapi/Diagnostics/CMakeLists.txt
+index 6240f15d3..375243432 100644
+--- a/src/llvm/projects/libtapi/include/tapi/Diagnostics/CMakeLists.txt
++++ b/src/llvm/projects/libtapi/include/tapi/Diagnostics/CMakeLists.txt
+@@ -1,5 +1,3 @@
+-#[[
+ tapi_clang_tablegen(DiagnosticTAPIKinds.inc -gen-clang-diags-defs
+   SOURCE DiagnosticTAPIKinds.td
+   TARGET TAPIDiagnosticTAPI)
+-]]
+diff --git a/src/llvm/projects/libtapi/include/tapi/Driver/DriverOptions.h b/src/llvm/projects/libtapi/include/tapi/Driver/DriverOptions.h
+index 49957d0db..b25c28776 100644
+--- a/src/llvm/projects/libtapi/include/tapi/Driver/DriverOptions.h
++++ b/src/llvm/projects/libtapi/include/tapi/Driver/DriverOptions.h
+@@ -36,7 +36,7 @@ enum ID {
+ #define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
+                HELPTEXT, METAVAR, VALUES)                                      \
+   OPT_##ID,
+-//#include "tapi/Driver/TAPIOptions.inc"
++#include "tapi/Driver/TAPIOptions.inc"
+   LastOption
+ #undef OPTION
+ };
+diff --git a/src/llvm/projects/libtapi/include/tapi/Driver/Snapshot.h b/src/llvm/projects/libtapi/include/tapi/Driver/Snapshot.h
+index 8d5fa9757..03401ea0a 100644
+--- a/src/llvm/projects/libtapi/include/tapi/Driver/Snapshot.h
++++ b/src/llvm/projects/libtapi/include/tapi/Driver/Snapshot.h
+@@ -6,7 +6,6 @@
+ // License. See LICENSE.TXT for details.
+ //
+ //===----------------------------------------------------------------------===//
+-#define TAPI_DRIVER_SNAPSHOT_H
+ #ifndef TAPI_DRIVER_SNAPSHOT_H
+ #define TAPI_DRIVER_SNAPSHOT_H
+ 
+diff --git a/src/llvm/projects/libtapi/include/tapi/Driver/SnapshotFileSystem.h b/src/llvm/projects/libtapi/include/tapi/Driver/SnapshotFileSystem.h
+index 59788e77f..ff0073579 100644
+--- a/src/llvm/projects/libtapi/include/tapi/Driver/SnapshotFileSystem.h
++++ b/src/llvm/projects/libtapi/include/tapi/Driver/SnapshotFileSystem.h
+@@ -11,7 +11,6 @@
+ /// \brief Defines the Snapshot Virtual File System.
+ ///
+ //===----------------------------------------------------------------------===//
+-#define TAPI_DRIVER_SNAPSHOT_FILE_SYSTEM_H
+ #ifndef TAPI_DRIVER_SNAPSHOT_FILE_SYSTEM_H
+ #define TAPI_DRIVER_SNAPSHOT_FILE_SYSTEM_H
+ 
+diff --git a/src/llvm/projects/libtapi/lib/Diagnostics/CMakeLists.txt b/src/llvm/projects/libtapi/lib/Diagnostics/CMakeLists.txt
+index f67657821..829b732db 100644
+--- a/src/llvm/projects/libtapi/lib/Diagnostics/CMakeLists.txt
++++ b/src/llvm/projects/libtapi/lib/Diagnostics/CMakeLists.txt
+@@ -1,4 +1,3 @@
+-#[[
+ add_tapi_library(tapiDiagnostics
+   Diagnostics.cpp
+ 
+@@ -8,4 +7,3 @@ add_tapi_library(tapiDiagnostics
+   LINK_LIBS
+   tapiCore
+   )
+-]]
+diff --git a/src/llvm/projects/libtapi/lib/Driver/CMakeLists.txt b/src/llvm/projects/libtapi/lib/Driver/CMakeLists.txt
+index a12f14442..11cc3c413 100644
+--- a/src/llvm/projects/libtapi/lib/Driver/CMakeLists.txt
++++ b/src/llvm/projects/libtapi/lib/Driver/CMakeLists.txt
+@@ -1,4 +1,3 @@
+-#[[
+ add_tapi_library(tapiDriver
+   API2XPIConverter.cpp
+   ArchiveDriver.cpp
+@@ -25,4 +24,3 @@ add_tapi_library(tapiDriver
+   tapiDiagnostics
+   tapiFrontend
+   )
+-]]
+diff --git a/src/llvm/projects/libtapi/tools/CMakeLists.txt b/src/llvm/projects/libtapi/tools/CMakeLists.txt
+index fcbf7c6cf..9a6fa2665 100644
+--- a/src/llvm/projects/libtapi/tools/CMakeLists.txt
++++ b/src/llvm/projects/libtapi/tools/CMakeLists.txt
+@@ -1,4 +1,4 @@
+ add_subdirectory(libtapi)
+-#add_subdirectory(tapi)
++add_subdirectory(tapi)
+ #add_subdirectory(tapi-run)
+ #add_subdirectory(tapi-frontend)
+diff --git a/src/llvm/projects/libtapi/tools/tapi/CMakeLists.txt b/src/llvm/projects/libtapi/tools/tapi/CMakeLists.txt
+index e6d3693fc..680b08890 100644
+--- a/src/llvm/projects/libtapi/tools/tapi/CMakeLists.txt
++++ b/src/llvm/projects/libtapi/tools/tapi/CMakeLists.txt
+@@ -30,4 +30,4 @@ install(TARGETS tapi
+ 
+ add_llvm_install_targets(install-tapi
+                          DEPENDS tapi install-tapi-clang-headers
+-                         COMPONENT tapi)
+\ No newline at end of file
++                         COMPONENT tapi)

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
   # not allowed for the stdenv.
   buildInputs = [ ncurses ];
 
+  postPatch = ''
+    patch -p3 < ${./build-tapi-command.patch}
+  '';
+
   cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=OFF" ];
 
   # fixes: fatal error: 'clang/Basic/Diagnostic.h' file not found
@@ -31,9 +35,9 @@ stdenv.mkDerivation rec {
     cmakeFlagsArray+=(-DCMAKE_CXX_FLAGS="$INCLUDE_FIX")
   '';
 
-  buildFlags = [ "clangBasic" "libtapi" ];
+  buildFlags = [ "clangBasic" "libtapi" "tapi" ];
 
-  installTargets = [ "install-libtapi" "install-tapi-headers" ];
+  installTargets = [ "install-libtapi" "install-tapi-headers" "install-tapi" ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     install_name_tool -id $out/lib/libtapi.dylib $out/lib/libtapi.dylib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This adds the `tapi` executable to the libtapi package. The `tapi` executable can be used to create TBD files, i.e. text-based stubs for macOS dynamic libraries.

The main use I have in mind for this is osxfuse (now macFUSE). The osxfuse library in nixpkgs is currently built from source, but this sadly isn't ideal because the library is closely tied to the osxfuse kernel extension which isn't packaged in nixpkgs. Replacing the current osxfuse library with a TBD would make FUSE packages work more reliably by making it link to the osxfuse library that matches its kernel counterpart.

I also did a quick check to see if I could use this copy of the tapi executable to generate [darwin-stubs](https://github.com/NixOS/nixpkgs/blob/36b27ccf777476ff6ff19e8df99d75681f820c98/pkgs/os-specific/darwin/darwin-stubs/default.nix), but that unfortunately didn't seem to work out well. This version of tapi lacks support for "zippered" binaries (whatever that means), so it couldn't generate a TBD for `libSystem.B.dylib`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Package closure size
```
/nix/store/6k24c94hwqn6zfq018whzzq1k1rg0nca-libtapi-1000.10.8	  46.0M  # 21.03pre256644.b3193b24e44
/nix/store/p66pkx6syhjfd4gxqckv1n68lf8pzvgz-libtapi-1000.10.8	  71.2M  # this PR
```