### PR TITLE
simdjson: init at 0.7.0

### DIFF
--- a/pkgs/development/libraries/simdjson/default.nix
+++ b/pkgs/development/libraries/simdjson/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "simdjson";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "simdjson";
+    repo = "simdjson";
+    rev = "v${version}";
+    sha256 = "14gi2zq430nfjy424q6r57imc2gnz30nhx4r0wbajzp9qvna819w";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DSIMDJSON_JUST_LIBRARY=ON"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://simdjson.org/";
+    description = "Parsing gigabytes of JSON per second";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ chessai ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2577,6 +2577,8 @@ in
 
   shell-hist = callPackage ../tools/misc/shell-hist { };
 
+  simdjson = callPackage ../development/libraries/simdjson { };
+
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
   simplenes = callPackage ../misc/emulators/simplenes { };


### PR DESCRIPTION
###### Motivation for this change
initialise simdjson library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
