### PR TITLE
tinygo: 0.13.1 -> 0.16.0

### DIFF
--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -6,13 +6,14 @@ let main = ./main.go;
 in
 buildGoModule rec {
   pname = "tinygo";
-  version = "0.13.1";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     rev = "v${version}";
-    sha256 = "0das5z5y2x1970yi9c4yssxvwrrjhdmsj495q0r5mb02amvc954v";
+    sha256 = "063aszbsnr0myq56kms1slmrfs7m4nmg0zgh2p66lxdsifrfly7j";
+    fetchSubmodules = true;
   };
 
   overrideModAttrs = (_: {
@@ -21,14 +22,22 @@ buildGoModule rec {
       rm -rf *
       cp ${main} main.go
       cp ${gomod} go.mod
+      chmod +w go.mod
       '';
   });
 
   preBuild = "cp ${gomod} go.mod";
 
-  vendorSha256 = "19194dlzpl6zzw2gqybma5pwip71rw8z937f104k6c158qzzgy62";
+  postBuild = "make gen-device";
+
+  vendorSha256 = "12k2gin0v7aqz5543m12yhifc0xsz26qyqra5l4c68xizvzcvkxb";
 
   doCheck = false;
+
+  prePatch = ''
+    sed -i s/', "-nostdlibinc"'// builder/builtins.go
+    sed -i s/'"-nostdlibinc", '// compileopts/config.go builder/picolibc.go
+  '';
 
   subPackages = [ "." ];
   buildInputs = [ llvm clang-unwrapped makeWrapper ];
@@ -37,7 +46,11 @@ buildGoModule rec {
   postInstall = ''
     mkdir -p $out/share/tinygo
     cp -a lib src targets $out/share/tinygo
-    wrapProgram $out/bin/tinygo --prefix "TINYGOROOT" : "$out/share/tinygo"
+    wrapProgram $out/bin/tinygo --prefix "TINYGOROOT" : "$out/share/tinygo" \
+      --prefix "PATH" : "$out/libexec/tinygo"
+    mkdir -p $out/libexec/tinygo
+    ln -s ${clang-unwrapped}/bin/clang $out/libexec/tinygo/clang-10
+    ln -s ${lld}/bin/lld $out/libexec/tinygo/ld.lld-10
     ln -sf $out/bin $out/share/tinygo
   '';
 

--- a/pkgs/development/compilers/tinygo/go.mod
+++ b/pkgs/development/compilers/tinygo/go.mod
@@ -1,13 +1,14 @@
 module github.com/tinygo-org/tinygo
 
-go 1.14
+go 1.11
 
 require (
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
+	github.com/chromedp/cdproto v0.0.0-20200709115526-d1f6fc58448b
+	github.com/chromedp/chromedp v0.5.4-0.20200303084119-2bb39134ab9e
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
-	github.com/marcinbor85/gohex v0.0.0-20180128172054-7a43cd876e46
+	github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892
 	go.bug.st/serial v1.0.0
-	golang.org/x/tools v0.0.0-20200512001501-aaeff5de670a
-	google.golang.org/appengine v1.4.0
-	tinygo.org/x/go-llvm v0.0.0-20200401165421-8d120882fc7a
+	golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2
+	tinygo.org/x/go-llvm v0.0.0-20201104183921-570e7a6841d9
 )


### PR DESCRIPTION
And enable microcontroller targets. Works for me for microbit.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The microbit target didn't work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
