### PR TITLE
[20.09] _1password-gui -> 0.8.4 -> 0.9.7

### DIFF
--- a/pkgs/development/tools/electron/default.nix
+++ b/pkgs/development/tools/electron/default.nix
@@ -1,11 +1,26 @@
-{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, glib, gtk3, unzip, atomEnv, libuuid, at-spi2-atk, at-spi2-core, libdrm, mesa }@args:
+{ stdenv
+, libXScrnSaver
+, makeWrapper
+, fetchurl
+, wrapGAppsHook
+, glib
+, gtk3
+, unzip
+, atomEnv
+, libuuid
+, at-spi2-atk
+, at-spi2-core
+, libdrm
+, mesa
+, libxkbcommon
+}@args:
 
 let
   mkElectron = import ./generic.nix args;
 in
 rec {
 
-  electron = electron_10;
+  electron = electron_11;
 
   electron_3 = mkElectron "3.1.13" {
     x86_64-linux = "1psmbplz6jhnnf6hmfhxbmmhn4n1dpnhzbc12pxn645xhfpk9ark";
@@ -69,5 +84,13 @@ rec {
     i686-linux = "009bbee26ddbf748b33588714ccc565257ff697cde2110e6b6547e3f510da85e";
     armv7l-linux = "e8999af21f7e58c4dc27594cd75438e1a5922d3cea62be63c927d29cba120951";
     aarch64-linux = "b906998ddaf96da94a43bbe38108d83250846222de2727c268ad50f24c55f0da";
+  };
+
+  electron_11 = mkElectron "11.0.2" {
+    x86_64-linux = "a6e4f789d99e2ed879b48e7cbca2051805c3727360074edfe903231756eb5636";
+    x86_64-darwin = "4a562646440c3f4fa1ec4bbdb238da420158e19f294a0fbcdf32004465dbd516";
+    i686-linux = "ffcb2e40f98ee521ac50aa849cd911e62dae8a610bcca3f6d393b3f8d9bb85d8";
+    armv7l-linux = "7552f0c2aad05844ceacaaf13588b06b16e9aadd947084e8249214b24d1da38d";
+    aarch64-linux = "56b5ae4a33a9aa666fbe1463c7780d4c737c84119eff77d403fb969e8ff90ce0";
   };
 }

--- a/pkgs/development/tools/electron/generic.nix
+++ b/pkgs/development/tools/electron/generic.nix
@@ -1,4 +1,19 @@
-{ stdenv, libXScrnSaver, makeWrapper, fetchurl, wrapGAppsHook, glib, gtk3, unzip, atomEnv, libuuid, at-spi2-atk, at-spi2-core, libdrm, mesa }:
+{ stdenv
+, libXScrnSaver
+, makeWrapper
+, fetchurl
+, wrapGAppsHook
+, glib
+, gtk3
+, unzip
+, atomEnv
+, libuuid
+, at-spi2-atk
+, at-spi2-core
+, libdrm
+, mesa
+, libxkbcommon
+}:
 
 version: hashes:
 let
@@ -34,7 +49,11 @@ let
     src = fetcher version (get tags platform) (get hashes platform);
   };
 
