### PR TITLE
sonobuoy: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
 # SHA of ${version} for the tool's help output
-let rev = "e03f9ee353717ccc5f58c902633553e34b2fe46a";
+let rev = "f6e19140201d6bf2f1274bf6567087bc25154210";
 in
 buildGoModule rec {
   pname = "sonobuoy";
-  version = "0.19.0";
+  version = "0.20.0";
 
   goPackagePath = "github.com/vmware-tanzu/sonobuoy";
 
@@ -19,7 +19,7 @@ buildGoModule rec {
     '';
 
   src = fetchFromGitHub {
-    sha256 = "1gw58a30akidk15wk8kk7f8lsyqr1q180j6fzr4462ahwxdbjgkr";
+    sha256 = "11qawsv82i1pl4mwfc85wb4fbq961bplvmygnjfm79m8z87863ri";
     rev = "v${version}";
     repo = "sonobuoy";
     owner = "vmware-tanzu";

--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
-# SHA of ${version} for the tool's help output
+# SHA of ${version} for the tool's help output. Unfortunately this is needed in build flags.
 let rev = "f6e19140201d6bf2f1274bf6567087bc25154210";
 in
 buildGoModule rec {
   pname = "sonobuoy";
-  version = "0.20.0";
+  version = "0.20.0"; # Do not forget to update `rev` above
 
   goPackagePath = "github.com/vmware-tanzu/sonobuoy";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update Sonobuoy from 0.19.0 -> 0.20.0 for Kubernetes 1.20

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
