### PR TITLE
Tree sitter fixes

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -60,10 +60,6 @@ in rustPlatform.buildRustPackage {
     # needed for the tests
     rm -rf test/fixtures/grammars
     ln -s ${grammars} test/fixtures/grammars
-
-    # These functions do not appear in the source code
-    sed -i /_ts_query_context/d lib/binding_web/exports.json
-    sed -i /___assert_fail/d lib/binding_web/exports.json
   '';
 
   # Compile web assembly with emscripten. The --debug flag prevents us from

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -41,8 +41,10 @@ let
 
   builtGrammars = let
     change = name: grammar:
-      callPackage ./library.nix {
-        language = name; inherit version; source = fetchGrammar grammar;
+      callPackage ./library.nix {} {
+        language = name;
+        inherit version;
+        source = fetchGrammar grammar;
       };
   in
     # typescript doesn't have parser.c in the same place as others

--- a/pkgs/development/tools/parsing/tree-sitter/library.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/library.nix
@@ -1,7 +1,15 @@
 { stdenv
-, language
 , tree-sitter
+}:
+
+# Build a parser grammar and put the resulting shared object in `$out/parser`
+
+{
+  # language name
+  language
+  # version of tree-sitter
 , version
+  # source for the language grammar
 , source
 }:
 


### PR DESCRIPTION
Small fixes to the tree-sitter build


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
