### PR TITLE
xdg_utils: 1.1.3 -> unstable-2020-10-21

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub
+{ lib, stdenv, fetchgit, fetchFromGitHub
 , file, libxslt, docbook_xml_dtd_412, docbook_xsl, xmlto
 , w3m, gnugrep, gnused, coreutils, xset, perlPackages
 , mimiSupport ? false, gawk ? null }:
@@ -22,11 +22,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "xdg-utils";
-  version = "1.1.3";
+  version = "unstable-2020-10-21";
 
-  src = fetchurl {
-    url = "https://portland.freedesktop.org/download/${pname}-${version}.tar.gz";
-    sha256 = "1nai806smz3zcb2l5iny4x7li0fak0rzmjg6vlyhdqm8z25b166p";
+  src = fetchgit {
+    url = "https://gitlab.freedesktop.org/xdg/${pname}.git";
+    rev = "d11b33ec7f24cfb1546f6b459611d440013bdc72";
+    sha256 = "sha256-8PtXfI8hRneEpnUvIV3M+6ACjlkx0w/NEiJFdGbbHnQ=";
   };
 
   # just needed when built from git


### PR DESCRIPTION
###### Motivation for this change

Upstream has not seen an official release since 2018-05, but a number of fixes and improvements have been committed.
It would be nice to have those available, since I don't think there's a release in sight (https://gitlab.freedesktop.org/xdg/xdg-utils/-/issues/178). I've been using an overlay to get a newer version for quite some time now, and I haven't had any issues.

This change affects a number of packages that are expensive to build (e.g. firefoxes, chromes), so I'm not sure if this should target staging instead? The number and size of packages prevents me from running nix-review on my own desktop.

```
107 packages updated:
alacritty anarchism appimage-run avrdudess bitwig-studio bitwig-studio bitwig-studio blueman brave caja-dropbox calibre calibre catfish catfish chromium chromium-beta chromium-dev chrysalis deltachat-electron devdocs-desktop dropbox dropbox-cli electronplayer eureka-editor far2l faust2firefox-unstable ferdi fff filezilla firefox firefox firefox firefox firefox firefox firefox-beta-bin firefox-bin firefox-devedition-bin franz genymotion git-open google-chrome google-chrome-beta google-chrome-dev hipchat irccloud joplin-desktop keeweb kodi-plugin-steam-launcher kotatogram-desktop lab ledger-live-desktop lens lunar-client lutris lutris manim marktext-v0.16.2-binary midori midori minetime mkvtoolnix mkvtoolnix molotov mpv-convert-script MyCrypto mytetra nestopia notable nuclear-v0.6.6 p3x-onenote Patchwork plexamp python3.7-papis qdirstat rabbitvcs radicle-upstream rambox reaper runwayml slack slack slimerjs sparkleshare standardnotes station steam steam-run steam-run steamcmd subtitleeditor Sylk teams teamviewer telegram-desktop timeular tusk-v0.23.0 ungoogled-chromium unityhub vimb vimb wavebox wayst-unstable wootility xdg_utils (1.1.3 → 2020-10-21) zettlr zulip
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
