### PR TITLE
nixos/prometheus-exporters/py-air-control: invoke exporter command

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/py-air-control.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/py-air-control.nix
@@ -5,10 +5,6 @@ with lib;
 let
   cfg = config.services.prometheus.exporters.py-air-control;
 
-  py-air-control-exporter-env = pkgs.python3.withPackages (pyPkgs: [
-      pyPkgs.py-air-control-exporter
-  ]);
-
   workingDir = "/var/lib/${cfg.stateDir}";
 
 in
@@ -45,18 +41,13 @@ in
       StateDirectory = cfg.stateDir;
       WorkingDirectory = workingDir;
       ExecStart = ''
-        ${py-air-control-exporter-env}/bin/python -c \
-          "from py_air_control_exporter import app; app.create_app().run( \
-              debug=False, \
-              port=${toString cfg.port}, \
-              host='${cfg.listenAddress}', \
-          )"
+        ${pkgs.python3Packages.py-air-control-exporter}/bin/py-air-control-exporter \
+          --host ${cfg.deviceHostname} \
+          --protocol ${cfg.protocol} \
+          --listen-port ${toString cfg.port} \
+          --listen-address ${cfg.listenAddress}
       '';
-      Environment = [
-        "PY_AIR_CONTROL_HOST=${cfg.deviceHostname}"
-        "PY_AIR_CONTROL_PROTOCOL=${cfg.protocol}"
-        "HOME=${workingDir}"
-      ];
+      Environment = [ "HOME=${workingDir}" ];
     };
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package `py-air-control exporter` v0.1.5 comes with a new CLI. This change uses the new CLI, which simplifies the exporter's systemd service setup.

###### Things done

1. Tested by deploying this change on a live server (Raspberry Pi 4).

2. Tested via `nix-build -vA pkgs.nixosTests.prometheus-exporters.py-air-control`


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @WilliButz 