### PR TITLE
melonDS: 0.8.3 -> 0.9 (and build fix)

### DIFF
--- a/pkgs/misc/emulators/melonDS/default.nix
+++ b/pkgs/misc/emulators/melonDS/default.nix
@@ -1,41 +1,42 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, SDL2, gtk3, libpcap, wrapGAppsHook }:
+{ stdenv
+, fetchFromGitHub
+, mkDerivation
+, cmake
+, pkgconfig
+, SDL2
+, qtbase
+, libpcap
+, libslirp
+, wrapGAppsHook
+}:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "melonDS";
-  version = "0.8.3";
-  ## When updating to the release after 0.8.3,
-  ##  - Uncomment:
-  ##      cmakeFlags = [ "-UUNIX_PORTABLE" ];
-  ##  - Remove the postInstall, since cmake should then take care of installing icons, .desktop file, and romlist.bin
-  ##    (see https://github.com/Arisotura/melonDS/pull/546)
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "Arisotura";
     repo = pname;
     rev = version;
-    sha256 = "1lqmfwjpkdqfkns1aaxlp4yrg6i0r66mxfr4rrj7b5286k44hqwn";
+    sha256 = "0m45m1ch0az8l3d3grjbqvi5vvydbffxwka9w3k3qiia50m7fnph";
   };
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook ];
-  buildInputs = [ SDL2 gtk3 libpcap ];
+  buildInputs = [
+    SDL2
+    qtbase
+    libpcap
+    libslirp
+  ];
 
-  postInstall = ''
-    install -Dm644 -t $out/share/melonDS/ ../romlist.bin
-    install -Dm644 -t $out/share/applications/ ../flatpak/*.desktop
-
-    for i in ../icon/melon_*.png; do
-      d="''${i##*_}"
-      d="$out/share/icons/hicolor/''${d%.png}/apps"
-      install -D $i "$d/net.kuribo64.melonds.png"
-    done
-  '';
+  cmakeFlags = [ "-UUNIX_PORTABLE" ];
 
   meta = with stdenv.lib; {
     homepage = "http://melonds.kuribo64.net/";
     description = "Work in progress Nintendo DS emulator";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ artemist benley ];
+    maintainers = with maintainers; [ artemist benley shamilton ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22605,7 +22605,7 @@ in
 
   melmatcheq.lv2 = callPackage ../applications/audio/melmatcheq.lv2 { };
 
-  melonDS = callPackage ../misc/emulators/melonDS { };
+  melonDS = libsForQt5.callPackage ../misc/emulators/melonDS { };
 
   meme = callPackage ../applications/graphics/meme { };
 


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/131268796

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

It runs fine but I don't use it and don't really know if it actually works fine.
@artemist 
@benley 