### PR TITLE
libsolv: Enable darwin support.

### DIFF
--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "A free package dependency solver";
     homepage    = "https://github.com/openSUSE/libsolv";
     license     = licenses.bsd3;
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ copumpkin ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This already compiles fine, no changes necesssary.
I am currently working on getting DNF to compile on darwin (long story) and this is one of the less problematic dependencies :)

Example:
```
/nix/store/r4i8ba7cjzr1nczsqw8p9i2mjcjqifkb-libsolv-0.7.16/bin/installcheck: <arch> [options..] repo [--nocheck repo]...
	--exclude <pattern>	whitespace-separated list of (sub-)packagenames to ignore
	--withobsoletes		Check for obsoletes on packages contained in repos
	--nocheck		Do not warn about all following repos (only use them to fulfill dependencies)
	--withsrc		Also check dependencies of src.rpm
```

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
