### PR TITLE
cmake: patch namelink regression

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
@@ -12,15 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-
-  # can be removed once https://github.com/awslabs/aws-c-common/pull/735 gets merged, and version bumped
-  patches = [
-    (fetchpatch {
-      name = "fix-re-export-of-target.patch";
-      url = "https://github.com/awslabs/aws-c-common/pull/735/commits/3fca5c629ce0c4d66f50f7152685f3fe73941cb4.patch";
-      sha256 = "056f9kyg1c4lwjq8n0r28w1n3zbwrwpi1wbqabk99gaayg46x35a";
-    })
-  ];
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin
     "-Wno-nullability-extension -Wno-typedef-redefinition";

--- a/pkgs/development/libraries/aws-checksums/default.nix
+++ b/pkgs/development/libraries/aws-checksums/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "aws-checksums";
@@ -12,14 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-
-  # can be removed once https://github.com/awslabs/aws-checksums/pull/40 gets merged, and version bumped
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/awslabs/aws-checksums/pull/40/commits/fb5a57b3c072bd88e45de76fbb76bdc89c67b193.patch";
-      sha256 = "056f9kyg1c4lwjq8n0r28w1n3zbwrwpi1wbqabk99gaayg46x35a";
-    })
-  ];
 
   cmakeFlags = [ "-DBUILD_SHARED_LIBS:BOOL=ON" ];
 

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -38,6 +38,12 @@ stdenv.mkDerivation rec {
     # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
     ./libuv-application-services.patch
 
+    # Fix namelink failures, can be removed in 3.19.2+
+    (fetchpatch {
+      url = "https://gitlab.kitware.com/cmake/cmake/-/commit/38bcb5c0a3accd2dd29fb7632c6b3bf31b990d82.patch";
+      sha256 = "17yr66wrayhmavsz46b37zfwp2jcwab1zig2xqps39ysndf74qjc";
+    })
+
   ] ++ lib.optional stdenv.isCygwin ./3.2.2-cygwin.patch;
 
   outputs = [ "out" ];


### PR DESCRIPTION
###### Motivation for this change
see:
 - https://github.com/NixOS/nixpkgs/issues/106329
 - https://github.com/awslabs/aws-c-common/issues/734

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
