### PR TITLE
python38Packages.sqlparse: install manpage

### DIFF
--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -1,7 +1,8 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, installShellFiles
+, pytestCheckHook
 , isPy3k
 }:
 
@@ -9,20 +10,22 @@ buildPythonPackage rec {
   pname = "sqlparse";
   version = "0.4.1";
 
+  disabled = !isPy3k;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8";
   };
 
-  checkInputs = [ pytest ];
-  checkPhase = ''
-    py.test
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  postInstall = ''
+    installManPage docs/sqlformat.1
   '';
 
-  # Package supports 3.x, but tests are clearly 2.x only.
-  doCheck = !isPy3k;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Non-validating SQL parser for Python";
     longDescription = ''
       Provides support for parsing, splitting and formatting SQL statements.
@@ -30,5 +33,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/andialbrecht/sqlparse";
     license = licenses.bsd3;
   };
-
 }

--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages }:
+{ lib, python3Packages, fetchpatch }:
 
 python3Packages.buildPythonApplication rec {
   pname = "litecli";
@@ -12,6 +12,14 @@ python3Packages.buildPythonApplication rec {
     inherit pname version;
     sha256 = "FARWjtbS5zi/XQDyAVImUmArLj8xATz1jZ4jnXFdq1w=";
   };
+
+  patches = [
+    # Fix compatibility with sqlparse >= 0.4.0. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/dbcli/litecli/commit/37957e401d22f88800bbdec2c690e731f2cc13bd.patch";
+      sha256 = "1x82s2h1rzflyiahyd8pfya30rzs6yx6ij4a4s16f8iix5x35zv9";
+    })
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     cli-helpers


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
