### PR TITLE
ssh-ident: change PATH

### DIFF
--- a/pkgs/tools/networking/ssh-ident/default.nix
+++ b/pkgs/tools/networking/ssh-ident/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, python3, makeWrapper, openssh }:
+{ stdenvNoCC, lib, fetchFromGitHub, python3, openssh}:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "ssh-ident";
   version = "2016-04-21";
   src = fetchFromGitHub  {
@@ -10,19 +10,22 @@ stdenv.mkDerivation {
     sha256 = "1jf19lz1gwn7cyp57j8d4zs5bq13iw3kw31m8nvr8h6sib2pf815";
   };
 
-  buildInputs = [ python3 makeWrapper ];
+  postPatch = ''
+    substituteInPlace ssh-ident \
+      --replace 'ssh-agent >' '${openssh}/bin/ssh-agent >'
+  '';
+  buildInputs = [ python3 ];
+
   installPhase = ''
     mkdir -p $out/bin
     install -m 755 ssh-ident $out/bin/ssh-ident
-    wrapProgram $out/bin/ssh-ident \
-      --prefix PATH : ${lib.makeBinPath [ openssh  ]}
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/ccontavalli/ssh-ident";
     description = "Start and use ssh-agent and load identities as necessary";
-    license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ telotortium ];
-    platforms = with lib.platforms; unix;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ telotortium ];
+    platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The wrapper is not working anymore, so the ssh-agent is no more shared,
as the script removes the environment PATH variable, I pinned the
ssh-agent binary and removed the wrapper.

Also, as this script doesn't require a compiler, I switched from stdenv
to stdenvNoCC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
