### PR TITLE
platformio: don't use multiPkgs in chrootenv

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -1,7 +1,9 @@
 { lib, buildFHSUserEnv, version, src }:
 
-let
-  pio-pkgs = pkgs:
+buildFHSUserEnv {
+  name = "platformio";
+
+  targetPkgs = pkgs:
     let
       python = pkgs.python3.override {
         packageOverrides = self: super: {
@@ -18,12 +20,6 @@ let
       bottle
       platformio
     ]);
-
-in buildFHSUserEnv {
-  name = "platformio";
-
-  targetPkgs = pio-pkgs;
-  multiPkgs = pio-pkgs;
 
   meta = with lib; {
     description = "An open source ecosystem for IoT development";


### PR DESCRIPTION
multiPkgs makes available 32-bits versions of dependencies
on 64-bits systems, but we're not aware of any toolchains
that require this.

As discussed in
https://github.com/NixOS/nixpkgs/pull/105454#issuecomment-743984034

See also https://community.platformio.org/t/any-i686-library-dependencies-for-platformio-core/17769

Co-Authored-By: makefu <github@syntax-fehler.de>


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).