### PR TITLE
python3Packages.tensorflow_2: relax h5py dependency

### DIFF
--- a/pkgs/development/python-modules/tensorflow/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow/2/default.nix
@@ -110,7 +110,7 @@ let
       # Fixes for NixOS jsoncpp
       ../system-jsoncpp.patch
 
-      ./lift-gast-restriction.patch
+      ./relax-dependencies.patch
 
       # see https://github.com/tensorflow/tensorflow/issues/40688
       (fetchpatch {

--- a/pkgs/development/python-modules/tensorflow/2/relax-dependencies.patch
+++ b/pkgs/development/python-modules/tensorflow/2/relax-dependencies.patch
@@ -1,11 +1,16 @@
 diff --git a/tensorflow/tools/pip_package/setup.py b/tensorflow/tools/pip_package/setup.py
-index 992f2eae22..d9386f9b13 100644
+index 594e74f40c0..bfbf010144f 100644
 --- a/tensorflow/tools/pip_package/setup.py
 +++ b/tensorflow/tools/pip_package/setup.py
-@@ -56,5 +56,5 @@ REQUIRED_PACKAGES = [
+@@ -54,9 +54,9 @@ _VERSION = '2.3.1'
+ REQUIRED_PACKAGES = [
+     'absl-py >= 0.7.0',
      'astunparse == 1.6.3',
 -    'gast == 0.3.3',
 +    'gast >= 0.3.3',
      'google_pasta >= 0.1.8',
-     'h5py >= 2.10.0, < 2.11.0',
+-    'h5py >= 2.10.0, < 2.11.0',
++    'h5py >= 2.10.0',
      'keras_preprocessing >= 1.1.1, < 1.2',
+     # TODO(mihaimaruseac): numpy 1.19.0 has ABI breakage
+     # https://github.com/numpy/numpy/pull/15355


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Relaxes the h5py dependency pin to fix the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
