### PR TITLE
nerdctl: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/nerdctl/default.nix
+++ b/pkgs/applications/networking/cluster/nerdctl/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, buildkit
+, cni-plugins
+, extraPackages ? []
+}:
+
+let
+  binPath = lib.makeBinPath ([
+    buildkit
+  ] ++ extraPackages);
+in
+buildGoModule rec {
+  pname = "nerdctl";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "AkihiroSuda";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "181qapqgp7zd0imk0zkn4wzpsw292ai2yz9pbiirpjcjx9h26w5h";
+  };
+
+  vendorSha256 = "0scywhllxk1m6456wggdmn7sgvy5x3gz2xnyfq9jnvvzap8byr2v";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-w"
+    "-s"
+    "-X github.com/AkihiroSuda/nerdctl/pkg/version.Version=v${version}"
+    "-X github.com/AkihiroSuda/nerdctl/pkg/version.Revision=<unknown>"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/nerdctl \
+      --prefix PATH : "${binPath}" \
+      --prefix CNI_PATH : "${cni-plugins}/bin"
+  '';
+
+  meta = with lib; {
+    description = "A Docker-compatible CLI for containerd";
+    homepage = src.meta.homepage;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5311,6 +5311,8 @@ in
 
   ncrack = callPackage ../tools/security/ncrack { };
 
+  nerdctl = callPackage ../applications/networking/cluster/nerdctl { };
+
   netdata = callPackage ../tools/system/netdata {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package `nerdctl`

There is `nerdctl-unwrapped` which is as-is, and `nerdctl` which is wrapped with `cni-plugins` and `buildkit` to allow for networking and building containers.

**Since there is `nerdctl` and `nerdctl-unwrapped` let me know if I need to change my commit message to fit contributing**

https://github.com/AkihiroSuda/nerdctl#install

I'm not sure why `podman` and `cri-o` can get away with `cni-plugins` just being arguments & not even in the PATH.
https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/virtualization/podman/wrapper.nix#L13
https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/virtualization/cri-o/wrapper.nix#L11
@adisbladis @zowoq 

`nerdctl` will explicitly look for several `cni-plugins` binaries in `/opt/cni/bin` which is overridden with the env var `CNI_PATH` in the wrapped version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
