### PR TITLE
nixos/network-interfaces-systemd: fix IPv6 privacy extensions

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -93,7 +93,17 @@ in
             (if i.useDHCP != null then i.useDHCP else false));
           address = forEach (interfaceIps i)
             (ip: "${ip.address}/${toString ip.prefixLength}");
-          networkConfig.IPv6PrivacyExtensions = "kernel";
+          # IPv6PrivacyExtensions=kernel seems to be broken with networkd.
+          # Instead of using IPv6PrivacyExtensions=kernel, configure it according to the value of
+          # `tempAddress`:
+          networkConfig.IPv6PrivacyExtensions = {
+            # generate temporary addresses and use them by default
+            "default" = true;
+            # generate temporary addresses but keep using the standard EUI-64 ones by default
+            "enabled" = "prefer-public";
+            # completely disable temporary addresses
+            "disabled" = false;
+          }.${i.tempAddress};
           linkConfig = optionalAttrs (i.macAddress != null) {
             MACAddress = i.macAddress;
           } // optionalAttrs (i.mtu != null) {


### PR DESCRIPTION
networkd seems to be buggy with IPv6PrivacyExtensions=kernel being set,
and the addresses don't appear anymore. In fact, the corresponding
sysctl seems to be set to -1 again.

Ran the `privacy` test, it succeeds now, so it should unblock channels.

cc @FRidh 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
