### PR TITLE
linux: build dtbs in parallel

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -56,7 +56,6 @@ let
   # Dependencies that are required to build kernel modules
   moduleBuildDependencies = optional (lib.versionAtLeast version "4.14") libelf;
 
-  buildDTBs = stdenv.platform.kernelDTB or false;
 
   installkernel = writeTextFile { name = "installkernel"; executable=true; text = ''
     #!${stdenv.shell} -e
@@ -89,6 +88,11 @@ let
       } // config_;
 
       isModular = config.isYes "MODULES";
+
+      # If the kernel config option for building DTBs is set, that
+      # takes priority. Otherwise, check if DTBs are usually enabled
+      # on the platform we're building for.
+      buildDTBs = if config.isSet "DTB" then config.isYes "DTB" else stdenv.hostPlatform.linux-kernel.DTB or false;
 
       installsFirmware = (config.isEnabled "FW_LOADER") &&
         (isModular || (config.isDisabled "FIRMWARE_IN_KERNEL")) &&

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -89,10 +89,7 @@ let
 
       isModular = config.isYes "MODULES";
 
-      # If the kernel config option for building DTBs is set, that
-      # takes priority. Otherwise, check if DTBs are usually enabled
-      # on the platform we're building for.
-      buildDTBs = if config.isSet "DTB" then config.isYes "DTB" else stdenv.hostPlatform.linux-kernel.DTB or false;
+      buildDTBs = kernelConf.DTB or false;
 
       installsFirmware = (config.isEnabled "FW_LOADER") &&
         (isModular || (config.isDisabled "FIRMWARE_IN_KERNEL")) &&


### PR DESCRIPTION
###### Motivation for this change
Slightly faster builds, especially on aarch64 machines with lots of cores.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
