### PR TITLE
purple-gowhatsapp: init at 0.4.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-gowhatsapp/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-gowhatsapp/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pidgin }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "purple-gowhatsapp";
   version = "2020-12-08";
 

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-gowhatsapp/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-gowhatsapp/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pidgin }:
+
+stdenv.mkDerivation {
+  pname = "purple-gowhatsapp";
+  version = "2020-12-08";
+
+  src = fetchurl {
+    url = "https://buildbot.hehoe.de/purple-gowhatsapp/builds/libgowhatsapp_0.4.1~gitb84fdd7+gowhatsapp~git64cc8cf_amd64_ubuntu18.04.so";
+    name = "purple-gowhatsapp.so";
+    sha256 = "1g8d4wic96jixkizn8lbszl1nvqrdwjjxqnin9cwfw4wwxmz4ki6";
+  };
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/purple-2
+    cp $src $out/lib/purple-2/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/hoehermann/purple-gowhatsapp";
+    description = "A libpurple/Pidgin plugin for WhatsApp Web.";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ vldn-dev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23468,6 +23468,8 @@ in
 
   purple-discord = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-discord { };
 
+  purple-gowhatsapp = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-gowhatsapp { };
+
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };
 
   purple-lurch = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-lurch { };


### PR DESCRIPTION
###### Motivation for this change
Additional Pidgin plugin which was missing.
Connect WhatsApp-Web with Pidgin via scanning the QR-Code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
