### PR TITLE
joycond: init at unstable-2021-03-27

### DIFF
--- a/pkgs/os-specific/linux/joycond/default.nix
+++ b/pkgs/os-specific/linux/joycond/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libevdev, udev }:
+
+stdenv.mkDerivation rec {
+  pname = "joycond";
+  version = "unstable-2021-03-27";
+
+  src = fetchFromGitHub {
+    owner = "DanielOgorchock";
+    repo = "joycond";
+    rev = "2d3f553060291f1bfee2e49fc2ca4a768b289df8";
+    sha256 = "0dpmwspll9ar3pxg9rgnh224934par8h8bixdz9i2pqqbc3dqib7";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libevdev udev ];
+
+  # CMake has hardcoded install paths
+  installPhase = ''
+    mkdir -p $out/{bin,etc/{systemd/system,udev/rules.d},lib/modules-load.d}
+
+    cp ./joycond $out/bin
+    cp $src/udev/{89,72}-joycond.rules $out/etc/udev/rules.d
+    cp $src/systemd/joycond.service $out/etc/systemd/system
+    cp $src/systemd/joycond.conf $out/lib/modules-load.d
+
+    substituteInPlace $out/etc/systemd/system/joycond.service --replace \
+      "ExecStart=/usr/bin/joycond" "ExecStart=$out/bin/joycond"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/DanielOgorchock/joycond";
+    description = "Userspace daemon to combine joy-cons from the hid-nintendo kernel driver";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2335,6 +2335,8 @@ in
 
   jotta-cli = callPackage ../applications/misc/jotta-cli { };
 
+  joycond = callPackage ../os-specific/linux/joycond { };
+
   jwt-cli = callPackage ../tools/security/jwt-cli {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
Saw `nintendo-hid` [got merged](https://www.phoronix.com/scan.php?page=news_item&px=Linux-5.10-Feature-Recap) with Linux 5.10, and thought this would be a nice addition to that.

Latest release tag is pretty old, so I've just fetched the last commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
