### PR TITLE
[staging] wafHook: Don't wrap Python 2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -287,6 +287,12 @@
        This avoids that the password gets exposed in the nix store.
      </para>
    </listitem>
+   <listitem>
+     <para>
+       The <literal>wafHook</literal> hook does not wrap Python anymore.
+       Packages depending on <literal>wafHook</literal> need to include any Python into their <literal>nativeBuildInputs</literal>.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/applications/audio/ams-lv2/default.nix
+++ b/pkgs/applications/audio/ams-lv2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cairo, fftw, gtkmm2, lv2, lvtk, pkgconfig
-, wafHook }:
+, wafHook, python3 }:
 
 stdenv.mkDerivation  rec {
   pname = "ams-lv2";
@@ -12,7 +12,7 @@ stdenv.mkDerivation  rec {
     sha256 = "1lz2mvk4gqsyf92yxd3aaldx0d0qi28h4rnnvsaz4ls0ccqm80nk";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
+  nativeBuildInputs = [ pkgconfig wafHook python3 ];
   buildInputs = [ cairo fftw gtkmm2 lv2 lvtk ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/mda-lv2/default.nix
+++ b/pkgs/applications/audio/mda-lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fftwSinglePrec, lv2, pkgconfig, wafHook }:
+{ stdenv, fetchurl, fftwSinglePrec, lv2, pkgconfig, wafHook, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "mda-lv2";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a3cv6w5xby9yn11j695rbh3c4ih7rxfxmkca9s1324ljphh06m8";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
+  nativeBuildInputs = [ pkgconfig wafHook python3 ];
   buildInputs = [ fftwSinglePrec lv2 ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gaia/default.nix
+++ b/pkgs/development/libraries/gaia/default.nix
@@ -5,6 +5,7 @@
 , swig
 , eigen
 , pkgconfig
+, python2
 , wafHook
 , makeWrapper
 , qt4
@@ -38,9 +39,10 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    wafHook
     pkgconfig
+    python2 # For wafHook
     swig
+    wafHook
   ]
     # The gaiafusion binary inside $out/bin needs a shebangs patch, and
     # wrapping with the appropriate $PYTHONPATH

--- a/pkgs/development/libraries/ntdb/default.nix
+++ b/pkgs/development/libraries/ntdb/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, python2
 , python3
 , pkg-config
 , readline
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
     docbook-xsl-nons
     docbook_xml_dtd_42
     wafHook
+    python2 # For wafHook
   ];
 
   buildInputs = [

--- a/pkgs/development/tools/build-managers/wafHook/default.nix
+++ b/pkgs/development/tools/build-managers/wafHook/default.nix
@@ -1,7 +1,6 @@
-{ lib, stdenv, pkgs, python, makeSetupHook, waf }:
+{ lib, stdenv, pkgs, makeSetupHook, waf }:
 
 makeSetupHook {
-  deps = [ python ];
   substitutions = {
     inherit waf;
     crossFlags = lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system)

--- a/pkgs/games/simutrans/default.nix
+++ b/pkgs/games/simutrans/default.nix
@@ -52,7 +52,7 @@ let
     "pak128.german" = {
       url = "mirror://sourceforge/simutrans/PAK128.german/"
         + "pak128.german_1.2_for_ST_121.0/PAK128.german_1.2_for_ST_121-0.zip";
-      sha256 = "1jxjckz4b02yv1mv1zc3pmajpq740dfnlvhr0x762lbrybymvagi";
+      sha256 = "1cv1rzl1a3i5dvk476zq094wawk9hhdh2f0y4xrdny5gn17mb2xi";
     };
 
     /* This release contains accented filenames that prevent unzipping.

--- a/pkgs/tools/networking/saldl/default.nix
+++ b/pkgs/tools/networking/saldl/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , pkgconfig
 , wafHook
+, python3
 , asciidoc
 , docbook_xml_dtd_45
 , docbook_xsl
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     wafHook
+    python3
     asciidoc
     docbook_xml_dtd_45
     docbook_xsl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16203,9 +16203,7 @@ in
 
   taglib-sharp = callPackage ../development/libraries/taglib-sharp { };
 
-  talloc = callPackage ../development/libraries/talloc {
-    wafHook = wafHook.override { python = python3; };
-  };
+  talloc = callPackage ../development/libraries/talloc { };
 
   tclap = callPackage ../development/libraries/tclap {};
 


### PR DESCRIPTION
###### Motivation for this change

Python 2 is dead, and just replacing it in the hook will most likely break builds that are not yet migrated to Python 3 (looking at you, gaia).

Closes #104701 
Related to #69310

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
