### PR TITLE
http-getter: unstable-2018-06-06 -> unstable-2020-12-08

### DIFF
--- a/pkgs/applications/networking/flent/http-getter.nix
+++ b/pkgs/applications/networking/flent/http-getter.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation {
   pname = "http-getter";
-  version = "unstable-2018-06-06";
+  version = "unstable-2020-12-08";
 
   src = fetchFromGitHub {
     owner = "tohojo";
     repo = "http-getter";
-    rev = "79bcccce721825a745f089d0c347bbaf2e6e12f4";
-    sha256 = "1zxk52s1h5qx62idil237zdpj8agrry0w1xwkfx05wvv9sw4ld35";
+    rev = "0b20f08133206aaf225946814ceb6b85ab37e136";
+    sha256 = "0plyqqwfm9bysichda0w3akbdxf6279wd4mx8mda0c4mxd4xy9nl";
   };
 
   buildInputs = [ cmake pkgconfig curl ];


### PR DESCRIPTION
Fixes build on darwin. No functional changes.

Diff: https://github.com/tohojo/http-getter/compare/79bcccce721825a745f089d0c347bbaf2e6e12f4...0b20f08133206aaf225946814ceb6b85ab37e136

Can be backported to 20.09.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
