### PR TITLE
dstat: 0.7.3 -> 0.7.4

### DIFF
--- a/pkgs/os-specific/linux/dstat/default.nix
+++ b/pkgs/os-specific/linux/dstat/default.nix
@@ -1,20 +1,35 @@
-{ lib, stdenv, fetchurl, python2Packages }:
+{ lib, fetchFromGitHub, fetchpatch, python3Packages }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "dstat";
   format = "other";
-  version = "0.7.3";
+  version = "0.7.4";
 
-  src = fetchurl {
-    url = "https://github.com/dagwieers/dstat/archive/${version}.tar.gz";
-    sha256 = "16286z3y2lc9nsq8njzjkv6k2vyxrj9xiixj1k3gnsbvhlhkirj6";
+  src = fetchFromGitHub {
+    owner = "dstat-real";
+    repo = "dstat";
+    rev = "v${version}";
+    sha256 = "1qnmkhqmjd1m3if05jj29dvr5hn6kayq9bkkkh881w472c0zhp8v";
   };
 
-  propagatedBuildInputs = with python2Packages; [ python-wifi ];
+  propagatedBuildInputs = with python3Packages; [ six ];
 
-  patches = [ ./fix_pluginpath.patch ];
+  patches = [
+    ./fix_pluginpath.patch
+    # this fixes another bug with python3
+    (fetchpatch {
+      url = https://github.com/efexgee/dstat/commit/220a785321b13b6df92a536080aca6ef1cb644ad.patch ;
+      sha256 = "08kcz3yxvl35m55y7g1pr73x3bjcqnv0qlswxqyq8cqxg9zd64cn";
+    })
+  ];
 
   makeFlags = [ "prefix=$(out)" ];
+
+  # remove deprecation warnings
+  preFixup = ''
+    sed -i "s/import collections/import collections.abc/g" $out/share/dstat/dstat.py $out/bin/dstat
+    sed -i "s/collections.Sequence/collections.abc.Sequence/g" "$out"/bin/dstat
+  '';
 
   meta = with lib; {
     homepage = "http://dag.wieers.com/home-made/dstat/";


### PR DESCRIPTION
###### Motivation for this change
Reduce the number of python2 dependent packages. I also needed to remove the python-wifi module since that is not available for python3 anymore.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
