### PR TITLE
Cassandra passthru tests

### DIFF
--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -67,6 +67,8 @@ rec {
 
           LOGFILE=/dev/null tests='exec(os.environ["testScript"])' ${driver}/bin/nixos-test-driver
         '';
+
+      passthru = driver.passthru;
     };
 
 
@@ -76,6 +78,7 @@ rec {
     , name ? "unnamed"
       # Skip linting (mainly intended for faster dev cycles)
     , skipLint ? false
+    , passthru ? {}
     , ...
     } @ t:
     let
@@ -137,7 +140,7 @@ rec {
             testScript = testScript';
             preferLocalBuild = true;
             testName = name;
-            passthru = {
+            passthru = passthru // {
               inherit nodes;
             };
           }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -49,7 +49,10 @@ in
   cadvisor = handleTestOn ["x86_64-linux"] ./cadvisor.nix {};
   cage = handleTest ./cage.nix {};
   cagebreak = handleTest ./cagebreak.nix {};
-  cassandra = handleTest ./cassandra.nix {};
+  cassandra_2_1 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_2_1; };
+  cassandra_2_2 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_2_2; };
+  cassandra_3_0 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_0; };
+  cassandra_3_11 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_11; };
   ceph-multi-node = handleTestOn ["x86_64-linux"] ./ceph-multi-node.nix {};
   ceph-single-node = handleTestOn ["x86_64-linux"] ./ceph-single-node.nix {};
   certmgr = handleTest ./certmgr.nix {};

--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -1,7 +1,5 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, testPackage ? pkgs.cassandra, ... }:
 let
-  # Change this to test a different version of Cassandra:
-  testPackage = pkgs.cassandra;
   clusterName = "NixOS Automated-Test Cluster";
 
   testRemoteAuth = lib.versionAtLeast testPackage.version "3.11";
@@ -47,7 +45,7 @@ let
   };
 in
 {
-  name = "cassandra";
+  name = "cassandra-${testPackage.version}";
   meta = {
     maintainers = with lib.maintainers; [ johnazoidberg ];
   };
@@ -128,4 +126,8 @@ in
             "nodetool status -p ${jmxPortStr} --resolve-ip | egrep '^UN[[:space:]]+cass2'"
         )
   '';
+
+  passthru = {
+    inherit testPackage;
+  };
 })

--- a/pkgs/servers/nosql/cassandra/2.1.nix
+++ b/pkgs/servers/nosql/cassandra/2.1.nix
@@ -3,4 +3,5 @@
 callPackage ./generic.nix (args // {
   version = "2.1.22";
   sha256 = "1wk57dz0kmc6d5y8d8dkx269lzh3ark3751z734gxncwdlclcyz3";
+  generation = "2_1";
 })

--- a/pkgs/servers/nosql/cassandra/2.2.nix
+++ b/pkgs/servers/nosql/cassandra/2.2.nix
@@ -1,6 +1,7 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "2.2.19";
-  sha256 = "1f8axpxxpmzlb22k3lqsnw3096qjp6xd36brvq5xbdk698jw15jl";
+  version = "2.2.14";
+  sha256 = "1b2x3q1ach44qg07sh8wr7d8a10n36w5522drd3p35djbiwa3d9q";
+  generation = "2_2";
 })

--- a/pkgs/servers/nosql/cassandra/3.0.nix
+++ b/pkgs/servers/nosql/cassandra/3.0.nix
@@ -3,4 +3,5 @@
 callPackage ./generic.nix (args // {
   version = "3.0.23";
   sha256 = "0cbia20bggq85q2p6gsybw045qdfqxd5xv8ihppq1hwl21sb2klz";
+  generation = "3_0";
 })

--- a/pkgs/servers/nosql/cassandra/3.11.nix
+++ b/pkgs/servers/nosql/cassandra/3.11.nix
@@ -3,4 +3,5 @@
 callPackage ./generic.nix (args // {
   version = "3.11.9";
   sha256 = "1ckaacc1z0j72llklrc4587ia6a0pab02bdyac6g3kl6kqvcz40c";
+  generation = "3_11";
 })

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl, python, makeWrapper, gawk, bash, getopt, procps
-, which, jre, version, sha256, coreutils, ...
+, which, jre, coreutils, nixosTests
+# generation is the attribute version suffix such as 3_11 in pkgs.cassandra_3_11
+, generation
+, version, sha256
+, ...
 }:
 
 let
@@ -82,6 +86,17 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin
     '';
+
+  passthru = {
+    tests =
+      let
+        test = nixosTests."cassandra_${generation}";
+      in {
+        nixos =
+          assert test.testPackage.version == version;
+          test;
+      };
+  };
 
   meta = with stdenv.lib; {
     homepage = "http://cassandra.apache.org/";

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -103,6 +103,6 @@ stdenv.mkDerivation rec {
     description = "A massively scalable open source NoSQL database";
     platforms = platforms.unix;
     license = licenses.asl20;
-    maintainers = [];
+    maintainers = [ maintainers.roberth ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Automate cassandra testing via ofborg.
 - Support passthru in NixOS tests (may have other uses)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date - **doesn't seem worth writing down. It just works, if you need it. Need is rare, so avoid noise in docs.**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
