### PR TITLE
haskellPackages.haskell-language-server: 027fq67 -> 15hyscf

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1402,6 +1402,7 @@ self: super: {
   # https://github.com/haskell/haskell-language-server/issues/611
   haskell-language-server = dontCheck (super.haskell-language-server.override {
     lsp-test = dontCheck self.lsp-test_0_11_0_7;
+    fourmolu = self.fourmolu_0_3_0_0;
   });
 
   fourmolu = dontCheck super.fourmolu;

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -22,6 +22,8 @@ self: super: {
   hls-brittany = self.callPackage ../tools/haskell/haskell-language-server/hls-brittany.nix { };
   hls-hlint-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-hlint-plugin.nix { };
   hls-tactics-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-tactics-plugin.nix { };
+  hls-explicit-imports-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-explicit-imports-plugin.nix { };
+  hls-retrie-plugin = self.callPackage ../tools/haskell/haskell-language-server/hls-retrie-plugin.nix { };
 
   nix-output-monitor = self.callPackage ../../tools/nix/nix-output-monitor { };
 

--- a/pkgs/development/tools/haskell/haskell-language-server/default.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/default.nix
@@ -2,21 +2,21 @@
 , bytestring, containers, data-default, deepseq, directory, extra
 , fetchgit, filepath, floskell, fourmolu, ghc, ghc-boot-th
 , ghc-paths, ghcide, gitrev, hashable, haskell-lsp, hie-bios
-, hls-hlint-plugin, hls-plugin-api, hls-tactics-plugin, hslogger
-, hspec, hspec-core, lens, lsp-test, mtl, optparse-applicative
-, optparse-simple, ormolu, process, regex-tdfa, retrie
-, safe-exceptions, shake, stdenv, stm, stylish-haskell, tasty
-, tasty-ant-xml, tasty-expected-failure, tasty-golden, tasty-hunit
-, tasty-rerun, temporary, text, time, transformers
-, unordered-containers, yaml
+, hls-explicit-imports-plugin, hls-hlint-plugin, hls-plugin-api
+, hls-retrie-plugin, hls-tactics-plugin, hslogger, hspec
+, hspec-core, lens, lsp-test, mtl, optparse-applicative
+, optparse-simple, ormolu, process, regex-tdfa, safe-exceptions
+, shake, stdenv, stm, stylish-haskell, tasty, tasty-ant-xml
+, tasty-expected-failure, tasty-golden, tasty-hunit, tasty-rerun
+, temporary, text, time, transformers, unordered-containers, yaml
 }:
 mkDerivation {
   pname = "haskell-language-server";
   version = "0.6.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "027fq6752024wzzq9izsilm5lkq9gmpxf82rixbimbijw0yk4pwj";
-    rev = "372a12e797069dc3ac4fa33dcaabe3b992999d7c";
+    sha256 = "15hyscfllyapqinihmal6xkqwxgay7sgk5wqkjfgmlqsvl0vm7b7";
+    rev = "9a742e2c6a31ff92a053735541e4cca9c2c18d3e";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -30,11 +30,12 @@ mkDerivation {
   executableHaskellDepends = [
     aeson base binary brittany bytestring containers deepseq directory
     extra filepath floskell fourmolu ghc ghc-boot-th ghc-paths ghcide
-    gitrev hashable haskell-lsp hie-bios hls-hlint-plugin
-    hls-plugin-api hls-tactics-plugin hslogger lens mtl
-    optparse-applicative optparse-simple ormolu process regex-tdfa
-    retrie safe-exceptions shake stylish-haskell temporary text time
-    transformers unordered-containers
+    gitrev hashable haskell-lsp hie-bios hls-explicit-imports-plugin
+    hls-hlint-plugin hls-plugin-api hls-retrie-plugin
+    hls-tactics-plugin hslogger lens mtl optparse-applicative
+    optparse-simple ormolu process regex-tdfa safe-exceptions shake
+    stylish-haskell temporary text time transformers
+    unordered-containers
   ];
   testHaskellDepends = [
     aeson base blaze-markup bytestring containers data-default

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-explicit-imports-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-explicit-imports-plugin.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, aeson, base, containers, deepseq, fetchgit, ghc
+, ghcide, haskell-lsp-types, hls-plugin-api, shake, stdenv, text
+, unordered-containers
+}:
+mkDerivation {
+  pname = "hls-explicit-imports-plugin";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/haskell/haskell-language-server.git";
+    sha256 = "15hyscfllyapqinihmal6xkqwxgay7sgk5wqkjfgmlqsvl0vm7b7";
+    rev = "9a742e2c6a31ff92a053735541e4cca9c2c18d3e";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/plugins/hls-explicit-imports-plugin; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    aeson base containers deepseq ghc ghcide haskell-lsp-types
+    hls-plugin-api shake text unordered-containers
+  ];
+  description = "Explicit imports plugin for Haskell Language Server";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-hlint-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-hlint-plugin.nix
@@ -10,8 +10,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "027fq6752024wzzq9izsilm5lkq9gmpxf82rixbimbijw0yk4pwj";
-    rev = "372a12e797069dc3ac4fa33dcaabe3b992999d7c";
+    sha256 = "15hyscfllyapqinihmal6xkqwxgay7sgk5wqkjfgmlqsvl0vm7b7";
+    rev = "9a742e2c6a31ff92a053735541e4cca9c2c18d3e";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/hls-hlint-plugin; echo source root reset to $sourceRoot";

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-retrie-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-retrie-plugin.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, base, containers, deepseq, directory, extra
+, fetchgit, ghc, ghcide, hashable, haskell-lsp, haskell-lsp-types
+, hls-plugin-api, retrie, safe-exceptions, shake, stdenv, text
+, transformers, unordered-containers
+}:
+mkDerivation {
+  pname = "hls-retrie-plugin";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/haskell/haskell-language-server.git";
+    sha256 = "15hyscfllyapqinihmal6xkqwxgay7sgk5wqkjfgmlqsvl0vm7b7";
+    rev = "9a742e2c6a31ff92a053735541e4cca9c2c18d3e";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/plugins/hls-retrie-plugin; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    aeson base containers deepseq directory extra ghc ghcide hashable
+    haskell-lsp haskell-lsp-types hls-plugin-api retrie safe-exceptions
+    shake text transformers unordered-containers
+  ];
+  description = "Retrie integration plugin for Haskell Language Server";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/pkgs/development/tools/haskell/haskell-language-server/hls-tactics-plugin.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/hls-tactics-plugin.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, base, checkers, containers, deepseq
 , directory, extra, fetchgit, filepath, fingertree, generic-lens
 , ghc, ghc-boot-th, ghc-exactprint, ghc-source-gen, ghcide
-, haskell-lsp, hie-bios, hls-plugin-api, hspec, lens, mtl
-, QuickCheck, refinery, retrie, shake, stdenv, syb, text
+, haskell-lsp, hie-bios, hls-plugin-api, hspec, hspec-discover
+, lens, mtl, QuickCheck, refinery, retrie, shake, stdenv, syb, text
 , transformers
 }:
 mkDerivation {
@@ -10,8 +10,8 @@ mkDerivation {
   version = "0.5.1.0";
   src = fetchgit {
     url = "https://github.com/haskell/haskell-language-server.git";
-    sha256 = "027fq6752024wzzq9izsilm5lkq9gmpxf82rixbimbijw0yk4pwj";
-    rev = "372a12e797069dc3ac4fa33dcaabe3b992999d7c";
+    sha256 = "15hyscfllyapqinihmal6xkqwxgay7sgk5wqkjfgmlqsvl0vm7b7";
+    rev = "9a742e2c6a31ff92a053735541e4cca9c2c18d3e";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/plugins/tactics; echo source root reset to $sourceRoot";
@@ -25,6 +25,7 @@ mkDerivation {
     base checkers containers ghc hie-bios hls-plugin-api hspec mtl
     QuickCheck
   ];
+  testToolDepends = [ hspec-discover ];
   homepage = "https://github.com/isovector/hls-tactics-plugin#readme";
   description = "LSP server for GHC";
   license = "unknown";

--- a/pkgs/development/tools/haskell/haskell-language-server/update.sh
+++ b/pkgs/development/tools/haskell/haskell-language-server/update.sh
@@ -51,5 +51,7 @@ echo "Running cabal2nix and outputting to ${hls_derivation_file}..."
 cabal2nix --revision "$hls_new_version" "https://github.com/haskell/haskell-language-server.git" > "$hls_derivation_file"
 cabal2nix --revision "$hls_new_version" --subpath plugins/tactics "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/hls-tactics-plugin.nix"
 cabal2nix --revision "$hls_new_version" --subpath plugins/hls-hlint-plugin "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/hls-hlint-plugin.nix"
+cabal2nix --revision "$hls_new_version" --subpath plugins/hls-explicit-imports-plugin "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/hls-explicit-imports-plugin.nix"
+cabal2nix --revision "$hls_new_version" --subpath plugins/hls-retrie-plugin "https://github.com/haskell/haskell-language-server.git" > "${script_dir}/hls-retrie-plugin.nix"
 
 echo "Finished."


### PR DESCRIPTION
Fix the update script to include hls-explicit-imports-plugin and hls-retrie-plugin

###### Motivation for this change

Not sure if this is an important update or not, but the change to
update.sh here might save the next person doing it some small amount of
work.

It should also be possible to drop the brittany fork too as the latest brittany release supports ghc 8.10.2.

update.sh could be improved too, it currently fetches the hls repo 5 times! (otoh, this is computer time and perhaps not worth valuable human time fixing)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
