### PR TITLE
PHP: Added SSH2 and msgpack extensions.

### DIFF
--- a/pkgs/development/php-packages/msgpack/default.nix
+++ b/pkgs/development/php-packages/msgpack/default.nix
@@ -1,0 +1,10 @@
+{ buildPecl, lib }:
+
+buildPecl {
+  pname = "msgpack";
+
+  version = "2.1.2";
+  sha256 = "10my5a0547x15jfc6r9a84afd7604fpgb7an0k5sfgij7z9z8bwi";
+
+  meta.maintainers = lib.teams.php.members;
+}

--- a/pkgs/development/php-packages/ssh2/default.nix
+++ b/pkgs/development/php-packages/ssh2/default.nix
@@ -1,0 +1,13 @@
+{ buildPecl, lib, pkgs }:
+
+buildPecl {
+  pname = "ssh2";
+
+  version = "1.2";
+  sha256 = "0afrxi69jzapvhafrwk2c0bn0672065bdzqhn3vr4mjmbdgj17vz";
+
+  buildInputs = [ pkgs.libssh2 ];
+  configureFlags = [ "--with-ssh2=${pkgs.libssh2.dev}" ];
+
+  meta.maintainers = lib.teams.php.members;
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -133,6 +133,8 @@ in
 
     sqlsrv = callPackage ../development/php-packages/sqlsrv { };
 
+    ssh2 = callPackage ../development/php-packages/ssh2 { };
+
     v8 = buildPecl {
       version = "0.2.2";
       pname = "v8";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -83,6 +83,8 @@ in
 
     mongodb = callPackage ../development/php-packages/mongodb { };
 
+    msgpack = callPackage ../development/php-packages/msgpack { };
+
     oci8 = callPackage ../development/php-packages/oci8 { };
 
     pcov = callPackage ../development/php-packages/pcov { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
