### PR TITLE
python3Packages.python-utils: remove unmaintained pytestpep8 dependency

### DIFF
--- a/pkgs/development/python-modules/python-utils/default.nix
+++ b/pkgs/development/python-modules/python-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, pytestrunner, pytestcov, pytest-flakes, pytestpep8, sphinx, six }:
+{ lib, buildPythonPackage, fetchPypi, pytest, pytestCheckHook, pytestrunner, pytestcov, pytest-flakes, sphinx, six }:
 
 buildPythonPackage rec {
   pname = "python-utils";
@@ -12,13 +12,10 @@ buildPythonPackage rec {
   postPatch = ''
     rm -r tests/__pycache__
     rm tests/*.pyc
+    substituteInPlace pytest.ini --replace "--pep8" ""
   '';
 
-  checkInputs = [ pytest pytestrunner pytestcov pytest-flakes pytestpep8 sphinx ];
-
-  checkPhase = ''
-    py.test tests
-  '';
+  checkInputs = [ pytestCheckHook pytest pytestrunner pytestcov pytest-flakes sphinx ];
 
   propagatedBuildInputs = [ six ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`cura` didn't build.

The `pytestpep8` package is unmaintained and broken with the latest pytest version (AFAICT).  Other packages are probably broken as well because they depend on `pytestpep8`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
