### PR TITLE
Fix paperless

### DIFF
--- a/pkgs/applications/office/paperless/default.nix
+++ b/pkgs/applications/office/paperless/default.nix
@@ -111,14 +111,8 @@ let
     {
       pyocr = pyocrWithUserTesseract super;
 
-      # Paperless only supports Django 2.0
-      django = customPkgs.django_2_0;
-
       # Paperless is incompatible with factory_boy >= 3
       factory_boy = customPkgs.factory_boy_2_12_0;
-
-      # The current version of django_extensions is incompatible with django 2.0
-      django_extensions = customPkgs.django_extensions_2_2_8;
 
       # These are pre-release versions, hence they are private to this pkg
       django-filter = self.callPackage ./python-modules/django-filter.nix {};

--- a/pkgs/applications/office/paperless/python-modules/default.nix
+++ b/pkgs/applications/office/paperless/python-modules/default.nix
@@ -1,24 +1,5 @@
 pyPkgs: fetchFromGitHub:
 {
-  django_2_0 = pyPkgs.django_2.overridePythonAttrs (old: rec {
-    version = "2.0.12";
-    src = pyPkgs.fetchPypi {
-      inherit (old) pname;
-      inherit version;
-      sha256 = "15s8z54k0gf9brnz06521bikm60ddw5pn6v3nbvnl47j1jjsvwz2";
-    };
-  });
-
-  django_extensions_2_2_8 = pyPkgs.django_extensions.overridePythonAttrs (old: rec {
-    version = "2.2.8";
-    src = fetchFromGitHub {
-      owner = old.pname;
-      repo = old.pname;
-      rev = version;
-      sha256 = "1gd3nykwzh3azq1p9cvgkc3l5dwrv7y86sfjxd9llbyj8ky71iaj";
-    };
-  });
-
   factory_boy_2_12_0 = pyPkgs.factory_boy.overridePythonAttrs (old: rec {
     version = "2.12.0";
     src = pyPkgs.fetchPypi {

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "django-extensions";
-  version = "3.0.8";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1z2si9wpc8irqhi5i2wp4wr05dqxyw4mn2vj3amp0rvsvydws92c";
+    sha256 = "hZ6GS2VkXH8KfKZuL1rR6JS/nDkx8SfKuUx5XrvTbec=";
   };
 
   LC_ALL = "en_US.UTF-8";
@@ -49,10 +49,11 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  # tests not compatible with pip>=20
+  # remove tests that need network access
   checkPhase = ''
     rm tests/management/commands/test_pipchecker.py
-    ${python.interpreter} setup.py test
+    DJANGO_SETTINGS_MODULE=tests.testapp.settings \
+      pytest django_extensions tests
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
paperless wasn't building because django-cors-headers didn't
build anymore with the pinned django version.

I tested the paperless service (editd a few documents) and it works
fine, even with django unpinned.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc maintainer of paperless: @erikarvstedt