### PR TITLE
gnomeExtensions.no-title-bar: 9 -> 11, unbreak

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
@@ -2,18 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-no-title-bar";
-  version = "9";
+  version = "2020-05-14";
 
   src = fetchFromGitHub {
-    owner = "franglais125";
+    owner = "poehlerj";
     repo = "no-title-bar";
-    rev = "v${version}";
-    sha256 = "02zm61fg40r005fn2rvgrbsz2hbcsmp2hkhyilqbmpilw35y0nbq";
+    rev = "4115905e1d3df51072a2c6b173a471667181b31a";
+    sha256 = "0hcbbfapk76lr8yajacx59cyzs2c1dnccf8fq3gv3zk1z8jfqb1h";
   };
 
-  nativeBuildInputs = [
-    glib gettext
-  ];
+  nativeBuildInputs = [ glib gettext ];
 
   patches = [
     (substituteAll {
@@ -25,14 +23,13 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "INSTALLBASE=$(out)/share/gnome-shell/extensions" ];
 
-  uuid = "no-title-bar@franglais125.gmail.com";
+  uuid = "no-title-bar@jonaspoehler.de";
 
   meta = with stdenv.lib; {
     description = "Integrates maximized windows with the top panel";
-    homepage = "https://github.com/franglais125/no-title-bar";
+    homepage = "https://github.com/poehlerj/no-title-bar";
     license = licenses.gpl2;
-    broken = true; # https://github.com/franglais125/no-title-bar/issues/114
-    maintainers = with maintainers; [ jonafato svsdep ];
+    maintainers = with maintainers; [ jonafato svsdep maxeaubrey ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-no-title-bar";
-  version = "2020-05-14";
+  version = "11";
 
   src = fetchFromGitHub {
     owner = "poehlerj";
     repo = "no-title-bar";
-    rev = "4115905e1d3df51072a2c6b173a471667181b31a";
-    sha256 = "0hcbbfapk76lr8yajacx59cyzs2c1dnccf8fq3gv3zk1z8jfqb1h";
+    rev = "V_${version}";
+    sha256 = "07ddw47binlsbyvgy4xkdjvd40zyp7nwd17r6k7w54d50vmnwhvb";
   };
 
   nativeBuildInputs = [ glib gettext ];

--- a/pkgs/desktops/gnome-3/extensions/no-title-bar/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/no-title-bar/fix-paths.patch
@@ -1,24 +1,44 @@
+diff --git a/decoration.js b/decoration.js
+index d1ff3dd..ff4193f 100644
 --- a/decoration.js
 +++ b/decoration.js
-@@ -181,7 +181,7 @@
+@@ -223,7 +223,7 @@ var Decoration = class {
+ 
+         let winId = this._guessWindowXID(win);
+ 
+-        let xprops = GLib.spawn_command_line_sync(`xprop -id ${winId}`);
++        let xprops = GLib.spawn_command_line_sync(`@xprop@ -id ${winId}`);
+         if (!xprops[0]) {
+             Utils.log_debug(`Unable to determine windows '${win.get_title()}' original state`);
+             return win._noTitleBarOriginalState = WindowState.UNKNOWN;
+@@ -237,7 +237,7 @@ var Decoration = class {
+         let prop = '_MOTIF_WM_HINTS';
+         let value = '0x2, 0x0, %s, 0x0, 0x0'.format(hide ? '0x2' : '0x1');
+ 
+-        GLib.spawn_command_line_sync(`xprop -id ${windId} -f ${prop} 32c -set ${prop} "${value}"`);
++        GLib.spawn_command_line_sync(`@xprop@ -id ${windId} -f ${prop} 32c -set ${prop} "${value}"`);
+         if (!hide && !win.titlebar_is_onscreen()) {
+             Utils.log_debug(`Shoving titlebar onscreen for window '${win.get_title()}'`);
+             win.shove_titlebar_onscreen();
+@@ -354,7 +354,7 @@ var Decoration = class {
          let act = win.get_compositor_private();
          let xwindow = act && act['x-window'];
          if (xwindow) {
 -            let xwininfo = GLib.spawn_command_line_sync('xwininfo -children -id 0x%x'.format(xwindow));
 +            let xwininfo = GLib.spawn_command_line_sync('@xwininfo@ -children -id 0x%x'.format(xwindow));
              if (xwininfo[0]) {
-                 let str = xwininfo[1].toString();
+                 let str = ByteArray.toString(xwininfo[1]);
  
-@@ -207,7 +207,7 @@
+@@ -384,7 +384,7 @@ var Decoration = class {
          // Try enumerating all available windows and match the title. Note that this
          // may be necessary if the title contains special characters and `x-window`
          // is not available.
 -        let result = GLib.spawn_command_line_sync('xprop -root _NET_CLIENT_LIST');
 +        let result = GLib.spawn_command_line_sync('@xprop@ -root _NET_CLIENT_LIST');
          if (result[0]) {
-             let str = result[1].toString();
+             let str = ByteArray.toString(result[1]);
  
-@@ -218,7 +218,7 @@
+@@ -395,7 +395,7 @@ var Decoration = class {
  
              // For each window ID, check if the title matches the desired title.
              for (var i = 0; i < windowList.length; ++i) {
@@ -27,30 +47,10 @@
                  let result = GLib.spawn_command_line_sync(cmd);
  
                  if (result[0]) {
-@@ -258,7 +258,7 @@
-         }
- 
-         let id = this._guessWindowXID(win);
--        let cmd = 'xprop -id ' + id;
-+        let cmd = '@xprop@ -id ' + id;
- 
-         let xprops = GLib.spawn_command_line_sync(cmd);
-         if (!xprops[0]) {
-@@ -277,7 +277,7 @@
-         m = str.match(/^_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED(\(CARDINAL\))? = ([0-9]+)$/m);
-         if (m) {
-             let state = !!parseInt(m[2]);
--            cmd = ['xprop', '-id', id,
-+            cmd = ['@xprop@', '-id', id,
-                   '-f', '_NO_TITLE_BAR_ORIGINAL_STATE', '32c',
-                   '-set', '_NO_TITLE_BAR_ORIGINAL_STATE',
-                   (state ? '0x1' : '0x0')];
-@@ -358,7 +358,7 @@
-         let winXID = this._guessWindowXID(win);
-         if (winXID == null)
-             return;
--        let cmd = ['xprop', '-id', winXID,
-+        let cmd = ['@xprop@', '-id', winXID,
-                    '-f', '_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED', '32c',
-                    '-set', '_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED',
-                    (hide ? '0x1' : '0x0')];
+@@ -455,4 +455,4 @@ var Decoration = class {
+         let styleContent = this._updateUserStyles();
+         GLib.file_set_contents(this._userStylesPath, styleContent);
+     }
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Second attempt at #88679, since upstream tagged a release. I've been running this on my system for a while, it all works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
