### PR TITLE
sfeed: init at 0.9.20

### DIFF
--- a/pkgs/tools/misc/sfeed/default.nix
+++ b/pkgs/tools/misc/sfeed/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  pname = "sfeed";
+  version = "0.9.20";
+
+  src = fetchgit {
+    url = "git://git.codemadness.org/sfeed";
+    rev = version;
+    sha256 = "17bs31wns71fx7s06rdzqkghkgv86r9d9i3814rznyzi9484c7aq";
+  };
+
+  installPhase = ''
+    mkdir $out
+    make install PREFIX=$out
+  '';
+
+  meta = with lib; {
+    homepage = "https://codemadness.org/sfeed-simple-feed-parser.html";
+    description = "A RSS and Atom parser (and some format programs)";
+    longDescription = ''
+      It converts RSS or Atom feeds from XML to a TAB-separated file. There are
+      formatting programs included to convert this TAB-separated format to
+      various other formats. There are also some programs and scripts included
+      to import and export OPML and to fetch, filter, merge and order feed
+      items.
+    '';
+    license = licenses.isc;
+    maintainers = [ maintainers.matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/sfeed/default.nix
+++ b/pkgs/tools/misc/sfeed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit }:
+{ stdenv, lib, fetchgit }:
 
 stdenv.mkDerivation rec {
   pname = "sfeed";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7654,6 +7654,8 @@ in
 
   sewer = callPackage ../tools/admin/sewer { };
 
+  sfeed = callPackage ../tools/misc/sfeed { };
+
   sftpman = callPackage ../tools/filesystems/sftpman { };
 
   screenfetch = callPackage ../tools/misc/screenfetch { };


### PR DESCRIPTION
###### Motivation for this change

Closes  #105090
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @humaidq for testing