### PR TITLE
vncdo: 0.11.2 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/vncdo/default.nix
+++ b/pkgs/development/python-modules/vncdo/default.nix
@@ -1,18 +1,23 @@
 { stdenv, fetchFromGitHub
-, python2Packages
+, buildPythonPackage, isPy27
+, pillow
+, twisted
+, pexpect
+, nose
+, ptyprocess
 }:
-python2Packages.buildPythonPackage {
+buildPythonPackage rec {
   pname = "vncdo";
-  version = "0.11.2";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "sibson";
     repo = "vncdotool";
-    rev = "5c03a82dcb5a3bd9e8f741f8a8d0c1ce082f2834";
-    sha256 = "0k03b09ipsz8vp362x7sx7z68mxgqw9qzvkii2f8j9vx2y79rjsh";
+    rev = "v${version}";
+    sha256 = "0h3ccr8zi7xpgn6hz43x1045x5l4bhha7py8x00g8bv6gaqlbwxn";
   };
 
-  propagatedBuildInputs = with python2Packages; [
+  propagatedBuildInputs = [
     pillow
     twisted
     pexpect
@@ -20,7 +25,7 @@ python2Packages.buildPythonPackage {
     ptyprocess
   ];
 
-  doCheck = false;
+  doCheck = !isPy27;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/sibson/vncdotool";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8340,7 +8340,7 @@ in
 
   vmtouch = callPackage ../tools/misc/vmtouch { };
 
-  vncdo = callPackage ../tools/admin/vncdo { };
+  vncdo = with python3Packages; toPythonApplication vncdo;
 
   volumeicon = callPackage ../tools/audio/volumeicon { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7690,6 +7690,8 @@ in {
 
   vmprof = callPackage ../development/python-modules/vmprof { };
 
+  vncdo = callPackage ../development/python-modules/vncdo { };
+
   vobject = callPackage ../development/python-modules/vobject { };
 
   voluptuous = callPackage ../development/python-modules/voluptuous { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Needed this in a project that uses vncdotool but it seems we've only supported the Python 2 variant since f8df74be4b4be4e9ddff6292c6600983357fbd54

Not sure if there are any functional differences or how well it works now, but the project I needed this for did stop complaining about missing imports for `vncdotool` and both Python 2 and Python 3 variants did build successfully.

Tests seemed to work fine with Python 3, but I wasn't able to get them working with Python 2, though I figure that's not too important now that Python 2 is EOL, etc.

`nixpkgs-review` seems to be happy?
<details>
<summary><span><code>nixpkgs review rev HEAD</code></span></summary>

```
vncdo/python2-and-3-support [$] ❯ nixpkgs-review rev HEAD
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 69, done.
remote: Counting objects: 100% (54/54), done.
remote: Compressing objects: 100% (13/13), done.
remote: Total 30 (delta 22), reused 18 (delta 14), pack-reused 0
Unpacking objects: 100% (30/30), 3.39 KiB | 267.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   3c535791c86..4a7bcab1d0a  master     -> refs/nixpkgs-review/0
$ git worktree add /home/evanjs/.cache/nixpkgs-review/rev-02860258e93460653967450b38fc6750f85b6ae1/nixpkgs 4a7bcab1d0a61d69688156376d5cdb38d81edff2
Preparing worktree (detached HEAD 4a7bcab1d0a)
Updating files: 100% (23482/23482), done.
HEAD is now at 4a7bcab1d0a flask-appbuilder: fix flask-babel dep
$ nix-env -f /home/evanjs/.cache/nixpkgs-review/rev-02860258e93460653967450b38fc6750f85b6ae1/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 02860258e93460653967450b38fc6750f85b6ae1
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/evanjs/.cache/nixpkgs-review/rev-02860258e93460653967450b38fc6750f85b6ae1/nixpkgs -qaP --xml --out-path --show-trace --meta
3 packages added:
python37Packages.vncdo (init at 0.12.0) python38Packages.vncdo (init at 0.12.0) python39Packages.vncdo (init at 0.12.0)

1 package updated:
vncdo (0.11.2 → 0.12.0)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/evanjs/.cache/nixpkgs-review/rev-02860258e93460653967450b38fc6750f85b6ae1/build.nix
3 packages built:
python37Packages.vncdo vncdo python39Packages.vncdo

$ nix-shell /home/evanjs/.cache/nixpkgs-review/rev-02860258e93460653967450b38fc6750f85b6ae1/shell.nix
these 4 paths will be fetched (0.51 MiB download, 2.47 MiB unpacked):
  /nix/store/63fv8bz35y6nkyif07mym7646n6qk4ns-bash-interactive-4.4-p23-dev
  /nix/store/82lxhlys1kvkvk9xlf8qd3ri6lwa43d3-bash-interactive-4.4-p23-info
  /nix/store/ab516d4hzp1z7nq8wqq3igzgagmnrc8j-bash-interactive-4.4-p23-doc
  /nix/store/l5pjvli9ln63yvnib9cmwvnq53sg5rby-bash-interactive-4.4-p23-man
copying path '/nix/store/ab516d4hzp1z7nq8wqq3igzgagmnrc8j-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/82lxhlys1kvkvk9xlf8qd3ri6lwa43d3-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/l5pjvli9ln63yvnib9cmwvnq53sg5rby-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/63fv8bz35y6nkyif07mym7646n6qk4ns-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
```

</details>


###### Things done
* Use `pythonPackages` instead of `python2Packages`

* Add `vncdo` to `top-level/python-packages` so the library can be used by
other Python programs
* Use `toPythonApplication` for vnc in `top-level/all-packages`
* run tests if using Python 3+