### PR TITLE
python3Packages.py3status: add file as runtime dependancy

### DIFF
--- a/pkgs/development/python-modules/py3status/default.nix
+++ b/pkgs/development/python-modules/py3status/default.nix
@@ -33,9 +33,8 @@ buildPythonPackage rec {
 
   doCheck = false;
   propagatedBuildInputs = [
-    pytz requests tzlocal i3ipc pydbus pygobject3 pyserial setuptools dbus-python
+    pytz requests tzlocal i3ipc pydbus pygobject3 pyserial setuptools dbus-python file
   ];
-  buildInputs = [ file ];
   prePatch = ''
     sed -i -e "s|'file|'${file}/bin/file|" py3status/parse_config.py
     sed -i -e "s|\[\"acpi\"|\[\"${acpi}/bin/acpi\"|" py3status/modules/battery_level.py


### PR DESCRIPTION
###### Motivation for this change

This helps to resolve issues:
- https://github.com/ultrabug/py3status/issues/1945
- https://github.com/ultrabug/py3status/issues/1961

If I install the `py3status` package without also installing `file` I get errors trying to execute `py3status -c my/config/path`. I updated this file locally and ran `nix-build -A python3Packages.py3status` and then tested the `py3status` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
