### PR TITLE
pythonPackages.ciscomobilityexpress: init at 0.3.9

### DIFF
--- a/pkgs/development/python-modules/ciscomobilityexpress/default.nix
+++ b/pkgs/development/python-modules/ciscomobilityexpress/default.nix
@@ -1,0 +1,20 @@
+{ buildPythonPackage, fetchPypi, lib, requests }:
+
+buildPythonPackage rec {
+  pname = "ciscomobilityexpress";
+  version = "0.3.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kj0i1963afxqw9apk0yxzj1f7kpi1949ggnkzkb8v90kxpgymma";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = {
+    description = "Module to interact with Cisco Mobility Express APIs to fetch connected devices";
+    homepage = "https://pypi.python.org/pypi/${pname}/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ uvnikita ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -113,7 +113,7 @@
     "channels" = ps: with ps; [ ]; # missing inputs: pychannels
     "circuit" = ps: with ps; [ ]; # missing inputs: circuit-webhook
     "cisco_ios" = ps: with ps; [ pexpect ];
-    "cisco_mobility_express" = ps: with ps; [ ]; # missing inputs: ciscomobilityexpress
+    "cisco_mobility_express" = ps: with ps; [ ciscomobilityexpress ];
     "cisco_webex_teams" = ps: with ps; [ ]; # missing inputs: webexteamssdk
     "citybikes" = ps: with ps; [ ];
     "clementine" = ps: with ps; [ ]; # missing inputs: python-clementine-remote

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1175,6 +1175,8 @@ in {
 
   cirq = callPackage ../development/python-modules/cirq { };
 
+  ciscomobilityexpress = callPackage ../development/python-modules/ciscomobilityexpress { };
+
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };
 
   citeproc-py = callPackage ../development/python-modules/citeproc-py { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes import module error when using `cisco_mobility_express` home assistant component: https://github.com/NixOS/nixpkgs/blob/b83e5b85bd373bafb292f56b3869799ebef90ba8/pkgs/servers/home-assistant/component-packages.nix#L116

@mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
