### PR TITLE
k3s: 1.18.12+k3s1 -> 1.18.12+k3s2 

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -156,8 +156,8 @@ let
       platforms = platforms.linux;
     };
   };
-  k3sBuild = buildGoPackage rec {
-    name = "k3s-build";
+  k3sBin = buildGoPackage rec {
+    name = "k3s-bin";
     version = "${k3sVersion}";
 
     goPackagePath = "github.com/rancher/k3s";
@@ -167,7 +167,9 @@ let
     patches = [ ./patches/0001-Use-rm-from-path-in-go-generate.patch ./patches/0002-Add-nixpkgs-patches.patch ];
 
     nativeBuildInputs = [ git pkgconfig ];
-    buildInputs = [ k3sBuildStage1 k3sPlugins runc ];
+    # These dependencies are embedded as compressed files in k3s at runtime.
+    # Propagate them to avoid broken runtime references to libraries.
+    propagatedBuildInputs = [ k3sPlugins k3sBuildStage1 runc ];
 
     # k3s appends a suffix to the final distribution binary for some arches
     archSuffix =
@@ -236,7 +238,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    k3sBuild
+    k3sBin
     makeWrapper
   ] ++ k3sRuntimeDeps;
 
@@ -250,7 +252,7 @@ stdenv.mkDerivation rec {
   # execute, but that we didn't bundle with it.
   installPhase = ''
     mkdir -p "$out/bin"
-    makeWrapper ${k3sBuild}/bin/k3s "$out/bin/k3s" \
+    makeWrapper ${k3sBin}/bin/k3s "$out/bin/k3s" \
       --prefix PATH : ${lib.makeBinPath k3sRuntimeDeps} \
       --prefix PATH : "$out/bin"
   '';

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -42,9 +42,9 @@ with lib;
 # Those pieces of software we entirely ignore upstream's handling of, and just
 # make sure they're in the path if desired.
 let
-  k3sVersion = "1.18.2+k3s1";     # k3s git tag
+  k3sVersion = "1.18.12+k3s2";    # k3s git tag
   traefikChartVersion = "1.81.0"; # taken from ./scripts/download at the above k3s tag
-  k3sRootVersion = "0.3.0";       # taken from .s/cripts/download at the above k3s tag
+  k3sRootVersion = "0.4.1";       # taken from .s/cripts/download at the above k3s tag
   # bundled into the k3s binary
   traefikChart = fetchurl {
     url = "https://kubernetes-charts.storage.googleapis.com/traefik-${traefikChartVersion}.tgz";
@@ -62,12 +62,12 @@ let
   k3sRoot = fetchzip {
     # Note: marked as apache 2.0 license
     url = "https://github.com/rancher/k3s-root/releases/download/v${k3sRootVersion}/k3s-root-amd64.tar";
-    sha256 = "12xafn5jivl8lqdcs25b28xrc4mf7yf1xif5np169nvvxgvmpdxp";
+    sha256 = "0ppj8y9g410hn6mjkfgfsi2j9yv7rcpic21znpmbrkx8b2070hf0";
     stripRoot = false;
   };
   k3sPlugins = buildGoPackage rec {
     name = "k3s-cni-plugins";
-    version = "0.7.6-k3s1"; # from ./scripts/version.sh 'VERSION_CNIPLUGINS'; update when k3s's repo is updated.
+    version = "0.8.6-k3s1"; # from ./scripts/version.sh 'VERSION_CNIPLUGINS'; update when k3s's repo is updated.
 
     goPackagePath = "github.com/containernetworking/plugins";
     subPackages = [ "." ];
@@ -76,7 +76,7 @@ let
       owner = "rancher";
       repo = "plugins";
       rev = "v${version}";
-      sha256 = "0ax72z1ziann352bp6khfds8vlf3bbkqckrkpx4l4jxgqks45izs";
+      sha256 = "13kx9msn5y9rw8v1p717wx0wbjqln59g6y3qfb1760aiwknva35q";
     };
 
     meta = {
@@ -93,7 +93,7 @@ let
     url = "https://github.com/rancher/k3s";
     rev = "v${k3sVersion}";
     leaveDotGit = true; # ./scripts/version.sh depends on git
-    sha256 = "01ww3d71mlri2fk6z54rbd697aqwj942kbg323k0hfsnx7flkhps";
+    sha256 = "0xc4j6rnjzqgzcil6h4hkhvx7n0xwqrfny20ffnxk5zrbjdjw65f";
   };
   # Stage 1 of the k3s build:
   # Let's talk about how k3s is structured.


### PR DESCRIPTION
###### Motivation for this change

Bumped to fix CVE-2020-15257. See the upstream release notes for that:
https://github.com/k3s-io/k3s/releases/tag/v1.18.12%2Bk3s2

This isn't a direct backport of 5ca87dc, since master has since moved
on on to 1.19.x, but it's related in spirit.

I cherry-picked over 6eb941d as well since it applies cleanly, and I believe was necessary for tests on this branch to pass too.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) (`nix-build nixos/tests/k3s.nix` passes).
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
