### PR TITLE
nvimpager: init at 0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4936,6 +4936,12 @@
     githubId = 45168934;
     name = "Louis Blin";
   };
+  lucc = {
+    email = "lucc+nix@posteo.de";
+    github = "lucc";
+    githubId = 1104419;
+    name = "Lucas Hoffmann";
+  };
   ldelelis = {
     email = "ldelelis@est.frba.utn.edu.ar";
     github = "ldelelis";

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -1,8 +1,10 @@
 { fetchFromGitHub
-, pkgs
+, stdenv
+, ncurses, neovim, procps
+, pandoc, lua51Packages, util-linux
 }:
 
-pkgs.stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "nvimpager";
   version = "0.9";
 
@@ -13,25 +15,24 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "1xy5387szfw0bp8dr7d4z33wd4xva7q219rvz8gc0vvv1vsy73va";
   };
 
-  buildInputs = with pkgs; [
+  buildInputs = [
     ncurses # for tput
-    neovim
     procps # for nvim_get_proc() which uses ps(1)
   ];
-  nativeBuildInputs = [ pkgs.pandoc ];
+  nativeBuildInputs = [ pandoc ];
 
   makeFlags = [ "PREFIX=$(out)" ];
   buildFlags = [ "nvimpager.configured" ];
   preBuild = ''
     patchShebangs nvimpager
-    substituteInPlace nvimpager --replace ':-nvim' ':-${pkgs.neovim}/bin/nvim'
+    substituteInPlace nvimpager --replace ':-nvim' ':-${neovim}/bin/nvim'
     '';
 
   doCheck = true;
-  checkInputs = with pkgs; [ lua51Packages.busted util-linux ];
+  checkInputs = [ lua51Packages.busted util-linux neovim ];
   checkPhase = ''script -c "busted --lpath './?.lua' test"'';
 
-  meta = with pkgs.stdenv.lib; {
+  meta = with stdenv.lib; {
     description = "Use neovim as pager";
     longDescription = ''
       Use neovim as a pager to view manpages, diffs, etc with nvim's syntax
@@ -41,6 +42,6 @@ pkgs.stdenv.mkDerivation rec {
     homepage = "https://github.com/lucc/nvimpager";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ lucc ];
+    maintainers = [ maintainers.lucc ];
   };
 }

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -23,9 +23,8 @@ pkgs.stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
   buildFlags = [ "nvimpager.configured" ];
   preBuild = ''
-    substituteInPlace nvimpager \
-      --replace '/usr/bin/env bash' '${pkgs.bash}/bin/bash' \
-      --replace ':-nvim' ':-${pkgs.neovim}/bin/nvim'
+    patchShebangs nvimpager
+    substituteInPlace nvimpager --replace ':-nvim' ':-${pkgs.neovim}/bin/nvim'
     '';
 
   # Defaults to false until I find out how to provide /dev/tty inside the

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -27,11 +27,9 @@ pkgs.stdenv.mkDerivation rec {
     substituteInPlace nvimpager --replace ':-nvim' ':-${pkgs.neovim}/bin/nvim'
     '';
 
-  # Defaults to false until I find out how to provide /dev/tty inside the
-  # sandbox.
-  doCheck = false;
-  checkInputs = with pkgs; [ lua51Packages.busted ];
-  checkPhase = "busted --lpath './?.lua' test";
+  doCheck = true;
+  checkInputs = with pkgs; [ lua51Packages.busted util-linux ];
+  checkPhase = ''script -c "busted --lpath './?.lua' test"'';
 
   meta = with pkgs.stdenv.lib; {
     description = "Use neovim as pager";

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -1,8 +1,5 @@
 { fetchFromGitHub
 , pkgs
-# Defaults to false until I find out how to provide /dev/tty inside the
-# sandbox.
-, doCheck ? false
 }:
 
 pkgs.stdenv.mkDerivation rec {
@@ -31,7 +28,9 @@ pkgs.stdenv.mkDerivation rec {
       --replace ':-nvim' ':-${pkgs.neovim}/bin/nvim'
     '';
 
-  inherit doCheck;
+  # Defaults to false until I find out how to provide /dev/tty inside the
+  # sandbox.
+  doCheck = false;
   checkInputs = with pkgs; [ lua51Packages.busted ];
   checkPhase = "busted --lpath './?.lua' test";
 

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -17,8 +17,8 @@ pkgs.stdenv.mkDerivation rec {
     ncurses # for tput
     neovim
     procps # for nvim_get_proc() which uses ps(1)
-    pandoc
   ];
+  nativeBuildInputs = [ pkgs.pandoc ];
 
   makeFlags = [ "PREFIX=$(out)" ];
   buildFlags = [ "nvimpager.configured" ];

--- a/pkgs/tools/misc/nvimpager/default.nix
+++ b/pkgs/tools/misc/nvimpager/default.nix
@@ -1,0 +1,50 @@
+{ fetchFromGitHub
+, pkgs
+# Defaults to false until I find out how to provide /dev/tty inside the
+# sandbox.
+, doCheck ? false
+}:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "nvimpager";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "lucc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xy5387szfw0bp8dr7d4z33wd4xva7q219rvz8gc0vvv1vsy73va";
+  };
+
+  buildInputs = with pkgs; [
+    ncurses # for tput
+    neovim
+    procps # for nvim_get_proc() which uses ps(1)
+    pandoc
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  buildFlags = [ "nvimpager.configured" ];
+  preBuild = ''
+    substituteInPlace nvimpager \
+      --replace '/usr/bin/env bash' '${pkgs.bash}/bin/bash' \
+      --replace ':-nvim' ':-${pkgs.neovim}/bin/nvim'
+    '';
+
+  inherit doCheck;
+  checkInputs = with pkgs; [ lua51Packages.busted ];
+  checkPhase = "busted --lpath './?.lua' test";
+
+  meta = with pkgs.stdenv.lib; {
+    description = "Use neovim as pager";
+    longDescription = ''
+      Use neovim as a pager to view manpages, diffs, etc with nvim's syntax
+      highlighting.  Includes a cat mode to print highlighted files to stdout
+      and a ansi esc mode to highlight ansi escape sequences in neovim.
+    '';
+    homepage = "https://github.com/lucc/nvimpager";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ lucc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6155,6 +6155,8 @@ in
 
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
+  nvimpgaer = callPackage ../tools/misc/nvimpager { };
+
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 
   nxdomain = python3.pkgs.callPackage ../tools/networking/nxdomain { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6155,7 +6155,7 @@ in
 
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
-  nvimpgaer = callPackage ../tools/misc/nvimpager { };
+  nvimpager = callPackage ../tools/misc/nvimpager { };
 
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make the software I develop available in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)\
  **I deactivated the tests because they currently fail (see below)**
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~\
 **I think this is not aplicable.**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`\
 **there should be none**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)\
 **returns `/nix/store/xnppbc4gmhf2s6v8s1zyibxx305431x5-nvimpager-0.9	  420365568`,no idea what to make of that. Probably not applicable for new derivations**
- [x] Ensured that relevant documentation is up to date \
  **no docs in nixpkgs are needed**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I answered this list to the best of my understanding, be warned that this is my first contribution to nixpkgs!

Currently the upstream tests are not run because they need `/dev/tty`  and we where unable to fix that in https://discourse.nixos.org/t/dev-tty-not-available-in-checkphase-when-writing-my-first-derivation/10492 . If anyone knows how to fix that I would be happy to run the upstream tests by default.