### PR TITLE
Second attempt at adding PeerTube package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8941,6 +8941,12 @@
     githubId = 1181362;
     name = "Stefan Junker";
   };
+  stevenroose = {
+    email = "github@stevenroose.org";
+    github = "stevenroose";
+    githubId = 853468;
+    name = "Steven Roose";
+  };
   stianlagstad = {
     email = "stianlagstad@gmail.com";
     github = "stianlagstad";

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -347,6 +347,7 @@ in
       #mailman = 316;  # removed 2019-08-30
       zigbee2mqtt = 317;
       # shadow = 318; # unused
+      peertube = 319;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -649,6 +650,7 @@ in
       #mailman = 316;  # removed 2019-08-30
       zigbee2mqtt = 317;
       shadow = 318;
+      peertube = 319;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -903,6 +903,7 @@
   ./services/web-apps/moodle.nix
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nexus.nix
+  ./services/web-apps/peertube.nix
   ./services/web-apps/plantuml-server.nix
   ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/matomo.nix

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -1,0 +1,186 @@
+{ lib, pkgs, config, ... }:
+
+let
+  name = "peertube";
+  cfg = config.services.peertube;
+
+  uid = config.ids.uids.peertube;
+  gid = config.ids.gids.peertube;
+in
+{
+  options.services.peertube = {
+    enable = lib.mkEnableOption "Enable Peertube’s service";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = name;
+      description = "User account under which Peertube runs";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = name;
+      description = "Group under which Peertube runs";
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        The configuration file path for Peertube.
+      '';
+    };
+
+    database = {
+      createLocally = lib.mkOption {
+        description = "Configure local PostgreSQL database server for PeerTube.";
+        type = lib.types.bool;
+        default = true;
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "peertube_prod";
+        description = "Database name.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "peertube";
+        description = "Database user.";
+      };
+    };
+
+    smtp = {
+      createLocally = lib.mkOption {
+        description = "Configure local Postfix SMTP server for PeerTube.";
+        type = lib.types.bool;
+        default = true;
+      };
+    };
+
+    redis = {
+      createLocally = lib.mkOption {
+        description = "Configure local Redis server for PeerTube.";
+        type = lib.types.bool;
+        default = true;
+      };
+    };
+
+    runtimeDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/${name}";
+      description = "The directory where Peertube stores its runtime data.";
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.peertube;
+      description = ''
+        Peertube package to use.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users = lib.optionalAttrs (cfg.user == name) {
+      "${name}" = {
+        inherit uid;
+        group = cfg.group;
+        description = "Peertube user";
+        home = cfg.runtimeDir;
+        useDefaultShell = true;
+        # todo: fix this. needed for postgres authentication
+        password = "peertube";
+      };
+    };
+    users.groups = lib.optionalAttrs (cfg.group == name) {
+      "${name}" = {
+        inherit gid;
+      };
+    };
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureUsers = [ { name = cfg.database.user; }];
+      # The database is created as a startup script of the peertube service.
+      authentication = ''
+        host ${cfg.database.name} ${cfg.database.user} 127.0.0.1/32 trust
+        host ${cfg.database.name} ${cfg.database.user} 127.0.0.1/32 md5
+      '';
+    };
+
+    services.postfix = lib.mkIf cfg.smtp.createLocally {
+      enable = true;
+    };
+
+    services.redis = lib.mkIf cfg.redis.createLocally {
+      enable = true;
+    };
+
+    # Make sure the runtimeDir exists with the desired permissions.
+    systemd.tmpfiles.rules = [
+      "d \"${cfg.runtimeDir}\" - ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.peertube = {
+      description = "Peertube";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "postgresql.service" "redis.service" ];
+      wants = [ "postgresql.service" "redis.service" ];
+
+      environment.NODE_CONFIG_DIR = "${cfg.runtimeDir}/config";
+      environment.NODE_ENV = "production";
+      environment.HOME = cfg.package;
+
+      path = [ pkgs.nodejs pkgs.bashInteractive pkgs.ffmpeg pkgs.openssl pkgs.sudo pkgs.youtube-dl ];
+
+      script = ''
+        install -m 0750 -d ${cfg.runtimeDir}/config
+        ln -sf ${cfg.configFile} ${cfg.runtimeDir}/config/production.yaml
+        exec npm start
+      '';
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.package;
+        StateDirectory = "peertube";
+        StateDirectoryMode = "0750";
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectControlGroups = true;
+        ProtectSystem = "full";
+        Restart = "always";
+        Type = "simple";
+        TimeoutSec = 60;
+        CapabilityBoundingSet = "~CAP_SYS_ADMIN";
+        ExecStartPre = let script = pkgs.writeScript "peertube-pre-start.sh" ''
+          #!/bin/sh
+          set -e
+
+          if ! [ -e "${cfg.runtimeDir}/.first_run" ]; then
+            set -v
+            if [ -e "${cfg.runtimeDir}/.first_run_partial" ]; then
+              echo "Warn: first run was interrupted"
+            fi
+            touch "${cfg.runtimeDir}/.first_run_partial"
+
+            echo "Running PeerTube's PostgreSQL initialization..."
+            echo "PeerTube is known to work with PostgreSQL v12, if any error occurs, please check your version."
+
+            sudo -u postgres "${config.services.postgresql.package}/bin/createdb" -O ${cfg.database.user} -E UTF8 -T template0 ${cfg.database.name}
+            sudo -u postgres "${config.services.postgresql.package}/bin/psql" -c "CREATE EXTENSION pg_trgm;" ${cfg.database.name}
+            sudo -u postgres "${config.services.postgresql.package}/bin/psql" -c "CREATE EXTENSION unaccent;" ${cfg.database.name}
+
+            touch "${cfg.runtimeDir}/.first_run"
+            rm "${cfg.runtimeDir}/.first_run_partial"
+          fi
+        '';
+        in "+${script}";
+      };
+
+      unitConfig.RequiresMountsFor = cfg.runtimeDir;
+    };
+  };
+}
+

