### PR TITLE
kakounePlugins.quickscope-kak: init at 1.0.0

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -13,4 +13,5 @@
   kak-prelude = pkgs.callPackage ./kak-prelude.nix { };
   kak-vertical-selection = pkgs.callPackage ./kak-vertical-selection.nix { };
   openscad-kak = pkgs.callPackage ./openscad.kak.nix { };
+  quickscope-kak = pkgs.callPackage ./quickscope.kak.nix { };
 }

--- a/pkgs/applications/editors/kakoune/plugins/quickscope.kak.nix
+++ b/pkgs/applications/editors/kakoune/plugins/quickscope.kak.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, lua5_3 }:
+
+stdenv.mkDerivation rec {
+  pname = "quickscope-kak";
+  version = "1.0.0";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~voroskoi/quickscope.kak";
+    rev = "v${version}";
+    sha256 = "0y1g3zpa2ql8l9rl5i2w84bka8a09kig9nq9zdchaff5pw660mcx";
+  };
+
+  buildInputs = [ lua5_3 ];
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins/
+    cp quickscope.* $out/share/kak/autoload/plugins/
+    # substituteInPlace does not like the pipe
+    sed -e 's,[|] *lua,|${lua5_3}/bin/lua,' quickscope.kak >$out/share/kak/autoload/plugins/quickscope.kak
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Highlight f and t jump positions";
+    homepage = "https://sr.ht/~voroskoi/quickscope.kak/";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ eraserhd ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

New Kakoune plugin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).