### PR TITLE
[20.09] gdb: Fix crash when exiting TUI with gdb -tui

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -40,6 +40,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./debug-info-from-env.patch
+
+    # backport of a350efd4fb368a35ada608f6bc26ccd3bed0ae6b from upstream
+    # to fix https://github.com/NixOS/nixpkgs/issues/106868
+    ./fix_crash_when_exiting_TUI_with_gdb_-tui.patch
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     ./darwin-target-match.patch
   ];

--- a/pkgs/development/tools/misc/gdb/fix_crash_when_exiting_TUI_with_gdb_-tui.patch
+++ b/pkgs/development/tools/misc/gdb/fix_crash_when_exiting_TUI_with_gdb_-tui.patch
@@ -1,0 +1,71 @@
+diff -ur gdb-9.2.orig/gdb/tui/tui.c gdb-9.2/gdb/tui/tui.c
+--- gdb-9.2.orig/gdb/tui/tui.c	2020-12-15 21:17:41.571078984 +0000
++++ gdb-9.2/gdb/tui/tui.c	2020-12-15 21:27:54.953799136 +0000
+@@ -324,8 +324,14 @@
+ /* Initialize readline and configure the keymap for the switching
+    key shortcut.  */
+ void
+-tui_initialize_readline (void)
++tui_ensure_readline_initialized (void)
+ {
++  static bool initialized;
++
++  if (initialized)
++    return;
++  initialized = true;
++
+   int i;
+   Keymap tui_ctlx_keymap;
+ 
+@@ -381,6 +387,9 @@
+   rl_bind_key_in_map ('q', tui_rl_next_keymap, tui_keymap);
+   rl_bind_key_in_map ('s', tui_rl_next_keymap, emacs_ctlx_keymap);
+   rl_bind_key_in_map ('s', tui_rl_next_keymap, tui_ctlx_keymap);
++
++  /* Initialize readline after the above.  */
++  rl_initialize ();
+ }
+ 
+ /* Return the TERM variable from the environment, or "<unset>"
+diff -ur gdb-9.2.orig/gdb/tui/tui.h gdb-9.2/gdb/tui/tui.h
+--- gdb-9.2.orig/gdb/tui/tui.h	2020-12-15 21:17:41.571078984 +0000
++++ gdb-9.2/gdb/tui/tui.h	2020-12-15 21:22:03.354662356 +0000
+@@ -52,9 +52,9 @@
+ extern int tui_get_command_dimension (unsigned int *width,
+ 				      unsigned int *height);
+ 
+-/* Initialize readline and configure the keymap for the switching
+-   key shortcut.  */
+-extern void tui_initialize_readline (void);
++/* Initialize readline and configure the keymap for the switching key
++   shortcut.  May be called more than once without issue.  */
++extern void tui_ensure_readline_initialized (void);
+ 
+ /* Enter in the tui mode (curses).  */
+ extern void tui_enable (void);
+diff -ur gdb-9.2.orig/gdb/tui/tui-interp.c gdb-9.2/gdb/tui/tui-interp.c
+--- gdb-9.2.orig/gdb/tui/tui-interp.c	2020-12-15 21:17:41.571078984 +0000
++++ gdb-9.2/gdb/tui/tui-interp.c	2020-12-15 21:18:49.771490624 +0000
+@@ -244,7 +244,7 @@
+   tui_initialize_io ();
+   tui_initialize_win ();
+   if (ui_file_isatty (gdb_stdout))
+-    tui_initialize_readline ();
++    tui_ensure_readline_initialized ();
+ }
+ 
+ void
+diff -ur gdb-9.2.orig/gdb/tui/tui-io.c gdb-9.2/gdb/tui/tui-io.c
+--- gdb-9.2.orig/gdb/tui/tui-io.c	2020-12-15 21:17:41.571078984 +0000
++++ gdb-9.2/gdb/tui/tui-io.c	2020-12-15 21:19:34.994763950 +0000
+@@ -769,6 +769,10 @@
+ 
+   if (mode)
+     {
++      /* Ensure that readline has been initialized before saving any
++         of its variables.  */
++      tui_ensure_readline_initialized ();
++
+       /* Redirect readline to TUI.  */
+       tui_old_rl_redisplay_function = rl_redisplay_function;
+       tui_old_rl_deprep_terminal = rl_deprep_term_function;


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #106868

This bug have been already been fixup in upstream and the fix version is already available in `master`. This commit backports the fix to `gdb-9.2` which is the supported version in `release-20.09`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jamii