### PR TITLE
flask-appbuilder: fix flask-babel dep

### DIFF
--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -67,7 +67,8 @@ buildPythonPackage rec {
       --replace "PyJWT>=1.7.1" "PyJWT" \
       --replace "Flask-SQLAlchemy>=2.4, <3" "Flask-SQLAlchemy" \
       --replace "Flask-JWT-Extended>=3.18, <4" "Flask-JWT-Extended" \
-      --replace "Flask-Login>=0.3, <0.5" "Flask-Login"
+      --replace "Flask-Login>=0.3, <0.5" "Flask-Login" \
+      --replace "Flask-Babel>=1, <2" "Flask-Babel"
   '';
 
   # majority of tests require network access or mongo


### PR DESCRIPTION
###### Motivation for this change
Should fix this https://hydra.nixos.org/build/131278146

###### Things done
Fixed Flask-Babel dependency version condition

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
