### PR TITLE
ksmoothdock: qt514 -> qt515 (fix build)

### DIFF
--- a/pkgs/applications/misc/ksmoothdock/default.nix
+++ b/pkgs/applications/misc/ksmoothdock/default.nix
@@ -25,6 +25,11 @@ mkDerivation rec {
       url = "https://github.com/dangvd/ksmoothdock/commit/00799bef8a1c1fe61ef9274866267d9fe9194041.patch";
       sha256 = "1nmb7gf1ggzicxz8k4fd67xhwjy404myqzjpgjym66wqxm0arni4";
     })
+    # Pull request to fix build on Qt 5.15 https://github.com/dangvd/ksmoothdock/pull/123
+    (fetchpatch {
+      url = "https://github.com/dangvd/ksmoothdock/commit/259527aacadb0fd9110d4425b9bf41a15bedce72.patch";
+      sha256 = "12nj58v9qqrynarn3gpywih3w27mr4n51z1b8mh0rfbnd2kib8dc";
+    })
   ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5124,7 +5124,7 @@ in
 
   peruse = libsForQt5.callPackage ../tools/misc/peruse { };
 
-  ksmoothdock = libsForQt514.callPackage ../applications/misc/ksmoothdock { };
+  ksmoothdock = libsForQt5.callPackage ../applications/misc/ksmoothdock { };
 
   kstars = libsForQt514.callPackage ../applications/science/astronomy/kstars { };
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/104474

###### Things done
Patched 6.2 to build with qt515

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
