### PR TITLE
nixos/mpd: conditionally provision required directories with StateDirectory

### DIFF
--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -27,10 +27,12 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       after = [ "mpd.service" ];
       wantedBy = [ "default.target" ];
       script = ''
-        mkdir -p ${musicDirectory} && chown -R ${user}:${group} ${musicDirectory}
         cp ${track} ${musicDirectory}
-        chown ${user}:${group} ${musicDirectory}/$(basename ${track})
       '';
+      serviceConfig = {
+        User = user;
+        Group = group;
+      };
     };
 
     mkServer = { mpd, musicService, }:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- current state isn't very reproducible when `stateDir` deviates from the expected value (`/var/lib/mpd`)... also we don't have the ability to understand what the filesystem looks in order to make the right choices
  - maybe the user has network mounted drives we don't know about
  - maybe the user is using btrfs subvolumes
  - maybe something else you never considered
- modules make too many assumptions about `stateDir`, resulting in various permissions issues:
  - https://github.com/NixOS/nixpkgs/issues/80827
  - https://github.com/NixOS/nixpkgs/issues/81910
  - https://discourse.nixos.org/t/nixpkgs-policy-as-for-systemd-prestart-setup-scripts-vs-systemd-tmpfiles/5839/7
- when given arbitrary paths `systemd.tmpfiles.rules` generally doesn't behave as most users would expect
  - `[ "d /a foo foo" "d /a/b/c foo foo" ]` produces an error (rightfully so) because `/a/b` would be owned by `root:root`
- in conclusion: it is great when NixOS "just works" because of defaults, but in the case of user customization we should push some of the work onto the user for maximum flexibility

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
