### PR TITLE
[20.09] pythonPackages.tldextract: add missing dependency

### DIFF
--- a/pkgs/development/python-modules/tldextract/default.nix
+++ b/pkgs/development/python-modules/tldextract/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchPypi, buildPythonPackage, setuptools_scm
-, requests, requests-file, idna, pytest
+, requests, requests-file, idna, filelock, pytest
 , responses
 }:
 
@@ -12,14 +12,17 @@ buildPythonPackage rec {
     sha256 = "ab0e38977a129c72729476d5f8c85a8e1f8e49e9202e1db8dca76e95da7be9a8";
   };
 
-  propagatedBuildInputs = [ requests requests-file idna ];
+  propagatedBuildInputs = [ requests requests-file idna filelock ];
   checkInputs = [ pytest responses ];
   nativeBuildInputs = [ setuptools_scm ];
 
+  # No tests included
+  doCheck = false;
+  pythonImportsCheck = [ "tldextract" ];
+
   meta = {
     homepage = "https://github.com/john-kurkowski/tldextract";
-    description = "Accurately separate the TLD from the registered domain and subdomains of a URL, using the Public Suffix List.";
+    description = "Accurately separate the TLD from the registered domain and subdomains of a URL, using the Public Suffix List";
     license = lib.licenses.bsd3;
   };
-
 }


### PR DESCRIPTION
(cherry picked from commit b7cf39083799736b505ccc1a9a4fa0bddde1eb84)
Original PR: https://github.com/NixOS/nixpkgs/pull/106420
Fixes the following issue: https://github.com/NixOS/nixpkgs/issues/106388

Package doesn't build without this.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
