### PR TITLE
gamenetworkingsockets: init at 1.2.0

### DIFF
--- a/pkgs/development/libraries/gamenetworkingsockets/default.nix
+++ b/pkgs/development/libraries/gamenetworkingsockets/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, go, protobuf, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "GameNetworkingSockets";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ValveSoftware";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zghyc4liml8gzxflyh5gp6zi11ny6ng5hv9wyqvp32rfx221gc6";
+  };
+
+  nativeBuildInputs = [ cmake ninja go ];
+
+  cmakeFlags = [ "-G Ninja" ];
+
+  # tmp home for go
+  preBuild = "export HOME=\"$(mktemp -d)\"";
+
+  buildInputs = [ protobuf openssl ];
+
+  meta = with stdenv.lib; {
+    description = "GameNetworkingSockets is a basic transport layer for games";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    inherit (src.meta) homepage;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12937,6 +12937,8 @@ in
 
   funambol = callPackage ../development/libraries/funambol { };
 
+  gamenetworkingsockets = callPackage ../development/libraries/gamenetworkingsockets { };
+
   gamin = callPackage ../development/libraries/gamin { };
   fam = gamin; # added 2018-04-25
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
