### PR TITLE
saga: 7.8.1 → 7.8.2

### DIFF
--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -32,11 +32,11 @@
 
 mkDerivation rec {
   pname = "saga";
-  version = "7.8.1";
+  version = "7.8.2";
 
   src = fetchurl {
-    url = "https://sourceforge.net/projects/saga-gis/files/SAGA%20-%20${lib.versions.major version}/SAGA%20-%20${version}/saga-${version}.tar.gz";
-    sha256 = "qwjuimeoadwf254bwJ7h2vSKaELkcaJdFrGj1WtvnbM=";
+    url = "mirror://sourceforge/saga-gis/SAGA%20-%20${lib.versions.major version}/SAGA%20-%20${version}/saga-${version}.tar.gz";
+    sha256 = "1008l8f4733vsxy3y6d1yg8m4h8pp65d2p48ljc9kp5nyrg5vfy5";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://sourceforge.net/p/saga-gis/wiki/Changelog%207.8.2/attachment/changelog_saga_7.8.2.txt)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
