### PR TITLE
nixos/test-driver: Fix wait_for_window() when X is running as non-root

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -392,6 +392,7 @@ in
   vector = handleTest ./vector.nix {};
   victoriametrics = handleTest ./victoriametrics.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
+  wait_for_window = handleTest ./wait_for_window.nix {};
   wasabibackend = handleTest ./wasabibackend.nix {};
   wireguard = handleTest ./wireguard {};
   wordpress = handleTest ./wordpress.nix {};

--- a/nixos/tests/wait_for_window.nix
+++ b/nixos/tests/wait_for_window.nix
@@ -1,0 +1,47 @@
+# This tests the test-framework's wait_for_window().
+# This is a regression test for https://github.com/NixOS/nixpkgs/issues/106685
+
+let
+  common = {
+    services.xserver = {
+      enable = true;
+      desktopManager.gnome3.enable = true;
+      displayManager.autoLogin = {
+        enable = true;
+        user = "alice";
+      };
+    };
+    users.users.alice.isNormalUser = true;
+    virtualisation.memorySize = 1024;
+  };
+  configs = {
+    lightdm = {
+      imports = [ common ];
+      services.xserver.displayManager.lightdm.enable = true;
+    };
+    gdmwayland = {
+      imports = [ common ];
+      services.xserver.displayManager.gdm = {
+        enable = true;
+        wayland = true;
+      };
+    };
+    gdmxorg = {
+      imports = [ common ];
+      services.xserver.displayManager.gdm = {
+        enable = true;
+        wayland = false;
+      };
+    };
+  };
+in builtins.mapAttrs (name: config:
+  import ./make-test-python.nix {
+    inherit name;
+    machine = {
+      imports = [ config ];
+      networking.hostName = name;
+    };
+    testScript = ''
+      ${name}.wait_for_window("GNOME Shell", "alice")
+    '';
+  } { }) configs


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Make wait_for_window() work when X is running as non-root.  (X shouldn't ever be running as root.)

Fixes #106685

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FYI:
@pbogdan who explained the problem in #37642
@xeji who added allow-root-login in 5f72169
@adisbladis who added XAUTHORITY user-systemd import in 40f402c