### PR TITLE
librepo: add darwin support

### DIFF
--- a/pkgs/tools/package-management/librepo/default.nix
+++ b/pkgs/tools/package-management/librepo/default.nix
@@ -35,11 +35,12 @@ stdenv.mkDerivation rec {
     libxml2
     glib
     openssl
-    zchunk
     curl
     check
     gpgme
-  ];
+  ]
+  # zchunk currently has issues compiling in darwin, fine in linux
+  ++ stdenv.lib.optional stdenv.isLinux zchunk;
 
   # librepo/fastestmirror.h includes curl/curl.h, and pkg-config specfile refers to others in here
   propagatedBuildInputs = [
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DPYTHON_DESIRED=${stdenv.lib.substring 0 1 python.pythonVersion}"
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin "-DWITH_ZCHUNK=OFF";
 
   postFixup = ''
     moveToOutput "lib/${python.libPrefix}" "$py"
@@ -60,7 +61,7 @@ stdenv.mkDerivation rec {
     description = "Library providing C and Python (libcURL like) API for downloading linux repository metadata and packages";
     homepage = "https://rpm-software-management.github.io/librepo/";
     license = licenses.lgpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ copumpkin ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I am currently working on getting DNF to compile on darwin (long story) and this is one of the less problematic dependencies :)

librepo compiles mostly fine, but on darwin zchunk still has issues.
For now, I disabled it zchunk support. I will add darwin support to zchunk over the next few days.
This means that for now librepo on darwin will be able to interact with repositories that use xz or gzip, but not zchunk.

Since it's a library I can't really run any executables, but I can show the exported symbols:

```
mseeger@mseeger-mbp lib % pwd
/nix/store/s6lv0ldjc5rr77bnyghldmchwjdp0b4z-librepo-1.12.1/lib
mseeger@mseeger-mbp lib % nm -gU librepo.dylib
000000000000edc0 T _appendFdValue
000000000000edf0 T _appendPath
000000000000f4b0 T _cleanup
0000000000015920 T _compare_records
000000000000ef00 T _create_repomd_xml_download_targets
00000000000094e0 T _ensure_socket_dir_exists
0000000000016be0 T _error_handling
000000000000ee20 T _fillInvalidationValues
000000000000ee80 T _handle_failure
0000000000015930 T _hmfcb
0000000000014d30 T _lr_best_checksum
0000000000015270 T _lr_char_handler
0000000000010390 T _lr_check_packages
0000000000015de0 T _lr_check_repomd_xml_asc_availability
0000000000010950 T _lr_checksum_error_quark
00000000000043f0 T _lr_checksum_fd
0000000000004760 T _lr_checksum_fd_cmp
0000000000004780 T _lr_checksum_fd_compare
0000000000004200 T _lr_checksum_type
00000000000043d0 T _lr_checksum_type_to_str
0000000000014b60 T _lr_copy_content
0000000000015bf0 T _lr_copy_metalink_content
000000000000dba0 T _lr_detect_protocol
0000000000004b00 T _lr_download
000000000000f520 T _lr_download_metadata
0000000000010310 T _lr_download_package
000000000000fbd0 T _lr_download_packages
0000000000007670 T _lr_download_single_cb
0000000000007530 T _lr_download_target
0000000000007580 T _lr_download_url
0000000000010970 T _lr_downloader_error_quark
0000000000007d30 T _lr_downloadtarget_free
0000000000007b60 T _lr_downloadtarget_new
0000000000007cf0 T _lr_downloadtarget_reset
0000000000007eb0 T _lr_downloadtarget_set_effectiveurl
0000000000007d70 T _lr_downloadtarget_set_error
0000000000007e90 T _lr_downloadtarget_set_usedmirror
0000000000007b30 T _lr_downloadtargetchecksum_free
0000000000007af0 T _lr_downloadtargetchecksum_new
0000000000008fa0 T _lr_fastestmirror
0000000000007f00 T _lr_fastestmirror_detailed
0000000000010990 T _lr_fastestmirror_error_quark
00000000000090c0 T _lr_fastestmirror_sort_internalmirrorlist
0000000000009100 T _lr_fastestmirror_sort_internalmirrorlists
0000000000014560 T _lr_free
0000000000016050 T _lr_get_best_checksum
000000000000a030 T _lr_get_curl_handle
0000000000016190 T _lr_get_metadata_failure_callback
0000000000015130 T _lr_get_recursive_files
0000000000014fb0 T _lr_get_recursive_files_rec
00000000000145f0 T _lr_gettmpdir
0000000000014580 T _lr_gettmpfile
0000000000014440 T _lr_global_init
0000000000009ad0 T _lr_gpg_check_signature
00000000000095a0 T _lr_gpg_check_signature_fd
00000000000109b0 T _lr_gpg_error_quark
0000000000009c30 T _lr_gpg_import_key
00000000000109d0 T _lr_handle_error_quark
000000000000a260 T _lr_handle_free
000000000000a100 T _lr_handle_free_list
000000000000cf00 T _lr_handle_getinfo
000000000000a160 T _lr_handle_init
000000000000cac0 T _lr_handle_perform
000000000000bdb0 T _lr_handle_prepare_internal_mirrorlist
000000000000a4d0 T _lr_handle_setopt
000000000001dc00 S _lr_interrupt
0000000000014ee0 T _lr_is_local_path
0000000000014f30 T _lr_key_file_save_to_file
00000000000143a0 T _lr_log_librepo_summary
0000000000007ed0 T _lr_lrfastestmirror_free
000000000000e020 T _lr_lrmirrorlist_append_lrmirrorlist
000000000000de80 T _lr_lrmirrorlist_append_metalink
000000000000dd60 T _lr_lrmirrorlist_append_mirrorlist
000000000000dc70 T _lr_lrmirrorlist_append_url
000000000000dc30 T _lr_lrmirrorlist_free
000000000000e0b0 T _lr_lrmirrorlist_nth
000000000000e0c0 T _lr_lrmirrorlist_nth_url
00000000000144f0 T _lr_malloc
0000000000014510 T _lr_malloc0
000000000000ec40 T _lr_metadatatarget_append_error
000000000000ec00 T _lr_metadatatarget_free
000000000000ea70 T _lr_metadatatarget_new
000000000000eb20 T _lr_metadatatarget_new2
00000000000109f0 T _lr_metalink_error_quark
000000000000e0f0 T _lr_metalink_free
000000000000e0e0 T _lr_metalink_init
000000000000e1f0 T _lr_metalink_parse_file
0000000000010a10 T _lr_mirrorlist_error_quark
000000000000f6a0 T _lr_mirrorlist_free
000000000000f690 T _lr_mirrorlist_init
000000000000f6d0 T _lr_mirrorlist_parse_file
0000000000007650 T _lr_multi_mf_func
00000000000075a0 T _lr_multi_progress_func
00000000000144c0 T _lr_out_of_memory
0000000000010a30 T _lr_package_downloader_error_quark
000000000000fba0 T _lr_packagetarget_free
000000000000f9f0 T _lr_packagetarget_new
000000000000faf0 T _lr_packagetarget_new_v2
000000000000fb30 T _lr_packagetarget_new_v3
000000000000fb80 T _lr_packagetarget_reset
0000000000014640 T _lr_pathconcat
0000000000015950 T _lr_prepare_repodata_dir
0000000000015d40 T _lr_prepare_repomd_xml_file
0000000000014c10 T _lr_prepend_url_protocol
0000000000014530 T _lr_realloc
0000000000014b40 T _lr_remove_dir
0000000000014af0 T _lr_remove_dir_cb
0000000000010a70 T _lr_repoconf_error_quark
0000000000010a90 T _lr_repomd_error_quark
0000000000013a20 T _lr_repoutil_yum_check_repo
0000000000010ab0 T _lr_repoutil_yum_error_quark
0000000000013b20 T _lr_repoutil_yum_parse_repomd
0000000000013d20 T _lr_result_clear
0000000000010ad0 T _lr_result_error_quark
0000000000013d70 T _lr_result_free
0000000000013dc0 T _lr_result_getinfo
0000000000013d10 T _lr_result_init
00000000000049d0 T _lr_sigint_handler
0000000000015aa0 T _lr_store_mirrorlist_files
0000000000010920 T _lr_strerror
0000000000014ce0 T _lr_string_chunk_insert
0000000000014e50 T _lr_strv_dup
0000000000014180 T _lr_url_substitute
0000000000014dc0 T _lr_url_without_path
0000000000014120 T _lr_urlvars_free
0000000000014000 T _lr_urlvars_set
00000000000049e0 T _lr_writecb
0000000000015230 T _lr_xml_parser_data_free
00000000000151c0 T _lr_xml_parser_data_new
0000000000010a50 T _lr_xml_parser_error_quark
00000000000155d0 T _lr_xml_parser_generic
0000000000015500 T _lr_xml_parser_strtoll
00000000000153c0 T _lr_xml_parser_warning
0000000000014d00 T _lr_xml_parser_warning_logger
0000000000016e30 T _lr_yum_download_repo
0000000000016cf0 T _lr_yum_download_repos
0000000000016200 T _lr_yum_download_url
0000000000010af0 T _lr_yum_error_quark
0000000000016f20 T _lr_yum_perform
00000000000157c0 T _lr_yum_repo_free
00000000000157b0 T _lr_yum_repo_init
0000000000015860 T _lr_yum_repo_path
0000000000011280 T _lr_yum_repoconf_getinfo
0000000000011180 T _lr_yum_repoconf_save
0000000000012210 T _lr_yum_repoconf_setopt
0000000000010bd0 T _lr_yum_repoconfs_add_empty_conf
0000000000010b20 T _lr_yum_repoconfs_free
0000000000010bc0 T _lr_yum_repoconfs_get_list
0000000000010b10 T _lr_yum_repoconfs_init
0000000000010fb0 T _lr_yum_repoconfs_load_dir
0000000000010ce0 T _lr_yum_repoconfs_parse
0000000000011100 T _lr_yum_repoconfs_save
0000000000012f00 T _lr_yum_repomd_free
0000000000013c90 T _lr_yum_repomd_get_age
0000000000012fe0 T _lr_yum_repomd_get_highest_timestamp
0000000000012f90 T _lr_yum_repomd_get_record
0000000000012ed0 T _lr_yum_repomd_init
0000000000013050 T _lr_yum_repomd_parse_file
00000000000163b0 T _prepare_repo_download_std_target
00000000000164f0 T _prepare_repo_download_targets
000000000000f2f0 T _process_repomd_xml
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I'm currently running "nixpkgs-review pr 107104" on my linux box as well

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
