### PR TITLE
pslib: Init at 0.4.6

### DIFF
--- a/pkgs/development/libraries/pslib/default.nix
+++ b/pkgs/development/libraries/pslib/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, cmake, pkgconfig, zlib, libpng, libjpeg, libungif, libtiff
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pslib";
+  version = "0.4.6";
+
+  src = fetchurl {
+    name = "${pname}-snixource-${version}.tar.gz";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0m191ckqj1kj2yvxiilqw26x4vrn7pnlc2vy636yphjxr02q8bk4";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ zlib libpng libjpeg libungif libtiff ];
+
+  doCheck = true;
+
+  outputs = [ "out" "dev" "doc" ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    for path in *.so *.so.* *.o *.o.*; do
+      mv $path $out/lib/
+    done
+    mkdir -p $dev/include
+    mv ../include/libps $dev/include
+    if test -d nix-support; then
+      mv nix-support $dev
+    fi
+    mkdir -p $doc/share/doc/${pname}
+    cp -r ../doc/. $doc/share/doc/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A C-library for generating multi page PostScript documents";
+    homepage = "http://pslib.sourceforge.net/";
+    changelog =
+      "https://sourceforge.net/p/pslib/git/ci/master/tree/pslib/ChangeLog";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15425,6 +15425,8 @@ in
   gnupth = callPackage ../development/libraries/pth { };
   pth = if stdenv.hostPlatform.isMusl then npth else gnupth;
 
+  pslib = callPackage ../development/libraries/pslib { };
+
   pstreams = callPackage ../development/libraries/pstreams {};
 
   pugixml = callPackage ../development/libraries/pugixml { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
pslib is a C-libreary to create PostScript files.
If applied, other nix package (e.g. the in-progress GNU Data Language)
with such dependency can be packaged easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) (44465072)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
