### PR TITLE
vtk_9: qt514 -> qt515

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16388,7 +16388,7 @@ in
                                           CoreText IOSurface ImageIO OpenGL GLUT;
   };
 
-  vtk_9 = libsForQt514.callPackage ../development/libraries/vtk/9.x.nix {
+  vtk_9 = libsForQt515.callPackage ../development/libraries/vtk/9.x.nix {
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.libs) xpc;
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreServices DiskArbitration


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

As requested in #104474

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"                                                                
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 50, done.
remote: Counting objects: 100% (50/50), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 54 (delta 43), reused 44 (delta 38), pack-reused 4
Unpacking objects: 100% (54/54), 9.88 KiB | 1.65 MiB/s, done.
From https://github.com/NixOS/nixpkgs
   0a907ad8488..1f8ef6970a1  master     -> refs/nixpkgs-review/0
$ git worktree add /home/thiago/.cache/nixpkgs-review/rev-0a907ad84884de0d6a65dba8484fb95d302d4b46-dirty-2/nixpkgs 1f8ef6970a146c49a601bec2a7750c3f560e1206
Preparing worktree (detached HEAD 1f8ef6970a1)
HEAD is now at 1f8ef6970a1 linux: 5.9.12 -> 5.9.14
$ nix-env -f /home/thiago/.cache/nixpkgs-review/rev-0a907ad84884de0d6a65dba8484fb95d302d4b46-dirty-2/nixpkgs -qaP --xml --out-path --show-trace
Applying `nixpkgs` diff...
$ nix-env -f /home/thiago/.cache/nixpkgs-review/rev-0a907ad84884de0d6a65dba8484fb95d302d4b46-dirty-2/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages updated:
f3d vtk

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/thiago/.cache/nixpkgs-review/rev-0a907ad84884de0d6a65dba8484fb95d302d4b46-dirty-2/build.nix
2 packages built:
f3d vtk_9
```