### PR TITLE
mapmap: build with libsForQt5

### DIFF
--- a/pkgs/applications/video/mapmap/default.nix
+++ b/pkgs/applications/video/mapmap/default.nix
@@ -46,6 +46,11 @@ mkDerivation rec {
       url = "https://github.com/mapmapteam/mapmap/pull/519/commits/22eeee59ba7de6de7b73ecec3b0ea93bdc7f04e8.patch";
       sha256 = "0is905a4lf9vvl5b1n4ky6shrnbs5kz9mlwfk78hrl4zabfmcl5l";
     })
+    # fix build with libsForQt515
+    (fetchpatch {
+      url = "https://github.com/mapmapteam/mapmap/pull/518/commits/ac49acc1e2ec839832b86838e93a8c13030affeb.patch";
+      sha256 = "sha256-tSLbyIDv5mSejnw9oru5KLAyQqjgJLLREKQomEUcGt8=";
+    })
   ];
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22589,7 +22589,7 @@ in
 
   mandelbulber = libsForQt5.callPackage ../applications/graphics/mandelbulber { };
 
-  mapmap = libsForQt514.callPackage ../applications/video/mapmap { };
+  mapmap = libsForQt5.callPackage ../applications/video/mapmap { };
 
   marathonctl = callPackage ../tools/virtualization/marathonctl { } ;
 


### PR DESCRIPTION
See #104474

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
