### PR TITLE
pythonPackages.awkward: 0.4.5 -> 1.0.1, awkward1 -> awkward

### DIFF
--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -9,12 +9,12 @@
 }:
 
 buildPythonPackage rec {
-  pname = "awkward1";
-  version = "0.4.5";
+  pname = "awkward";
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8c786d1641343e9887c21794f9a3bf51716b00ed3b182491f1acbc9e389b31bb";
+    sha256 = "d856b4a166ae054363368aed2e4a44338fec069baa4242e7d567c8323ebcc1eb";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -505,7 +505,7 @@ in {
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify { };
 
   awkward0 = callPackage ../development/python-modules/awkward0 { };
-  awkward1 = callPackage ../development/python-modules/awkward1 { };
+  awkward = callPackage ../development/python-modules/awkward { };
 
   aws-adfs = callPackage ../development/python-modules/aws-adfs { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Pick up work started in #106175

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
