### PR TITLE
hal-hardware-analyzer: 2.0.0 -> 3.1.9

### DIFF
--- a/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
+++ b/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
@@ -1,28 +1,28 @@
 { stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, python3Packages
 , boost, rapidjson, qtbase, qtsvg, igraph, spdlog, wrapQtAppsHook
-, fmt, llvmPackages ? null
+, fmt, graphviz, llvmPackages ? null
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.0.0";
+  version = "3.1.9";
   pname = "hal-hardware-analyzer";
 
   src = fetchFromGitHub {
     owner = "emsec";
     repo = "hal";
     rev = "v${version}";
-    sha256 = "11xmqxnryksl645wmm1d69k1b5zwvxxf0admk4iblzaa3ggf7cv1";
+    sha256 = "0yvvlx0hq73x20va4csa8kyx3x4z648s6l6qqirzjpmxa1w91xc6";
   };
   # make sure bundled dependencies don't get in the way - install also otherwise
   # copies them in full to the output, bloating the package
   postPatch = ''
-    rm -rf deps/*/*
-    substituteInPlace cmake/detect_dependencies.cmake \
-      --replace 'spdlog 1.4.2 EXACT' 'spdlog 1.4.2 REQUIRED'
+    shopt -s extglob
+    rm -rf deps/!(sanitizers-cmake)/*
+    shopt -u extglob
   '';
 
   nativeBuildInputs = [ cmake ninja pkgconfig ];
-  buildInputs = [ qtbase qtsvg boost rapidjson igraph spdlog fmt wrapQtAppsHook ]
+  buildInputs = [ qtbase qtsvg boost rapidjson igraph spdlog fmt graphviz wrapQtAppsHook ]
     ++ (with python3Packages; [ python pybind11 ])
     ++ stdenv.lib.optional stdenv.cc.isClang llvmPackages.openmp;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4603,7 +4603,7 @@ in
 
   hal-flash = callPackage ../os-specific/linux/hal-flash { };
 
-  hal-hardware-analyzer = libsForQt514.callPackage ../applications/science/electronics/hal-hardware-analyzer { };
+  hal-hardware-analyzer = libsForQt5.callPackage ../applications/science/electronics/hal-hardware-analyzer { };
 
   half = callPackage ../development/libraries/half { };
 


### PR DESCRIPTION
###### Motivation for this change
Bump, allows me to remove requirement for `libsForQt514` as requested in #104474

Tested non-nixos linux x86_64 & macos 10.14

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
