### PR TITLE
vscode, vscodium: 1.51.1 -> 1.52.1 & add aarch64-linux, armv7l-linux builds

### DIFF
--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -27,3 +27,11 @@ sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_LINUX_SHA256}\"/"
 VSCODE_DARWIN_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/darwin/stable"
 VSCODE_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_DARWIN_URL})
 sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODE_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
+
+VSCODE_LINUX_AARCH64_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-arm64/stable"
+VSCODE_LINUX_AARCH64_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_AARCH64_URL})
+sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODE_LINUX_AARCH64_SHA256}\"/" "$ROOT/vscode.nix"
+
+VSCODE_LINUX_ARMV7L_URL="https://vscode-update.azurewebsites.net/${VSCODE_VER}/linux-armhf/stable"
+VSCODE_LINUX_ARMV7L_SHA256=$(nix-prefetch-url ${VSCODE_LINUX_ARMV7L_URL})
+sed -i "s/armv7l-linux = \".\{52\}\"/armv7l-linux = \"${VSCODE_LINUX_ARMV7L_SHA256}\"/" "$ROOT/vscode.nix"

--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -19,10 +19,18 @@ fi
 VSCODIUM_VER=$(curl -Ls -w %{url_effective} -o /dev/null https://github.com/VSCodium/vscodium/releases/latest | awk -F'/' '{print $NF}')
 sed -i "s/version = \".*\"/version = \"${VSCODIUM_VER}\"/" "$ROOT/vscodium.nix"
 
-VSCODIUM_LINUX_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-linux-x64-${VSCODIUM_VER}.tar.gz"
-VSCODIUM_LINUX_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_URL})
-sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODIUM_LINUX_SHA256}\"/" "$ROOT/vscodium.nix"
+VSCODIUM_LINUX_X64_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-linux-x64-${VSCODIUM_VER}.tar.gz"
+VSCODIUM_LINUX_X64_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_X64_URL})
+sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODIUM_LINUX_X64_SHA256}\"/" "$ROOT/vscodium.nix"
 
