### PR TITLE
woof: 2012-05-31 -> 2020-12-17

### DIFF
--- a/pkgs/tools/misc/woof/default.nix
+++ b/pkgs/tools/misc/woof/default.nix
@@ -1,24 +1,25 @@
-{ stdenv, fetchurl, python }:
+{ stdenv, fetchFromGitHub, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "2012-05-31";
+  version = "2020-12-17";
   pname = "woof";
 
-  src = fetchurl {
-    url = "http://www.home.unix-ag.org/simon/woof-${version}.py";
-    sha256 = "d84353d07f768321a1921a67193510bf292cf0213295e8c7689176f32e945572";
+  src = fetchFromGitHub {
+    owner = "simon-budig";
+    repo = "woof";
+    rev = "4aab9bca5b80379522ab0bdc5a07e4d652c375c5";
+    sha256 = "0ypd2fs8isv6bqmlrdl2djgs5lnk91y1c3rn4ar6sfkpsqp9krjn";
   };
 
-  buildInputs = [ python ];
+  propagatedBuildInputs = [ python3 ];
 
   dontUnpack = true;
 
-  installPhase =
-    ''
-      mkdir -p $out/bin
-      cp $src $out/bin/woof
-      chmod +x $out/bin/woof
-    '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/woof $out/bin/woof
+    chmod +x $out/bin/woof
+  '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.home.unix-ag.org/simon/woof.html";


### PR DESCRIPTION
Also, fetch from github and bring python3 into scope with it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
