### PR TITLE
pythonPackages.clize: fix build

### DIFF
--- a/pkgs/development/python-modules/clize/default.nix
+++ b/pkgs/development/python-modules/clize/default.nix
@@ -10,7 +10,7 @@
 , repeated_test
 , pygments
 , unittest2
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -22,12 +22,17 @@ buildPythonPackage rec {
     sha256 = "f54dedcf6fea90a3e75c30cb65e0ab1e832760121f393b8d68edd711dbaf7187";
   };
 
+  # Remove overly restrictive version constraints
+  postPatch = ''
+    substituteInPlace setup.py --replace "attrs>=19.1.0,<20" "attrs"
+  '';
+
   checkInputs = [
+    pytestCheckHook
     dateutil
     pygments
     repeated_test
     unittest2
-    pytest
   ];
 
   propagatedBuildInputs = [
@@ -38,14 +43,11 @@ buildPythonPackage rec {
     six
   ];
 
-  checkPhase = ''
-    pytest
-  '';
+  pythonImportsCheck = [ "clize" ];
 
   meta = with stdenv.lib; {
     description = "Command-line argument parsing for Python";
     homepage = "https://github.com/epsy/clize";
     license = licenses.mit;
   };
-
 }


### PR DESCRIPTION

###### Motivation for this change
Saw this [failing on hydra](https://hydra.nixos.org/build/132405393/nixlog/1) because of an overly restrictive version constraint.

This should be backported as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
