### PR TITLE
phpExtensions.imagick: upgrade to ImageMagick 7

### DIFF
--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -12,9 +12,14 @@ buildPecl {
       url = "https://github.com/Imagick/imagick/pull/336.patch";
       sha256 = "nuRdh02qaMx0s/5OzlfWjyYgZG1zgrYnAjsZ/UVIrUM=";
     })
+    # Fix detection of ImageMagick 7.
+    (fetchpatch {
+      url = "https://github.com/Imagick/imagick/commit/09551fbf38c16cdaf4ade7c08744501cd82d2747.patch";
+      sha256 = "qUeQHP08kKOzuQdEpR8RSZ18Yhi0U9z24KwQcAx1UVg=";
+    })
   ];
 
-  configureFlags = [ "--with-imagick=${pkgs.imagemagick.dev}" ];
+  configureFlags = [ "--with-imagick=${pkgs.imagemagick7.dev}" ];
   nativeBuildInputs = [ pkgs.pkgconfig ];
   buildInputs = [ pcre' ];
 


### PR DESCRIPTION
###### Motivation for this change

We use the imagick extension for conversion of PDFs to images, among other things. ImageMagick 6 invokes Ghostscript with `-sDEVICE=pamcmyk32`, which results in a lot of breakage, specifically large portions of text missing in the output. This appears to have been fixed in ImageMagick 7.

**Note**: I'm unclear about the impact of simply upgrading ImageMagick here. I assume the imagick API stays the same, but there are obviously behavioural changes going on here. How do we deal with this?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
