### PR TITLE
plasma-workspace: fix QtQuick style used by KCMs

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -15,7 +15,7 @@
   appstream-qt,
 
   qtgraphicaleffects, qtquickcontrols, qtquickcontrols2, qtscript, qttools,
-  qtwayland, qtx11extras,
+  qtwayland, qtx11extras, qqc2-desktop-style,
 }:
 
 let inherit (lib) getBin getLib; in
@@ -34,7 +34,8 @@ mkDerivation {
     libqalculate networkmanager-qt phonon plasma-framework prison solid
     kholidays kquickcharts appstream-qt
 
-    qtgraphicaleffects qtquickcontrols qtquickcontrols2 qtscript qtwayland qtx11extras
+    qtgraphicaleffects qtquickcontrols qtquickcontrols2 qtscript qtwayland
+    qtx11extras qqc2-desktop-style
   ];
   propagatedUserEnvPkgs = [ qtgraphicaleffects ];
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

This lets the KCMs in `plasma-workspace` use the style provided by `qqc2-desktop-style` instead of the default QtQuick one. The KCMs in `plasma-desktop` already have this.

| Before | After |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/19176616/101550147-aeac3900-3963-11eb-949a-f742f0f10ac5.png" width=400>|<img src="https://user-images.githubusercontent.com/19176616/101550169-b5d34700-3963-11eb-8f95-9cf76f54f78f.png" width=400>|

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
