### PR TITLE
platformio: Enable shell completion generation

### DIFF
--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, buildPythonApplication, fetchpatch
-, bottle, click, colorama, semantic-version
+{ stdenv, lib, buildPythonApplication, bottle
+, click, click-completion, colorama, semantic-version
 , lockfile, pyserial, requests
 , tabulate, pyelftools, marshmallow
 , pytest, tox, jsondiff
@@ -79,8 +79,8 @@ in buildPythonApplication rec {
   inherit version src;
 
   propagatedBuildInputs =  [
-    bottle click colorama git lockfile
-    pyserial requests semantic-version
+    bottle click click-completion colorama git
+    lockfile pyserial requests semantic-version
     tabulate pyelftools marshmallow
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The `platformio system completion install` command relies on the `click-completion` python package to derive completions from the current `click` argument logic. When this command is ran, it currently errors on pip exceptions. If a nix-shell is used to run this command with `click-completion` installed, shell completion is broken when outside of the nix-shell.

After this change:
```
$ platformio system completion install
PlatformIO CLI completion has been installed for zsh shell to /home/kyle/.zshrc
Please restart a current shell session.

# In new shell, showing `platformio project` completions
$ platformio<TAB>pro<TAB><TAB>
config  -- Show computed configuration
data    -- Dump data intended for IDE extensions/plugins
init    -- Initialize a project or update existing
```

###### Things done
- Add `click-completion` to python build's `propagatedBuildInputs`
- Remove `core.nix`'s unused `fetchpatch`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
