### PR TITLE
pythonPackages.psautohint: 2.1.2 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -1,12 +1,13 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder
-, fonttools, lxml, fs
+, fonttools
+, lxml, fs # for fonttools extras
 , setuptools_scm
 , pytestCheckHook, pytest_5, pytestcov, pytest_xdist
 }:
 
 buildPythonPackage rec {
   pname = "psautohint";
-  version = "2.1.2";
+  version = "2.2.0";
 
   disabled = pythonOlder "3.6";
 
@@ -14,7 +15,7 @@ buildPythonPackage rec {
     owner = "adobe-type-tools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1s2l54gzn11y07zaggprwif7r3ia244qijjhkbvjdx4jsgc5df8n";
+    sha256 = "0gsgfr190xy2rnjf1gf7688xrh13ihgq10s19s4rv5hp6pmg9iaa";
     fetchSubmodules = true; # data dir for tests
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/adobe-type-tools/psautohint/releases/tag/v2.2.0>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
