### PR TITLE
smesh: fix building with clang

### DIFF
--- a/pkgs/development/libraries/smesh/default.nix
+++ b/pkgs/development/libraries/smesh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, ninja, opencascade }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, ninja, opencascade }:
 
 stdenv.mkDerivation rec {
   pname = "smesh";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1b07j3bw3lnxk8dk3x1kkl2mbsmfwi98si84054038lflaaijzi0";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-build-with-clang.patch";
+      url = "https://github.com/tpaviot/smesh/commit/e32c430f526f1637ec5973c9723acbc5be571ae3.patch";
+      sha256 = "0s4j5rb70g3jvvkgfbrxv7q52wk6yjyjiaya61gy2j64khplcjlb";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ninja ];
   buildInputs = [ opencascade ];


### PR DESCRIPTION
so the darwin build has a chance of succeeding again


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).