-  electronLibPath = with stdenv.lib; makeLibraryPath ([ libuuid at-spi2-atk at-spi2-core ] ++ optionals (! versionOlder version "9.0.0") [ libdrm mesa ]);
+  electronLibPath = with stdenv.lib; makeLibraryPath (
+    [ libuuid at-spi2-atk at-spi2-core ]
+    ++ optionals (! versionOlder version "9.0.0") [ libdrm mesa ]
+    ++ optionals (! versionOlder version "11.0.0") [ libxkbcommon ]
+  );
 
   linux = {
     buildInputs = [ glib gtk3 ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.8-1";
+  version = "0.8.9";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "0afx0sr2nrdayaxjhr0x2mx5mi92s781a6r2r9rpva9q4cdrf6w7";
+    sha256 = "0gmflx7psyajxx6g82lrhmfwnh306sixwd1hykrn2xl3ncw65ydr";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.2-1";
+  version = "0.9.3";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "19m8qfhmdzgz76xba9wi5cb12jqwr17afqzajvgq681i52fij0lr";
+    sha256 = "wO1HwXl6Lf7+2fXX7i8nrD/hi9dAWn50Jkoztx6aT0Q=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.1";
+  version = "0.9.2-1";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "04hv7hw4s3f65kf3ggh9l0nrx25k5yj2kqv83nl7pvam5lvnv8sz";
+    sha256 = "19m8qfhmdzgz76xba9wi5cb12jqwr17afqzajvgq681i52fij0lr";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "109jsls4515y78zhhsxqlgms30i5rzhi60p3b9wx6y8v0iq331wp";
+    sha256 = "04hv7hw4s3f65kf3ggh9l0nrx25k5yj2kqv83nl7pvam5lvnv8sz";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.10";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "0jxq7gc1m2flv3wr055bkwhfh73c2cdpspg437dv4yvfvjqsk7mm";
+    sha256 = "109jsls4515y78zhhsxqlgms30i5rzhi60p3b9wx6y8v0iq331wp";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://1password.com/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ danieldk ];
+    maintainers = with maintainers; [ danieldk timstott ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.6";
+  version = "0.9.7";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "0464a5d39g20hif3dz3qr78dqb0cmxbazy0q48j9gkawhxm30c1h";
+    hash = "sha256-JaYFJL24Pgwh5CrsKjJPL8u0fx1x0beFTK+EGNT1iqA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.7";
+  version = "0.8.8-1";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "1101q5yavzl8imf8gqa3h929gcyy6lh7dy2dw0zs52qdcrb4z49j";
+    sha256 = "0afx0sr2nrdayaxjhr0x2mx5mi92s781a6r2r9rpva9q4cdrf6w7";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.9";
+  version = "0.8.10";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "0gmflx7psyajxx6g82lrhmfwnh306sixwd1hykrn2xl3ncw65ydr";
+    sha256 = "0jxq7gc1m2flv3wr055bkwhfh73c2cdpspg437dv4yvfvjqsk7mm";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -2,22 +2,17 @@
 , fetchurl
 , appimageTools
 , makeWrapper
-, electron_9
+, electron_11
 , openssl
 }:
 
-let
-  electron = electron_9;
-
-in
-
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.5-2";
+  version = "0.9.6";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "1fj8gab5frxnzx6cafkcxmic9z1wvfqi4v511wsg9dy4mn5dc6qw";
+    sha256 = "0464a5d39g20hif3dz3qr78dqb0cmxbazy0q48j9gkawhxm30c1h";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -51,7 +46,7 @@ stdenv.mkDerivation rec {
     cp -a ${appimageContents}/usr/share/icons $out/share
 
     # Wrap the application with Electron.
-    makeWrapper "${electron}/bin/electron" "$out/bin/${pname}" \
+    makeWrapper "${electron_11}/bin/electron" "$out/bin/${pname}" \
       --add-flags "$out/share/${pname}/resources/app.asar" \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath runtimeLibs}"
   '';

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.4-1";
+  version = "0.9.5-2";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "1d5k7066hzc7j2nncrj6b85nklpjbn88izlyisznb3m1yxi8jm5i";
+    sha256 = "1fj8gab5frxnzx6cafkcxmic9z1wvfqi4v511wsg9dy4mn5dc6qw";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.9.3";
+  version = "0.9.4-1";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "wO1HwXl6Lf7+2fXX7i8nrD/hi9dAWn50Jkoztx6aT0Q=";
+    sha256 = "1d5k7066hzc7j2nncrj6b85nklpjbn88izlyisznb3m1yxi8jm5i";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.6-2";
+  version = "0.8.7";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "1m7sql2y2kj94gr607n48m0h4b3rijyzvxrssyizv75spmxr4d5r";
+    sha256 = "1101q5yavzl8imf8gqa3h929gcyy6lh7dy2dw0zs52qdcrb4z49j";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.5-1";
+  version = "0.8.6-2";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "1jardsyxkf7qfhz8jwzwick5r9jf9yjwsdqvmc2rrnrflzzpscm9";
+    sha256 = "1m7sql2y2kj94gr607n48m0h4b3rijyzvxrssyizv75spmxr4d5r";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/1password-gui/default.nix
+++ b/pkgs/tools/security/1password-gui/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "1password";
-  version = "0.8.4";
+  version = "0.8.5-1";
 
   src = fetchurl {
     url = "https://onepassword.s3.amazonaws.com/linux/appimage/${pname}-${version}.AppImage";
-    sha256 = "04rjlyi465pkg75pql3rfzmfj9zf8pfnxynz110x1wkqnvqmsxgw";
+    sha256 = "1jardsyxkf7qfhz8jwzwick5r9jf9yjwsdqvmc2rrnrflzzpscm9";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10469,7 +10469,7 @@ in
   aws-adfs = with python3Packages; toPythonApplication aws-adfs;
 
   inherit (callPackages ../development/tools/electron { })
-    electron electron_3 electron_4 electron_5 electron_6 electron_7 electron_8 electron_9 electron_10;
+    electron electron_3 electron_4 electron_5 electron_6 electron_7 electron_8 electron_9 electron_10 electron_11;
 
   autobuild = callPackage ../development/tools/misc/autobuild { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #106684. However, also requires that we add Electron 11 to release 20.09. @NixOS/nixos-release-managers: is this acceptable?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
