### PR TITLE
archi: unbreak build

### DIFF
--- a/pkgs/tools/misc/archi/default.nix
+++ b/pkgs/tools/misc/archi/default.nix
@@ -2,6 +2,8 @@
 , fetchurl
 , fetchzip
 , autoPatchelfHook
+, makeWrapper
+, jdk
 , libsecret
 }:
 
@@ -29,17 +31,20 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    makeWrapper
   ];
 
   installPhase =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       ''
-      mkdir -p $out/bin
-        for f in configuration features p2 plugins Archi.ini Archi; do
-          cp $f $out/bin/
+        mkdir -p $out/bin $out/libexec
+        for f in configuration features p2 plugins Archi.ini; do
+          cp -r $f $out/libexec
         done
 
-        install -D -m755 Archi $out/bin/Archi
+        install -D -m755 Archi $out/libexec/Archi
+        makeWrapper $out/libexec/Archi $out/bin/Archi \
+          --prefix PATH : ${jdk}/bin
       ''
     else
       ''


### PR DESCRIPTION
Additionally make a wrapper to put the jdk in the PATH to avoid
needed a global JDK

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unbreak Archi build and add a wrapper to put jdk in the PATH

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
