### PR TITLE
[staging] stdenv: trim random seed to avoid reference cycles

### DIFF
--- a/pkgs/build-support/setup-hooks/reproducible-builds.sh
+++ b/pkgs/build-support/setup-hooks/reproducible-builds.sh
@@ -1,4 +1,9 @@
 # Use the last part of the out path as hash input for the build.
 # This should ensure that it is deterministic across rebuilds of the same
 # derivation and not easily collide with other builds.
-export NIX_CFLAGS_COMPILE+=" -frandom-seed=${out##*/}"
+# We also truncate the hash so that it cannot cause reference cycles.
+export NIX_CFLAGS_COMPILE+=" -frandom-seed=$(
+    outbase="${out##*/}"
+    randomseed="${outbase:0:10}"
+    echo $randomseed
+)"


### PR DESCRIPTION
Using the full store hash as the random seed occasionally caused
reference cycles when the compiler invocation was stored in output artifacts.
For example, cross-compiled gcc was failing due to this:
https://hydra.nixos.org/eval/1631713#tabs-now-fail

Simply truncating the hash is sufficient to avoid this.

cc @symphorien: https://github.com/NixOS/nixpkgs/pull/102251#issuecomment-744221628

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
