### PR TITLE
osm2pgsql: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/tools/misc/osm2pgsql/default.nix
+++ b/pkgs/tools/misc/osm2pgsql/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osm2pgsql";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = pname;
     rev = version;
-    sha256 = "1dsyhcifixmcw05qxjald02pml0zfdij81pgy9yh8p00v0rqq57x";
+    sha256 = "1if76vw9jkc9jn4v0vvgwnpscjckk2cap93a8iqah8mqzx233y8s";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "OpenStreetMap data to PostgreSQL converter";
-    homepage = "https://github.com/openstreetmap/osm2pgsql";
+    homepage = "https://osm2pgsql.org";
     license = licenses.gpl2;
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ jglukasik das-g ];


### PR DESCRIPTION
###### Motivation for this change

- [Upstream release](https://github.com/openstreetmap/osm2pgsql/releases/tag/1.4.0) ([news entry](https://osm2pgsql.org/news/2020/12/07/release-1.4.0.html) on new website https://osm2pgsql.org)
- new project website https://osm2pgsql.org


###### Note on upstream man page build changes

The man page is now [maintained in Markdown](https://github.com/openstreetmap/osm2pgsql/blob/1.4.0/docs/osm2pgsql.md) and converted with Pandoc, but as the [compiled version of the man page is checked into the repo](https://github.com/openstreetmap/osm2pgsql/blob/1.4.0/docs/osm2pgsql.1) by upstream, we don't need to do that conversion as part of our build and the derivation doesn't have to depend on Pandoc. See README.md of [upstream's `docs/` subdir](https://github.com/openstreetmap/osm2pgsql/tree/1.4.0/docs).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
