### PR TITLE
xfce.exo: fix $out/lib/xfce4/exo/exo-compose-mail

### DIFF
--- a/pkgs/desktops/xfce/core/exo/default.nix
+++ b/pkgs/desktops/xfce/core/exo/default.nix
@@ -1,5 +1,5 @@
-{ mkXfceDerivation, docbook_xsl, glib, libxslt, perlPackages, gtk2, gtk3
-, libxfce4ui, libxfce4util }:
+{ mkXfceDerivation, docbook_xsl, glib, libxslt, gtk2, gtk3
+, libxfce4ui, libxfce4util, perl }:
 
 mkXfceDerivation {
   category = "xfce";
@@ -10,7 +10,6 @@ mkXfceDerivation {
 
   nativeBuildInputs = [
     libxslt
-    perlPackages.URI
     docbook_xsl
   ];
 
@@ -20,6 +19,8 @@ mkXfceDerivation {
     glib
     libxfce4ui
     libxfce4util
+
+    (perl.withPackages(ps: with ps; [ URI ])) # for $out/lib/xfce4/exo/exo-compose-mail
   ];
 
   # Workaround https://bugzilla.xfce.org/show_bug.cgi?id=15825


### PR DESCRIPTION
fixes #106755


Tested on 20.09 only

I intend to backport this to 20.09.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
