### PR TITLE
android-file-transfer: 4.0 -> 4.1

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "android-file-transfer";
-  version = "4.0";
+  version = "4.1";
 
   src = fetchFromGitHub {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
     rev = "v${version}";
-    sha256 = "11d4n4ybmc25gz18nlps3v11m3y8dw5bcb817gkik5m4nvqnbcsf";
+    sha256 = "0xmnwxr649wdzsa1vf3spl387hxs4pq0rldyrsr9hz43da4v081k";
   };
 
   nativeBuildInputs = [ cmake readline pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

New release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
