### PR TITLE
tageditor: init at 3.3.10, tagparser: init at 9.4.0

### DIFF
--- a/pkgs/applications/audio/tageditor/default.nix
+++ b/pkgs/applications/audio/tageditor/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, pkgs
+, fetchFromGitHub
+, pkg-config
+, cmake
+
+, cpp-utilities
+, qtutilities
+, mp4v2
+, libid3tag
+, qtbase
+, qttools
+, qtwebengine
+, qtx11extras
+, tagparser
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tageditor";
+  version = "3.3.10";
+
+  src = fetchFromGitHub {
+    owner = "martchus";
+    repo = "tageditor";
+    rev = "v${version}";
+    sha256 = "16cmq7dyalcwc8gx1y9acngw5imjh8ydp4prxy7qpzk4fj3kpsak";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    mp4v2
+    libid3tag
+    pkg-config
+    qtbase
+    qttools
+    qtx11extras
+    qtwebengine
+    cpp-utilities
+    qtutilities
+    tagparser
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with pkgs.lib; {
+    homepage = "https://github.com/Martchus/tageditor";
+    description = "A tag editor with Qt GUI and command-line interface supporting MP4/M4A/AAC (iTunes), ID3, Vorbis, Opus, FLAC and Matroska";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/development/libraries/tagparser/default.nix
+++ b/pkgs/development/libraries/tagparser/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, pkgs
+, fetchFromGitHub
+, cmake
+, cpp-utilities
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tagparser";
+  version = "9.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Martchus";
+    repo = "tagparser";
+    rev = "v${version}";
+    sha256 = "097dq9di19d3mvnlrav3fm78gzjni5babswyv10xnrxfhnf14f6x";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    cpp-utilities zlib
+  ];
+
+  meta = with pkgs.lib; {
+    homepage = "https://github.com/Martchus/tagparser";
+    description = "C++ library for reading and writing MP4/M4A/AAC (iTunes), ID3, Vorbis, Opus, FLAC and Matroska tags";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16809,6 +16809,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
+  tageditor = libsForQt5.callPackage ../applications/audio/tageditor { };
+
   taglib = callPackage ../development/libraries/taglib { };
 
   taglib_extras = callPackage ../development/libraries/taglib-extras { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16817,6 +16817,8 @@ in
 
   talloc = callPackage ../development/libraries/talloc { };
 
+  tagparser = callPackage ../development/libraries/tagparser { };
+
   tclap = callPackage ../development/libraries/tclap {};
 
   tcllib = callPackage ../development/libraries/tcllib { };


### PR DESCRIPTION
###### Motivation for this change

Closes #107006


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


CC @luxferresum for testing.