### PR TITLE
ocaml-ng.ocamlPackages_4_12.ocaml: 4.12.0~α2 → 4.12.0~α3

### DIFF
--- a/pkgs/development/compilers/ocaml/4.12.nix
+++ b/pkgs/development/compilers/ocaml/4.12.nix
@@ -1,9 +1,9 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "12";
-  patch_version = "0-alpha2";
+  patch_version = "0-alpha3";
   src = fetchTarball {
-    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~alpha2.tar.xz";
-    sha256 = "148vgjcfajjvrvh0q9kb2y7fszqd02cikb5wyznz7kjxka6xxyn9";
+    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~alpha3.tar.xz";
+    sha256 = "1hqlf9fi5gmvb6r13z5819rg6k813bw9ihgbbji67hhh4q361wlw";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://inbox.ocaml.org/caml-list/695788234.25188042.1608280295194.JavaMail.zimbra@inria.fr/T/#u

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
