### PR TITLE
[20.09] nomad: 0.11.4 -> 0.11.8, 0.12.2 -> 0.12.9

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.11.7";
-  sha256 = "sha256-wp1Je+I3iijD/pHHQtylMQhOiVhS6AT/y2/pUiLr0M4=";
+  version = "0.11.8";
+  sha256 = "1dhh07bifr02jh2lls8fv1d9ra67ymgh8qxqvpvm0cd0qdd469z1";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.11.5";
-  sha256 = "0g7i7qd0zksd7s8y4l63kk7xdc7nrw8radba6ws3hw0h2kr2cmp8";
+  version = "0.11.6";
+  sha256 = "09ym9fd4fp2461ddhrb5nlz8l24iq4hsbqikzc21ainagq2g1azf";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -1,6 +1,7 @@
-{ callPackage }:
+{ callPackage, buildGoPackage }:
 
 callPackage ./generic.nix {
+  inherit buildGoPackage;
   version = "0.11.4";
   sha256 = "1sykp9sji6f564s7bz0cvnr9w5x92n0l1r1djf1bl7jvv2mi1mcb";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.11.4";
-  sha256 = "1sykp9sji6f564s7bz0cvnr9w5x92n0l1r1djf1bl7jvv2mi1mcb";
+  version = "0.11.5";
+  sha256 = "0g7i7qd0zksd7s8y4l63kk7xdc7nrw8radba6ws3hw0h2kr2cmp8";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.11.6";
-  sha256 = "09ym9fd4fp2461ddhrb5nlz8l24iq4hsbqikzc21ainagq2g1azf";
+  version = "0.11.7";
+  sha256 = "sha256-wp1Je+I3iijD/pHHQtylMQhOiVhS6AT/y2/pUiLr0M4=";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.12.7";
-  sha256 = "0y1nwmpc4fqgjyb19n1f2w4y5k7fy4p68v2vnnry11nj3im7ia14";
+  version = "0.12.9";
+  sha256 = "1a0ig6pb0z3qp7zk4jgz3h241bifmjlyqsfikyy3sxdnzj7yha27";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.12.4";
-  sha256 = "0lwrkynq7iksfjk2m7i56l59d06gibyn6vd9bw80x5h08yw2zdks";
+  version = "0.12.5";
+  sha256 = "15cadw8rwdi7iphki8hg3jvxfh0cbxn4i0b1mds1j8z0s7j75mci";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.12.3";
-  sha256 = "100ynhc4nm4mmjxx1jhq2kjbqshxvi5x8y482520j8gsyn40g6zc";
+  version = "0.12.4";
+  sha256 = "0lwrkynq7iksfjk2m7i56l59d06gibyn6vd9bw80x5h08yw2zdks";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.12.6";
-  sha256 = "1fd7i50zc7g7d879bijh1ckvyq0h28169p6hw5ip71n71zhvvgp0";
+  version = "0.12.7";
+  sha256 = "0y1nwmpc4fqgjyb19n1f2w4y5k7fy4p68v2vnnry11nj3im7ia14";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -2,6 +2,6 @@
 
 callPackage ./generic.nix {
   inherit buildGoPackage;
-  version = "0.12.5";
-  sha256 = "15cadw8rwdi7iphki8hg3jvxfh0cbxn4i0b1mds1j8z0s7j75mci";
+  version = "0.12.6";
+  sha256 = "1fd7i50zc7g7d879bijh1ckvyq0h28169p6hw5ip71n71zhvvgp0";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,6 +1,7 @@
-{ callPackage }:
+{ callPackage, buildGoPackage }:
 
 callPackage ./generic.nix {
+  inherit buildGoPackage;
   version = "0.12.3";
   sha256 = "100ynhc4nm4mmjxx1jhq2kjbqshxvi5x8y482520j8gsyn40g6zc";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "0.12.2";
-  sha256 = "1gc286ag6plk5kxw7jzr32cp3n5rwydj1z7rds1rfd0fyq7an404";
+  version = "0.12.3";
+  sha256 = "100ynhc4nm4mmjxx1jhq2kjbqshxvi5x8y482520j8gsyn40g6zc";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5737,8 +5737,15 @@ in
   noip = callPackage ../tools/networking/noip { };
 
   nomad = nomad_0_11;
-  nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix { };
-  nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix { };
+  # Nomad never updates major go versions within a release series and is unsupported
+  # on Go versions that it did not ship with. Due to historic bugs when compiled
+  # with different versions we pin Go for all versions.
+  nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix {
+    buildGoPackage = buildGo114Package;
+  };
+  nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix {
+    buildGoPackage = buildGo114Package;
+  };
 
   notable = callPackage ../applications/misc/notable { };
 


### PR DESCRIPTION
###### Motivation for this change
closes: https://github.com/NixOS/nixpkgs/issues/106213
closes: https://github.com/NixOS/nixpkgs/issues/106215
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
