### PR TITLE
thunderbird: Add gpg/gpgme dependencies to fix smartcard usage

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -39,6 +39,7 @@
 , gnused
 , gnugrep
 , gnupg
+, gpgme
 , runtimeShell
 }:
 
@@ -118,6 +119,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  # See "Note on GPG support" in `../thunderbird/default.nix` for explanations
+  # on adding `gnupg` and `gpgme` into PATH/LD_LIBRARY_PATH.
+
   installPhase =
     ''
       mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
@@ -158,7 +162,9 @@ stdenv.mkDerivation {
         --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
         --set SNAP_NAME "thunderbird" \
         --set MOZ_LEGACY_PROFILES 1 \
-        --set MOZ_ALLOW_DOWNGRADE 1
+        --set MOZ_ALLOW_DOWNGRADE 1 \
+        --prefix PATH : "${stdenv.lib.getBin gnupg}/bin" \
+        --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib gpgme}/lib"
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -1,22 +1,31 @@
-{ stdenv, fetchurl, config, makeWrapper
+{ stdenv, lib, fetchurl, config, makeWrapper
 , alsaLib
 , at-spi2-atk
 , atk
 , cairo
+, coreutils
 , cups
 , curl
-, dbus-glib
 , dbus
+, dbus-glib
 , fontconfig
 , freetype
 , gdk-pixbuf
 , glib
 , glibc
+, gnome3
+, gnugrep
+, gnupg
+, gnused
+, gpgme
 , gtk2
 , gtk3
 , kerberos
+, libcanberra
+, libGL
+, libGLU
 , libX11
-, libXScrnSaver
+, libxcb
 , libXcomposite
 , libXcursor
 , libXdamage
@@ -25,22 +34,14 @@
 , libXi
 , libXinerama
 , libXrender
+, libXScrnSaver
 , libXt
-, libxcb
-, libcanberra
-, gnome3
-, libGLU, libGL
 , nspr
 , nss
 , pango
+, runtimeShell
 , writeScript
 , xidel
-, coreutils
-, gnused
-, gnugrep
-, gnupg
-, gpgme
-, runtimeShell
 }:
 
 # imports `version` and `sources`
@@ -59,9 +60,9 @@ let
 
   systemLocale = config.i18n.defaultLocale or "en-US";
 
-  defaultSource = stdenv.lib.findFirst (sourceMatches "en-US") {} sources;
+  defaultSource = lib.findFirst (sourceMatches "en-US") {} sources;
 
-  source = stdenv.lib.findFirst (sourceMatches systemLocale) defaultSource sources;
+  source = lib.findFirst (sourceMatches systemLocale) defaultSource sources;
 
   name = "thunderbird-bin-${version}";
 in
@@ -76,7 +77,7 @@ stdenv.mkDerivation {
 
   phases = "unpackPhase installPhase";
 
-  libPath = stdenv.lib.makeLibraryPath
+  libPath = lib.makeLibraryPath
     [ stdenv.cc.cc
       alsaLib
       at-spi2-atk
@@ -111,7 +112,7 @@ stdenv.mkDerivation {
       nspr
       nss
       pango
-    ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
+    ] + ":" + lib.makeSearchPathOutput "lib" "lib64" [
       stdenv.cc.cc
     ];
 
@@ -163,8 +164,8 @@ stdenv.mkDerivation {
         --set SNAP_NAME "thunderbird" \
         --set MOZ_LEGACY_PROFILES 1 \
         --set MOZ_ALLOW_DOWNGRADE 1 \
-        --prefix PATH : "${stdenv.lib.getBin gnupg}/bin" \
-        --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib gpgme}/lib"
+        --prefix PATH : "${lib.getBin gnupg}/bin" \
+        --prefix LD_LIBRARY_PATH : "${lib.getLib gpgme}/lib"
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {
@@ -174,14 +175,14 @@ stdenv.mkDerivation {
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
   };
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Mozilla Thunderbird, a full-featured email client (binary package)";
     homepage = "http://www.mozilla.org/thunderbird/";
     license = {
       free = false;
       url = "http://www.mozilla.org/en-US/foundation/trademarks/policy/";
     };
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -15,6 +15,8 @@
 , glib
 , gnugrep
 , gnused
+, gnupg
+, gpgme
 , icu
 , jemalloc
 , lib
@@ -288,6 +290,15 @@ stdenv.mkDerivation rec {
     rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
   '';
 
+  # Note on GPG support:
+  # Thunderbird's native GPG support does not yet support smartcards.
+  # The official upstream recommendation is to configure fall back to gnupg
+  # using the Thunderbird config `mail.openpgp.allow_external_gnupg`
+  # and GPG keys set up; instructions with pictures at:
+  # https://anweshadas.in/how-to-use-yubikey-or-any-gpg-smartcard-in-thunderbird-78/
+  # For that to work out of the box, it requires `gnupg` on PATH and
+  # `gpgme` in `LD_LIBRARY_PATH`; we do this below.
+
   preFixup = ''
     # Needed to find Mozilla runtime
     gappsWrapperArgs+=(
@@ -297,6 +308,8 @@ stdenv.mkDerivation rec {
       --set SNAP_NAME "thunderbird"
       --set MOZ_LEGACY_PROFILES 1
       --set MOZ_ALLOW_DOWNGRADE 1
+      --prefix PATH : "${lib.getBin gnupg}/bin"
+      --prefix LD_LIBRARY_PATH : "${lib.getLib gpgme}/lib"
     )
   '';
 

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -14,15 +14,15 @@
 , freetype
 , glib
 , gnugrep
-, gnused
 , gnupg
+, gnused
 , gpgme
 , icu
 , jemalloc
 , lib
+, libevent
 , libGL
 , libGLU
-, libevent
 , libjpeg
 , libnotify
 , libpng
@@ -338,7 +338,7 @@ stdenv.mkDerivation rec {
 
   requiredSystemFeatures = [ "big-parallel" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A full-featured e-mail client";
     homepage = "https://www.thunderbird.net";
     maintainers = with maintainers; [


### PR DESCRIPTION
###### Motivation for this change

Fixes #98765.

This enables to configure Thunderbird to use gnupg directly, which is the
official upstream recommendation when using GPG with smartcards, which are not
yet supported by Thunderbird's native GPG support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
     - [x] `master` @ fe8f5586d5955dca0207d76b1514fba8efb257aa
     - [x] I've tested on NixOS 20.09 but not yet on `master`
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `576 MB` -> `599 MB`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
