### PR TITLE
alttpr-opentracker: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3733,6 +3733,16 @@
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
     }];
   };
+  islandusurper = {
+    email = "ashagua@gmail.com";
+    name = "Lyle Mantooth";
+    github = "IslandUsurper";
+    githubId = 17701;
+    keys = [{
+      longkeyid = "rsa3072/0x6DB52EAE123A5789";
+      fingerprint = "CA84 771F 492B C486 E07D  255C 6DB5 2EAE 123A 5789";
+    }];
+  };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";

--- a/pkgs/applications/misc/alttpr-opentracker/default.nix
+++ b/pkgs/applications/misc/alttpr-opentracker/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchurl, autoPatchelfHook, makeWrapper, wrapGAppsHook,
+  curl, dotnet-netcore, dpkg, fontconfig, gcc, gsettings-desktop-schemas, gtk3, lttng-ust, openssl, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "alttpr-opentracker";
+  version = "1.6.1";
+  src = fetchurl {
+    url = "https://github.com/trippsc2/OpenTracker/releases/download/${version}/OpenTracker.${version}.debian-x64.deb";
+    sha256 = "159c9k5nd4iq7c8f7bqmj3373w24bchayfyq9blsmx68349ls8x8";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    curl
+    dotnet-netcore
+    dpkg
+    fontconfig
+    gcc
+    gsettings-desktop-schemas
+    gtk3
+    lttng-ust
+    makeWrapper
+    openssl
+    wrapGAppsHook
+  ];
+
+  ld_path = stdenv.lib.makeLibraryPath [
+    gtk3
+    openssl
+    xorg.libX11
+    xorg.libXi
+    xorg.xinput
+  ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    dpkg --fsys-tarfile $src | tar --extract
+
+    mkdir -p $out/bin
+    mv usr/* $out
+    rm -r $out/local
+
+    chmod -R g-w $out
+
+    makeWrapper $out/share/OpenTracker/OpenTracker $out/bin/OpenTracker \
+      --set DOTNET_SYSTEM_GLOBALIZATION_INVARIANT 1 \
+      --prefix LD_LIBRARY_PATH : ${ld_path}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An open-source cross-platform tracking app for A Link to the Past Randomizer";
+    homepage = "https://github.com/trippsc2/OpenTracker";
+    downloadPage = "https://github.com/trippsc2/OpenTracker/releases";
+    maintainers = with maintainers; [ islandusurper ];
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20084,6 +20084,8 @@ in
     tcl = tcl-8_5;
   };
 
+  alttpr-opentracker = callPackage ../applications/misc/alttpr-opentracker { };
+
   msgviewer = callPackage ../applications/networking/mailreaders/msgviewer { };
 
   amarok = libsForQt5.callPackage ../applications/audio/amarok { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add desktop tracker of game state of A Link to the Past Randomizer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
