### PR TITLE
cjson: init at 1.7.14

### DIFF
--- a/pkgs/development/libraries/cjson/default.nix
+++ b/pkgs/development/libraries/cjson/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "cjson";
+  version = "1.7.14";
+
+  src = fetchFromGitHub {
+    owner = "DaveGamble";
+    repo = "cJSON";
+    rev = "v${version}";
+    sha256 = "1a3i9ydl65dgwgmlg79n5q8qilmjkaakq56sam1w25zcrd8jy11q";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://github.com/DaveGamble/cJSON";
+    description = "Ultralightweight JSON parser in ANSI C";
+    license = licenses.mit;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3080,6 +3080,8 @@ in
 
   cjdns = callPackage ../tools/networking/cjdns { };
 
+  cjson = callPackage ../development/libraries/cjson { };
+
   cksfv = callPackage ../tools/networking/cksfv { };
 
   clementine = libsForQt514.callPackage ../applications/audio/clementine {


### PR DESCRIPTION
###### Motivation for this change

Closes #107161


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @fabaff for testing