### PR TITLE
minecraft: Update script URL

### DIFF
--- a/pkgs/games/minecraft/update.sh
+++ b/pkgs/games/minecraft/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq gnugrep common-updater-scripts
+#!nix-shell -i bash -p curl jq common-updater-scripts
 
 set -eu -o pipefail
 
-version=$(curl -s 'https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=minecraft-launcher' | jq '.results[0].Version' | grep -Po '[.\d]*(?=-)')
-update-source-version minecraft "$version"
+version=$(curl -s 'https://launchermeta.mojang.com/v1/products/launcher/6f083b80d5e6fabbc4236f81d0d8f8a350c665a9/linux.json' | jq -r '."launcher-core"[0].version.name')
+update-source-version minecraft "${version}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I just accidentally downgraded Minecraft because we depended on Arch's AUR and they were not up-to-date yet.
This change points the version logic at the source of truth for the Minecraft launcher.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Pinging people who have previously updated Minecraft:
@hyperfekt @cpages @TredwellGit 

References:
https://github.com/flathub/com.mojang.Minecraft/issues/36
https://bugs.mojang.com/secure/attachment/224554/launcher_log.txt <-- This shows us that the URL has been used since at least June 2019
