### PR TITLE
zfs: fix build with linux-rt

### DIFF
--- a/pkgs/os-specific/linux/kernel/export-rt-sched-migrate.patch
+++ b/pkgs/os-specific/linux/kernel/export-rt-sched-migrate.patch
@@ -1,0 +1,11 @@
+Export linux-rt (PREEMPT_RT) specific symbols needed by ZFS.
+(Regular kernel provides them static inline in linux/preempt.h.)
+
+--- a/kernel/sched/core.c
++++ b/kernel/sched/core.c
+@@ -1812 +1812 @@ void migrate_disable(void)
+-EXPORT_SYMBOL_GPL(migrate_disable);
++EXPORT_SYMBOL(migrate_disable);
+@@ -1843 +1843 @@ void migrate_enable(void)
+-EXPORT_SYMBOL_GPL(migrate_enable);
++EXPORT_SYMBOL(migrate_enable);

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -87,6 +87,11 @@
     };
   };
 
+  export-rt-sched-migrate = {
+    name = "export-rt-sched-migrate";
+    patch = ./export-rt-sched-migrate.patch;
+  };
+
   # patches from https://lkml.org/lkml/2019/7/15/1748
   mac_nvme_t2 = rec {
     name = "mac_nvme_t2";

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -176,6 +176,11 @@ let
         maintainers = with maintainers; [ hmenke jcumming jonringer wizeman fpletz globin mic92 ];
       };
     };
+
+  linux-rt-patch = fetchpatch {
+    url = "https://github.com/openzfs/zfs/commit/ab4fb9b74e9d089fc9a261c4f41e19697ad6a4ca.patch";
+    sha256 = "1nrxmb4rhrkgncav6dzwm66l0700fi72qkkcs0w6pkm850srws36";
+  };
 in {
   # also check if kernel version constraints in
   # ./nixos/modules/tasks/filesystems/zfs.nix needs
@@ -188,6 +193,8 @@ in {
     version = "2.0.0";
 
     sha256 = "1kriz6pg8wj98izvjc60wp23lgcp4k3mzhpkgj74np73rzgy6v8r";
+
+    extraPatches = [ linux-rt-patch ];
   };
 
   zfsUnstable = common {
@@ -198,5 +205,7 @@ in {
     version = "2.0.0";
 
     sha256 = "1kriz6pg8wj98izvjc60wp23lgcp4k3mzhpkgj74np73rzgy6v8r";
+
+    extraPatches = [ linux-rt-patch ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18363,6 +18363,7 @@ in
       kernelPatches.bridge_stp_helper
       kernelPatches.request_key_helper
       kernelPatches.export_kernel_fpu_functions."5.3"
+      kernelPatches.export-rt-sched-migrate
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes zfs 2.0.0 with linux-rt, with an additional fix for the new 5.9 kernel.

Upstream issue: https://github.com/openzfs/zfs/issues/11097

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
