### PR TITLE
linuxPackages.rtl8821ce: 5.5.2_34066.20200325 -> unstable-2020-12-16

### DIFF
--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -1,13 +1,14 @@
 { lib, stdenv, fetchFromGitHub, kernel, bc }:
+
 stdenv.mkDerivation rec {
-  name = "rtl8821ce-${kernel.version}-${version}";
-  version = "5.5.2_34066.20200325";
+  pname = "rtl8821ce-${kernel.version}";
+  version = "unstable-2020-12-16";
 
   src = fetchFromGitHub {
     owner = "tomaspinho";
     repo = "rtl8821ce";
-    rev = "8d7edbe6a78fd79cfab85d599dad9dc34138abd1";
-    sha256 = "1hsf8lqjnkrkvk0gps8yb3lx72mvws6xbgkbdmgdkz7qdxmha8bp";
+    rev = "14b536f0c9ad2d0abbdab8afc7ade684900ca9cf";
+    sha256 = "0z7r7spsgn22gwv9pcmkdjn9ingi8jj7xkxasph8118h46fw8ip2";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
###### Motivation for this change
I noticed that on kernel 5.9.12 the wifi driver seems to sometimes not work correctly, which causes the system to not boot into my graphical session. Based on my minimal testing, this seems to fix that.

Tested with `linuxPackages_latest`.

Versioning was (as far as i can tell) based on [this](https://github.com/tomaspinho/rtl8821ce/blob/69765eb288a8dfad3b055b906760b53e02ab1dea/dkms-install.sh#L11). This does not increment on every commit, while we weren't fetching a specific version, but instead a git commit. I've switch to the `unstable-${date}` convention.

This fixes: #107829

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nixpkgs-review pr 106661`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
