### PR TITLE
steamPackages.steam-runtime: 0.20200720.0 → 0.20201203.1

### DIFF
--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -1,8 +1,12 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl
+
+# for update script
+, writeShellScript, curl, nix-update
+}:
 
 stdenv.mkDerivation rec {
 
-  name = "steam-runtime";
+  pname = "steam-runtime";
   # from https://repo.steampowered.com/steamrt-images-scout/snapshots/
   version = "0.20200720.0";
 
@@ -16,6 +20,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     tar -C $out --strip=1 -x -f $src
   '';
+
+  passthru = {
+    updateScript = writeShellScript "update.sh" ''
+      version=$(${curl}/bin/curl https://repo.steampowered.com/steamrt-images-scout/snapshots/latest-steam-client-general-availability/VERSION.txt)
+      ${nix-update}/bin/nix-update --version "$version" steamPackages.steam-runtime
+    '';
+  };
 
   meta = with stdenv.lib; {
     description = "The official runtime used by Steam";

--- a/pkgs/games/steam/runtime.nix
+++ b/pkgs/games/steam/runtime.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
 
   pname = "steam-runtime";
   # from https://repo.steampowered.com/steamrt-images-scout/snapshots/
-  version = "0.20200720.0";
+  version = "0.20201203.1";
 
   src = fetchurl {
     url = "https://repo.steampowered.com/steamrt-images-scout/snapshots/${version}/steam-runtime.tar.xz";
-    sha256 = "03qdlr1xk84jb4c60ilis00vjhj70bxc0bbgk5g5b1883l2frljd";
+    sha256 = "sha256-hOHfMi0x3K82XM3m/JmGYbVk5RvuHG+m275eAC0MoQc=";
     name = "scout-runtime-${version}.tar.gz";
   };
 


### PR DESCRIPTION

###### Motivation for this change
bump the steam-runtime, having issues with crusader kings III

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
