### PR TITLE
unused: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/unused/default.nix
+++ b/pkgs/development/tools/unused/default.nix
@@ -1,0 +1,28 @@
+{ rustPlatform, fetchFromGitHub, lib, stdenv
+, pkgconfig
+, cmake
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "unused";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "unused-code";
+    repo = "unused";
+    rev = version;
+    sha256 = "0ympdwqv9l66cn1cmg7g2d1rsq34a2bp5yv22ljr859hbk3w1jbq";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  cargoSha256 = "1scs4yjf70k54i94d520xkd1q4wbqfcs5048j7zhiphmkykx22br";
+
+  meta = with lib; {
+    homepage = "https://github.com/unused-code/unused/";
+    license = licenses.mit;
+    description = "A tool to identify potentially unused code";
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12221,6 +12221,8 @@ in
 
   universal-ctags = callPackage ../development/tools/misc/universal-ctags { };
 
+  unused = callPackage ../development/tools/unused { };
+
   vagrant = callPackage ../development/tools/vagrant {};
 
   vala-language-server = callPackage ../development/tools/vala-language-server {};


### PR DESCRIPTION
Closes #107074 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
