### PR TITLE
pythonPackages.psautohint: fix test failures due to pytest 6

### DIFF
--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -4,6 +4,10 @@
 , pytest, pytestcov, pytest_xdist, pytest-randomly
 }:
 
+let
+  pytestSix = lib.versionAtLeast pytest.version "6.0";
+in
+
 buildPythonPackage rec {
   pname = "psautohint";
   version = "2.1.2";
@@ -29,7 +33,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ fonttools lxml fs ];
 
   checkInputs = [ pytest pytestcov pytest_xdist pytest-randomly ];
-  checkPhase = "pytest tests";
+  checkPhase = ''
+    pytest tests ${lib.optionalString pytestSix "-k 'not test_hashmap_old_version'"}
+  '';
 
   meta = with lib; {
     description = "Script to normalize the XML and other data inside of a UFO";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4833,7 +4833,9 @@ in {
 
   prox-tv = callPackage ../development/python-modules/prox-tv { };
 
-  psautohint = callPackage ../development/python-modules/psautohint { };
+  psautohint = callPackage ../development/python-modules/psautohint {
+    pytest = self.pytest_5;
+  };
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #106558. Alternative solution to #106464. 

The issue with the `psautohint` test suite was the update to pytest 6. 

The proposed solution is to default to pytest 5 and to disable the offending
test if the package is overriden to use pytest 6.

See <https://github.com/adobe-type-tools/psautohint/issues/284#issuecomment-742800965>
for the explanation and upstream issue.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
