### PR TITLE
bacula: fix for #89057 - systemd and bacula fight

### DIFF
--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     description = "Enterprise ready, Network Backup Tool";
     homepage    = "http://bacula.org/";
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ domenkozar lovek323 eleanor ];
+    maintainers = with maintainers; [ domenkozar lovek323 eleanor redvers ];
     platforms   = platforms.all;
   };
 }


### PR DESCRIPTION
The application's hard-coded working directory was set to /var/lib/bacula.
Thie directory is also used by systemd which changes the ownership
of that direction to root meaning the application can't write to it.

This fix provides an additional configuration option which allows our
configuration to specify a new working directory.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
