### PR TITLE
[staging] rust: cleanup, use correct llvm version

### DIFF
--- a/pkgs/development/compilers/rust/1_45.nix
+++ b/pkgs/development/compilers/rust/1_45.nix
@@ -11,14 +11,23 @@
 , buildPackages
 , newScope, callPackage
 , CoreFoundation, Security
-, llvmPackages
-, pkgsBuildTarget, pkgsBuildBuild
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
+, llvmPackages_5, llvm_10
 } @ args:
 
 import ./default.nix {
   rustcVersion = "1.45.2";
   rustcSha256 = "0273a1g3f59plyi1n0azf21qjzwml1yqdnj5z472crz37qggr8xp";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvm_10.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvm_10.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvm_10.override { enableSharedLibraries = true; };
+
+  llvmBootstrapForDarwin = llvmPackages_5;
+
+  # For use at runtime
+  llvmShared = llvm_10.override { enableSharedLibraries = true; };
 
   # Note: the version MUST be one version prior to the version we're
   # building
@@ -41,4 +50,4 @@ import ./default.nix {
   ];
 }
 
-(builtins.removeAttrs args [ "fetchpatch" ])
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_5" "llvm_10" ])

--- a/pkgs/development/compilers/rust/1_48.nix
+++ b/pkgs/development/compilers/rust/1_48.nix
@@ -13,14 +13,23 @@
 , buildPackages
 , newScope, callPackage
 , CoreFoundation, Security
-, llvmPackages
-, pkgsBuildTarget, pkgsBuildBuild
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
 , makeRustPlatform
+, llvmPackages_5, llvm_11
 } @ args:
 
 import ./default.nix {
   rustcVersion = "1.48.0";
   rustcSha256 = "0fz4gbb5hp5qalrl9lcl8yw4kk7ai7wx511jb28nypbxninkwxhf";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvm_11.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvm_11.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvm_11.override { enableSharedLibraries = true; };
+
+  llvmBootstrapForDarwin = llvmPackages_5;
+
+  # For use at runtime
+  llvmShared = llvm_11.override { enableSharedLibraries = true; };
 
   # Note: the version MUST be one version prior to the version we're
   # building
@@ -43,4 +52,4 @@ import ./default.nix {
   ];
 }
 
-(builtins.removeAttrs args [ "fetchpatch" ])
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_5" "llvm_11"])

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -5,12 +5,16 @@
 , bootstrapHashes
 , selectRustPackage
 , rustcPatches ? []
+, llvmBootstrapForDarwin
+, llvmShared
+, llvmSharedForBuild
+, llvmSharedForHost
+, llvmSharedForTarget
 }:
 { stdenv, lib
 , buildPackages
 , newScope, callPackage
 , CoreFoundation, Security
-, llvmPackages
 , pkgsBuildTarget, pkgsBuildBuild
 , makeRustPlatform
 }: rec {
@@ -76,16 +80,17 @@
         version = rustcVersion;
         sha256 = rustcSha256;
         inherit enableRustcDev;
+        inherit llvmShared llvmSharedForBuild llvmSharedForHost llvmSharedForTarget;
 
         patches = rustcPatches;
 
         # Use boot package set to break cycle
         rustPlatform = bootRustPlatform;
       } // lib.optionalAttrs (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) {
-        stdenv = llvmPackages.stdenv;
-        pkgsBuildBuild = pkgsBuildBuild // { targetPackages.stdenv = llvmPackages.stdenv; };
-        pkgsBuildHost = pkgsBuildBuild // { targetPackages.stdenv = llvmPackages.stdenv; };
-        pkgsBuildTarget = pkgsBuildTarget // { targetPackages.stdenv = llvmPackages.stdenv; };
+        stdenv = llvmBootstrapForDarwin.stdenv;
+        pkgsBuildBuild = pkgsBuildBuild // { targetPackages.stdenv = llvmBootstrapForDarwin.stdenv; };
+        pkgsBuildHost = pkgsBuildBuild // { targetPackages.stdenv = llvmBootstrapForDarwin.stdenv; };
+        pkgsBuildTarget = pkgsBuildTarget // { targetPackages.stdenv = llvmBootstrapForDarwin.stdenv; };
       });
       rustfmt = self.callPackage ./rustfmt.nix { inherit Security; };
       cargo = self.callPackage ./cargo.nix {

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,6 +1,7 @@
 { stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
+, llvmShared, llvmSharedForBuild, llvmSharedForHost, llvmSharedForTarget
 , fetchurl, file, python3
-, llvm_10, darwin, cmake, rust, rustPlatform
+, darwin, cmake, rust, rustPlatform
 , pkgconfig, openssl
 , which, libffi
 , withBundledLLVM ? false
@@ -13,13 +14,6 @@
 let
   inherit (stdenv.lib) optionals optional optionalString concatStringsSep;
   inherit (darwin.apple_sdk.frameworks) Security;
-
-  llvmSharedForBuild = pkgsBuildBuild.llvm_10.override { enableSharedLibraries = true; };
-  llvmSharedForHost = pkgsBuildHost.llvm_10.override { enableSharedLibraries = true; };
-  llvmSharedForTarget = pkgsBuildTarget.llvm_10.override { enableSharedLibraries = true; };
-
-  # For use at runtime
-  llvmShared = llvm_10.override { enableSharedLibraries = true; };
 in stdenv.mkDerivation rec {
   pname = "rustc";
   inherit version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10030,11 +10030,9 @@ in
   # So this commit doesn't remove the 1.45.2 release.
   rust_1_45 = callPackage ../development/compilers/rust/1_45.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
-    llvmPackages = if stdenv.cc.isClang then llvmPackages_5 else llvmPackages_10;
   };
   rust_1_48 = callPackage ../development/compilers/rust/1_48.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
-    llvmPackages = if stdenv.cc.isClang then llvmPackages_5 else llvmPackages_11;
   };
   rust = rust_1_48;
 


### PR DESCRIPTION
###### Motivation for this change

I've noticed rustc 1.48 uses LLVM 10 while version 11 is set in all-packages:
```
$ rustc -vV
rustc 1.48.0
binary: rustc
commit-hash: unknown
commit-date: unknown
host: x86_64-unknown-linux-gnu
release: 1.48.0
LLVM version: 10.0
```
This change properly propagates correct runtime LLVM version. ~I've also removed bootstrap override
for clang based stdenv, which should be unnecessary, I didn't test it.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
