### PR TITLE
gnudatalanguage: Init at 1.0.0

### DIFF
--- a/pkgs/development/interpreters/gnudatalanguage/default.nix
+++ b/pkgs/development/interpreters/gnudatalanguage/default.nix
@@ -1,0 +1,203 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, wrapGAppsHook
+, readline
+, ncurses
+, zlib
+, gsl
+, openmp
+, graphicsmagick
+, fftw
+, fftwFloat
+, fftwLongDouble
+, proj
+, shapelib
+, expat
+, udunits
+, eigen
+, pslib
+, eccodes
+, glpk
+, libpng
+, plplot
+, libtiff
+, libgeotiff
+, libjpeg
+  # We enable it in hdf4 and use libtirpc as a dependency here from the passthru
+  # of hdf4
+, enableLibtirpc ? stdenv.isLinux
+, libtirpc
+, python3
+, enableMPI ? (stdenv.isLinux || stdenv.isDarwin)
+  # Choose MPICH over OpenMPI because it currently builds on AArch and Darwin
+, mpi
+  # Unfree optional dependency for hdf4 and hdf5
+, enableSzip ? false
+, szip
+, enableHDF4 ? true
+, hdf4
+, hdf4-forced ? null
+, enableHDF5 ? true
+  # HDF5 format version (API version) 1.10 and 1.12 is not fully compatible
+  # Specify if the API version should default to 1.10
+  # netcdf currently depends on hdf5 with `usev110Api=true`
+  # If you wish to use HDF5 API version 1.12 (`useHdf5v110Api=false`),
+  # you will need to turn NetCDF off.
+, useHdf5v110Api ? true
+, hdf5
+, hdf5-forced ? null
+, enableNetCDF ? true
+, netcdf
+, netcdf-forced ? null
+, plplot-forced ? null
+  # wxWidgets is preferred over X11 for this project but we only have it on Linux
+  # and Darwin. Also, we use the wxWidgets dependency here from the passthru of
+  # plplot.
+, enableWX ? (stdenv.isLinux || stdenv.isDarwin)
+  # X11: OFF by default for platform consistency. Use X where WX is not available
+, enableXWin ? (!stdenv.isLinux && !stdenv.isDarwin)
+}:
+
+let
+  hdf4-custom =
+    if hdf4-forced != null
+    then hdf4-forced
+    else
+      hdf4.override {
+        uselibtirpc = enableLibtirpc;
+        szipSupport = enableSzip;
+        inherit szip;
+      };
+  hdf5-custom =
+    if hdf5-forced != null
+    then hdf5-forced
+    else
+      hdf5.override {
+        usev110Api = useHdf5v110Api;
+        mpiSupport = enableMPI;
+        inherit mpi;
+        szipSupport = enableSzip;
+        inherit szip;
+      };
+  netcdf-custom =
+    if netcdf-forced != null
+    then netcdf-forced
+    else
+      netcdf.override {
+        hdf5 = hdf5-custom;
+      };
+  enablePlplotDrivers = enableWX || enableXWin;
+  plplot-with-drivers =
+    if plplot-forced != null
+    then plplot-forced
+    else
+      plplot.override {
+        inherit
+          enableWX
+          enableXWin
+          ;
+      };
+in
+stdenv.mkDerivation rec {
+  pname = "gnudatalanguage";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "gdl";
+    rev = "v${version}";
+    sha256 = "sha256-Y9LVRaWjQqpWqjNngxB406PE/rl/9S8rs0u0CK5ivUA=";
+  };
+
+  buildInputs = [
+    readline
+    ncurses
+    zlib
+    gsl
+    openmp
+    graphicsmagick
+    fftw
+    fftwFloat
+    fftwLongDouble
+    proj
+    shapelib
+    expat
+    mpi
+    udunits
+    eigen
+    pslib
+    eccodes
+    glpk
+    libpng
+    libtiff
+    libgeotiff
+    libjpeg
+    hdf4-custom
+    hdf5-custom
+    netcdf-custom
+    plplot-with-drivers
+  ] ++ lib.optional enableXWin plplot-with-drivers.libX11
+  ++ lib.optional enableWX plplot-with-drivers.wxWidgets
+  ++ lib.optional enableMPI mpi
+  ++ lib.optional enableLibtirpc hdf4-custom.libtirpc
+  ++ lib.optional enableSzip szip;
+
+  propagatedBuildInputs = [
+    (python3.withPackages (ps: with ps; [ numpy ]))
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optional enableWX wrapGAppsHook;
+
+  cmakeFlags = lib.optional (!enableHDF4) "-DHDF=OFF"
+    ++ [ (if enableHDF5 then "-DHDF5DIR=${hdf5-custom}" else "-DHDF5=OFF") ]
+    ++ lib.optional (!enableNetCDF) "-DNETCDF=OFF"
+    ++ lib.optional (!enablePlplotDrivers) "-DINTERACTIVE_GRAPHICS=OFF"
+    ++ lib.optional (!enableWX) "-DWXWIDGETS=OFF"
+    ++ lib.optional enableSzip "-DSZIPDIR=${szip}"
+    ++ lib.optionals enableXWin [ "-DX11=ON" "-DX11DIR=${plplot-with-drivers.libX11}" ]
+    ++ lib.optionals enableMPI [ "-DMPI=ON" "-DMPIDIR=${mpi}" ];
+
+  doCheck = true;
+
+  # Opt-out unstable tests
+  # https://github.com/gnudatalanguage/gdl/issues/482
+  # https://github.com/gnudatalanguage/gdl/issues/1079
+  # https://github.com/gnudatalanguage/gdl/issues/460
+  preCheck = ''
+    checkFlagsArray+=("ARGS=-E 'test_tic_toc.pro|test_byte_conversion.pro|test_bytscl.pro|test_call_external.pro'")
+  '';
+
+  passthru = {
+    hdf4 = hdf4-custom;
+    hdf5 = hdf5-custom;
+    netcdf = netcdf-custom;
+    plplot = plplot-with-drivers;
+    python = python3;
+    inherit
+      enableMPI
+      mpi
+      useHdf5v110Api
+      enableSzip
+      enableWX
+      enableXWin
+      ;
+  };
+
+  meta = with lib; {
+    description = "Free incremental compiler of IDL";
+    longDescription = ''
+      GDL (GNU Data Language) is a free/libre/open source incremental compiler
+      compatible with IDL (Interactive Data Language) and to some extent with PV-WAVE.
+      GDL is aimed as a drop-in replacement for IDL.
+    '';
+    homepage = "https://github.com/gnudatalanguage/gdl";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ ShamrockLee ];
+    platforms = platforms.all;
+    mainProgram = "gdl";
+  };
+}

