### PR TITLE
rofimoji: unbreak

### DIFF
--- a/pkgs/applications/misc/rofimoji/default.nix
+++ b/pkgs/applications/misc/rofimoji/default.nix
@@ -33,7 +33,10 @@ buildPythonApplication rec {
 
   # The 'extractors' sub-module is used for development
   # and has additional dependencies.
-  postPatch = "rm -rf extractors";
+  postPatch = ''
+    rm -rf extractors
+    substituteInPlace setup.py --replace 'pyxdg==0.26' 'pyxdg'
+  '';
 
   meta = with lib; {
     description = "A simple emoji and character picker for rofi";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package was broken by https://github.com/NixOS/nixpkgs/commit/40389df3d223ccb4c4497fd6987f3d862909dc1a, but I fixed it by patching the setup.py

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
