### PR TITLE
nixos/clamav-unofficial-sigs: init at 7.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -808,6 +808,7 @@
   ./services/security/certmgr.nix
   ./services/security/cfssl.nix
   ./services/security/clamav.nix
+  ./services/security/clamav-unofficial-sigs.nix
   ./services/security/fail2ban.nix
   ./services/security/fprintd.nix
   ./services/security/fprot.nix

--- a/nixos/modules/services/security/clamav-unofficial-sigs.nix
+++ b/nixos/modules/services/security/clamav-unofficial-sigs.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.clamav-unofficial-sigs;
+in {
+  options.services.clamav-unofficial-sigs = with types; {
+    enable = mkEnableOption "Unofficial ClamAV signatures";
+
+    user = mkOption {
+      type = str;
+      description = "User to run systemd service under";
+      default = "clamav";
+    };
+
+    group = mkOption {
+      type = str;
+      description = "Group to run systemd service under. Should be the same as used by clamav in order to allow this service access to the clamav database.";
+      default = "clamav";
+    };
+
+    extraConfig = mkOption {
+      type = attrsOf str;
+      description = "Extra key-value pairs to configure in user.conf";
+      example = { malwarepatrol_receipt_code = "YOUR-RECEIPT-NUMBER"; };
+      default = {};
+    };
+
+    extraConfigFiles = mkOption {
+      type = listOf str;
+      description = "Extra configuration files to include";
+      default = [];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d /var/lib/secrets/clamav-unofficial-sigs 0700 ${cfg.user} ${cfg.group} -"
+    ];
+
+    systemd.services.clamav-unofficial-sigs = {
+      startAt = "hourly";
+      description = "Update unofficial ClamAV signatures";
+
+      serviceConfig = {
+        ExecStart = "${pkgs.clamav-unofficial-sigs}/bin/clamav-unofficial-sigs.sh";
+        User = "${cfg.user}";
+        Group = "${cfg.group}";
+        StateDirectory = "clamav-unofficial-sigs";
+        ReadWritePaths = [ "/var/lib/clamav/" ];
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+
+        ProtectKernelModules = true;
+        SystemCallArchitectures = "native";
+        ProtectKernelLogs = true;
+        ProtectClock = true;
+
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+
+        LockPersonality = true;
+        ProtectHostname = true;
+        RestrictRealtime = true;
+        MemoryDenyWriteExecute = true;
+        RestrictNamespaces = true;
+        RemoveIPC = true;
+        UMask = "0077";
+      };
+    };
+
+    environment.etc."clamav-unofficial-sigs/master.conf".source = "${pkgs.clamav-unofficial-sigs}/etc/clamav-unofficial-sigs/master.conf";
+    environment.etc."clamav-unofficial-sigs/os.conf".source = "${pkgs.clamav-unofficial-sigs}/etc/clamav-unofficial-sigs/os.conf";
+    environment.etc."clamav-unofficial-sigs/user.conf".text = ''
+      ${concatStringsSep "\n" (mapAttrsToList (k: v: ''${k}="${v}"'') cfg.extraConfig)}
+      ${concatStringsSep "\n" (map (path: "source '${path}'") cfg.extraConfigFiles)}
+    '';
+  };
+}

