### PR TITLE
ocamlPackages.torch: 0.10 → 0.11

### DIFF
--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , cmdliner
 , ctypes
+, dune-configurator
 , npy
 , ocaml-compiler-libs
 , ppx_custom_printf
@@ -16,16 +17,20 @@
 
 buildDunePackage rec {
   pname = "torch";
-  version = "0.10";
+  version = "0.11";
 
-  minimumOCamlVersion = "4.07";
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "LaurentMazare";
     repo   = "ocaml-${pname}";
     rev    = version;
-    sha256 = "1rqrv6hbical8chk0bl2nf60q6m4b5d1gab9fc5q03vkz2987f9b";
+    sha256 = "19zbl9zn6fslrcm6x9cis6nswhwz8mc57nrhkada658n7rcdmskr";
   };
+
+  buildInputs = [ dune-configurator ];
 
   propagatedBuildInputs = [
     cmdliner


### PR DESCRIPTION
###### Motivation for this change

Fix build (broken since the update of pytorch to 1.7).

cc maintainer @bcdarwin

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
