### PR TITLE
libinfinity: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -13,10 +13,10 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "libinfinity";
-    version = "0.7.1";
+    version = "0.7.2";
     src = fetchurl {
-      url = "http://releases.0x539.de/libinfinity/${pname}-${version}.tar.gz";
-      sha256 = "1jw2fhrcbpyz99bij07iyhy9ffyqdn87vl8cb1qz897y3f2f0vk2";
+      url = "https://github.com/gobby/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+      sha256 = "17i3g61hxz9pzl3ryd1yr15142r25m06jfzjrpdy7ic1b8vjjw3f";
     };
 
     outputs = [ "bin" "out" "dev" "man" "devdoc" ];
@@ -43,7 +43,7 @@ let
     };
 
     meta = {
-      homepage = "http://gobby.0x539.de/";
+      homepage = "https://gobby.github.io/";
       description = "An implementation of the Infinote protocol written in GObject-based C";
       license = stdenv.lib.licenses.lgpl2Plus;
       maintainers = [ stdenv.lib.maintainers.phreedom ];


### PR DESCRIPTION
###### Motivation for this change

Update libinfinity with the most recent upstream release

This contains an important stability fix with recent glib versions that might cause a desync by ensuring that the user table is in a consistent order.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Tested gobby5 specifically
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
