### PR TITLE
linux_lqx: init at 5.9.15

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-lqx.nix
+++ b/pkgs/os-specific/linux/kernel/linux-lqx.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, buildLinux, ... } @ args:
+
+let
+  version = "5.9.15";
+in
+
+buildLinux (args // {
+  modDirVersion = "${version}-lqx1";
+  inherit version;
+  isZen = true;
+
+  src = fetchFromGitHub {
+    owner = "zen-kernel";
+    repo = "zen-kernel";
+    rev = "v${version}-lqx1";
+    sha256 = "1srkybhgm3rsmhs4m8ipv1zi4y1dxnlicgh0x9v2g4myn58lin57";
+  };
+
+  extraMeta = {
+    branch = "5.9/master";
+    maintainers = with stdenv.lib.maintainers; [ atemu ];
+  };
+
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-lqx.nix
+++ b/pkgs/os-specific/linux/kernel/linux-lqx.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildLinux, ... } @ args:
+{ stdenv, fetchFromGitHub, buildLinux, linux_zen, ... } @ args:
 
 let
   version = "5.9.16";
@@ -19,6 +19,7 @@ buildLinux (args // {
   extraMeta = {
     branch = "5.9/master";
     maintainers = with stdenv.lib.maintainers; [ atemu ];
+    description = linux_zen.meta.description + " (Same as linux_zen but less aggressive release schedule)";
   };
 
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-lqx.nix
+++ b/pkgs/os-specific/linux/kernel/linux-lqx.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, buildLinux, ... } @ args:
 
 let
-  version = "5.9.15";
+  version = "5.9.16";
 in
 
 buildLinux (args // {
@@ -13,7 +13,7 @@ buildLinux (args // {
     owner = "zen-kernel";
     repo = "zen-kernel";
     rev = "v${version}-lqx1";
-    sha256 = "1srkybhgm3rsmhs4m8ipv1zi4y1dxnlicgh0x9v2g4myn58lin57";
+    sha256 = "0ljvqf91nxpql98z75bicg5y3nzkm41rq5b0rm1kcnsk0ji829ps";
   };
 
   extraMeta = {

--- a/pkgs/os-specific/linux/kernel/linux-zen.nix
+++ b/pkgs/os-specific/linux/kernel/linux-zen.nix
@@ -19,6 +19,7 @@ buildLinux (args // {
   extraMeta = {
     branch = "5.9/master";
     maintainers = with stdenv.lib.maintainers; [ atemu andresilva ];
+    description = "Built using the best configuration and kernel sources for desktop, multimedia, and gaming workloads.";
   };
 
 } // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18448,6 +18448,14 @@ in
     ];
   };
 
