### PR TITLE
r8125: 9.003.05 -> 9.004.01

### DIFF
--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -4,16 +4,16 @@ stdenv.mkDerivation rec {
   pname = "r8125";
   # On update please verify (using `diff -r`) that the source matches the
   # realtek version.
-  version = "9.003.05";
+  version = "9.004.01";
 
   # This is a mirror. The original website[1] doesn't allow non-interactive
   # downloads, instead emailing you a download link.
   # [1] https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software
   src = fetchFromGitHub {
-    owner = "ibmibmibm";
+    owner = "louistakepillz";
     repo = "r8125";
     rev = version;
-    sha256 = "016vh997xjs01si0zzs572vgflq3czxd0v4m7h1m3qxcv2cvq7i0";
+    sha256 = "0h2y4mzydhc7var5281bk2jj1knig6i64k11ii4b94az3g9dbq24";
   };
 
   hardeningDisable = [ "pic" ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   buildFlags = [ "modules" ];
 
   meta = with lib; {
-    homepage = "https://github.com/ibmibmibm/r8125";
+    homepage = "https://github.com/louistakepillz/r8125";
     downloadPage = "https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software";
     description = "Realtek r8125 driver";
     longDescription = ''

--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     longDescription = ''
       A kernel module for Realtek 8125 2.5G network cards.
     '';
+    # r8125 has been integrated into the kernel as of v5.9.1
+    broken = lib.versionAtLeast kernel.version "5.9.1";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ peelz ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Initially, I made a github mirror for r8125 when I submitted the original r8125 PR.
Turns out there was another mirror that was made for the AUR, so I used that instead (to avoid duplication of effort).
As of recently (2020-11-02), [r8125 no longer exists on the AUR](https://repology.org/project/r8125/history) (~~not sure why either~~ see edit).
[I tried contacting the maintainer of the AUR repo but to no avail.](https://github.com/ibmibmibm/r8125/issues/2)

In this patch, I changed the derivation to use my original repo instead.

Edit: [apparently the r8125 AUR package was deleted because it's now included in Linux >=5.9.1](https://lists.archlinux.org/pipermail/aur-requests/2020-October/045793.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
