### PR TITLE
parsimonious: excluding unpredictable tests

### DIFF
--- a/pkgs/development/python-modules/parsimonious/default.nix
+++ b/pkgs/development/python-modules/parsimonious/default.nix
@@ -17,6 +17,9 @@ buildPythonPackage rec {
   checkInputs = [ nose ];
   propagatedBuildInputs = [ six ];
 
+  # performance tests tend to fail sometimes
+  NOSE_EXCLUDE = "test_benchmarks";
+
   meta = with stdenv.lib; {
     homepage = "https://github.com/erikrose/parsimonious";
     description = "Fast arbitrary-lookahead parser written in pure Python";


### PR DESCRIPTION
###### Motivation for this change

makes the build more reliable. performance tests tend to fail sometimes, breaking the build as a result.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
