### PR TITLE
firefox: 83 -> 84

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "84.0b4";
+  version = "85.0b2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ach/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ach/firefox-85.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "da9290899d245d86b3d2d378072af403106596ae1e02a36d40a93deea9e57000";
+      sha256 = "628cf83823cf28f48b9c69b9c1d5c966b3525802f8883759c66872b6a851aa05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/af/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/af/firefox-85.0b2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "28810946bde4c2335714c0f8b0dffad1a1650c167370e38c6eb5e2ee5d2e54be";
+      sha256 = "1206089088cc4cf88dba63b50b71c365db44fc7a9052868e4c7900222a3df6a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/an/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/an/firefox-85.0b2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "d32e9e13b2c1f484686d9394f20a87e2c1d833703e0115de1f9c8c552d1e9d8a";
+      sha256 = "7b11406db06ef3c77ae06dff1d911a797bda7bc348e141e2e9f7e3a1cea75d81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ar/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ar/firefox-85.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "de8348caf98ca0551f3f080eb32ef94c00706676bc8df1723377d98f10221e56";
+      sha256 = "9222a3eec3abab949c96d9e32073f32148da9069670a6577fc06aed7c64fe1a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ast/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ast/firefox-85.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "104cc96b0e14c030848be4bc07a1b2b836a241e9ddba581b9ca24018c54356ee";
+      sha256 = "6dd5f9ae82d04e139eeddac7d938e78d1409ebc781fb4e27a399bf41939a21b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/az/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/az/firefox-85.0b2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "e96087b52f1dc18c8bd29d486faa00ad06a2165d1e14cbd47e37cafb40602a87";
+      sha256 = "490d98a746c45446e237f84af894768fd0c78ed6d4937eec086e1fce8101890c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/be/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/be/firefox-85.0b2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d67c2c1556b6859e0acae5b69b3b7eeac77b3bb1594b48682a97a72742c79d05";
+      sha256 = "ce25d9eeba02850693bb8df813af694c00192abd64b9420bb422ef1b704cf26c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/bg/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/bg/firefox-85.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b3bad1b330a5d4c515b37cddb3e89e538c5cd66ffce68dbf8d1e9adaf4881431";
+      sha256 = "027021477cda6f203500d725146db27b3ff3ca4ea38991b74be65a68659163a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/bn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/bn/firefox-85.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "9c50c4e12061279133177ade4b22b7e2bb7e14dcc1875464f57efb7c7e360bf7";
+      sha256 = "38465864ae3694fd810bfeb8077d90fc2dde1a1b6a97fea9ef413b48bbe4b6e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/br/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/br/firefox-85.0b2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "79eb76af707b26fa4d46acf11d0be25ccd144abda6c853373c9ec0cc872c2a8f";
+      sha256 = "d42480e934cf4ea14ab8f1cba15c95749efae727c52908a77f5f076865a40024";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/bs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/bs/firefox-85.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "2cbf15a604f90c4a6212f5da251372d09e2247f5ed338193ff93a94695bca308";
+      sha256 = "36e50b4abad8d9cdd6b281135467f639268670d857cd0f86bb827fdba70d5ab4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ca-valencia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ca-valencia/firefox-85.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a9b6cacf6ee8a6a1f733f3ff3741c1bb12eff823664279205906e8e59b646679";
+      sha256 = "45433be09e4b01efe768c9178d26d68cd7fbab0505d7f6ccce230718fee5ea7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ca/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ca/firefox-85.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1ea49a5d59129c820f359fbad2253e051adbb260cedd4b62bb20122562466bfd";
+      sha256 = "147993df562fbaec1a07ab634b8db112883d0d37c7c021804b8c000dc2549454";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/cak/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/cak/firefox-85.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "b18651df9ae2e16ea9855c30fa393dd34103cf338a515d41d3c1802e52fb92a1";
+      sha256 = "126b7154f9e943b922a5a5284e9eb51b2569f5494431f6273b7c32a8d1c6a9f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/cs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/cs/firefox-85.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "4dca051e5349372d6caf5a7f6e8e6e12fe42bf96110a1c6e2f7f6e408f365b80";
+      sha256 = "152bb5937e5baab421f60bdaa27c948f37c0a55da0d05175c7689e8fa50ed6e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/cy/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/cy/firefox-85.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "3117d47bcec1cf0f5a547a33c62ca5ecfee34435c13a478f23d1d9f0ac187f4f";
+      sha256 = "d294f03b0791b42bb944e3338a6d5d488005524e192ed36ba9e6306af72d084e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/da/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/da/firefox-85.0b2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "34a38c76997bdd41e6b12cebf08345e7cd19838bd92f5a8d082ba3087cb063c7";
+      sha256 = "baa162dbe4bd9830f06225d247fd771e328a3a50b6583accd407d06a757fbe1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/de/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/de/firefox-85.0b2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "65e417603cf383d92058b8976c1f6499dc5804d02a22bb639e416c4e730b4a62";
+      sha256 = "c9f7d9e2af245b63e88ae36bf095495fbd6cb3c852d79a8ca41db2159c243c01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/dsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/dsb/firefox-85.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "08dacb91773d7b49eb8f08668627badae2967193c441ff2fb6b9d88063c5ffb9";
+      sha256 = "a474a5404b8142bface3eee5008a87c4015c9762a76bc9a1a8caa0f26a5b7ba7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/el/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/el/firefox-85.0b2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "78e870b673c204e4d9fca2a3fbab06031c724a8b0696a3b6e2dea5ac07a5bb88";
+      sha256 = "19a60bc3baecbe1ba2d4e0d6fc60a60ad6b792a3024ab6226729983dc530c1a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/en-CA/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/en-CA/firefox-85.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "4c862eb5c53e65af1ddc212a093eb23e33653341fa7db53d935ed8482637aed8";
+      sha256 = "d35de987f9e686679e7feed27fd99b73478f19f000a3004ea40d67e6598ce5f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/en-GB/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/en-GB/firefox-85.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f505cf16328603d0164e330fcef60fcfeccdad186d1f91e0b4cee1b8cc7c740d";
+      sha256 = "120926431e18449e1b422037d491245792e4f62e8a9d0b38df25e16b485dbaa9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/en-US/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/en-US/firefox-85.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "f0561469f04ab83dd52ae4e3a8ca451d6569845e37d9e04c5a91085654661f8a";
+      sha256 = "f1b26bf2d9e62f86c36b7de154f014e5ea893e1674986f1cb59f2711cf6663f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/eo/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/eo/firefox-85.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "c64d227d6b21876ea48182795d6fd8ec3ca486e5328629a0bbfb936e8463b0a8";
+      sha256 = "3eca3b6ac4b952c508445bd0783804d5dc76a8f6d7492ae9d65bad0060f242a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-AR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/es-AR/firefox-85.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "73b45f6b8d1e53bef003b3e77cc1217b8a85dde49cb0900b4fa2991895e5c184";
+      sha256 = "3c67f7e3572a97262ff4b37fb165b474a4f91429f59ff2b568910f4d3f8dab38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-CL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/es-CL/firefox-85.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "e7025e4c5fc311aae2798da99ec5e5863bca5ad8b8460981cef86e29ae37d74a";
+      sha256 = "e5b2167a4ec5f7eede57c394bfb7ee01ffd1b0d81d36a586a6d562dffe2f50a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-ES/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/es-ES/firefox-85.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "e819644eb6337255004fda8286e1f2ed898423c4b97694c8355c28f4d449da61";
+      sha256 = "dbd7505430897e38ba8f46b0081027c276184ff4085f801accac976cea68281b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/es-MX/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/es-MX/firefox-85.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "07de091ca3b06b94e35b84add7fbc5c8fa6ea84ddfe548e5f55b3bc7980a9bd3";
+      sha256 = "1a82057ebd73698db2d3f8753733f52fed2c5f853470a553c05d7c85dce7d3d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/et/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/et/firefox-85.0b2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d6af9ab39f1a13efc772cbb63dd731dcf988c10f13649f348d7ddb3f6ab6ca60";
+      sha256 = "da22407a7c9505cc876ca3473cee8ef1f894f84d8ffea8c10425340a8b6358f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/eu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/eu/firefox-85.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "110e667568429dd2b0c752962e1148884c44aaef9939926c6b0f49ba5bdb1182";
+      sha256 = "6facb92bcb4f03ac2e9b1f0288ad94b43e395b9113d38f924c372c8e78ddd749";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fa/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/fa/firefox-85.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "f7a783f12bb08ccb06074f903bb2eaaab13b348c6a2950a9699beee28ad97b5e";
+      sha256 = "b982f5211f262c9c5091d65ac941fa9f900707f1212a84df434f62e1d5c9a059";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ff/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ff/firefox-85.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "b2e47bc8ae8d1e54a1b5799a87b4742d049696edd9913f0cc6beb52a89cc261d";
+      sha256 = "eb35a619db24de04f30dabdab45a3c53358c36706b3c6018de9798c3a79afb1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/fi/firefox-85.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "f5ee09f1b9d41506ad1023ad05dbdee95ac049eb4bfd38dd99c06cf682e111a8";
+      sha256 = "b39e892c9084a34a608b9385f7b8c6d25f1f9cda8c9891ea92e8fdc49e4ed63c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/fr/firefox-85.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "f8c33819a6ceab041bed80f1663d94a80ee3bdb6e859eab1eb8ec9d0b67f4222";
+      sha256 = "9de9f9342fa3d3bc721bbcb72b4b5ec42b8500e179222e229e7a45d724ec878f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/fy-NL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/fy-NL/firefox-85.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "6ed233042e570e9a04ecc1e25f6211deb7685c117db75f32a541076d95d1cebf";
+      sha256 = "1f1511fb51c1ba7ad3602da39a3b4c95c86096edf155a652f0033a2d7cd173df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ga-IE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ga-IE/firefox-85.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "b28337429a0c1d26653fda1d93b59ea0383061a253be5b763442166fdb21bbca";
+      sha256 = "295a46724cd89639feae42dda983bc5a48a78996d6c3fd1022bb81400e11567c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gd/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/gd/firefox-85.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "546bf2f1a4a8a643b161554bc92e771644ff9ae46c6b10fb2a60b920a2454f44";
+      sha256 = "2926449119034ac81ecffb0a366ee521e29437c64b6bd37a7254ad392bc90061";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/gl/firefox-85.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "cfc32d3e7e3ba5379895a8b348d9399bd3962a819d0677f14a365f6e0c314676";
+      sha256 = "2df55d15357b45e643c4b8a020c7ad235fa2579c16f05f5dc84be8d52b6b0066";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/gn/firefox-85.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "b2b5e826540d3f9b52d67e092fa755b26a34ea9acd0cb1c69eb6f0bc332354d0";
+      sha256 = "3a7686ad5d4f4b3adb96c6ea05844f890aeb456983af43827ff787e373733456";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/gu-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/gu-IN/firefox-85.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "497b8a954ed2c9fa13e207462730dd39d2d0de10a38e3762dac3ef1fbd36282c";
+      sha256 = "b64c32a495d72f7c710e9a0168d4967743067f0f85ebf7109aed5b53db919cc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/he/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/he/firefox-85.0b2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "8cdac2e9d2cf10171f2744727ddd80e21a4d46e2082947e49f4a255f174db968";
+      sha256 = "8c1a1b96eca7d84123c602543f1ac8f54ecb0111e195495e8a3265b2537b31cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hi-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/hi-IN/firefox-85.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "d37c55e60329220de3d792894d7b801adf7dc7ab8ff4ab39bd2e24b59443b973";
+      sha256 = "bc561d6399a1dfd9aa1f7afcfb4b7ee1c600985dd45a9a195cd89256cd2493c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/hr/firefox-85.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "bebb6709dd3be119be45d9fdb0bac41b81514d78a384a221e2ffbb51b46dbea8";
+      sha256 = "071ce5aeac01ef79ae210595305fd014d5a893594bbf2b547d15a6126a784848";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/hsb/firefox-85.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "c43aea7fdd8a57653d6d9af4aa7c0be6e860f5292366ddd91c5860dfde2ee1bf";
+      sha256 = "7ffe23f37f8908a31a3f0b29b361ef3c49917753300c6a492955237ca188fd6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/hu/firefox-85.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "71e6b509dd3a6937d9851c262fc7a1bc9e551cbe0515089586fc22098bc51151";
+      sha256 = "60101a07d1ae5c50b44bb55bf52b5b962f0f0912e574f1a58ba6021951fcedf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/hy-AM/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/hy-AM/firefox-85.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "c92eaf9f6bfa97651075d2342e45b988ae89c1a4cb55559dad71bfae5912ee83";
+      sha256 = "89bffc83a11fd8ff4b8ee143173c6d4d37124f63d476f130d7931efbf5a723aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ia/firefox-85.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "3c71aafb7dddcd3f9bcc8e169281614ac1087400d1d0ba02afb18c68b1914128";
+      sha256 = "f317ebb0622f0286d648803dab6a917bacd6471214388b201558c9ec23e8e431";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/id/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/id/firefox-85.0b2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "8075ef0b1d7eb2fc6141262cbb0d3831c3d8508eb43d3e9e142d96946ed2036d";
+      sha256 = "cdfd0cc0bd1b10bb96ca044f18aa2bfb857b18d83ae15a46533a8657eabbb168";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/is/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/is/firefox-85.0b2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "5ef96d77bea5c94e7147a5657d76eb5c7f206208a0464245242cca3fc7fb79f0";
+      sha256 = "0834e007713da632917bb546b6be21117dcbfc3ecdf8062ecb1819611df62ee5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/it/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/it/firefox-85.0b2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "eb76a1f3bd1ac065772d4ea4a435c53b5f7b1d5b643c7b62b7ccfee205ea4e81";
+      sha256 = "57a071d56cbdb3fd754e91dbe9930ab90ff87ae9cb10e2e1bcb0f2a62165a62c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ja/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ja/firefox-85.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "80b644648b9e40ed592ab9ea2b9d7f1e2abcf8d6b0f925aa57cd6cf28d53dcf0";
+      sha256 = "d9fd58cb8ba9a30821c717c9047ce149efb7b1f06c2ab820208684d13436ad19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ka/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ka/firefox-85.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "03c34e7b08a8b6140e612739118c35b05dcdef1257b4857d2fda87a1cf8852ff";
+      sha256 = "7a6071fa1daa7875308c26073b0f690ef5e408e18c9d1063a321468ff3d92015";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/kab/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/kab/firefox-85.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "419a4758cf2e2e24968f4da384dbfb03ef8398713c6070ab29ce379772168f18";
+      sha256 = "b25e902a6819cc252b23f9eb0019643deed468f65615fca808c55cf7a6c6a5ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/kk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/kk/firefox-85.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cfe96420e125dd12c9a9e79e45a8d7ee260d1957abddab5ed887afd1a1e3f499";
+      sha256 = "0767c4cd2b99ef045135ae278c79466333ac1808c7503eda37d82a2941b0004f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/km/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/km/firefox-85.0b2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "4b3599a9b30132b6105e4bbda7de370e54e21d8e498bb3c4c3d9807282fbf246";
+      sha256 = "d6006640aacb18dcc8c8df330d60f831c12bdc214210c257bd6ace8763d88eed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/kn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/kn/firefox-85.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "5da3ddc9d9824e3ba59e1cdc89ee3fb8900c661faec1f539c829d0917be5d4d1";
+      sha256 = "37e8b5177ed9fd2341a39164769384c233da4378100617edc19060604002480d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ko/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ko/firefox-85.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "2db9a494693091832e578959144d172d5135b82bbf44c041949da8ffec2de9dc";
+      sha256 = "9fc2ddd0a9dffeb327ff33c24454a189e552c840ffcc916abe37b49836891cc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/lij/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/lij/firefox-85.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "2219d5235f0ed9d2015ead5782976727d2b7103afd987eb445f3f274856e6af6";
+      sha256 = "925a665aa1cc6ceb8cc0a70b5eaca499a82b59577770c006af73423c637f7d74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/lt/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/lt/firefox-85.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "a335e0d835bcc7ae9563bb3efe6b926ad71e08f3ccbd164aa2b9f257acd1341d";
+      sha256 = "7669ece40b4269062d50191f46d41d65511f4b6553280bf2e22990592c584cee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/lv/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/lv/firefox-85.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "1f89f8f2715254ef335af9b01ca1503caecb1c93b1a900ee1643c3f9e00c6821";
+      sha256 = "d6c86314f58044c30b03e176db1273861f0d1c47a6ea168fb5ac6a4cc047ac24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/mk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/mk/firefox-85.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "86eb9f1e8189ce45c03925337a90f1b204dbdc902c1c4a817a924410a26b0048";
+      sha256 = "87cf9485d579da404bd2ef47c39785232eed16f31eb7cd2108cc9698378c5358";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/mr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/mr/firefox-85.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "d5214647403f85c5f7a95871e8d6fb4d4c448af92e6475841fd8474857f21067";
+      sha256 = "5179a1d37c6c9504b5bd0c41ef91f9f9dfa1e0458cbe2b0dba36829de04d4a6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ms/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ms/firefox-85.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "23af07562748448a35242a6cd77bce25a5576d2b71177fb682da58adb21671e3";
+      sha256 = "4722459468f6507be8aa111efdbcb17356970c8b4b2a355a27036b154356d341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/my/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/my/firefox-85.0b2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "bfec2f3ad0853fb36ec4aac9ad97ba14d30a275eff2582c2e9df600b5940c004";
+      sha256 = "d398c8395ebbdfa5f799dd08e33935156f5bc99631f782e6e5c637b35e2a98f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/nb-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/nb-NO/firefox-85.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "32be6fe8aa661f6098b4600d824846738664f254ecd4ab0d0a1e705b28a94e74";
+      sha256 = "b58379bf0b1da5a85ccbae9b88081f384762ceef1ca2fe95700867f4416a5342";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ne-NP/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ne-NP/firefox-85.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "dfa3e6b9f31fa716a2c80fda07c24717a526ef96033b5b1861fcdad43c99b29e";
+      sha256 = "66047291e50429e9d0e50eb4959ab0b321c920d65fd3ec612cd0d136ebe86dc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/nl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/nl/firefox-85.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "e253d963b66855c44f41c43baba1b5c952b37dd1b83aac8243c60581ca674a49";
+      sha256 = "b57675671a91478b60cd0c8a2b697c8d7f574f84eca1695f9eb20d5eb27e64cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/nn-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/nn-NO/firefox-85.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "5d9b90cdee03a544a78f44d4f0566b5b59ae802af4fa60367a1a4836c01197f1";
+      sha256 = "c9b56bce646f09a0f2ff9990dbafec12f07aa1c92e5d6ceb419a450378662252";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/oc/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/oc/firefox-85.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "b37f9a283d9dd2ff9e8998d83e0c147bfbb75e4b64b3936cb344243e1277c370";
+      sha256 = "2be07d5d2a582ad3d9d40a54243c97c4c4ca45d7691e19d5263440abd510d37f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pa-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/pa-IN/firefox-85.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "68f6bae2e6f064e22503145b5fd57d027899f23fcf109010a98397dd8c0d7cf6";
+      sha256 = "2febc1c6a6369236467d440b44bb15682dd975e8d5f399364c76518f869b37fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/pl/firefox-85.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "789d6925c3b17f96bb92eef54c05fc8787f32ce2c9846931e185dc5a1de9f303";
+      sha256 = "2d107f89149db4be89a73f1c1fc825bcb73e7f3266f33bffce7ad75d02869d13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pt-BR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/pt-BR/firefox-85.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "329eecf74dc8d9d1d8f4578389553d92a368c972fcb2468e0b936f21508bd1bc";
+      sha256 = "c443b3d55413dff75de4a88f726b0c80df6a687ce0fcd10a10fa41e8c42a021a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/pt-PT/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/pt-PT/firefox-85.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "b30ba75dbd5f5ff3ff709722acdf36acf4de9993d230eb27996e81406779dd0a";
+      sha256 = "dc63f909e2f59a08cabc37fddd03fa6f42a20d5708329d1d660ae9dcc3c1ffa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/rm/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/rm/firefox-85.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "ad90ce4fbcd094bebf77b36a63e38326c613bffb580743c9a4c19df845907dfb";
+      sha256 = "6f7458b0f03034867f370d449e0ab0f33a8c154faedea3347c89be681cb24105";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ro/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ro/firefox-85.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "8f7864bc6577724f20829ad79901d92775200860dd8c43bb2443c7bf22d7a435";
+      sha256 = "cde050b50475442e8d9c8f1228a84da4bdacc4202e387dd9c3d6b639f3a70b2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ru/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ru/firefox-85.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "8b52d5eaee53805422bb2fd6dd8b2e0c7a5b01feccbc6fb6c77e4fb8678d30a9";
+      sha256 = "fb99e81c93dfaac97468061dec682fb5da1f0b3c1c6b22b4b98a5c1f23b6694a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/si/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/si/firefox-85.0b2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "a71df756e97f58271715f3d79a86c0407487dd5820500127cbd9373361bd016f";
+      sha256 = "e4786b5b9adb260000cf7e1b49006c86b2ac4d5d50329e925adf82594213302b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/sk/firefox-85.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "71eefff1538a2978d9e4e65fdd5a2322ad81ddfee33464c0d70b95eda1649fda";
+      sha256 = "b386c895de5d07ddb4caf734014a2fbc47d9acd6ee364e59004511a817fd8144";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/sl/firefox-85.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "91b2938be8230b6301fe3d15c6d9ba3f031c1e5fca886da228f47a2e0a2cd144";
+      sha256 = "058f2047df24199bae7a7b30a913929035a996dac65988665818d900ebbd3e3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/son/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/son/firefox-85.0b2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "57e456cd14418c41c2e5f8eb0ec6b0807459f41e15207f6997c7742fd3dc8a1a";
+      sha256 = "c48206706c8c3170d40d5718704d35532cbc03ecf3b84b241ecca5142011d8f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sq/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/sq/firefox-85.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "0f343e2442523f0e422309cc36518484a242db4116f0e6b7dcfe251cdfea76cf";
+      sha256 = "2dbf91ea3c6714b1dc0a36661edf8d30ee05ecc3cd87f9446d9806958cd68cf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/sr/firefox-85.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "cf8fb723611506fff356cabd91a0ca3fdd9cc5d806167df6dd385438d467eeff";
+      sha256 = "ef21f1c5ae483dea2e522f8575573d2c43b706938572c682eea1fb69dc66284e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/sv-SE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/sv-SE/firefox-85.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "258020bbc7a75139fee340e50d41676d234be19c931f0228485f06fcab2eef81";
+      sha256 = "a285c9e3274ea0e97997bb177e521d5c671c322e7a00a11367176ff9e5e3fb2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ta/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ta/firefox-85.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "7783166c0f9ceed0f7d037c1e92b988818a70522945af2c96db958966eed8b66";
+      sha256 = "df18247c65c74b7f84e5c18ba2948224e960df4fb3abb4057e291c0e0ec12f35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/te/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/te/firefox-85.0b2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "02662946b3506da6432c48eb1c7e0f522ffaed2abcfcc474332a799ef3be2b92";
+      sha256 = "7a134e7398eaff92a9e6b10b26e4ef26c8406aad91e22ad9c4e4cb8de55a96cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/th/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/th/firefox-85.0b2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "1592b372b8e767e5b7369f356fb733a2daf51b4f45c8c4c94041845d63b3c604";
+      sha256 = "91b3a69c2b660005050abd47fe50903aca9390da44bb074850e9440875aa378d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/tl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/tl/firefox-85.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "2b831feaae729c674e8a9ee207dea007df100bbbd8cf7553791aee3eede37224";
+      sha256 = "b1813765c4a9292995bb529df922137f92ce4a39bdec97378dd71ce4225759d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/tr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/tr/firefox-85.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "aedf8b7684f204109e42a3797ba00bd7a8c5bd3f827c31ea3fd4eea1679d8af5";
+      sha256 = "0c2a166cff9a3731bc378552b3baf36fbd53e0d9a37a3caa939a17829dd008e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/trs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/trs/firefox-85.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "232cae54f6120a47455fdd7e0d88dde1f64d5a1931bcd7d54f6bf8bd376583e8";
+      sha256 = "69bc6b9532bf040d5311a864baa5ff88b182553ea9b0110c172a12f6f27f8eae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/uk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/uk/firefox-85.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "e00de7cbe1f00aa082f9a448857cc19f011bb1d5b579e79457bb0dfc72b7a12d";
+      sha256 = "2653f28322a4adb50ecf00d9fe12f4ffa679a68616516c84af3eecacac692b9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/ur/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/ur/firefox-85.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "7ece4d8af476eef174c0c175b65841da8d826702fb255587c2e1d259bb9ef3ba";
+      sha256 = "637acba1c21f19f6414e864b2142b05c530c2b06d5acea907bc4a423774d0d04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/uz/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/uz/firefox-85.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "09c7e7d641f703404aa7927860f2924e6be376b2e39b1f0fe012dc87469edb62";
+      sha256 = "4a3e1155821b870d8d84de11c4c3e53100cf88e043bcd024493f5d196f1fb6bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/vi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/vi/firefox-85.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "18121867e6b8c2a52c5324f653f82afbae97481b5ac3df811e881ec39bbb3b0e";
+      sha256 = "bad32bc9d6dccdf87e1a5f36f359d379411837bbb55e109d088820bf0461ae2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/xh/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/xh/firefox-85.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "04f5bb96ef9002eeb0869236f70168e7cbd7842b8e12b66dd6d5d67db9acd28a";
+      sha256 = "2b92d825d913068f4707848df34fea54b2bee3da088cdb8b6dc99bc2a23a7d2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/zh-CN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/zh-CN/firefox-85.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "142286cf9136bcb9b6af7ea1df3cf77821c0793ab7b9fe533a2963c453f45a7d";
+      sha256 = "6018f1350df63cf15317b6b60c1968d365c6f19a643b24fc359515b12d6d21a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-x86_64/zh-TW/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-x86_64/zh-TW/firefox-85.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "fef32e5817140bbcb6d1b614a72a29523235606192078eb04420ff7a2453cb9a";
+      sha256 = "4df049ce4e35a66db2fa6e6e32045d89e3d3d6c89cda7cc07d3e843a26543065";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ach/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ach/firefox-85.0b2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "40e9b7a738e06cec731c69b659b14ca48b119ae20016e0214e1160edf03919b0";
+      sha256 = "71423d13d132c50df51a1aff2884280716ed865abe658cda2957a86816cc3f35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/af/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/af/firefox-85.0b2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "9bb05361a51f836b2de5614127f8df768e504f4d5bc136e3f169741098f0bcbd";
+      sha256 = "5fbe29f38605f08f65ebf3222ce12ae46168e96c107dc743b56d865d3daa8647";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/an/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/an/firefox-85.0b2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "ee62418444c76b709204962ed47af8ef3d61b80e628600201b5a12293651c70d";
+      sha256 = "a66e2d52b2af65f4bfd624dfe7883e8231b7f511e551f486a2b78c3ec164c57b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ar/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ar/firefox-85.0b2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "10b5d4f1616e078bf83ab5ff942dabe89a8eaca63f24e96b53726dfb2bc9e36b";
+      sha256 = "fa8c2083030e26c8d61f213e66b2bf5e1e9fdbdffc570216e7c97cee0e067b8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ast/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ast/firefox-85.0b2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "a4e5ccae125edaa0696b696a5342320707f0c39c8985437b6aed60faede71de0";
+      sha256 = "5a5b01eca7665b91f8fb11b34c7eb1c0e681cf130cc5f1443686913a8d9e662e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/az/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/az/firefox-85.0b2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "c13d9ed183c7b9256801708014f38405749cdfcead9f243e80eef78d06a9b78e";
+      sha256 = "a0b1d6c634b38a72403ca48de6c527d9bf966a905f03ae6699df014595b3bba4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/be/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/be/firefox-85.0b2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "57d8eafc3d45784dbad71eb49d5a4c0483d939719b43b0f16e4db1d5a96ff4a8";
+      sha256 = "76d6e8286c947513951ea977d205d8cdeff87e142b1664a5a01cca4f187a1623";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/bg/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/bg/firefox-85.0b2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "0a65ad71cc9d97277535f07a8dbc7ca248508c24dea8520f92fecbb806f87a31";
+      sha256 = "153249e545295ff4e8adecc5ea0dda230645fd0f4afa06f24a7e551d87e0d7fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/bn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/bn/firefox-85.0b2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "3cead08f4d746def6cfb909107f4739400498c970f10fbd542259c04b84b5852";
+      sha256 = "14f439c1b3acbde375fc1c4cfbf8f20a274e8d04b32cfdd6bdde389a6ad6b19c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/br/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/br/firefox-85.0b2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "40c6e963e8e52ef51cd4d4e63d501f2a6cecec1800541941458b896ad90e5b93";
+      sha256 = "9dd2fbc10b2515691c47fb0496b0fb78d1602ff9a6cffa11cc0a83d43d809e46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/bs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/bs/firefox-85.0b2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "1e9df53642c442ead4318b0cc886653fdfcecf5275d6e7218acb390bb13e0021";
+      sha256 = "4223186d487b4d43ae08450bc896161b5060ea96da8cec63f19d2ba5d6f9c6b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ca-valencia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ca-valencia/firefox-85.0b2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "3b5699dad93291921979fc6da21d16f94ef471e9a8ef3d877001400ba4abe316";
+      sha256 = "2dcdd7c1172375c5358ea5957822f3cefaf77edce286a9e9abcb7cf4f2b09396";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ca/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ca/firefox-85.0b2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c52b9cc25dc72eeb6ef3e7c3add4066c005399afdba2cd0964e695a891a1d314";
+      sha256 = "6d9c112fcfc56a39212a31ecef8b36f78c7d0130899a2630e8de53870f64276d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/cak/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/cak/firefox-85.0b2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "355df19615fddd85c51b033a413a3de524f19fb2d97a2ba77f3b8001b231338f";
+      sha256 = "c7cef2e121d960328aeaf43a933aa9b18911dae0c73b21edb483b1c036f7525e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/cs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/cs/firefox-85.0b2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "e10f35795f19ea10c4de34687eacad6f9bd863002e9d66b87cbace01b97c8628";
+      sha256 = "9edc6df70bef140abe8b43d60369cfc17a10d2c20f9e06e4182035e1a33f48fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/cy/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/cy/firefox-85.0b2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f2fd90b19e8c4ac98bd6ee262084ef7842e52a304abe10cfcda2fc14ccb5ce30";
+      sha256 = "789bc341344eaafbaeee8e9db4128d12e1cc54490d544168ddbc3c88b2374630";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/da/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/da/firefox-85.0b2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "01e468f3a445276aea85425b4b8a58e44a2e4cf8552a02aa3d4d31775bff9575";
+      sha256 = "678f6a6931f0c733b5836d994875f1c133a0f865a2eb496d0e30cbe3ce5faf5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/de/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/de/firefox-85.0b2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "9dd3d806a4ff60c9cfd5b81cdf212f72c281f75ce554555cfd443f0696f700d5";
+      sha256 = "e5721e408165ddf927e7810e6a940c50d2b2fe30ad5e2ccdb6811074ca0c4287";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/dsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/dsb/firefox-85.0b2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "eb26cbad496bc1c4f97e6027a1f2cd9166d479a503a3f0ac566a766c86bdf8b5";
+      sha256 = "b4aeb111e1124ead137bf3497e95bdced3f1a158f48585b644a73d50432a7d6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/el/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/el/firefox-85.0b2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "e173622f06f64156d749d0f56d98be72f067077c3e41090aa16a3b0c6d7a5e43";
+      sha256 = "66ce828c90be502cdb820bd69f4216450db60a16a40ca038f75eecea3fd0d640";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/en-CA/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/en-CA/firefox-85.0b2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c1c6aa503e1565cb0c0239d562f11322265a7bce4005211b8007579f8f56c318";
+      sha256 = "ab7c8f8626ac88afec096210d75ac972308ae75cb3ebb315b30ab21b51e0b064";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/en-GB/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/en-GB/firefox-85.0b2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "57b2670f515e2a17c10df602d93a6960e5c4710462098d89568efd446e4480e5";
+      sha256 = "38cdf3449f82c51d6d1bdf3b6fd00a3f8bb057255ba2418a9547e48804744bef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/en-US/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/en-US/firefox-85.0b2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "81cf4a4fe610de3342bdea340d450ff67c594e7e4924a08b6b69de75510da698";
+      sha256 = "b044f5e64dfd2bd5dba00f8530abb3f49b82d600aca6d3165dd1ea7504975483";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/eo/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/eo/firefox-85.0b2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "dd61c4bacfe39f7887c6d21d139df6a2df17f263c4be5689f5f9dd6bb4ee6e63";
+      sha256 = "8ded13c7dc12d539efc5a3ed8a9d7fce556b7f012a184a1d1b96e8e2ec10a1c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-AR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/es-AR/firefox-85.0b2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3ae8695c57befa3552033bcb867b48f9ba491a08e31168ba22901fcb3276a3af";
+      sha256 = "f3dbe9b5f621bdfd1a19489a749db8bf452f4b5079ea4f79bfc9378056caa54a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-CL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/es-CL/firefox-85.0b2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "5ae14208cdbf0dd50edecb8a56bfe7dba0e7520f2ef135abb092761acc8630ae";
+      sha256 = "9c8f486cce81c331588271cb6a82624cf4bc4daf480150e66f24237e42e9389a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-ES/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/es-ES/firefox-85.0b2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "d786cf3b623a05e5156b020a436897525e80117ab7fa9f25ca42fca9fb4c0eba";
+      sha256 = "0f04e9217d3981dae74a534bea8c5085e0a147e2e8ebf34090932cc4e5ee1bc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/es-MX/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/es-MX/firefox-85.0b2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "c2ec749bb5befffd81189503d87a57bda462897bba858904924ae999923a4e42";
+      sha256 = "7b696644fdb7c270a08155ee1a6896172966de078b9e172ca24b128b2e869651";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/et/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/et/firefox-85.0b2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "7a2e1078ff1a3bb975baa5488f89e8161e20354d7f55b98c964efa5bfce6f696";
+      sha256 = "579bc62b32ea7805fdf5ca456c9343a40e0fbb1a2a040b8cbad7e70a54ab0172";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/eu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/eu/firefox-85.0b2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c635006a367f68bfabad7a3874f3333ac3f486f0001ca9641ac8ce12dd9bd01e";
+      sha256 = "6c3049d47d9c35f96eee579b5d790a2b651f4f126fcea41b2fb05eca1fe686ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fa/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/fa/firefox-85.0b2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "f897a5d316c436fc20d8c2737902e29dfd0ece3c9ffdb90fda2fa454ad398257";
+      sha256 = "33cca96a63f1f4a1598ab3c2daf4f758633d8be5316b8d1c194eca404f38d6f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ff/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ff/firefox-85.0b2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "3a31d43cb5242a0aec516d8fe99dc916144e8b7250b81c7de0b1361b19f067fa";
+      sha256 = "2c2151136438802148d7cf22253e9681b5076f6831271a149f76fecc3c5d1a18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/fi/firefox-85.0b2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "50261499bd4725f08684c9042056c9da2029f55b0dee4a856a9de661412c06e8";
+      sha256 = "ff96c7c1efea803822524ea5d47a25147d03547eb9e662bdeec42d30513f8a92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/fr/firefox-85.0b2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "7b793590a975a64b6fcfcccb4e6c07cd5346ec457af1ae31b5fb1032d4217c64";
+      sha256 = "e5679dc6f70a9d56604431e25954da2eb6592fefa6d6a99436b761ffc17dfc4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/fy-NL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/fy-NL/firefox-85.0b2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "468c7463503a34de44a74ff6a751e8614abbe6bd23f39f50308f23000614331e";
+      sha256 = "c1be73adad9145d881228cc0567d677f94380489dc6aae9b4ff707207eb3a24e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ga-IE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ga-IE/firefox-85.0b2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "92b49316d122c8c91995766e28387d5587955e022f844c7a85fe491ca602e222";
+      sha256 = "40a2f2e6eade53f32c9fea90e0945376e5f06a0b220815c124630f419f319ede";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gd/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/gd/firefox-85.0b2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "4bd2901b705f99bd1889b21f4af9ba7dd022f608960807f96f115a110c96a80a";
+      sha256 = "7fa079c7e79971914f425db4877489e8aeda145af2968d51adfed235036d4576";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/gl/firefox-85.0b2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "391d62de840d53d531130fef0018c71add0ef7134fbc758eb869da7c1cc3b5f3";
+      sha256 = "84d2b44fec8d9276b787eec99311384d83b626b3b9f75da2a725eeb50202ff81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/gn/firefox-85.0b2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "d51f75a7718e78bfb1e9d0974db0a404294e577e186794d3480778c7facce418";
+      sha256 = "b9b528eaccb7f081b9ff7c0bad618d96faa5dbca0f200d197b760f1185f8cb53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/gu-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/gu-IN/firefox-85.0b2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "7cbbf4846153f79fc72e217872fd64b92ed8968aaf618eeededa375ac268a12e";
+      sha256 = "5ffeb05e20bf3b4c2f89c4b81bc40656a943bd56687946ea10ca85308a8482d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/he/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/he/firefox-85.0b2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "44c0bfad535a4e3c225d948d87935e08e5d77ea22638e971cc833877462edc32";
+      sha256 = "62d8b9327c77aea9b0b3070c0b5f5c9e48ec90f9f95b7d001a8efdfbea2656d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hi-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/hi-IN/firefox-85.0b2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "fc64673429972967238b5bb101beb2117cfdb0360e405d4d3b53f013791c0b8c";
+      sha256 = "497c96a2b69e2890725ba8b8a464970bab77988a0ba8b2b88cab068c13a69cd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/hr/firefox-85.0b2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f256eb4e655a14b1a084af7f72ef4673d33b42d1c23ffc1ff3b4ede42d966246";
+      sha256 = "714e557e682e7a2a4bae5d457cb35c2e19273d613871b678bd2a8373f1e4a9b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/hsb/firefox-85.0b2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "9e1e478e501875ac259e22287aece77f1bbc1f898355ab1c29fa26543b38acbb";
+      sha256 = "94f4d2e8017fba63c8376e2d5daeceecf2bcfe0da1cbe5cf2422552faf6512b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/hu/firefox-85.0b2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "e8605e1b9d2c92c2eafa35cbe647bdda6af22eb030d8656262473b0b17650de9";
+      sha256 = "b7e0e33363de83462ebf94a9490f95ef7f088aa6dd665707e416772cbeed7de1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/hy-AM/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/hy-AM/firefox-85.0b2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "be21fea69e27ce54498b6b003c1db20b42d7d52702ac56d1a1fc2c6fc24558f1";
+      sha256 = "7e7fb17fccca63b9614c5077e1c8e2c82ea778efaad332375d38ecff602db9fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ia/firefox-85.0b2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "039f50fc10d95bdef4468174a8486f45bbf9313e1b9b6cecb0d094bb3766ca9c";
+      sha256 = "baee0674ebb53768a13b889976bb6dcc9fe76b799873f9c3064279a3231bbe6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/id/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/id/firefox-85.0b2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ecd6f3e031529e1fed8fb7ae77bf6e0497c9ad0e4996e31a86c4b79489ba9811";
+      sha256 = "d3c1e1e0bd774e1af092cc40c2b912a7d510e3c99944dd0810d6314d865d69cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/is/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/is/firefox-85.0b2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1f6fbf55f1384141826a4b6a39ec617cc798b0c0a0e1ee02d6cd65a79d6784a9";
+      sha256 = "4d8260ea95a026246dfd3da112fa1911ff52456656ec5f2896e8f6a5bdc510ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/it/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/it/firefox-85.0b2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "73eebb1d351b5d746d3447c7a68d7a906c4db6df8cd257c6a048ea16cf908e64";
+      sha256 = "7f922294874c4a5876d8131572a93a9669b0f20b4381e7f6b82d5413b6fe6f5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ja/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ja/firefox-85.0b2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ff1c630c6c41cd31c8ecab5fc48e8879dbc4aa295492368cae93061de6558b64";
+      sha256 = "8a92ecb5b8f62ecc4c64ca566071a3ca42cf9338f5ada718f196f63d0972cc79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ka/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ka/firefox-85.0b2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "b6976def40cfd05543b70597347ea7c632c591660a2dd08332f81411a6ce6723";
+      sha256 = "35c4b28506f026a2c3beaff67db693aff09fa197e5c158056ac9419804b05aee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/kab/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/kab/firefox-85.0b2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "403bd985ff7ab44324d12c8c7f1386eec9fbae97ac9a0597d12d09d387686db4";
+      sha256 = "34db7140b10611dafa089ff930215eff8ff521b14542d742edb5af6ff710bafe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/kk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/kk/firefox-85.0b2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "3860b0e8d53655669afcb4bece7637e9a1c0daa66d453e9548b2336eb45d94ad";
+      sha256 = "67ebfa76f660e6beeba6d4190f20503f88397e8e5730736f2416b5a91639d69d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/km/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/km/firefox-85.0b2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "5753474371c7b8663d45f7f9591958afb9e9e2777df3e89840f6f34894ddf491";
+      sha256 = "3d0c6a8a3387454f1d0fd0d99c19176085088a413ba11be59660ff2622bf957d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/kn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/kn/firefox-85.0b2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "d0dbeceacf93c3a581cc581e09507e401636350b763c8c9f5342b33a0640bd8e";
+      sha256 = "73e01f0f6e28b29d49c1b2025af3ef188252afd7bfc5b38ae3bb4c29dc1f5158";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ko/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ko/firefox-85.0b2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "095930063eae8e3d6a78a6d9adb3d28cff0bb0c9ccdec977c8c80765a4c60560";
+      sha256 = "471ffd1d4950a1b2dfceaf91ff538f6582b3c21be89b5bce4f7605cc3102cc42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/lij/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/lij/firefox-85.0b2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "587bced8e4480eba25e8597ab6b838a4f18553dd44b4f0ff48f245406f78e896";
+      sha256 = "11785be018c86839b225b9028d4cb9aad4bc86dd1dbeef0b26834e50bdb40797";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/lt/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/lt/firefox-85.0b2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "e214c23914e05152973428f5ed1df20054df054848d99ff23e5eb09e19b4557c";
+      sha256 = "868bdf38c6e26286db62df32475ec8a521574899ea23eb8f12d543ab1d74df6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/lv/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/lv/firefox-85.0b2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "67657d4abb394ef76d37c321625d99dcf228ee00cc109e6d1c80cb3659db9879";
+      sha256 = "83b2e75858d984ea450c3b8867da0d7bd4321a139fe7cdd7fe968e83c3567588";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/mk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/mk/firefox-85.0b2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "bac0e98b7a68dda441195cbebcdbea583f104188112449b14723c1086c3c4f19";
+      sha256 = "4b09567527422259087d69d78d55cf1310daaf6000fa6303b9dc0f1ad8f504df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/mr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/mr/firefox-85.0b2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "125a63c875f4be6e246fa01289386295172d999e0e523c1171578adea24b022e";
+      sha256 = "68cf8cbec32be8571efb0bf8b9eec9e33f08e78985a68328748af6ca46f3b1a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ms/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ms/firefox-85.0b2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "6dc44f34449c915e93bf9c012ce7286b16d6418ca8f576d8a008b7ceb90bcb13";
+      sha256 = "729642b22529b9b6caed5089fa6fdcfe7a05f0e50c898b816a01ee358012b2f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/my/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/my/firefox-85.0b2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "af5e2f1f9dcca84f41d3701035a00fc6b581aee2bf00f9f926928b99ab42d06e";
+      sha256 = "2de61bfd5e438099f5a263eb8c5d22d675562843ee000cf023fc602ef8f6d623";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/nb-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/nb-NO/firefox-85.0b2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d168631cc1518e17cc9cd85f481f1047f6ae7df593d9197de5710fca0d87965b";
+      sha256 = "4f96948cd2b2887a413b0ce1ed7815e502db1b26499ea6ad6f2d8a05db803b25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ne-NP/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ne-NP/firefox-85.0b2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "4b6065882ddd9e02441eff830808b31e6104d076cefed8386cff4ec7cb12330a";
+      sha256 = "47b9c401d432002b457d9bd55f6558383870b8d976fe0a2e885610b9cb03a7f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/nl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/nl/firefox-85.0b2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "96298283a2dbd9e3242c27551ee29829b21c8b9a32ca33b85da3142c47084dd5";
+      sha256 = "d8cf656041406c15f54da4df8989b956c92837a3b17df08c071f43d8183e0cb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/nn-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/nn-NO/firefox-85.0b2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "19475301d3d93a633a1555b4436d63546a71160a992daa760a8c76a808791b89";
+      sha256 = "81e4789c887a07fc00428d9af00b3552c5fbf22beeec31f7839e72c96f0aa60c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/oc/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/oc/firefox-85.0b2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "48af4af195173b541d76bb623acc357c3a2a8d03227406a21de89ab2d6c8c757";
+      sha256 = "4650fe41db72f2fd6317cb35980356149610180e00ad8c79e6f7203852a42649";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pa-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/pa-IN/firefox-85.0b2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "582ec12fbe2f8b07f8f4ae11ddf05c62db2d84508ee63ad6bfead9493a1424cc";
+      sha256 = "a50c61b670b011651f61c0d36f87180ddc75686f7a125e7a6a4da05208801bb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/pl/firefox-85.0b2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "df8fcb5fe32325d45fbc1c9349065cd2d7f283e6a33d944282f3ed948c1174ee";
+      sha256 = "b808e322fc60b7efaea73728e5f58292e3764f1ef22f47298b7dab2e2b2fe689";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pt-BR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/pt-BR/firefox-85.0b2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "fa48bc301c9b7dac4802b50980c573039648eb41bf0c0fb3ef75d0ba1dce9b67";
+      sha256 = "323f5083225046500a368f86dad5581eb1d08078db5f0cbcf789da7fde2ea872";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/pt-PT/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/pt-PT/firefox-85.0b2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b0075346738d9a5f61fe4c3265c3a50f639f017551d3bdb2479e622d9561bd33";
+      sha256 = "0e59076c66d290d98b315451a3170a9d7ee9cda1285ae5bf2a59f9300be5749f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/rm/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/rm/firefox-85.0b2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c9ad20ff328c8c0693cab58fbfb1d6c1f85bb63fdd20eb8d371e82d4df5c2e50";
+      sha256 = "1b01c79a9c7601816dbeca84e7eb66d2d9240e883e4379d132efff2adc71eec5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ro/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ro/firefox-85.0b2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "7816302b6f70c0e24b848d3d396876ee0d870d90561c37e440bb8b7722f54ff2";
+      sha256 = "92e49c4dc22795b8f71a74e673f9c1713c182cb80c3811898c132c532d600a6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ru/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ru/firefox-85.0b2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "8f4969a16f4e70b59dd2da78b73532ff39589c984512d16fcd7106d2cf503342";
+      sha256 = "82826401517e04b61ce8728496dafe2314560736cd5737202edf20353fa443fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/si/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/si/firefox-85.0b2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "0dfc4c1c797366ac9e65489b07de756a1b03b5498c9e4a6a10ac0d3a60345471";
+      sha256 = "dc7fdcf680ab7aa71a9f06681ca35d521118cb9a9b07897ee28086f399bd5ef1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/sk/firefox-85.0b2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5e16b451058d64ea0cb61fa92e17fd72e591009803170b0b220237cac7180167";
+      sha256 = "f4af1988166e39ecb93b0a2b2b2ca8473764d33217ec976f60a320277ec950c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/sl/firefox-85.0b2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "36216a3b474d3fd1d27886495f92eca83d24a465690efe7356ca9e7e4c08163d";
+      sha256 = "22b192c317d9cdf7744f04636cf1534f940244d8db491ccc127f0486ce254868";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/son/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/son/firefox-85.0b2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "1116bbb70b7ff8538d3ce4e7df190bd152c98889d1612fa8485cb0197a83868c";
+      sha256 = "73ca06a27c14ca81b2c102503fe4e4a00b39b41800d774387f64a4e29d82e709";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sq/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/sq/firefox-85.0b2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "006948f771f4964f5f4f078615cbb85aee23051e371ff7b871caee7c4659fe64";
+      sha256 = "61783c5a14d81ac3aee9d354a8259347d5dcf2f14306a23cf6a89d852527c7d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/sr/firefox-85.0b2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "20b0b9d605603e525d046424d290e6b2a0c963c0eae2a9a6c6ccdb72a9803e9e";
+      sha256 = "2972079539e598fa558bb52237e7ccea45d7faba5e64dc26747e5e100f69a833";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/sv-SE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/sv-SE/firefox-85.0b2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a132b97019c75aa8929830f873974e1ab36b69ca7e3c9ab44dd2a5b11bbe4f7f";
+      sha256 = "4ccf2fe7e32204184b2a643a780444bd60419b39f6611466dae2572ecd34b4b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ta/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ta/firefox-85.0b2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "3f24d965ee5c89edd447e8a52a0241a5d1cedb0aae6ed1ad1c212ba4dbed210a";
+      sha256 = "3cb1bc787c91a8fb583472429151c7f5eb1bf53c9614f44632a69a06e75dd3f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/te/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/te/firefox-85.0b2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "2b65c7bb7df93b2bdffa687bd4309352f0d73ecdd66767db0db860f33f17c6a6";
+      sha256 = "e197f97e88c40955e422cde9cf86109b3030ac2c826495e110b925636c9df59f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/th/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/th/firefox-85.0b2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "21e2dca4e194a38de97b9b717150441bdd32466ee43e721f41afde004bc8e3e2";
+      sha256 = "b9ad4d253cb8f4169acdf25eb1a1178441c7d0f8df20294fa256fe37d7abf29f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/tl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/tl/firefox-85.0b2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "9f4dc351f5244b0837a95d4afbfa0af373fe056e5eb106a2b177a57ba4c85ee7";
+      sha256 = "b4ffaff8a4bd5dde81adc027935b5ea85877c997085d4f64635d1f657f294d69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/tr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/tr/firefox-85.0b2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "50cabe6fea43e2212d0b0a9a5a382e085fdabc3ff6b6b0694b8f9d3d327c3ffc";
+      sha256 = "0fa4e91de70badb0dceef368bea48c2ed7a0ff201e4abcc74597a220bb29b481";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/trs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/trs/firefox-85.0b2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "c4db90a9a0677430fa591cc387bf1255f260208a4907cb760649cd7a6db03808";
+      sha256 = "e1f46d6ac7beff9048c3844379b3b375b3f1cd78f4464e70822194d6febb9ebe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/uk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/uk/firefox-85.0b2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "7c92d619dd827a9f7ef9297f784cff582aba44684dca91c3b9873337b4318fb3";
+      sha256 = "84bfa5825e4cd047d577ec5ec73c9c21ba356f10254b64cdd30259946744f184";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/ur/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/ur/firefox-85.0b2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ef46130577072c6fe6b14aa0710c75344dea46124093f483db47cbc8c9cb4ec6";
+      sha256 = "bd254f994c6fb977154dfcabe6038d851cd00903ed12b376bc33e858e1aa4d8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/uz/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/uz/firefox-85.0b2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "34c28440a7772a7fcf7f920be760f92057d813648372fe7cb8ae9f2c3fb3a846";
+      sha256 = "54cf0f273950124152ec3e980e1d0a0fb84d2a4fab0660677636d1e46868c714";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/vi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/vi/firefox-85.0b2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "c02c1737b56e1ae4f20ffa9abd392fb69f19d68348341977d0f39bfefab465b6";
+      sha256 = "1af267979115d152f8282495de9e9280aae4d85ce1148a287b45c390bcc25bd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/xh/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/xh/firefox-85.0b2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "6be6defb443480c536639d99d124d8c636d70f049f126a793d627c131035c9c2";
+      sha256 = "0dd914e24a2e42dfc424ce1d2257e6439e676f9f6a658c4e87b24c48c6fc4bc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/zh-CN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/zh-CN/firefox-85.0b2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "454af78f3ea4aa00676c4b97dff278dd404116e1da7993b5a2593167d11db885";
+      sha256 = "9e6b05b2897011b6e9c5c93c3f1117c4ef4955042ee05d40533809a20e5843de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0b4/linux-i686/zh-TW/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b2/linux-i686/zh-TW/firefox-85.0b2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7e6b1b0ad56916759b01df06b23bb6a23b0c59815538cb1edb3e95edf7b772d7";
+      sha256 = "112263f15ebc4f6a7f8a79113f2f43c61ef402f6037700112143f1b3bf6a3516";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "83.0";
+  version = "84.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ach/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ach/firefox-84.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "cea6ad61bd402e6c84a81a3f504f1b9292079c9d48d2353b51db4f03a8837fb6";
+      sha256 = "12a2a0c416d491a867c3c68d2dec4efde37d1e21b50512971527d491dd173d21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/af/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/af/firefox-84.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "d4bd0a9579f38d53f559412cc3cc04f11871ba22c81eee54dd9ab16c56303513";
+      sha256 = "73ac394e073b3964befef66a3a82a09f9904ed36b4de2d12d21600feba5ac1ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/an/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/an/firefox-84.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "10741a6921210643250013c45e9e21bc295da8e41f2bb5c5fadcd86c0e828c80";
+      sha256 = "5b8208b477ae3590311bef51cdbb8c5b786e3d943316760cc4ece3d27ebbc4a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ar/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ar/firefox-84.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "3fd4aeef281e5aafdda572d4814e70295c018b7fae6d214c40dabcac367ace69";
+      sha256 = "d53c3899a160d0381339d2e30bff8060961cc2db64cdfdc90af091c4d375cdba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ast/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ast/firefox-84.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "237e8ff5b3fbc9d7c4095951ca014a5c26cc076305aee705ca943d81e72541dd";
+      sha256 = "78d159ee9c969c2b7acd9a42695695477fcd2ef958a3a4397e03662fe7422150";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/az/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/az/firefox-84.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "79ca0c798243841cc34281f917aad06c2f546a5e11b443a96e5030aefb8de9b3";
+      sha256 = "2c625c4b1ed1413f9ffa399d84a73fbd99bd1c4650d786429f6b9ca9fb38cd81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/be/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/be/firefox-84.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "c15b0f929b3e3c6ad5618ccf6f9f6b143f893b6f77e176b52ecc608ca3157ab8";
+      sha256 = "c6cf89add52fccb933fcb9544b286b31a42d6af4f556a84bc81de721053f024d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/bg/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/bg/firefox-84.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "fd2094c59a057e8c35054f7d09c31699aeef927cf9688a87559a8ba69a93f600";
+      sha256 = "eb0a8986c13e375cd834800686a94d52548df451d81d774377890a5b1e286411";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/bn/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/bn/firefox-84.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "c9755c408ca1a4f426f1432339020ef3d7c675d426fae9d8697cded4c7d493f4";
+      sha256 = "8f2baed5e81aeb9ecc579e9f4450a71c7dca13c869c8c39064bb900049884308";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/br/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/br/firefox-84.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "d47b889d31b945a5b768b3bbb336fdc43d62c9cc86f13916225cbfe68a560972";
+      sha256 = "cfdab10e0f57bdcd37d7749ee379cc9a2f31552c67312cf63858fcde31b39b42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/bs/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/bs/firefox-84.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "c36da445560b989ae9cf16a1ec72cd2cae82db670f90d27abe0499f8cc025eee";
+      sha256 = "1739b138e23fe56eb6ba8748f89adbc24673552ab0916250441af8e2a613fff6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ca-valencia/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ca-valencia/firefox-84.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "ef5ee80cc0d6b1b299bc8bb6577b8e26f5de8b541530ddda231e2fafa863e6a1";
+      sha256 = "7cc19e90635c1cfb723be27b9917f35b64136afcdc1ef1d9359565af4bbb19d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ca/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ca/firefox-84.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7c349aa7406899835bc9e70893f28c8109e17ee9ef018e7a723085117f8dd32f";
+      sha256 = "833334e585193387b45f087ecb7b034ca81ebebb649539db13e39b4276b3e65f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/cak/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/cak/firefox-84.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3e7aabe665ce423bd47e7d0474039d7bfeb9958849c18e98c37f28def5fae1aa";
+      sha256 = "d4fdda0de3a95d7f4b7774da21af960b40b49c2dc5a85e1b234f7efec8f942de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/cs/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/cs/firefox-84.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "97d5e4c255fc87430751c81edc62186e1b4ec901ccf17bfdad7a8ef918077bc1";
+      sha256 = "0a1887ed3fe2e325836c4592f830a95e11d6022f4156b0af6b525000847394d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/cy/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/cy/firefox-84.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "c1856b51dedc5788b40671faee8f8cb996108eb514d1263de998043377f2f7c2";
+      sha256 = "fb6ba5719cf4a3405b75b58331d07d00c309fd88a5a54df77da006c6724d06fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/da/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/da/firefox-84.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "990da1f47d04ec9200d41fa401b23d9607a8e4c11d7cc78989e81785b9633cb0";
+      sha256 = "e2eed6ac1be7a1b21027325439e59459780fe549075051f83b27e418a0c52264";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/de/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/de/firefox-84.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "94ad875d88a18f24ae38f20b324d074a367969368e660ea2b4b0645e31300c94";
+      sha256 = "5789b1e6ba14a36c8c08247d123d062e5e6bb448b54d786089a7f5bed5e96eba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/dsb/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/dsb/firefox-84.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "c3edd46c44bae1b00803e587e6f52560b28ddc2fc935c1fe62714bf16fa72d80";
+      sha256 = "c70c169c917a3d910e824430cc1cbc0316a0f474f6f77aea873213a6d810a806";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/el/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/el/firefox-84.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "3572a260ec17f76631ca627747ed53d1911ee1180d3e574051b3baf0afd9dcd1";
+      sha256 = "d64d5b2ec25e4b5901a195c45dcbe6c979e50fdaac1121af2b309f8942ed5603";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/en-CA/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/en-CA/firefox-84.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e3c9363e8b93c625234624ac5c3ab0274055c5b8f4f854da955409b9bdf28d52";
+      sha256 = "dddfc08d2e2966adb9a613d48fe505052e326402055c09372b73cf4cf91482f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/en-GB/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/en-GB/firefox-84.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "240a732c034bf2ac286cefc33b02b56df205c4e175457cd84adb7666418e0be4";
+      sha256 = "74db586969ebad002996154ad983f58d38918089a89c370aa8822e4657fcac75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/en-US/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/en-US/firefox-84.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "93ff827fdcba92ddb71851c46ac8192a727ed61402e896c6262943e382f92412";
+      sha256 = "601e5a9a12ce680ecd82177c7887dae008d8f33690da43be1a690b76563cd992";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/eo/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/eo/firefox-84.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "456933a6c1fb1e6ad5b2217a7e3730bd54ff037d3d718414b2c92557fea3659d";
+      sha256 = "b67ef713a518415e7e03f5b11162ef8e950604aa0d6741be41d6bf4580111311";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-AR/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/es-AR/firefox-84.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "040e8a4a74b8bc77e1d485c3376690f4c5ba85015b360f679ceacd848b0ca574";
+      sha256 = "a52880fea1c8c2364c680c1e09bdd355600c3468d61089ba7908cd5cb6dd9fd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-CL/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/es-CL/firefox-84.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "80e8189ce09c736af1d9927d4943e08e30bc70e9aa7e116f150f14c0dab3fb15";
+      sha256 = "ef31a73e08e53fa5d257d9243e2b3bec36df93bdcc6a6776e531a36cde7fd2d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-ES/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/es-ES/firefox-84.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "f48489abac5358a10d8ed36b77398493b6a9189a8327bf61bec6ceaca51ab696";
+      sha256 = "e5303528ea8d84dbf805db38a337a76fbfc50aae454f54272ba87539dc81511b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/es-MX/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/es-MX/firefox-84.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "0d4805b30f05fb8a65b81a42337a8a3732c7664b322557e844929d2b049d0111";
+      sha256 = "64e93de2fb59f95f0eea6f5a85ea4bd78a5a150c26b9c513b8c20318900419de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/et/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/et/firefox-84.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "eb4a463b9271fdde45bddad28ce871953739b55126ae5613963a69a319908fb2";
+      sha256 = "02aab2612552c42f584fa627a2d739729cf1f599c3383970130205253c499047";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/eu/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/eu/firefox-84.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3a662c575554d3a542e65950352c527cc51e82ae7a8f9d7ca1b69e30a683731e";
+      sha256 = "e7f14e47edd2c7b6b712f0dc35454d42760f1f4e8b8994416d3d2a75a7ade6ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fa/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/fa/firefox-84.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "b5ad3a5d39674d60b6e97cd656c77d7d2fb90943a66a590a29e4d42ec1e18c42";
+      sha256 = "b9b9ecdcec2ba0ae689541a8f568356c0026859058e4bbe93dff74b1ddde1a3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ff/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ff/firefox-84.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2db83d638474186f52fde5fe1ee25201e84b198e44397074203d7ce50e23e74c";
+      sha256 = "59e158fd6fb66de985bc956538116e00c15b2044ec7d2f7a74477d5fa1771e3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fi/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/fi/firefox-84.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "98bd9c50b5db43bf5fcdc829aa295975d3ec106bbc598fda3d7f26679c0ba08c";
+      sha256 = "fa3ca0125e271798bec62c213485a6b84ee3a0e0f072c39b04002b9d44c2337c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/fr/firefox-84.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ab3427f5cf7cc88d5108b8be21806197420bd775f33d3f2dc983f0f4dec44d5b";
+      sha256 = "e85a694d66eff7679f0e19593508f6e273f8bdbe7491df78deececff2368ec21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/fy-NL/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/fy-NL/firefox-84.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9f21d91d1529a05a2da7ba29cc8e875b23ffb4b453077b5e899133cf31813397";
+      sha256 = "e38f39ca5b60e3569d63377c9b416323e03a79245b722e3ca42e8d817e9a51fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ga-IE/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ga-IE/firefox-84.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "4c22b166cccede0bcea4e75f826e100dfa4f2def01f904fbffcef789d2d61695";
+      sha256 = "4dfcaedece96eb802c83cc23801bf3999fa9e42bc1ad2d5dd1a180386cc79823";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gd/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/gd/firefox-84.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6ca04d381205121dc695dff78ff646499a21976ae64c110763845eda0598b414";
+      sha256 = "0249ff8660779e95ae356d0cce85067ead2160701d3a1ba4660651ed5f9524f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/gl/firefox-84.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d08f4ea821af5e38c21364037c17b8c97c775d60f0697eb0817dcfc7c6d4c7dd";
+      sha256 = "0aca9ad329c4a748cf9e093d5b931b228b003f09aa53cd041430afc1ada7ecad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gn/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/gn/firefox-84.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "90a8b2fdf1d3471311671761e81637d6771a61744eb480c0788cf03d295c30ee";
+      sha256 = "cb911f23f0e805537ce71f657b1f086d833bb2055152fed15b2975034b5209b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/gu-IN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/gu-IN/firefox-84.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "bfe65e5c9795ecdff4dc947d2e2e84d01da894b0ae55c08d73f9397c5730ce17";
+      sha256 = "d611bbec579ae153b65c6c5c371aadea7c97a5c814576f59853e8fa0aee05075";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/he/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/he/firefox-84.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "2dc01c5a929aa79056a66feb522d50cbbb567bc85589f8106e553c9ddfc02a7c";
+      sha256 = "cb52716e4c1ae8c35e054b6475bd33eabc9b6672073f751b57f1ad38d546522a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hi-IN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/hi-IN/firefox-84.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "ef2a61dce3ee713a4be3cee5a9dda8498095a7db69304a7d6585ac674970958a";
+      sha256 = "1cbc946e6d0073768fa066f985bf8eda377121714c8cfa09c9dff1f2a02a3b77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/hr/firefox-84.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "ab8357cc1f36965ccbd6f4298ffdbb3d77b09cc4b789a3be708d2c51468402bd";
+      sha256 = "dc08dfe6ea67009d12347512e9fe398b86bc699621f1c55d352ea3fca00a81af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hsb/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/hsb/firefox-84.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6a34074a96be7911672b7e83151244f1f963a8cc8930c8d1d113afe8a49c9529";
+      sha256 = "cfa4a0905b61efe3ff4a808c994e1e062620bee907ed6af7489114d4a1cdb80f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hu/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/hu/firefox-84.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ffec1646df872a757b771a03c00e3e6df3397e7f4af46bd1d6c0fcab242b1721";
+      sha256 = "81da1cba517a80cfd4ebf6bee95f88801192cfaee864a420af03c8bc96a882cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/hy-AM/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/hy-AM/firefox-84.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1b9da538ced466302584fef4ecf415aeae5bee51a87d38bd0a6bb3ea155af66d";
+      sha256 = "1a2b4703b2b186c24c82a6264a95d7555fb0e33d4f057fdcf7664b7f8f386f88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ia/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ia/firefox-84.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5f8582508155f858c7e52e623579daa7da1aa77bb4e41c2c46d3e6ae8ace6b1e";
+      sha256 = "67b1effbe9ad34e4e41bc42bcc6745ef4bcf40410913603e687e7ab97d093150";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/id/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/id/firefox-84.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e5690dcc6b933ddbd27fcfb22f8ab9fc4e4c999d935b6088da38c87af2c567d1";
+      sha256 = "718ed11d1ecd4d04ba53fbba85ba77c06156e4d2db29d53a1e6724139d72643a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/is/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/is/firefox-84.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "3776fe6aad623e9b74807a48e105d1619143e78e122906360c4efbc73c2891ee";
+      sha256 = "21cb12e80c51180741a97f1dddefcd8d2568fc820841ff79d47946c6a89d4968";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/it/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/it/firefox-84.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "eb54c4596602150c619db6d0d5572a59f7d9c4def68a34cb874cbc6535939e2a";
+      sha256 = "7717b32c7cb4528a205748f239dc0a14a53cb88562978ccfe38b4aac8eab4187";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ja/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ja/firefox-84.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "54b70bef0507611ad1ea7560668b46385661b5275c7a0ecaad723db44fd8af88";
+      sha256 = "9523b9e9738c62a7088eddd4424c9a2a435bd57ed96913713460e413c2291e14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ka/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ka/firefox-84.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "56e72349133297d61dfdec4933a01c2cd8fa3d0da3d784e0598506c2db05938c";
+      sha256 = "a9cfa1ff040471ebec43962486482bd103697a37cd73589dd3447501f22ba24c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/kab/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/kab/firefox-84.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "45f554342449405990c84e910dc6436489046acd00fdc4a0ddabb4b28d7c1284";
+      sha256 = "43bc7f3395d69df38b302eb4536333f913160b479bef4e44dc5419de58621107";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/kk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/kk/firefox-84.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "3463c4ea5df4e072dfca22e8983fdc016adbe2326bf186a0168ea9ee2c36b3bd";
+      sha256 = "6c440f99e31ec9e62a51f44387e6a37316e1f9a89bbfe7d172aa9ba063db0d8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/km/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/km/firefox-84.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "3bb7d2c3e5278d9c51b87d8140096ae01532e99160b866164d1920fb012c085c";
+      sha256 = "f1ade955303019e8bdccdfc8066a0490b76ce72c94cf5a587eb7ebc799a8aa1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/kn/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/kn/firefox-84.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "c9086912382dbff66045c79130403385b9f075bf782220aeb84f03f62a563638";
+      sha256 = "09c4819813e8b343e5abee96623c3da4cc932263a9ce58dab072a26282dcd70b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ko/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ko/firefox-84.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "6f70169cd58ee1559ab224c3ea6f5309bf75267d9f315e389b7971e8e1feed09";
+      sha256 = "7d4681545929bbc3d8946d554475d2a90a3ec1a96a6eba94996aacc3e04e03fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/lij/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/lij/firefox-84.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "0b089e6f7954f4d99e9e59bd25148c4be620f9486f8d36c3db68fec5ea700d94";
+      sha256 = "a7f7e4aa713c295f7e7e5d4e42e5c5b65d497a1d2dfc5726b0b6e8286033fd9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/lt/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/lt/firefox-84.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "b76c545aad6e5b66bd8ab34bf02f7d4f69ecee348381b16c271f4de0243c660d";
+      sha256 = "9816a62da4f983b45402ec4ea0acef040559aa13d3118356f907356046cd67b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/lv/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/lv/firefox-84.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "8504d5c00c5569f008b2e308a9193cf62130e89a6e61b33fc842081e4d504322";
+      sha256 = "5084574d7d1d4b20b35ef239da626cb2d0468fbeb8bb137f66d473c225f73e89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/mk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/mk/firefox-84.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "636a421f6238de1fee37014c3af147220af6a1f3c04e2ce6ec9dd17898bc7c20";
+      sha256 = "f7aaa2c2d36e10f052ad0b39d4a436af312ba3d148588d53221c09e6516c041f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/mr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/mr/firefox-84.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "1e00d369be11ad8bfb2dda0ceeb3b7b516fd66427d9e85bff4cc1d699ff3659f";
+      sha256 = "4244dca771907b6ab91ac86cc30913dd255b1f4b0d71fc5c3e91ffdf4daa2e51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ms/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ms/firefox-84.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "0590f2bff7e43b9f6c081d57276299f8327df73415a8e2a2243e3c4ec9154200";
+      sha256 = "7707153b7e841979d77953442fb4d08ff9c7a2f654657747c1353aded880c4c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/my/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/my/firefox-84.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "ae43f0e8d4ff32274b25a1b78e0af44446ea6989edc4eb3c0d9fae36fcf80908";
+      sha256 = "4efd86100aebfe964d9425f8b58930da8779c58849e4c6590c8f3d03df45ac9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/nb-NO/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/nb-NO/firefox-84.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "9c3a74fc7670e2202be1f4f75208f0113c115169ef70614af631cf16879e081f";
+      sha256 = "b94bd5e53679f1fdff9ef8445bc5fcb94733c6986ad96f22d79ea2d8203caf0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ne-NP/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ne-NP/firefox-84.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "d830f802cccc7351a447fc59ed64562cac1521d281ddf218c84d1c9af8a65cb3";
+      sha256 = "331d3f46f36eb3c26eb8023dae89306e5148d0c14b3bca74d201e29a0099f3ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/nl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/nl/firefox-84.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "ecfd03850a48ebf7c3ec9400838100514826b8f35744b0167f61c9086893ae66";
+      sha256 = "3ff0b28ceb0ddf2bb3af0c89da193728fa765f6b23429b77f8bc7b02f34092f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/nn-NO/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/nn-NO/firefox-84.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "ad0e4a89afabf1929d441129066dfcbf532d37da31c76bc79108d123cf5cc649";
+      sha256 = "8f55248fbf565462e69116884237f242c3dd09c6a15627d8081720b85492f5de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/oc/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/oc/firefox-84.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "9b9bbba334c4d7d3907f55a6647cecdf0bb2cd6294569a0008d866cd6eb70a35";
+      sha256 = "9d6eae0d5097a5bcbb1c00345ff0420f269c54b2941dfb6c39d31ac690f2b88f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pa-IN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/pa-IN/firefox-84.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "083266958874618042ee8f2a6162184cd71bc725a994aeb68158d59edb0cafaa";
+      sha256 = "9a8bcf68808292eb8af5948be605e430d4891dcbb31b4bbfaaa4ed9e554b1766";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/pl/firefox-84.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "cb7c72fdc91cd9269a2e53725a26ee94db0e2e608a60ff1120fbe5c1627814bf";
+      sha256 = "fa065ac8620b29ae362f9def816662fb7dd350a0c77a65acedfe82ec2ffd35c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pt-BR/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/pt-BR/firefox-84.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "a2a188a222fc6054ca59d24370528e8c8d4d7dc8e4ab18f71510b415dde73d05";
+      sha256 = "0f671b31c2a2696dcd0673c65740b57032c1bdc2d2d28269453b015a546e724b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/pt-PT/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/pt-PT/firefox-84.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "528e1893438ead94afd4013d3c4f4f51107a5d0c4b6d6e018a0687f0d25f9e53";
+      sha256 = "12918be45174c8224458cc46e4e8a2a0ba8ba67b971359378a9f93ddd2b025f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/rm/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/rm/firefox-84.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "e4d6e53b642da4de5c7f30297c6fec22b37921a55cb744962dc0d60e26812549";
+      sha256 = "ca71913a9f69ac64fd3a1b9409b631e3497ef26b6e153408466ca9a808405a0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ro/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ro/firefox-84.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "04ffa3eda69ea0dfc6251564c4c6bc742d5f8e5dbaf6184b4ee9461226ce5c86";
+      sha256 = "c33e39f5ddb653ef70b1db606f18bd8f8af101a41d7cb175af856075cd1d558b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ru/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ru/firefox-84.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "697ddeb8ec024b5459492ebd652a612cfa1911267071b230f5ea6ac78a1e3075";
+      sha256 = "c5bd750a3c882edc312d7fe653c96e99d51184d3434fe188c305e8914bdd6219";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/si/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/si/firefox-84.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "a3256c648ea75ce36009306a3c039af228e645ea2e54361fe239ad0cf0869ead";
+      sha256 = "ef4218b55b49877fa432641fdfbbfacacbd90820e4ed67e084b5e5e53b2bda13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/sk/firefox-84.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "1ae0f898d34c74ea427228d93646ae47990834d14bc4f5563427409dba066f8d";
+      sha256 = "f4985f1d41a1a7577ebd804f10183c7e63e6db08eaa9971e91f5944a942f14b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/sl/firefox-84.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9e14b4ad7bd9a8026074e0a3da3d3ba74dbb1be31a2e9cae787802d090c7a965";
+      sha256 = "66c1436489bb92900d8e93750ca876753cd663de141acedfbb00bdfef4a09e6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/son/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/son/firefox-84.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "1b928ca974133a346950ffc663fbed9d1876a4c0bca53fd807d8077d031531d5";
+      sha256 = "fbcd98f61bd42e7ce8f73680efb4cac59062133f1242a0fff1e3bbf1335a7279";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sq/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/sq/firefox-84.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7bb9bcfe490bf5d577e55e9b612c932c93ac58252cef592b2af39c17987e700b";
+      sha256 = "5078f10233331aa3ab0a0a79a68b62c4a3059c863620a854341debf477739ea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/sr/firefox-84.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "90e496a5fe9c5d8c38dfcf5a1a07ea04be983fe78c68cb13a2b99067b0f02e7a";
+      sha256 = "22d31d3d7e0a97f8cbbab543aea767214fb135f6212e6c1d4dcf430e3c24dfc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/sv-SE/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/sv-SE/firefox-84.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "eab8a1e51a90d36b58901db6175e724f38afb91270b05c51a93c03f8c51fe432";
+      sha256 = "f1f7f281b99ab9db28315e4c99c8e7c6c1d0832abf48b555c1076aa39ad3af15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ta/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ta/firefox-84.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "bb6d49500393d20134a6f749a77de1fc4cae2feba4e49261862f8a634b4b9276";
+      sha256 = "0244fb189fd965bf5dd83c22cf8589f26f20b11e4eddd2c2bad9e419ae0d303d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/te/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/te/firefox-84.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a1104e292f949976e423b587fe9728fc741b7a11e276e7d747afd3a93abe3eb5";
+      sha256 = "1dc3959508233378ac2924ff4ec313569b1b5f6532bda09fe7d57164735a9bfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/th/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/th/firefox-84.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "403e4a86b5f95cb22cdb2100372c55d92fcb4708e3f719da72b643637c711458";
+      sha256 = "544eeca7272347865ad794f23308e475bfe73b1fcabdbcdbdbc82aa15fa73a44";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/tl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/tl/firefox-84.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "993cf86a1b045a477fd4c683e503314fc2aea5a0a52f1faaacd18a0fdc5c7def";
+      sha256 = "cd10d90a650536f1469d86b8f1047d616846e415288f4d4c32c6273edbb7a327";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/tr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/tr/firefox-84.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "8e9e96d0b1a2014dc7374ea893fe72bc72f3840742d305a6e73417468dd6245b";
+      sha256 = "5cbad19746a07d2ce404d9a98a615a709827818de11f30ba7e3e6a29d1d22cd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/trs/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/trs/firefox-84.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "3590ebb4c888cf92ebd615df9eda2413fd0a3031293d68809fef74fc92fa759b";
+      sha256 = "c3067c7639dc6b054f7529e19a33d4de1e5384372d33a546b2a1f6c4d4d4858a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/uk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/uk/firefox-84.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7a3a2bae67ddd2afd2d6953f5f045a831595ea29e5cc6ad7083b8ac89e55917b";
+      sha256 = "0486b6d307fc90245b7a4329ed4180f242930ab2383471e4281fee6778f8e60b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/ur/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/ur/firefox-84.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "445a599ba623d8673d71f6ebde70c64a93e28e57b6859e325b0151240f1d49e5";
+      sha256 = "501c1f1c917198d481f37987073562194adba665a4454743955db182db9f321f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/uz/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/uz/firefox-84.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "b63e6c1c6afdc3694ee1d2b21175f4a5603c4454e43f0a08e87ccf800862b6bc";
+      sha256 = "04bef2a9b6762a04925b031c1821730ce14a34f36ccc50a2e16d1704910ff58c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/vi/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/vi/firefox-84.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "7127340d189ff601f96ba6f5e6a6175d850e822599e10762908d406b2174a256";
+      sha256 = "fc53827a4b14180bfb81d0ab59d6f89019b3b9decba5871aebcfba6b2efb031f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/xh/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/xh/firefox-84.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "41772e457eaf385230086a461033854ad214b4160c6f99f7eb6c4df8dd137dc5";
+      sha256 = "fb3a892bdb72a8542f24671d384b53e75c7fae7b96dddc368907c7c3df2f60f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/zh-CN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/zh-CN/firefox-84.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "013fe88aea216fbc4de9fdaaf559d65678ba389049bcff896540dae8d0a9564d";
+      sha256 = "9b45c70bdfce252ca018511d39f3f2c9fa45d75cc4e064c118523ab1d3b0f3b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-x86_64/zh-TW/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/zh-TW/firefox-84.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7e9eea2a326842f652aad4995f796af9550d03c034587d171e4b2a33da934645";
+      sha256 = "dabfb6ec2f8b55fbfdd86487d32ca7c0d207f1d403126bf1aef636b840347b13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ach/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ach/firefox-84.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "9974b19f4f15d9aa33b5432cceea05efe44f31c4123596aca9fb5cd3dd734152";
+      sha256 = "1451c261dac71047e39228744b132993fc70d65b9753f5b4d4ffbc9f944a2a22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/af/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/af/firefox-84.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "5600ad5fad398648d2e7a2d7bdf7901769fa428f9ef9f79046917133e12a7eb6";
+      sha256 = "a5cf4473eeb289781d7c7a29085109b6a4235b6e48bb1e1308d05288d9683453";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/an/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/an/firefox-84.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d8e0843dafcaf1b010773b83a665fd593741858b60aaba61d4c308a86f765146";
+      sha256 = "97147495e41f79afed553ca8f3e39405fc917e2ad73219a3e75f26995208f114";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ar/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ar/firefox-84.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "952b2ad360662341b9281cfdd93a141fe2efd16f73baa4fc4be1de7b8f12c8c3";
+      sha256 = "b50211de0a0e051828e38c2f4cd617029c5109534d3096a2aea6b2836fe47a02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ast/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ast/firefox-84.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "a7728b09f7e96983a031a32b1b938fa362e1a1e58722b37ec03a4048a152f0b1";
+      sha256 = "a36089aa9e4684cb473067a86f517f557525d5502c2943b0d77592b2f33cb8fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/az/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/az/firefox-84.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "c6019a3f7ef56583445acc5ab310770c937b44182a1bb3ed54ac452e6e19f8fc";
+      sha256 = "4166d192bfbf8293c14b65edae460a7c6037a6bed335e2966e3d565c0f0b0c2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/be/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/be/firefox-84.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "12ead04878e308682f04afb6ac9ce9ab134a5a542af328e029cd973c14fe7444";
+      sha256 = "5aec2961ff8b57ed09d4923da199ba2486ffc5e7b5f0ba7a2c7dcfd639e19c1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/bg/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/bg/firefox-84.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "7134539d5c259cdf6dd316205b857acae87730ca01bd6ef2efcca75f9d06d027";
+      sha256 = "fbbd60cbb4975a61f9e0d501490b3354afe5f4e65b1a550c441b11d2500f6bb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/bn/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/bn/firefox-84.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "a97524e0d6f6f61045b2573ac2fe98e31fa372429f5f53c25fb4cb4d32a31940";
+      sha256 = "2ec9330098ce5645443e8730425c9a913e45191d6ae496ab0cb19e6d5a172f15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/br/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/br/firefox-84.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "4619705703a6878fba4de4227d90143abb92237ba556a8c5f4a51c9701671821";
+      sha256 = "c847065e169dc3900105e681dc53c705caef8e182f1fd5d469964ba6dff57894";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/bs/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/bs/firefox-84.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "2131babd061761fa1119a536ae354145315875c5d8cd300405a35924bbbfcc34";
+      sha256 = "e4ed084ecc7f3d106b9757fff691fdec4c9469f06ed10d54ce7eb3c00437076e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ca-valencia/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ca-valencia/firefox-84.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "73238eb95ac828f4bc2ac220e4b953b950a75b88600b457bf3bd528245574cd8";
+      sha256 = "30eb8aed4ac3923df65eea78136237df12a9375ed92a6a2c3699059136730f11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ca/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ca/firefox-84.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "73e65093a587c89c9a392e3b65375ad2158c88e2905ab116eaf8da7cc5841cda";
+      sha256 = "edf2a0e3ec9165a1c77488f516c46a93663d15a5cb7100b43f0d2f4845453734";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/cak/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/cak/firefox-84.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "7f2dd3fdf1e0cae21a1517286b60bbbabd310dfc0dc18588fbe21ba671e97dd3";
+      sha256 = "769dc346360e41ed800981002fe85ee82fc11ddedc4ae6a578a3a45ffff38a11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/cs/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/cs/firefox-84.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "5f639cc6d14b06ae62f73fc01b909182efea32710dfd817be60499f4da3eafd7";
+      sha256 = "ad4b4bf00b730ce5c5a1cb5075ab4e3f83fca92bf1dc1bcd1c11823cbc3315f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/cy/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/cy/firefox-84.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "7a3e9921b2e6e407ebeeb22f1ac4b529222a1f5fbdc84c44fc902b8db6aeb1ef";
+      sha256 = "7653f67150699878208ef741ca7d6698e474760330f5f483d1328f92d9feccdc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/da/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/da/firefox-84.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "05dc3274927f692ec3c60f8353a30e2bcb1a36b54f4ddff90407e2818a497a38";
+      sha256 = "885d0e55a2d827e75b6bb49bc8e073dd1c954ff2d4cb22246bb3babff728f039";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/de/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/de/firefox-84.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c95affb4655b7a0ad6959651cf10090970035c74601ea141366cbb5d44f8a526";
+      sha256 = "6c12e40e26c13d55d1495da3f83eca9a83c800a0e71df96e9a99553c132c0a6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/dsb/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/dsb/firefox-84.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c9baf7df51fdebbb2521dd10830f759110a9c92dcdb579fad99d0c4112126e66";
+      sha256 = "bb6ab0d953ce4c9adf584373b6a04639b5e5fd027cdfcca1ad914b390dbf3993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/el/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/el/firefox-84.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "52afcd2037b9cda2c66975dd184276bcccca27833cd7a6da989e32c591a06060";
+      sha256 = "6c51226b866cc905c74c88b0414ca8143a5832935c1c931e0c3513ad979fd7db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/en-CA/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/en-CA/firefox-84.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "375d3a11f236560f06397f157209b1ce476197a0e7b327cf187dc2002d053c90";
+      sha256 = "900738c62147b8abe5974ed5b7ba04e079dfd8504b6a1ad60d8c560ec2191608";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/en-GB/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/en-GB/firefox-84.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "610657a623b5680c2ea350a5f3d1ec676e9dac8720e0e67b3e627e37a58b0ad6";
+      sha256 = "7a5de0be8c0a2697e0cb277af09575efd72fc86632527bdc45ddc2404b8728bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/en-US/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/en-US/firefox-84.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ac4df9d78ac0321f6be266e7fbf6b79d80bee7cfdf1b00c433072d2283c5fdf8";
+      sha256 = "011598d4ccaccf87b9dd655ca266805378d5fcfd87fd9213ae4d5be9dee56278";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/eo/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/eo/firefox-84.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "f23479cb30cf27fa368e9e04591aad2051eedde5e69d105bfc9ba6168792b44b";
+      sha256 = "acf6bf1cf7aa5635a07e6b58a4c70318cf4f915f8146afc928ca00e471c2cd61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-AR/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/es-AR/firefox-84.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5657636c105d301474cf5d2707733a35ac5f5687790002d5778dffb32a727adc";
+      sha256 = "cd3f40e85c558b247dce4c34c6cae58b92f37e1d77d8dbabb59a433d22e690d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-CL/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/es-CL/firefox-84.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "896f2ac45b98eccd487de64b6c5aa98733d97bd4422dd1a16d02883e3a06c132";
+      sha256 = "35e78b21ec7137b78a394fbb3d49f5ff0dec784aa19315459c7e5ecc6e7d3db0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-ES/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/es-ES/firefox-84.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "9d337fc821dae150c4f3ce26c427ad0efa22c53f3b311b4ce7693b33c9ea4d7d";
+      sha256 = "d13572cc97f21bfc447951def9a5be7df77ed55bd7d414cd16d5f5f5c605f67b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/es-MX/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/es-MX/firefox-84.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f9cbd03f9813157835ef7faf9fa2374e488144930ffdec765c370a95a9c72120";
+      sha256 = "d0e2cdb77cec5565e2f9f68046eeb237c1fd85e73187e10995cc317c1e9aaefd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/et/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/et/firefox-84.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "4f33cbb67003da1b4db4dc12ee2e7b9fe942bc6e6d770608361355ce7fcf8214";
+      sha256 = "4f074c663de7a0bd4883b600985d96da0191d387263332f8cf3282cd09ae47aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/eu/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/eu/firefox-84.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "31970c98d028a83a6198dcee9c5f8191343cd84ec6a7fa032a31730db2cc7b00";
+      sha256 = "dbd39da7c58abf53ad8545eaf5ea2b49f9ef6e372818e2bbb1d0403f78b9b31a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fa/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/fa/firefox-84.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1125c534f2067e57701fab7ae3df55c52dc10693b069817021072c74b8b9bdcf";
+      sha256 = "bf951d5a0dacccc4ca785ac665e979b44e4ae4909d26c5952710156cc7dd61df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ff/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ff/firefox-84.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "ef6c66b0d8a6edce0c982eaee55cd14a4ac4d365478976a0c4f1cd48a6c10c6d";
+      sha256 = "7b2910636e68419041989e196841820cdfd49cca79d39165f693be68a2000450";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fi/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/fi/firefox-84.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "bcd529c0227bd64403dc023ef91459556fbb186e072c12075b705d50293d86c3";
+      sha256 = "b4effa12c09d22d9dcab2c988eaeadec0336f0cc4c2d501899717bcd458f33a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/fr/firefox-84.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "47c56fe2b88054d97622e9c0ff2043323b7a916da1e11541e96cf7b05c3e7d52";
+      sha256 = "8080503687cead7ec1e54a8cea9bfa5785725f5cdad694864374b942c16b5b6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/fy-NL/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/fy-NL/firefox-84.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b0ed17e5022b0817d6b4f58ef990ce22774bde875151c60be1f7251ec90cb189";
+      sha256 = "c7bff7755f08df3d5b4f824710e69fd4823500f3bc9a58b536be7f86d518efd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ga-IE/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ga-IE/firefox-84.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "380aad276cadff8221e4f675751278ba994e08ddb46a0ebde12d87b741c23263";
+      sha256 = "4c5937b345de4e2461821c38d19cf719a65b9d801591f5e54278b7aa817af6ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gd/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/gd/firefox-84.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "0489ed6e1e9150a0facb4e6fb59bea7673e89669d167806d5651224b939fada5";
+      sha256 = "297e0a412f3ed31115533f523ceb23c0d856b4612654882ee44cb1a70d057165";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/gl/firefox-84.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "bc41c2b611ecb4ccdedbbf480138a3bc6326106d6c1641d6a06e40f502427af0";
+      sha256 = "bc6efc2884cc4af00bfc90261f8b05afd55ce755479c36aabc870ce427a0cff1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gn/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/gn/firefox-84.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "ade8fe9ab75b0a5f75ce80ba0f8065c4b4cbf54d7772f4c3be96886ca166b373";
+      sha256 = "a2942241c8d78ee123abda87a663868185f5b6bbe550f51807af3acee3c0c5fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/gu-IN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/gu-IN/firefox-84.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "bc20ad60eee0e6a3d532e436d9b62175872fcb27dab4c9a5083ed6f4bda5f036";
+      sha256 = "de8ad6a7b9907f163f405dc07ab6a288348ce8a0a1d51c9882b7ee4fb8d916ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/he/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/he/firefox-84.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "a08862d8ebdfa2d6c4f038b91f264c9abe873537d1a7cd2997a1eb4d73bf6f4c";
+      sha256 = "a202905c4b0a02beeecb4a6430c4f806c92d79cb07b143f3e56e043809f116e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hi-IN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/hi-IN/firefox-84.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "8ed5b454bdc38f07c79924a1dc08e76e65a48bd671991744a441693185683916";
+      sha256 = "d722f0afc8fc92876ddd98f680c14d6cb1ad10ab44c0d5c4b643eee5ca2db853";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/hr/firefox-84.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "97356a661d56d51a9210109db8ad75d61e3e00e4c7570d4e824712b52337af27";
+      sha256 = "3df6bfce880a925b29580626a9ba7f33e2186517055aa00d5b2e3a610845a36a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hsb/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/hsb/firefox-84.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "5706aa76b23161baf24b79d2b45dd706006fb73aeedd06f41f3273f8078f371b";
+      sha256 = "ca27b4d54ebf03df0c4a28ab6abf44d585e9ea9041a2d794c0f519cbce8d69bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hu/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/hu/firefox-84.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "3b894beaef35012df54ba4c7509a06ece1a0cdf741308b3510ddc702c4eb3656";
+      sha256 = "2b85490e099c161752400aa87006c7166bd1b959502110e6c76adf6af2288b0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/hy-AM/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/hy-AM/firefox-84.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "b2894092de59b7d6bd6dcd2111fa4591b1a4ed054fd107e2093bd0962edb4405";
+      sha256 = "459f6488de6c740b9bed48ea4f8f99804be0616e30993cd39e92b77f0eec6b18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ia/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ia/firefox-84.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "9d9ee7e05a02078b7d4041c3b63e79f91f0a888b919cf726e2e69090ff05f71d";
+      sha256 = "5cb034cf8835cf9d02e6b853b1fb81be587ebff8b6872fedcabd4d6a4ee19f82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/id/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/id/firefox-84.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "13e54589a23323e9043d4dac5586a31e5d43bdde0356b1a00a86f91ee5813eb2";
+      sha256 = "993d0893a1b429d9ce9203df35eb5d542396861b17e363525cd9c4f43f5168a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/is/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/is/firefox-84.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "955a8a4ff1c5ba7124593b3c8537201ffb1fe33ea5c3edd6ab30e80e6b28f60a";
+      sha256 = "f9db0f82c1caf4d6d00c00bf9c78cb546d32aea95f1807a12c7ce6d623df7b0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/it/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/it/firefox-84.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "23927419191d7aee8b29da29d213ee9c7ff39363f3fc9171c70d801158cb895b";
+      sha256 = "7f26ab3fa8f5972db64f03dfcde69477f73bf708f98a642347a56cb49c500cf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ja/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ja/firefox-84.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "4ffaf6df345922bcd82942956a0f344c4b52ac49ec64879fef7307a0c34eb8e9";
+      sha256 = "651a21c91413603c6d20d042f9cf196cb868ac491931f6910543b3dd02434d56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ka/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ka/firefox-84.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "df1027754efd054bae379b35228067799e75820b08ca7e6aff5a527fdaf046a8";
+      sha256 = "0328acc0fd12640bd8005bd0ef6c5db41907703b19429fe11d2e250406d019ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/kab/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/kab/firefox-84.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "6fc1e5d662ce742a48c003145b1b4b58cb296b43a20f718bdcffdc05e386078f";
+      sha256 = "708502d90ed114f9abd8d79170a6c803a14d13cb023f414f6cfd05c75bd41ffe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/kk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/kk/firefox-84.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "52cb3ac3a33da1227c3aa5e47e04620be2cc020bc520fcf013fe11ad74ad6378";
+      sha256 = "de2be2de243e74b8b76957e31f15f0e918f88f9b675ebcd6df29456c353451ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/km/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/km/firefox-84.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "c598fa97bb79f56d01afb30caeff29a2c7dd1f162d2fb49c0632ee259d0fe860";
+      sha256 = "47ce408cfd299b0cb29a59eed50f5fdfb3183f2e997c48a901e30a89560aa8d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/kn/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/kn/firefox-84.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "d6795f3f3c0978dbc399768fd824cceb6a3c1c883c153f65102ef476f74d6408";
+      sha256 = "8bfc11f38e69f1c59f02f79946e845a26a706ade17923b316bdee6aa55e807b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ko/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ko/firefox-84.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "b4d0b62cdfd332d8e9878b75918a0362a7b68db0b62e4e4508dfa176e79b8ed7";
+      sha256 = "35443f1184b83a5d6801c1c6694ae6ee45d7ccab2b3bd1385339c3c25c991f9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/lij/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/lij/firefox-84.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "257eec8bead076119b0c3679feb4f3de34c9cf66bd05215e7d76936e6d3ce052";
+      sha256 = "275e09a16c19cfa9aaf4b3edbde22ae22b374fec881163f6f656470d626c4e15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/lt/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/lt/firefox-84.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "326925d68306ec6e5b7334eb413cff395ce6a27abf5b0981dee25a7888c64079";
+      sha256 = "e2eebd6411a3d5ea722356e0589e084e92bb9c6de6ef857c59f5073d1cf45faa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/lv/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/lv/firefox-84.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "036264de51a7a81b3d636b8217db571db70631231d485f353e64e9f43f0192f4";
+      sha256 = "2fa8dae6d41e45ff180aaacc351a5e649e97c7b19d07185b71d128c7c1107b09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/mk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/mk/firefox-84.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "6d4966ae49ba7746395b17b98c158c07d33293b68a6c648d0238107812ccfc03";
+      sha256 = "ed515998a2a59368012613f29ae328df232f8b53c84cbb0a76d0bc28d790de87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/mr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/mr/firefox-84.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "88a90205bfd157fbcb0697efbd4884772a463f776f5110aae9903dbc1151fcbc";
+      sha256 = "1f1f39175dc1ed91417fae9cd4508152e0f34c483a972469059cda2484d8c4d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ms/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ms/firefox-84.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "67d3651739404a73f263251896c129dc121808d4859169b3469b640345433e9e";
+      sha256 = "7c4129ca5630473536d11ccb9ee818739e68deb618a230371d7cda448a686e1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/my/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/my/firefox-84.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "d7e9a1fe6d2e0e32c2ab9a773d198de241ac2a7d330d9eddce4f3afb9a67671b";
+      sha256 = "0608c452c89b1dc71aa99d540baa7a301f9c7974ff0f92e3bd567a577d6a8801";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/nb-NO/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/nb-NO/firefox-84.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "66c165884d4397db3e420151d2b6fa3d7bb7c6de790e6d284815cdcc323da3fe";
+      sha256 = "b480530a21a49b00e8c3666c6856ad281c060e0bf2471c5363b1af5fe842ca1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ne-NP/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ne-NP/firefox-84.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "f75832bd74f5ce8db3765201eee058f0386f196f407223e186c0be3d2a665fcf";
+      sha256 = "7874273d946dea1821e594eae22b5c9efca48c429c922a181b5033ed834a19d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/nl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/nl/firefox-84.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "beb68fb193dfcccbe22369f9adcbebe701fd4c9ab5943ec685d5d20398a1ea5d";
+      sha256 = "f54431c579a32aa9c822d834facdd56dc22f319f56b3d8849beb2dba2cd92f3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/nn-NO/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/nn-NO/firefox-84.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "de2716b8f4c13c6ef76537ef52f1d0529016302ce220a90d9b5062af9becb5b7";
+      sha256 = "52d56abf19671927427755a91d34f97e8ea3beeeb4f855c43e5c17198c8a0033";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/oc/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/oc/firefox-84.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "af2a788560a65cb9f3d2ce98acce4ecd3b3105b6c924c6a4de1a9deb6f2a4d42";
+      sha256 = "adb1fe2efc7c422ff032a7786ff4681964cbec3764d1a4cf0408db34f84c2af8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pa-IN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/pa-IN/firefox-84.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "a3575371b20bab63a8bccc110343e0cd0736cffbc5c72dd7aa371c646a057060";
+      sha256 = "92c62a054d5755fd6aaf7527812bf2080e94a0b99bbadd8101b120e5a97a834b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/pl/firefox-84.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "daa554b493ce1efa90a1b040e78d2f2e7ad8ca70c16ee19312c69ed4a12f00e3";
+      sha256 = "ced027c3eed4912bf52a0e0fd87c3bb3e8fdb495310d54fa3e27202ceef6b181";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pt-BR/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/pt-BR/firefox-84.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "4f3fe4a1ce0e12383b37832f44b59fbb40b8fb6e95786edc57ea67ea3d5530bd";
+      sha256 = "407b4bb3ff178be28dd475e8e8265a6db0728362011f155c58126af0ec3418e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/pt-PT/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/pt-PT/firefox-84.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "c16bcb116b845a6b28b72096ae43d50f19c7b9868c8bbb833db60eaaa70b001d";
+      sha256 = "4d5a1246694c849fc5f9dacff55a8d77b15cfdf9fad1c13dcc3379aaba08aca7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/rm/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/rm/firefox-84.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "334d3dcf333a66f4bd169536f7f3b56ba4b257793dfd0837badff2a77b3668f4";
+      sha256 = "020268365761b5e1667e62d9668b3ec72802f970335424eb0facc1d861010e1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ro/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ro/firefox-84.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "1e6ad9735fe0046beaf80ac35d0a1831aade14f388d08991b9bc583135ebd94c";
+      sha256 = "890c046200b68226cd4efe1170c95582456fda0df1004ddc5a96ab4544bbbf80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ru/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ru/firefox-84.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "a252bcd66f01375fbc4ce040b89c853c34745e8dede116d200303c56d6307f15";
+      sha256 = "7a502fd6c96506809bfaf6c5784a49f4219fd859628938c4a536bc82ed2d1d5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/si/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/si/firefox-84.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "ebc5ce83b456f75b671694ac954258ca480caee563e0cb395786692aedf24d88";
+      sha256 = "d4432722999b424c3d2b1f6aad41632db9051a33e40dea317acf933159630c20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/sk/firefox-84.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "28aac94a71298c459f14949c9c82b379762d3192a16d92e90605ab8925cb31ad";
+      sha256 = "68f7b7769bcba9eec44bde88a7c0579c07d2501af8b1494271eeda207d8d256b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/sl/firefox-84.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "7fe0eb68a898488bcb697120542fbdcfd1d972c658b4c361bba351a8f5eb76e0";
+      sha256 = "aa33d8fd7bcfbd340dd4251aedae9f1e5671715bebd2db7f4d4e40e1288dd875";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/son/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/son/firefox-84.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "f9cb1327834b6a6e41d4abf531410391a40f33a8d168d562dc367faf31d9e042";
+      sha256 = "c22bfd8925e30ac477e554d8e17939969d5479425d44180a6b409113f2be961f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sq/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/sq/firefox-84.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "15370cc0527797f451a5a1f47637c6663437c8f49fc5c056ccbc2e7510cd6c94";
+      sha256 = "ecb182d80021e37933c8e34671fff744b24bfb66fd7b11382a921315664547fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/sr/firefox-84.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c44773c36eb39067e429fb4a4b57676abc7eb9fcf45bd6654d96761f64747c6a";
+      sha256 = "d0d2121473dd5ff2ff16029abcdde740e9d4b56470c56c8d0e26f062c0972e1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/sv-SE/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/sv-SE/firefox-84.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "aa8d2dc50dce8a53a926c71a4a7a57023a017d5fbd54cd1e446ef74b5eef7dea";
+      sha256 = "dfc1c0c89fd89b6d3ef450d16b489b57d6324b27ca2da628ce136091fb46e19b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ta/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ta/firefox-84.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "5fc3e8a048ec24e49c4c4a0e36712b378687e927c30dc8ecb3ec63bcf983062a";
+      sha256 = "ad117c4e87e7623eb46d9ec23448cf6c9dd0efc950f04359dfbfcb25d88a78bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/te/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/te/firefox-84.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "ff123410cec64c47d239a432d32eaefa494e7cd7fb0157cc45917fe04b2916ef";
+      sha256 = "1906a1dc8c981f4a3ff631cbe5451b5b3ffd2d66a6868bcb0c075e7cc53fb1b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/th/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/th/firefox-84.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "cb7cbf97884a5b4f62c4e0932ead0e5de018c9623590ac3798a86986916258dc";
+      sha256 = "953b0a336557f91e3d1831e0c77ba1da61e63fd6b76a9383dbf7703781a9ffc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/tl/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/tl/firefox-84.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "0d55a23e2c0b7da80a6c042e50fc3c9364c3f24309cf255bfbe55a320ec2cf00";
+      sha256 = "09edec56fa57de6fc29be4e3848059d6e975a44fe49edff426f4cd8c17c0d76e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/tr/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/tr/firefox-84.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "bfc1adb570f79b4f095bc87ab5a54c6b5179579840ded61319a10ad5ff39d52f";
+      sha256 = "d93f502786328023bde8f025345acb835fc5b46ecf545d42fa5ef0ab7bee9dab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/trs/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/trs/firefox-84.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "05b5a2252380147ec47561e29514e3f994414b46aae3dd168909f03e7dec16ef";
+      sha256 = "2c1ccaa3879d25fa8c63eba446a5ad2c4668e32210b5927e4c5280cf2c46f3a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/uk/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/uk/firefox-84.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "7e34b52f4d46a735e36f549295d0f9704113024058a7d8d69a8ee6a023d03755";
+      sha256 = "050645f728c545f8febd5a2f3b886cfd0cdd9f3873d1f2c8248b625b16b1958b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/ur/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/ur/firefox-84.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "1d48e536c09f862bc00fcaf9a175eaeffac1e0aaff66d71ca49123c00cc885bc";
+      sha256 = "96a1f37238376b3e2321945a92e6663d9a8a78956d6e37c227b597cb9cd312ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/uz/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/uz/firefox-84.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "1f1cf131b3196886aa0f923c5dbaa279b86c3473dc048ce23d58fe811ca1266c";
+      sha256 = "3d51cb2280b706c7ab944ad612d8b7cdd5d175563f470a96c1f8540fc97dfa53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/vi/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/vi/firefox-84.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "b98507cd809abd28c51514448bf995661dede7c727808ab8c2db46da8da0a164";
+      sha256 = "4052e4a9edef39e7a5ab7167e284c9f5ba1bec85d3774cf6a79943df7d68fc0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/xh/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/xh/firefox-84.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "73de4ec29cd09610359909ada39820a119a15c3ae0cc1658c2e9b874801a9015";
+      sha256 = "0f55bc55fa4674a6736bdf11cf3265747ece6acc2b644ad555f40c3825736026";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/zh-CN/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/zh-CN/firefox-84.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "fea085476f4456133c1f0973121319f1c3efadcc50134cbf5ccde351bbe2ff06";
+      sha256 = "a0dd3688a1a4da9d3b6de14758c4cd68508852b23dfebc1050ab8bbbaec13a21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/83.0/linux-i686/zh-TW/firefox-83.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0/linux-i686/zh-TW/firefox-84.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "5aebd374f2e73f83bec4c14239555d9f2771d3379280fc55f90f1ae0909be009";
+      sha256 = "236f2a5014478e0a722f9d0b42b509585f2fdc289e56149fd867f88914c1c11d";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -118,8 +118,9 @@ buildStdenv.mkDerivation ({
 
   patches = [
     ./env_var_for_system_dir.patch
-    ./no-buildconfig-ffx76.patch
   ] ++
+  lib.optional (lib.versionOlder ffversion "83") ./no-buildconfig-ffx76.patch ++
+  lib.optional (lib.versionAtLeast ffversion "84") ./no-buildconfig-ffx84.patch ++
 
   # there are two flavors of pipewire support
   # The patches for the ESR release and the patches for the current stable
@@ -141,13 +142,7 @@ buildStdenv.mkDerivation ({
         url = "https://src.fedoraproject.org/rpms/firefox/raw/${fedora_revision}/f/${spec.name}";
       };
     in map mkPWPatch [
-        { name = "pw1.patch"; sha256 = "1a7zvngn3k7dg886zmi38kmrsdzh2rrr46aw59bhr1gfmq8wlwn0"; }
-        { name = "pw2.patch"; sha256 = "17irg3yb2mchcy0z0nr4k65mwvkps467cvvczr10fnm06lhkhw1l"; }
-        { name = "pw3.patch"; sha256 = "12p6ql5ff2lfzlni6xkpz63h2xr6n2a9zf8hhjl99fj56rif6706"; }
-        { name = "pw4.patch"; sha256 = "0rvysc92rdm98s47w5lvbnrklrf7d299k3918qnldniyb4b9p4mg"; }
-        { name = "pw5.patch"; sha256 = "0kk2yxq4qkfwc4px6m08jrn18a7a7dhrngfiaw84r9ga6sgn0z00"; }
         { name = "pw6.patch"; sha256 = "12lhx9wjpw0ahbfmw07wsx76bb223mr453q9cg8cq951vyskch3s"; }
-        { name = "pw7.patch"; sha256 = "0afw7cfd48vn62zb9y5kd2l26fg44s3aq1kyg3gm4q3rj34xidf6"; }
     ])
 
   ++ patches;

--- a/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx84.patch
+++ b/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx84.patch
@@ -1,0 +1,25 @@
+diff --git a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
+index 10ac77b..0125d9b 100644
+--- a/docshell/base/nsAboutRedirector.cpp
++++ b/docshell/base/nsAboutRedirector.cpp
+@@ -63,8 +63,6 @@ static const RedirEntry kRedirMap[] = {
+     {"about", "chrome://global/content/aboutAbout.html", 0},
+     {"addons", "chrome://mozapps/content/extensions/extensions.xhtml",
+      nsIAboutModule::ALLOW_SCRIPT},
+-    {"buildconfig", "chrome://global/content/buildconfig.html",
+-     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT},
+     {"checkerboard", "chrome://global/content/aboutCheckerboard.html",
+      nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+          nsIAboutModule::ALLOW_SCRIPT},
+diff --git a/toolkit/content/jar.mn b/toolkit/content/jar.mn
+index c83b3e2..d543140 100644
+--- a/toolkit/content/jar.mn
++++ b/toolkit/content/jar.mn
+@@ -40,7 +40,6 @@ toolkit.jar:
+    content/global/plugins.css
+    content/global/plugins.js
+    content/global/browser-child.js
+-*   content/global/buildconfig.html
+    content/global/buildconfig.css
+    content/global/contentAreaUtils.js
+    content/global/datepicker.xhtml

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,22 +7,11 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "83.0";
+    ffversion = "84.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3va5a9471677jfzkhqp8xkba45n0bcpphbabhqbcbnps6p85m3y98pl5jy9q7cpq3a6gxc4ax7bp90yz2nfvfq7i64iz397xpprri2a";
+      sha512 = "37d5hc2wv1b6il4flgsw5g7ihw2jx3qrrmgm4cjg3lmk91q8k7908sy79z24na6529y7jxpj4m05l6yb850wnnwjhyc4c3vxqbldnba";
     };
-
-    patches = [
-      # Fix compilation on aarch64 with newer rust version
-      # See https://bugzilla.mozilla.org/show_bug.cgi?id=1677690
-      # and https://bugzilla.redhat.com/show_bug.cgi?id=1897675
-      (fetchpatch {
-        name = "aarch64-simd-bgz-1677690.patch";
-        url = "https://github.com/mozilla/gecko-dev/commit/71597faac0fde4f608a60dd610d0cefac4972cc3.patch";
-        sha256 = "1f61nsgbv2c2ylgjs7wdahxrrlgc19gjy5nzs870zr1g832ybwin";
-      })
-    ];
 
     meta = {
       description = "A web browser built from Firefox source tree";


### PR DESCRIPTION
###### Motivation for this change
Upstream release https://www.mozilla.org/en-US/firefox/84.0/releasenotes/

cc @taku0 @andir 

###### Things done
- [x] Tested compilation and basic features on x86_64 with X11 + Pulseaudio
- [x] Tested compilation and basic features on x86_64 with Wayland
- [ ] Tested compilation and basic features on x86_64 with Pipewire
- [ ] Tested compilation and basic features on aarch64