### PR TITLE
rpm: 4.15.1 -> 4.16.1.2

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -1,21 +1,22 @@
-{ stdenv, lib
+{ stdenv, lib, fetchpatch
 , pkgconfig, autoreconfHook
-, fetchurl, cpio, zlib, bzip2, file, elfutils, libbfd, libarchive, nspr, nss, popt, db, xz, python, lua, llvmPackages
+, fetchurl, cpio, zlib, bzip2, file, elfutils, libbfd, libgcrypt, libarchive, nspr, nss, popt, db, xz, python, lua, llvmPackages
+, sqlite
 }:
 
 stdenv.mkDerivation rec {
   pname = "rpm";
-  version = "4.15.1";
+  version = "4.16.1.2";
 
   src = fetchurl {
     url = "http://ftp.rpm.org/releases/rpm-${lib.versions.majorMinor version}.x/rpm-${version}.tar.bz2";
-    sha256 = "0c6jwail90fhha3bpx70w4a2i8ycxwvnx6zwxm121l8wc3wlbvyx";
+    sha256 = "1k6ank2aad7r503w12m6m494mxr6iccj52wqhwbc94pwxsf34mw3";
   };
 
   outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ cpio zlib bzip2 file libarchive nspr nss db xz python lua ]
+  buildInputs = [ cpio zlib bzip2 file libarchive libgcrypt nspr nss db xz python lua sqlite ]
                 ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
   # rpm/rpmlib.h includes popt.h, and then the pkg-config file mentions these as linkage requirements
@@ -28,14 +29,23 @@ stdenv.mkDerivation rec {
     "--with-external-db"
     "--with-lua"
     "--enable-python"
+    "--enable-ndb"
+    "--enable-sqlite"
     "--localstatedir=/var"
     "--sharedstatedir=/com"
   ];
 
-  postPatch = ''
-    # For Python3, the original expression evaluates as 'python3.4' but we want 'python3.4m' here
-    substituteInPlace configure.ac --replace 'python''${PYTHON_VERSION}' ${python.executable}
+  # Small fixes for ndb on darwin
+  # https://github.com/rpm-software-management/rpm/pull/1465
+  patches = [
+    (fetchpatch {
+      name = "darwin-support.patch";
+      url = "https://github.com/rpm-software-management/rpm/commit/2d20e371d5e38f4171235e5c64068cad30bda557.patch";
+      sha256 = "0p3j5q5a4hl357maf7018k3826jhcpqg6wfrnccrkv30g0ayk171";
+    })
+  ];
 
+  postPatch = ''
     substituteInPlace Makefile.am --replace '@$(MKDIR_P) $(DESTDIR)$(localstatedir)/tmp' ""
   '';
 


### PR DESCRIPTION
Looking at http://rpm.org/timeline, 4.16.1.2 is the newest release.

With 4.16 the NDB backend was "promoted to stable", so I also enabled it in our builds.
NDB is included in the rpm codebase, so no additional dependencies for that . It just required a few small changes to compile on macOS.

sqlite will be the default for e.g. fedora 33 (https://fedoraproject.org/wiki/Changes/Sqlite_Rpmdb), so I also enable it as a backend. Without these two, the resulting binary won't be able to read the majority of rpm DBs in the near future, so it seems like a sane default.

Also, as you can see, enabling these two doesn't change the default backend when not specified otherwise. It's still bdb:

```
mseeger@mseeger-mbp nixpkgs % /nix/store/x0kafl4cqlng73v9px04y1x7dww52cqq-rpm-4.16.1.2/bin/rpm --eval '%_db_backend'
bdb
```

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
