### PR TITLE
fbcat: init at 0.5.1

### DIFF
--- a/pkgs/tools/misc/fbcat/default.nix
+++ b/pkgs/tools/misc/fbcat/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub } :
+
+stdenv.mkDerivation rec {
+  pname = "fbcat";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "jwilk";
+    repo = pname;
+    rev = version;
+    sha256 = "08y79br4a4cgkjnslw0hw57441ybsapaw7wjdbak19mv9lnl5ll9";
+  };
+
+  # hardcoded because makefile target "install" depends on libxslt dependencies from network
+  # that are just too hard to monkeypatch here
+  # so this is the simple fix.
+  installPhase = ''
+    mkdir -p $out
+    install -d $out/bin
+    install -m755 fbcat $out/bin/
+    install -m755 fbgrab $out/bin/
+    install -d $out/share/man/man1
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://jwilk.net/software/fbcat";
+    description = "Framebuffer screenshot tool";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3985,6 +3985,8 @@ in
 
   feedgnuplot = callPackage ../tools/graphics/feedgnuplot { };
 
+  fbcat = callPackage ../tools/misc/fbcat { };
+
   fbv = callPackage ../tools/graphics/fbv { };
 
   fbvnc = callPackage ../tools/admin/fbvnc {};


### PR DESCRIPTION
###### Motivation for this change

Closes #106771

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @SeraphyBR for testing