### PR TITLE
php.packages: Make packages overridable

### DIFF
--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -135,3 +135,21 @@ Example of building `composer` with additional extensions:
   enabled ++ (with all; [ imagick redis ]))
 ).packages.composer
 ```
+
+### Overriding PHP packages {#ssec-php-user-guide-overriding-packages}
+
+`php-packages.nix` form a scope, allowing us to override the packages defined within. For example, to apply a patch to a `mysqlnd` extension, you can simply pass an overlay-style function to `php`’s `packageOverrides` argument:
+
+```nix
+php.override {
+  packageOverrides = final: prev: {
+    extensions = prev.extensions // {
+      mysqlnd = prev.extensions.mysqlnd.overrideAttrs (attrs: {
+        patches = attrs.patches or [] ++ [
+          …
+        ];
+      });
+    };
+  };
+}
+```

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -49,7 +49,7 @@ let
               php = generic filteredArgs;
 
               php-packages = (callPackage ../../../top-level/php-packages.nix {
-                php = phpWithExtensions;
+                phpPackage = phpWithExtensions;
               });
 
               allExtensionFunctions = prevExtensionFunctions ++ [ extensions ];
@@ -112,7 +112,8 @@ let
                   phpIni = "${phpWithExtensions}/lib/php.ini";
                   unwrapped = php;
                   tests = nixosTests.php;
-                  inherit (php-packages) packages extensions buildPecl;
+                  inherit (php-packages) extensions buildPecl;
+                  packages = php-packages.tools;
                   meta = php.meta // {
                     outputsToInstall = [ "out" ];
                   };

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -13,6 +13,7 @@ let
     , version
     , sha256
     , extraPatches ? []
+    , packageOverrides ? (final: prev: {})
 
     # Sapi flags
     , cgiSupport ? true
@@ -50,7 +51,7 @@ let
 
               php-packages = (callPackage ../../../top-level/php-packages.nix {
                 phpPackage = phpWithExtensions;
-              });
+              }).overrideScope' packageOverrides;
 
               allExtensionFunctions = prevExtensionFunctions ++ [ extensions ];
               enabledExtensions =

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, pkgs, fetchgit, php, autoconf, pkgconfig, re2c
+{ stdenv, lib, pkgs, fetchgit, phpPackage, autoconf, pkgconfig, re2c
 , gettext, bzip2, curl, libxml2, openssl, gmp, icu64, oniguruma, libsodium
 , html-tidy, libzip, zlib, pcre, pcre2, libxslt, aspell, openldap, cyrus_sasl
 , uwimap, pam, libiconv, enchant1, libXpm, gd, libwebp, libjpeg, libpng
@@ -6,7 +6,7 @@
 , readline, rsync, fetchpatch, valgrind
 }:
 
-let
+lib.makeScope pkgs.newScope (self: with self; {
   buildPecl = import ../build-support/build-pecl.nix {
     php = php.unwrapped;
     inherit lib;
@@ -21,15 +21,10 @@ let
 
   pcre' = if (lib.versionAtLeast php.version "7.3") then pcre2 else pcre;
 
-  callPackage = pkgs.newScope {
-    inherit mkDerivation php buildPecl pcre';
-  };
-in
-{
-  inherit buildPecl;
+  php = phpPackage;
 
   # This is a set of interactive tools based on PHP.
-  packages = {
+  tools = {
     box = callPackage ../development/php-packages/box { };
 
     composer = callPackage ../development/php-packages/composer { };
@@ -550,4 +545,4 @@ in
 
     # Produce the final attribute set of all extensions defined.
   in builtins.listToAttrs namedExtensions);
-}
+})


### PR DESCRIPTION
###### Motivation for this change
This will allow patching extensions without having to manually having to patch all occurrences in the dependency tree (like I did in https://github.com/fossar/selfoss/commit/cb22131a29ae25ff94f044d5079044dfb22b3a2b), see [clean-up PR](https://github.com/fossar/selfoss/pull/1235) depending on this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
