### PR TITLE
python3Packages.zigpy: 0.26.0 -> 0.28.2, python3Packages.aiosqlite: 0.12.0 -> 0.16.0, python3Packages.zha-quirks: 0.0.47 -> 0.0.48, fix tests

### DIFF
--- a/pkgs/development/python-modules/aiosqlite/default.nix
+++ b/pkgs/development/python-modules/aiosqlite/default.nix
@@ -1,31 +1,37 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, setuptools
+, typing-extensions
 , aiounittest
-, isPy27
-, pytest
+, coverage
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aiosqlite";
-  version = "0.12.0";
-  disabled = isPy27;
+  version = "0.16.0";
+  format = "flit";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    owner = "jreese";
+    owner = "omnilib";
     repo = pname;
     rev = "v${version}";
-    sha256 = "090vdv210zfry0bms5b3lmm06yhiyjb8ga96996cqs611l7c2a2j";
+    sha256 = "qdWD3yyN9E+SHecZrpD/MDGWBpsx95/14CY1ElBTbX4=";
   };
 
-  buildInputs = [
-    setuptools
+  propagatedBuildInputs = [
+    typing-extensions
   ];
 
   checkInputs = [
     aiounittest
+    coverage
   ];
+
+  checkPhase = ''
+    python -m coverage run -m aiosqlite.tests
+  '';
 
   meta = with lib; {
     description = "Asyncio bridge to the standard sqlite3 module";

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -1,24 +1,39 @@
-{ lib, buildPythonPackage, fetchPypi
-, aiohttp, zigpy, conftest, asynctest
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, zigpy
+, conftest
+, asynctest
 , pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.47";
+  version = "0.0.48";
 
-  propagatedBuildInputs = [ aiohttp zigpy ];
-  checkInputs = [ pytestCheckHook conftest asynctest ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "bf7dbd5d1c1a3849b059e62afcef248b6955f5ceef78f87201ae2fc8420738de";
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zha-device-handlers";
+    rev = version;
+    sha256 = "KyTttpD3i2Y+mAGMtjCDKhwoBuDTpnuPyOP6sLmbCis=";
   };
+
+  propagatedBuildInputs = [
+    aiohttp
+    zigpy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    conftest
+    asynctest
+  ];
 
   meta = with lib; {
     description = "ZHA Device Handlers are custom quirks implementations for Zigpy";
     homepage = "https://github.com/dmulcahey/zha-device-handlers";
     license = licenses.asl20;
-    maintainers = with maintainers; [ etu ];
+    maintainers = with maintainers; [ etu mvnetbiz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -1,5 +1,6 @@
 { lib
 , aiohttp
+, aiosqlite
 , asynctest
 , buildPythonPackage
 , crccheck
@@ -14,17 +15,18 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.26.0";
+  version = "0.28.2";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     rev = version;
-    sha256 = "ba8Ru6RCbFOHhctFtklnrxVD3uEpxF4XDvO5RMgXPBs=";
+    sha256 = "iZJJhTh6BPc4capTkyBB0TO8OysrBWC9li/VTsOLIMA=";
   };
 
   propagatedBuildInputs = [
     aiohttp
+    aiosqlite
     crccheck
     pycrypto
     pycryptodome


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix zigpy modules

###### Things done
- Updated zigpy
- updated aiosqlite

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
