### PR TITLE
autogen: fix patchelf invocation to remove generic build path from rpath

### DIFF
--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   '' + stdenv.lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # remove /build/** from RPATHs
     for f in "$bin"/bin/*; do
-      local nrp="$(patchelf --print-rpath "$f" | sed -E 's@(:|^)/build/[^:]*:@\1@g')"
+      local nrp="$(patchelf --print-rpath "$f" | sed -E 's@(:|^)'$TEMP'[^:]*:@\1@g')"
       patchelf --set-rpath "$nrp" "$f"
     done
   '';


### PR DESCRIPTION
Refers to #106165 

###### Motivation for this change


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
