### PR TITLE
nixos/acme: Fixes for account creation and remove tmpfiles usage

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -441,6 +441,15 @@
    </listitem>
    <listitem>
     <para>
+     In the ACME module, the data used to build the hash for the account
+     directory has changed to accomodate new features to reduce account
+     rate limit issues. This will trigger new account creation on the first
+     rebuild following this update. No issues are expected to arise from this,
+     thanks to the new account creation handling.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      <xref linkend="opt-users.users._name_.createHome" /> now always ensures home directory permissions to be <literal>0700</literal>.
      Permissions had previously been ignored for already existing home directories, possibly leaving them readable by others.
      The option's description was incorrect regarding ownership management and has been simplified greatly.

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -24,7 +24,7 @@ let
       Type = "oneshot";
       User = "acme";
       Group = mkDefault "acme";
-      UMask = 0027;
+      UMask = 0023;
       StateDirectoryMode = 750;
       ProtectSystem = "full";
       PrivateTmp = true;

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -272,13 +272,12 @@ let
 
       # Working directory will be /tmp
       script = ''
-        set -euo pipefail
+        set -euxo pipefail
 
         ${optionalString (data.webroot != null) ''
           # Ensure the webroot exists
           mkdir -p '${data.webroot}/.well-known/acme-challenge'
-          chown 'acme:${data.group}' ${data.webroot}/{.well-known,.well-known/acme-challenge} \
-          || echo "Please fix the permissions under ${data.webroot}/.well-known/acme-challenge" && exit 1
+          chown 'acme:${data.group}' ${data.webroot}/{.well-known,.well-known/acme-challenge}
         ''}
 
         echo '${domainHash}' > domainhash.txt

--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -162,6 +162,9 @@ services.httpd = {
 <xref linkend="opt-security.acme.certs"/>."foo.example.com" = {
   <link linkend="opt-security.acme.certs._name_.webroot">webroot</link> = "/var/lib/acme/.challenges";
   <link linkend="opt-security.acme.certs._name_.email">email</link> = "foo@example.com";
+  # Ensure that the web server you use can read the generated certs
+  # Take a look at the <link linkend="opt-services.nginx.group">group</link> option for the web server you choose.
+  <link linkend="opt-security.acme.certs._name_.group">group</link> = "nginx";
   # Since we have a wildcard vhost to handle port 80,
   # we can generate certs for anything!
   # Just make sure your DNS resolves them.
@@ -257,10 +260,11 @@ chmod 400 /var/lib/secrets/certs.secret
   <para>
    Should you need to regenerate a particular certificate in a hurry, such
    as when a vulnerability is found in Let's Encrypt, there is now a convenient
-   mechanism for doing so. Running <literal>systemctl clean acme-example.com.service</literal>
-   will remove all certificate files for the given domain, allowing you to then
-   <literal>systemctl start acme-example.com.service</literal> to generate fresh
-   ones.
+   mechanism for doing so. Running
+   <literal>systemctl clean --what=state acme-example.com.service</literal>
+   will remove all certificate files and the account data for the given domain,
+   allowing you to then <literal>systemctl start acme-example.com.service</literal>
+   to generate fresh ones.
   </para>
  </section>
  <section xml:id="module-security-acme-fix-jws">

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -77,6 +77,27 @@ in import ./make-test-python.nix ({ lib, ... }: {
         after = [ "acme-a.example.test.service" "nginx-config-reload.service" ];
       };
 
+      # Test that account creation is collated into one service
+      specialisation.account-creation.configuration = { nodes, pkgs, lib, ... }: let
+        email = "newhostmaster@example.test";
+        caDomain = nodes.acme.config.test-support.acme.caDomain;
+        # Exit 99 to make it easier to track if this is the reason a renew failed
+        testScript = ''
+          test -e accounts/${caDomain}/${email}/account.json || exit 99
+        '';
+      in {
+        security.acme.email = lib.mkForce email;
+        systemd.services."b.example.test".serviceConfig.preStart = testScript;
+        systemd.services."c.example.test".serviceConfig.preStart = testScript;
+
+        services.nginx.virtualHosts."b.example.test" = (vhostBase pkgs) // {
+          enableACME = true;
+        };
+        services.nginx.virtualHosts."c.example.test" = (vhostBase pkgs) // {
+          enableACME = true;
+        };
+      };
+
       # Cert config changes will not cause the nginx configuration to change.
       # This tests that the reload service is correctly triggered.
       # It also tests that postRun is exec'd as root
@@ -289,7 +310,7 @@ in import ./make-test-python.nix ({ lib, ... }: {
       acme.start()
       webserver.start()
 
-      acme.wait_for_unit("default.target")
+      acme.wait_for_unit("network-online.target")
       acme.wait_for_unit("pebble.service")
 
       client.succeed("curl https://${caDomain}:15000/roots/0 > /tmp/ca.crt")
@@ -313,6 +334,15 @@ in import ./make-test-python.nix ({ lib, ... }: {
           webserver.succeed("systemctl start test-renew-nginx.target")
           check_issuer(webserver, "a.example.test", "pebble")
           check_connection(client, "a.example.test")
+
+      with subtest("Runs 1 cert for account creation before others"):
+          switch_to(webserver, "account-creation")
+          webserver.wait_for_unit("acme-finished-a.example.test.target")
+          check_connection(client, "a.example.test")
+          webserver.wait_for_unit("acme-finished-b.example.test.target")
+          webserver.wait_for_unit("acme-finished-c.example.test.target")
+          check_connection(client, "b.example.test")
+          check_connection(client, "c.example.test")
 
       with subtest("Can reload web server when cert configuration changes"):
           switch_to(webserver, "cert-change")

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -87,8 +87,8 @@ in import ./make-test-python.nix ({ lib, ... }: {
         '';
       in {
         security.acme.email = lib.mkForce email;
-        systemd.services."b.example.test".serviceConfig.preStart = testScript;
-        systemd.services."c.example.test".serviceConfig.preStart = testScript;
+        systemd.services."b.example.test".preStart = testScript;
+        systemd.services."c.example.test".preStart = testScript;
 
         services.nginx.virtualHosts."b.example.test" = (vhostBase pkgs) // {
           enableACME = true;


### PR DESCRIPTION
###### Motivation for this change

Closes #106565
Possibly closes some other ACME tickets related to JWS token errors too. A new systemd target named `acme-account-$hash.target` has been added, which is depended on (requiredBy + after) by all but 1 cert service associated with the same account. The one remainder is depended on (requires + before) to do the account creation.
Note that I changed the hash data for the account directory which will trigger new account creation on all systems. Given that rate limit issues should now be resolved, this will simply test that I did a good enough job of it ;)

Closes #106603
Umask is changed to 0023 to accommodate for lighttpd

Closes #103121
Remove systemd-tmpfiles dependency follows from [this discussion](https://github.com/NixOS/nixpkgs/pull/97702#issuecomment-733963047) and ~may solve~ has been reported to solve #103121. I was tempted to totally remove the use of tmpfiles but I couldn't find a good home for the webroot directory creation. Ideally, it should already be created by the user but since most users don't set a webroot at all and expect it to "just work" through httpd/nginx I left it in.

Docs update are primarily to cover follow-up in #81634 and fix the `systemctl clean` command.

In the test suite, I added a wait for "network-online.target" on the pebble server due to a one time test failure I had because the host wasn't reachable. I hope this resolves it, but it's hard to test.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
