### PR TITLE
libsurvive, monado, xrgears init

### DIFF
--- a/pkgs/applications/graphics/xrgears/default.nix
+++ b/pkgs/applications/graphics/xrgears/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitLab, meson, ninja, pkgconfig, xxd, glslang, vulkan-loader
+, vulkan-headers, openxr-loader, glm }:
+
+stdenv.mkDerivation rec {
+  pname = "xrgears";
+  version = "2020-04-15";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "monado";
+    repo = "demos/xrgears";
+    rev = "d0bee35fbf8f181e8313f1ead13d88c4fb85c154";
+    sha256 = "1k0k8dkclyiav99kf0933kyd2ymz3hs1p0ap2wbciq9s62jgz29i";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig xxd glslang ];
+
+  buildInputs = [ vulkan-headers vulkan-loader openxr-loader glm ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.freedesktop.org/monado/demos/xrgears";
+    description = "An OpenXR example using Vulkan for rendering";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/development/libraries/libsurvive/default.nix
+++ b/pkgs/development/libraries/libsurvive/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, libusb1, openblas, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "libsurvive";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "cntools";
+    repo = "libsurvive";
+    rev = "v${version}";
+    sha256 = "0m21fnq8pfw2pcvqfgjws531zmalda423q9i65v4qzm8sdb54hl4";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libusb1 openblas zlib ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/cntools/libsurvive";
+    description = "An open source Lighthouse Tracking System";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}
+

--- a/pkgs/development/libraries/monado/default.nix
+++ b/pkgs/development/libraries/monado/default.nix
@@ -1,7 +1,12 @@
 { stdenv, fetchFromGitLab, writeText, cmake, doxygen, glslang, pkgconfig
 , python3, SDL2, dbus, eigen, gst-plugins-base, gstreamer, hidapi, libXrandr
 , libav, libjpeg, libsurvive, libusb1, libuv, opencv, openhmd, vulkan-headers
-, vulkan-loader, wayland, wayland-protocols }:
+, vulkan-loader, wayland, wayland-protocols
+# Set as 'false' to build monado without service support, i.e. allow VR
+# applications linking against libopenxr_monado.so to use OpenXR standalone
+# instead of via the monado-service program. For more information see:
+# https://gitlab.freedesktop.org/monado/monado/-/blob/master/doc/targets.md#xrt_feature_service-disabled
+, serviceSupport ? true }:
 
 stdenv.mkDerivation rec {
   pname = "monado";
@@ -17,7 +22,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake doxygen glslang pkgconfig python3 ];
 
-  cmakeFlags = [ "-DXRT_BUILD_DRIVER_SURVIVE=On" ];
+  cmakeFlags = [
+    "-DXRT_BUILD_DRIVER_SURVIVE=On"
+    "-DXRT_FEATURE_SERVICE=${if serviceSupport then "ON" else "OFF"}"
+  ];
 
   buildInputs = [
     SDL2

--- a/pkgs/development/libraries/monado/default.nix
+++ b/pkgs/development/libraries/monado/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchFromGitLab, writeText, cmake, doxygen, glslang, pkgconfig
+, python3, SDL2, dbus, eigen, gst-plugins-base, gstreamer, hidapi, libXrandr
+, libav, libjpeg, libsurvive, libusb1, libuv, opencv, openhmd, vulkan-headers
+, vulkan-loader, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  pname = "monado";
+  version = "0.4.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "monado";
+    repo = "monado";
+    rev = "v${version}";
+    sha256 = "114aif79dqyn2qg07mkv6lzmqn15k6fdcii818rdf5g4bp7zzzgm";
+  };
+
+  nativeBuildInputs = [ cmake doxygen glslang pkgconfig python3 ];
+
+  cmakeFlags = [ "-DXRT_BUILD_DRIVER_SURVIVE=On" ];
+
+  buildInputs = [
+    SDL2
+    dbus
+    eigen
+    gst-plugins-base
+    gstreamer
+    hidapi
+    libav
+    libjpeg
+    libsurvive
+    libusb1
+    libuv
+    opencv
+    openhmd
+    vulkan-headers
+    vulkan-loader
+    wayland
+    wayland-protocols
+    libXrandr
+  ];
+
+  # Help openxr-loader find this runtime
+  setupHook = writeText "setup-hook" ''
+    export XDG_CONFIG_DIRS=@out@/etc/xdg''${XDG_CONFIG_DIRS:+:''${XDG_CONFIG_DIRS}}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.freedesktop.org/monado/monado";
+    description = "An open source OpenXR runtime";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5553,6 +5553,8 @@ in
 
   libspf2 = callPackage ../development/libraries/libspf2 { };
 
+  libsurvive = callPackage ../development/libraries/libsurvive { };
+
   libsrs2 = callPackage ../development/libraries/libsrs2 { };
 
   libtermkey = callPackage ../development/libraries/libtermkey { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25459,6 +25459,8 @@ in
 
   xrestop = callPackage ../tools/X11/xrestop { };
 
+  xrgears = callPackage ../applications/graphics/xrgears { };
+
   xsd = callPackage ../development/libraries/xsd { };
 
   xscope = callPackage ../applications/misc/xscope { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25666,6 +25666,11 @@ in
 
   lnd = callPackage ../applications/blockchains/lnd.nix { };
 
+  monado = callPackage ../development/libraries/monado {
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+    inherit (xorg) libXrandr;
+  };
+
   monero = callPackage ../applications/blockchains/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
     boost = boost17x;


### PR DESCRIPTION
`xrgears` worked with no trouble at all with `monado`

Run with the following after calibrating with `survive-cli`

```
nix-shell -p monado xrgears
monado-service &
xrgears
```

I am unable to test with SteamVR because of several
OpenXR/SteamVR issues. Hopefully having xrgears packaged will help in
resolving these.

- https://github.com/ValveSoftware/SteamVR-for-Linux/issues/412
- https://github.com/ValveSoftware/SteamVR-for-Linux/issues/413
- https://github.com/ValveSoftware/SteamVR-for-Linux/issues/95
- https://github.com/NixOS/nixpkgs/issues/92795


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).