### PR TITLE
qbittorrent: extending path to include Python3 for default functionality

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,13 +1,13 @@
 { mkDerivation, lib, fetchFromGitHub, pkgconfig
 , boost, libtorrentRasterbar, qtbase, qttools, qtsvg
-, debugSupport ? false # Debugging
-, guiSupport ? true, dbus ? null # GUI (disable to run headless)
+, debugSupport ? false
+, guiSupport ? true, dbus ? null # GUI OR headless
 , webuiSupport ? true # WebUI
 }:
 
 assert guiSupport -> (dbus != null);
-with lib;
 
+with lib;
 mkDerivation rec {
   pname = "qbittorrent";
   version = "4.3.1";
@@ -19,7 +19,6 @@ mkDerivation rec {
     sha256 = "17ih00q7idrpl3b2vgh4smva6lazs5jw06pblriscn1lrwdvrc38";
   };
 
-  # NOTE: 2018-05-31: CMake is working but it is not officially supported
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ boost libtorrentRasterbar qtbase qttools qtsvg ]


### PR DESCRIPTION
###### Motivation for this change

Since people regularly open reports about tracker search not working because
`python` is not found. The most recent of reports/discussions being https://github.com/NixOS/nixpkgs/issues/104221.

And since Tracker Search in qBittorrent can not be disabled & at the same time
the Python is needed for it to work - including Python for default
functionality to work.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
(no dependent packages)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
462,853,024
516,526,608
(delta) 53,673,584 aka 53 MB
```

- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
