### PR TITLE
mapproxy: 1.12.0 -> 1.13.0

### DIFF
--- a/pkgs/applications/misc/mapproxy/default.nix
+++ b/pkgs/applications/misc/mapproxy/default.nix
@@ -1,38 +1,15 @@
 { lib
 , pkgs
-, python
+, python3
 }:
-let
-  py = python.override {
-    packageOverrides = self: super: {
-      pyproj = super.pyproj.overridePythonAttrs (oldAttrs: rec {
-      version = "1.9.6";
-      src = pkgs.fetchFromGitHub {
-        owner = "pyproj4";
-        repo = "pyproj";
-        rev = "v${version}rel";
-        sha256 = "18v4h7jx4mcc0x2xy8y7dfjq9bzsyxs8hdb6v67cabvlz2njziqy";
-      };
-      nativeBuildInputs = with python.pkgs; [ cython ];
-      patches = [ ];
-      checkPhase = ''
-        runHook preCheck
-        pushd unittest  # changing directory should ensure we're importing the global pyproj
-        ${python.interpreter} test.py && ${python.interpreter} -c "import doctest, pyproj, sys; sys.exit(doctest.testmod(pyproj)[0])"
-        popd
-        runHook postCheck
-      '';
-      });
-    };
-  };
-in
-with py.pkgs;
+
+with python3.pkgs;
 buildPythonApplication rec {
   pname = "MapProxy";
-  version = "1.12.0";
+  version = "1.13.0";
   src = fetchPypi {
   inherit pname version;
-  sha256 = "622e3a7796ef861ba21e42231b49c18d00d75f03eaf3f01a2b7687be7568e2ec";
+  sha256 = "0qi63ap8yi5g2cas33jv4jsmdrl6yv3qp6bh0zxrfpkb704lcng4";
   };
   prePatch = ''
     substituteInPlace mapproxy/util/ext/serving.py --replace "args = [sys.executable] + sys.argv" "args = sys.argv"


### PR DESCRIPTION
###### Motivation for this change

Switched to using python3, because pyproj fails to build with python2.

https://mapproxy.org/blog/new-mapproxy-1.13.0-release/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
