### PR TITLE
libhandy_1: init at 1.0.2 (backport)

### DIFF
--- a/pkgs/development/libraries/libhandy/0.x.nix
+++ b/pkgs/development/libraries/libhandy/0.x.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchFromGitLab, fetchpatch, meson, ninja, pkgconfig, gobject-introspection, vala
+, gtk-doc, docbook_xsl, docbook_xml_dtd_43
+, gtk3, gnome3, glade
+, dbus, xvfb_run, libxml2
+, hicolor-icon-theme
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libhandy";
+  version = "0.0.13";
+
+  outputs = [ "out" "dev" "devdoc" "glade" ];
+  outputBin = "dev";
+
+  src = fetchFromGitLab {
+    domain = "source.puri.sm";
+    owner = "Librem5";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1y23k623sjkldfrdiwfarpchg5mg58smcy1pkgnwfwca15wm1ra5";
+  };
+
+  patches = [
+    # Fix build with Glade 3.36.0
+    # https://source.puri.sm/Librem5/libhandy/merge_requests/451
+    (fetchpatch {
+      url = "https://source.puri.sm/Librem5/libhandy/commit/887beedb467984ab5c7b91830181645fadef7849.patch";
+      sha256 = "0qgh4i0l1028qxqmig4x2c10yj5s80skl70qnc5wnp71s45alvk5";
+      excludes = [ "glade/glade-hdy-header-bar.c" ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig gobject-introspection vala libxml2
+    gtk-doc docbook_xsl docbook_xml_dtd_43
+  ];
+  buildInputs = [ gnome3.gnome-desktop gtk3 glade libxml2 ];
+  checkInputs = [ dbus xvfb_run hicolor-icon-theme ];
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "-Dglade_catalog=enabled"
+    "-Dintrospection=enabled"
+  ];
+
+  PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";
+  PKG_CONFIG_GLADEUI_2_0_CATALOGDIR = "${placeholder "glade"}/share/glade/catalogs";
+
+  doCheck = true;
+
+  checkPhase = ''
+    NO_AT_BRIDGE=1 \
+    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share" \
+    xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+      --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      meson test --print-errorlogs
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library full of GTK widgets for mobile phones";
+    homepage = "https://source.puri.sm/Librem5/libhandy";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -1,66 +1,89 @@
-{ stdenv, fetchFromGitLab, fetchpatch, meson, ninja, pkgconfig, gobject-introspection, vala
-, gtk-doc, docbook_xsl, docbook_xml_dtd_43
-, gtk3, gnome3, glade
-, dbus, xvfb_run, libxml2
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_43
+, gtk3
+, gnome3
+, glade
+, dbus
+, xvfb_run
+, libxml2
+, gdk-pixbuf
+, librsvg
 , hicolor-icon-theme
 }:
 
 stdenv.mkDerivation rec {
   pname = "libhandy";
-  version = "0.0.13";
+  version = "1.0.0";
 
   outputs = [ "out" "dev" "devdoc" "glade" ];
   outputBin = "dev";
 
-  src = fetchFromGitLab {
-    domain = "source.puri.sm";
-    owner = "Librem5";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1y23k623sjkldfrdiwfarpchg5mg58smcy1pkgnwfwca15wm1ra5";
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    hash = "sha256-qTmFgvR7fXKSBdbqwMBo/vNarySf3Vfuo3JPhRjSZpk=";
   };
 
-  patches = [
-    # Fix build with Glade 3.36.0
-    # https://source.puri.sm/Librem5/libhandy/merge_requests/451
-    (fetchpatch {
-      url = "https://source.puri.sm/Librem5/libhandy/commit/887beedb467984ab5c7b91830181645fadef7849.patch";
-      sha256 = "0qgh4i0l1028qxqmig4x2c10yj5s80skl70qnc5wnp71s45alvk5";
-      excludes = [ "glade/glade-hdy-header-bar.c" ];
-    })
+  nativeBuildInputs = [
+    docbook_xml_dtd_43
+    docbook_xsl
+    gobject-introspection
+    gtk-doc
+    libxml2
+    meson
+    ninja
+    pkgconfig
+    vala
   ];
 
-  nativeBuildInputs = [
-    meson ninja pkgconfig gobject-introspection vala libxml2
-    gtk-doc docbook_xsl docbook_xml_dtd_43
+  buildInputs = [
+    gdk-pixbuf
+    glade
+    gtk3
+    libxml2
   ];
-  buildInputs = [ gnome3.gnome-desktop gtk3 glade libxml2 ];
-  checkInputs = [ dbus xvfb_run hicolor-icon-theme ];
+
+  checkInputs = [
+    dbus
+    hicolor-icon-theme
+    xvfb_run
+  ];
 
   mesonFlags = [
     "-Dgtk_doc=true"
-    "-Dglade_catalog=enabled"
-    "-Dintrospection=enabled"
   ];
 
+  # Uses define_variable in pkgconfig, but we still need it to use the glade output
   PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";
   PKG_CONFIG_GLADEUI_2_0_CATALOGDIR = "${placeholder "glade"}/share/glade/catalogs";
 
-  doCheck = true;
+  # Bail out! dbind-FATAL-WARNING:
+  # AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown:
+  # The name org.a11y.Bus was not provided by any .service files
+  doCheck = false;
 
   checkPhase = ''
     NO_AT_BRIDGE=1 \
-    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share" \
+    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share"
+    GDK_PIXBUF_MODULE_FILE="${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       meson test --print-errorlogs
   '';
 
   meta = with stdenv.lib; {
-    description = "A library full of GTK widgets for mobile phones";
-    homepage = "https://source.puri.sm/Librem5/libhandy";
+    changelog = "https://gitlab.gnome.org/GNOME/libhandy/-/tags/${version}";
+    description = "Building blocks for modern adaptive GNOME apps";
+    homepage = "https://gitlab.gnome.org/GNOME/libhandy";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = teams.gnome.members;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -17,18 +17,20 @@
 , gdk-pixbuf
 , librsvg
 , hicolor-icon-theme
+, at-spi2-atk
+, at-spi2-core
 }:
 
 stdenv.mkDerivation rec {
   pname = "libhandy";
-  version = "1.0.0";
+  version = "1.0.1";
 
   outputs = [ "out" "dev" "devdoc" "glade" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-qTmFgvR7fXKSBdbqwMBo/vNarySf3Vfuo3JPhRjSZpk=";
+    sha256 = "106qa4d2rcbvd3g3avbgkd59aq0bjvwpx8vfz1cikvwrarnfvql4";
   };
 
   nativeBuildInputs = [
@@ -52,8 +54,11 @@ stdenv.mkDerivation rec {
 
   checkInputs = [
     dbus
-    hicolor-icon-theme
     xvfb_run
+    at-spi2-atk
+    at-spi2-core
+    librsvg
+    hicolor-icon-theme
   ];
 
   mesonFlags = [
@@ -64,14 +69,11 @@ stdenv.mkDerivation rec {
   PKG_CONFIG_GLADEUI_2_0_MODULEDIR = "${placeholder "glade"}/lib/glade/modules";
   PKG_CONFIG_GLADEUI_2_0_CATALOGDIR = "${placeholder "glade"}/share/glade/catalogs";
 
-  # Bail out! dbind-FATAL-WARNING:
-  # AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown:
-  # The name org.a11y.Bus was not provided by any .service files
-  doCheck = false;
+  doCheck = true;
 
   checkPhase = ''
     NO_AT_BRIDGE=1 \
-    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share"
+    XDG_DATA_DIRS="$XDG_DATA_DIRS:${hicolor-icon-theme}/share" \
     GDK_PIXBUF_MODULE_FILE="${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -23,14 +23,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libhandy";
-  version = "1.0.1";
+  version = "1.0.2";
 
   outputs = [ "out" "dev" "devdoc" "glade" ];
   outputBin = "dev";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "106qa4d2rcbvd3g3avbgkd59aq0bjvwpx8vfz1cikvwrarnfvql4";
+    sha256 = "0b8wvjabv5mg8jbng8rsd5g84lk571nm0qpna20pwp0njh2qvmrs";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5153,7 +5153,11 @@ in
 
   libgaminggear = callPackage ../development/libraries/libgaminggear { };
 
-  libhandy = callPackage ../development/libraries/libhandy { };
+  libhandy = libhandy_0;
+  # stable branch
+  libhandy_1 = callPackage ../development/libraries/libhandy { };
+  # Needed for apps that still depend on the unstable verison of the library (not libhandy-1)
+  libhandy_0 = callPackage ../development/libraries/libhandy/0.x.nix { };
 
   libgumath = callPackage ../development/libraries/libgumath { };
 


### PR DESCRIPTION
This commit follows the same naming scheme currently in use in for `libhandy` in the 'master' branch.
References to `libhandy` were renamed to `libhandy_0`.

Effectively the changes introduced are only meant to allow `libhandy` to be upgraded to 1.x without breaking depending packages.

###### Motivation for this change

[`cpupower-gui v1.0.0`](https://github.com/NixOS/nixpkgs/pull/100120) requires libhandy 1.x . 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
