### PR TITLE
notcurses: init at 2.1.0

### DIFF
--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, cmake, pkgconfig, pandoc, libunistring, ncurses, ffmpeg,
+  fetchFromGitHub, lib,
+  multimediaSupport ? true
+}:
+let
+  version = "2.1.0";
+in
+stdenv.mkDerivation {
+  pname = "notcurses";
+  inherit version;
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ cmake pkgconfig pandoc ];
+
+  buildInputs = [ libunistring ncurses ]
+    ++ lib.optional multimediaSupport ffmpeg;
+
+  cmakeFlags =
+    [ "-DUSE_QRCODEGEN=OFF" ]
+    ++ lib.optional (!multimediaSupport) "-DUSE_MULTIMEDIA=none";
+
+  src = fetchFromGitHub {
+    owner  = "dankamongmen";
+    repo   = "notcurses";
+    rev    = "v${version}";
+    sha256 = "0jvngg40c1sqf85kqy6ya0vflpxsj7j4g6cw609992rifaghxiny";
+  };
+
+  meta = {
+    description = "blingful TUIs and character graphics";
+
+    longDescription = ''
+      A library facilitating complex TUIs on modern terminal emulators,
+      supporting vivid colors, multimedia, and Unicode to the maximum degree
+      possible. Things can be done with Notcurses that simply can't be done
+      with NCURSES.
+
+      It is not a source-compatible X/Open Curses implementation, nor a
+      replacement for NCURSES on existing systems.
+    '';
+
+    homepage = "https://github.com/dankamongmen/notcurses";
+
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jb55 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15085,6 +15085,8 @@ in
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };
 
+  notcurses = callPackage ../development/libraries/notcurses { };
+
   ncurses5 = ncurses.override {
     abiVersion = "5";
   };


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit 16b7254d1d1fce8f1d4e439ac3cbd491d1dfa622
Author: William Casarin <jb55@jb55.com>
Date:   Tue Dec 15 07:01:09 2020 -0800

    notcurses: init at 2.1.0

    This is a neat ncurses alternative. See the demo here:

    https://www.youtube.com/watch?v=cYhZ7myXyyg

    Here's something interesting to package after this:

    https://github.com/dankamongmen/growlight

    Message-Id: <20201215150109.30656-1-jb55@jb55.com>
```

You can find the submission in the [archive](https://lists.sr.ht/~andir/nixpkgs-dev/%3C20201215150109.30656-1-jb55%40jb55.com%3E).