### PR TITLE
libsmartcols: init at v2.36.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7343,6 +7343,12 @@
     githubId = 1758708;
     name = "Răzvan Flavius Panda";
   };
+  rb2k = {
+    email = "nix@marc-seeger.com";
+    github = "rb2k";
+    githubId = 9519;
+    name = "Marc Seeger";
+  };
   rbasso = {
     email = "rbasso@sharpgeeks.net";
     github = "rbasso";

--- a/pkgs/development/libraries/libsmartcols/default.nix
+++ b/pkgs/development/libraries/libsmartcols/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "libsmartcols";
+  version = "v2.36.1";
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig python3 ];
+
+  src = fetchFromGitHub {
+    owner = "karelzak";
+    repo = "util-linux";
+    rev = version;
+    sha256 = "0z7nv054pqhlihqiw0vk3h40j0cxk1yxf8zzh0ddmvk6834cnyxs";
+  };
+
+  configureFlags = [ "--disable-all-programs" "--enable-libsmartcols" ];
+
+  buildPhase = ''
+    make libsmartcols.la
+  '';
+
+  installTargets = [ "install-am" "install-pkgconfigDATA" ];
+
+  meta = {
+    description = "smart column output alignment library";
+    homepage = https://github.com/karelzak/util-linux/tree/master/libsmartcols;
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    maintainers = with stdenv.lib.maintainers; [ rb2k ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5174,6 +5174,8 @@ in
 
   libcryptui = callPackage ../development/libraries/libcryptui { };
 
+  libsmartcols = callPackage ../development/libraries/libsmartcols { };
+
   libsmi = callPackage ../development/libraries/libsmi { };
 
   libgen-cli = callPackage ../tools/misc/libgen-cli { };


### PR DESCRIPTION
###### Motivation for this change

A requirement for an upcoming package I'm working on (microdnf/libdnf)

This library is a bit weird in that it's part of a different repo (https://github.com/karelzak/util-linux/tree/master/libsmartcols).
That being said, it compiles, I was able to use it as a dependency for libdnf and the build output looks complete (this one s on darwin, hence the dylib):
```
% find /nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/bin
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/include
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/include/libsmartcols
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/include/libsmartcols/libsmartcols.h
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/sbin
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/lib
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/lib/pkgconfig
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/lib/pkgconfig/smartcols.pc
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/lib/libsmartcols.1.dylib
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/lib/libsmartcols.la
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/lib/libsmartcols.dylib
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/man
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/man/man5
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/man/man5/terminal-colors.d.5.gz
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/man/man3
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/man/man8
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/man/man1
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/bash-completion
/nix/store/c0fsi4h9n9yiapwzayx2ac78wvbiqwa7-libsmartcols/share/bash-completion/completions
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
