### PR TITLE
[staging] cdparanoia: cleanup, fix build on powerpc

### DIFF
--- a/pkgs/applications/audio/cdparanoia/default.nix
+++ b/pkgs/applications/audio/cdparanoia/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, autoreconfHook, gnu-config, IOKit, Carbon }:
+{ lib, stdenv, fetchurl, gnu-config, IOKit, Carbon }:
 
 stdenv.mkDerivation rec {
   name = "cdparanoia-III-10.2";
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
     ] ++ lib.optional stdenv.hostPlatform.isMusl ./utils.patch
     ++ [./fix_private_keyword.patch];
 
-  nativeBuildInputs = lib.optional stdenv.isAarch64 autoreconfHook;
-
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [
     Carbon
     IOKit
@@ -29,7 +27,9 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  preConfigure = "unset CC" + lib.optionalString stdenv.isAarch64 '';
+  preConfigure = ''
+    unset CC
+  '' + lib.optionalString (!stdenv.hostPlatform.isx86) ''
     cp ${gnu-config}/config.sub configure.sub
     cp ${gnu-config}/config.guess configure.guess
   '';


### PR DESCRIPTION
The configure helpers are old and already need to be updated on aarch64,
so let's just do this on all non-x86 platforms. This will probably fix
other architectures that weren't well-supported at the time.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes build on ppc64le (and possibly others)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
