### PR TITLE
dgen: init at 1.33

### DIFF
--- a/pkgs/misc/emulators/dgen-sdl/default.nix
+++ b/pkgs/misc/emulators/dgen-sdl/default.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, fetchurl
+, libarchive
+, doxygen
+, SDL
+}:
+
+let
+  pname = "dgen-sdl";
+  version = "1.33";
+in stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/dgen/files/dgen/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-meLAYBfCKHPHf4gYbrzAmGckTrbgQsdjuwlLArje9h4=";
+  };
+
+  buildInputs = [ SDL libarchive ];
+
+  configureFlags = [
+    "--enable-joystick"
+    "--enable-debugger"
+    "--enable-debug-vdp"
+    "--enable-pico" # experimental
+    "--enable-vgmdump"
+    "--with-star=no" # Needs ASM support
+    "--with-musa"
+    "--with-cyclone=no" # Needs ASM support
+    "--with-mz80"
+    "--with-cz80"
+    "--with-drz80=no" # Needs ASM support
+    "--with-dz80"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://dgen.sourceforge.net/";
+    description = "Sega Genesis/Mega Drive emulator";
+    longDescription = ''
+      DGen/SDL is a free, open source emulator for Sega Genesis/Mega Drive
+      systems. DGen was originally written by Dave, then ported to SDL by Joe
+      Groff and Phil K. Hornung in 1998.
+
+      It features:
+
+      - Game Genie/Hex codes support
+      - PAL/NTSC, fullscreen modes
+      - Joypad/joystick support
+      - Mouse support
+      - Highly configurable controls
+      - OpenGL textured video output
+      - Portable (64‐bit, endian safe), runs in Windows using MinGW
+      - Screenshots, demos recording and playback
+      - Musashi (generic) and StarScream (x86‐only) CPU cores
+      - Cyclone 68000 and DrZ80 (both ARM‐only) CPU cores
+      - CZ80 (generic) and MZ80 (generic and x86‐only versions)
+      - 16‐bit, 8000 to 48000Hz sound output
+      - Support for 8, 15, 16, 24 and 32 bpp modes
+      - Archived/compressed ROMs support
+      - M68K debugger (contributed by Edd Barrett)
+      - Z80 debugger
+      - hqx and scale2x upscaling filters
+      - VGM dumping
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}
+# TODO: implement configure options

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2000,6 +2000,8 @@ in
 
   dlx = callPackage ../misc/emulators/dlx { };
 
+  dgen-sdl = callPackage ../misc/emulators/dgen-sdl { };
+
   doitlive = callPackage ../tools/misc/doitlive { };
 
   dokuwiki = callPackage ../servers/web-apps/dokuwiki { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
