### PR TITLE
nixos/tor: don't do privoxy stuff by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -265,6 +265,19 @@
       located in <literal>/run/rspamd</literal> instead of <literal>/run</literal>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      Enabling the Tor client no longer silently also enables and
+      configures Privoxy, and the
+      <varname>services.tor.client.privoxy.enable</varname> option has
+      been removed.  To enable Privoxy, and to configure it to use
+      Tor's faster port, use the following configuration:
+    </para>
+    <programlisting>
+      <xref linkend="opt-services.privoxy.enable" /> = true;
+      <xref linkend="opt-services.privoxy.enableTor" /> = true;
+    </programlisting>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/networking/privoxy.nix
+++ b/nixos/modules/services/networking/privoxy.nix
@@ -8,15 +8,22 @@ let
 
   cfg = config.services.privoxy;
 
-  confFile = pkgs.writeText "privoxy.conf" ''
+  confFile = pkgs.writeText "privoxy.conf" (''
     user-manual ${privoxy}/share/doc/privoxy/user-manual
     confdir ${privoxy}/etc/
     listen-address  ${cfg.listenAddress}
     enable-edit-actions ${if (cfg.enableEditActions == true) then "1" else "0"}
     ${concatMapStrings (f: "actionsfile ${f}\n") cfg.actionsFiles}
     ${concatMapStrings (f: "filterfile ${f}\n") cfg.filterFiles}
+  '' + optionalString cfg.enableTor ''
+    forward-socks4a / ${config.services.tor.client.socksListenAddressFaster} .
+    toggle 1
+    enable-remote-toggle 0
+    enable-edit-actions 0
+    enable-remote-http-toggle 0
+  '' + ''
     ${cfg.extraConfig}
-  '';
+  '');
 
 in
 
@@ -69,6 +76,15 @@ in
         default = false;
         description = ''
           Whether or not the web-based actions file editor may be used.
+        '';
+      };
+
+      enableTor = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to configure Privoxy to use Tor's faster SOCKS port,
+          suitable for HTTP.
         '';
       };
 

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -107,6 +107,9 @@ let
 in
 {
   imports = [
+    (mkRemovedOptionModule [ "services" "tor" "client" "privoxy" "enable" ] ''
+      Use services.privoxy.enable and services.privoxy.enableTor instead.
+    '')
     (mkRenamedOptionModule [ "services" "tor" "relay" "portSpec" ] [ "services" "tor" "relay" "port" ])
     (mkRemovedOptionModule [ "services" "tor" "relay" "isBridge" ] "Use services.tor.relay.role instead.")
     (mkRemovedOptionModule [ "services" "tor" "relay" "isExit" ] "Use services.tor.relay.role instead.")
@@ -269,23 +272,6 @@ in
             example = [".onion"];
             description = "List of suffixes to use with automapHostsOnResolve";
           };
-        };
-
-        privoxy.enable = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Whether to enable and configure the system Privoxy to use Tor's
-            faster port, suitable for HTTP.
-
-            To have anonymity, protocols need to be scrubbed of identifying
-            information, and this can be accomplished for HTTP by Privoxy.
-
-            Privoxy can also be useful for KDE torification. A good setup would be:
-            setting SOCKS proxy to the default Tor port, providing maximum
-            circuit isolation where possible; and setting HTTP proxy to Privoxy
-            to route HTTP traffic over faster, but less isolated port.
-          '';
         };
       };
 
@@ -784,16 +770,5 @@ in
       };
 
     environment.systemPackages = [ cfg.package ];
-
-    services.privoxy = mkIf (cfg.client.enable && cfg.client.privoxy.enable) {
-      enable = true;
-      extraConfig = ''
-        forward-socks4a / ${cfg.client.socksListenAddressFaster} .
-        toggle  1
-        enable-remote-toggle 0
-        enable-edit-actions 0
-        enable-remote-http-toggle 0
-      '';
-    };
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It's very surprising that services.tor.client.enable would set
services.privoxy.enable.  This violates the principle of least
astonishment, because it's Privoxy that can integrate with Tor, rather
than the other way around.

So this patch moves the Privoxy Tor integration to the Privoxy module,
and it also disables it by default.  This change is documented in the
release notes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
