### PR TITLE
tests.cc-wrapper: disable static compilation macOS

### DIFF
--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -30,14 +30,17 @@ in stdenv.mkDerivation {
       ./core-foundation-check
     ''}
 
-    printf "checking whether compiler builds valid static C binaries... " >&2
-    $CC ${staticLibc} -static -o cc-static ${./cc-main.c}
-    ./cc-static
-    # our glibc does not have pie enabled yet.
-    ${optionalString (stdenv.hostPlatform.isMusl && stdenv.cc.isGNU) ''
-      printf "checking whether compiler builds valid static pie C binaries... " >&2
-      $CC ${staticLibc} -static-pie -o cc-static-pie ${./cc-main.c}
-      ./cc-static-pie
+
+    ${optionalString (!stdenv.isDarwin) ''
+      printf "checking whether compiler builds valid static C binaries... " >&2
+      $CC ${staticLibc} -static -o cc-static ${./cc-main.c}
+      ./cc-static
+      # our glibc does not have pie enabled yet.
+      ${optionalString (stdenv.hostPlatform.isMusl && stdenv.cc.isGNU) ''
+        printf "checking whether compiler builds valid static pie C binaries... " >&2
+        $CC ${staticLibc} -static-pie -o cc-static-pie ${./cc-main.c}
+        ./cc-static-pie
+      ''}
     ''}
 
     printf "checking whether compiler uses NIX_CFLAGS_COMPILE... " >&2


### PR DESCRIPTION
macOS does not support this

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Follow up to: https://github.com/NixOS/nixpkgs/pull/106908#discussion_r542491625

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
