### PR TITLE
wezterm: add licenses, install extra files, and update to a revision of 20210314

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -55,11 +55,6 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     free = false;
   };
 
-  angle = {
-    fullName = "ANGLE";
-    url = "https://github.com/google/angle/blob/master/LICENSE";
-  };
-
   apsl20 = spdx {
     spdxId = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -55,6 +55,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     free = false;
   };
 
+  angle = {
+    fullName = "ANGLE";
+    url = "https://github.com/google/angle/blob/master/LICENSE";
+  };
+
   apsl20 = spdx {
     spdxId = "APSL-2.0";
     fullName = "Apple Public Source License 2.0";

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage {
     fetchSubmodules = true;
     sha256 = "0p4krjc7k31k9qdc23g26rja9xqpm94dcv1vk7a73sr2dlfj06hn";
   };
-  cargoSha256 = "0cv7bi57pwv221pp7fw9k80wcias8wl024sxi0znkj6wrvrsyarx";
+  cargoSha256 = "0r6bgxx5qcbxy1qc3igvjp33in60ll45rsnbh2lc643a3pfkgrr6";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -69,8 +69,16 @@ rustPlatform.buildRustPackage {
   installPhase = ''
     for artifact in wezterm wezterm-gui wezterm-mux-server strip-ansi-escapes; do
       patchelf --set-rpath "${lib.makeLibraryPath runtimeDeps}" $releaseDir/$artifact
-      install -D $releaseDir/$artifact -t $out/bin
+      install -Dsm755 $releaseDir/$artifact $out/bin/$artifact
     done
+
+    install -Dm644 assets/shell-integration/* -t $out/etc/profile.d
+    install -Dm644 assets/icon/terminal.png $out/usr/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
+    install -Dm644 assets/wezterm.desktop $out/usr/share/applications/org.wezfurlong.wezterm.desktop
+    install -Dm644 assets/wezterm.appdata.xml $out/usr/share/metainfo/org.wezfurlong.wezterm.appdata.xml
+    )
+
+    runHook postInstall
   '';
 
   # prevent further changes to the RPATH
@@ -79,7 +87,7 @@ rustPlatform.buildRustPackage {
   meta = with lib; {
     description = "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
     homepage = "https://wezfurlong.org/wezterm";
-    license = licenses.mit;
+    license = with licenses; [ angle mit ofl ];
     maintainers = with maintainers; [ steveej ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -42,6 +42,8 @@ let
     freetype
   ];
   pname = "wezterm";
+  version = "2020-12-15";
+  rev = "7e49377313cd2f9bc7e406ed6ad3216d883875f3";
 in
 
 rustPlatform.buildRustPackage {
@@ -51,11 +53,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "wez";
     repo = pname;
-    rev = "3bd8d8c84591f4d015ff9a47ddb478e55c231fda";
-    sha256 = "13xf3685kir4p159hsxrqkj9p2lwgfp0n13h9zadslrd44l8b8j8";
+    inherit rev;
     fetchSubmodules = true;
+    sha256 = "0p4krjc7k31k9qdc23g26rja9xqpm94dcv1vk7a73sr2dlfj06hn";
   };
-  cargoSha256 = "1ghjpyd3f5dqi6bblr6d2lihdschpyj5djfd1600hvb41x75lmhx";
+  cargoSha256 = "0cv7bi57pwv221pp7fw9k80wcias8wl024sxi0znkj6wrvrsyarx";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -88,7 +88,7 @@ rustPlatform.buildRustPackage {
   meta = with lib; {
     description = "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
     homepage = "https://wezfurlong.org/wezterm";
-    license = with licenses; [ angle mit ofl ];
+    license = with licenses; [ bsd3 mit ofl ];
     maintainers = with maintainers; [ steveej ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -78,7 +78,6 @@ rustPlatform.buildRustPackage {
     install -Dm644 assets/icon/terminal.png $out/usr/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
     install -Dm644 assets/wezterm.desktop $out/usr/share/applications/org.wezfurlong.wezterm.desktop
     install -Dm644 assets/wezterm.appdata.xml $out/usr/share/metainfo/org.wezfurlong.wezterm.appdata.xml
-    )
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change
* Missing licenses
* New version

Follows up on https://github.com/NixOS/nixpkgs/pull/104704 

/cc @teto 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
