### PR TITLE
[staging] libzip: 1.6.1 -> 1.7.3

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -1,20 +1,27 @@
-{ lib, stdenv, fetchurl, cmake, perl, zlib }:
+{ lib, stdenv
+, cmake
+, fetchpatch
+, fetchurl
+, perl
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "libzip";
-  version = "1.6.1";
+  version = "1.7.3";
 
   src = fetchurl {
     url = "https://www.nih.at/libzip/${pname}-${version}.tar.gz";
-    sha256 = "120xgf7cgjmz9d3yp10lks6lhkgxqb4skbmbiiwf46gx868qxsq6";
+    sha256 = "1k5rihiz7m1ahhjzcbq759hb9crzqkgw78pkxga118y5a32pc8hf";
   };
 
-  # Fix pkg-config file paths
-  postPatch = ''
-    sed -i CMakeLists.txt \
-      -e 's#\\''${exec_prefix}/''${CMAKE_INSTALL_LIBDIR}#''${CMAKE_INSTALL_FULL_LIBDIR}#' \
-      -e 's#\\''${prefix}/''${CMAKE_INSTALL_INCLUDEDIR}#''${CMAKE_INSTALL_FULL_INCLUDEDIR}#'
-  '';
+  # Remove in next release
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/nih-at/libzip/commit/351201419d79b958783c0cfc7c370243165523ac.patch";
+      sha256 = "0d93z98ki0yiaza93268cxkl35y1r7ll9f7l8sivx3nfxj2c1n8a";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
libzip's pkgconfig paths are now fixed on git master and the patch backports cleanly.

See previous auto-update attempt https://github.com/NixOS/nixpkgs/pull/90610

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
