### PR TITLE
nomad: add optional nvml support

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -1,7 +1,11 @@
-{ callPackage, buildGoPackage }:
+{ callPackage
+, buildGoPackage
+, nvidia_x11
+, nvidiaGpuSupport
+}:
 
 callPackage ./generic.nix {
-  inherit buildGoPackage;
+  inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
   version = "0.11.8";
   sha256 = "1dhh07bifr02jh2lls8fv1d9ra67ymgh8qxqvpvm0cd0qdd469z1";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,7 +1,11 @@
-{ callPackage, buildGoPackage }:
+{ callPackage
+, buildGoPackage
+, nvidia_x11
+, nvidiaGpuSupport
+}:
 
 callPackage ./generic.nix {
-  inherit buildGoPackage;
+  inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
   version = "0.12.9";
   sha256 = "1a0ig6pb0z3qp7zk4jgz3h241bifmjlyqsfikyy3sxdnzj7yha27";
 }

--- a/pkgs/applications/networking/cluster/nomad/generic.nix
+++ b/pkgs/applications/networking/cluster/nomad/generic.nix
@@ -1,4 +1,12 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, version, sha256 }:
+{ lib
+, buildGoPackage
+, fetchFromGitHub
+, version
+, sha256
+, nvidiaGpuSupport
+, patchelf
+, nvidia_x11
+}:
 
 buildGoPackage rec {
   pname = "nomad";
@@ -14,23 +22,33 @@ buildGoPackage rec {
     inherit rev sha256;
   };
 
+  nativeBuildInputs = lib.optionals nvidiaGpuSupport [
+    patchelf
+  ];
+
   # ui:
   #  Nomad release commits include the compiled version of the UI, but the file
   #  is only included if we build with the ui tag.
-  # nonvidia:
-  #  We disable Nvidia GPU scheduling on Linux, as it doesn't work there:
-  #  Ref: https://github.com/hashicorp/nomad/issues/5535
-  preBuild = let
-    tags = ["ui"]
-      ++ stdenv.lib.optional stdenv.isLinux "nonvidia";
-    tagsString = stdenv.lib.concatStringsSep " " tags;
-  in ''
-    export buildFlagsArray=(
-      -tags="${tagsString}"
-    )
- '';
+  preBuild =
+    let
+      tags = [ "ui" ] ++ lib.optional (!nvidiaGpuSupport) "nonvidia";
+      tagsString = lib.concatStringsSep " " tags;
+    in
+    ''
+      export buildFlagsArray=(
+        -tags="${tagsString}"
+      )
+    '';
 
-  meta = with stdenv.lib; {
+  # The dependency on NVML isn't explicit. We have to make it so otherwise the
+  # binary will not know where to look for the relevant symbols.
+  postFixup = lib.optionalString nvidiaGpuSupport ''
+    for bin in $out/bin/*; do
+      patchelf --add-needed "${nvidia_x11}/lib/libnvidia-ml.so" "$bin"
+    done
+  '';
+
+  meta = with lib; {
     homepage = "https://www.nomadproject.io/";
     description = "A Distributed, Highly Available, Datacenter-Aware Scheduler";
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6042,9 +6042,13 @@ in
   # with different versions we pin Go for all versions.
   nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix {
     buildGoPackage = buildGo114Package;
+    inherit (linuxPackages) nvidia_x11;
+    nvidiaGpuSupport = config.cudaSupport or (!stdenv.isLinux);
   };
   nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix {
     buildGoPackage = buildGo114Package;
+    inherit (linuxPackages) nvidia_x11;
+    nvidiaGpuSupport = config.cudaSupport or (!stdenv.isLinux);
   };
 
   notable = callPackage ../applications/misc/notable { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The rationale for this change is to support GPU device resources in Nomad to inform its scheduler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Using this test configuration:
```
❯ bat -p client.hcl
data_dir = "/var/lib/nomad"

plugin "nvidia-gpu" {
  config {
    enabled = true
  }
}

client {
  enabled = true
}

server {
  enabled = true
  bootstrap_expect = 1
}
```
then running:

```
❯ sudo ./result/bin/nomad agent -dev -config=./client.hcl
```
we see that indeed the plugin is discovered:

```
==> Nomad agent started! Log data will stream in below:

    2020-12-16T09:19:50.330-0500 [WARN]  agent.plugin_loader: skipping external plugins since plugin_dir doesn't exist: plugin_dir=/var/lib/nomad/plugins
    2020-12-16T09:19:50.331-0500 [DEBUG] agent.plugin_loader.docker: using client connection initialized from environment: plugin_dir=/var/lib/nomad/plugins
    2020-12-16T09:19:50.331-0500 [DEBUG] agent.plugin_loader.docker: using client connection initialized from environment: plugin_dir=/var/lib/nomad/plugins
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=docker type=driver plugin_version=0.1.0
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=mock_driver type=driver plugin_version=0.1.0
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=raw_exec type=driver plugin_version=0.1.0
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=exec type=driver plugin_version=0.1.0
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=qemu type=driver plugin_version=0.1.0
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=java type=driver plugin_version=0.1.0
    2020-12-16T09:19:50.331-0500 [INFO]  agent: detected plugin: name=nvidia-gpu type=device plugin_version=0.1.0
```

Running the examples [here](https://www.nomadproject.io/docs/devices/nvidia#examples) locally:

Looking at the basics:

```
❯ ./result/bin/nomad node status f83f7c5d
...

Device Resource Utilization
nvidia/gpu/GeForce RTX 2080 SUPER[GPU-16efc9cd-6886-5c12-52f8-2bef887747d9]  0 / 7979 MiB

...
```

More detailed info: 
```
❯ ./result/bin/nomad node status -stats f83f7c5d
...

Device Stats
Device              = nvidia/gpu/GeForce RTX 2080 SUPER[GPU-16efc9cd-6886-5c12-52f8-2bef887747d9]
BAR1 buffer state   = 2 / 256 MiB
Decoder utilization = 0 %
ECC L1 errors       = N/A
ECC L2 errors       = N/A
ECC memory errors   = N/A
Encoder utilization = 0 %
GPU utilization     = 0 %
Memory state        = 0 / 7979 MiB
Memory utilization  = 0 %
Power usage         = 23 / 250 W
Temperature         = 38 C

...
```