### PR TITLE
mailspring: Disable trackerSupport for it's gtk3

### DIFF
--- a/pkgs/applications/networking/mailreaders/mailspring/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailspring/default.nix
@@ -34,7 +34,9 @@ stdenv.mkDerivation rec {
     alsaLib
     db
     glib
-    gtk3
+    # We don't know why with trackerSupport the executable fail to launch, See:
+    # https://github.com/NixOS/nixpkgs/issues/106732
+    (gtk3.override {trackerSupport = false; })
     libkrb5
     libsecret
     nss


### PR DESCRIPTION
I'd be delighted to know why this works. Asked @jtojnar for a review because you authored https://github.com/NixOS/nixpkgs/pull/101537 . 

###### Motivation for this change

Fix this error:

```
mailspring: ../src/workers/open.cc:28: virtual void OpenWorker::Execute(): Assertion `sqlite3_db_mutex(db->db_handle) == __null' failed.
```

It's a (mostly) closed source software so perhaps it's not going to be easy to explain this.

Close #106732 . 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