--- a/nixos/modules/services/security/clamav-unofficial-sigs.nix
+++ b/nixos/modules/services/security/clamav-unofficial-sigs.nix
@@ -6,18 +6,6 @@ in {
   options.services.clamav-unofficial-sigs = with types; {
     enable = mkEnableOption "Unofficial ClamAV signatures";
 
-    user = mkOption {
-      type = str;
-      description = "User to run systemd service under";
-      default = "clamav";
-    };
-
-    group = mkOption {
-      type = str;
-      description = "Group to run systemd service under. Should be the same as used by clamav in order to allow this service access to the clamav database.";
-      default = "clamav";
-    };
-
     extraConfig = mkOption {
       type = attrsOf str;
       description = "Extra key-value pairs to configure in user.conf";
@@ -33,18 +21,14 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d /var/lib/secrets/clamav-unofficial-sigs 0700 ${cfg.user} ${cfg.group} -"
-    ];
-
     systemd.services.clamav-unofficial-sigs = {
       startAt = "hourly";
       description = "Update unofficial ClamAV signatures";
 
       serviceConfig = {
         ExecStart = "${pkgs.clamav-unofficial-sigs}/bin/clamav-unofficial-sigs";
-        User = "${cfg.user}";
-        Group = "${cfg.group}";
+        User = "clamav";
+        Group = "clamav";
         StateDirectory = "clamav-unofficial-sigs";
         ReadWritePaths = [ "/var/lib/clamav/" ];
 

--- a/nixos/modules/services/security/clamav-unofficial-sigs.nix
+++ b/nixos/modules/services/security/clamav-unofficial-sigs.nix
@@ -42,7 +42,7 @@ in {
       description = "Update unofficial ClamAV signatures";
 
       serviceConfig = {
-        ExecStart = "${pkgs.clamav-unofficial-sigs}/bin/clamav-unofficial-sigs.sh";
+        ExecStart = "${pkgs.clamav-unofficial-sigs}/bin/clamav-unofficial-sigs";
         User = "${cfg.user}";
         Group = "${cfg.group}";
         StateDirectory = "clamav-unofficial-sigs";

--- a/pkgs/tools/security/clamav-unofficial-sigs.nix
+++ b/pkgs/tools/security/clamav-unofficial-sigs.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, clamav, rsync, coreutils, gnutar, curl, gzip, dnsutils, gnupg, glibc, gawk, diffutils, bind }:
+
+stdenv.mkDerivation rec {
+  pname = "clamav-unofficial-sigs";
+  version = "7.2";
+
+  src = fetchFromGitHub {
+    owner = "extremeshok";
+    repo = "clamav-unofficial-sigs";
+    rev = "${version}";
+    sha256 = "sha256-KZh8f4BB31b4ZBOrp4z/+TCqsppa2cyfteM3OUVv57A=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/etc/clamav-unofficial-sigs
+    mkdir -p $out/bin
+
+    cp clamav-unofficial-sigs.sh $out/bin
+    chmod +x $out/bin/clamav-unofficial-sigs.sh
+
+    cp config/master.conf $out/etc/clamav-unofficial-sigs
+
+    echo '
+    allow_upgrades="no"
+    allow_update_checks="no"
+    clam_user="clamav"
+    clam_group="clamav"
+    clamd_pid="/run/clamav/clamd.pid"
+    clamd_socket="/run/clamav/clamd.ctl"
+    log_pipe_cmd="systemd-cat -t clamav-unofficial-sigs"
+    enable_random="no"
+    user_configuration_complete="yes"
+    ' > $out/etc/clamav-unofficial-sigs/os.conf
+
+    wrapProgram $out/bin/clamav-unofficial-sigs.sh --prefix PATH : "${lib.makeBinPath [ clamav coreutils gzip rsync gnutar curl dnsutils bind.host gnupg glibc gawk diffutils ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/extremeshok/clamav-unofficial-sigs";
+    description = "ClamAV Unofficial Signatures Updater";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ SlothOfAnarchy ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/security/clamav-unofficial-sigs.nix
+++ b/pkgs/tools/security/clamav-unofficial-sigs.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, clamav, rsync, coreutils, gnutar, curl, gzip, dnsutils, gnupg, glibc, gawk, diffutils, bind }:
+{ stdenv, fetchFromGitHub, makeWrapper, clamav, rsync, coreutils, gnutar, curl, gzip, dnsutils, gnupg, glibc, gawk, diffutils, bind }:
 
 stdenv.mkDerivation rec {
   pname = "clamav-unofficial-sigs";
@@ -7,18 +7,17 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "extremeshok";
     repo = "clamav-unofficial-sigs";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-KZh8f4BB31b4ZBOrp4z/+TCqsppa2cyfteM3OUVv57A=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/etc/clamav-unofficial-sigs
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/etc/clamav-unofficial-sigs
 
-    cp clamav-unofficial-sigs.sh $out/bin
-    chmod +x $out/bin/clamav-unofficial-sigs.sh
+    cp clamav-unofficial-sigs.sh $out/bin/clamav-unofficial-sigs
+    chmod +x $out/bin/clamav-unofficial-sigs
 
     cp config/master.conf $out/etc/clamav-unofficial-sigs
 
@@ -34,7 +33,8 @@ stdenv.mkDerivation rec {
     user_configuration_complete="yes"
     ' > $out/etc/clamav-unofficial-sigs/os.conf
 
-    wrapProgram $out/bin/clamav-unofficial-sigs.sh --prefix PATH : "${lib.makeBinPath [ clamav coreutils gzip rsync gnutar curl dnsutils bind.host gnupg glibc gawk diffutils ]}"
+    wrapProgram $out/bin/clamav-unofficial-sigs \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ clamav coreutils gzip rsync gnutar curl dnsutils bind.host gnupg glibc gawk diffutils ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/clamav-unofficial-sigs.nix
+++ b/pkgs/tools/security/clamav-unofficial-sigs.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, makeWrapper, clamav, rsync, coreutils, gnutar, curl, gzip, dnsutils, gnupg, glibc, gawk, diffutils, bind }:
+{ stdenv, fetchFromGitHub, makeWrapper, clamav, rsync, coreutils, gnutar, gnugrep, curl, gzip, dnsutils, gnupg, glibc, gawk, diffutils }:
 
 stdenv.mkDerivation rec {
   pname = "clamav-unofficial-sigs";
-  version = "7.2";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "extremeshok";
     repo = "clamav-unofficial-sigs";
     rev = version;
-    sha256 = "sha256-KZh8f4BB31b4ZBOrp4z/+TCqsppa2cyfteM3OUVv57A=";
+    sha256 = "sha256-utGr7phrLyZojTVg1V2MnlhYmCBP6K6L4OYfug+/5D0=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     ' > $out/etc/clamav-unofficial-sigs/os.conf
 
     wrapProgram $out/bin/clamav-unofficial-sigs \
-      --prefix PATH : "${stdenv.lib.makeBinPath [ clamav coreutils gzip rsync gnutar curl dnsutils bind.host gnupg glibc gawk diffutils ]}"
+      --prefix PATH : "${stdenv.lib.makeBinPath [ clamav coreutils gzip rsync gnutar gnugrep curl dnsutils gnupg glibc gawk diffutils ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3120,6 +3120,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
 
+  clamav-unofficial-sigs = callPackage ../tools/security/clamav-unofficial-sigs.nix {};
+
   clex = callPackage ../tools/misc/clex { };
 
   client-ip-echo = callPackage ../servers/misc/client-ip-echo { };


### PR DESCRIPTION
###### Motivation for this change

Initialize package and module for https://github.com/extremeshok/clamav-unofficial-sigs

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ajs124 