+  linux_lqx = callPackage ../os-specific/linux/kernel/linux-lqx.nix {
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.request_key_helper
+      kernelPatches.export_kernel_fpu_functions."5.3"
+    ];
+  };
+
   /* Linux kernel modules are inherently tied to a specific kernel.  So
      rather than provide specific instances of those packages for a
      specific kernel, we have a function that builds those packages
@@ -18762,6 +18770,7 @@ in
 
   # zen-kernel
   linuxPackages_zen = recurseIntoAttrs (linuxPackagesFor pkgs.linux_zen);
+  linuxPackages_lqx = recurseIntoAttrs (linuxPackagesFor pkgs.linux_lqx);
 
   # A function to build a manually-configured kernel
   linuxManualConfig = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {});


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Same source as linux_zen but not quite as bleeding edge and stays on an older
version for longer (e.g. currenly on the newest 5.9 release while linux_zen is
already on 5.10)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review pr 107148` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxPackages_lqx.ixgbevf</li>
    <li>linuxPackages_lqx.lttng-modules</li>
    <li>linuxPackages_lqx.ndiswrapper</li>
    <li>linuxPackages_lqx.nvidia_x11_legacy304</li>
    <li>linuxPackages_lqx.phc-intel</li>
    <li>linuxPackages_lqx.rtl8723bs</li>
    <li>linuxPackages_lqx.sch_cake</li>
    <li>linuxPackages_lqx.tbs</li>
  </ul>
</details>
<details>
  <summary>17 packages failed to build:</summary>
  <ul>
    <li>linuxPackages_lqx.amdgpu-pro</li>
    <li>linuxPackages_lqx.anbox</li>
    <li>linuxPackages_lqx.ati_drivers_x11</li>
    <li>linuxPackages_lqx.broadcom_sta</li>
    <li>linuxPackages_lqx.chipsec</li>
    <li>linuxPackages_lqx.cryptodev</li>
    <li>linuxPackages_lqx.dpdk</li>
    <li>linuxPackages_lqx.evdi</li>
    <li>linuxPackages_lqx.mwprocapture</li>
    <li>linuxPackages_lqx.mxu11x0</li>
    <li>linuxPackages_lqx.nvidia_x11_legacy340</li>
    <li>linuxPackages_lqx.nvidia_x11_legacy390</li>
    <li>linuxPackages_lqx.oci-seccomp-bpf-hook</li>
    <li>linuxPackages_lqx.rtl8814au</li>
    <li>linuxPackages_lqx.rtl8821au</li>
    <li>linuxPackages_lqx.rtl88xxau-aircrack</li>
    <li>linuxPackages_lqx.rtlwifi_new</li>
  </ul>
</details>
<details>
  <summary>56 packages built:</summary>
  <ul>
    <li>linuxPackages_lqx.acpi_call</li>
    <li>linuxPackages_lqx.akvcam</li>
    <li>linuxPackages_lqx.asus-wmi-sensors</li>
    <li>linuxPackages_lqx.batman_adv</li>
    <li>linuxPackages_lqx.bbswitch</li>
    <li>linuxPackages_lqx.bcc</li>
    <li>linuxPackages_lqx.bpftrace</li>
    <li>linuxPackages_lqx.can-isotp</li>
    <li>linuxPackages_lqx.cpupower</li>
    <li>linuxPackages_lqx.ddcci-driver</li>
    <li>linuxPackages_lqx.digimend</li>
    <li>linuxPackages_lqx.ena</li>
    <li>linuxPackages_lqx.facetimehd</li>
    <li>linuxPackages_lqx.fwts-efi-runtime</li>
    <li>linuxPackages_lqx.gcadapter-oc-kmod</li>
    <li>linuxPackages_lqx.hyperv-daemons</li>
    <li>linuxPackages_lqx.intel-speed-select</li>
    <li>linuxPackages_lqx.it87</li>
    <li>linuxPackages_lqx.jool</li>
    <li>linuxPackages_lqx.kernel</li>
    <li>linuxPackages_lqx.mba6x_bl</li>
    <li>linuxPackages_lqx.netatop</li>
    <li>linuxPackages_lqx.nvidia_x11</li>
    <li>linuxPackages_lqx.nvidia_x11_vulkan_beta</li>
    <li>linuxPackages_lqx.nvidiabl</li>
    <li>linuxPackages_lqx.openafs</li>
    <li>linuxPackages_lqx.openafs_1_9</li>
    <li>linuxPackages_lqx.openrazer</li>
    <li>linuxPackages_lqx.perf</li>
    <li>linuxPackages_lqx.ply</li>
    <li>linuxPackages_lqx.r8125</li>
    <li>linuxPackages_lqx.r8168</li>
    <li>linuxPackages_lqx.rtl8192eu</li>
    <li>linuxPackages_lqx.rtl8812au</li>
    <li>linuxPackages_lqx.rtl8821ce</li>
    <li>linuxPackages_lqx.rtl8821cu</li>
    <li>linuxPackages_lqx.rtl88x2bu</li>
    <li>linuxPackages_lqx.sysdig</li>
    <li>linuxPackages_lqx.system76</li>
    <li>linuxPackages_lqx.system76-acpi</li>
    <li>linuxPackages_lqx.system76-io</li>
    <li>linuxPackages_lqx.systemtap</li>
    <li>linuxPackages_lqx.tmon</li>
    <li>linuxPackages_lqx.tp_smapi</li>
    <li>linuxPackages_lqx.turbostat</li>
    <li>linuxPackages_lqx.tuxedo-keyboard</li>
    <li>linuxPackages_lqx.usbip</li>
    <li>linuxPackages_lqx.v4l2loopback</li>
    <li>linuxPackages_lqx.v86d</li>
    <li>linuxPackages_lqx.vhba</li>
    <li>linuxPackages_lqx.virtualbox</li>
    <li>linuxPackages_lqx.virtualboxGuestAdditions</li>
    <li>linuxPackages_lqx.x86_energy_perf_policy</li>
    <li>linuxPackages_lqx.xpadneo</li>
    <li>linuxPackages_lqx.zenpower</li>
    <li>linuxPackages_lqx.zfs (linuxPackages_lqx.zfsUnstable)</li>
  </ul>
</details>


cc @andresilva