### PR TITLE
Add Darwin support for directx-shader-compiler

### DIFF
--- a/pkgs/tools/graphics/directx-shader-compiler/default.nix
+++ b/pkgs/tools/graphics/directx-shader-compiler/default.nix
@@ -36,14 +36,14 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/lib $dev/include
     mv bin/dxc* $out/bin/
-    mv lib/libdxcompiler.so* $out/lib/
+    mv lib/libdxcompiler.so* lib/libdxcompiler.*dylib $out/lib/
     cp -r $src/include/dxc $dev/include/
   '';
 
   meta = with stdenv.lib; {
     description = "A compiler to compile HLSL programs into DXIL and SPIR-V";
     homepage = "https://github.com/microsoft/DirectXShaderCompiler";
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     license = licenses.ncsa;
     maintainers = with maintainers; [ expipiplus1 ];
   };


### PR DESCRIPTION
I can't test this so if someone would be kind enough to check it runs
I'd be grateful.

Built on https://github.com/NixOS/nixpkgs/pull/104377

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).