### PR TITLE
luna-icons: 0.6 -> 0.9

### DIFF
--- a/pkgs/data/icons/luna-icons/default.nix
+++ b/pkgs/data/icons/luna-icons/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "luna-icons";
-  version = "0.6";
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "darkomarko42";
     repo = pname;
     rev = version;
-    sha256 = "1lm7ws7in8cjjl38c7xw67jr42d717kk5kkfac7rprk0z7pb104l";
+    sha256 = "1pwbmw20kzlxnwln92nxq7f5s1xwbpv6j7il7jxymlw0y31rl281";
   };
 
   nativeBuildInputs = [
@@ -34,6 +34,12 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/icons
     cp -a Luna* $out/share/icons
+
+    # remove files with spaces in the name, otherwise
+    # gtk-update-icon-cache fails with the message "The generated cache
+    # was invalid"
+    # https://github.com/darkomarko42/Luna-Icons/issues/2
+    rm "$out/share/icons/Luna/scalable/apps/yast-checkmedia (copia).svg"
 
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache "$theme"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [0.9](https://github.com/darkomarko42/Luna-Icons/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
