### PR TITLE
mlarchive2maildir: 0.0.8 -> 0.0.9

### DIFF
--- a/pkgs/applications/networking/mailreaders/mlarchive2maildir/default.nix
+++ b/pkgs/applications/networking/mailreaders/mlarchive2maildir/default.nix
@@ -2,11 +2,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "mlarchive2maildir";
-  version = "0.0.8";
+  version = "0.0.9";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "1din3yay2sas85178v0xr0hbm2396y4dalkcqql1ny9vdm94h6sp";
+    sha256 = "02zjwa7zbcbqj76l0qmg7bbf3fqli60pl2apby3j4zwzcrrryczs";
   };
 
   nativeBuildInputs = with python3.pkgs; [ setuptools_scm ];


### PR DESCRIPTION
###### Motivation for this change

New release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
