### PR TITLE
libsForQt5.phonon-backend-gstreamer: add missing deps

### DIFF
--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -1,5 +1,19 @@
-{ stdenv, lib, fetchurl, cmake, gst_all_1, phonon, pkgconfig
-, extra-cmake-modules, qttools, qtbase, qtx11extras
+{ stdenv, lib, fetchurl
+, cmake
+, elfutils # for libdw
+, gst_all_1
+, libselinux
+, libsepol
+, libunwind
+, orc
+, pcre
+, phonon
+, pkgconfig
+, util-linuxMinimal ? null # for libmount
+, extra-cmake-modules
+, qttools
+, qtbase
+, qtx11extras
 , debug ? false
 }:
 
@@ -45,11 +59,19 @@ stdenv.mkDerivation rec {
     ];
 
   buildInputs = with gst_all_1; [
+    elfutils # for libdw
     gstreamer
     gst-plugins-base
+    libunwind
+    orc
+    pcre
     phonon
     qtbase
     qtx11extras
+  ] ++ optionals stdenv.isLinux [
+    libselinux
+    libsepol
+    util-linuxMinimal # for libmount
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
This fixes the majority of dependencies reported as not found, except of
CDDA support and GStreamer netbuffer support.

###### Motivation for this change
Get rid of warnings about dependencies not being found during the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] (N/A, no tests) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (`nixpkgs-review` doesn't work due to https://github.com/Mic92/nixpkgs-review/issues/146)
- [x] (N/A, libs only) Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (no impact, before and after is 890566576)
- [x] (N/A) Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
