### PR TITLE
firefox: fix running wayland firefox built with LTO and some miscellaneous improvements

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -2,7 +2,7 @@
 , src, unpackPhase ? null, patches ? []
 , extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? [] }:
 
-{ lib, stdenv, pkgconfig, pango, perl, python2, python3, zip
+{ lib, stdenv, pkgconfig, pango, perl, python3, zip
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
 , freetype, fontconfig, file, nspr, nss, nss_3_53
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
@@ -223,7 +223,6 @@ buildStdenv.mkDerivation ({
       nodejs
       perl
       pkgconfig
-      python2
       python3
       rust-cbindgen
       rustc

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -174,9 +174,9 @@ buildStdenv.mkDerivation ({
   ++ lib.optional  gtk3Support gtk3
   ++ lib.optional  gssSupport kerberos
   ++ lib.optional  ltoSupport llvmPackages.libunwind
-  ++ lib.optionals waylandSupport [ libxkbcommon ]
-  ++ lib.optionals pipewireSupport [ pipewire ]
-  ++ lib.optionals (lib.versionAtLeast ffversion "82") [ gnum4 ]
+  ++ lib.optional  waylandSupport libxkbcommon
+  ++ lib.optional  pipewireSupport pipewire
+  ++ lib.optional  (lib.versionAtLeast ffversion "82") gnum4
   ++ lib.optionals buildStdenv.isDarwin [ CoreMedia ExceptionHandling Kerberos
                                           AVFoundation MediaToolbox CoreLocation
                                           Foundation libobjc AddressBook cups ];

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -197,7 +197,7 @@ buildStdenv.mkDerivation ({
     substituteInPlace \
       media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_generic_gn/moz.build \
       --replace /usr/include ${pipewire.dev}/include
-  '' + lib.optionalString (lib.versionAtLeast ffversion "80") ''
+  '' + lib.optionalString (lib.versionAtLeast ffversion "80" && lib.versionOlder ffversion "81") ''
     substituteInPlace dom/system/IOUtils.h \
       --replace '#include "nspr/prio.h"'          '#include "prio.h"'
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -173,7 +173,6 @@ buildStdenv.mkDerivation ({
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optional  gtk3Support gtk3
   ++ lib.optional  gssSupport kerberos
-  ++ lib.optional  ltoSupport llvmPackages.libunwind
   ++ lib.optional  waylandSupport libxkbcommon
   ++ lib.optional  pipewireSupport pipewire
   ++ lib.optional  (lib.versionAtLeast ffversion "82") gnum4
@@ -182,7 +181,6 @@ buildStdenv.mkDerivation ({
                                           Foundation libobjc AddressBook cups ];
 
   NIX_LDFLAGS = lib.optionalString ltoSupport ''
-    -rpath ${placeholder "out"}/lib/${binaryName}
     -rpath ${llvmPackages.libunwind.out}/lib
   '';
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -4,7 +4,7 @@
 
 { lib, stdenv, pkgconfig, pango, perl, python2, python3, zip
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
-, freetype, fontconfig, file, nspr, nss, nss_3_53, libnotify
+, freetype, fontconfig, file, nspr, nss, nss_3_53
 , yasm, libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libXdamage, libevent, libstartup_notification
 , libvpx_1_8
@@ -157,7 +157,7 @@ buildStdenv.mkDerivation ({
     gtk2 perl zip libjpeg zlib bzip2
     dbus dbus-glib pango freetype fontconfig xorg.libXi xorg.libXcursor
     xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
-    libnotify xorg.pixman yasm libGLU libGL
+    xorg.pixman yasm libGLU libGL
     xorg.xorgproto
     xorg.libXext unzip makeWrapper
     libevent libstartup_notification /* cairo */
@@ -336,18 +336,6 @@ buildStdenv.mkDerivation ({
     gappsWrapperArgs+=(--argv0 "$out/bin/.${binaryName}-wrapped")
   '';
 
-  postFixup = lib.optionalString buildStdenv.isLinux ''
-    # Fix notifications. LibXUL uses dlopen for this, unfortunately; see #18712.
-    patchelf --set-rpath "${lib.getLib libnotify
-      }/lib:$(patchelf --print-rpath "$out"/lib/${binaryName}*/libxul.so)" \
-        "$out"/lib/${binaryName}*/libxul.so
-    patchelf --add-needed ${xorg.libXScrnSaver.out}/lib/libXss.so $out/lib/${binaryName}/${binaryName}
-    ${lib.optionalString (pipewireSupport && lib.versionAtLeast ffversion "83") ''
-      patchelf --add-needed "${lib.getLib pipewire}/lib/libpipewire-0.3.so" \
-        "$out"/lib/${binaryName}/${binaryName}
-    ''}
-  '';
-
   doInstallCheck = true;
   installCheckPhase = ''
     # Some basic testing
@@ -360,6 +348,7 @@ buildStdenv.mkDerivation ({
     isFirefox3Like = true;
     gtk = gtk2;
     inherit alsaSupport;
+    inherit pipewireSupport;
     inherit nspr;
     inherit ffmpegSupport;
     inherit gssSupport;

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -186,11 +186,6 @@ buildStdenv.mkDerivation ({
     -rpath ${llvmPackages.libunwind.out}/lib
   '';
 
-  NIX_CFLAGS_COMPILE = toString [
-    "-I${glib.dev}/include/gio-unix-2.0"
-    "-I${nss_pkg.dev}/include/nss"
-  ];
-
   MACH_USE_SYSTEM_PYTHON = "1";
 
   postPatch = ''

--- a/pkgs/applications/networking/browsers/firefox/lto-dependentlibs-generation-ffx83.patch
+++ b/pkgs/applications/networking/browsers/firefox/lto-dependentlibs-generation-ffx83.patch
@@ -1,0 +1,45 @@
+--- a/toolkit/library/build/dependentlibs.py
++++ b/toolkit/library/build/dependentlibs.py
+@@ -36,26 +36,17 @@ def dependentlibs_win32_objdump(lib):
+     proc.wait()
+     return deps
+ 
+-def dependentlibs_readelf(lib):
++def dependentlibs_elf_objdump(lib):
+     '''Returns the list of dependencies declared in the given ELF .so'''
+-    proc = subprocess.Popen([substs.get('TOOLCHAIN_PREFIX', '') + 'readelf', '-d', lib], stdout = subprocess.PIPE,
++    proc = subprocess.Popen([substs['LLVM_OBJDUMP'], '--private-headers', lib], stdout = subprocess.PIPE,
+                             universal_newlines=True)
+     deps = []
+     for line in proc.stdout:
+-        # Each line has the following format:
+-        #  tag (TYPE)          value
+-        # or with BSD readelf:
+-        #  tag TYPE            value
+-        # Looking for NEEDED type entries
+-        tmp = line.split(' ', 3)
+-        if len(tmp) > 3 and 'NEEDED' in tmp[2]:
+-            # NEEDED lines look like:
+-            # 0x00000001 (NEEDED)             Shared library: [libname]
+-            # or with BSD readelf:
+-            # 0x00000001 NEEDED               Shared library: [libname]
+-            match = re.search('\[(.*)\]', tmp[3])
+-            if match:
+-                deps.append(match.group(1))
++        # We are looking for lines with the format:
++        #   NEEDED             libname
++        tmp = line.split()
++        if len(tmp) == 2 and tmp[0] == 'NEEDED':
++            deps.append(tmp[1])
+     proc.wait()
+     return deps
+ 
+@@ -110,7 +101,7 @@ def gen_list(output, lib):
+     libpaths = [os.path.join(substs['DIST'], 'bin')]
+     binary_type = get_type(lib)
+     if binary_type == ELF:
+-        func = dependentlibs_readelf
++        func = dependentlibs_elf_objdump
+     elif binary_type == MACHO:
+         func = dependentlibs_mac_objdump
+     else:

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -3,9 +3,9 @@
 
 ## various stuff that can be plugged in
 , flashplayer, hal-flash
-, ffmpeg, xorg, alsaLib, libpulseaudio, libcanberra-gtk2, libglvnd
+, ffmpeg, xorg, alsaLib, libpulseaudio, libcanberra-gtk2, libglvnd, libnotify
 , gnome3/*.gnome-shell*/
-, browserpass, chrome-gnome-shell, uget-integrator, plasma5, bukubrow
+, browserpass, chrome-gnome-shell, uget-integrator, plasma5, bukubrow, pipewire
 , tridactyl-native
 , fx_cast_bridge
 , udev
@@ -51,6 +51,7 @@ let
       ffmpegSupport = browser.ffmpegSupport or false;
       gssSupport = browser.gssSupport or false;
       alsaSupport = browser.alsaSupport or false;
+      pipewireSupport = browser.pipewireSupport or false;
 
       plugins =
         let
@@ -80,7 +81,8 @@ let
           ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
         );
-      libs =   lib.optionals stdenv.isLinux [ udev libva mesa ]
+      libs =   lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver ]
+            ++ lib.optional (pipewireSupport && lib.versionAtLeast version "83") pipewire
             ++ lib.optional ffmpegSupport ffmpeg
             ++ lib.optional gssSupport kerberos
             ++ lib.optional useGlvnd libglvnd


### PR DESCRIPTION
###### Motivation for this change

Resolves #101429 which is Firefox crashing when running under wayland and being built with LTO. This means building with LTO support by default on Linux once again. There are also some commits with cleaning up the overall expression which hopefully is fine but if it is preferred to pull them out to another pull request I can do that.

The commits contain relevant information on the changes done but to recap, the issue seemed to be a borked generation of `dependentlibs.list` which caused Firefox's wayland stub library to be loaded first. I could not discern why `readelf -d` was returning incorrect results when building under LTO support but fine when building without LTO. However, switching to a different tool in this case `llvm-objdump` fixed the issue.

I have built and tested `firefox` with LTO support on X11 and Wayland. Would appreciate if the other firefox variants could be tested too.

cc @andir @artemist 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
