### PR TITLE
ocamlPackages: add ppxlib 0.20.0 and split ppxlib versions into different attrs

### DIFF
--- a/pkgs/development/ocaml-modules/cinaps/default.nix
+++ b/pkgs/development/ocaml-modules/cinaps/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildDunePackage, fetchurl, re, ppx_jane }:
+
+let
+  major = "0.14";
+in
+
+buildDunePackage rec {
+  pname = "cinaps";
+  version = "${major}.0";
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://ocaml.janestreet.com/ocaml-core/v${major}/files/cinaps-v${version}.tar.gz";
+    sha256 = "1zacmcp97c75r03l1p9wpg81qj9g2r52dhiag7xqhn94q33zklcc";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [ re ];
+
+  doCheck = true;
+  checkInputs = [ ppx_jane ];
+
+  meta = with lib; {
+    description = "Trivial Metaprogramming tool using the OCaml toplevel";
+    license = licenses.mit;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/ocaml-ppx/cinaps";
+  };
+}

--- a/pkgs/development/ocaml-modules/ppxlib/0.12.x.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/0.12.x.nix
@@ -1,30 +1,16 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml
-, legacy ? false
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 }:
 
-let param =
-  if legacy then {
-    version = "0.8.1";
-    sha256 = "0vm0jajmg8135scbg0x60ivyy5gzv4abwnl7zls2mrw23ac6kml6";
-  } else {
-    version = "0.12.0";
-    sha256 = "1cg0is23c05k1rc94zcdz452p9zn11dpqxm1pnifwx5iygz3w0a1";
-  }; in
-
-if lib.versionAtLeast ocaml.version "4.10" && legacy
-then throw "ppxlib-${param.version} is not available for OCaml ${ocaml.version}"
-else
-
 buildDunePackage rec {
   pname = "ppxlib";
-  inherit (param) version;
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = pname;
     rev = version;
-    inherit (param) sha256;
+    sha256 = "1cg0is23c05k1rc94zcdz452p9zn11dpqxm1pnifwx5iygz3w0a1";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/ppxlib/0.20.x.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/0.20.x.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
+, ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, sexplib0, stdlib-shims
+, stdio, base, cinaps
+}:
+
+buildDunePackage rec {
+  pname = "ppxlib";
+  version = "0.20.0";
+
+  minimumOCamlVersion = "4.04.1";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = pname;
+    rev = version;
+    sha256 = "0nwwvh58hf18wpfh6i5mgsykiaw0rj9vy5id4xmja36s3pm5bcn3";
+  };
+
+  propagatedBuildInputs = [
+    ocaml-compiler-libs ocaml-migrate-parsetree ppx_derivers sexplib0 stdlib-shims
+  ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.10";
+  checkInputs = [
+    stdio base cinaps
+  ];
+
+  meta = {
+    description = "Comprehensive ppx tool set";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/development/ocaml-modules/ppxlib/0.8.x.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/0.8.x.nix
@@ -1,0 +1,34 @@
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
+, ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
+}:
+
+let
+  version = "0.8.1";
+in
+
+if lib.versionAtLeast ocaml.version "4.10"
+then throw "ppxlib-${version} is not available for OCaml ${ocaml.version}"
+else
+
+buildDunePackage rec {
+  pname = "ppxlib";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = pname;
+    rev = version;
+    sha256 = "0vm0jajmg8135scbg0x60ivyy5gzv4abwnl7zls2mrw23ac6kml6";
+  };
+
+  propagatedBuildInputs = [
+    ocaml-compiler-libs ocaml-migrate-parsetree ppx_derivers stdio
+  ];
+
+  meta = {
+    description = "Comprehensive ppx tool set";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -129,6 +129,8 @@ let
 
     cil = callPackage ../development/ocaml-modules/cil { };
 
+    cinaps = callPackage ../development/ocaml-modules/cinaps { };
+
     cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
 
     cohttp = callPackage ../development/ocaml-modules/cohttp { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -806,7 +806,13 @@ let
 
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 
-    ppxlib = callPackage ../development/ocaml-modules/ppxlib { };
+    ppxlib = ppxlib-0-12;
+
+    ppxlib-0-12 = callPackage ../development/ocaml-modules/ppxlib { };
+
+    ppxlib-0-20 = callPackage ../development/ocaml-modules/ppxlib/0.20.x.nix {
+      ocaml-migrate-parsetree = ocaml-migrate-parsetree-2-1;
+    };
 
     psmt2-frontend = callPackage ../development/ocaml-modules/psmt2-frontend { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -808,7 +808,9 @@ let
 
     ppxlib = ppxlib-0-12;
 
-    ppxlib-0-12 = callPackage ../development/ocaml-modules/ppxlib { };
+    ppxlib-0-8 = callPackage ../development/ocaml-modules/ppxlib/0.8.x.nix { };
+
+    ppxlib-0-12 = callPackage ../development/ocaml-modules/ppxlib/0.12.x.nix { };
 
     ppxlib-0-20 = callPackage ../development/ocaml-modules/ppxlib/0.20.x.nix {
       ocaml-migrate-parsetree = ocaml-migrate-parsetree-2-1;
@@ -898,7 +900,9 @@ let
 
     ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
 
-    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
+    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc {
+      ppxlib = ppxlib-0-8;
+    };
 
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 
@@ -1078,14 +1082,14 @@ let
     then import ../development/ocaml-modules/janestreet/0.12.nix {
       inherit ctypes janePackage num octavius re;
       inherit (pkgs) openssl;
-      ppxlib = ppxlib.override { legacy = true; };
+      ppxlib = ppxlib-0-8;
     }
     else import ../development/ocaml-modules/janestreet {
       inherit janePackage ocamlbuild angstrom ctypes cryptokit;
       inherit magic-mime num ocaml-migrate-parsetree octavius ounit;
       inherit ppx_deriving re;
       inherit (pkgs) openssl;
-      ppxlib = ppxlib.override { legacy = true; };
+      ppxlib = ppxlib-0-8;
     };
 
     janeStreet_0_9_0 = import ../development/ocaml-modules/janestreet/old.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some new packages require newer `ppxlib` versions, but we can't update the 0.12.0 version we have, since it would break a lot of packages.

Also includes `cinaps` from #106344.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
