### PR TITLE
mopidy-local: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/applications/audio/mopidy/local.nix
+++ b/pkgs/applications/audio/mopidy/local.nix
@@ -5,11 +5,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "Mopidy-Local";
-  version = "3.1.1";
+  version = "3.2.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "13m0iz14lyplnpm96gfpisqvv4n89ls30kmkg21z7v238lm0h19j";
+    sha256 = "14f78sb3wkg83dg3xcqlq77dh059zzcwry5l9ilyhnmvmyrkhqx0";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

A new version was released upstream: https://github.com/mopidy/mopidy-local/releases/tag/v3.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also tested building a Mopidy with this plugin enabled and running `mopidy local scan`.