### PR TITLE
gauche: 0.9.9 → 0.9.10

### DIFF
--- a/pkgs/development/interpreters/gauche/boot.nix
+++ b/pkgs/development/interpreters/gauche/boot.nix
@@ -1,24 +1,18 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, gaucheBootstrap, pkg-config, texinfo
-,  libiconv, gdbm, openssl, zlib, mbedtls, cacert }:
+{ stdenv, lib, fetchurl, pkg-config, texinfo, libiconv, gdbm, openssl, zlib
+, mbedtls, cacert }:
 
 stdenv.mkDerivation rec {
-  pname = "gauche";
-  version = "0.9.10";
+  pname = "gauche-bootstrap";
+  version = "0.9.9";
 
-  src = fetchFromGitHub {
-    owner = "shirok";
-    repo = pname;
-    rev = "release${lib.replaceChars [ "." ] [ "_" ] version}";
-    sha256 = "0ki1w7sa10ivmg51sqjskby0gsznb0d3738nz80x589033km5hmb";
+  src = fetchurl {
+    url = "mirror://sourceforge/gauche/Gauche-${version}.tgz";
+    sha256 = "1yzpszhw52vkpr65r5d4khf3489mnnvnw58dd2wsvvx7499k5aac";
   };
 
-  nativeBuildInputs = [ gaucheBootstrap pkg-config texinfo autoreconfHook ];
+  nativeBuildInputs = [ pkg-config texinfo ];
 
   buildInputs = [ libiconv gdbm openssl zlib mbedtls cacert ];
-
-  autoreconfPhase = ''
-    ./DIST gen
-  '';
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21214,6 +21214,8 @@ in
 
   ganttproject-bin = callPackage ../applications/misc/ganttproject-bin { };
 
+  gaucheBootstrap = callPackage ../development/interpreters/gauche/boot.nix { };
+
   gauche = callPackage ../development/interpreters/gauche { };
 
   gcal = callPackage ../applications/misc/gcal { };


### PR DESCRIPTION
###### Motivation for this change
So that r-ryantm can update automatically in the future. I tried bumping the version but would involve some changes to the build process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
