### PR TITLE
emacs: fix siteVersionDir path

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -141,8 +141,7 @@ in stdenv.mkDerivation {
 
     siteVersionDir=`ls $out/share/emacs | grep -v site-lisp | head -n 1`
 
-    rm -rf $out/var
-    rm -rf $siteVersionDir
+    rm -r $out/share/emacs/$siteVersionDir/site-lisp
   '' + lib.optionalString withCsrc ''
     for srcdir in src lisp lwlib ; do
       dstdir=$out/share/emacs/$siteVersionDir/$srcdir


### PR DESCRIPTION
siteVersionDir isn't a full path, it's just the name of the version
directory entry in $out/share/emacs, e.g. "27.1", so since
d1b0eef9b51 ("emacs: Don't use interpolation for version"), we've been
trying to remove a non-existent directory.  This would have been
caught if we hadn't been giving -f to rm unnecessarily, because -f
suppresses errors.  As well as fixing the path, I've removed the -f
from rm.  Doing this to the line above as well revealed that rm-ing
$out/var was no longer necessary, since nothing has been put there
since ac23a7c459d8 ("emacs: 25.3 → 26.1") -- it would now only be
created if we set the --with-gameuser configure option, which we
don't.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
