### PR TITLE
nixos/users-groups: createHome: Ensure HOME permissions, fix description

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -409,6 +409,13 @@
      been dropped from upstream releases.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <xref linkend="opt-users.users._name_.createHome" /> now always ensures home directory permissions to be <literal>0700</literal>.
+     Permissions had previously been ignored for already existing home directories, possibly leaving them readable by others.
+     The option's description was incorrect regarding ownership management and has been simplified greatly.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -209,10 +209,11 @@ foreach my $u (@{$spec->{users}}) {
         }
     }
 
-    # Create a home directory.
+    # Ensure home directory incl. ownership and permissions.
     if ($u->{createHome}) {
         make_path($u->{home}, { mode => 0700 }) if ! -e $u->{home};
         chown $u->{uid}, $u->{gid}, $u->{home};
+        chmod 0700, $u->{home};
     }
 
     if (defined $u->{passwordFile}) {

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -198,10 +198,8 @@ let
         type = types.bool;
         default = false;
         description = ''
-          If true, the home directory will be created automatically. If this
-          option is true and the home directory already exists but is not
-          owned by the user, directory owner and group will be changed to
-          match the user.
+          Whether to create the home directory and ensure ownership as well as
+          permissions to match the user.
         '';
       };
 


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit 8833983f261c6afa0361465f31c4dbc39c45b386
Author: Klemens Nanni <klemens@posteo.de>
Date:   Sun Nov 22 23:42:02 2020 +0100

    nixos/users-groups: createHome: Ensure HOME permissions, fix description

    configuration.nix(1) states

        users.extraUsers.<name>.createHome
            [...] If [...] the home directory already exists but is not
            owned by the user, directory owner and group will be changed to
            match the user.

    i.e. ownership would change only if the user mismatched;  the code
    however ignores the owner, it is sufficient to enable `createHome`:

        if ($u->{createHome}) {
            make_path($u->{home}, { mode => 0700 }) if ! -e $u->{home};
            chown $u->{uid}, $u->{gid}, $u->{home};
        }

    Furthermore, permissions are ignored on already existing directories and
    therefore may allow others to read private data eventually.

    Given that createHome already acts as switch to not only create but
    effectively own the home directory, manage permissions in the same
    manner to ensure the intended default and cover all primary attributes.

    Avoid yet another configuration option to have administrators make a
    clear and simple choice between securely managing home directories
    and optionally defering management to own code (taking care of custom
    location, ownership, mode, extended attributes, etc.).

    While here, simplify and thereby fix misleading documentation.
```