### PR TITLE
ocamlPackages.base: 0.13.1 -> 0.13.2

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.13.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.13.nix
@@ -26,8 +26,8 @@ rec {
 
   base = janePackage {
     pname = "base";
-    version = "0.13.1";
-    hash = "08a5aymcgr5svvm8v0v20msd5cad64m6maakfbhz4172g7kd9jzw";
+    version = "0.13.2";
+    hash = "0x6r37a8j9z9kvx9syg6qkm7zgmjg41m40hfshls98h61zlzp3gv";
     meta.description = "Full standard library replacement for OCaml";
     propagatedBuildInputs = [ sexplib0 ];
   };


### PR DESCRIPTION
###### Motivation for this change

Update base to the latest version, 0.13.2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I noticed, when running `nixpkgs-review rev HEAD`, that irmin-http, irmin-unix, and torch failed to build.  torch doesn't build for me in master anyway.  irmin-http and irmin-unix build fine for me if I just run `nix build -f .` at the tip of this PR.  🤷 