### PR TITLE
systemd: 247.1 -> 247.2

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -111,7 +111,7 @@ assert withCryptsetup ->
 let
   wantCurl = withRemote || withImportd;
 
-  version = "247.1";
+  version = "247.2";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -122,7 +122,7 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "0nj362m2zwvszmpywirym0jbkhz07m71hpqj4fw1zzlq4zi23c6n";
+    sha256 = "091pwrvxz3gcf80shlp28d6l4gvjzc6pb61v4mwxmk9d71qaq7ry";
   };
 
   # If these need to be regenerated, `git am path/to/00*.patch` them into a


### PR DESCRIPTION
Contains the following fixes:

 - 937118a5b2 journalctl: don't skip the entries that have the same seqnum
 - e017ac6a26 sd-bus: use SOCK_CLOEXEC on one more socket
 - db31432861 resolved: create stub-resolv.conf symlink with correct security label
 - f2ec15e2e5 efi: Only use arm flags if supported
 - cd43eee770 core: detect_container() may return negative errno
 - 04be042a1f meson: Fix reallocarray check
 - 5e906f483b network: do not assume address ready callback is always set to static addresses
 - 2ad7a2a96a network: drop assertions to check link state in netlink callback handlers
 - f375c8cbb5 network: do not reconfigure interface when the link gains carrier but udev not initialized it yet
 - 5d4909decf veritysetup: also place udev socket dep
 - 57ddb74245 cryptsetup: Fix crypto device missing issue after bootup
 - d3c224d441 network: fix SIGABRT related to unreachable route with DHCP6
 - c91648cc83 network: revert previous changes to address_compare_func()
 - d8b5d8c8c3 udev: Fix sound.target dependency
 - 669107ae68 meson: specify correct libqrencode version in meson dep
 - c07dc6cedc udev: link_update() should fail if the entry in symlink dir couldn't have been created
 - 367006c806 man: document that automount units are privileged
 - 5129808141 logind: fix closing of button input devices
 - 37f06c91ef Update logind-button.c
 - 9e9fda0a2d async: add trivial cleanup wrapper for asynchronous_close()
 - 4a2ca1ca4a Silence cgroups v1 read-only filesystem warning
 - ed1f8f4ba2 manager: Fix HW watchdog when systemd starts before driver loaded
 - 383a747164 cgroup: Also set blkio.bfq.weight
 - 48d41091ac nss-resolve: varlink_call() set error_id only when r >= 0
 - 56daba2deb missing: Define several syscall numbers for Alpha arch
 - f2a4b96276 Don't assume /run/systemd exists when creating unit-root
 - 553530fdc7 mkosi: Add findutils to Fedora config
 - e42990dfe3 mkosi: Add rpm to Fedora BuildPackages as it's needed by pkg-config
 - 6bacd1d971 mkosi: Replace iptables-dev with libiptc-dev in debian config
 - f1fc515c21 dissect: don't declare unused variables on archs that have no GPT discovery
 - 30d0c3f58c resolved: synthesize NODATA instead of NXDOMAIN if gateway exists, but of other protocol
 - 538ebbd7f3 local-addresses: make returning accumulated list optional
 - 228a22bb63 resolved: improve log message when we use TCP a bit
 - aa31dd9128 network: ignore broadcast address for /31 or /32 addresses
 - 85607cc094 network: fix verification for broadcast address
 - dc6ad6482a network: do not set broadcast if prefixlen is 31 or 32
 - 39ee319c75 stub: don't ever respond to datagrams coming in on non-localhost addreses, on the stub
 - cbea0e5a83 resolved: never allow _gateway lookups to go to the network
 - c4df66816b resolved: lower SERVFAIL cache timeout from 30s to 10s
 - b5e39c20d9 dns-domain: try IDN2003 rules if IDN2008 doesn't work
 - 2c354cedd2 virt: Properly detect nested UML inside another hypervisor
 - 10f2cfb715 resolved: properly check per-link NTA list
 - a8437c07e4 meson: use '_' as separator in fuzz test names
 - 81ef7623c8 man: mention that --key= is about *secret* keys
 - 4ef70ecefc meson: check that cxx variable is set before using it

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
