### PR TITLE
linux: allow disabling common-config

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -23,6 +23,9 @@
 , # kernel intermediate config overrides, as a set
  structuredExtraConfig ? {}
 
+, # use default config for nixos kernels (disable for embedded use)
+  useCommonConfig ? true
+
 , # The version number used for the module directory
   modDirVersion ? version
 
@@ -159,13 +162,11 @@ let
       #   check = false;
       # The result is a set of two attributes
       moduleStructuredConfig = (lib.evalModules {
-        modules = [
-          module
-          { settings = commonStructuredConfig; _file = "pkgs/os-specific/linux/kernel/common-config.nix"; }
-          { settings = structuredExtraConfig; _file = "structuredExtraConfig"; }
-        ]
-        ++  structuredConfigFromPatches
-        ;
+        modules =
+          [module]
+          ++ lib.optional useCommonConfig { settings = commonStructuredConfig; _file = "pkgs/os-specific/linux/kernel/common-config.nix"; }
+          ++ [{ settings = structuredExtraConfig; _file = "structuredExtraConfig"; }]
+          ++  structuredConfigFromPatches;
       }).config;
 
       structuredConfig = moduleStructuredConfig.settings;


### PR DESCRIPTION
###### Motivation for this change
This is useful for building kernels for embedded systems with the
nixpkgs kernel config tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- [x] Produces no change in existing derivations
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
