### PR TITLE
kapp: init at 0.34.0

### DIFF
--- a/pkgs/tools/networking/kapp/default.nix
+++ b/pkgs/tools/networking/kapp/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "kapp";
+  version = "0.34.0";
+
+  src = fetchFromGitHub {
+    owner = "vmware-tanzu";
+    repo = "carvel-kapp";
+    rev = "v${version}";
+    sha256 = "145909cbq4yb25r6ccpdhzfwk60q5g2hw6qdp2h6ja1ckrnvffld";
+  };
+
+  vendorSha256 = null;
+
+  subPackages = [ "cmd/kapp" ];
+
+  meta = with lib; {
+    description = "CLI tool that encourages Kubernetes users to manage bulk resources with an application abstraction for grouping";
+    homepage = "https://get-kapp.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ brodes ];
+  };
+}

--- a/pkgs/tools/networking/kapp/default.nix
+++ b/pkgs/tools/networking/kapp/default.nix
@@ -1,13 +1,13 @@
 { lib, buildGoModule, fetchFromGitHub }:
 buildGoModule rec {
   pname = "kapp";
-  version = "0.34.0";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "vmware-tanzu";
     repo = "carvel-kapp";
     rev = "v${version}";
-    sha256 = "145909cbq4yb25r6ccpdhzfwk60q5g2hw6qdp2h6ja1ckrnvffld";
+    sha256 = "1i4hpqpbwqb0yg3rx4z733zfslq3svmahfr39ss1ydylsipl02mg";
   };
 
   vendorSha256 = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5218,6 +5218,8 @@ in
 
   lvmsync = callPackage ../tools/backup/lvmsync { };
 
+  kapp = callPackage ../tools/networking/kapp {};
+
   kdbg = libsForQt5.callPackage ../development/tools/misc/kdbg { };
 
   kippo = callPackage ../servers/kippo { };


### PR DESCRIPTION
###### Motivation for this change
kapp is a useful drop-in replacement for kubectl which offers abstractions for managing many kubernetes resources. It's currently absent from nixpkgs.

kapp is part of the carvel collection of kubernetes tooling with [ytt](https://github.com/NixOS/nixpkgs/pull/105071), which was added to nixpkgs last week.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
