### PR TITLE
boops: init at 1.2.0

### DIFF
--- a/pkgs/applications/audio/boops/default.nix
+++ b/pkgs/applications/audio/boops/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, xorg, cairo, lv2, libsndfile, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "BOops";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sjaehn";
+    repo = pname;
+    rev = version;
+    sha256 = "0mhb0x1rdf1bcqnralg12mdpd7ihzv8ifzp9xv5c2ybcsjx4d9ad";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    xorg.libX11 cairo lv2 libsndfile
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sjaehn/BOops";
+    description = "Sound glitch effect sequencer LV2 plugin";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20554,6 +20554,8 @@ in
 
   bonzomatic = callPackage ../applications/editors/bonzomatic { };
 
+  boops = callPackage ../applications/audio/boops { };
+
   brackets = callPackage ../applications/editors/brackets { gconf = gnome2.GConf; };
 
   brave = callPackage ../applications/networking/browsers/brave { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).