### PR TITLE
fetchMavenArtifact: switch mirrors to https

### DIFF
--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -3,10 +3,10 @@
 { fetchurl, stdenv }:
 let
   defaultRepos = [
-    "http://repo1.maven.org/maven2"
-    "http://oss.sonatype.org/content/repositories/releases"
-    "http://oss.sonatype.org/content/repositories/public"
-    "http://repo.typesafe.com/typesafe/releases"
+    "https://repo1.maven.org/maven2"
+    "https://oss.sonatype.org/content/repositories/releases"
+    "https://oss.sonatype.org/content/repositories/public"
+    "https://repo.typesafe.com/typesafe/releases"
   ];
 in
 

--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -50,7 +50,7 @@ let
       (replaceChars ["."] ["/"] groupId)
       artifactId
       version
-      "${artifactId}-${version}-${optionalString (!isNull classifier) "-${classifier}"}.jar"
+      "${artifactId}-${version}${optionalString (!isNull classifier) "-${classifier}"}.jar"
     ];
   urls_ =
     if url != "" then [url]

--- a/pkgs/development/interpreters/clojurescript/lumo/deps.nix
+++ b/pkgs/development/interpreters/clojurescript/lumo/deps.nix
@@ -4,9 +4,9 @@
 let repos = [
       "https://repo.clojars.org/"
       "https://repo1.maven.org/"
-      "http://oss.sonatype.org/content/repositories/releases/"
-      "http://oss.sonatype.org/content/repositories/public/"
-      "http://repo.typesafe.com/typesafe/releases/"
+      "https://oss.sonatype.org/content/repositories/releases/"
+      "https://oss.sonatype.org/content/repositories/public/"
+      "https://repo.typesafe.com/typesafe/releases/"
     ];
 
 in rec {


### PR DESCRIPTION
Maven repositories are disabling HTTP support for security.
Even though Nix adds some security with its own hash validation,
broken mirrors are a, well, suboptimal experience.
I don't know of any plans by sonatype, but it seems like a matter
of time.

https://www.lightbend.com/blog/lightbend-to-require-https-on-repos-starting-august-5-2020

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

 - Fix fetchMavenArtifact for the typesafe repo.
 - Make the other mirrors future proof

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
