### PR TITLE
autoPatchelfHook: fix bug introduced by #101142

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 declare -a autoPatchelfLibs
 declare -Ag autoPatchelfFailedDeps
 
@@ -11,6 +13,8 @@ runPatchelf() {
   patchelf "$@" || (echo "Command failed: patchelf $*" && exit 1)
 }
 
+# shellcheck disable=SC2154
+# (targetOffset is referenced but not assigned.)
 addEnvHooks "$targetOffset" gatherLibraries
 
 isExecutable() {
@@ -116,6 +120,8 @@ autoPatchelfFile() {
     interpreter="$(< "$NIX_CC/nix-support/dynamic-linker")"
     if isExecutable "$toPatch"; then
         runPatchelf --set-interpreter "$interpreter" "$toPatch"
+        # shellcheck disable=SC2154
+        # (runtimeDependencies is referenced but not assigned.)
         if [ -n "$runtimeDependencies" ]; then
             for dep in $runtimeDependencies; do
                 rpath="$rpath${rpath:+:}$dep/lib"
@@ -129,10 +135,11 @@ autoPatchelfFile() {
     # clear the RPATH first.
     runPatchelf --remove-rpath "$toPatch"
 
-    local missing="$(
+    local missing
+    missing="$(
         ldd "$toPatch" 2> /dev/null | \
             sed -n -e 's/^[\t ]*\([^ ]\+\) => not found.*/\1/p'
-    )"
+    )" || return 0
 
     # This ensures that we get the output of all missing dependencies instead
     # of failing at the first one, because it's more useful when working on a
@@ -174,10 +181,10 @@ addAutoPatchelfSearchPath() {
         esac
     done
 
-    for file in \
-      $(find "$@" "${findOpts[@]}" \! -type d \
-          \( -name '*.so' -o -name '*.so.*' \))
-    do addToDepCache "$file"; done
+    while IFS= read -r -d '' file; do
+    addToDepCache "$file"
+    done <  <(find "$@" "${findOpts[@]}" \! -type d \
+            \( -name '*.so' -o -name '*.so.*' \) -print0)
 }
 
 autoPatchelf() {
@@ -230,6 +237,8 @@ autoPatchelf() {
       echo "autoPatchelfHook could not satisfy dependency $failedDep wanted by ${autoPatchelfFailedDeps[$failedDep]}"
       depsMissing=1
     done
+    # shellcheck disable=SC2154
+    # (autoPatchelfIgnoreMissingDeps is referenced but not assigned.)
     if [[ $depsMissing == 1 && -z "$autoPatchelfIgnoreMissingDeps" ]]; then
       echo "Add the missing dependencies to the build inputs or set autoPatchelfIgnoreMissingDeps=true"
       exit 1

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -135,6 +135,8 @@ autoPatchelfFile() {
     # clear the RPATH first.
     runPatchelf --remove-rpath "$toPatch"
 
+    # If the file is not a dynamic executable, ldd/sed will fail,
+    # in which case we return, since there is nothing left to do.
     local missing
     missing="$(
         ldd "$toPatch" 2> /dev/null | \

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -129,8 +129,7 @@ autoPatchelfFile() {
     # clear the RPATH first.
     runPatchelf --remove-rpath "$toPatch"
 
-    local missing
-    missing="$(
+    local missing="$(
         ldd "$toPatch" 2> /dev/null | \
             sed -n -e 's/^[\t ]*\([^ ]\+\) => not found.*/\1/p'
     )"


### PR DESCRIPTION
Fixes breakage intrduced by #101142

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
