### PR TITLE
cedille: 1.1.1 -> 1.1.2; fix build

### DIFF
--- a/pkgs/applications/science/logic/cedille/Fix-to-string.agda-to-compile-with-Agda-2.6.1.patch
+++ b/pkgs/applications/science/logic/cedille/Fix-to-string.agda-to-compile-with-Agda-2.6.1.patch
@@ -1,0 +1,31 @@
+From 563f023aba1034f4f433f412302b825b059ef5a5 Mon Sep 17 00:00:00 2001
+From: Mark Barbone <mark.l.barbone@gmail.com>
+Date: Sun, 19 Jul 2020 17:24:30 -0400
+Subject: [PATCH] Fix to-string.agda to compile with Agda 2.6.1
+
+---
+Adapted from https://github.com/cedille/cedille/pull/156.
+
+ src/to-string.agda | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/to-string.agda b/src/to-string.agda
+index 2505942..051a2da 100644
+--- a/src/to-string.agda
++++ b/src/to-string.agda
+@@ -100,9 +100,9 @@ no-parens {TK} _ _ _ = tt
+ no-parens {QUALIF} _ _ _ = tt
+ no-parens {ARG} _ _ _ = tt
+ 
+-pattern ced-ops-drop-spine = cedille-options.options.mk-options _ _ _ _ ff _ _ _ ff _
+-pattern ced-ops-conv-arr = cedille-options.options.mk-options _ _ _ _ _ _ _ _ ff _
+-pattern ced-ops-conv-abs = cedille-options.options.mk-options _ _ _ _ _ _ _ _ tt _
++pattern ced-ops-drop-spine = cedille-options.mk-options _ _ _ _ ff _ _ _ ff _
++pattern ced-ops-conv-arr = cedille-options.mk-options _ _ _ _ _ _ _ _ ff _
++pattern ced-ops-conv-abs = cedille-options.mk-options _ _ _ _ _ _ _ _ tt _
+ 
+ drop-spine : cedille-options.options → {ed : exprd} → ctxt → ⟦ ed ⟧ → ⟦ ed ⟧
+ drop-spine ops @ ced-ops-drop-spine = h
+-- 
+2.27.0
+

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -10,16 +10,20 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.1";
+  version = "1.1.2";
   pname = "cedille";
 
   src = fetchFromGitHub {
     owner = "cedille";
     repo = "cedille";
     rev = "v${version}";
-    sha256 = "16pc72wz6kclq9yv2r8hx85mkp0s125h12snrhcjxkbl41xx2ynb";
+    sha256 = "1j745q9sd32fhcb96wjq6xvyqq1k6imppjnya6x0n99fyfnqzvg9";
     fetchSubmodules = true;
   };
+
+  patches = [
+    ./Fix-to-string.agda-to-compile-with-Agda-2.6.1.patch
+  ];
 
   nativeBuildInputs = [ alex happy ];
   buildInputs = [ Agda (ghcWithPackages (ps: [ps.ieee])) ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Noticed this was broken.  I don’t use it and haven’t tested it works, but it does at least build now, so that’s an improvement.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
