### PR TITLE
qusb2snes: init at 0.7.19.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3733,6 +3733,16 @@
       fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293";
     }];
   };
+  islandusurper = {
+    email = "ashagua@gmail.com";
+    name = "Lyle Mantooth";
+    github = "IslandUsurper";
+    githubId = 17701;
+    keys = [{
+      longkeyid = "rsa3072/0x6DB52EAE123A5789";
+      fingerprint = "CA84 771F 492B C486 E07D  255C 6DB5 2EAE 123A 5789";
+    }];
+  };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";

--- a/pkgs/applications/networking/qusb2snes/default.nix
+++ b/pkgs/applications/networking/qusb2snes/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub, mkDerivation, git, qmake, qtbase, qtserialport, qtwebsockets }:
+
+mkDerivation rec {
+  pname = "QUsb2snes";
+  version = "0.7.19.1";
+
+  src = fetchFromGitHub {
+    owner = "Skarsnik";
+    repo = "QUsb2snes";
+    rev = "v${version}";
+    sha256 = "1fj09sj072j3055dfjfbhzil0hqz2bv3mwv09477iz17bvifhf3k";
+  };
+
+  buildInputs = [ git qtbase qtserialport qtwebsockets ];
+  nativeBuildInputs = [ qmake ];
+
+  qmakeFlags = [ "${src}/QUsb2snes.pro" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./QUsb2Snes $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A Qt based webserver for usb2snes";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.islandusurper ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6763,6 +6763,8 @@ in
 
   quota = if stdenv.isLinux then linuxquota else unixtools.quota;
 
+  qusb2snes = libsForQt5.callPackage ../applications/networking/qusb2snes { };
+
   qvge = libsForQt5.callPackage ../applications/graphics/qvge { };
 
   qview = libsForQt5.callPackage ../applications/graphics/qview {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable auto-tracking, netplay, etc for SNES emulators.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
