### PR TITLE
arduino-ci: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/development/arduino/arduino-ci/default.nix
+++ b/pkgs/development/arduino/arduino-ci/default.nix
@@ -1,23 +1,22 @@
-{ stdenv, fetchFromGitHub,  makeWrapper, arduino-cli, ruby, python3, patchelf }:
+{ stdenv, fetchFromGitHub,  makeWrapper, arduino-cli, ruby, python3 }:
 
 let
 
   runtimePath = stdenv.lib.makeBinPath [
     arduino-cli
-    (python3.withPackages (ps: [ ps.pyserial ])) # required by esp32 core
-    patchelf # required by esp32 core
+    python3 # required by the esp8266 core
   ];
 
 in
 stdenv.mkDerivation rec {
   pname = "arduino-ci";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner  = "pololu";
     repo   = "arduino-ci";
     rev    = "v${version}";
-    sha256 = "sha256-uLCLupzJ446WcxXZtzJk1wnae+k1NTSy0cGHLqW7MZU=";
+    sha256 = "sha256-9RbBxgwsSQ7oGGKr1Vsn9Ug9AsacoRgvQgd9jbRQ034=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

new version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
