### PR TITLE
feedparser: keep 5.2.1 available for python-2.7

### DIFF
--- a/pkgs/applications/networking/feedreaders/rawdog/default.nix
+++ b/pkgs/applications/networking/feedreaders/rawdog/default.nix
@@ -11,6 +11,10 @@ python2Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python2Packages; [ feedparser ];
 
+  # Requested by @SuperSandro20001
+  pythonImportsCheck = [ "feedparser" ];
+  doCheck = false;
+
   namePrefix = "";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/feedparser/5.nix
+++ b/pkgs/development/python-modules/feedparser/5.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "feedparser";
+  version = "5.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ycva69bqssalhqg45rbrfipz3l6hmycszy26k0351fhq990c0xx";
+  };
+
+  # lots of networking failures
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/kurtmckee/feedparser";
+    description = "Universal feed parser";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2070,7 +2070,10 @@ in {
 
   feedgenerator = callPackage ../development/python-modules/feedgenerator { inherit (pkgs) glibcLocales; };
 
-  feedparser = callPackage ../development/python-modules/feedparser { };
+  feedparser = if isPy3k then
+    callPackage ../development/python-modules/feedparser { }
+  else
+    callPackage ../development/python-modules/feedparser/5.nix { };
 
   fenics = callPackage ../development/libraries/science/math/fenics {
     inherit (pkgs) pkg-config;


### PR DESCRIPTION
###### Motivation for this change

Fix python-2.7 packages that depend on feedparser (calibre-py2 being the case that interests me), as recorded in #106448

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
