### PR TITLE
arduino-ci: init at 0.1.0

### DIFF
--- a/pkgs/development/arduino/arduino-ci/default.nix
+++ b/pkgs/development/arduino/arduino-ci/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub,  makeWrapper, arduino-cli, ruby, python3, patchelf }:
+
+let
+
+  runtimePath = stdenv.lib.makeBinPath [
+    arduino-cli
+    (python3.withPackages (ps: [ ps.pyserial ])) # required by esp32 core
+    patchelf # required by esp32 core
+  ];
+
+in
+stdenv.mkDerivation rec {
+  pname = "arduino-ci";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner  = "pololu";
+    repo   = "arduino-ci";
+    rev    = "v${version}";
+    sha256 = "sha256-uLCLupzJ446WcxXZtzJk1wnae+k1NTSy0cGHLqW7MZU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install $src/ci.rb $out/bin/arduino-ci
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    substituteInPlace $out/bin/arduino-ci --replace "/usr/bin/env nix-shell" "${ruby}/bin/ruby"
+    wrapProgram $out/bin/arduino-ci --prefix PATH ":" "${runtimePath}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "CI for Arduino Libraries";
+    homepage = src.meta.homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ryantm ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -870,6 +870,8 @@ in
 
   arduino = arduino-core.override { withGui = true; };
 
+  arduino-ci = callPackage ../development/arduino/arduino-ci { };
+
   arduino-cli = callPackage ../development/arduino/arduino-cli { };
 
   arduino-core = callPackage ../development/arduino/arduino-core { };


### PR DESCRIPTION
arduino-ci allows you to quickly add continuous integration (CI) tests
to Arduino libraries. It uses arduino-cli to install dependencies and
then it compiles every example with every board.

I am the primary author of the `arduino-ci` project.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
