### PR TITLE
docopts: init at 0.6.3-rc2

### DIFF
--- a/pkgs/development/tools/misc/docopts/default.nix
+++ b/pkgs/development/tools/misc/docopts/default.nix
@@ -15,9 +15,10 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
+  subPackages = [ "./" ];
+
   postInstall = ''
     install -D -m 755 ./go/src/$goPackagePath/docopts.sh $out/bin/docopts.sh
-    rm $out/bin/json_t
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/docopts/default.nix
+++ b/pkgs/development/tools/misc/docopts/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "docopts";
+  version = "0.6.3-rc2";
+
+  src = fetchFromGitHub {
+    owner = "docopt";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-PmsTkPT/sf70MKYLhHvjCDb2o3VQ1k7d++RUW7rcoAg=";
+  };
+
+  goPackagePath = "github.com/docopt/${pname}";
+
+  goDeps = ./deps.nix;
+
+  postInstall = ''
+    install -D -m 755 ./go/src/$goPackagePath/docopts.sh $out/bin/docopts.sh
+    rm $out/bin/json_t
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/docopt/${pname}";
+    description = "docopt CLI tool for shell scripting";
+    license = licenses.mit;
+    maintainers = [ maintainers.confus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/docopts/deps.nix
+++ b/pkgs/development/tools/misc/docopts/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/docopt/docopt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docopt/docopt.go";
+      rev = "ee0de3bc6815ee19d4a46c7eb90f829db0e014b1"; # "0.6.2";
+      sha256 = "sha256-0mCKIC5x7aauBL8ahXB9ExMfoTJl55HaafWWWPNRmUI=";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12725,6 +12725,8 @@ in
 
   docopt_cpp = callPackage ../development/libraries/docopt_cpp { };
 
+  docopts = callPackage ../development/tools/misc/docopts { };
+
   dotconf = callPackage ../development/libraries/dotconf { };
 
   draco = callPackage ../development/libraries/draco { };


### PR DESCRIPTION
###### Motivation for this change
[Docopts](https://github.com/docopt/docopts), mind the trailing "s", is the shell scripting tool for the well known [docopt python](https://github.com/docopt/docopt) library. Written in go.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
