### PR TITLE
ocamlPackages.ocaml-lsp: 1.1.0 -> 1.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -2,6 +2,8 @@
 , stdlib-shims
 , ppx_yojson_conv_lib
 , ocaml-syntax-shims
+, yojson
+, result
 , omd
 , octavius
 , dune-build-info
@@ -12,10 +14,10 @@
 , lib
 }:
 let
-  version = "1.1.0";
+  version = "1.4.0";
   src = fetchzip {
-    url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/ocaml-lsp-server-${version}.tbz";
-    sha256 = "0al89waw43jl80k9z06kh44byhjhwb5hmzx07sddwi1kr1vc6jrb";
+    url = "https://github.com/ocaml/ocaml-lsp/releases/download/${version}/jsonrpc-${version}.tbz";
+    sha256 = "16vvwq3d9xmr91r6yv5i2gyqcdliji7asyq4g6iygi617233fa33";
   };
 
   # unvendor some (not all) dependencies.
@@ -23,7 +25,7 @@ let
   # ocaml-lsp without messing with your opam switch, but nix should prevent
   # this type of problems without resorting to vendoring.
   preBuild = ''
-    rm -r vendor/{octavius,uutf,ocaml-syntax-shims,omd,cmdliner}
+    rm -r ocaml-lsp-server/vendor/{octavius,uutf,ocaml-syntax-shims,omd,cmdliner}
   '';
 
   buildInputs = [
@@ -36,6 +38,7 @@ let
     dune-build-info
     omd
     cmdliner
+    jsonrpc
   ];
 
   lsp = buildDunePackage {
@@ -45,6 +48,15 @@ let
     minimumOCamlVersion = "4.06";
 
     inherit buildInputs preBuild;
+  };
+
+  jsonrpc = buildDunePackage {
+    pname = "jsonrpc";
+    inherit version src;
+    useDune2 = true;
+    minimumOCamlVersion = "4.06";
+
+    buildInputs = [ yojson stdlib-shims ocaml-syntax-shims ppx_yojson_conv_lib result ];
   };
 
 in


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
