### PR TITLE
keeweb: 1.16.0 → 1.16.5

### DIFF
--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -4,19 +4,21 @@ let
   throwSystem = throw "Unsupported system: ${system}";
 
   pname = "keeweb";
-  version = "1.16.0";
+  version = "1.16.5";
   name = "${pname}-${version}";
 
   suffix = {
     x86_64-linux = "linux.AppImage";
-    x86_64-darwin = "mac.dmg";
+    x86_64-darwin = "mac.x64.dmg";
+    aarch64-darwin = "mac.arm64.dmg";
   }.${system} or throwSystem;
 
   src = fetchurl {
     url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.${suffix}";
     sha256 = {
-      x86_64-linux = "1pivic7n5nv00s8bb51i2jz2mxgjn92hkc8n0p8662ai1cdng47g";
-      x86_64-darwin = "0q6k0qgkgzid9yjbfsfpp8l9dr0n8xp25a4jf2bxwickm4irs9mz";
+      x86_64-linux = "18qcr8zyn20n5zrrha0qwgq2ic10bp189fps87lbnmcjknrkac9g";
+      x86_64-darwin = "0crpjkcqgs7q5c814bx2npjh9kpyyb87yagm5wcy9j21kwrbqv6k";
+      aarch64-darwin = "1wkf9inrm5qg0c4xrk0s97mx5j21xvlqwwkvydl513gyfzi2g9gp";
     }.${system} or throwSystem;
   };
 
@@ -29,7 +31,7 @@ let
     homepage = "https://keeweb.info/";
     license = licenses.mit;
     maintainers = with maintainers; [ sikmir ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 
   linux = appimageTools.wrapType2 rec {


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/keeweb/keeweb/releases)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
