### PR TITLE
spdlog: use nixpkgs' fmt instead of bundled one

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -17,6 +17,7 @@
 , mtxclient
 , boost17x
 , spdlog
+, fmt
 , olm
 , pkgconfig
 , nlohmann_json
@@ -47,6 +48,7 @@ mkDerivation rec {
     boost17x
     lmdb
     spdlog
+    fmt
     cmark
     qtbase
     qtmultimedia

--- a/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
+++ b/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   # the qt mkDerivation - the latter forcibly overrides this.
   cmakeBuildType = "MinSizeRel";
 
-  meta = with stdenv.lib {
+  meta = with stdenv.lib; {
     description = "A comprehensive reverse engineering and manipulation framework for gate-level netlists";
     homepage = "https://github.com/emsec/hal";
     license = licenses.mit;

--- a/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
+++ b/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, python3Packages
 , boost, rapidjson, qtbase, qtsvg, igraph, spdlog, wrapQtAppsHook
-, llvmPackages ? null
+, fmt, llvmPackages ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ninja pkgconfig ];
-  buildInputs = [ qtbase qtsvg boost rapidjson igraph spdlog wrapQtAppsHook ]
+  buildInputs = [ qtbase qtsvg boost rapidjson igraph spdlog fmt wrapQtAppsHook ]
     ++ (with python3Packages; [ python pybind11 ])
     ++ stdenv.lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
@@ -42,11 +42,11 @@ stdenv.mkDerivation rec {
   # the qt mkDerivation - the latter forcibly overrides this.
   cmakeBuildType = "MinSizeRel";
 
-  meta = {
+  meta = with stdenv.lib {
     description = "A comprehensive reverse engineering and manipulation framework for gate-level netlists";
     homepage = "https://github.com/emsec/hal";
-    license = stdenv.lib.licenses.mit;
-    platforms = with stdenv.lib.platforms; unix;
-    maintainers = with stdenv.lib.maintainers; [ ris ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ris shamilton ];
   };
 }

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, fmt }:
 
 let
   generic = { version, sha256 }:
@@ -14,12 +14,14 @@ let
       };
 
       nativeBuildInputs = [ cmake ];
+      buildInputs = [ fmt ];
 
       cmakeFlags = [
         "-DSPDLOG_BUILD_SHARED=ON"
         "-DSPDLOG_BUILD_EXAMPLE=OFF"
         "-DSPDLOG_BUILD_BENCH=OFF"
         "-DSPDLOG_BUILD_TESTS=ON"
+        "-DSPDLOG_FMT_EXTERNAL=ON"
       ];
 
       outputs = [ "out" "doc" ];

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -8,6 +8,7 @@
 , catch2
 , cmake
 , cython
+, fmt
 , muparserx
 , ninja
 , nlohmann_json
@@ -47,6 +48,7 @@ buildPythonPackage rec {
   buildInputs = [
     blas
     catch2
+    fmt
     muparserx
     nlohmann_json
     spdlog

--- a/pkgs/tools/filesystems/lizardfs/cmake-def-spdlog-fmt-external.patch
+++ b/pkgs/tools/filesystems/lizardfs/cmake-def-spdlog-fmt-external.patch
@@ -1,0 +1,11 @@
+diff --color -ur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2020-12-10 10:39:37.775694976 +0100
++++ b/CMakeLists.txt	2020-12-10 10:40:41.984575938 +0100
+@@ -127,6 +127,7 @@
+ add_definitions(-D__STDC_LIMIT_MACROS)
+ add_definitions(-D__STDC_CONSTANT_MACROS)
+ add_definitions(-D__STDC_FORMAT_MACROS)
++add_definitions(-DSPDLOG_FMT_EXTERNAL)
+ if(MINGW)
+   add_definitions(-DWINVER=0x0602)
+   add_definitions(-D_WIN32_WINNT=0x0602)

--- a/pkgs/tools/filesystems/lizardfs/default.nix
+++ b/pkgs/tools/filesystems/lizardfs/default.nix
@@ -16,6 +16,7 @@
 , judy
 , pam
 , spdlog
+, fmt
 , zlib # optional
 }:
 
@@ -29,13 +30,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0zk73wmx82ari3m2mv0zx04x1ggsdmwcwn7k6bkl5c0jnxffc4ax";
   };
-
-  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
-
-  buildInputs =
-    [ db fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
-      zlib boost judy pam spdlog python2
-    ];
 
   patches = [
     # Use system-provided spdlog instead of downloading an old one (next two patches)
@@ -53,13 +47,26 @@ stdenv.mkDerivation rec {
       url = "https://github.com/lizardfs/lizardfs/commit/5d20c95179be09241b039050bceda3c46980c004.patch";
       sha256 = "185bfcz2rjr4cnxld2yc2nxwzz0rk4x1fl1sd25g8gr5advllmdv";
     })
+    # Add SPDLOG_FMT_EXTERNAL flag to disable spdlog from using bundled fmt
+    # Would use https://github.com/lizardfs/lizardfs/commit/31b0cd40f84ee75f99643ad19122061e3d6fb6cc.patch
+    # if it didn't failed to patch
+    ./cmake-def-spdlog-fmt-external.patch
   ];
+
+  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
+
+  buildInputs =
+  [ db fuse asciidoc libxml2 libxslt docbook_xml_dtd_412 docbook_xsl
+    zlib boost judy pam spdlog fmt python2
+  ];
+  
+  cmakeFlags = [ "-DSPDLOG_FMT_EXTERNAL=ON" ];
 
   meta = with stdenv.lib; {
     homepage = "https://lizardfs.com";
     description = "A highly reliable, scalable and efficient distributed file system";
     platforms = platforms.linux;
     license = licenses.gpl3;
-    maintainers = [ maintainers.rushmorem ];
+    maintainers = with maintainers; [ rushmorem shamilton ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Better fix than https://github.com/NixOS/nixpkgs/pull/106387 to gerbera. (and it's always better to use external libs).

###### Things done
This fixes the gerbera build (thus the pull request above is obsolete)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
