### PR TITLE
protontricks: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/misc/emulators/wine/winetricks.nix
+++ b/pkgs/misc/emulators/wine/winetricks.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
 
   # coreutils is for sha1sum
   pathAdd = stdenv.lib.concatMapStringsSep ":" (x: x + "/bin")
-    [ wine perl which coreutils zenity curl cabextract unzip p7zip gnused gnugrep bash ];
+    (stdenv.lib.filter (x: x != null)
+      [ wine perl which coreutils zenity curl cabextract unzip p7zip gnused gnugrep bash ]);
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -35,7 +35,11 @@ buildPythonApplication rec {
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [
       steam-run
-      winetricks
+      (winetricks.override {
+        # Remove default build of wine to reduce closure size.
+        # Falls back to wine in PATH when --no-runtime is passed.
+        wine = null;
+      })
       zenity
     ]}"
   ];

--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonApplication rec {
   pname = "protontricks";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "Matoking";
     repo = pname;
     rev = version;
-    sha256 = "0ri4phi1rna9snrxa6gl23walyack09mgax7zpjqfpxivwls3ach";
+    sha256 = "0a5727igwafwvj8rr5lv0lx8rlfji3qkzmrbp0d15w5dc4fhknp0";
   };
 
   patches = [
@@ -44,6 +44,11 @@ buildPythonApplication rec {
   disabledTests = [
     # Steam runtime is hard-coded with steam-run.patch and can't be configured
     "test_run_steam_runtime_not_found"
+    "test_unknown_steam_runtime_detected"
+
+    # Steam runtime 2 currently isn't supported
+    # See https://github.com/NixOS/nixpkgs/issues/100655
+    "test_run_winetricks_steam_runtime_v2"
   ];
 
   meta = with lib; {

--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -1,13 +1,12 @@
-{ stdenv
-, lib
+{ lib
 , buildPythonApplication
 , fetchFromGitHub
 , setuptools_scm
 , vdf
-, wine
+, steam-run
 , winetricks
 , zenity
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonApplication rec {
@@ -21,11 +20,10 @@ buildPythonApplication rec {
     sha256 = "0ri4phi1rna9snrxa6gl23walyack09mgax7zpjqfpxivwls3ach";
   };
 
-  # Fix interpreter in mock run.sh for tests
-  postPatch = ''
-    substituteInPlace tests/conftest.py \
-      --replace '#!/bin/bash' '#!${stdenv.shell}' \
-  '';
+  patches = [
+    # Use steam-run to run Proton binaries
+    ./steam-run.patch
+  ];
 
   preBuild = ''
     export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
@@ -34,22 +32,21 @@ buildPythonApplication rec {
   nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ vdf ];
 
-  # The wine install shipped with Proton must run under steam's
-  # chrootenv, but winetricks and zenity break when running under
-  # it. See https://github.com/NixOS/nix/issues/902.
-  #
-  # The current workaround is to use wine from nixpkgs
   makeWrapperArgs = [
-    "--set STEAM_RUNTIME 0"
-    "--set-default WINE ${wine}/bin/wine"
-    "--set-default WINESERVER ${wine}/bin/wineserver"
-    "--prefix PATH : ${lib.makeBinPath [ winetricks zenity ]}"
+    "--prefix PATH : ${lib.makeBinPath [
+      steam-run
+      winetricks
+      zenity
+    ]}"
   ];
 
-  checkInputs = [ pytest ];
-  checkPhase = "pytest";
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [
+    # Steam runtime is hard-coded with steam-run.patch and can't be configured
+    "test_run_steam_runtime_not_found"
+  ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A simple wrapper for running Winetricks commands for Proton-enabled games";
     homepage = "https://github.com/Matoking/protontricks";
     license = licenses.gpl3;

--- a/pkgs/tools/package-management/protontricks/steam-run.patch
+++ b/pkgs/tools/package-management/protontricks/steam-run.patch
@@ -1,0 +1,211 @@
+diff --git a/src/protontricks/cli.py b/src/protontricks/cli.py
+index 6506dae..2f762c9 100755
+--- a/src/protontricks/cli.py
++++ b/src/protontricks/cli.py
+@@ -14,7 +14,7 @@ import os
+ import logging
+ 
+ from . import __version__
+-from .steam import (find_proton_app, find_steam_path, find_steam_runtime_path,
++from .steam import (find_proton_app, find_steam_path,
+                     get_steam_apps, get_steam_lib_paths)
+ from .winetricks import get_winetricks_path
+ from .gui import select_steam_app_with_gui
+@@ -75,8 +75,7 @@ def main(args=None):
+             "WINE: path to a custom 'wine' executable\n"
+             "WINESERVER: path to a custom 'wineserver' executable\n"
+             "STEAM_RUNTIME: 1 = enable Steam Runtime, 0 = disable Steam "
+-            "Runtime, valid path = custom Steam Runtime path, "
+-            "empty = enable automatically (default)"
++            "Runtime, empty = enable automatically (default)"
+         ),
+         formatter_class=argparse.RawTextHelpFormatter
+     )
+@@ -133,14 +132,10 @@ def main(args=None):
+         sys.exit(-1)
+ 
+     # 2. Find Steam Runtime if enabled
+-    steam_runtime_path = None
++    steam_runtime = False
+ 
+     if os.environ.get("STEAM_RUNTIME", "") != "0" and not args.no_runtime:
+-        steam_runtime_path = find_steam_runtime_path(steam_root=steam_root)
+-
+-        if not steam_runtime_path:
+-            print("Steam Runtime was enabled but couldn't be found!")
+-            sys.exit(-1)
++        steam_runtime = True
+     else:
+         logger.info("Steam Runtime disabled.")
+ 
+@@ -194,7 +189,7 @@ def main(args=None):
+             winetricks_path=winetricks_path,
+             proton_app=proton_app,
+             steam_app=steam_app,
+-            steam_runtime_path=steam_runtime_path,
++            steam_runtime=steam_runtime,
+             command=[winetricks_path, "--gui"]
+         )
+         return
+@@ -261,7 +256,7 @@ def main(args=None):
+             winetricks_path=winetricks_path,
+             proton_app=proton_app,
+             steam_app=steam_app,
+-            steam_runtime_path=steam_runtime_path,
++            steam_runtime=steam_runtime,
+             command=[winetricks_path] + args.winetricks_command)
+     elif args.command:
+         run_command(
+@@ -269,7 +264,7 @@ def main(args=None):
+             proton_app=proton_app,
+             steam_app=steam_app,
+             command=args.command,
+-            steam_runtime_path=steam_runtime_path,
++            steam_runtime=steam_runtime,
+             # Pass the command directly into the shell *without*
+             # escaping it
+             cwd=steam_app.install_path,
+diff --git a/src/protontricks/steam.py b/src/protontricks/steam.py
+index 0d3670e..d01cabe 100644
+--- a/src/protontricks/steam.py
++++ b/src/protontricks/steam.py
+@@ -12,7 +12,7 @@ from .util import lower_dict
+ 
+ __all__ = (
+     "COMMON_STEAM_DIRS", "SteamApp", "find_steam_path",
+-    "find_steam_proton_app", "find_proton_app", "find_steam_runtime_path",
++    "find_steam_proton_app", "find_proton_app",
+     "find_appid_proton_prefix", "get_steam_lib_paths", "get_steam_apps",
+     "get_custom_proton_installations"
+ )
+@@ -207,38 +207,6 @@ def find_steam_path():
+     return None, None
+ 
+ 
+-def find_steam_runtime_path(steam_root):
+-    """
+-    Find the Steam Runtime either using the STEAM_RUNTIME env or
+-    steam_root
+-    """
+-    env_steam_runtime = os.environ.get("STEAM_RUNTIME", "")
+-
+-    if env_steam_runtime == "0":
+-        # User has disabled Steam Runtime
+-        logger.info("STEAM_RUNTIME is 0. Disabling Steam Runtime.")
+-        return None
+-    elif os.path.isdir(env_steam_runtime):
+-        # User has a custom Steam Runtime
+-        logger.info(
+-            "Using custom Steam Runtime at %s", env_steam_runtime)
+-        return env_steam_runtime
+-    elif env_steam_runtime in ["1", ""]:
+-        # User has enabled Steam Runtime or doesn't have STEAM_RUNTIME set;
+-        # default to enabled Steam Runtime in either case
+-        steam_runtime_path = os.path.join(
+-            steam_root, "ubuntu12_32", "steam-runtime")
+-
+-        logger.info(
+-            "Using default Steam Runtime at %s", steam_runtime_path)
+-        return steam_runtime_path
+-
+-    logger.error(
+-        "Path in STEAM_RUNTIME doesn't point to a valid Steam Runtime!")
+-
+-    return None
+-
+-
+ APPINFO_STRUCT_HEADER = "<4sL"
+ APPINFO_STRUCT_SECTION = "<LLLLQ20sL"
+ 
+diff --git a/src/protontricks/util.py b/src/protontricks/util.py
+index bd77b01..6f39389 100644
+--- a/src/protontricks/util.py
++++ b/src/protontricks/util.py
+@@ -6,7 +6,7 @@ import stat
+ from pathlib import Path
+ from subprocess import check_output, run
+ 
+-__all__ = ("get_runtime_library_path", "create_wine_bin_dir", "run_command")
++__all__ = ("create_wine_bin_dir", "run_command")
+ 
+ logger = logging.getLogger("protontricks")
+ 
+@@ -21,29 +21,10 @@ def lower_dict(d):
+     return {k.lower(): v for k, v in d.items()}
+ 
+ 
+-def get_runtime_library_path(steam_runtime_path, proton_app):
+-    """
+-    Get LD_LIBRARY_PATH value to run a command using Steam Runtime
+-    """
+-    steam_runtime_paths = check_output([
+-        os.path.join(steam_runtime_path, "run.sh"),
+-        "--print-steam-runtime-library-paths"
+-    ])
+-    steam_runtime_paths = str(steam_runtime_paths, "utf-8")
+-    # Add Proton installation directory first into LD_LIBRARY_PATH
+-    # so that libwine.so.1 is picked up correctly (see issue #3)
+-    return "".join([
+-        os.path.join(proton_app.install_path, "dist", "lib"), os.pathsep,
+-        os.path.join(proton_app.install_path, "dist", "lib64"), os.pathsep,
+-        steam_runtime_paths
+-    ])
+-
+-
+ WINE_SCRIPT_TEMPLATE = (
+-    "#!/bin/bash\n"
++    "#!/bin/sh\n"
+     "# Helper script created by Protontricks to run Wine binaries using Steam Runtime\n"
+-    "export LD_LIBRARY_PATH=\"$PROTON_LD_LIBRARY_PATH\"\n"
+-    "exec \"$PROTON_PATH\"/dist/bin/{name} \"$@\""
++    "exec steam-run \"$PROTON_PATH\"/dist/bin/{name} \"$@\""
+ )
+ 
+ 
+@@ -106,7 +87,7 @@ def create_wine_bin_dir(proton_app):
+ 
+ def run_command(
+         winetricks_path, proton_app, steam_app, command,
+-        steam_runtime_path=None,
++        steam_runtime=False,
+         **kwargs):
+     """Run an arbitrary command with the correct environment variables
+     for the given Proton app
+@@ -114,7 +95,7 @@ def run_command(
+     The environment variables are set for the duration of the call
+     and restored afterwards
+ 
+-    If 'steam_runtime_path' is provided, run the command using Steam Runtime
++    If 'steam_runtime' is provided, run the command using Steam Runtime
+     """
+     # Make a copy of the environment variables to restore later
+     environ_copy = os.environ.copy()
+@@ -157,13 +138,11 @@ def run_command(
+     os.environ.pop("WINEARCH", "")
+ 
+     wine_bin_dir = None
+-    if steam_runtime_path:
++    if steam_runtime:
+         # When Steam Runtime is enabled, create a set of helper scripts
+         # that load the underlying Proton Wine executables with Steam Runtime
+         # and Proton libraries instead of system libraries
+         wine_bin_dir = create_wine_bin_dir(proton_app=proton_app)
+-        os.environ["PROTON_LD_LIBRARY_PATH"] = \
+-            get_runtime_library_path(steam_runtime_path, proton_app)
+         os.environ["PATH"] = \
+             str(wine_bin_dir) + os.pathsep + os.environ["PATH"]
+         os.environ["WINE"] = str(wine_bin_dir / "wine")
+diff --git a/tests/test_cli.py b/tests/test_cli.py
+index 0e0425f..d471c7d 100644
+--- a/tests/test_cli.py
++++ b/tests/test_cli.py
+@@ -113,9 +113,6 @@ class TestCLIRun:
+         assert command.args[0].endswith(".local/bin/winetricks")
+         assert command.args[1] == "winecfg"
+         assert command.env["PATH"].startswith(str(wine_bin_dir))
+-        assert (
+-            "fake_steam_runtime/lib64" in command.env["PROTON_LD_LIBRARY_PATH"]
+-        )
+         assert command.env["WINE"] == str(wine_bin_dir / "wine")
+         assert command.env["WINELOADER"] == str(wine_bin_dir / "wine")
+         assert command.env["WINESERVER"] == str(wine_bin_dir / "wineserver")

--- a/pkgs/tools/package-management/protontricks/steam-run.patch
+++ b/pkgs/tools/package-management/protontricks/steam-run.patch
@@ -66,10 +66,10 @@ index 6506dae..2f762c9 100755
              # escaping it
              cwd=steam_app.install_path,
 diff --git a/src/protontricks/steam.py b/src/protontricks/steam.py
-index 0d3670e..d01cabe 100644
+index 215b31d..aa545b8 100644
 --- a/src/protontricks/steam.py
 +++ b/src/protontricks/steam.py
-@@ -12,7 +12,7 @@ from .util import lower_dict
+@@ -11,7 +11,7 @@ from .util import lower_dict
  
  __all__ = (
      "COMMON_STEAM_DIRS", "SteamApp", "find_steam_path",
@@ -78,7 +78,7 @@ index 0d3670e..d01cabe 100644
      "find_appid_proton_prefix", "get_steam_lib_paths", "get_steam_apps",
      "get_custom_proton_installations"
  )
-@@ -207,38 +207,6 @@ def find_steam_path():
+@@ -245,37 +245,6 @@ def find_steam_path():
      return None, None
  
  
@@ -93,19 +93,18 @@ index 0d3670e..d01cabe 100644
 -        # User has disabled Steam Runtime
 -        logger.info("STEAM_RUNTIME is 0. Disabling Steam Runtime.")
 -        return None
--    elif os.path.isdir(env_steam_runtime):
+-    elif env_steam_runtime and Path(env_steam_runtime).is_dir():
 -        # User has a custom Steam Runtime
 -        logger.info(
 -            "Using custom Steam Runtime at %s", env_steam_runtime)
--        return env_steam_runtime
+-        return Path(env_steam_runtime)
 -    elif env_steam_runtime in ["1", ""]:
 -        # User has enabled Steam Runtime or doesn't have STEAM_RUNTIME set;
 -        # default to enabled Steam Runtime in either case
--        steam_runtime_path = os.path.join(
--            steam_root, "ubuntu12_32", "steam-runtime")
+-        steam_runtime_path = steam_root / "ubuntu12_32" / "steam-runtime"
 -
 -        logger.info(
--            "Using default Steam Runtime at %s", steam_runtime_path)
+-            "Using default Steam Runtime at %s", str(steam_runtime_path))
 -        return steam_runtime_path
 -
 -    logger.error(
@@ -118,36 +117,77 @@ index 0d3670e..d01cabe 100644
  APPINFO_STRUCT_SECTION = "<LLLLQ20sL"
  
 diff --git a/src/protontricks/util.py b/src/protontricks/util.py
-index bd77b01..6f39389 100644
+index a850427..390fc01 100644
 --- a/src/protontricks/util.py
 +++ b/src/protontricks/util.py
 @@ -6,7 +6,7 @@ import stat
  from pathlib import Path
- from subprocess import check_output, run
+ from subprocess import check_output, run, PIPE
  
--__all__ = ("get_runtime_library_path", "create_wine_bin_dir", "run_command")
+-__all__ = ("get_runtime_library_paths", "create_wine_bin_dir", "run_command")
 +__all__ = ("create_wine_bin_dir", "run_command")
  
  logger = logging.getLogger("protontricks")
  
-@@ -21,29 +21,10 @@ def lower_dict(d):
+@@ -25,70 +25,10 @@ def lower_dict(d):
      return {k.lower(): v for k, v in d.items()}
  
  
--def get_runtime_library_path(steam_runtime_path, proton_app):
+-def get_host_library_paths():
+-    """
+-    Get host library paths to use when creating the LD_LIBRARY_PATH environment
+-    variable for use with newer Steam Runtime installations
+-    """
+-    # The traditional Steam Runtime does the following when running the
+-    # `run.sh --print-steam-runtime-library-paths` command.
+-    # Since that command is unavailable with newer Steam Runtime releases,
+-    # do it ourselves here.
+-    result = run(
+-        ["/sbin/ldconfig", "-XNv"],
+-        check=True, stdout=PIPE, stderr=PIPE
+-    )
+-    lines = result.stdout.decode("utf-8").split("\n")
+-    paths = [
+-        line.split(":")[0] for line in lines
+-        if line.startswith("/") and ":" in line
+-    ]
+-
+-    return ":".join(paths)
+-
+-
+-def get_runtime_library_paths(steam_runtime_path, proton_app):
 -    """
 -    Get LD_LIBRARY_PATH value to run a command using Steam Runtime
 -    """
+-    if proton_app.required_tool_app:
+-        # bwrap based Steam Runtime is used for Proton installations that
+-        # use separate Steam runtimes
+-        # TODO: Try to run the Wine binaries inside an user namespace somehow.
+-        # Newer Steam Runtime environments may rely on a newer glibc than what
+-        # is available on the host system, which may cause potential problems
+-        # otherwise.
+-        runtime_root = next(
+-            proton_app.required_tool_app.install_path.glob("*/files/")
+-        )
+-        return "".join([
+-            str(proton_app.install_path / "dist" / "lib"), os.pathsep,
+-            str(proton_app.install_path / "dist" / "lib64"), os.pathsep,
+-            get_host_library_paths(), os.pathsep,
+-            str(runtime_root / "i686-pc-linux-gnu" / "lib"), os.pathsep,
+-            str(runtime_root / "x86_64-pc-linux-gnu" / "lib")
+-        ])
+-
+-    # Traditional LD_LIBRARY_PATH based Steam Runtime is used otherwise
 -    steam_runtime_paths = check_output([
--        os.path.join(steam_runtime_path, "run.sh"),
+-        str(steam_runtime_path / "run.sh"),
 -        "--print-steam-runtime-library-paths"
 -    ])
 -    steam_runtime_paths = str(steam_runtime_paths, "utf-8")
 -    # Add Proton installation directory first into LD_LIBRARY_PATH
 -    # so that libwine.so.1 is picked up correctly (see issue #3)
 -    return "".join([
--        os.path.join(proton_app.install_path, "dist", "lib"), os.pathsep,
--        os.path.join(proton_app.install_path, "dist", "lib64"), os.pathsep,
+-        str(proton_app.install_path / "dist" / "lib"), os.pathsep,
+-        str(proton_app.install_path / "dist" / "lib64"), os.pathsep,
 -        steam_runtime_paths
 -    ])
 -
@@ -162,7 +202,7 @@ index bd77b01..6f39389 100644
  )
  
  
-@@ -106,7 +87,7 @@ def create_wine_bin_dir(proton_app):
+@@ -149,7 +89,7 @@ def create_wine_bin_dir(proton_app):
  
  def run_command(
          winetricks_path, proton_app, steam_app, command,
@@ -171,7 +211,7 @@ index bd77b01..6f39389 100644
          **kwargs):
      """Run an arbitrary command with the correct environment variables
      for the given Proton app
-@@ -114,7 +95,7 @@ def run_command(
+@@ -157,7 +97,7 @@ def run_command(
      The environment variables are set for the duration of the call
      and restored afterwards
  
@@ -180,27 +220,30 @@ index bd77b01..6f39389 100644
      """
      # Make a copy of the environment variables to restore later
      environ_copy = os.environ.copy()
-@@ -157,13 +138,11 @@ def run_command(
+@@ -200,7 +140,7 @@ def run_command(
      os.environ.pop("WINEARCH", "")
  
      wine_bin_dir = None
 -    if steam_runtime_path:
 +    if steam_runtime:
-         # When Steam Runtime is enabled, create a set of helper scripts
+         if proton_app.required_tool_app:
+             runtime_name = proton_app.required_tool_app.name
+             logger.info(
+@@ -217,8 +157,6 @@ def run_command(
          # that load the underlying Proton Wine executables with Steam Runtime
          # and Proton libraries instead of system libraries
          wine_bin_dir = create_wine_bin_dir(proton_app=proton_app)
 -        os.environ["PROTON_LD_LIBRARY_PATH"] = \
--            get_runtime_library_path(steam_runtime_path, proton_app)
-         os.environ["PATH"] = \
-             str(wine_bin_dir) + os.pathsep + os.environ["PATH"]
-         os.environ["WINE"] = str(wine_bin_dir / "wine")
+-            get_runtime_library_paths(steam_runtime_path, proton_app)
+         os.environ["PATH"] = "".join([
+             str(wine_bin_dir), os.pathsep, os.environ["PATH"]
+         ])
 diff --git a/tests/test_cli.py b/tests/test_cli.py
-index 0e0425f..d471c7d 100644
+index 19e1137..2ef56d6 100644
 --- a/tests/test_cli.py
 +++ b/tests/test_cli.py
-@@ -113,9 +113,6 @@ class TestCLIRun:
-         assert command.args[0].endswith(".local/bin/winetricks")
+@@ -114,9 +114,6 @@ class TestCLIRun:
+         assert str(command.args[0]).endswith(".local/bin/winetricks")
          assert command.args[1] == "winecfg"
          assert command.env["PATH"].startswith(str(wine_bin_dir))
 -        assert (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26109,13 +26109,10 @@ in
 
   steamcmd = steamPackages.steamcmd;
 
-  protontricks = callPackage ../tools/package-management/protontricks {
-    inherit (python3Packages) buildPythonApplication pytest setuptools_scm vdf;
+  protontricks = python3Packages.callPackage ../tools/package-management/protontricks {
+    inherit steam-run;
+    inherit winetricks;
     inherit (gnome3) zenity;
-    wine = wineWowPackages.minimal;
-    winetricks = winetricks.override {
-      wine = wineWowPackages.minimal;
-    };
   };
 
   stepmania = callPackage ../games/stepmania {


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://github.com/Matoking/protontricks/releases/tag/1.4.3

Also, now uses steam-run to run Proton wine instead of wineWowPackages.minimal.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - `protontricks --help`
  - `protontricks --gui`
  - `protontricks 8190 d3dcompiler_43 d3dx10`
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  1.8G -> 2.3G (1.8 -> 4.1G without removing default build of wine from winetricks)
  Effectively 1.8G -> 459.6M, since anyone using protontricks should already have steam & it's runtime installed.
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).