### PR TITLE
sbc: 1.4 -> 1.5

### DIFF
--- a/pkgs/development/libraries/sbc/default.nix
+++ b/pkgs/development/libraries/sbc/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, libsndfile }:
 
 stdenv.mkDerivation rec {
-  name = "sbc-1.4";
+  pname = "sbc";
+  version = "1.5";
 
   src = fetchurl {
-    url = "http://www.kernel.org/pub/linux/bluetooth/${name}.tar.xz";
-    sha256 = "1jal98pnrjkzxlkiqy0ykh4qmgnydz9bmsp1jn581p5kddpg92si";
+    url = "http://www.kernel.org/pub/linux/bluetooth/${pname}-${version}.tar.xz";
+    sha256 = "1liig5856crb331dps18mp0s13zbkv7yh007zqhq97m94fcddfhc";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -14,6 +15,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "SubBand Codec Library";
     homepage = "http://www.bluez.org/";
+    maintainers = with maintainers; [ gebner ];
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
