### PR TITLE
wireshark: Do $PATH lookup in wireshark.desktop instead of hardcoding derivation

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -80,9 +80,6 @@ in stdenv.mkDerivation {
   '' else optionalString withQt ''
     install -Dm644 -t $out/share/applications ../wireshark.desktop
 
-    substituteInPlace $out/share/applications/*.desktop \
-        --replace "Exec=wireshark" "Exec=$out/bin/wireshark"
-
     install -Dm644 ../image/wsicon.svg $out/share/icons/wireshark.svg
     mkdir $dev/include/{epan/{wmem,ftypes,dfilter},wsutil,wiretap} -pv
 


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit 251349dac30e4de0d9d0c982ccbe4e12c3217ccb
Author: Klemens Nanni <klemens.nanni@siticom.de>
Date:   Wed Nov 18 23:30:58 2020 +0100

    wireshark: Do $PATH lookup in wireshark.desktop instead of hardcoding derivation

    See db236e588de "steam: Do $PATH lookup in steam.desktop [...]".
    tl;dr: Otherwise widget/panel/desktop icons in DEs like KDE break.

    As upstream's .desktop file does not contain any executable paths,
    simply avoid substitution.

    Message-Id: <97c3e797-d844-4d0a-9ccf-397745f83aeb@siticom.de>
```