-VSCODIUM_DARWIN_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-darwin-x64-${VSCODIUM_VER}.zip"
-VSCODIUM_DARWIN_SHA256=$(nix-prefetch-url ${VSCODIUM_DARWIN_URL})
-sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODIUM_DARWIN_SHA256}\"/" "$ROOT/vscodium.nix"
+VSCODIUM_DARWIN_X64_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-darwin-x64-${VSCODIUM_VER}.zip"
+VSCODIUM_DARWIN_X64_SHA256=$(nix-prefetch-url ${VSCODIUM_DARWIN_X64_URL})
+sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODIUM_DARWIN_X64_SHA256}\"/" "$ROOT/vscodium.nix"
+
+VSCODIUM_LINUX_AARCH64_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-linux-arm64-${VSCODIUM_VER}.tar.gz"
+VSCODIUM_LINUX_AARCH64_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_AARCH64_URL})
+sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODIUM_LINUX_AARCH64_SHA256}\"/" "$ROOT/vscodium.nix"
+
+VSCODIUM_LINUX_ARMV7L_URL="https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VER}/VSCodium-linux-armhf-${VSCODIUM_VER}.tar.gz"
+VSCODIUM_LINUX_ARMV7L_SHA256=$(nix-prefetch-url ${VSCODIUM_LINUX_ARMV7L_URL})
+sed -i "s/armv7l-linux = \".\{52\}\"/armv7l-linux = \"${VSCODIUM_LINUX_ARMV7L_SHA256}\"/" "$ROOT/vscodium.nix"

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -6,6 +6,8 @@ let
   plat = {
     x86_64-linux = "linux-x64";
     x86_64-darwin = "darwin";
+    aarch64-linux = "linux-arm64";
+    armv7l-linux = "linux-armhf";
   }.${system};
 
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
@@ -13,6 +15,8 @@ let
   sha256 = {
     x86_64-linux = "1kbjbqb03yapz7067q589gaa7d6cqaipj7hmp1l3nh0bmggzsc4c";
     x86_64-darwin = "1qgadm52c5lzkvgvqrz0n8brm4qbjg8hf1dk6a2ynqhqjxcwbj4r";
+    aarch64-linux = "0i3yl9rx9h7qkl3k9qk6gg35nhz737qzzbvzvdwkqjaacsbpfgf8";
+    armv7l-linux = "19iz2bxcq6y8sklr6zcnbp47kki9l00x3nvr213lkk3kj08l0afv";
   }.${system};
 in
   callPackage ./generic.nix rec {
@@ -52,6 +56,6 @@ in
       downloadPage = "https://code.visualstudio.com/Updates";
       license = licenses.unfree;
       maintainers = with maintainers; [ eadwu synthetica ];
-      platforms = [ "x86_64-linux" "x86_64-darwin" ];
+      platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "armv7l-linux" ];
     };
   }

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -11,8 +11,8 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    x86_64-linux = "0hn4pqmabz3qf3bbqnn1fz7fcgzdkp2lwr2yzgmx8hhh3cff8bnb";
-    x86_64-darwin = "1x3wx0d99ihyya0n89qclc3jlhh0m72hs8hj7l0h3z6zmh6q2vzv";
+    x86_64-linux = "1ckg279vvg8h1n8ippa9vlyw4vk3frinb6fvvi47zggs31168m7b";
+    x86_64-darwin = "168g34v2b8r1pdbnqrs0c0k9aa60n5rspixziywnq7m61i23nlgd";
   }.${system};
 
   sourceRoot = {
@@ -27,7 +27,7 @@ in
 
     # Please backport all compatible updates to the stable release.
     # This is important for the extension ecosystem.
-    version = "1.51.1";
+    version = "1.52.1";
     pname = "vscodium";
 
     executableName = "codium";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -6,6 +6,8 @@ let
   plat = {
     x86_64-linux = "linux-x64";
     x86_64-darwin = "darwin";
+    aarch64-linux = "linux-arm64";
+    armv7l-linux = "linux-armhf";
   }.${system};
 
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
@@ -13,11 +15,15 @@ let
   sha256 = {
     x86_64-linux = "1ckg279vvg8h1n8ippa9vlyw4vk3frinb6fvvi47zggs31168m7b";
     x86_64-darwin = "168g34v2b8r1pdbnqrs0c0k9aa60n5rspixziywnq7m61i23nlgd";
+    aarch64-linux = "1cd4sg6k7sqmj3yzmprq1rz928bvc3zrch8agfd8zfap1d6nfaal";
+    armv7l-linux = "0f8z4lws027dyqhcrkzm9rvifwid5m0icprg0xk01l7y18n3q923";
   }.${system};
 
   sourceRoot = {
     x86_64-linux = ".";
     x86_64-darwin = "";
+    aarch64-linux = ".";
+    armv7l-linux = ".";
   }.${system};
 in
   callPackage ./generic.nix rec {
@@ -55,6 +61,6 @@ in
       downloadPage = "https://github.com/VSCodium/vscodium/releases";
       license = licenses.mit;
       maintainers = with maintainers; [ synthetica turion ];
-      platforms = [ "x86_64-linux" "x86_64-darwin" ];
+      platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "armv7l-linux" ];
     };
   }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add VSCode/VSCodium ARM builds (added a few versions ago in v1.50.0 (Sept): https://code.visualstudio.com/updates/v1_50#_linux-arm-builds).
Closes #106739 (cherry-picks those changes into this branch)

HELP NEEDED: when testing the ``aarch64`` build (on WSL, testing with binfmt-support), the build errors out when patching ``/nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node``. I don't believe this file should be patched, because I get the following ``not a dynamic executable`` message when calling ``ldd .../keytar.node``. It seems that the [``auto-patchelf.sh::isExecutable()`` function](https://github.com/NixOS/nixpkgs/blob/b568bcf001636e7f5828d87a52389c019ffc20f3/pkgs/build-support/setup-hooks/auto-patchelf.sh#L16-L29) is incorrectly reading this as an executable.

<details>
<summary>Detailed build log for autoPatchelfHook failure</summary>

```
+++ isELF /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/vscode-oniguruma/release/onig.wasm
+++ local fn=/nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/vscode-oniguruma/release/onig.wasm
+++ local fd
+++ local magic
+++ exec
+++ read -r -n 4 -u 11 magic
+++ exec
+++ '[' $'asm\001' = $'\177ELF' ']'
+++ return 1
+++ continue
+++ IFS=
+++ read -r -d '' file
+++ isELF /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ local fn=/nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ local fd
+++ local magic
+++ exec
+++ read -r -n 4 -u 11 magic
+++ exec
+++ '[' $'\177ELF' = $'\177ELF' ']'
+++ return 0
++++ LANG=C
++++ readelf -l /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ segmentHeaders='
Elf file type is DYN (Shared object file)
Entry point 0x4340
There are 7 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000000 0x00000000 0x00000000 0x0ff58 0x0ff58 R E 0x1000
  LOAD           0x010bd0 0x00011bd0 0x00011bd0 0x0063c 0x00640 RW  0x1000
  DYNAMIC        0x010e7c 0x00011e7c 0x00011e7c 0x00130 0x00130 RW  0x4
  NOTE           0x000114 0x00000114 0x00000114 0x00024 0x00024 R   0x4
  GNU_EH_FRAME   0x00ccd0 0x0000ccd0 0x0000ccd0 0x00214 0x00214 R   0x4
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x10
  GNU_RELRO      0x010bd0 0x00011bd0 0x00011bd0 0x00430 0x00430 R   0x1

 Section to Segment mapping:
  Segment Sections...
   00     .note.gnu.build-id .hash .gnu.hash .dynsym .dynstr .gnu.version .gnu.version_r .rel.dyn .rel.plt .init .plt .plt.got .text .fini .rodata .eh_frame_hdr .eh_frame .gcc_except_table
   01     .init_array .fini_array .jcr .data.rel.ro .dynamic .got .got.plt .data .bss
   02     .dynamic
   03     .note.gnu.build-id
   04     .eh_frame_hdr
   05
   06     .init_array .fini_array .jcr .data.rel.ro .dynamic .got '
++++ grep '^Program Headers:'
++++ echo '
Elf file type is DYN (Shared object file)
Entry point 0x4340
There are 7 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000000 0x00000000 0x00000000 0x0ff58 0x0ff58 R E 0x1000
  LOAD           0x010bd0 0x00011bd0 0x00011bd0 0x0063c 0x00640 RW  0x1000
  DYNAMIC        0x010e7c 0x00011e7c 0x00011e7c 0x00130 0x00130 RW  0x4
  NOTE           0x000114 0x00000114 0x00000114 0x00024 0x00024 R   0x4
  GNU_EH_FRAME   0x00ccd0 0x0000ccd0 0x0000ccd0 0x00214 0x00214 R   0x4
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x10
  GNU_RELRO      0x010bd0 0x00011bd0 0x00011bd0 0x00430 0x00430 R   0x1

 Section to Segment mapping:
  Segment Sections...
   00     .note.gnu.build-id .hash .gnu.hash .dynsym .dynstr .gnu.version .gnu.version_r .rel.dyn .rel.plt .init .plt .plt.got .text .fini .rodata .eh_frame_hdr .eh_frame .gcc_except_table
   01     .init_array .fini_array .jcr .data.rel.ro .dynamic .got .got.plt .data .bss
   02     .dynamic
   03     .note.gnu.build-id
   04     .eh_frame_hdr
   05
   06     .init_array .fini_array .jcr .data.rel.ro .dynamic .got '
+++ '[' -n 'Program Headers:' ']'
+++ isExecutable /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
++++ LANG=C
++++ grep '^ *Type: *EXEC\>\|^ *INTERP\>'
++++ readelf -h -l /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ isExeResult=
+++ '[' -n '' ']'
+++ patchelf /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ autoPatchelfFile /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ local dep rpath= toPatch=/nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ local interpreter
+++ interpreter=/nix/store/izx89ff9anm1a5yhllp1hr8mjp4vcah3-glibc-2.32-10/lib/ld-linux-aarch64.so.1
+++ isExecutable /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
++++ grep '^ *Type: *EXEC\>\|^ *INTERP\>'
++++ LANG=C
++++ readelf -h -l /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ isExeResult=
+++ '[' -n '' ']'
+++ echo 'searching for dependencies of /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node'
searching for dependencies of /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ runPatchelf --remove-rpath /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ patchelf --remove-rpath /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
+++ local missing
++++ ldd /nix/store/f8xv80klmw2lpxhw68qqm168h4zqr03g-vscodium-1.52.0/lib/vscode/resources/app/node_modules.asar.unpacked/keytar/build/Release/keytar.node
++++ sed -n -e 's/^[\t ]*\([^ ]\+\) => not found.*/\1/p'
+++ missing=
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
