### PR TITLE
bashup-events: init at it's-complicated

### DIFF
--- a/pkgs/development/libraries/bashup-events/3.2.nix
+++ b/pkgs/development/libraries/bashup-events/3.2.nix
@@ -1,0 +1,26 @@
+{ callPackage, fetchFromGitHub }:
+
+callPackage ./generic.nix {
+  variant = "3.2";
+  version = "2019-07-27";
+  branch = "master";
+  src = fetchFromGitHub {
+    owner = "bashup";
+    repo = "events";
+    rev = "83744c21bf720afb8325343674c62ab46a8f3d94";
+    hash = "sha256-0VDjd+1T1JBmSDGovWOOecUZmNztlwG32UcstfdigbI=";
+  };
+  fake = {
+    # Note: __ev.encode is actually defined, but it happens in a
+    # quoted arg to eval, which resholve currently doesn't (and may
+    # never) parse into. See abathur/resholve/issues/2.
+    function = [ "__ev.encode" ];
+  };
+  keep = {
+    # allow vars in eval
+    eval = [ "e" "f" "q" "r" ];
+    # allow vars executed as commands
+    "$f" = true;
+    "$n" = true;
+  };
+}

--- a/pkgs/development/libraries/bashup-events/4.4.nix
+++ b/pkgs/development/libraries/bashup-events/4.4.nix
@@ -1,0 +1,20 @@
+{ callPackage, fetchFromGitHub }:
+
+callPackage ./generic.nix {
+  variant = "4.4";
+  version = "2020-04-04";
+  branch = "bash44";
+  src = fetchFromGitHub {
+    owner = "bashup";
+    repo = "events";
+    rev = "e97654f5602fc4e31083b27afa18dcc89b3e8296";
+    hash = "sha256-51OSIod3mEg3MKs4rrMgRcOimDGC+3UIr4Bl/cTRyGM=";
+  };
+  keep = {
+    # allow vars in eval
+    eval = [ "e" "bashup_ev" "n" ];
+    # allow vars executed as commands
+    "$f" = true;
+    "$n" = true;
+  };
+}

--- a/pkgs/development/libraries/bashup-events/default.nix
+++ b/pkgs/development/libraries/bashup-events/default.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+
+{
+  bashup-events32 = callPackage ./3.2.nix { };
+  bashup-events44 = callPackage ./4.4.nix { };
+}

--- a/pkgs/development/libraries/bashup-events/generic.nix
+++ b/pkgs/development/libraries/bashup-events/generic.nix
@@ -1,0 +1,83 @@
+{
+  # general
+  lib
+, callPackage
+, runCommand
+, resholvePackage
+, bash
+, shellcheck
+, doCheck ? true
+, doInstallCheck ? true
+  # variant-specific
+, variant
+, version
+, branch
+, src
+, fake ? false
+, keep
+}:
+let
+  # extracting this so that it's trivial to test in other shells
+  installCheck = shell:
+    ''
+      echo "testing bashup.events in ${shell}"
+      ${shell} <<'EOF'
+      source $out/bin/bashup.events
+      neat(){
+        echo $0: Hi from event \'test event\'. I can have both $1 and $2 arguments.
+        exit 0
+      }
+      event on "test event" @2 neat curried
+      echo event registered
+      event emit "test event" runtime
+      exit 1 # fail if emitting event didn't exit clean
+      EOF
+    '';
+
+in
+resholvePackage rec {
+  # bashup.events doesn't version yet but it has two variants with
+  # differing features/performance characteristics:
+  # - branch master: a variant for bash 3.2+
+  # - branch bash44: a variant for bash 4.4+
+  pname = "bashup-events${variant}-unstable";
+  # should be YYYY-MM-DD
+  inherit version;
+  inherit src;
+
+  installPhase = ''
+    install -Dt $out/bin bashup.events
+  '';
+
+  inherit doCheck;
+  checkInputs = [ shellcheck bash ];
+
+  # check based on https://github.com/bashup/events/blob/master/.dkrc
+  checkPhase = ''
+    SHELLCHECK_OPTS='-e SC2016,SC2145' ${shellcheck}/bin/shellcheck ./bashup.events
+    ${bash}/bin/bash -n ./bashup.events
+    ${bash}/bin/bash ./bashup.events
+  '';
+
+  solutions = {
+    events = {
+      inputs = [ ];
+      interpreter = "none";
+      scripts = [ "bin/bashup.events" ];
+      inherit keep;
+    } // lib.optionalAttrs (lib.isAttrs fake) { inherit fake; };
+  };
+
+  inherit doInstallCheck;
+  installCheckInputs = [ bash ];
+  installCheckPhase = installCheck "${bash}/bin/bash";
+
+  meta = with lib; {
+    inherit branch;
+    description = "An event listener/callback API for creating extensible bash programs";
+    homepage = "https://github.com/bashup/events";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ abathur ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12594,6 +12594,8 @@ in
 
   bamf = callPackage ../development/libraries/bamf { };
 
+  inherit (callPackages ../development/libraries/bashup-events { }) bashup-events32 bashup-events44;
+
   bcg729 = callPackage ../development/libraries/bcg729 { };
 
   bctoolbox = callPackage ../development/libraries/bctoolbox { };


### PR DESCRIPTION
###### Motivation for this change
1. Add [bashup.events](https://github.com/bashup/events), a Bash event/callback/promise library. 
    - I've found the abstractions it provides make it easier to build and interface modular shell libraries. 
    - Here's an example of how the package for a shell script/program/library that needs to source this can [use it as an input](https://github.com/abathur/shellswain/blob/890fe8479dc535e7167ac8ba4ade93c88e5e96b2/default.nix#L21).)

1. <details>
    <summary>Introduce the nixiverse to its new Bash/shell-packaging superpower that landed in #85827</summary>
    
    ![champagne](https://user-images.githubusercontent.com/2548365/102674471-bf2a9380-415b-11eb-8844-b14d2756f529.gif) 
    </details> 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested ~execution~ sourcing of all ~binary files~ scripts (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Other notes
- The library isn't versioned, per-se. It has two variants (one for Bash 3.2+, and one for 4.4+) that the author considers current/maintained. I'm not really sure how to handle this, so I just took a stab at it. :) You can see the issue I opened to ask about this at bashup/events#3. 