### PR TITLE
linux: fix generate-config's handling of "no-choice" options

### DIFF
--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -61,6 +61,12 @@ sub runConfig {
             # Remember choice alternatives ("> 1. bla (FOO)" or " 2. bla (BAR) (NEW)").
             if ($line =~ /^\s*>?\s*(\d+)\.\s+.*?\(([A-Za-z0-9_]+)\)(?:\s+\(NEW\))?\s*$/) {
                 $choices{$2} = $1;
+            } else {
+                # The list of choices has ended without us being
+                # asked. This happens for options where only one value
+                # is valid, for instance. The results can foul up
+                # later options, so forget about it.
+                %choices = ();
             }
 
             $line = "";


### PR DESCRIPTION

###### Motivation for this change

Prior to this change, the script could potentially get confused by
"menus" containing only one valid option. Thus, with

CPU_BIG_ENDIAN = no;
CPU_LITTLE_ENDIAN = yes;
ARM64_PA_BITS_48 = yes;

the endianness would be set incorrectly:

GOT: Physical address space size
GOT: > 1. 48-bit (ARM64_PA_BITS_48)
GOT: choice[1]: 1
GOT: Endianness
GOT:   1. Build big-endian kernel (CPU_BIG_ENDIAN)
GOT: > 2. Build little-endian kernel (CPU_LITTLE_ENDIAN)
CHOICE: 1-2?, ANSWER: 1

This commit fixes this error by forgetting previous menu choices if a
line that follows a menu option is neither another menu option nor the
prompt for choosing one of the options.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

- [x] Compared `linux.configfile` before and after this change → identical
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
