### PR TITLE
fluxcd: init at 0.5.0

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/default.nix
+++ b/pkgs/applications/networking/cluster/fluxcd/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "fluxcd";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "fluxcd";
+    repo = "flux2";
+    rev = "v${version}";
+    sha256 = "125im8br7x8djd6zagvikpc02k55pxbd97rjj3g2frj9plbryh8n";
+  };
+
+  vendorSha256 = "0f818a0z71nl061db93iqb87njx66vbrra1zh92warbx8djdsr7k";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  doCheck = false;
+
+  subPackages = [ "cmd/flux" ];
+
+  buildFlagsArray = [ "-ldflags=-s -w -X main.VERSION=${version}" ];
+
+  postInstall = ''
+    for shell in bash fish zsh; do
+      $out/bin/flux completion $shell > flux.$shell
+      installShellCompletion flux.$shell
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open and extensible continuous delivery solution for Kubernetes";
+    longDescription = ''
+      Flux is a tool for keeping Kubernetes clusters in sync
+      with sources of configuration (like Git repositories), and automating
+      updates to configuration when there is new code to deploy.
+    '';
+    homepage = "https://fluxcd.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jlesquembre ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22199,6 +22199,8 @@ in
 
   fluxctl = callPackage ../applications/networking/cluster/fluxctl { };
 
+  fluxcd = callPackage ../applications/networking/cluster/fluxcd { };
+
   linkerd = callPackage ../applications/networking/cluster/linkerd { };
 
   kubernetes-helm = callPackage ../applications/networking/cluster/helm { };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [fluxcd](https://fluxcd.io/)

This is flux v2. There is also [fluxctl](https://github.com/NixOS/nixpkgs/blob/dfe13f9152d67dee707c1ac67dbd4c7197ce470e/pkgs/applications/networking/cluster/fluxctl/default.nix) (flux v1). v1 is in maintenance
mode, and it will be deprecated at some point, but some people may still
depend on v1.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
