### PR TITLE
maintainers/scripts/update.nix: Do not traverse lists

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -34,7 +34,7 @@ let
 
   /* Recursively find all packages (derivations) in `pkgs` matching `cond` predicate.
 
-    Type: packagesWithPath :: AttrPath → (AttrPath → derivation → bool) → (AttrSet | List) → List<AttrSet{attrPath :: str; package :: derivation; }>
+    Type: packagesWithPath :: AttrPath → (AttrPath → derivation → bool) → AttrSet → List<AttrSet{attrPath :: str; package :: derivation; }>
           AttrPath :: [str]
 
     The packages will be returned as a list of named pairs comprising of:
@@ -60,8 +60,6 @@ let
                 if path == rootPath || evaluatedPathContent.recurseForDerivations or false || evaluatedPathContent.recurseForRelease or false then
                   dedupResults (lib.mapAttrsToList (name: elem: packagesWithPathInner (path ++ [name]) elem) evaluatedPathContent)
                 else []
-              else if lib.isList evaluatedPathContent then
-                dedupResults (lib.imap0 (i: elem: packagesWithPathInner (path ++ [i]) elem) evaluatedPathContent)
               else []
           else [];
     in


### PR DESCRIPTION
###### Motivation for this change

﻿Lists items are not directly accessible like attributes in attrsets are. This makes it hard to represent their address in `UPDATE_NIX_ATTR_PATH` environment variable passed to update scripts.

Given that I only introduced list support for `gnome3` attribute set and we stopped using them there, let’s remove the list support again. NixOS modules are better place for package collections anyway.

This was meant to go in with https://github.com/NixOS/nixpkgs/pull/98304 but got accidentally omitted somehow.

Fixes: https://github.com/NixOS/nixpkgs/issues/106935

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
