### PR TITLE
newsflash: 1.0.5 -> 1.1.1

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsflash/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsflash/default.nix
@@ -8,7 +8,7 @@
 , gdk-pixbuf
 , glib
 , gtk3
-, libhandy_0
+, libhandy
 , openssl
 , sqlite
 , webkitgtk
@@ -19,16 +19,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "newsflash";
-  version = "1.0.5";
+  version = "1.1.1";
 
   src = fetchFromGitLab {
     owner = "news-flash";
     repo = "news_flash_gtk";
     rev = version;
-    sha256 = "0kh1xqvxfz58gnrl8av0zkig9vcgmx9iaxw5p6gdm8a7gv18nvp3";
+    sha256 = "1z47h23g87dqmr9sfjl36fs5xjm2wj7z2bri9g0a4jcpwzl5awsd";
   };
 
-  cargoSha256 = "059sppidbxzjk8lmjq41d5qbymp9j9v2qr0jxd7xg9avr0klwc2s";
+  cargoSha256 = "0rnrdh9ganj63hf9j890yj9pahcgza95z7x020w72mbb4648hq26";
 
   patches = [
     ./no-post-install.patch
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     gtk3
-    libhandy_0
+    libhandy
     openssl
     sqlite
     webkitgtk


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest version: https://gitlab.com/news-flash/news_flash_gtk/-/tags/1.1.1

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).