### PR TITLE
use newer libproc.h

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libc/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libc/default.nix
@@ -16,6 +16,7 @@ appleDerivation {
     cp ${Libc_10-9}/include/NSSystemDirectories.h $out/include
 
     # Ugh Apple stopped releasing this stuff so we need an older one...
+    # NOTE: a newer libproc.h is shipped with xnu, we drop this old one.
     cp    ${Libc_old}/include/spawn.h    $out/include
     cp    ${Libc_old}/include/setjmp.h   $out/include
     cp    ${Libc_old}/include/ucontext.h $out/include
@@ -25,7 +26,6 @@ appleDerivation {
 
     mkdir -p $out/include/libkern
     cp ${Libc_old}/include/asl.h                    $out/include
-    cp ${Libc_old}/include/libproc.h                $out/include
     cp ${Libc_old}/include/libkern/OSAtomic.h       $out/include/libkern
     cp ${Libc_old}/include/libkern/OSCacheControl.h $out/include/libkern
   '';

--- a/pkgs/os-specific/darwin/apple-source-releases/xnu/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/xnu/default.nix
@@ -98,6 +98,9 @@ appleDerivation ({
     cp EXTERNAL_HEADERS/Availability*.h $out/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/
     cp -r EXTERNAL_HEADERS/corecrypto $out/include
 
+    # FIXME: libproc.h is no longer shipped with Libc, we kidnap the newer one here.
+    cp libsyscall/wrappers/libproc/libproc.h $out/include
+
     # Build the mach headers we crave
     export SRCROOT=$PWD/libsyscall
     export DERIVED_SOURCES_DIR=$out/include


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
libproc.h is too old.

###### Things done
Replace it with a new one in xnu.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
