### PR TITLE
zsteg: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -686,6 +686,16 @@
     githubId = 1078530;
     name = "Alexandre Peyroux";
   };
+  applePrincess = {
+    email = "appleprincess@appleprincess.io";
+    github = "applePrincess";
+    githubId = 17154507;
+    name = "Lein Matsumaru";
+    keys = [{
+      longkeyid = "rsa4096/0xAAA50652F0479205";
+      fingerprint = "BF8B F725 DA30 E53E 7F11  4ED8 AAA5 0652 F047 9205";
+   }];
+  };
   ar1a = {
     email = "aria@ar1as.space";
     github = "ar1a";

--- a/pkgs/tools/security/zsteg/Gemfile
+++ b/pkgs/tools/security/zsteg/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'zsteg'

--- a/pkgs/tools/security/zsteg/Gemfile.lock
+++ b/pkgs/tools/security/zsteg/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    iostruct (0.0.4)
+    rainbow (3.0.0)
+    zpng (0.3.1)
+      rainbow
+    zsteg (0.2.2)
+      iostruct
+      zpng (>= 0.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  zsteg
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/tools/security/zsteg/default.nix
+++ b/pkgs/tools/security/zsteg/default.nix
@@ -1,0 +1,16 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "zsteg";
+
+  gemdir = ./.;
+
+  exes = [ "zsteg" ];
+
+  meta = with lib; {
+    description = "Detect stegano-hidden data in PNG & BMP.";
+    homepage = "http://zed.0xff.me/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ applePrincess ];
+  };
+}

--- a/pkgs/tools/security/zsteg/gemset.nix
+++ b/pkgs/tools/security/zsteg/gemset.nix
@@ -1,0 +1,44 @@
+{
+  iostruct = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0kwp6ryis32j3z7myw8g7v1yszwrwyl04g2c7flr42pwxga1afxc";
+      type = "gem";
+    };
+    version = "0.0.4";
+  };
+  rainbow = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bb2fpjspydr6x0s8pn1pqkzmxszvkfapv0p4627mywl7ky4zkhk";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  zpng = {
+    dependencies = ["rainbow"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ciyab7qxqsxjhfvr6rbpdzg655fi1zygqg9sd9m6wmgc037dj74";
+      type = "gem";
+    };
+    version = "0.3.1";
+  };
+  zsteg = {
+    dependencies = ["iostruct" "zpng"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mwajlsgs27449n2yf2f9hz8g46qv9bz9f58i9cz1jg58spvpxpk";
+      type = "gem";
+    };
+    version = "0.2.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26363,6 +26363,8 @@ in
 
   zscroll = callPackage ../applications/misc/zscroll {};
 
+  zsteg = callPackage ../tools/security/zsteg { };
+
   zynaddsubfx = zyn-fusion;
 
   zynaddsubfx-fltk = callPackage ../applications/audio/zynaddsubfx {


### PR DESCRIPTION

###### Motivation for this change
Add zsteg package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
