### PR TITLE
boost175: init at 1.75.0

### DIFF
--- a/pkgs/development/libraries/boost/1.75.nix
+++ b/pkgs/development/libraries/boost/1.75.nix
@@ -1,0 +1,15 @@
+{ stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.75.0";
+
+  src = fetchurl {
+    urls = [
+      "mirror://sourceforge/boost/boost_1_75_0.tar.bz2"
+      "https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2"
+    ];
+    # SHA256 from http://www.boost.org/users/history/version_1_75_0.html
+    sha256 = "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb";
+  };
+})
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12488,7 +12488,8 @@ in
   boost172 = callPackage ../development/libraries/boost/1.72.nix { };
   boost173 = callPackage ../development/libraries/boost/1.73.nix { };
   boost174 = callPackage ../development/libraries/boost/1.74.nix { };
-  boost17x = boost174;
+  boost175 = callPackage ../development/libraries/boost/1.75.nix { };
+  boost17x = boost175;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
###### Motivation for this change
https://www.boost.org/users/history/version_1_75_0.html

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
