### PR TITLE
auto-cpufreq: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8725,6 +8725,12 @@
     githubId = 2389333;
     name = "Andy Tockman";
   };
+  Technical27 = {
+    email = "38222826+Technical27@users.noreply.github.com";
+    github = "Technical27";
+    githubId = 38222826;
+    name = "Aamaruvi Yogamani";
+  };
   teh = {
     email = "tehunger@gmail.com";
     github = "teh";

--- a/pkgs/tools/system/autocpu-freq/default.nix
+++ b/pkgs/tools/system/autocpu-freq/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "auto-cpufreq";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "AdnanHodzic";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "uVhftO6AqFnZ0uaEYRAPvVskkouNOXPtNVYXx7WJKyw=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ click distro psutil ];
+
+  doCheck = false;
+  pythonImportsCheck = [ "source" ];
+
+  # patch to prevent script copying and to disable install
+  patches = [ ./prevent-install-and-copy.patch ];
+
+  postInstall = ''
+    # copy script manually
+    cp ${src}/scripts/cpufreqctl.sh $out/bin/cpufreqctl
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/AdnanHodzic/auto-cpufreq";
+    description = "Automatic CPU speed & power optimizer for Linux";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.Technical27 ];
+  };
+}

--- a/pkgs/tools/system/autocpu-freq/prevent-install-and-copy.patch
+++ b/pkgs/tools/system/autocpu-freq/prevent-install-and-copy.patch
@@ -1,0 +1,178 @@
+diff --git a/scripts/cpufreqctl.sh b/scripts/cpufreqctl.sh
+index 63a2b5b..e157efe 100755
+--- a/scripts/cpufreqctl.sh
++++ b/scripts/cpufreqctl.sh
+@@ -467,35 +467,21 @@ fi
+ 
+ if [ $OPTION = "--install" ]
+ then
+-  echo 'installing helpers...'
+-  cp $0 /usr/bin/
+-  echo 'installing policy...'
+-  cp $(dirname "$(readlink -f "$0")")/konkor.cpufreq.policy /usr/share/polkit-1/actions/
+-  echo 'installing fonts...'
+-  mkdir -p /usr/share/fonts/truetype/cpufreq
+-  cp $(dirname "$(readlink -f "$0")")/fonts/cpufreq.ttf /usr/share/fonts/truetype/cpufreq/
+-  echo "done"
++  echo "install is disabled in the nix package"
+   exit
+ fi
+ if [ $OPTION = "--update-fonts" ]
+ then
+-  fc-cache -f
++  echo "update-fonts is disabled in the nix package"
+   exit
+ fi
+ if [ $OPTION = "--uninstall" ]
+ then
+-  echo 'uninstalling cpufreqctl helper...'
+-  rm /usr/bin/cpufreqctl
+-  echo 'uninstalling policy...'
+-  rm /usr/share/polkit-1/actions/konkor.cpufreq.policy
+-  echo 'uninstalling fonts...'
+-  rm -rf /usr/share/fonts/truetype/cpufreq
+-  echo "done"
++  echo "uninstall is disabled in the nix package"
+   exit
+ fi
+ if [ $OPTION = "--reset" ]
+ then
+-  echo 'reset to default values...'
+-  dconf reset -f "/org/gnome/shell/extensions/cpufreq/"
++  echo "reset is disabled in the nix package"
+   exit
+ fi
+diff --git a/source/core.py b/source/core.py
+index 531c0c4..2e27e65 100644
+--- a/source/core.py
++++ b/source/core.py
+@@ -24,8 +24,6 @@ warnings.filterwarnings("ignore")
+ # - re-enable CPU fan speed display and make more generic and not only for thinkpad
+ # - replace get system/CPU load from: psutil.getloadavg() | available in 5.6.2)
+ 
+-SCRIPTS_DIR = Path("/usr/local/share/auto-cpufreq/scripts/")
+-
+ # from the highest performance to the lowest
+ ALL_GOVERNORS = ("performance", "ondemand", "conservative", "schedutil", "userspace", "powersave")
+ CPUS = os.cpu_count()
+@@ -156,34 +154,16 @@ def cpufreqctl():
+     """
+     deploy cpufreqctl script
+     """
+-
+-    # detect if running on a SNAP
+-    if os.getenv('PKG_MARKER') == "SNAP":
+-        pass
+-    else:
+-        # deploy cpufreqctl script (if missing)
+-        if os.path.isfile("/usr/bin/cpufreqctl"):
+-            shutil.copy("/usr/bin/cpufreqctl", "/usr/bin/cpufreqctl.auto-cpufreq.bak")
+-            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl")
+-        else:
+-            shutil.copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/bin/cpufreqctl")
++    # scripts are already in the correct place
++    pass
+ 
+ 
+ def cpufreqctl_restore():
+     """
+     restore original cpufreqctl script
+     """
+-    # detect if running on a SNAP
+-    if os.getenv('PKG_MARKER') == "SNAP":
+-        pass
+-    else:
+-        # restore original cpufreqctl script
+-        if os.path.isfile("/usr/bin/cpufreqctl.auto-cpufreq.bak"):
+-            os.system("cp /usr/bin/cpufreqctl.auto-cpufreq.bak /usr/bin/cpufreqctl")
+-            os.remove("/usr/bin/cpufreqctl.auto-cpufreq.bak")
+-        # ToDo: implement mechanism to make sure cpufreqctl (auto-cpufreq) file is
+-        # restored if overwritten by system. But during tool removal to also remove it
+-        # in def cpufreqctl
++    # no need to restore
++    pass
+ 
+ 
+ def footer(l=79):
+@@ -209,71 +189,13 @@ def remove_complete_msg():
+ 
+ 
+ def deploy_daemon():
+-    print("\n" + "-" * 21 + " Deploying auto-cpufreq as a daemon " + "-" * 22 + "\n")
+-
+-    # deploy cpufreqctl script func call
+-    cpufreqctl()
+-
+-    print("* Turn off bluetooth on boot")
+-    btconf = Path("/etc/bluetooth/main.conf")
+-    try:
+-        orig_set = "AutoEnable=true"
+-        change_set = "AutoEnable=false"
+-        with btconf.open(mode="r+") as f:
+-            content = f.read()
+-            f.seek(0)
+-            f.truncate()
+-            f.write(content.replace(orig_set, change_set))
+-    except:
+-        print("\nERROR:\nWas unable to turn off bluetooth on boot")
+-
+-    auto_cpufreq_log_file.touch(exist_ok=True)
+-
+-    print("\n* Deploy auto-cpufreq install script")
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/bin/auto-cpufreq-install")
+-
+-    print("\n* Deploy auto-cpufreq remove script")
+-    shutil.copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/bin/auto-cpufreq-remove")
+-
+-    call("/usr/bin/auto-cpufreq-install", shell=True)
++    # prevent needless copying and system changes
++    pass
+ 
+ 
+ # remove auto-cpufreq daemon
+ def remove():
+-
+-    # check if auto-cpufreq is installed
+-    if not os.path.exists("/usr/bin/auto-cpufreq-remove"):
+-        print("\nauto-cpufreq daemon is not installed.\n")
+-        sys.exit(1)
+-        
+-    print("\n" + "-" * 21 + " Removing auto-cpufreq daemon " + "-" * 22 + "\n")
+-
+-    print("* Turn on bluetooth on boot")
+-    btconf = "/etc/bluetooth/main.conf"
+-    try:
+-        orig_set = "AutoEnable=true"
+-        change_set = "AutoEnable=false"
+-        with open(btconf, "r+") as f:
+-            content = f.read()
+-            f.seek(0)
+-            f.truncate()
+-            f.write(content.replace(change_set, orig_set))
+-    except:
+-        print("\nERROR:\nWas unable to turn on bluetooth on boot")
+-
+-    # run auto-cpufreq daemon install script
+-    call("/usr/bin/auto-cpufreq-remove", shell=True)
+-
+-    # remove auto-cpufreq-remove
+-    os.remove("/usr/bin/auto-cpufreq-remove")
+-
+-    # delete log file
+-    if auto_cpufreq_log_file.exists():
+-        auto_cpufreq_log_file.unlink()
+-
+-    # restore original cpufrectl script
+-    cpufreqctl_restore()
+-
++    pass
+ 
+ def gov_check():
+     for gov in get_avail_gov():
+@@ -798,4 +720,4 @@ def running_daemon():
+         exit(1)
+     elif os.getenv("PKG_MARKER") == "SNAP" and dcheck == "enabled":
+         deploy_complete_msg()
+-        exit(1)
+\ No newline at end of file
++        exit(1)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28374,6 +28374,8 @@ in
 
   ssh-audit = callPackage ../tools/security/ssh-audit { };
 
+  autocpu-freq = callPackage ../tools/system/autocpu-freq {  };
+
   thermald = callPackage ../tools/system/thermald { };
 
   throttled = callPackage ../tools/system/throttled { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I wanted to use auto-cpufreq and so do others AdnanHodzic/auto-cpufreq#130

###### Things done
Create the auto-cpufreq package and add myself to maintainers
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

There really needs to be a NixOS module, but I will work on it after this gets merged.
Here is a temporary solution to get the systemd service:
```nix
environment.systemPackages = [ pkgs.auto-cpufreq ];

systemd.services.auto-cpufreq = {
    description = "auto-cpufreq - Automatic CPU speed & power optimizer for Linux";
    after = [ "network.target" "network-online.target" ];
    unitConfig.ConditionPathExists = "/var/log/auto-cpufreq.log";
    path = with pkgs; [ ncurses bash ];
    serviceConfig = {
      Type = "simple";
      User = "root";
      ExecStart = "${pkgs.auto-cpufreq}/bin/auto-cpufreq --daemon";
      StandardOutput = "append:/var/log/auto-cpufreq.log";
    };
    wantedBy = [ "multi-user.target" ];
  };
};
``` 