### PR TITLE
nextcloud: 19.0.4 -> 19.0.6, 20.0.1 -> 20.0.3, mark v19 as insecure

### DIFF
--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -1,7 +1,10 @@
 { stdenv, fetchurl, nixosTests }:
 
 let
-  generic = { version, sha256, insecure ? false }: stdenv.mkDerivation rec {
+  generic = {
+    version, sha256,
+    eol ? false, extraVulnerabilities ? []
+  }: stdenv.mkDerivation rec {
     pname = "nextcloud";
     inherit version;
 
@@ -23,7 +26,8 @@ let
       maintainers = with maintainers; [ schneefux bachp globin fpletz ma27 ];
       license = licenses.agpl3Plus;
       platforms = with platforms; unix;
-      knownVulnerabilities = optional insecure "Nextcloud version ${version} is EOL";
+      knownVulnerabilities = extraVulnerabilities
+        ++ (optional eol "Nextcloud version ${version} is EOL");
     };
   };
 in {
@@ -42,16 +46,19 @@ in {
   nextcloud18 = generic {
     version = "18.0.10";
     sha256 = "0kv9mdn36shr98kh27969b8xs7pgczbyjklrfskxy9mph7bbzir6";
-    insecure = true;
+    eol = true;
   };
 
   nextcloud19 = generic {
-    version = "19.0.4";
-    sha256 = "0y5fccn61qf9fxjjpqdvhmxr9w5n4dgl1d7wcl2dzjv4bmqi2ms6";
+    version = "19.0.6";
+    sha256 = "sha256-pqqIayE0OyTailtd2zeYi+G1APjv/YHqyO8jCpq7KJg=";
+    extraVulnerabilities = [
+      "Nextcloud 19 is still supported, but CVE-2020-8259 & CVE-2020-8152 are unfixed!"
+    ];
   };
 
   nextcloud20 = generic {
-    version = "20.0.1";
-    sha256 = "1z1fzz1i41k4dhdhi005l3gzkvnmmgqqz3rdr374cvk73q7bbiln";
+    version = "20.0.3";
+    sha256 = "sha256-4PZFBNM49k08Z3NX8AEs+LDtDcQuwI+Vi23E/3Dt8XU=";
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ChangeLogs:

* https://nextcloud.com/changelog/#20-0-3
* https://nextcloud.com/changelog/#19-0-6

For Nextcloud 20, security advisories for CVE-2020-8259[1] &
CVE-2020-8152[2] were published. The only way to fix those is to upgrade
to v20, although v19 and v18 are supported, the issue won't be fixed
there[3].

Even though both CVEs are only related to the encryption module[4] which
is turned off by default, I decided to add a vulnerability note to
`nextcloud19` since CVE-2020-8259's is rated as "High" by NIST (in
contrast to Nextcloud which rates it as "Low").

If one is not affected by the issue, `nextcloud19` can still be used by
declaring `permittedInsecurePackages`[5].

[1] https://nvd.nist.gov/vuln/detail/CVE-2020-8259,
    https://nextcloud.com/security/advisory/?id=NC-SA-2020-041
[2] https://nvd.nist.gov/vuln/detail/CVE-2020-8152,
    https://nextcloud.com/security/advisory/?id=NC-SA-2020-040
[3] https://help.nextcloud.com/t/fixes-for-cve-2020-8259-cve-2020-8152-in-nextcloud-18-19/98289
[4] https://docs.nextcloud.com/server/20/admin_manual/configuration_files/encryption_configuration.html
[5] https://nixos.org/manual/nixpkgs/stable/#sec-allow-insecure

Closes #106212


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