--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -8,8 +8,7 @@
 }:
 
 let
-  mpiSupport = hdf5.mpiSupport;
-  mpi = hdf5.mpi;
+  inherit (hdf5) mpiSupport mpi;
 in stdenv.mkDerivation rec {
   pname = "netcdf";
   version = "4.8.0"; # Remove patch mentioned below on upgrade
@@ -44,8 +43,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ hdf5 curl mpi ];
 
   passthru = {
-    mpiSupport = mpiSupport;
-    inherit mpi;
+    inherit mpiSupport mpi;
   };
 
   configureFlags = [

--- a/pkgs/development/libraries/plplot/default.nix
+++ b/pkgs/development/libraries/plplot/default.nix
@@ -1,6 +1,16 @@
-{ lib, stdenv, fetchurl, cmake }:
+{ lib
+, stdenv
+, fetchurl
+, cmake
+, enableWX ? false
+, wxGTK31, wxmac
+, enableXWin ? false
+, libX11
+}:
 
-stdenv.mkDerivation rec {
+let
+  wxWidgets = (if stdenv.isDarwin then wxmac else wxGTK31);
+in stdenv.mkDerivation rec {
   pname   = "plplot";
   version = "5.15.0";
 
@@ -10,6 +20,21 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+  ]
+  ++ lib.optional enableWX wxWidgets
+  ++ lib.optional enableXWin libX11
+  ;
+
+  passthru = {
+    inherit
+      enableWX
+      wxWidgets
+      enableXWin
+      libX11
+    ;
+  };
 
   cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" "-DBUILD_TEST=ON" ];
 

--- a/pkgs/development/libraries/plplot/default.nix
+++ b/pkgs/development/libraries/plplot/default.nix
@@ -21,11 +21,8 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [
-  ]
-  ++ lib.optional enableWX wxWidgets
-  ++ lib.optional enableXWin libX11
-  ;
+  buildInputs = lib.optional enableWX wxWidgets
+    ++ lib.optional enableXWin libX11;
 
   passthru = {
     inherit

--- a/pkgs/tools/misc/hdf5/1.10.nix
+++ b/pkgs/tools/misc/hdf5/1.10.nix
@@ -1,7 +1,9 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
 , removeReferencesTo
-, zlib ? null
+, zlibSupport ? true
+, zlib
 , enableShared ? !stdenv.hostPlatform.isStatic
 , javaSupport ? false
 , jdk
@@ -24,10 +26,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ removeReferencesTo ];
 
-  propagatedBuildInputs = optional (zlib != null) zlib;
+  propagatedBuildInputs = optional zlibSupport zlib;
 
-  configureFlags = []
-    ++ optional enableShared "--enable-shared"
+  configureFlags = optional enableShared "--enable-shared"
     ++ optional javaSupport "--enable-java";
 
   patches = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5900,7 +5900,9 @@ with pkgs;
 
   pixz = callPackage ../tools/compression/pixz { };
 
-  plplot = callPackage ../development/libraries/plplot { };
+  plplot = callPackage ../development/libraries/plplot {
+    inherit (xorg) libX11;
+  };
 
   pxattr = callPackage ../tools/archivers/pxattr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5969,9 +5969,7 @@ with pkgs;
 
   hddtemp = callPackage ../tools/misc/hddtemp { };
 
-  hdf4 = callPackage ../tools/misc/hdf4 {
-    szip = null;
-  };
+  hdf4 = callPackage ../tools/misc/hdf4 { };
 
   hdf5 = callPackage ../tools/misc/hdf5 {
     gfortran = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5972,23 +5972,22 @@ with pkgs;
   hdf4 = callPackage ../tools/misc/hdf4 { };
 
   hdf5 = callPackage ../tools/misc/hdf5 {
-    gfortran = null;
-    szip = null;
+    fortranSupport = false;
+    fortran = gfortran;
   };
 
   hdf5_1_10 = callPackage ../tools/misc/hdf5/1.10.nix { };
 
   hdf5-mpi = appendToName "mpi" (hdf5.override {
-    szip = null;
     mpiSupport = true;
   });
 
   hdf5-cpp = appendToName "cpp" (hdf5.override {
-    cpp = true;
+    cppSupport = true;
   });
 
   hdf5-fortran = appendToName "fortran" (hdf5.override {
-    inherit gfortran;
+    fortranSupport = true;
   });
 
   hdf5-threadsafe = appendToName "threadsafe" (hdf5.overrideAttrs (oldAttrs: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12858,6 +12858,12 @@ with pkgs;
 
   inherit (beam.packages.erlangR21) lfe lfe_1_3;
 
+  gnudatalanguage = callPackage ../development/interpreters/gnudatalanguage {
+    inherit (llvmPackages) openmp;
+    # MPICH currently build on Darwin
+    mpi = mpich;
+  };
+
   groovy = callPackage ../development/interpreters/groovy { };
 
   inherit (callPackages ../applications/networking/cluster/hadoop {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Interactive Data Language (IDL) is an array-oriented programming language and commercial software similar to MATLAB, and GNU Data Language (GDL) is a free and open source implementation of IDL.

Making this program available in nixpkgs makes the IDL/GDL runnable on NixOS and other supported platforms, and may benefit researchers and students in the realm of astronomy and atmospheric science. (It is [hard to install IDL on NixOS](https://discourse.nixos.org/t/how-to-install-idl-interactive-data-language-on-nixos/8448) )

This package depends on overridden `plplot` in order to have PlPlot drivers.

Status of Darwin support:
*   Though efforts are made to support Darwin (by choosing MPICH instead of OpenMPI, making libfabric and udunits build on Darwin, etc.), the built are still blocked by some dependencies.
*   The current issue is the `plplot` with `wxmac` backend (driver) failing to find `<Carbon/Carbon.h>`, which would be solved by injecting `graphite2` somewhere. (See [the issue comment](https://github.com/NixOS/nixpkgs/pull/107056#issuecomment-927172738))
*   As soon as the dependency issues get solved (by other PRs), this package should build. Please file an issue or another PR if it doesn't.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) (1247605984)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).