--- a/pkgs/servers/peertube/client.nix
+++ b/pkgs/servers/peertube/client.nix
@@ -1,0 +1,30 @@
+{ yarnModulesConfig, mkYarnModulesFixed, server, sources, version, nodejs, stdenv }:
+rec {
+  modules = mkYarnModulesFixed rec {
+    inherit version;
+    pname = "peertube-client-yarn-modules";
+    name = "${pname}-${version}";
+    packageJSON = "${sources}/client/package.json";
+    yarnLock = "${sources}/client/yarn.lock";
+    pkgConfig = yarnModulesConfig;
+  };
+  dist = stdenv.mkDerivation {
+    inherit version;
+    pname = "peertube-client";
+    src = sources;
+    buildPhase = ''
+      ln -s ${server.modules}/node_modules .
+      cp -a ${modules}/node_modules client/
+      chmod -R +w client/node_modules
+      patchShebangs .
+      npm run build:client
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -a client/dist $out
+    '';
+
+    buildInputs = [ nodejs ];
+  };
+}

--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -1,0 +1,121 @@
+{ light ? null, pkgs, stdenv, lib, fetchurl, fetchFromGitHub, callPackage
+, nodejs ? pkgs.nodejs-12_x
+, jq, youtube-dl, nodePackages, yarn2nix-moretea }:
+
+let
+  version = "3.0.1";
+
+  source = fetchFromGitHub {
+    owner = "Chocobozzz";
+    repo = "PeerTube";
+    rev = "v${version}";
+    sha256 = "bIXt5bQiBBlNDFXYzcdQA8qp4nse5epUx/XQOguDOX8=";
+  };
+
+  patchedSource = stdenv.mkDerivation {
+    pname = "peertube";
+    inherit version;
+    src = source;
+    phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+    patches = [ ./fix_yarn_lock.patch ];
+    installPhase = ''
+      mkdir $out
+      cp -a . $out/
+    '';
+  };
+  yarnModulesConfig = {
+    bcrypt = {
+      buildInputs = [ nodePackages.node-pre-gyp ];
+
+      postInstall = let
+        bcrypt_version = "5.0.0";
+        bcrypt_lib = fetchurl {
+          url = "https://github.com/kelektiv/node.bcrypt.js/releases/download/v${bcrypt_version}/bcrypt_lib-v${bcrypt_version}-napi-v3-linux-x64-glibc.tar.gz";
+          sha256 = "0j3p2px1xb17sw3gpm8l4apljajxxfflal1yy552mhpzhi21wccn";
+        };
+      in ''
+        if [ "${bcrypt_version}" != "$(cat package.json | ${jq}/bin/jq -r .version)" ]; then
+          echo "Mismatching version please update bcrypt in derivation"
+          false
+        fi
+        mkdir -p lib/binding && tar -C lib/binding -xf ${bcrypt_lib}
+        patchShebangs ../node-pre-gyp
+        npm run install
+      '';
+    };
+
+    utf-8-validate = {
+      buildInputs = [ nodePackages.node-gyp-build ];
+    };
+
+    youtube-dl = {
+      postInstall = ''
+        mkdir bin
+        ln -s ${youtube-dl}/bin/youtube-dl bin/youtube-dl
+        cat > bin/details <<EOF
+        {"version":"${youtube-dl.version}","path":null,"exec":"youtube-dl"}
+        EOF
+      '';
+    };
+  };
+
+  mkYarnModulesFixed = args: (yarn2nix-moretea.mkYarnModules args).overrideAttrs(old: {
+    # This hack permits to workaround the fact that the yarn.lock
+    # file doesn't respect the semver requirements
+    buildPhase = builtins.replaceStrings [" ./package.json"] [" /dev/null; cp deps/*/package.json ."] old.buildPhase;
+  });
+
+  server = callPackage ./server.nix {
+    inherit version yarnModulesConfig mkYarnModulesFixed;
+    sources = patchedSource;
+  };
+
+  client = callPackage ./client.nix {
+    inherit server version yarnModulesConfig mkYarnModulesFixed;
+    sources = patchedSource;
+  };
+
+in stdenv.mkDerivation rec {
+  inherit version;
+  pname = "peertube";
+  src = patchedSource;
+
+  buildPhase = ''
+    ln -s ${server.modules}/node_modules .
+    rm -rf dist && cp -a ${server.dist}/dist dist
+    rm -rf client/dist && cp -a ${client.dist}/dist client/
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp -a * $out
+    ln -s /tmp $out/.cache
+  '';
+
+  meta = {
+    description = "A free software to take back control of your videos";
+
+    longDescription = ''
+      PeerTube aspires to be a decentralized and free/libre alternative to video
+      broadcasting services.
+      PeerTube is not meant to become a huge platform that would centralize
+      videos from all around the world. Rather, it is a network of
+      inter-connected small videos hosters.
+      Anyone with a modicum of technical skills can host a PeerTube server, aka
+      an instance. Each instance hosts its users and their videos. In this way,
+      every instance is created, moderated and maintained independently by
+      various administrators.
+      You can still watch from your account videos hosted by other instances
+      though if the administrator of your instance had previously connected it
+      with other instances.
+    '';
+
+    license = lib.licenses.agpl3Plus;
+
+    homepage = "https://joinpeertube.org/";
+    platforms = lib.platforms.unix;
+
+    maintainers = with lib.maintainers; [ immae stevenroose ];
+  };
+}
+

