### PR TITLE
unused: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5228,6 +5228,10 @@
     githubId = 10626;
     name = "Andreas Wagner";
   };
+  lrworth = {
+    email = "luke@worth.id.au";
+    name = "Luke Worth";
+  };
   lschuermann = {
     email = "leon.git@is.currently.online";
     github = "lschuermann";

--- a/pkgs/development/tools/misc/unused/default.nix
+++ b/pkgs/development/tools/misc/unused/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform, cmake }:
+rustPlatform.buildRustPackage rec {
+  pname = "unused";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "unused-code";
+    repo = pname;
+    rev = version;
+    sha256 = "06r6m7k570rdm9szghnp3g4r6ij0vp8apfanqzzxv2hd7gf8v62b";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cargoSha256 = "1c0gj2wp0nydv0binxj3ikm5sm6y5z3pklp5b06dgvq02licz57a";
+
+  meta = with stdenv.lib; {
+    description = "A tool to identify potentially unused code";
+    homepage = "https://unused.codes";
+    license = licenses.mit;
+    maintainers = [ maintainers.lrworth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12228,6 +12228,8 @@ in
 
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };
 
+  unused = callPackage ../development/tools/misc/unused { };
+
   vagrant = callPackage ../development/tools/vagrant {};
 
   vala-language-server = callPackage ../development/tools/vala-language-server {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the `unused` tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
