### PR TITLE
yaml-language-server: Fails to start due to missing `prettier` dependency

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -258,5 +258,13 @@ let
         echo /var/lib/thelounge > $out/lib/node_modules/thelounge/.thelounge_home
       '';
     };
+
+    yaml-language-server = super.yaml-language-server.override {
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postInstall = ''
+        wrapProgram "$out/bin/yaml-language-server" \
+        --prefix NODE_PATH : ${self.prettier}/lib/node_modules
+      '';
+    };
   };
 in self


### PR DESCRIPTION
Latest `yaml-language-server` fails to start:

```
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'prettier'
Require stack:
- /nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlFormatter.js
- /nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.js
- /nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/server.js
- /nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/bin/yaml-language-server
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlFormatter.js:9:18)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlFormatter.js',
    '/nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.js',
    '/nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/out/server/src/server.js',
    '/nix/store/0rgyg64rwgi2vpk27bi84094h27sd2w9-node_yaml-language-server-0.13.0/lib/node_modules/yaml-language-server/bin/yaml-language-server'
  ]
}
```

Problem goes away if `prettier-2.2.1` is added as a dependency to the node package for `yaml-language-server`