--- a/pkgs/servers/peertube/fix_yarn_lock.patch
+++ b/pkgs/servers/peertube/fix_yarn_lock.patch
@@ -1,0 +1,28 @@
+diff --git a/client/yarn.lock b/client/yarn.lock
+index d27cdaec8..26706a9fc 100644
+--- a/client/yarn.lock
++++ b/client/yarn.lock
+@@ -5703,7 +5703,8 @@ http-errors@~1.7.2:
+ 
+ "http-node@github:feross/http-node#webtorrent":
+   version "1.2.0"
+-  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974"
++  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974#33fa312d37f0000b17acdb1a5086565400419a13"
++  integrity sha1-M/oxLTfwAAsXrNsaUIZWVABBmhM=
+   dependencies:
+     chrome-net "^3.3.3"
+     freelist "^1.0.3"
+diff --git a/yarn.lock b/yarn.lock
+index 61a2ea05e..c742276c7 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -3873,7 +3873,8 @@ http-errors@~1.7.2:
+ 
+ "http-node@github:feross/http-node#webtorrent":
+   version "1.2.0"
+-  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974"
++  resolved "https://codeload.github.com/feross/http-node/tar.gz/342ef8624495343ffd050bd0808b3750cf0e3974#33fa312d37f0000b17acdb1a5086565400419a13"
++  integrity sha1-M/oxLTfwAAsXrNsaUIZWVABBmhM=
+   dependencies:
+     chrome-net "^3.3.3"
+     freelist "^1.0.3"

--- a/pkgs/servers/peertube/server.nix
+++ b/pkgs/servers/peertube/server.nix
@@ -1,0 +1,28 @@
+{ yarnModulesConfig, mkYarnModulesFixed, sources, version, nodejs, stdenv }:
+rec {
+  modules = mkYarnModulesFixed rec {
+    inherit version;
+    pname = "peertube-server-yarn-modules";
+    name = "${pname}-${version}";
+    packageJSON = "${sources}/package.json";
+    yarnLock = "${sources}/yarn.lock";
+    pkgConfig = yarnModulesConfig;
+  };
+  dist = stdenv.mkDerivation {
+    inherit version;
+    pname = "peertube-server";
+    src = sources;
+    buildPhase = ''
+      ln -s ${modules}/node_modules .
+      patchShebangs scripts/build/server.sh
+      npm run build:server
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -a dist $out
+    '';
+
+    buildInputs = [ nodejs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24440,6 +24440,10 @@ in
 
   peek = callPackage ../applications/video/peek { };
 
+  peertube = callPackage ../servers/peertube {
+    nodejs = pkgs.nodejs-12_x;
+  };
+
   pflask = callPackage ../os-specific/linux/pflask {};
 
   pfsshell = callPackage ../tools/misc/pfsshell { };


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/46987.

So there was an attempt at packaging PeerTube here: https://github.com/NixOS/nixpkgs/pull/84189. I squashed that attempt into a single commit, just in order to preserve its content.

I'm totally new to making Nix packages (been using NixOS as a user for a while), so I've been trying to learn things over the past weekend. It seems that https://github.com/NixOS/nixpkgs/pull/84189 is hand-rolling the building of PeerTube as a Yarn package instead of using the yarn tooling like `mkYarnPackage`.

However, it seems that the yarn tooling is unable to build the yarn package anyway.

I'm looking into what's causing this by making modifications to the yarn tooling.