### PR TITLE
mosh: Hermeticize mosh-client path reference from mosh.pl

### DIFF
--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./ssh_path.patch
+    ./mosh-client_path.patch
     ./utempter_path.patch
     # Fix w/c++17, ::bind vs std::bind
     (fetchpatch {
@@ -32,6 +33,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace scripts/mosh.pl \
         --subst-var-by ssh "${openssh}/bin/ssh"
+    substituteInPlace scripts/mosh.pl \
+        --subst-var-by mosh-client "$out/bin/mosh-client"
   '';
 
   configureFlags = [ "--enable-completion" ] ++ lib.optional withUtempter "--with-utempter";

--- a/pkgs/tools/networking/mosh/mosh-client_path.patch
+++ b/pkgs/tools/networking/mosh/mosh-client_path.patch
@@ -1,0 +1,22 @@
+diff --git a/scripts/mosh.pl b/scripts/mosh.pl
+index 56e96d7..2a2177e 100755
+--- a/scripts/mosh.pl
++++ b/scripts/mosh.pl
+@@ -61,7 +61,7 @@ my $have_ipv6 = eval {
+ 
+ $|=1;
+ 
+-my $client = 'mosh-client';
++my $client = '@mosh-client@';
+ my $server = 'mosh-server';
+ 
+ my $predict = undef;
+@@ -91,7 +91,7 @@ my @cmdline = @ARGV;
+ my $usage =
+ qq{Usage: $0 [options] [--] [user@]host [command...]
+         --client=PATH        mosh client on local machine
+-                                (default: "mosh-client")
++                                (default: "@mosh-client@")
+         --server=COMMAND     mosh server on remote machine
+                                 (default: "mosh-server")
+ 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes #97061: the mosh perl wrapper only works when the mosh package's whole bin/ directory is on $PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
