### PR TITLE
cryptoverif: 2.03pl1 → 2.04

### DIFF
--- a/pkgs/applications/science/logic/cryptoverif/default.nix
+++ b/pkgs/applications/science/logic/cryptoverif/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   ** from under $out/libexec. By default, it expects to find the files
   ** in $CWD which doesn't work. */
   patchPhase = ''
-    substituteInPlace ./src/settings.ml \
+    substituteInPlace ./src/syntax.ml \
       --replace \"default\" \"$out/libexec/default\"
   '';
 

--- a/pkgs/applications/science/logic/cryptoverif/default.nix
+++ b/pkgs/applications/science/logic/cryptoverif/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "cryptoverif";
-  version = "2.03pl1";
+  version = "2.04";
 
   src = fetchurl {
     url    = "http://prosecco.gforge.inria.fr/personal/bblanche/cryptoverif/cryptoverif${version}.tar.gz";
-    sha256 = "0q7qa1qm7mbky3m36445gdmgmkb9mrhrdsk7mmwn8fzw0rfc6z00";
+    sha256 = "1mzk6n0g2vdsv38y493zg85lxrpz72b92cmsray3g970xzanqd6s";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
###### Motivation for this change

The patch to fix the path to the standard library does not work.

The update brings fixes & improvements.

cc maintainer @thoughtpolice

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
