### PR TITLE
maestral-gui: 1.2.1 -> 1.3.1

### DIFF
--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.3.0";
+  version = "1.3.1";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-WkjSIsr048b9iskjx6H36Jmvb+QtUmpW7JsYeVeXnhE=";
+    sha256 = "sha256-2S2sa2/HVt3IRsE98PT2XwpONjaYENBzYW+ezBFrJYI=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "maestral-qt";
-  version = "1.2.1";
+  version = "1.3.0";
   disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-qt";
     rev = "v${version}";
-    sha256 = "sha256-7qpVyQUbT+GChJl1TnKOONSyRDvzQ0M2z9RdN7PNl9U=";
+    sha256 = "sha256-WkjSIsr048b9iskjx6H36Jmvb+QtUmpW7JsYeVeXnhE=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -24,6 +24,8 @@ python3.pkgs.buildPythonApplication rec {
     maestral
     packaging
     pyqt5
+  ] ++ stdenv.lib.optionals (pythonOlder "3.9") [
+    importlib-resources
   ];
 
   nativeBuildInputs = [ wrapQtAppsHook ];

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.3.0";
+  version = "1.3.1";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "sha256-jAkSLWGv1UpdZslAast3Z5TnDCnxx5wNTxW4kvoH8GE=";
+    sha256 = "sha256-SspyTdmAbbmWN3AqVp9bj/QfAKLVgU2bLiiHjZO0aCM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/maestral/default.nix
+++ b/pkgs/development/python-modules/maestral/default.nix
@@ -3,20 +3,22 @@
 , fetchFromGitHub
 , pythonOlder
 , python
-, alembic, bugsnag, click, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, sqlalchemy, watchdog
+, alembic, bugsnag, click, dropbox, fasteners, keyring, keyrings-alt, packaging, pathspec, Pyro5, requests, setuptools, sdnotify, sqlalchemy, survey, watchdog
+, importlib-metadata
+, importlib-resources
 , dbus-next
 }:
 
 buildPythonPackage rec {
   pname = "maestral";
-  version = "1.2.1";
+  version = "1.3.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral";
     rev = "v${version}";
-    sha256 = "sha256-kh3FYBSVOU4ywrYl6ONEIbLbkSuZmexNJC9dB+JtUjM=";
+    sha256 = "sha256-jAkSLWGv1UpdZslAast3Z5TnDCnxx5wNTxW4kvoH8GE=";
   };
 
   propagatedBuildInputs = [
@@ -34,7 +36,12 @@ buildPythonPackage rec {
     setuptools
     sdnotify
     sqlalchemy
+    survey
     watchdog
+  ] ++ stdenv.lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ] ++ stdenv.lib.optionals (pythonOlder "3.9") [
+    importlib-resources
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     dbus-next
   ];

--- a/pkgs/development/python-modules/survey/default.nix
+++ b/pkgs/development/python-modules/survey/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, wrapio
+}:
+
+buildPythonPackage rec {
+  pname = "survey";
+  version = "3.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-R/PfXW/CnqYiOWbCxPAYwneg6j6CLvdIpITZ2eIXn+M=";
+  };
+
+  propagatedBuildInputs = [
+    wrapio
+  ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "survey" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Exahilosys/survey";
+    description = "A simple library for creating beautiful interactive prompts";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sfrijters ];
+  };
+}

--- a/pkgs/development/python-modules/wrapio/default.nix
+++ b/pkgs/development/python-modules/wrapio/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "wrapio";
+  version = "0.3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-jGupLh+xzwil+VBtAjIG+ZYT+dy+QaZOTIfipTQeyWo";
+  };
+
+  doCheck = false;
+  pythonImportsCheck = [ "wrapio" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Exahilosys/wrapio";
+    description = "Handling event-based streams";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sfrijters ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7801,6 +7801,8 @@ in {
 
   wptserve = callPackage ../development/python-modules/wptserve { };
 
+  wrapio = callPackage ../development/python-modules/wrapio { };
+
   wrapt = callPackage ../development/python-modules/wrapt { };
 
   wrf-python = callPackage ../development/python-modules/wrf-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3646,7 +3646,24 @@ in {
 
   macropy = callPackage ../development/python-modules/macropy { };
 
-  maestral = callPackage ../development/python-modules/maestral { };
+  maestral = callPackage ../development/python-modules/maestral {
+
+    # https://github.com/SamSchott/maestral/issues/250#issuecomment-739510048
+    survey = self.survey.overridePythonAttrs (old: rec {
+      version = "2.2.1";
+      src = old.src.override {
+        inherit version;
+        sha256 = "sha256-7ubWkqk1vyaJDLMOuKwUx2Bjziyi3HqpaQq4pKp4Z+0=";
+      };
+    });
+    watchdog = self.watchdog.overridePythonAttrs (old: rec {
+      version = "0.10.3";
+      src = old.src.override {
+        inherit version;
+        sha256 = "4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04";
+      };
+    });
+  };
 
   magic = callPackage ../development/python-modules/magic { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7113,6 +7113,8 @@ in {
 
   sure = callPackage ../development/python-modules/sure { };
 
+  survey = callPackage ../development/python-modules/survey { };
+
   suseapi = callPackage ../development/python-modules/suseapi { };
 
   svg2tikz = callPackage ../development/python-modules/svg2tikz { };


### PR DESCRIPTION
###### Motivation for this change

Upstream update.
Also added some missing requirements.

Note that the 1.3 release was a bit messy according to https://github.com/SamSchott/maestral/issues/250#issuecomment-739510048, hence the overrides for `watchdog` and `survey`. I tried to follow other similar occurrences in `python-packages.nix` but maybe this is not the way to go?

```
$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev maestral-1.3"
[...]
6 packages added:
python37Packages.survey (init at 3.1.1) python37Packages.wrapio (init at 0.3.8) python38Packages.survey (init at 3.1.1) python38Packages.wrapio (init at 0.3.8) python39Packages.survey (init at 3.1.1) python39Packages.wrapio (init at 0.3.8)

4 packages updated:
maestral (1.2.1 → 1.3.1) maestral-gui (1.2.1 → 1.3.1) python37Packages.maestral (1.2.1 → 1.3.1) python38Packages.maestral (1.2.1 → 1.3.1)
[...]
9 packages built:
maestral maestral-gui python37Packages.maestral python37Packages.survey python37Packages.wrapio python38Packages.survey python38Packages.wrapio python39Packages.survey python39Packages.wrapio
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
