### PR TITLE
rapidcheck: refactor `postInstall` to install all extras

### DIFF
--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchFromGitHub, rsync }:
+{ stdenv, cmake, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "rapidcheck";
@@ -11,12 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "0n8l0mlq9xqmpkgcj5xicicd1my2cfwxg25zdy8347dqkl1ppgbs";
   };
 
-  nativeBuildInputs = [ cmake rsync ];
+  nativeBuildInputs = [ cmake ];
 
   # Install the extras headers
   postInstall = ''
-    cd $src
-    rsync --filter="- **CMakeLists.txt" -acRv extras $out
+    cp -r $src/extras $out
+    chmod -R +w $out/extras
+    rm $out/extras/CMakeLists.txt
+    rm $out/extras/**/CMakeLists.txt
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchFromGitHub }:
+{ stdenv, cmake, fetchFromGitHub, rsync }:
 
 stdenv.mkDerivation rec {
   pname = "rapidcheck";
@@ -11,10 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "0n8l0mlq9xqmpkgcj5xicicd1my2cfwxg25zdy8347dqkl1ppgbs";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake rsync ];
 
+  # Install the extras headers
   postInstall = ''
-    cp ../extras/boost_test/include/rapidcheck/boost_test.h $out/include/rapidcheck
+    cd $src
+    rsync --filter="- **CMakeLists.txt" -acRv extras $out
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
RapidCheck's extras were not accessible through the package, with the exception of boost_test, which was being copied directly into the core include directory.  [RapidTest's documentation](https://github.com/emil-e/rapidcheck/blob/master/doc/boost_test.md#usage) for that module says to add the `extras/boost_test/include` directory to your include path, but the nixpkgs derivation for it puts the file in `$out/include/rapidtest`.

> This support is available through the `extras/boost_test` module. You can either directly add the `extras/boost_test/include` directory to your include path or link against the `rapidcheck_boost_test` target in your `CMakeLists.txt`. You can then simply `#include <rapidcheck/boost_test.h>`. Note that `rapidcheck/boost_test.h` needs to be included after any Boost Test headers.

This commit replaces the copy of that one header with an `rsync` of all files, except `CMakeLists.txt`s, from `$src/extras` into `$out/extras` so that the output path matches what the rapidtest documentation expects.  Accessing all extras is now possible by adding `"${pkgs.rapidtest}/extras/<extra>/include"` to your list of include paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
