### PR TITLE
steam: fix paradox launchers, and electron apps

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -268,6 +268,10 @@ in buildFHSUserEnv rec {
     broken = nativeOnly;
   };
 
+  # allows for some gui applications to share IPC
+  # this fixes certain issues where they don't render correctly
+  unshareIpc = false;
+
   passthru.run = buildFHSUserEnv {
     name = "steam-run";
 

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -35,6 +35,10 @@ let
       # Steam VR
       procps
       usbutils
+
+      # electron based launchers need newer versions of these libraries than what runtime provides
+      mesa
+      sqlite
     ] ++ lib.optional withJava jdk8 # TODO: upgrade https://github.com/NixOS/nixpkgs/pull/89731
       ++ lib.optional withPrimus primus
       ++ extraPkgs pkgs;
@@ -175,7 +179,6 @@ in buildFHSUserEnv rec {
     libidn
     tbb
     wayland
-    mesa
     libxkbcommon
 
     # Other things from runtime


### PR DESCRIPTION
###### Motivation for this change
Got tired of the paradox launcher failing to start correctly, preventing me from playing CK III whenever I want.

expanded the options passed to buildFHSUserEnvBubblewrap to allow for unsharing certain pieces, the defaults reflect the previous code. But allows for ipc to be passed through which allows for certain applications to render better.

cc @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/106409
37 packages built:
Sylk android-studio androidStudioPackages.beta androidStudioPackages.canary androidStudioPackages.dev deltachat-electron devdocs-desktop electronplayer irccloud joplin-desktop keeweb kodiPlugins.steam-launcher ledger-live-desktop lunar-client lutris lutris-free marktext minetime molotov mycrypto notable nuclear p3x-onenote plexamp runwayml ssb-patchwork standardnotes station steam steam-run steam-run-native steamcmd timeular tusk unityhub wootility zettlr
```