### PR TITLE
python3Packages.soco: fixup and adopt

### DIFF
--- a/pkgs/development/python-modules/soco/default.nix
+++ b/pkgs/development/python-modules/soco/default.nix
@@ -1,29 +1,60 @@
-{ lib, buildPythonPackage, fetchPypi, xmltodict, requests
-, toml
-
-# Test dependencies
-, pytest, pytestcov, coveralls, pylint, flake8, graphviz, mock, sphinx
+{ buildPythonPackage
+, coveralls
+, fetchFromGitHub
+, flake8
+, graphviz
+, lib
+, mock
+, pytestCheckHook
+, requests
+, sphinx
 , sphinx_rtd_theme
+, toml
+, xmltodict
 }:
 
 buildPythonPackage rec {
   pname = "soco";
   version = "0.20";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "929d4fae20b32efc08bb9985798c592aa7268162885541513eddbff0a757418f";
+  # N.B. We fetch from GitHub because the PyPI tarball doesn't contain the
+  # required files to run the tests.
+  src = fetchFromGitHub {
+    owner = "SoCo";
+    repo = "SoCo";
+    rev = "v${version}";
+    sha256 = "0p87aw7wxgdjz0m0nqqcfvbn24hlbq1hh1zxdq2c0k2jcbmaj8zc";
   };
 
-  propagatedBuildInputs = [ xmltodict requests toml ];
+  # N.B. These exist because:
+  # 1. Upstream's pinning isn't well maintained, leaving dependency versions no
+  #    longer in nixpkgs.
+  # 2. There is no benefit for us to be running linting and coverage tests.
+  postPatch = ''
+    sed -i "/black/d" ./requirements-dev.txt
+    sed -i "/pylint/d" ./requirements-dev.txt
+    sed -i "/pytest-cov/d" ./requirements-dev.txt
+  '';
+
+  propagatedBuildInputs = [
+    requests
+    toml
+    xmltodict
+  ];
   checkInputs = [
-    pytest pytestcov coveralls pylint flake8 graphviz mock sphinx
+    pytestCheckHook
+    coveralls
+    flake8
+    graphviz
+    mock
+    sphinx
     sphinx_rtd_theme
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "http://python-soco.com/";
     description = "A CLI and library to control Sonos speakers";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The package is currently failing to build and, in turn, breaking beets.

This fixes the build, as well as add me as maintainer, since the package was
orphaned.

cc. @jonringer, @supersandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
