### PR TITLE
nix-index: Wrap an unwrapped derivation

### DIFF
--- a/pkgs/tools/package-management/nix-index/default.nix
+++ b/pkgs/tools/package-management/nix-index/default.nix
@@ -1,5 +1,10 @@
-{ stdenv, rustPlatform, fetchFromGitHub, pkgconfig, makeWrapper, openssl, curl
-, nix, Security
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkgconfig
+, openssl
+, curl
+, Security
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -15,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0apdr9z18p6m4lfjv8k9zv2mqc7vssd2d536zfv1pns0pdqsfw50";
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl curl ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;
 
@@ -26,8 +31,6 @@ rustPlatform.buildRustPackage rec {
     cp ./command-not-found.sh $out/etc/profile.d/command-not-found.sh
     substituteInPlace $out/etc/profile.d/command-not-found.sh \
       --replace "@out@" "$out"
-    wrapProgram $out/bin/nix-index \
-      --prefix PATH : "${stdenv.lib.makeBinPath [ nix ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/package-management/nix-index/wrapper.nix
+++ b/pkgs/tools/package-management/nix-index/wrapper.nix
@@ -1,0 +1,72 @@
+{ lib
+, darwin
+, callPackage
+# For the wrapper
+, symlinkJoin
+, makeWrapper
+, nix
+}:
+
+/*
+To override the `nix` used here, use the overlay:
+
+```
+self: super: {
+  nixUnstable-index = super.nix-index.override {
+    nix = super.nixUnstable;
+  };
+}
+```
+
+If you wish to override the unwrapped derivation, use:
+
+```
+self: super: {
+  nix-index-with-unwrapped-modified = super.nix-index.wrapper
+    (super.nix-index.unwrapped.override { curl = curl.override { ... }; })
+  ;
+}
+```
+
+Or if you need overrideAttrs then use:
+
+```
+self: super: {
+  nix-index-with-unwrapped-modified = super.nix-index.wrapper
+    (super.nix-index.unwrapped.overrideAttrs(oldAttrs: { 
+      src = super.fetchFromGitHub {
+        ...
+      };
+      version = ...;
+      patches = [
+       ...
+      ];
+    }))
+  ;
+}
+```
+
+*/
+
+let
+  unwrapped = callPackage ./default.nix {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+  # A function that wraps the unwrapped derivation, and gets an optional
+  # argument "self" which exposes the function itself to others.
+  wrapper = unwrapped: {self ? null}: symlinkJoin {
+    paths = [ unwrapped ];
+    name = "${unwrapped.pname}-${unwrapped.version}";
+    inherit (unwrapped) meta;
+    buildInputs = [ makeWrapper ];
+    passthru = {
+      inherit unwrapped;
+      wrapper = self;
+    };
+
+    postBuild = ''
+      wrapProgram $out/bin/nix-index \
+        --prefix PATH : "${lib.makeBinPath [ nix ]}"
+    '';
+  };
+in wrapper unwrapped {self = wrapper;}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27979,9 +27979,7 @@ in
   nix-info = callPackage ../tools/nix/info { };
   nix-info-tested = nix-info.override { doCheck = true; };
 
-  nix-index = callPackage ../tools/package-management/nix-index {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
+  nix-index = callPackage ../tools/package-management/nix-index/wrapper.nix { };
 
   nix-linter = haskell.lib.justStaticExecutables (haskellPackages.callPackage ../development/tools/analysis/nix-linter { });
 


### PR DESCRIPTION
Essentially allow overriding the `nix` package used in the wrapping,
without rebuilding the rust package.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/106515 - cc @poscat0x04 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
