### PR TITLE
terraform-providers.checkly: init at 0.7.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/checkly/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/checkly/default.nix
@@ -13,9 +13,11 @@ buildGoModule rec {
 
   vendorSha256 = "1k4rpin0ijs31hlfcrgyz97yll89ff6lbnkkscyfiw61xcsz6mhm";
 
-  postInstall = "mv $out/bin/terraform-provider-checkly{,_v${version}}";
+  postInstall = ''
+    mv $out/bin/terraform-provider-checkly{,_v${version}}
+  '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/checkly/terraform-provider-checkly";
     description = "Terraform provider for Checkly";
     license = licenses.mit;

--- a/pkgs/applications/networking/cluster/terraform-providers/checkly/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/checkly/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "terraform-provider-checkly";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "checkly";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wv7zdzzg8cjcz5h8vvnaznnbp8r7kbdc9hj10s8dmnmqkf9rf83";
+  };
+
+  vendorSha256 = "1k4rpin0ijs31hlfcrgyz97yll89ff6lbnkkscyfiw61xcsz6mhm";
+
+  postInstall = "mv $out/bin/terraform-provider-checkly{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/checkly/terraform-provider-checkly";
+    description = "Terraform provider for Checkly";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -55,7 +55,7 @@ let
 
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
-    checkly = callPackage ./checkly {};
+    checkly = callPackage ./checkly { };
     cloudfoundry = callPackage ./cloudfoundry {};
     elasticsearch = callPackage ./elasticsearch {};
     gandi = callPackage ./gandi {};

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -55,6 +55,7 @@ let
 
     # Packages that don't fit the default model
     ansible = callPackage ./ansible {};
+    checkly = callPackage ./checkly {};
     cloudfoundry = callPackage ./cloudfoundry {};
     elasticsearch = callPackage ./elasticsearch {};
     gandi = callPackage ./gandi {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
