### PR TITLE
qrcodegen: init at 1.6.0

### DIFF
--- a/pkgs/development/libraries/qrcodegen/default.nix
+++ b/pkgs/development/libraries/qrcodegen/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  pname = "qrcodegen";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "nayuki";
+    repo = "QR-Code-generator";
+    rev = "v${version}";
+    sha256 = "0iq9sv9na0vg996aqrxrjn9rrbiyy7sc9vslw945p3ky22pw3lql";
+  };
+
+  preBuild = "cd c";
+  installPhase = ''
+    mkdir -p $out/lib $out/include/qrcodegen
+    cp libqrcodegen.a $out/lib
+    cp qrcodegen.h $out/include/qrcodegen/
+  '';
+
+  meta = with stdenv.lib;
+    {
+      description = "qrcode generator library in multiple languages";
+
+      longDescription = ''
+        This project aims to be the best, clearest library for generating QR Codes. My primary goals are flexible options and absolute correctness. Secondary goals are compact implementation size and good documentation comments.
+      '';
+
+      homepage = "https://github.com/nayuki/QR-Code-generator";
+
+      license = licenses.mit;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ mcbeth ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21744,6 +21744,8 @@ in
     java = if stdenv.isLinux then jre else jdk;
   };
 
+  qrcodegen = callPackage ../development/libraries/qrcodegen { };
+
   qrencode = callPackage ../development/libraries/qrencode { };
 
   geeqie = callPackage ../applications/graphics/geeqie { };


### PR DESCRIPTION
###### Motivation for this change
Library is used in notcurses #106993

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
