### PR TITLE
libmodplug: Fix build on darwin

### DIFF
--- a/pkgs/development/libraries/libmodplug/default.nix
+++ b/pkgs/development/libraries/libmodplug/default.nix
@@ -1,10 +1,16 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, file }:
 
 let
   version = "0.8.9.0";
 in stdenv.mkDerivation rec {
   pname = "libmodplug";
   inherit version;
+
+  preConfigure = ''
+     substituteInPlace configure \
+        --replace ' -mmacosx-version-min=10.5' "" \
+        --replace /usr/bin/file ${file}/bin/file
+  '';
 
   meta = with stdenv.lib; {
     description = "MOD playing library";


### PR DESCRIPTION
###### Motivation for this change

The libmodplug builds on darwin are broken for quite some time. See #105573 

Removing the `-mmacosx-min-version` clang flag makes it work again.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
