### PR TITLE
gerbera: revert fmt to supported version

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -45,4 +45,8 @@ in
     version = "7.1.3";
     sha256 = "08hyv73qp2ndbs0isk8pspsphdzz5qh8czl3wgyxy3mmif9xdg29";
   };
+  fmt_7_0_1 = generic {
+    version = "7.0.1";
+    sha256 = "1xxl3yjv38n8i6lify467qlhlas0yzpyl9y22fzayxq6famdry95";
+  };
 }

--- a/pkgs/servers/gerbera/default.nix
+++ b/pkgs/servers/gerbera/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub
 , cmake, pkg-config
 # required
-, libupnp, libuuid, pugixml, libiconv, sqlite, zlib, spdlog, fmt
+, libupnp, libuuid, pugixml, libiconv, sqlite, zlib, spdlog, fmt_7_0
 , pkgs
 # options
 , enableDuktape ? true
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [
-    libupnp libuuid pugixml libiconv sqlite zlib fmt.dev
+    libupnp libuuid pugixml libiconv sqlite zlib fmt_7_0.dev
     spdlog
   ]
   ++ optionals enableDuktape [ pkgs.duktape ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12849,7 +12849,7 @@ in
 
   flyway = callPackage ../development/tools/flyway { };
 
-  inherit (callPackages ../development/libraries/fmt { }) fmt_7;
+  inherit (callPackages ../development/libraries/fmt { }) fmt_7 fmt_7_0_1;
 
   fmt = fmt_7;
 


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/131263502, gerbera doesn't build

###### Things done
Bisected fmt to find which commit introduced a build failure. (Took a bit of time but hopefully I could reduce the build failure testing build with a restricted payload command : only building the few files concerned). This is the failing commit https://github.com/fmtlib/fmt/commit/a2c4fed9819340b8ab3604d36e2579ced7c586ee.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
