### PR TITLE
GlobalProtect-OpenConnect: init at 1.2.6

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -692,6 +692,7 @@
   ./services/networking/gdomap.nix
   ./services/networking/ghostunnel.nix
   ./services/networking/git-daemon.nix
+  ./services/networking/globalprotect-vpn.nix
   ./services/networking/gnunet.nix
   ./services/networking/go-neb.nix
   ./services/networking/go-shadowsocks2.nix

--- a/nixos/modules/services/networking/globalprotect-vpn.nix
+++ b/nixos/modules/services/networking/globalprotect-vpn.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.globalprotect;
+
+  execStart = if cfg.csdWrapper == null then
+      "${pkgs.globalprotect-openconnect}/bin/gpservice"
+    else
+      "${pkgs.globalprotect-openconnect}/bin/gpservice --csd-wrapper=${cfg.csdWrapper}";
+in
+
+{
+  options.services.globalprotect = {
+    enable = mkEnableOption "globalprotect";
+
+    csdWrapper = mkOption {
+      description = ''
+        A script that will produce a Host Integrity Protection (HIP) report,
+        as described at <link xlink:href="https://www.infradead.org/openconnect/hip.html" />
+      '';
+      default = null;
+      example = literalExample "\${pkgs.openconnect}/libexec/openconnect/hipreport.sh";
+      type = types.nullOr types.path;
+    };
+  };
+
+  config = {
+    services.dbus.packages = [ pkgs.globalprotect-openconnect ];
+
+    systemd.services.gpservice = {
+      description = "GlobalProtect openconnect DBus service";
+      serviceConfig = {
+        Type="dbus";
+        BusName="com.yuezk.qt.GPService";
+        ExecStart=execStart;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+    };
+  };
+}

--- a/pkgs/tools/networking/globalprotect-openconnect/default.nix
+++ b/pkgs/tools/networking/globalprotect-openconnect/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchFromGitHub
+, qmake, qtwebsockets, qtwebengine, wrapQtAppsHook, openconnect
+}:
+
+stdenv.mkDerivation rec {
+  pname = "globalprotect-openconnect";
+  version = "1.2.6";
+
+  src = fetchFromGitHub {
+    owner = "yuezk";
+    repo = "GlobalProtect-openconnect";
+    rev = "c14a6ad1d2b62f8d297bc4cfbcb1dcea4d99112f";
+    fetchSubmodules = true;
+    sha256 = "1zkc3vk1j31n2zs5ammzv23dah7x163gfrzz222ynbkvsccrhzrk";
+  };
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  buildInputs = [ openconnect qtwebsockets qtwebengine ];
+
+  patchPhase = ''
+    for f in GPClient/GPClient.pro \
+      GPClient/com.yuezk.qt.gpclient.desktop \
+      GPService/GPService.pro \
+      GPService/dbus/com.yuezk.qt.GPService.service \
+      GPService/systemd/gpservice.service; do
+        substituteInPlace $f \
+          --replace /usr $out \
+          --replace /etc $out/lib;
+    done;
+
+    substituteInPlace GPService/gpservice.h \
+      --replace /usr/local/bin/openconnect ${openconnect}/bin/openconnect;
+  '';
+
+  meta = with lib; {
+    description = "GlobalProtect VPN client (GUI) for Linux based on OpenConnect that supports SAML auth mode";
+    homepage = "https://github.com/yuezk/GlobalProtect-openconnect";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.jerith666 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -9,7 +9,7 @@
 , stoken
 , zlib
 , fetchgit
-, darwin
+, PCSC
 , head ? false
   , fetchFromGitLab
   , autoreconfHook
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openssl gnutls gmp libxml2 stoken zlib ]
-    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.PCSC;
+    ++ lib.optional stdenv.isDarwin PCSC;
   nativeBuildInputs = [ pkg-config ]
     ++ lib.optional head autoreconfHook;
 

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -8,7 +8,7 @@
 , libxml2
 , stoken
 , zlib
-, fetchgit
+, vpnc-scripts
 , PCSC
 , head ? false
   , fetchFromGitLab
@@ -17,13 +17,7 @@
 
 assert (openssl != null) == (gnutls == null);
 
-let vpnc = fetchgit {
-  url = "git://git.infradead.org/users/dwmw2/vpnc-scripts.git";
-  rev = "c0122e891f7e033f35f047dad963702199d5cb9e";
-  sha256 = "11b1ls012mb704jphqxjmqrfbbhkdjb64j2q4k8wb5jmja8jnd14";
-};
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "openconnect${lib.optionalString head "-head"}";
   version = if head then "2021-05-05" else "8.10";
 
@@ -42,7 +36,7 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   configureFlags = [
-    "--with-vpnc-script=${vpnc}/vpnc-script"
+    "--with-vpnc-script=${vpnc-scripts}/bin/vpnc-script"
     "--disable-nls"
     "--without-openssl-version-check"
   ];

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "VPN Client for Cisco's AnyConnect SSL VPN";
-    homepage = "http://www.infradead.org/openconnect/";
+    homepage = "https://www.infradead.org/openconnect/";
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ pradeepchhetri tricktron ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/tools/networking/vpnc-scripts/default.nix
+++ b/pkgs/tools/networking/vpnc-scripts/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchgit
+, makeWrapper
+, nettools, gawk, openresolv, coreutils, gnugrep
+}:
+
+stdenv.mkDerivation {
+  pname = "vpnc-scripts";
+  version = "unstable-2020-02-21";
+  src = fetchgit {
+    url = "git://git.infradead.org/users/dwmw2/vpnc-scripts.git";
+    rev = "c0122e891f7e033f35f047dad963702199d5cb9e";
+    sha256 = "11b1ls012mb704jphqxjmqrfbbhkdjb64j2q4k8wb5jmja8jnd14";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp vpnc-script $out/bin
+  '';
+
+  preFixup = ''
+    substituteInPlace $out/bin/vpnc-script \
+      --replace "which" "type -P"
+  '' + lib.optionalString stdenv.isLinux ''
+    substituteInPlace $out/bin/vpnc-script \
+      --replace "/sbin/resolvconf" "${openresolv}/bin/resolvconf"
+  '' + ''
+    wrapProgram $out/bin/vpnc-script \
+      --prefix PATH : "${lib.makeBinPath ([ nettools gawk coreutils gnugrep ] ++ lib.optionals stdenv.isLinux [ openresolv ])}"
+  '';
+
+  meta = with lib; {
+    description = "script for vpnc to configure the network routing and name service";
+    homepage = "https://www.infradead.org/openconnect/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ jerith666 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/tools/networking/vpnc-scripts/default.nix
+++ b/pkgs/tools/networking/vpnc-scripts/default.nix
@@ -1,15 +1,15 @@
 { lib, stdenv, fetchgit
 , makeWrapper
-, nettools, gawk, openresolv, coreutils, gnugrep
+, nettools, gawk, systemd, openresolv, coreutils, gnugrep
 }:
 
 stdenv.mkDerivation {
   pname = "vpnc-scripts";
-  version = "unstable-2020-02-21";
+  version = "unstable-2021-03-21";
   src = fetchgit {
     url = "git://git.infradead.org/users/dwmw2/vpnc-scripts.git";
-    rev = "c0122e891f7e033f35f047dad963702199d5cb9e";
-    sha256 = "11b1ls012mb704jphqxjmqrfbbhkdjb64j2q4k8wb5jmja8jnd14";
+    rev = "8fff06090ed193c4a7285e9a10b42e6679e8ecf3";
+    sha256 = "14bzzpwz7kdmlbx825h6s4jjdml9q6ziyrq8311lp8caql68qdq1";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -24,7 +24,8 @@ stdenv.mkDerivation {
       --replace "which" "type -P"
   '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace $out/bin/vpnc-script \
-      --replace "/sbin/resolvconf" "${openresolv}/bin/resolvconf"
+      --replace "/sbin/resolvconf" "${openresolv}/bin/resolvconf" \
+      --replace "/usr/bin/resolvectl" "${systemd}/bin/resolvectl"
   '' + ''
     wrapProgram $out/bin/vpnc-script \
       --prefix PATH : "${lib.makeBinPath ([ nettools gawk coreutils gnugrep ] ++ lib.optionals stdenv.isLinux [ openresolv ])}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9468,14 +9468,17 @@ in
   openconnect = openconnect_gnutls;
 
   openconnect_openssl = callPackage ../tools/networking/openconnect {
+    inherit (darwin.apple_sdk.frameworks) PCSC;
     gnutls = null;
   };
 
   openconnect_gnutls = callPackage ../tools/networking/openconnect {
+    inherit (darwin.apple_sdk.frameworks) PCSC;
     openssl = null;
   };
 
   openconnect_head = callPackage ../tools/networking/openconnect {
+    inherit (darwin.apple_sdk.frameworks) PCSC;
     head = true;
     openssl = null;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9485,6 +9485,8 @@ in
     openssl = null;
   };
 
+  globalprotect-openconnect = libsForQt5.callPackage ../tools/networking/globalprotect-openconnect { };
+
   ding-libs = callPackage ../tools/misc/ding-libs { };
 
   sssd = callPackage ../os-specific/linux/sssd {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9456,6 +9456,8 @@ in
 
   vpnc = callPackage ../tools/networking/vpnc { };
 
+  vpnc-scripts = callPackage ../tools/networking/vpnc-scripts { };
+
   vpn-slice = python3Packages.callPackage ../tools/networking/vpn-slice { };
 
   vp = callPackage ../applications/misc/vp {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
