### PR TITLE
diffpdf: fix icon

### DIFF
--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -34,7 +34,6 @@ mkDerivation rec {
     install -dpm755 $out/share/doc/${pname}-${version} $out/share/licenses/${pname}-${version} $out/share/icons $out/share/pixmaps $out/share/applications
     install -Dpm644 CHANGES README help.html $out/share/doc/${pname}-${version}/
     install -Dpm644 gpl-2.0.txt $out/share/licenses/${pname}-${version}/
-    install -Dpm644 images/icon.png $out/share/icons/diffpdf.png
     install -Dpm644 images/icon.png $out/share/pixmaps/diffpdf.png
 
     cat > $out/share/applications/diffpdf.desktop <<EOF


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Installing an icon file in `share/icons` (and not a subdirectory) prevents GNOME from display the icon.

The icon is now installed only in `share/pixmaps`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
