### PR TITLE
sqitch: package cleanup

### DIFF
--- a/pkgs/development/tools/misc/sqitch/default.nix
+++ b/pkgs/development/tools/misc/sqitch/default.nix
@@ -1,32 +1,46 @@
-{ name, stdenv, perl, makeWrapper, sqitchModule, databaseModule, shortenPerlShebang }:
+{ stdenv
+, lib
+, perlPackages
+, makeWrapper
+, shortenPerlShebang
+, mysqlSupport ? false
+, postgresqlSupport ? false
+}:
+
+let
+  sqitch = perlPackages.AppSqitch;
+  modules = with perlPackages; [ ]
+    ++ lib.optional mysqlSupport DBDmysql
+    ++ lib.optional postgresqlSupport DBDPg;
+in
 
 stdenv.mkDerivation {
-  name = "${name}-${sqitchModule.version}";
+  pname = "sqitch";
+  version = sqitch.version;
 
-  buildInputs = [ perl makeWrapper sqitchModule databaseModule ];
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isDarwin shortenPerlShebang;
 
-  src = sqitchModule;
+  src = sqitch;
   dontBuild = true;
-
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;
 
   installPhase = ''
     mkdir -p $out/bin
     for d in bin/sqitch etc lib share ; do
       # make sure dest alreay exists before symlink
       # this prevents installing a broken link into the path
-      if [ -e ${sqitchModule}/$d ]; then
-        ln -s ${sqitchModule}/$d $out/$d
+      if [ -e ${sqitch}/$d ]; then
+        ln -s ${sqitch}/$d $out/$d
       fi
     done
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/sqitch
   '';
   dontStrip = true;
-  postFixup = "wrapProgram $out/bin/sqitch --prefix PERL5LIB : $PERL5LIB";
+  postFixup = ''
+    wrapProgram $out/bin/sqitch --prefix PERL5LIB : ${perlPackages.makeFullPerlPath modules}
+  '';
 
   meta = {
-    platforms = stdenv.lib.platforms.unix;
-    inherit (sqitchModule.meta) license;
+    inherit (sqitch.meta) description homepage license platforms;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16803,17 +16803,13 @@ in
 
   perlcritic = perlPackages.PerlCritic;
 
-  sqitchMysql = callPackage ../development/tools/misc/sqitch {
-    name = "sqitch-mysql";
-    databaseModule = perlPackages.DBDmysql;
-    sqitchModule = perlPackages.AppSqitch;
-  };
+  sqitchMysql = (callPackage ../development/tools/misc/sqitch {
+    mysqlSupport = true;
+  }).overrideAttrs (oldAttrs: { pname = "sqitch-mysql"; });
 
-  sqitchPg = callPackage ../development/tools/misc/sqitch {
-    name = "sqitch-pg";
-    databaseModule = perlPackages.DBDPg;
-    sqitchModule = perlPackages.AppSqitch;
-  };
+  sqitchPg = (callPackage ../development/tools/misc/sqitch {
+    postgresqlSupport = true;
+  }).overrideAttrs (oldAttrs: { pname = "sqitch-pg"; });
 
   ### DEVELOPMENT / R MODULES
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package cleanup.

I'm not a user of `sqitch` so I only did minimal testing (ran a migration with `mysql`). I was specifically hoping for some `darwin` testing (@marsam ?) to make sure I didn't break anything there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

ping @datafoo for possible testing too :heart: 