### PR TITLE
thunderbird, thunderbird-bin: 78.5.1 -> 78.6.0 [Critical security fix]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,665 +1,665 @@
 {
-  version = "78.5.1";
+  version = "78.6.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/af/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/af/thunderbird-78.6.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "87cb38398aaa5af68e562a5fc6d20d3d3477d871979bd4a635c94c440e66a482";
+      sha256 = "7f8fd3a1f0e869ee03a4f120c88b606fbe4ae35d9865394fccd291caa9ae7069";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ar/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ar/thunderbird-78.6.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "935efae7caa116e16c341d64634954d77cafbc5e28626b46f5385b8416060f51";
+      sha256 = "73e7beba4e5a2b9cd92ded3ee8e662be9a80d65d59790ed1d5401b5a61c8d147";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ast/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ast/thunderbird-78.6.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "a5868dc7987529790910e638b64b15295a2d57e449fa515f4e17a4ab88a830e6";
+      sha256 = "890cda9e6a9582d43d61c9b4deb2241f46d34dbac5516d9a808dfbb472a22eec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/be/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/be/thunderbird-78.6.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "af52b29567ce26159890f70fcdccd4cafd49c7fc75c620bb606727fd27b7049a";
+      sha256 = "b951394def900c975b2796e47d948c03c59f0fde445f22d1b9a0d89ae8b7dd83";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/bg/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/bg/thunderbird-78.6.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "91856a4745a8bdefac7c2b0193766a4f0009378dfe941dbbe1afcae2ffae2337";
+      sha256 = "2440a8ea3a49d4fe7a84b0c6e67a98889bf98c5f828699bd980705c100a0e585";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/br/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/br/thunderbird-78.6.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "d5ba5fe368c99377a264d8574607335fc4317dad447bb38fdc6a5b53d2e95b49";
+      sha256 = "74b48030e64ff509379dd92d08734804006a8cc6176c69e387e03596138c48b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ca/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ca/thunderbird-78.6.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "396a1d7b668c7f47b56d7cb41e6e914f03e9e517a14b4698abedb501037ef2c1";
+      sha256 = "4b951a13352db2cc90aadf94c1e57bc5b40660d82dab855aa80751bbce9aa3b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/cak/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/cak/thunderbird-78.6.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "914b76ad8268db608be0595039a68189146ded384c23407ccbcd78a5e74e19ae";
+      sha256 = "bfb2ebc8a6b376603b9e310ad664a099725a29183c67b02ee13ecf3eb9a3bdac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/cs/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/cs/thunderbird-78.6.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "4b62702cabecfbb2567b19446f405936c9d948dad6f65a2e3f21809d4f2b1176";
+      sha256 = "de30e9d948ade3c82b7ebd58a3bbed5e880abcdb2d9c58f8e64d9d3d78bb336d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/cy/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/cy/thunderbird-78.6.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "736d245bd7766ac8c611a6801b3769a84baf4abae94818e0cfcadde8521850ad";
+      sha256 = "b7d0bb95acb861c453d8649673d9e582920a6df6a9662b8a6f996636d54c68c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/da/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/da/thunderbird-78.6.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "53143b51b84ee74ee9131d3b3b80e2cf873e5a8c22478c87db34a9d2ac34607a";
+      sha256 = "2c4765b34f1d63a9eae942531b7f489150d6850f68487565082ea18c94f3ad0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/de/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/de/thunderbird-78.6.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2f3a4d8bf96e9653dd3883ac4399c650e87831d7df137358401966683d382e6c";
+      sha256 = "e29280a519f4eca06d4e5862085d8fb8cefb9577918ba953cdc6f63ffc44a6ed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/dsb/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/dsb/thunderbird-78.6.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "81a3674dd2495da673a2fe3e3d200d7cadf83f9c67ff92bf2d607f6546bc2f38";
+      sha256 = "d638be5a999fd1b287628b449235e9995169c06c2cf46d1f7e6de282bf4357b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/el/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/el/thunderbird-78.6.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "651e8f535b2518bc4e56706cfb76da6d0e35d4fec031f8426cbefb404e4790d7";
+      sha256 = "34cbbca7eb8ecd5078d52d429b76ed0b5334398040d6e00aa5b5926bf8eeaba8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/en-CA/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/en-CA/thunderbird-78.6.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "775983115d98e3581db993f6202fdad1de6b23d38e5bb7edfd965ad6bc0ae425";
+      sha256 = "d50be05404a4b51e3a9c2fc4a73d75504f11e12a7ba7331ca43d5f078f462303";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/en-GB/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/en-GB/thunderbird-78.6.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "d0a3569c76b85fdca01e5098cf279b08a63d2d9023e92cadf3f8dc136d76c619";
+      sha256 = "4d11d73b268369117861250f4fecd5c6d19a904145caaaeb7ee86c7eb9e63f9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/en-US/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/en-US/thunderbird-78.6.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "4363d8fd759ac4f4783eeb76726c8cf22e5afb3c171f26fe5cca5ab194ab6959";
+      sha256 = "6691e528ac3fc88a023507e1172d67daac235fa1fce97e75e6fbd7072a493e0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/es-AR/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/es-AR/thunderbird-78.6.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "3a04a2e42935c97c7ef003e4a690c0433783b57ce56700f07ad8b590e48b4ad0";
+      sha256 = "2f45d7f6e42fdef4f8bb8ab815879157cd962c91afa352a35f8cbc3fcf52fd82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/es-ES/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/es-ES/thunderbird-78.6.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "f70a3feb09b79153d18e2a382017abbd6e015c78d4d55ff66f8b199b450172c4";
+      sha256 = "7bf50cefecce82e20c06441f003cc51eb7cc16d3a0e55a118213eee78e8b8494";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/et/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/et/thunderbird-78.6.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c739f5306a2526baf74e57a029371390d02f8c119681b0f154481ae32c67c18c";
+      sha256 = "2b2c624808f75ae0d713ad37e9959ad518ae5702caa10845fb3aa8089e77bc9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/eu/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/eu/thunderbird-78.6.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "9f95f4f1ec40e2732e053e68b31529b827f95876ad890d752f5380158f53b9e6";
+      sha256 = "3495821650563af2a62f36f928fb7503568de920211b9ef2f21904884d4fa3ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fa/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/fa/thunderbird-78.6.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "e53dd458656ee9f39e996042016256949c974161c51b1bee63a401d90d59bace";
+      sha256 = "90b9ff389550e5801bc7ca7e1e4d7db5b281081bef2d0d30b7c2e9799e8cd0c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fi/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/fi/thunderbird-78.6.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b0a96b08e986e49ee6526ab098fb0d44700b3a2aa7f96205b318fdd4b938ef51";
+      sha256 = "cd5819b7ed9e3017cbef8e1ca33cb92e1804fc8ece9edf6a74133db90b61ee6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/fr/thunderbird-78.6.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "872da741245da7466de58d766a0362983d59a111a65a333881d3636defe00eb4";
+      sha256 = "82b382d1ea014a26a397c3fe06c586732df756104533c7450494ad43b11e43a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/fy-NL/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/fy-NL/thunderbird-78.6.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "d57862f51ec01e63ab77916ab352276b7f4992b089508dee0c9c5d389ab88d95";
+      sha256 = "3b4b0c4a23ad63f2d152eb8741a30fe4092c2d37d1bbb2cd56eb75c85d885f4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ga-IE/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ga-IE/thunderbird-78.6.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "bda41b8eff5a5004f753944c49f15ddbd1f76c19b0310481251e04ff64309597";
+      sha256 = "093b76080942d3e7584f7948dc65003c20878e8bf4bec4808669f012183cf97f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/gd/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/gd/thunderbird-78.6.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "0671af342859574cb96dbe119d76d7ffa92a8c3fef11eee2a03f662ea71fb84a";
+      sha256 = "a726c67ab384b58c3a1ff84a3a1fe95f73219996e7e26f5dcdfe5dda30d34cdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/gl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/gl/thunderbird-78.6.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b458d6f79914fc4c551b3fa4444dc5ad4fa8d3310907a33a3480bf363bcdbfdb";
+      sha256 = "b731c512c61ece7b811d74e5f40cdae742207463799cccfa9906b43f58d5f2fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/he/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/he/thunderbird-78.6.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "146f2a8417827d2d6352f7cc20486ecca8fd1e0ad384d4eb2d8b2635edf2075f";
+      sha256 = "d15591239235d2f7debc8454e65c1e67101b8f32901fcc7543025986c524b156";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/hr/thunderbird-78.6.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "5c510bd3a8f8015e5c8a7c0cff401e3557b0cdca83bff77d2384c8f75f287152";
+      sha256 = "003d02062016c8f13038e61f189b7ebb75753ffd9a55879e1f8fd3ee1c1f2a2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hsb/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/hsb/thunderbird-78.6.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "605ae5746f0df98c7a561550da9cc938d0e06a222f422910ab118fa89d09e793";
+      sha256 = "2325fd29cadc8c824ddd90ba7d0975ca42c2d9964c62269f0361b5318274155f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hu/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/hu/thunderbird-78.6.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "7d42f5e242e04d06bb9abd9bde8fe21571fa13f91b027369a048447d4de8526c";
+      sha256 = "15650cc17e75780f17927ced485a03a23dcf771dd7d8343b28acd0ae1f0e1f9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/hy-AM/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/hy-AM/thunderbird-78.6.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "74b0b31089be36c0538eb24c98e57123f24599b4122aac5b08c4eb914f6a8f7d";
+      sha256 = "c20a4f0ccf2bce093986e3758784190215bf19d31469f6bb51f5a494ed54fb03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/id/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/id/thunderbird-78.6.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "291ad6b1fcdc537e723ee76cf0a40a3084bdf1ebec68fc3c8c54714618f5d790";
+      sha256 = "286eb0484f9a4b9c2d24dd836abcc07b00218a6c870535df1e4947482de1a79f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/is/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/is/thunderbird-78.6.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "188e2cab8e00421b8a5f9c9a174e8a529ab404a0f4f3976797e41848eb0abc4d";
+      sha256 = "b291df9b76800c56424ed8c9ad8e55be68f2606968abef2eb83ee3c86d56fc6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/it/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/it/thunderbird-78.6.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "12daeb5314ae81a82ce95c35dc9e34d676fe8b666a84a38aea36367b52aa2c95";
+      sha256 = "51d112544b67c44d82b4d0f54bd35f0dfb485917ad72c09ce6136a8750e58eb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ja/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ja/thunderbird-78.6.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "cdd41967d60abff6053f1736375cbbdb521bbdf5aa25110ca8e08bb365c853ca";
+      sha256 = "931815f8f2e0e3a9e3b9eb150fe8f0112b26537b02cc0c0c0dce9c14c1959ac9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ka/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ka/thunderbird-78.6.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9548232d8df327e6282b5413d904d5742aadfa75574b1333a235df2097337032";
+      sha256 = "d51b241842f8da9d6cfc8307b11b73fe813d46a7d6cd9651c46e1af18201e89c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/kab/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/kab/thunderbird-78.6.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "ca35aa36ed5794661372e76f24dd6c98d11d35da76aff5396215ebe9331aa881";
+      sha256 = "935d2e485aff93ee91c20710c286cb591379f5fae1a34851454707710c75df88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/kk/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/kk/thunderbird-78.6.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "dd90fff1a4ee8380e03e59ef324298d1591833a021d14a11fdb2829cd3a934f3";
+      sha256 = "4534b9c69f44c197997283f455d4b692ff96df122e9d633288d2874b8657833b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ko/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ko/thunderbird-78.6.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "4dae3766bf420a0cfb5473fa95356f0061b657a7ebfdc808b69a8e639564893b";
+      sha256 = "bb083026c53734d3956126a7bc11f1e02e122e463b0f8cb72757cc7cf94cb911";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/lt/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/lt/thunderbird-78.6.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "de4b448d9651692bc4eb38447d94c94e37d93dae816edb5f3936d56a58aa41af";
+      sha256 = "a9cd61089e2898a3e27cd0d10d9295c295b579324a30ff58f7500c0dd9fa1977";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ms/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ms/thunderbird-78.6.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "08593e72643de8f79b6d90a0c41d6031f915097d3f28f1e7e901c21caa0ab037";
+      sha256 = "f84ac7f403802271c2730979dd7da85ec976d970aa39c1f50215ba1902449245";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/nb-NO/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/nb-NO/thunderbird-78.6.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "21caa07be03725788c41fa527e7656a0467194e8a498de87f2455b571c4e14b2";
+      sha256 = "98fd61d91149b26750f06e12f64605ffe04f243d96c5ead0d11a2a600c4baa7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/nl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/nl/thunderbird-78.6.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "7c1c00a8e03d0a8e4fa9cdc3b4acce51215e9f273660e48ad76347e6003a1985";
+      sha256 = "44dbe77dbfb8d74c2c79052e1152e0da0a751d0cccea5b643c5019704454b0ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/nn-NO/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/nn-NO/thunderbird-78.6.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "103bc1307f47c20102e14362fcd6da696eb122fe77f680e70cd0849c9c03c47a";
+      sha256 = "e88e668c434b5b2469ef8268985015735ba5ff8639a1c670d1c9d42e1dd0b30b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pa-IN/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/pa-IN/thunderbird-78.6.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "388d01d0881573164816d7ddf6a08c17ad966616f1c8e8e429f821d2bb179a62";
+      sha256 = "388b87f10db2a0dc9c73580ccc5248c492d6274766e4350981f8289db39c95cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/pl/thunderbird-78.6.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "160651e72037bb89ac62534714ce9ecbebdec0cf1f8a6127396c68ab531745f9";
+      sha256 = "cc0e7c7bf4fd33ab255b1bcca808e6ae84c9575b3555228f84da8dad83b02d2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pt-BR/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/pt-BR/thunderbird-78.6.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "6d2064a6ed4bb684384f7e79b61cfceb66a9a26900e9947b3666c36d6b8793cd";
+      sha256 = "a8b4b7db5ed2a45af8bc595c85f15f9ea78d2a790bb62a9e419b7b2c78616a66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/pt-PT/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/pt-PT/thunderbird-78.6.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "2ccc7a3d9d845f1a3e2ad3869cbd4cefa10e44992c27444a599f6f1429070f32";
+      sha256 = "c4504cebf2b2c831ec94029605b3068ab1cf220d3cce33b085d658c20fbf4dc4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/rm/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/rm/thunderbird-78.6.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "05e45497c19d46292617de4f247f014f7b14a684f74bfd314caf408416dc5b19";
+      sha256 = "b1be40d4a3f6f26c9a06e3179244ae2ad9c9c259e76cdd695cb3f881e43de919";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ro/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ro/thunderbird-78.6.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "bf01cf8c987e46f03236dbaab14aa551464019f471aa111299b6c7538e995f80";
+      sha256 = "305ecbe685a107461aa3dad94e7b74d9f32b343a3d9813cf7d570e0919d5d931";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/ru/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/ru/thunderbird-78.6.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "a3cbdfa26ff487d0efdabfa9dc324b75ec1446964f1c0192afcd67565dfc4a51";
+      sha256 = "4d49f15c2c9e69a6156e89017c71f5cbda3114940bfdf273efd0e82dfcc3457b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/si/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/si/thunderbird-78.6.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "fb26eef7b0c5b233e41f8d4ad79f11aa7d0db21b155bf0d9284881cabb51f6e4";
+      sha256 = "9d108c3b3d54d12c5008f0d77c4a6741ab94c7fcfec1cb4ff59bb2730938d01f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sk/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/sk/thunderbird-78.6.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d462f2606bfd7f6e0e45334a68d266889f0f9f927f08d5b92c39329711a8c4cf";
+      sha256 = "a6e51284b554fd6a8970757d519870098baa26d3fd23561e335105ec5bf836ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/sl/thunderbird-78.6.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "b6011aefaf1eb60c8849b4ecc7a7a6fa0a72def8ba690f5b7ca61de3e089c9a4";
+      sha256 = "99b80fb6efd174beaf885e3d5451557a353693158ef147c931aa4d8560966122";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sq/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/sq/thunderbird-78.6.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "aeed36c0d6129dc58d496f8f6177a88950a4c4cfe2e4ac157fb389ea79488b11";
+      sha256 = "5bba738143daec5c687fedf566052c9d387a87520e510acdb963ae80c5d24b3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/sr/thunderbird-78.6.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f55cb398b3e6420acf6791d9ab5592b9915d299c5111ea917934b5729d22dd7f";
+      sha256 = "c18424e503d87ee7ea940a4d9551b9ec51a90b76b73180c89541872dbba27674";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/sv-SE/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/sv-SE/thunderbird-78.6.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "036b4f2b3d6cd24bcdcdbc1da1f44df2fba012f22ab96d0840a8c7ae0b945055";
+      sha256 = "d0eb7a8a1a6248e40142a62b61f9fe3e78bb8c277c9734d821358e0a075d5184";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/th/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/th/thunderbird-78.6.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "316ae39fb02b9ad1b28bbe7a21342e5e85dd7593978b4935b7be20253fe6b761";
+      sha256 = "04d3465fb8afcff051ce9a578901f3e9a8fbfab65f31cd7245b0b9321daa102f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/tr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/tr/thunderbird-78.6.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "73811e185274d880abdb15503a928a537428460080245426a07cf1c01e38f1c6";
+      sha256 = "46acaf32f9f035dd320d4e28d6b36ef8ce2d8ff5f753cfb6a7b02f37e8edb09f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/uk/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/uk/thunderbird-78.6.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8ff9e333cf16a02e7888f297851b5a9316c5b57cf546f592f12d2aab6e3bed48";
+      sha256 = "60b0be6207532039958f03a81e5fdf070d15cd624a0583c4d8e87e0528ccd240";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/uz/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/uz/thunderbird-78.6.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "899c0c8c886fbaa6a6609a500bb374797bd36272138a6fcdc6aca7c7b6a6fe66";
+      sha256 = "070963c90b858e9ab75cee1490671ec3f9f46190896eca554fde0ced205d0d44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/vi/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/vi/thunderbird-78.6.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "13afdad34f64a1c96f9612c10c8af880e9718ae10d8a1578bc397b238a936dbd";
+      sha256 = "9040ed756aa19c0e850391bd9fa148eb0fbca45b84eea888c874a9c93ee0428b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/zh-CN/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/zh-CN/thunderbird-78.6.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "00a1d01acabd210ba70ed6d0842ab5e1674109c7f39f561e8295d1ffd5f80a0d";
+      sha256 = "caba2b9f3fabf1231b947c578c9761a241178f732c110fcd4cf620146ce5002b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-x86_64/zh-TW/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-x86_64/zh-TW/thunderbird-78.6.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "19b84b15a6bbf593a342c874822764bd73022d2c846fe20a6d7d91aceeb1ee15";
+      sha256 = "b48378e3833a0710bca60cb9c87396f0163cf9cd6211725ea711e116557e5abc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/af/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/af/thunderbird-78.6.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "4c1487a6b823a76d477085e66b377f536f2cfd95b4ddc6804b97c792af77c554";
+      sha256 = "b4ca4cd2535fb02c059db2783f2428634373730217d420530d7c2f6441191fe7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ar/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ar/thunderbird-78.6.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d33576a1d8c346195a20c8a222281d682d14f604654ff173eb28ca8a9343574b";
+      sha256 = "29c287ff2ce37f3d4c23770f85aa220d7b9265df2b188aa38730fca68f8ea40b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ast/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ast/thunderbird-78.6.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "09d68977bc121e562f3c697bd1d87b21250c8a0bcac013940e3806d4a69a749d";
+      sha256 = "e1267edf8d35bfaf1f2bab751b5235855ce9ab768acc607ff308021dc917cd8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/be/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/be/thunderbird-78.6.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bb58501c902788b2d1f8f308468aa57447a15979cab59dc89c27e3738748b6d9";
+      sha256 = "1359027429e2c1ed2535f0878105bc0485f52b569aa342246d380acd1df13e4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/bg/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/bg/thunderbird-78.6.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "373bd3548f518a4ae56e8a103b64eb76c3139b984a5af8013de56b133a0d44c0";
+      sha256 = "4e2d1a02d6ef6ee123c68db8ff299037cbfa017334599f5e3ac7114ee3e8874b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/br/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/br/thunderbird-78.6.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "40934c8ec7070ad29cb0111624de431a0cdeeff9c7c01d8781444e33f65acbca";
+      sha256 = "526e73827d595452c40bcd2066885d41a9497bf7d61043a5236d600cb9202e94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ca/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ca/thunderbird-78.6.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "fbce4213fe7564f2af3f980f5844961cac9a7ec2a30b23d7cdd4e5db6aa4ebaa";
+      sha256 = "73605bd265262a8f538b7d15b26915ecb030a76824a09192e7b2e897ac5affe5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/cak/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/cak/thunderbird-78.6.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "2aaf7ea23606be03f5f7168aaa4286760f236d084babd1f81540f8b62b37962c";
+      sha256 = "bbdcb9447938bc2ae8b4dc0a5a250cf82e316c7ef56abca2962f871abf9d1d4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/cs/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/cs/thunderbird-78.6.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "880e36431f76161674fdb9f2902c9d5487bed528a198722458b7e6e76e80e9b5";
+      sha256 = "4052bda928576a30657dc4087bdded6ea2339e271bff36194bbd37e610f55d13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/cy/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/cy/thunderbird-78.6.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "eddb4dcac8063e5b245eb1c095c4ff98cb03714bf5b07f0366b89d670a9d95dd";
+      sha256 = "d3b337be4b64903d075f8e2269ff5f88831d5a88f24a56deead19ea534867d10";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/da/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/da/thunderbird-78.6.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "2425487caaab7979f504d37cf6b100c7cb030e8e5495b6723fa4f953348e4f40";
+      sha256 = "96080cee994410b59935c0baaa4d8bc0c592d1654242b00540b3b1997398951a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/de/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/de/thunderbird-78.6.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "81df3e5ba46fe5959f785c06bef0b70daa55e8f8721cfff0bf55a76f7343b32f";
+      sha256 = "46b4c8b867fbc4f5ed288f0c503a776a256c229799601d7810ac51b73685d6a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/dsb/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/dsb/thunderbird-78.6.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "995d3aaf3df22aa3166f161b98113fc25b813dc7cee2743b2bdd6913b4a620c4";
+      sha256 = "f1b8576a1c5ed9dea2b92b10b03e2f16e17207c1f5dce4f83556b11a846de754";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/el/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/el/thunderbird-78.6.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ad5162a76dba9c37e2542fa7ed08c63edce9955600e9b50889abb03e352ddf23";
+      sha256 = "01d559767ff8a2562b81c7e42007993065b4d46319fe4890e157a2450a34875f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/en-CA/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/en-CA/thunderbird-78.6.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c605520e5e65449855c355147f18b813f66d38dce52e8d3a23b90afbec5bcbf1";
+      sha256 = "99571e51cc28c9dbc5aab42fa5d5f7f680fdfa287f7f8b96c5548949155735a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/en-GB/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/en-GB/thunderbird-78.6.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "63b0d984ee8296c5185ed1aab279a0ef065986d989edbd0a7683b9db6a6d94bb";
+      sha256 = "e515ef917801e0fa67b9d4821f7185b21e36b35b7df8bb43b6a917851bcae753";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/en-US/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/en-US/thunderbird-78.6.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "b5404037f2678d36acbb225f43d426a86db9a4828a69b1beaf44dc3b5264ae7e";
+      sha256 = "cee59a70210f9fc8672a914179c957d67556b068d8ce9387c01636e89e54aba9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/es-AR/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/es-AR/thunderbird-78.6.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "cefe0ff79bacc9c16fe649c0d7b4f932afca6ebb10c8426fac527485e92f4422";
+      sha256 = "e30605e7460ff80a1c26107d0393d7cd12ecfd95d55f256db6f808076d03c53d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/es-ES/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/es-ES/thunderbird-78.6.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "de7c6685c4e73ee334faf83c809b2f45d55c971282ba99aecfd5d1c8b05577da";
+      sha256 = "0e2301dd592c06a2628aeba21f38fe4b422ed2690531c1487e958c6cea1b236c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/et/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/et/thunderbird-78.6.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "e5174b12c61221436a5926224f61f218bfe762086f1d5bb814af5f7708592392";
+      sha256 = "d15684c68e9bef8902e9dcdb87bacda263953cc93ba7368b69fd318739b58fdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/eu/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/eu/thunderbird-78.6.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "66bfbb4edc775117a6f048f52084fff9828633166ac6234a7c1dc0d67311677f";
+      sha256 = "4144e7de84ce0a6b39d8c29a96221532951c76679a8ac5a85aa07a62b99680d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fa/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/fa/thunderbird-78.6.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "072163a9d1a94b1f5c297c794791b4bd3e7f7e6897e7f7615df59a9dd2232a52";
+      sha256 = "028ac9a6ad5d6e7360e597d961a7422238d96cda848042975ececec6f3a06aa3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fi/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/fi/thunderbird-78.6.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "9c269f267251bee9828acfd78d04bf149767dfe5247ae4f53ec5b0bd65c410ba";
+      sha256 = "ee5adee4c249edd9b61fcacc0a2150d4471a7897aa1057fe3ea04e16729de966";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/fr/thunderbird-78.6.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "6ccfac2b5d96491c4d5dc7b00e4458617ca68fe07917941559534a31424c977c";
+      sha256 = "d5d0190541184198a6c628b3c79c7dc96ec911ab195ed3419f33c4817d401e01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/fy-NL/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/fy-NL/thunderbird-78.6.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "1b470c45c9d52a8a84c59dbb4ed0e6966d124ffdc3ea865e4d02289bd39b346f";
+      sha256 = "c7b8ee6e8b66a6948f80f10e1ebf2d61c70e5be439f197953bff91f499fa8d51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ga-IE/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ga-IE/thunderbird-78.6.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a1cbb9a4c1bf91f920da9e4e0e39e6ecff0a8c87413898c1930ce69dadad9a26";
+      sha256 = "32a1d8ded34b26136b2884d24f31c5b08c965c10061758b87df9510395f8dc7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/gd/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/gd/thunderbird-78.6.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "909be2cc362ed839f373eb22d27c5f3c569b1c82fc2ba5aaf270d605029d336c";
+      sha256 = "a65ff1d77deb34ed46bb84ab480afad20fcf417f39c714021ccd83b4a9d3212e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/gl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/gl/thunderbird-78.6.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "8ffadcffd16aca8befd4b9c230b7da750e6a694add7ee465227a0c3f31a5c655";
+      sha256 = "87660c561fc92396c1eeafb82e907fbc2670b6649e2c7f0bdc73714fefa3de55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/he/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/he/thunderbird-78.6.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "a9242889345131a405d138d0ec8e470eb49c59ada18b1e8f78004f307ceb41b1";
+      sha256 = "1e5c7324c57de9e5e2a87dceb1d41994a74f55e108e8d97161e0fd428f6b197f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/hr/thunderbird-78.6.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "eb1f5496811677e28b2ed034da40ebf1fef324673e0f3acb2c21f0db5c71f592";
+      sha256 = "cad204c16e1b8ee26809321aa27c73220e64bcd86d261474c636d088ade006e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hsb/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/hsb/thunderbird-78.6.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "643a2b11a0775a71a8fa6c25097cfe297e6bc190fb29eee18ddd3d16fb61d989";
+      sha256 = "9d3e8988b5e8a3f089a0334304e255a716bc24f4ec9b08dd6594b7ddb4daa3cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hu/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/hu/thunderbird-78.6.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "61d91bed542a7e014a8d11e46e1b3d97e8bef1303bba397b3d4da0585b1e68af";
+      sha256 = "f46e9d49a74ccb2172c78e6e149149ff49c0be7c93336c62f8c17b30a1b1d15f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/hy-AM/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/hy-AM/thunderbird-78.6.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "2e6739d14a45529ed2a68abb8ed03ad901b4e7770efebd382f6e9626c86da036";
+      sha256 = "f3f7e033489907339055d0ef02abf4a423434248b1a10623736fdcf09a3edd79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/id/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/id/thunderbird-78.6.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8753bc4c7292cd0c6ee382bb5572e432222e7c39ed739904d91ed1ece5a8197e";
+      sha256 = "581cbae2f96a616d29d30eda0dad30992eaa7fe71f65c20af10f528d130d83d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/is/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/is/thunderbird-78.6.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4f624262b72fce7d258b6f7c264f7d2266ebcfdd59fce895e4e85c72fa784637";
+      sha256 = "8653b1e05517a723a4113995e0e69a73fa59196f5625e2c1b0e51d9d60561646";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/it/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/it/thunderbird-78.6.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6298ce45c4a659e47877302d61a50dfc7e0634e7c3e7036aeec49da5a2839073";
+      sha256 = "98faf75b5216cc75c2348962769fcdaa98ff59c4f4870b44cb6e7a69b7b5e9bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ja/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ja/thunderbird-78.6.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "85a7b01f65c79b0e13c4f8a18f3950f0a250f380fc8756b8fb1709680a148554";
+      sha256 = "ad34916c36ac06eec4c1a900ff33639c6238e01c6426693261433b9bdf44ea91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ka/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ka/thunderbird-78.6.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "f7b18243b9985b54eb8684b62bad47b7b021eb959f467fec9876c866d92b1727";
+      sha256 = "c3468772b8667784814f6d323a74aef24f561cf3fbd2c5dfbfed16f73e7e7c6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/kab/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/kab/thunderbird-78.6.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "cc8eb77d0d0ea95a1e2b13db51da4f18a9500aeacee1cbe505da67f2b6a9b979";
+      sha256 = "1ba665c91e38df62809a601223238dc3c34a50c96e42e5792b145eb9aed3aef7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/kk/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/kk/thunderbird-78.6.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "6999faf34774806e1e4257a139dd97dd50a889a7729fef4f51a8b41bb4ad169e";
+      sha256 = "651fda1baa62acfae3f13bb65096368719461d206ce45b84a3ff5540e09d9e24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ko/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ko/thunderbird-78.6.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "42b0bf1ebfce252fdfca3ed8de9f227bbb054bf591e6155b716b18e9613a9cff";
+      sha256 = "49b82df2eaa66e658b4ff0f84af7b128a92eddce7e9ce129f0f28b8239367967";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/lt/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/lt/thunderbird-78.6.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6ffe9b52189579bee34604499649901be5c8be2a026eb70a33ac9eb4e3b21880";
+      sha256 = "6d263e236457576a0e853fd0b00711182c34c32436f65c8fc952aa2810fa500d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ms/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ms/thunderbird-78.6.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "640942eb04d84d24bd28cf5e49e57497934810394b50693bad591cf3b783e1bf";
+      sha256 = "45b050930b8357e3a988701d46234ccdd43ba7b38e56b88d157dee6309c375c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/nb-NO/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/nb-NO/thunderbird-78.6.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "c0d35274192ae664314e91fd9364609cbbf142f8177d37210c9c49fdf8d31086";
+      sha256 = "23760a375705d8c3d22aaefab60c9a761fe73f5d6c97f3a3621312ba362f77ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/nl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/nl/thunderbird-78.6.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "864ac834a0f44ce112deb107abce170802abaa63556f0aad88ee828bf3f8a98c";
+      sha256 = "8f006195886d26a519363c1a61940a53388952a67bae4fad07de50ab24ee21c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/nn-NO/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/nn-NO/thunderbird-78.6.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e821eaf0388885e3b5e88001a2c4410cdf065059b79a3581c324f53d1cf59eb5";
+      sha256 = "85710ff8542c6d592a939a55300040633f5b8fa8587f5c6c0ba0c3c2c7e5e62e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pa-IN/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/pa-IN/thunderbird-78.6.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "5a0afbf815683afd24c258ac66a45dc300028b4d41a9950784355645874459ed";
+      sha256 = "cc1120713915ba43b74e9a4daa5814cf83b32317bc1503061c233e5fe28f8214";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/pl/thunderbird-78.6.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "cebdc0a0188edc63fce0b4fe0a4a3f22ab792ad486bd1e10e635ac8f641f1b5d";
+      sha256 = "bf3da9722d7c9602304f64c7b11aba83cb899a23c1ddd179d5eb431aca23301b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pt-BR/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/pt-BR/thunderbird-78.6.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "7bbf9aa4d48bf84a7455dcebc6b7476e4c1ffa085c1771fbdf302f71d10e4825";
+      sha256 = "0104d48b2de1e26e3b66545a76b7892e2b1b17f56ebf8558353e031fb8741614";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/pt-PT/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/pt-PT/thunderbird-78.6.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b84c28dfb5d677768a6e0f69c8ea63fcaf884839739789ac72f50e7b8884f8ca";
+      sha256 = "b376bc3cc3f87484c9f976f30a3049bd4873ec67982574ec570c5c96d7643285";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/rm/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/rm/thunderbird-78.6.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "f34eea430a9e929c25ad961b1c92724c5539a46cbbfb9a97a5c7edca4996115a";
+      sha256 = "d68e60b06b03b5313a1ddc42464ee5a3ead106655860e1d2c359802875276778";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ro/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ro/thunderbird-78.6.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "115cd666282822f35924d4de3b33fd0dd3d790d278bb35849ada579d43d5ac54";
+      sha256 = "051c01b3e2f69258e1d44599c6c485785c1624a67fa6548517ec242c69bf47fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/ru/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/ru/thunderbird-78.6.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "961eb62e639f8f7c7c5695bd39df50fe4b3401e7aeade8281600779bb8edd374";
+      sha256 = "db0f48c765e7ec9c090e1d5f43f42faa5ac6cc9e4d593dbc6b8ff6f8f7210027";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/si/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/si/thunderbird-78.6.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "0887999609e47839a0f7600215c3083ce939fe13abc0c38cf701449224dbc87a";
+      sha256 = "fc104d206779b8b909f645a86151b193da0792c9af6360fbb4933d8224f23bb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sk/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/sk/thunderbird-78.6.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "a3b9281efc4c0cd6cb454f2c5b97567b4d2c6567076cee188e85c30a45213f98";
+      sha256 = "d08d8fe02577ad931020fdfd45b673fd2b71e41d66c1532b8025012e493c869d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sl/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/sl/thunderbird-78.6.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "141e9a41dba4c2a3eee4370d2db6e14f8805fee2d70c20ecbb9865b7a0dcaa77";
+      sha256 = "6907401bb3973911ece57b9b3bd56032b02c2c140ab79ec554f4574a7e2121cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sq/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/sq/thunderbird-78.6.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "6a50fdac7993294937756a169b4b0ac7fe021611c5c6a730ea194ee7302c95dc";
+      sha256 = "bca13f569b5cd0e6a4bac8ae59a8f1b228010a95871763600080473f45ffe5a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/sr/thunderbird-78.6.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "2ec4c2f367bceb3f05c75e55366cc66fae6593fc35c79d7bea57f34f93d79dba";
+      sha256 = "df9328979af4c36d553992e0928d63a6cfcf0a54541e091fe7bb57e2e934057f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/sv-SE/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/sv-SE/thunderbird-78.6.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "4a9027f9aa74bd9c6e3cbf02ac1918f1b9dfbda57ed0344a99fccad9fa271f79";
+      sha256 = "a310b66e76a2062354d2ec10dbe0827188610618ac87f866010b418d26032a50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/th/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/th/thunderbird-78.6.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "f394b18a364fa84ff5eeeee00c841248ba4095285833ce625b700fd500b9c0cc";
+      sha256 = "efb37f15a311d2c66678f42f13085e77eaf8819b2fe16ee52e3410dde5e85bee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/tr/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/tr/thunderbird-78.6.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "9f180c1b6b604fc597bf1ecb10e3521c70953cb70d4292105cb3bc7cbeb806c0";
+      sha256 = "4f9f9088ab91ebc3e4e022ba77cf8c168ab961c73317fccd07e987e38ec6eb57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/uk/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/uk/thunderbird-78.6.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f828ac8f52bda71f913462e60fb7ea2221de4f824063b95b85709320a820db8a";
+      sha256 = "d9c527045270007c74e84d9f77ab6cbab2f07112d8688757920f5adbc5bbdf1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/uz/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/uz/thunderbird-78.6.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "8d3dd4a1bbe008e4d346c22c01bafe988dde88fa6c9919c50194b9b155bc821f";
+      sha256 = "9ea90845e8668afff622f412f571b59e03e6c02d49a4e47cb99ab93f5da822dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/vi/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/vi/thunderbird-78.6.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "4db40b3debca281c59e926bd0f9cb4e5cd2150bf27235f1178ed8e497616a031";
+      sha256 = "ccf4bd8c6269fb8ae15413923d556ecafb808ef205688dfb78379347a5bce5f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/zh-CN/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/zh-CN/thunderbird-78.6.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "399707f970a01e2f3c2eacc81f2f3bb33b1f49433c3ba6c49f4615b499f0c246";
+      sha256 = "22f0b4a72f995a9936fed178138d3e0c40fb3aefeda989c9ba83fc82a4296fcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.5.1/linux-i686/zh-TW/thunderbird-78.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/78.6.0/linux-i686/zh-TW/thunderbird-78.6.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "27ad21908069582a4a7641dc9a7d9acc69d4842382499cef2cee2f84d0fc3856";
+      sha256 = "b8c8633732641b8ab87bfc2a2867a95b817ce6d0fd0e8f569221bc51ac23e849";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -71,13 +71,13 @@ assert waylandSupport -> gtk3Support == true;
 
 stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "78.5.1";
+  version = "78.6.0";
 
   src = fetchurl {
     url =
       "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 =
-      "202s2h9fsvg4chy93rgxdf4vlavf3wbp9vqgh0nrgk5wcdhz17144vhw1bmxia8hf99snq2a3ix6haidwl8d2n6l2nfsjzcnphhxd9z";
+      "0hx9gg3ngpvgshrz9j7ni4kh3chadqd5w5fpywjjw4naj0k53d0i9jjhq4p6fyvf6rb2g825ibqq794lr9drn6nrfndh5w1yn5lw69n";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Critical security fix
- Other updates and fixes

https://www.thunderbird.net/en-US/thunderbird/78.6.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2020-56/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).