### PR TITLE
imhex: init at 1.6.0-git

### DIFF
--- a/pkgs/applications/editors/imhex/default-db.patch
+++ b/pkgs/applications/editors/imhex/default-db.patch
@@ -1,0 +1,105 @@
+diff --git a/source/views/view_information.cpp b/source/views/view_information.cpp
+index bf9439d..a6792de 100644
+--- a/source/views/view_information.cpp
++++ b/source/views/view_information.cpp
+@@ -83,41 +83,27 @@ namespace hex {
+                         this->m_fileDescription.clear();
+                         this->m_mimeType.clear();
+ 
+-                        std::string magicFiles;
+-
+-                        std::error_code error;
+-                        for (const auto &entry : std::filesystem::directory_iterator("magic", error)) {
+-                            if (entry.is_regular_file() && entry.path().extension() == ".mgc")
+-                                magicFiles += entry.path().string() + MAGIC_PATH_SEPARATOR;
++                        {
++                            magic_t cookie = magic_open(MAGIC_NONE);
++                            if (magic_load(cookie, nullptr) != -1)
++                                this->m_fileDescription = magic_buffer(cookie, buffer.data(), buffer.size());
++                            else
++                                this->m_fileDescription = "";
++
++                            magic_close(cookie);
+                         }
+ 
+-                        if (!error) {
+-                            magicFiles.pop_back();
+-
+-                            {
+-                                magic_t cookie = magic_open(MAGIC_NONE);
+-                                if (magic_load(cookie, magicFiles.c_str()) != -1)
+-                                    this->m_fileDescription = magic_buffer(cookie, buffer.data(), buffer.size());
+-                                else
+-                                    this->m_fileDescription = "";
+-
+-                                magic_close(cookie);
+-                            }
+-
+-
+-                            {
+-                                magic_t cookie = magic_open(MAGIC_MIME);
+-                                if (magic_load(cookie, magicFiles.c_str()) != -1)
+-                                    this->m_mimeType = magic_buffer(cookie, buffer.data(), buffer.size());
+-                                else
+-                                    this->m_mimeType = "";
+ 
+-                                magic_close(cookie);
+-                            }
++                        {
++                            magic_t cookie = magic_open(MAGIC_MIME);
++                            if (magic_load(cookie, nullptr) != -1)
++                                this->m_mimeType = magic_buffer(cookie, buffer.data(), buffer.size());
++                            else
++                                this->m_mimeType = "";
+ 
++                            magic_close(cookie);
+                         }
+ 
+-
+                         this->m_shouldInvalidate = false;
+                         this->m_dataValid = true;
+                     }
+@@ -192,4 +178,4 @@ namespace hex {
+ 
+     }
+ 
+-}
+\ No newline at end of file
++}
+diff --git a/source/views/view_pattern.cpp b/source/views/view_pattern.cpp
+index 87e1db6..87be968 100644
+--- a/source/views/view_pattern.cpp
++++ b/source/views/view_pattern.cpp
+@@ -99,24 +99,13 @@ namespace hex {
+                 return;
+ 
+             lang::Preprocessor preprocessor;
+-            std::string magicFiles;
+-
+-            std::error_code error;
+-            for (const auto &entry : std::filesystem::directory_iterator("magic", error)) {
+-                if (entry.is_regular_file() && entry.path().extension() == ".mgc")
+-                    magicFiles += entry.path().string() + MAGIC_PATH_SEPARATOR;
+-            }
+-
+-            if (error)
+-                return;
+-
+             std::vector<u8> buffer(std::min(this->m_dataProvider->getSize(), size_t(0xFFFF)), 0x00);
+             this->m_dataProvider->read(0, buffer.data(), buffer.size());
+ 
+             std::string mimeType;
+ 
+             magic_t cookie = magic_open(MAGIC_MIME_TYPE);
+-            if (magic_load(cookie, magicFiles.c_str()) != -1)
++            if (magic_load(cookie, nullptr) != -1)
+                 mimeType = magic_buffer(cookie, buffer.data(), buffer.size());
+ 
+             magic_close(cookie);
+@@ -320,4 +309,4 @@ namespace hex {
+         this->postEvent(Events::PatternChanged);
+     }
+ 
+-}
+\ No newline at end of file
++}

--- a/pkgs/applications/editors/imhex/default.nix
+++ b/pkgs/applications/editors/imhex/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, gcc10Stdenv, cmake, pkgconfig, nlohmann_json, capstone, file, glfw3, glm, jsoncpp, llvm_9, openssl, python38, fetchFromGitHub }:
+gcc10Stdenv.mkDerivation rec {
+  pname = "imhex";
+  version = "1.6.0-git"; # adds install target
+
+  src = fetchFromGitHub {
+    owner = "WerWolv";
+    repo = "ImHex";
+    #rev = "v${version}";
+    rev = "e3b5a55eba51aaab1473abf4c2a40975ddd1e9fa";
+    sha256 = "1nfq2yy21chldkg79r9nnb8n7g9fma6c9fnfy7yqgsl6y7iffxqw";
+  };
+
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ nlohmann_json capstone file glfw3 glm jsoncpp llvm_9 openssl python38 ];
+
+  patches = [ ./default-db.patch ];
+
+  postPatch = let
+    patterns = fetchFromGitHub {
+      name = "imhex-patterns";
+
+      owner = "WerWolv";
+      repo = "ImHex-Patterns";
+      rev = "f5e5345aa6986ddaeb87a9648f5c539ae38a61a1";
+      sha256 = "1dh77jc8dzc7xvzrabjrspn6lf3w8ab4lddvgpwaq6hd7lkdfpf6";
+    };
+  in ''
+  substituteInPlace source/views/view_pattern.cpp --replace 'patterns' "${patterns}/patterns"
+  substituteInPlace source/lang/preprocessor.cpp --replace 'include/' "${patterns}/includes/"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/WerWolv/ImHex";
+    description = "A hex editor for reverse engineers, programmers and people that value their eye sight when working at 3 AM";
+    license = licenses.gpl2Only;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1270,6 +1270,8 @@ in
 
   imageworsener = callPackage ../tools/graphics/imageworsener { };
 
+  imhex = callPackage ../applications/editors/imhex { };
+
   imgpatchtools = callPackage ../development/mobile/imgpatchtools { };
 
   ipgrep = callPackage ../tools/networking/ipgrep { };


### PR DESCRIPTION
###### Motivation for this change
ImHex has been receiving a lot of attention the past few days, I know the author, and I wanted to try it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
