### PR TITLE
adoptopenjdk-bin, zulu8, zulu, graalvm8-ce, graalvm11-ce: remove demo, sample, and broken man pages

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -23,10 +23,10 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
 
     mv $sourceRoot $out
 
-    rm -rf $out/Home/demo
+    rm -rf $out/Contents/Home/sample
 
     # Remove some broken manpages.
-    rm -rf $out/Home/man/ja*
+    rm -rf $out/Contents/Home/man/ja*
 
     ln -s $out/Contents/Home/* $out/
 

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -65,7 +65,7 @@ let result = stdenv.mkDerivation rec {
 
     mv $sourceRoot $out
 
-    rm -rf $out/demo
+    rm -rf $out/sample
 
     # Remove some broken manpages.
     rm -rf $out/man/ja*

--- a/pkgs/development/compilers/graalvm/community-edition.nix
+++ b/pkgs/development/compilers/graalvm/community-edition.nix
@@ -163,6 +163,10 @@ let
 
             # allow using external truffle-api.jar and languages not included in the distrubution
             rm $out/jre/lib/jvmci/parentClassLoader.classpath
+
+            rm -rf $out/sample
+            # Remove some broken manpages.
+            rm -rf $out/man/ja*
           '';
           "11-linux-amd64" = ''
             # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -70,6 +70,12 @@ in stdenv.mkDerivation {
     mkdir -p $out
     cp -r ./* "$out/"
 
+    rm -rf $out/demo
+    rm -rf $out/sample
+
+    # Remove some broken manpages.
+    rm -rf $out/man/ja*
+
     mkdir -p $out/nix-support
     printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 
@@ -89,6 +95,10 @@ in stdenv.mkDerivation {
   preFixup = ''
     find "$out" -name libfontmanager.so -exec \
       patchelf --add-needed libfontconfig.so {} \;
+  '';
+
+  postFixup = stdenv.lib.optional stdenv.isDarwin ''
+    ln -sf $out/zulu-*.jdk/Contents/Home/man $out/share/man
   '';
 
   passthru = {

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -72,6 +72,11 @@ in stdenv.mkDerivation {
     mkdir -p $out
     cp -r ./* "$out/"
 
+    rm -rf $out/demo
+
+    # Remove some broken manpages.
+    rm -rf $out/man/ja*
+
     mkdir -p $out/nix-support
     printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See: #106716.

Note that AdoptOpenJDK doesn't have demo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
