### PR TITLE
python3Packages.spacy: 2.3.4 -> 2.3.5

### DIFF
--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -30,19 +30,19 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-   blis
-   catalogue
-   cymem
-   jsonschema
-   murmurhash
-   numpy
-   plac
-   preshed
-   requests
-   setuptools
-   srsly
-   thinc
-   wasabi
+    blis
+    catalogue
+    cymem
+    jsonschema
+    murmurhash
+    numpy
+    plac
+    preshed
+    requests
+    setuptools
+    srsly
+    thinc
+    wasabi
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   checkInputs = [
@@ -65,7 +65,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "spacy" ];
 
-  passthru.tests = callPackage ./annotation-test {};
+  passthru.tests = callPackage ./annotation-test { };
 
   meta = with lib; {
     description = "Industrial-strength Natural Language Processing (NLP) with Python and Cython";

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -22,11 +22,11 @@
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "2.3.4";
+  version = "2.3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a5c8805759114aac3a1db1b20f42af1124da5315be903ccb4c472cc8452393fb";
+    sha256 = "315278ab60094643baecd866017c7d4cbd966efd2d517ad0e6c888edf7fa5aef";
   };
 
   propagatedBuildInputs = [
@@ -56,11 +56,11 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "blis>=0.4.0,<0.5.0" "blis>=0.4.0,<1.0" \
+      --replace "blis>=0.4.0,<0.8.0" "blis>=0.4.0,<1.0" \
       --replace "catalogue>=0.0.7,<1.1.0" "catalogue>=0.0.7,<3.0" \
       --replace "plac>=0.9.6,<1.2.0" "plac>=0.9.6,<2.0" \
       --replace "srsly>=1.0.2,<1.1.0" "srsly>=1.0.2,<3.0" \
-      --replace "thinc==7.4.1" "thinc>=7.4.1,<8"
+      --replace "thinc>=7.4.1,<7.5.0" "thinc>=7.4.1,<8"
   '';
 
   pythonImportsCheck = [ "spacy" ];

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "spacy" ];
 
-  passthru.tests = callPackage ./annotation-test { };
+  passthru.tests.annotation = callPackage ./annotation-test { };
 
   meta = with lib; {
     description = "Industrial-strength Natural Language Processing (NLP) with Python and Cython";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

python3Packagese.spacy: 2.3.4 -> 2.3.5
    
Changelog:
    
https://github.com/explosion/spacy/releases/tag/v2.3.5

Also reformat with `nixpkgs-fmt` and make `passthru.tests` an attrset.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
