### PR TITLE
pyopenssl: skip test that fails on i686

### DIFF
--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -54,6 +54,9 @@ let
     optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests
   ) ++ (
     optionals (versionAtLeast (getVersion openssl.name) "1.1") failingOpenSSL_1_1Tests
+  ) ++ (
+    # https://github.com/pyca/pyopenssl/issues/974
+    optionals stdenv.isi686 [ "test_verify_with_time" ]
   );
 
   # Compose the final string expression, including the "-k" and the single quotes.


### PR DESCRIPTION
Found in https://github.com/NixOS/nixpkgs/pull/105454#issuecomment-743973848

Upstream issue https://github.com/pyca/pyopenssl/issues/974

###### Motivation for this change

to make e.g. platformio build again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).