### PR TITLE
pappl: init at 1.0.0

### DIFF
--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, fetchFromGitHub
+, avahi
+, cups
+, gnutls
+, libjpeg
+, libpng
+, libusb1
+, pkg-config
+, withPAMSupport ? true, pam
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pappl";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "michaelrsweet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1cg06v8hxska0hnybnmfda1v4h3ifjir24nx2iqx80kb6jq0hayb";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    cups
+    libjpeg
+    libpng
+    libusb1
+    zlib
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    # upstream mentions these are not needed for Mac
+    # see: https://github.com/michaelrsweet/pappl#requirements
+    avahi
+    gnutls
+  ] ++ lib.optionals withPAMSupport [
+    pam
+  ];
+
+  # testing requires some networking
+  # doCheck = true;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/pappl-makeresheader --help
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "C-based framework/library for developing CUPS Printer Applications";
+    homepage = "https://github.com/michaelrsweet/pappl";
+    license = licenses.asl20;
+    platforms = platforms.linux; # should also work for darwin, but requires additional work
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6408,6 +6408,8 @@ in
 
   papertrail = callPackage ../tools/text/papertrail { };
 
+  pappl = callPackage ../applications/printing/pappl { };
+
   par2cmdline = callPackage ../tools/networking/par2cmdline { };
 
   parallel = callPackage ../tools/misc/parallel { };


### PR DESCRIPTION
###### Motivation for this change
been in the news recently, looks promising

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
