### PR TITLE
nixos/doc: fix manual build

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -650,7 +650,7 @@ See https://github.com/NixOS/nixpkgs/pull/71684 for details.
       <listitem>
        <para>
          <literal>boot.extraTTYs</literal> renamed to
-         <link linkend="opt-console.extraTTYs">console.extraTTYs</link>
+         <literal>console.extraTTYs</literal>.
        </para>
       </listitem>
     </itemizedlist>


### PR DESCRIPTION
###### Motivation for this change
This is a fixup of 9728907c.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via `nix build -f nixos config.system.build.manual.manualHTML`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @jboyens 