### PR TITLE
python3Packages.[psautohint, afdko]: disable slow & failing tests

### DIFF
--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -3,7 +3,7 @@
 , brotli, fontmath, mutatormath, booleanoperations
 , ufoprocessor, ufonormalizer, psautohint, tqdm
 , setuptools_scm
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -52,10 +52,18 @@ buildPythonPackage rec {
   # https://github.com/adobe-type-tools/afdko/issues/1163
   # https://github.com/adobe-type-tools/afdko/issues/1216
   doCheck = stdenv.isx86_64;
-  checkInputs = [ pytest ];
-  checkPhase = ''
-    PATH="$PATH:$out/bin" py.test
-  '';
+  checkInputs = [ pytestCheckHook ];
+  preCheck = "export PATH=$PATH:$out/bin";
+  disabledTests = [
+    # Disable slow tests, reduces test time ~25 %
+    "test_report"
+    "test_post_overflow"
+    "test_cjk"
+    "test_extrapolate"
+    "test_filename_without_dir"
+    "test_overwrite"
+    "test_options"
+  ];
 
   meta = with stdenv.lib; {
     description = "Adobe Font Development Kit for OpenType";

--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder
 , fonttools, lxml, fs
 , setuptools_scm
-, pytest, pytestcov, pytest_xdist, pytest-randomly
+, pytestCheckHook, pytest_5, pytestcov, pytest_xdist
 }:
 
 buildPythonPackage rec {
@@ -11,10 +11,10 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    owner  = "adobe-type-tools";
-    repo   = pname;
+    owner = "adobe-type-tools";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "1s2l54gzn11y07zaggprwif7r3ia244qijjhkbvjdx4jsgc5df8n";
-    rev    = "v${version}";
     fetchSubmodules = true; # data dir for tests
   };
 
@@ -28,8 +28,24 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ fonttools lxml fs ];
 
-  checkInputs = [ pytest pytestcov pytest_xdist pytest-randomly ];
-  checkPhase = "pytest tests";
+  checkInputs = [
+    # Override pytestCheckHook to use pytest v5, because some tests fail on pytest >= v6
+    # https://github.com/adobe-type-tools/psautohint/issues/284#issuecomment-742800965
+    # Override might be able to be removed in future, check package dependency pins (coverage.yml)
+    (pytestCheckHook.override{ pytest = pytest_5; })
+    pytestcov
+    pytest_xdist
+  ];
+  disabledTests = [
+    # Slow tests, reduces test time from ~5 mins to ~30s
+    "test_mmufo"
+    "test_flex_ufo"
+    "test_ufo"
+    "test_flex_otf"
+    "test_multi_outpath"
+    "test_mmhint"
+    "test_otf"
+  ];
 
   meta = with lib; {
     description = "Script to normalize the XML and other data inside of a UFO";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

When building a NixOS build on Raspberry Pi, found that ``python3Packages.psautohint`` was taking FAR too long to build (~5 mins for native x86 build). This disables the slowest tests and fixes up a few minor issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
