### PR TITLE
[20.09] chrysalis: init at 0.7.9

### DIFF
--- a/pkgs/applications/misc/chrysalis/default.nix
+++ b/pkgs/applications/misc/chrysalis/default.nix
@@ -1,0 +1,28 @@
+{ lib, appimageTools, fetchurl }:
+
+let
+  pname = "chrysalis";
+  version = "0.7.9";
+in appimageTools.wrapType2 rec {
+  name = "${pname}-${version}-binary";
+
+  src = fetchurl {
+    url = "https://github.com/keyboardio/${pname}/releases/download/${pname}-${version}/${pname}-${version}.AppImage";
+    sha256 = "12w4vv7dwfpvxpc8kpfas90y7yy8mb8dj2096z3vw1bli5lrn3zi";
+  };
+
+  multiPkgs = null;
+  extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [
+    p.glib
+  ];
+
+  extraInstallCommands = "mv $out/bin/${name} $out/bin/${pname}";
+
+  meta = with lib; {
+    description = "A graphical configurator for Kaleidoscope-powered keyboards";
+    homepage = "https://github.com/keyboardio/Chrysalis";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ aw ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -172,6 +172,8 @@ in
 
   cereal = callPackage ../development/libraries/cereal { };
 
+  chrysalis = callPackage ../applications/misc/chrysalis { };
+
   clj-kondo = callPackage ../development/tools/clj-kondo { };
 
   cmark = callPackage ../development/libraries/cmark { };


### PR DESCRIPTION
(cherry picked from commit 0262af9cce20f30a163b2b17ba7962883b8c7302)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I use the Keyboardio Atreus as my daily driver so I'd really like to have this available in stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
