### PR TITLE
freenukum: init at 0.3.5

### DIFF
--- a/pkgs/games/freenukum/default.nix
+++ b/pkgs/games/freenukum/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitLab
+, makeDesktopItem
+, installShellFiles
+, dejavu_fonts
+, SDL2
+, SDL2_ttf
+}:
+let
+  pname = "freenukum";
+  description = "Clone of the original Duke Nukum 1 Jump'n Run game";
+
+  desktopItem = makeDesktopItem {
+    desktopName = pname;
+    name = pname;
+    exec = pname;
+    icon = pname;
+    terminal = "false";
+    comment = description;
+    type = "Application";
+    categories = "Game;ArcadeGame;ActionGame";
+    genericName = pname;
+    fileValidation = false;
+  };
+
+in
+rustPlatform.buildRustPackage rec {
+  inherit pname;
+  version = "0.3.5";
+
+  src = fetchFromGitLab {
+    owner = "silwol";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yqfzh0c8fqk92q9kmidy15dc5li0ak1gbn3v7p3xw5fkrzf99gy";
+  };
+
+  cargoSha256 = "1mi98ccp4026gdc5x9jc6518zb7z4dplxl8vir78ivgdpifzz4pw";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_ttf
+  ];
+
+  postPatch = ''
+    substituteInPlace src/graphics.rs \
+      --replace /usr $out
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/fonts/truetype/dejavu
+    ln -sf \
+      ${dejavu_fonts}/share/fonts/truetype/DejaVuSans.ttf \
+      $out/share/fonts/truetype/dejavu/DejaVuSans.ttf
+    mkdir -p $out/share/doc/freenukum
+    install -Dm644 README.md CHANGELOG.md COPYING $out/share/doc/freenukum/
+    installManPage doc/freenukum.6
+    install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Clone of the original Duke Nukum 1 Jump'n Run game";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ _0x4A6F ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4051,6 +4051,8 @@ in
 
   freedroidrpg = callPackage ../games/freedroidrpg { };
 
+  freenukum = callPackage ../games/freenukum { };
+
   freebind = callPackage ../tools/networking/freebind { };
 
   freeipmi = callPackage ../tools/system/freeipmi {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Include [freenukum](https://gitlab.com/silwol/freenukum) into nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
