### PR TITLE
rofi: Add option to symlink dmenu

### DIFF
--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, lib, rofi-unwrapped, makeWrapper, wrapGAppsHook, gdk-pixbuf, hicolor-icon-theme, theme ? null, plugins ? [] }:
+{ symlinkJoin, lib, rofi-unwrapped, makeWrapper, wrapGAppsHook, gdk-pixbuf, hicolor-icon-theme, theme ? null, plugins ? [], symlink-dmenu ? false }:
 
 symlinkJoin {
   name = "rofi-${rofi-unwrapped.version}";
@@ -28,6 +28,8 @@ symlinkJoin {
       ${lib.optionalString (plugins != []) ''--prefix XDG_DATA_DIRS : ${lib.concatStringsSep ":" (lib.forEach plugins (p: "${p.out}/share"))}''} \
       ${lib.optionalString (theme != null) ''--add-flags "-theme ${theme}"''} \
       ${lib.optionalString (plugins != []) ''--add-flags "-plugin-path $out/lib/rofi"''}
+
+    ${lib.optionalString symlink-dmenu ''ln -s ${rofi-unwrapped}/bin/rofi $out/bin/dmenu''}
 
     rm $out/bin/rofi-theme-selector
     makeWrapper ${rofi-unwrapped}/bin/rofi-theme-selector $out/bin/rofi-theme-selector \

--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -29,7 +29,7 @@ symlinkJoin {
       ${lib.optionalString (theme != null) ''--add-flags "-theme ${theme}"''} \
       ${lib.optionalString (plugins != []) ''--add-flags "-plugin-path $out/lib/rofi"''}
 
-    ${lib.optionalString symlink-dmenu ''ln -s ${rofi-unwrapped}/bin/rofi $out/bin/dmenu''}
+    ${lib.optionalString symlink-dmenu "ln -s ${rofi-unwrapped}/bin/rofi $out/bin/dmenu"}
 
     rm $out/bin/rofi-theme-selector
     makeWrapper ${rofi-unwrapped}/bin/rofi-theme-selector $out/bin/rofi-theme-selector \


### PR DESCRIPTION
Rofi has the ability to handle input from scripts designed for `dmenu`. As per the documentation, all it's needed to get this working is a symlink:

> If argv[0] (calling command) is dmenu, rofi will start in dmenu mode. This way it can be used as a drop-in replacement for dmenu. just copy or symlink rofi to dmenu in $PATH.

I'm adding this ability to the Rofi derivation by adding the `symlink-dmenu` bool argument