### PR TITLE
nixos-container: fix `nixpkgs` container options being ignored

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -476,8 +476,6 @@ in
                 merge = loc: defs: (import (confPkgs.path + "/nixos/lib/eval-config.nix") {
                   inherit system;
                   pkgs = confPkgs;
-                  baseModules = import (confPkgs.path + "/nixos/modules/module-list.nix");
-                  inherit (confPkgs) lib;
                   modules =
                     let
                       extraConfig = {

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -469,13 +469,11 @@ in
                 A specification of the desired configuration of this
                 container, as a NixOS module.
               '';
-              type = let
-                confPkgs = if config.pkgs == null then pkgs else config.pkgs;
-              in lib.mkOptionType {
+              type = lib.mkOptionType {
                 name = "Toplevel NixOS config";
-                merge = loc: defs: (import (confPkgs.path + "/nixos/lib/eval-config.nix") {
+                merge = loc: defs: (import (config.pkgs.path + "/nixos/lib/eval-config.nix") {
                   inherit system;
-                  pkgs = confPkgs;
+                  pkgs = config.pkgs;
                   modules =
                     let
                       extraConfig = {
@@ -525,9 +523,9 @@ in
             };
 
             pkgs = mkOption {
-              type = types.nullOr types.attrs;
-              default = null;
-              example = literalExample "pkgs";
+              type = types.attrs;
+              default = pkgs;
+              defaultText = "pkgs";
               description = ''
                 Customise which nixpkgs to use for this container.
               '';

--- a/nixos/tests/containers-custom-pkgs.nix
+++ b/nixos/tests/containers-custom-pkgs.nix
@@ -1,5 +1,3 @@
-# Test for NixOS' container support.
-
 import ./make-test-python.nix ({ pkgs, lib, ...} : let
 
   customPkgs = pkgs // {
@@ -9,34 +7,27 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : let
   };
 
 in {
-  name = "containers-hosts";
+  name = "containers-custom-pkgs";
   meta = with lib.maintainers; {
     maintainers = [ adisbladis ];
   };
 
-  machine =
-    { ... }:
-    {
-      virtualisation.memorySize = 256;
-      virtualisation.vlans = [];
-
-      containers.simple = {
-        autoStart = true;
-        pkgs = customPkgs;
-        config = {pkgs, config, ... }: {
-          environment.systemPackages = [
-            pkgs.hello
-          ];
-        };
+  machine = { ... }: {
+    containers.test = {
+      autoStart = true;
+      pkgs = customPkgs;
+      config = {pkgs, config, ... }: {
+        environment.systemPackages = [
+          pkgs.hello
+        ];
       };
-
     };
+  };
 
   testScript = ''
-    start_all()
     machine.wait_for_unit("default.target")
     machine.succeed(
-        "test $(nixos-container run simple -- readlink -f /run/current-system/sw/bin/hello) = ${customPkgs.hello}/bin/hello"
+        "test $(nixos-container run test -- readlink -f /run/current-system/sw/bin/hello) = ${customPkgs.hello}/bin/hello"
     )
   '';
 })


### PR DESCRIPTION
Since the introduction of option `containers.<name>.pkgs`, the `nixpkgs.*` options (including `nixpkgs.pkgs`, `nixpkgs.config`, ...) were always ignored in container configs, which broke existing containers.
                                                                                                                                    
This was due to `containers.<name>.pkgs` having two separate effects:
1. It sets the source for the modules that are used to evaluate the container.
2. It sets the `pkgs` arg (`_module.args.pkgs`) that is used inside the container  modules.
    This happens even when the default value of `containers.<name>.pkgs` is unchanged, in which
    case the container `pkgs` arg is set to the pkgs of the host system.
    Previously, the `pkgs` arg was determined by the `containers.<name>.config.nixpkgs.*` options.
                                                                                                                                    
This commit reverts the breaking change (2.) while adding a backwards-compatible way to achieve (1.).
It removes option `pkgs` and adds option `nixpkgs` which implements (1.).
Existing users of `pkgs` are informed by an error message to use option `nixpkgs` for (1.) or to achieve only (2.) by setting option `containers.<name>.config.nixpkgs.pkgs`.

The first three commits
`tests/containers-custom-pkgs: improve test`
`nixos-container: simplify 'pkgs' option type`
`nixos-containers: remove redundant eval-config args`
are refactorings without any functional changes.

### Reproduce

The following config was broken before and is fixed by this PR:
```bash
nix-instantiate --eval - <<'EOF'
let
  configuration = {
    containers.mycontainer = {
      config = { pkgs, ... }: {
        nixpkgs.overlays = [ (self: super: {
          myval = "hello";
        }) ];
        networking.hostName = pkgs.myval;
      };
    };
  };
in
(import <nixpkgs/nixos> { inherit configuration; }).vm.outPath
EOF

# error: attribute 'myval' missing, at (string):8:31
```

Fixes #88621.
cc @adisbladis

This PR is an improved version of #98655