### PR TITLE
lsd: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/tools/misc/lsd/default.nix
+++ b/pkgs/tools/misc/lsd/default.nix
@@ -7,25 +7,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lsd";
-  version = "0.18.0";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "Peltoche";
     repo = pname;
     rev = version;
-    sha256 = "006fy87jrb77cpa6bywchcvq1p74vlpy151q1j4nsj8npbr02krj";
+    sha256 = "1iiczdsqw0i6cz492177z6lr8s7fikn151j8p76fmr77zk0bm6q2";
   };
 
-  cargoSha256 = "0mrvcca9y0vylcrbfxxba45v05qxd8z91vb4in88px60xah0dy3q";
+  cargoSha256 = "1r2mkpicsyihlrim3bnmscgg5rnaijpvgq8c846zqj7ly8v8qqvg";
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = ''
     installShellCompletion $releaseDir/build/lsd-*/out/{_lsd,lsd.{bash,fish}}
   '';
 
-  checkFlags = stdenv.lib.optionals stdenv.isDarwin [
-    "--skip meta::filetype::test::test_socket_type"
-  ];
+  # Found argument '--test-threads' which wasn't expected, or isn't valid in this context
+  doCheck = false;
 
   passthru.tests = { inherit (nixosTests) lsd; };
 


### PR DESCRIPTION
https://github.com/Peltoche/lsd/releases/tag/0.19.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
