### PR TITLE
python3Packages.aiomysql: fix patch to dependencies

### DIFF
--- a/pkgs/development/python-modules/aiomysql/default.nix
+++ b/pkgs/development/python-modules/aiomysql/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "PyMySQL>=0.9,<=0.9.2" "PyMySQL"
+      --replace "PyMySQL>=0.9,<=0.9.3" "PyMySQL"
   '';
 
   checkPhase = ''


### PR DESCRIPTION
the build was failing as upstream changed their pinning
