### PR TITLE
emacsPackages: mark some packages as broken

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -438,6 +438,9 @@ let
         # upstream issue: doesn't build
         eterm-256color = markBroken super.eterm-256color;
 
+        # upstream issue: doesn't build
+        per-buffer-theme = markBroken super.per-buffer-theme;
+
         # upstream issue: missing file header
         qiita = markBroken super.qiita;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -421,6 +421,9 @@ let
         initsplit = markBroken super.initsplit;
 
         # upstream issue: missing file header
+        instapaper = markBroken super.instapaper;
+
+        # upstream issue: missing file header
         jsfmt = markBroken super.jsfmt;
 
         # upstream issue: missing file header

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -252,12 +252,6 @@ let
             (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
         });
 
-        magit-stgit = super.magit-stgit.overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or [ ]) ++ [ external.git ];
-        });
-
         magit-tbdiff = super.magit-tbdiff.overrideAttrs (attrs: {
           # searches for Git at build time
           nativeBuildInputs =
@@ -431,6 +425,9 @@ let
 
         # upstream issue: missing file header
         maxframe = markBroken super.maxframe;
+
+        # upstream issue: doesn't build
+        magit-stgit = markBroken super.magit-stgit;
 
         # upstream issue: doesn't build
         eterm-256color = markBroken super.eterm-256color;

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -448,6 +448,9 @@ let
         speech-tagger = markBroken super.speech-tagger;
 
         # upstream issue: missing file header
+        sql-presto = markBroken super.sql-presto;
+
+        # upstream issue: missing file header
         textmate = markBroken super.textmate;
 
         # upstream issue: missing file header

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -429,6 +429,9 @@ let
         # upstream issue: doesn't build
         magit-stgit = markBroken super.magit-stgit;
 
+        # upstream issue: missing file header
+        melancholy-theme = markBroken super.melancholy-theme;
+
         # upstream issue: doesn't build
         eterm-256color = markBroken super.eterm-256color;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
