### PR TITLE
gitAndTools.git-when-merged: init at 1.2.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -170,6 +170,8 @@ let
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  git-when-merged = callPackage ./git-when-merged { };
+
   git-workspace = callPackage ./git-workspace {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/applications/version-management/git-and-tools/git-when-merged/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-when-merged/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "git-when-merged";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "mhagger";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0sw98gmsnd4iki9fx455jga9m80bxvvfgys8i1r2fc7d5whc2qa6";
+  };
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    install -D --target-directory $out/bin/ bin/git-when-merged
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "Helps you figure out when and why a commit was merged into a branch";
+    longDescription = ''
+      If you use standard Git workflows, then you create a feature
+      branch for each feature that you are working on. When the feature
+      is complete, you merge it into your master branch. You might even
+      have sub-feature branches that are merged into a feature branch
+      before the latter is merged.
+
+      In such a workflow, the first-parent history of master consists
+      mainly of merges of feature branches into the mainline. git
+      when-merged can be used to ask, "When (and why) was commit C
+      merged into the current branch?"
+    '';
+    homepage = "https://github.com/mhagger/git-when-merged";
+    license = licenses.gpl2Only;
+    platforms = python3.meta.platforms;
+    maintainers = with maintainers; [ DamienCassou ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
