### PR TITLE
python3Packages.pre-commit-hooks: init at 3.3.0

### DIFF
--- a/pkgs/development/python-modules/pre-commit-hooks/default.nix
+++ b/pkgs/development/python-modules/pre-commit-hooks/default.nix
@@ -1,0 +1,43 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, fetchPypi
+, git
+, isPy27
+, lib
+, pytestCheckHook
+, ruamel_yaml
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "pre-commit-hooks";
+  version = "3.3.0";
+  disabled = isPy27;
+
+  # fetchPypi does not provide tests
+  src = fetchFromGitHub {
+    owner = "pre-commit";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1sppwcqsbr9gv2cpjslngcbggsxvdr84zgrin94yjr40jgkjzdpq";
+  };
+
+  propagatedBuildInputs = [ toml ruamel_yaml ];
+  checkInputs = [ git pytestCheckHook ];
+
+  # the tests require a functional git installation which requires a valid HOME
+  # directory.
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+
+    git config --global user.name "Nix Builder"
+    git config --global user.email "nix-builder@nixos.org"
+  '';
+
+  meta = with lib; {
+    description = "Some out-of-the-box hooks for pre-commit";
+    homepage = "https://github.com/pre-commit/pre-commit-hooks";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4789,6 +4789,8 @@ in {
 
   pre-commit = callPackage ../development/python-modules/pre-commit { };
 
+  pre-commit-hooks = callPackage ../development/python-modules/pre-commit-hooks { };
+
   preggy = callPackage ../development/python-modules/preggy { };
 
   premailer = callPackage ../development/python-modules/premailer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In order to use the pre-commit-hooks with http://github.com/cachix/pre-commit-hooks.nix, we need to be able to define an entry point that is accessible locally. This pull requests adds the pre-commit-hooks repository as its own Python module so we can access it and run its hooks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
