### PR TITLE
gopass: fix impurity which breaks gopass after 'nix-store --gc'

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -46,10 +46,12 @@ buildGoModule rec {
     ln -s $out/bin/gopass $out/bin/pass
   '';
 
+  # --run to work around WONTFIX in https://github.com/gopasspw/gopass/issues/1662
   postFixup = ''
     for bin in $out/bin/*; do
       wrapProgram $bin \
-        --prefix PATH : "${wrapperPath}"
+        --prefix PATH : "${wrapperPath}" \
+        --run 'rm -f "''${XDG_CONFIG_HOME:-~/.config}/gopass/gpg-binary.loc"'
     done
   '';
 


### PR DESCRIPTION
gopass maintains a ~/.cache/gopass/gpg-binary.loc file
which stores an absolute path to the gpg executable,
overriding (and ignoring) the environment $PATH.

This creates a situation where gopass will work for a period of time
after install, but after gpg is upgraded and a 'nix-store --gc' is
performed, the cached gpg path will throw an error.

A gopass maintainer has declared this a wont-fix in
https://github.com/gopasspw/gopass/issues/1662

As a workaround, add a --run clause in the wrapper script
that removes this cache file.

Once (if) upstream fixes this issue, this cruft can be removed.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Broken gopass after `nix-store --gc`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
