### PR TITLE
aqbanking & gwenhywfar: update to latest versions

### DIFF
--- a/pkgs/development/libraries/aqbanking/sources.nix
+++ b/pkgs/development/libraries/aqbanking/sources.nix
@@ -1,11 +1,11 @@
 {
-  gwenhywfar.version = "5.1.3";
-  gwenhywfar.sha256 = "0xjr9d94y46h7pfdhz5ygn01pmlm66rhiybr520h13nvjh4zid0r";
-  gwenhywfar.releaseId = "242";
+  gwenhywfar.version = "5.4.1";
+  gwenhywfar.sha256 = "16waq39mbhhjcma2ykdbqvpcw0ba3ksqqwsp55zczhg320s41zgv";
+  gwenhywfar.releaseId = "344";
   libchipcard.version = "5.0.4";
   libchipcard.sha256 = "0fj2h39ll4kiv28ch8qgzdbdbnzs8gl812qnm660bw89rynpjnnj";
   libchipcard.releaseId = "158";
-  aqbanking.version = "6.0.2";
-  aqbanking.sha256 = "0n41n3yki1wmax4i9wi485g8zqb43z1adywcixzfq9gbdjhz05hx";
-  aqbanking.releaseId = "273";
+  aqbanking.version = "6.2.5";
+  aqbanking.sha256 = "1pyny15g8y5dzzl4yg7jjnavygfzsi2g1jl7as9grqy77q70cnyg";
+  aqbanking.releaseId = "342";
 }


### PR DESCRIPTION
###### Motivation for this change

The versions of these packages that are currently in nixpkgs cause segfaults when trying to use OFX online banking with GnuCash.

https://bugs.launchpad.net/ubuntu/+source/gnucash/+bug/1875679 records such behavior on other distributions.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have tested the OFX transfer using the resulting GnuCash, and it is working once more.