### PR TITLE
libmodulemd: Enable darwin support.

### DIFF
--- a/pkgs/development/libraries/libmodulemd/default.nix
+++ b/pkgs/development/libraries/libmodulemd/default.nix
@@ -83,6 +83,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/fedora-modularity/libmodulemd";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin ;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This already compiles fine, no changes necesssary.
I am currently working on getting DNF to compile on darwin (long story) and this is one of the less problematic dependencies :)

Example:
```
% /nix/store/svsyagf509zn9n00qc2nqja883vfbf5k-libmodulemd-2.9.2-bin/bin/modulemd-validator --help
Usage:
  modulemd-validator [OPTION…] FILES - Simple modulemd YAML validator

Help Options:
  -h, --help        Show help options

Application Options:
  --debug           Output debugging messages
  -q, --quiet       Print no output
  -v, --verbose     Be verbose
  -V, --version     Print version number, then exit
```

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).