### PR TITLE
tt-rss-plugin-fever: Init at 2.2.0

### DIFF
--- a/pkgs/servers/tt-rss/plugin-fever/default.nix
+++ b/pkgs/servers/tt-rss/plugin-fever/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
+  pname = "tt-rss-plugin-fever";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "DigitalDJ";
+    repo = "tinytinyrss-fever-plugin";
+    rev = "${version}";
+    #sha256 = "0bylgm9w8rxgrgsh2zrq2wsjy3ff1mz09ad5zmv7pn547cldhqv6";
+    sha256 = "000ys6r6a90x1v6fjyb86b0aab6j7g2d29w8d5sccyv895m4x8r1";
+  };
+
+  installPhase = ''
+    mkdir -p $out/fever
+    cp *.php $out/fever
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Allows Fever compatible RSS clients to use Tiny Tiny RSS";
+    longDescription = ''
+    This is an open source plugin for Tiny Tiny RSS which simulates the Fever API.
+    This allows Fever compatible RSS clients to use Tiny Tiny RSS.
+    end-point URL is https://example.com/tt-rss/plugins.local/fever/
+    '';
+    license = licenses.gpl3;
+    homepage = "https://github.com/DigitalDJ/tinytinyrss-fever-plugin";
+    maintainers = with maintainers; [ madahin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17693,6 +17693,7 @@ in
   tt-rss-plugin-ff-instagram = callPackage ../servers/tt-rss/plugin-ff-instagram { };
   tt-rss-plugin-tumblr-gdpr = callPackage ../servers/tt-rss/plugin-tumblr-gdpr { };
   tt-rss-plugin-auth-ldap = callPackage ../servers/tt-rss/plugin-auth-ldap { };
+  tt-rss-plugin-fever = callPackage ../servers/tt-rss/plugin-fever { };
   tt-rss-theme-feedly = callPackage ../servers/tt-rss/theme-feedly { };
 
   rss-bridge = callPackage ../servers/web-apps/rss-bridge { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Added [tinytinyrss-fever-plugin ](https://github.com/DigitalDJ/tinytinyrss-fever-plugin)

This is a plugin to add a fever endpoint to tiny tiny rss. It is usefull for some agregator like [NewsFlash](https://gitlab.com/news-flash/news_flash_gtk).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
