### PR TITLE
qvge: 0.6.1 → 0.6.2

### DIFF
--- a/pkgs/applications/graphics/qvge/default.nix
+++ b/pkgs/applications/graphics/qvge/default.nix
@@ -9,13 +9,13 @@
 
 mkDerivation rec {
   pname = "qvge";
-  version = "0.6.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "ArsMasiuk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0j4ih03nl6iihhnxrfldkarg9hvxb62lpr58xspn417d3gj6xjll";
+    sha256 = "0qy73dngl1xm6mr2306ddzbbrzk6yszp3y15phs861bfxynzkqjz";
   };
 
   prePatch = "cd src";


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/ArsMasiuk/qvge/releases/tag/v0.6.2)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
