### PR TITLE
firefox-wayland: fix ScreenCast #106812

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -352,6 +352,10 @@ buildStdenv.mkDerivation ({
       }/lib:$(patchelf --print-rpath "$out"/lib/${binaryName}*/libxul.so)" \
         "$out"/lib/${binaryName}*/libxul.so
     patchelf --add-needed ${xorg.libXScrnSaver.out}/lib/libXss.so $out/lib/${binaryName}/${binaryName}
+    ${lib.optionalString (pipewireSupport && lib.versionAtLeast ffversion "83") ''
+      patchelf --add-needed "${lib.getLib pipewire}/lib/libpipewire-0.3.so" \
+        "$out"/lib/${binaryName}/${binaryName}
+    ''}
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
With the update to FF83, screencasting through pipewire was no longer possible. It would be possible to select "Use operating system settings" and click "Allow" without errors on https://mozilla.github.io/webrtc-landing/gum_test.html, but the actual ScreenCast video was never visible on that page.

Within the updated patches for FF83 from fedora, the `pipewire` library got inlined. Probably the nixpkgs `pipewire` buildInput got stripped in fixupPhase. Adding it to needed libraries with `patchelf --add-needed` makes the ScreenCast video visible again.

Fix #106812

- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
