### PR TITLE
lib: Clean up how linux and gcc config is specified

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -24,8 +24,6 @@ rec {
       # Either of these can be losslessly-extracted from `parsed` iff parsing succeeds.
       system = parse.doubleFromSystem final.parsed;
       config = parse.tripleFromSystem final.parsed;
-      # Just a guess, based on `system`
-      platform = platforms.select final;
       # Determine whether we are compatible with the provided CPU
       isCompatible = platform: parse.isCompatible final.parsed.cpu platform.parsed.cpu;
       # Derived meta-data
@@ -79,7 +77,16 @@ rec {
       };
       isStatic = final.isWasm || final.isRedox;
 
-      kernelArch =
+      # Just a guess, based on `system`
+      inherit
+        ({
+          linux-kernel = args.linux-kernel or {};
+          gcc = args.gcc or {};
+          rustc = args.rust or {};
+        } // platforms.select final)
+        linux-kernel gcc rustc;
+
+      linuxArch =
         if final.isAarch32 then "arm"
         else if final.isAarch64 then "arm64"
         else if final.isx86_32 then "x86"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -7,7 +7,6 @@ let
 
   riscv = bits: {
     config = "riscv${bits}-unknown-linux-gnu";
-    platform = platforms.riscv-multiplatform;
   };
 in
 
@@ -17,84 +16,68 @@ rec {
   #
   powernv = {
     config = "powerpc64le-unknown-linux-gnu";
-    platform = platforms.powernv;
   };
   musl-power = {
     config = "powerpc64le-unknown-linux-musl";
-    platform = platforms.powernv;
   };
 
   sheevaplug = {
     config = "armv5tel-unknown-linux-gnueabi";
-    platform = platforms.sheevaplug;
-  };
+  } // platforms.sheevaplug;
 
   raspberryPi = {
     config = "armv6l-unknown-linux-gnueabihf";
-    platform = platforms.raspberrypi;
-  };
+  } // platforms.raspberrypi;
 
   remarkable1 = {
     config = "armv7l-unknown-linux-gnueabihf";
-    platform = platforms.zero-gravitas;
-  };
+  } // platforms.zero-gravitas;
 
   remarkable2 = {
     config = "armv7l-unknown-linux-gnueabihf";
-    platform = platforms.zero-sugar;
-  };
+  } // platforms.zero-sugar;
 
   armv7l-hf-multiplatform = {
     config = "armv7l-unknown-linux-gnueabihf";
-    platform = platforms.armv7l-hf-multiplatform;
   };
 
   aarch64-multiplatform = {
     config = "aarch64-unknown-linux-gnu";
-    platform = platforms.aarch64-multiplatform;
   };
 
   armv7a-android-prebuilt = {
     config = "armv7a-unknown-linux-androideabi";
     sdkVer = "29";
     ndkVer = "21";
-    platform = platforms.armv7a-android;
     useAndroidPrebuilt = true;
-  };
+  } // platforms.armv7a-android;
 
   aarch64-android-prebuilt = {
     config = "aarch64-unknown-linux-android";
     sdkVer = "29";
     ndkVer = "21";
-    platform = platforms.aarch64-multiplatform;
     useAndroidPrebuilt = true;
   };
 
-  scaleway-c1 = armv7l-hf-multiplatform // rec {
-    platform = platforms.scaleway-c1;
-    inherit (platform.gcc) fpu;
-  };
+  scaleway-c1 = armv7l-hf-multiplatform // platforms.scaleway-c1;
 
   pogoplug4 = {
     config = "armv5tel-unknown-linux-gnueabi";
-    platform = platforms.pogoplug4;
-  };
+  } // platforms.pogoplug4;
 
   ben-nanonote = {
     config = "mipsel-unknown-linux-uclibc";
-    platform = platforms.ben_nanonote;
-  };
+  } // platforms.ben_nanonote;
 
   fuloongminipc = {
     config = "mipsel-unknown-linux-gnu";
-    platform = platforms.fuloong2f_n32;
-  };
+  } // platforms.fuloong2f_n32;
 
   muslpi = raspberryPi // {
     config = "armv6l-unknown-linux-musleabihf";
   };
 
-  aarch64-multiplatform-musl = aarch64-multiplatform // {
+  aarch64-multiplatform-musl = {
     config = "aarch64-unknown-linux-musl";
   };
 
@@ -110,13 +93,11 @@ rec {
   riscv64-embedded = {
     config = "riscv64-none-elf";
     libc = "newlib";
-    platform = platforms.riscv-multiplatform;
   };
 
   riscv32-embedded = {
     config = "riscv32-none-elf";
     libc = "newlib";
-    platform = platforms.riscv-multiplatform;
   };
 
   mmix = {
@@ -136,13 +117,11 @@ rec {
   vc4 = {
     config = "vc4-elf";
     libc = "newlib";
-    platform = {};
   };
 
   or1k = {
     config = "or1k-elf";
     libc = "newlib";
-    platform = {};
   };
 
   arm-embedded = {
@@ -204,7 +183,6 @@ rec {
     xcodeVer = "11.3.1";
     xcodePlatform = "iPhoneOS";
     useiOSPrebuilt = true;
-    platform = {};
   };
 
   iphone32 = {
@@ -214,7 +192,6 @@ rec {
     xcodeVer = "11.3.1";
     xcodePlatform = "iPhoneOS";
     useiOSPrebuilt = true;
-    platform = {};
   };
 
   iphone64-simulator = {
@@ -224,7 +201,6 @@ rec {
     xcodeVer = "11.3.1";
     xcodePlatform = "iPhoneSimulator";
     useiOSPrebuilt = true;
-    platform = {};
   };
 
   iphone32-simulator = {
@@ -234,7 +210,6 @@ rec {
     xcodeVer = "11.3.1";
     xcodePlatform = "iPhoneSimulator";
     useiOSPrebuilt = true;
-    platform = {};
   };
 
   #
@@ -245,7 +220,6 @@ rec {
   mingw32 = {
     config = "i686-w64-mingw32";
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
-    platform = {};
   };
 
   # 64 bit mingw-w64
@@ -253,7 +227,6 @@ rec {
     # That's the triplet they use in the mingw-w64 docs.
     config = "x86_64-w64-mingw32";
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
-    platform = {};
   };
 
   # BSDs
@@ -275,6 +248,5 @@ rec {
   # Ghcjs
   ghcjs = {
     config = "js-unknown-ghcjs";
-    platform = {};
   };
 }

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -1,39 +1,36 @@
 { lib }:
 rec {
-  pcBase = {
-    name = "pc";
-    kernelBaseConfig = "defconfig";
-    # Build whatever possible as a module, if not stated in the extra config.
-    kernelAutoModules = true;
-    kernelTarget = "bzImage";
+  pc = {
+    linux-kernel = {
+      name = "pc";
+
+      baseConfig = "defconfig";
+      # Build whatever possible as a module, if not stated in the extra config.
+      autoModules = true;
+      target = "bzImage";
+    };
   };
 
-  pc64 = pcBase // { kernelArch = "x86_64"; };
-
-  pc32 = pcBase // { kernelArch = "i386"; };
-
-  pc32_simplekernel = pc32 // {
-    kernelAutoModules = false;
-  };
-
-  pc64_simplekernel = pc64 // {
-    kernelAutoModules = false;
+  pc_simplekernel = lib.recursiveUpdate pc {
+    linux-kernel.autoModules = false;
   };
 
   powernv = {
-    name = "PowerNV";
-    kernelArch = "powerpc";
-    kernelBaseConfig = "powernv_defconfig";
-    kernelTarget = "zImage";
-    kernelInstallTarget = "install";
-    kernelFile = "vmlinux";
-    kernelAutoModules = true;
-    # avoid driver/FS trouble arising from unusual page size
-    kernelExtraConfig = ''
-      PPC_64K_PAGES n
-      PPC_4K_PAGES y
-      IPV6 y
-    '';
+    linux-kernel = {
+      name = "PowerNV";
+
+      baseConfig = "powernv_defconfig";
+      target = "zImage";
+      installTarget = "install";
+      file = "vmlinux";
+      autoModules = true;
+      # avoid driver/FS trouble arising from unusual page size
+      extraConfig = ''
+        PPC_64K_PAGES n
+        PPC_4K_PAGES y
+        IPV6 y
+      '';
+    };
   };
 
   ##
@@ -41,17 +38,12 @@ rec {
   ##
 
   pogoplug4 = {
-    name = "pogoplug4";
+    linux-kernel = {
+      name = "pogoplug4";
 
-    gcc = {
-      arch = "armv5te";
-    };
-
-    kernelBaseConfig = "multi_v5_defconfig";
-    kernelArch = "arm";
-    kernelAutoModules = false;
-    kernelExtraConfig =
-      ''
+      baseConfig = "multi_v5_defconfig";
+      autoModules = false;
+      extraConfig = ''
         # Ubi for the mtd
         MTD_UBI y
         UBIFS_FS y
@@ -61,136 +53,144 @@ rec {
         UBIFS_FS_ZLIB y
         UBIFS_FS_DEBUG n
       '';
-    kernelMakeFlags = [ "LOADADDR=0x8000" ];
-    kernelTarget = "uImage";
-    # TODO reenable once manual-config's config actually builds a .dtb and this is checked to be working
-    #kernelDTB = true;
+      makeFlags = [ "LOADADDR=0x8000" ];
+      target = "uImage";
+      # TODO reenable once manual-config's config actually builds a .dtb and this is checked to be working
+      #DTB = true;
+    };
+    gcc = {
+      arch = "armv5te";
+    };
   };
 
   sheevaplug = {
-    name = "sheevaplug";
-    kernelBaseConfig = "multi_v5_defconfig";
-    kernelArch = "arm";
-    kernelAutoModules = false;
-    kernelExtraConfig = ''
-      BLK_DEV_RAM y
-      BLK_DEV_INITRD y
-      BLK_DEV_CRYPTOLOOP m
-      BLK_DEV_DM m
-      DM_CRYPT m
-      MD y
-      REISERFS_FS m
-      BTRFS_FS m
-      XFS_FS m
-      JFS_FS m
-      EXT4_FS m
-      USB_STORAGE_CYPRESS_ATACB m
+    linux-kernel = {
+      name = "sheevaplug";
 
-      # mv cesa requires this sw fallback, for mv-sha1
-      CRYPTO_SHA1 y
-      # Fast crypto
-      CRYPTO_TWOFISH y
-      CRYPTO_TWOFISH_COMMON y
-      CRYPTO_BLOWFISH y
-      CRYPTO_BLOWFISH_COMMON y
+      baseConfig = "multi_v5_defconfig";
+      autoModules = false;
+      extraConfig = ''
+        BLK_DEV_RAM y
+        BLK_DEV_INITRD y
+        BLK_DEV_CRYPTOLOOP m
+        BLK_DEV_DM m
+        DM_CRYPT m
+        MD y
+        REISERFS_FS m
+        BTRFS_FS m
+        XFS_FS m
+        JFS_FS m
+        EXT4_FS m
+        USB_STORAGE_CYPRESS_ATACB m
 
-      IP_PNP y
-      IP_PNP_DHCP y
-      NFS_FS y
-      ROOT_NFS y
-      TUN m
-      NFS_V4 y
-      NFS_V4_1 y
-      NFS_FSCACHE y
-      NFSD m
-      NFSD_V2_ACL y
-      NFSD_V3 y
-      NFSD_V3_ACL y
-      NFSD_V4 y
-      NETFILTER y
-      IP_NF_IPTABLES y
-      IP_NF_FILTER y
-      IP_NF_MATCH_ADDRTYPE y
-      IP_NF_TARGET_LOG y
-      IP_NF_MANGLE y
-      IPV6 m
-      VLAN_8021Q m
+        # mv cesa requires this sw fallback, for mv-sha1
+        CRYPTO_SHA1 y
+        # Fast crypto
+        CRYPTO_TWOFISH y
+        CRYPTO_TWOFISH_COMMON y
+        CRYPTO_BLOWFISH y
+        CRYPTO_BLOWFISH_COMMON y
 
-      CIFS y
-      CIFS_XATTR y
-      CIFS_POSIX y
-      CIFS_FSCACHE y
-      CIFS_ACL y
+        IP_PNP y
+        IP_PNP_DHCP y
+        NFS_FS y
+        ROOT_NFS y
+        TUN m
+        NFS_V4 y
+        NFS_V4_1 y
+        NFS_FSCACHE y
+        NFSD m
+        NFSD_V2_ACL y
+        NFSD_V3 y
+        NFSD_V3_ACL y
+        NFSD_V4 y
+        NETFILTER y
+        IP_NF_IPTABLES y
+        IP_NF_FILTER y
+        IP_NF_MATCH_ADDRTYPE y
+        IP_NF_TARGET_LOG y
+        IP_NF_MANGLE y
+        IPV6 m
+        VLAN_8021Q m
 
-      WATCHDOG y
-      WATCHDOG_CORE y
-      ORION_WATCHDOG m
+        CIFS y
+        CIFS_XATTR y
+        CIFS_POSIX y
+        CIFS_FSCACHE y
+        CIFS_ACL y
 
-      ZRAM m
-      NETCONSOLE m
+        WATCHDOG y
+        WATCHDOG_CORE y
+        ORION_WATCHDOG m
 
-      # Disable OABI to have seccomp_filter (required for systemd)
-      # https://github.com/raspberrypi/firmware/issues/651
-      OABI_COMPAT n
+        ZRAM m
+        NETCONSOLE m
 
-      # Fail to build
-      DRM n
-      SCSI_ADVANSYS n
-      USB_ISP1362_HCD n
-      SND_SOC n
-      SND_ALI5451 n
-      FB_SAVAGE n
-      SCSI_NSP32 n
-      ATA_SFF n
-      SUNGEM n
-      IRDA n
-      ATM_HE n
-      SCSI_ACARD n
-      BLK_DEV_CMD640_ENHANCED n
+        # Disable OABI to have seccomp_filter (required for systemd)
+        # https://github.com/raspberrypi/firmware/issues/651
+        OABI_COMPAT n
 
-      FUSE_FS m
+        # Fail to build
+        DRM n
+        SCSI_ADVANSYS n
+        USB_ISP1362_HCD n
+        SND_SOC n
+        SND_ALI5451 n
+        FB_SAVAGE n
+        SCSI_NSP32 n
+        ATA_SFF n
+        SUNGEM n
+        IRDA n
+        ATM_HE n
+        SCSI_ACARD n
+        BLK_DEV_CMD640_ENHANCED n
 
-      # systemd uses cgroups
-      CGROUPS y
+        FUSE_FS m
 
-      # Latencytop
-      LATENCYTOP y
+        # systemd uses cgroups
+        CGROUPS y
 
-      # Ubi for the mtd
-      MTD_UBI y
-      UBIFS_FS y
-      UBIFS_FS_XATTR y
-      UBIFS_FS_ADVANCED_COMPR y
-      UBIFS_FS_LZO y
-      UBIFS_FS_ZLIB y
-      UBIFS_FS_DEBUG n
+        # Latencytop
+        LATENCYTOP y
 
-      # Kdb, for kernel troubles
-      KGDB y
-      KGDB_SERIAL_CONSOLE y
-      KGDB_KDB y
-    '';
-    kernelMakeFlags = [ "LOADADDR=0x0200000" ];
-    kernelTarget = "uImage";
-    kernelDTB = true; # Beyond 3.10
+        # Ubi for the mtd
+        MTD_UBI y
+        UBIFS_FS y
+        UBIFS_FS_XATTR y
+        UBIFS_FS_ADVANCED_COMPR y
+        UBIFS_FS_LZO y
+        UBIFS_FS_ZLIB y
+        UBIFS_FS_DEBUG n
+
+        # Kdb, for kernel troubles
+        KGDB y
+        KGDB_SERIAL_CONSOLE y
+        KGDB_KDB y
+      '';
+      makeFlags = [ "LOADADDR=0x0200000" ];
+      target = "uImage";
+      DTB = true; # Beyond 3.10
+    };
     gcc = {
       arch = "armv5te";
     };
   };
 
   raspberrypi = {
-    name = "raspberrypi";
-    kernelBaseConfig = "bcm2835_defconfig";
-    kernelDTB = true;
-    kernelArch = "arm";
-    kernelAutoModules = true;
-    kernelPreferBuiltin = true;
-    kernelExtraConfig = ''
-      # Disable OABI to have seccomp_filter (required for systemd)
-      # https://github.com/raspberrypi/firmware/issues/651
-      OABI_COMPAT n
-    '';
-    kernelTarget = "zImage";
+    linux-kernel = {
+      name = "raspberrypi";
+
+      baseConfig = "bcm2835_defconfig";
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      extraConfig = ''
+        # Disable OABI to have seccomp_filter (required for systemd)
+        # https://github.com/raspberrypi/firmware/issues/651
+        OABI_COMPAT n
+      '';
+      target = "zImage";
+    };
     gcc = {
       arch = "armv6";
       fpu = "vfp";
@@ -201,13 +201,15 @@ rec {
   raspberrypi2 = armv7l-hf-multiplatform;
 
   zero-gravitas = {
-    name = "zero-gravitas";
-    kernelBaseConfig = "zero-gravitas_defconfig";
-    kernelArch = "arm";
-    # kernelTarget verified by checking /boot on reMarkable 1 device
-    kernelTarget = "zImage";
-    kernelAutoModules = false;
-    kernelDTB = true;
+    linux-kernel = {
+      name = "zero-gravitas";
+
+      baseConfig = "zero-gravitas_defconfig";
+      # Target verified by checking /boot on reMarkable 1 device
+      target = "zImage";
+      autoModules = false;
+      DTB = true;
+    };
     gcc = {
       fpu = "neon";
       cpu = "cortex-a9";
@@ -215,13 +217,15 @@ rec {
   };
 
   zero-sugar = {
-    name = "zero-sugar";
-    kernelBaseConfig = "zero-sugar_defconfig";
-    kernelArch = "arm";
-    kernelDTB = true;
-    kernelAutoModules = false;
-    kernelPreferBuiltin = true;
-    kernelTarget = "zImage";
+    linux-kernel = {
+      name = "zero-sugar";
+
+      baseConfig = "zero-sugar_defconfig";
+      DTB = true;
+      autoModules = false;
+      preferBuiltin = true;
+      target = "zImage";
+    };
     gcc = {
       cpu = "cortex-a7";
       fpu = "neon-vfpv4";
@@ -229,7 +233,7 @@ rec {
     };
   };
 
-  scaleway-c1 = armv7l-hf-multiplatform // {
+  scaleway-c1 = lib.recursiveUpdate armv7l-hf-multiplatform {
     gcc = {
       cpu = "cortex-a9";
       fpu = "vfpv3";
@@ -237,12 +241,11 @@ rec {
   };
 
   utilite = {
-    name = "utilite";
-    kernelBaseConfig = "multi_v7_defconfig";
-    kernelArch = "arm";
-    kernelAutoModules = false;
-    kernelExtraConfig =
-      ''
+    linux-kernel = {
+      name = "utilite";
+      maseConfig = "multi_v7_defconfig";
+      autoModules = false;
+      extraConfig = ''
         # Ubi for the mtd
         MTD_UBI y
         UBIFS_FS y
@@ -252,35 +255,37 @@ rec {
         UBIFS_FS_ZLIB y
         UBIFS_FS_DEBUG n
       '';
-    kernelMakeFlags = [ "LOADADDR=0x10800000" ];
-    kernelTarget = "uImage";
-    kernelDTB = true;
+      makeFlags = [ "LOADADDR=0x10800000" ];
+      target = "uImage";
+      DTB = true;
+    };
     gcc = {
       cpu = "cortex-a9";
       fpu = "neon";
     };
   };
 
-  guruplug = sheevaplug // {
+  guruplug = lib.recursiveUpdate sheevaplug {
     # Define `CONFIG_MACH_GURUPLUG' (see
     # <http://kerneltrap.org/mailarchive/git-commits-head/2010/5/19/33618>)
     # and other GuruPlug-specific things.  Requires the `guruplug-defconfig'
     # patch.
-
-    kernelBaseConfig = "guruplug_defconfig";
+    linux-kernel.baseConfig = "guruplug_defconfig";
   };
 
-  beaglebone = armv7l-hf-multiplatform // {
-    name = "beaglebone";
-    kernelBaseConfig = "bb.org_defconfig";
-    kernelAutoModules = false;
-    kernelExtraConfig = ""; # TBD kernel config
-    kernelTarget = "zImage";
+  beaglebone = lib.recursiveUpdate armv7l-hf-multiplatform {
+    linux-kernel = {
+      name = "beaglebone";
+      baseConfig = "bb.org_defconfig";
+      autoModules = false;
+      extraConfig = ""; # TBD kernel config
+      target = "zImage";
+    };
   };
 
   # https://developer.android.com/ndk/guides/abis#v7a
-  armv7a-android =  {
-    name = "armeabi-v7a";
+  armv7a-android = {
+    linux-kernel.name = "armeabi-v7a";
     gcc = {
       arch = "armv7-a";
       float-abi = "softfp";
@@ -289,29 +294,31 @@ rec {
   };
 
   armv7l-hf-multiplatform = {
-    name = "armv7l-hf-multiplatform";
-    kernelBaseConfig = "multi_v7_defconfig";
-    kernelArch = "arm";
-    kernelDTB = true;
-    kernelAutoModules = true;
-    kernelPreferBuiltin = true;
-    kernelTarget = "zImage";
-    kernelExtraConfig = ''
-      # Serial port for Raspberry Pi 3. Upstream forgot to add it to the ARMv7 defconfig.
-      SERIAL_8250_BCM2835AUX y
-      SERIAL_8250_EXTENDED y
-      SERIAL_8250_SHARE_IRQ y
+    linux-kernel = {
+      name = "armv7l-hf-multiplatform";
+      Major = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
+      baseConfig = "multi_v7_defconfig";
+      DTB = true;
+      autoModules = true;
+      PreferBuiltin = true;
+      target = "zImage";
+      extraConfig = ''
+        # Serial port for Raspberry Pi 3. Upstream forgot to add it to the ARMv7 defconfig.
+        SERIAL_8250_BCM2835AUX y
+        SERIAL_8250_EXTENDED y
+        SERIAL_8250_SHARE_IRQ y
 
-      # Fix broken sunxi-sid nvmem driver.
-      TI_CPTS y
+        # Fix broken sunxi-sid nvmem driver.
+        TI_CPTS y
 
-      # Hangs ODROID-XU4
-      ARM_BIG_LITTLE_CPUIDLE n
+        # Hangs ODROID-XU4
+        ARM_BIG_LITTLE_CPUIDLE n
 
-      # Disable OABI to have seccomp_filter (required for systemd)
-      # https://github.com/raspberrypi/firmware/issues/651
-      OABI_COMPAT n
-    '';
+        # Disable OABI to have seccomp_filter (required for systemd)
+        # https://github.com/raspberrypi/firmware/issues/651
+        OABI_COMPAT n
+      '';
+    };
     gcc = {
       # Some table about fpu flags:
       # http://community.arm.com/servlet/JiveServlet/showImage/38-1981-3827/blogentry-103749-004812900+1365712953_thumb.png
@@ -336,34 +343,35 @@ rec {
   };
 
   aarch64-multiplatform = {
-    name = "aarch64-multiplatform";
-    kernelBaseConfig = "defconfig";
-    kernelArch = "arm64";
-    kernelDTB = true;
-    kernelAutoModules = true;
-    kernelPreferBuiltin = true;
-    kernelExtraConfig = ''
-      # Raspberry Pi 3 stuff. Not needed for kernels >= 4.10.
-      ARCH_BCM2835 y
-      BCM2835_MBOX y
-      BCM2835_WDT y
-      RASPBERRYPI_FIRMWARE y
-      RASPBERRYPI_POWER y
-      SERIAL_8250_BCM2835AUX y
-      SERIAL_8250_EXTENDED y
-      SERIAL_8250_SHARE_IRQ y
+    linux-kernel = {
+      name = "aarch64-multiplatform";
+      baseConfig = "defconfig";
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      extraConfig = ''
+        # Raspberry Pi 3 stuff. Not needed for   s >= 4.10.
+        ARCH_BCM2835 y
+        BCM2835_MBOX y
+        BCM2835_WDT y
+        RASPBERRYPI_FIRMWARE y
+        RASPBERRYPI_POWER y
+        SERIAL_8250_BCM2835AUX y
+        SERIAL_8250_EXTENDED y
+        SERIAL_8250_SHARE_IRQ y
 
-      # Cavium ThunderX stuff.
-      PCI_HOST_THUNDER_ECAM y
+        # Cavium ThunderX stuff.
+        PCI_HOST_THUNDER_ECAM y
 
-      # Nvidia Tegra stuff.
-      PCI_TEGRA y
+        # Nvidia Tegra stuff.
+        PCI_TEGRA y
 
-      # The default (=y) forces us to have the XHCI firmware available in initrd,
-      # which our initrd builder can't currently do easily.
-      USB_XHCI_TEGRA m
-    '';
-    kernelTarget = "Image";
+        # The default (=y) forces us to have the XHCI firmware available in initrd,
+        # which our initrd builder can't currently do easily.
+        USB_XHCI_TEGRA m
+      '';
+      target = "Image";
+    };
     gcc = {
       arch = "armv8-a";
     };
@@ -374,8 +382,9 @@ rec {
   ##
 
   ben_nanonote = {
-    name = "ben_nanonote";
-    kernelArch = "mips";
+    linux-kernel = {
+      name = "ben_nanonote";
+    };
     gcc = {
       arch = "mips32";
       float = "soft";
@@ -383,75 +392,76 @@ rec {
   };
 
   fuloong2f_n32 = {
-    name = "fuloong2f_n32";
-    kernelBaseConfig = "lemote2f_defconfig";
-    kernelArch = "mips";
-    kernelAutoModules = false;
-    kernelExtraConfig = ''
-      MIGRATION n
-      COMPACTION n
+    linux-kernel = {
+      name = "fuloong2f_n32";
+      baseConfig = "lemote2f_defconfig";
+      autoModules = false;
+      extraConfig = ''
+        MIGRATION n
+        COMPACTION n
 
-      # nixos mounts some cgroup
-      CGROUPS y
+        # nixos mounts some cgroup
+        CGROUPS y
 
-      BLK_DEV_RAM y
-      BLK_DEV_INITRD y
-      BLK_DEV_CRYPTOLOOP m
-      BLK_DEV_DM m
-      DM_CRYPT m
-      MD y
-      REISERFS_FS m
-      EXT4_FS m
-      USB_STORAGE_CYPRESS_ATACB m
+        BLK_DEV_RAM y
+        BLK_DEV_INITRD y
+        BLK_DEV_CRYPTOLOOP m
+        BLK_DEV_DM m
+        DM_CRYPT m
+        MD y
+        REISERFS_FS m
+        EXT4_FS m
+        USB_STORAGE_CYPRESS_ATACB m
 
-      IP_PNP y
-      IP_PNP_DHCP y
-      IP_PNP_BOOTP y
-      NFS_FS y
-      ROOT_NFS y
-      TUN m
-      NFS_V4 y
-      NFS_V4_1 y
-      NFS_FSCACHE y
-      NFSD m
-      NFSD_V2_ACL y
-      NFSD_V3 y
-      NFSD_V3_ACL y
-      NFSD_V4 y
+        IP_PNP y
+        IP_PNP_DHCP y
+        IP_PNP_BOOTP y
+        NFS_FS y
+        ROOT_NFS y
+        TUN m
+        NFS_V4 y
+        NFS_V4_1 y
+        NFS_FSCACHE y
+        NFSD m
+        NFSD_V2_ACL y
+        NFSD_V3 y
+        NFSD_V3_ACL y
+        NFSD_V4 y
 
-      # Fail to build
-      DRM n
-      SCSI_ADVANSYS n
-      USB_ISP1362_HCD n
-      SND_SOC n
-      SND_ALI5451 n
-      FB_SAVAGE n
-      SCSI_NSP32 n
-      ATA_SFF n
-      SUNGEM n
-      IRDA n
-      ATM_HE n
-      SCSI_ACARD n
-      BLK_DEV_CMD640_ENHANCED n
+        # Fail to build
+        DRM n
+        SCSI_ADVANSYS n
+        USB_ISP1362_HCD n
+        SND_SOC n
+        SND_ALI5451 n
+        FB_SAVAGE n
+        SCSI_NSP32 n
+        ATA_SFF n
+        SUNGEM n
+        IRDA n
+        ATM_HE n
+        SCSI_ACARD n
+        BLK_DEV_CMD640_ENHANCED n
 
-      FUSE_FS m
+        FUSE_FS m
 
-      # Needed for udev >= 150
-      SYSFS_DEPRECATED_V2 n
+        # Needed for udev >= 150
+        SYSFS_DEPRECATED_V2 n
 
-      VGA_CONSOLE n
-      VT_HW_CONSOLE_BINDING y
-      SERIAL_8250_CONSOLE y
-      FRAMEBUFFER_CONSOLE y
-      EXT2_FS y
-      EXT3_FS y
-      REISERFS_FS y
-      MAGIC_SYSRQ y
+        VGA_CONSOLE n
+        VT_HW_CONSOLE_BINDING y
+        SERIAL_8250_CONSOLE y
+        FRAMEBUFFER_CONSOLE y
+        EXT2_FS y
+        EXT3_FS y
+        REISERFS_FS y
+        MAGIC_SYSRQ y
 
-      # The kernel doesn't boot at all, with FTRACE
-      FTRACE n
-    '';
-    kernelTarget = "vmlinux";
+        # The kernel doesn't boot at all, with FTRACE
+        FTRACE n
+      '';
+      target = "vmlinux";
+    };
     gcc = {
       arch = "loongson2f";
       float = "hard";
@@ -464,34 +474,36 @@ rec {
   ##
 
   riscv-multiplatform = {
-    name = "riscv-multiplatform";
-    kernelArch = "riscv";
-    kernelTarget = "vmlinux";
-    kernelAutoModules = true;
-    kernelBaseConfig = "defconfig";
-    kernelExtraConfig = ''
-      FTRACE n
-      SERIAL_OF_PLATFORM y
-    '';
+    linux-kernel = {
+      name = "riscv-multiplatform";
+      target = "vmlinux";
+      autoModules = true;
+      baseConfig = "defconfig";
+      extraConfig = ''
+        FTRACE n
+        SERIAL_OF_PLATFORM y
+      '';
+    };
   };
 
   select = platform:
     # x86
-    /**/ if platform.isx86_32 then pc32
-    else if platform.isx86_64 then pc64
+    /**/ if platform.isx86 then pc
 
     # ARM
     else if platform.isAarch32 then let
       version = platform.parsed.cpu.version or null;
-      in     if version == null then pcBase
+      in     if version == null then pc
         else if lib.versionOlder version "6" then sheevaplug
         else if lib.versionOlder version "7" then raspberrypi
         else armv7l-hf-multiplatform
     else if platform.isAarch64 then aarch64-multiplatform
 
+    else if platform.isRiscV then riscv-multiplatform
+
     else if platform.parsed.cpu == lib.systems.parse.cpuTypes.mipsel then fuloong2f_n32
 
     else if platform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le then powernv
 
-    else pcBase;
+    else pc;
 }

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -592,6 +592,22 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
      <literal>/etc/netgroup</literal> defines network-wide groups and may affect to setups using NIS.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Platforms, like <varname>stdenv.hostPlatform</varname>, no longer have a <varname>platform</varname> attribute.
+     It has been (mostly) flattoned away:
+    </para>
+    <itemizedlist>
+     <listitem><para><varname>platform.gcc</varname> is now <varname>gcc</varname></para></listitem>
+     <listitem><para><literal>platform.kernel*</literal> is now <literal>linux-kernel.*</literal></para></listitem>
+    </itemizedlist>
+    <para>
+     Additionally, <varname>platform.kernelArch</varname> moved to the top level as <varname>linuxArch</varname> to match the other <literal>*Arch</literal> variables.
+    </para>
+    <para>
+     The <varname>platform</varname> grouping of these things never meant anything, and was just a historial/implementation artifact that was overdue removal.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -68,11 +68,11 @@ let
       patchShebangs scripts/*
       substituteInPlace scripts/Makefile.lib \
         --replace 'DTC_FLAGS += $(DTC_FLAGS_$(basetarget))' 'DTC_FLAGS += $(DTC_FLAGS_$(basetarget)) -@'
-      make ${pkgs.stdenv.hostPlatform.platform.kernelBaseConfig} ARCH="${pkgs.stdenv.hostPlatform.platform.kernelArch}"
-      make dtbs ARCH="${pkgs.stdenv.hostPlatform.platform.kernelArch}"
+      make ${pkgs.stdenv.hostPlatform.linux-kernel.baseConfig} ARCH="${pkgs.stdenv.hostPlatform.linuxArch}"
+      make dtbs ARCH="${pkgs.stdenv.hostPlatform.linuxArch}"
     '';
     installPhase = ''
-      make dtbs_install INSTALL_DTBS_PATH=$out/dtbs  ARCH="${pkgs.stdenv.hostPlatform.platform.kernelArch}"
+      make dtbs_install INSTALL_DTBS_PATH=$out/dtbs  ARCH="${pkgs.stdenv.hostPlatform.linuxArch}"
     '';
   };
 
@@ -115,7 +115,7 @@ in
   options = {
       hardware.deviceTree = {
         enable = mkOption {
-          default = pkgs.stdenv.hostPlatform.platform.kernelDTB or false;
+          default = pkgs.stdenv.hostPlatform.linux-kernel.DTB or false;
           type = types.bool;
           description = ''
             Build device tree files. These are used to describe the

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -88,7 +88,7 @@ with lib;
 
     system.build.netbootIpxeScript = pkgs.writeTextDir "netboot.ipxe" ''
       #!ipxe
-      kernel ${pkgs.stdenv.hostPlatform.platform.kernelTarget} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams}
+      kernel ${pkgs.stdenv.hostPlatform.linux-kernel.target} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams}
       initrd initrd
       boot
     '';

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -587,10 +587,10 @@ in
 
     nix.systemFeatures = mkDefault (
       [ "nixos-test" "benchmark" "big-parallel" "kvm" ] ++
-      optionals (pkgs.hostPlatform.platform ? gcc.arch) (
-        # a builder can run code for `platform.gcc.arch` and inferior architectures
-        [ "gccarch-${pkgs.hostPlatform.platform.gcc.arch}" ] ++
-        map (x: "gccarch-${x}") lib.systems.architectures.inferiors.${pkgs.hostPlatform.platform.gcc.arch}
+      optionals (pkgs.hostPlatform ? gcc.arch) (
+        # a builder can run code for `gcc.arch` and inferior architectures
+        [ "gccarch-${pkgs.hostPlatform.gcc.arch}" ] ++
+        map (x: "gccarch-${x}") lib.systems.architectures.inferiors.${pkgs.hostPlatform.gcc.arch}
       )
     );
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -190,7 +190,7 @@ in
 
     system.boot.loader.kernelFile = mkOption {
       internal = true;
-      default = pkgs.stdenv.hostPlatform.platform.kernelTarget;
+      default = pkgs.stdenv.hostPlatform.linux-kernel.target;
       type = types.str;
       description = ''
         Name of the kernel file to be passed to the bootloader.

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
@@ -59,7 +59,7 @@ in
 
     system.build.installBootLoader = generationsDirBuilder;
     system.boot.loader.id = "generationsDir";
-    system.boot.loader.kernelFile = platform.kernelTarget;
+    system.boot.loader.kernelFile = linux-kernel.target;
 
   };
 }

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -103,6 +103,6 @@ in
 
     system.build.installBootLoader = builder;
     system.boot.loader.id = "raspberrypi";
-    system.boot.loader.kernelFile = platform.kernelTarget;
+    system.boot.loader.kernelFile = linux-kernel.target;
   };
 }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -79,7 +79,7 @@ let
     in
       tarball //
         { meta = {
-            description = "NixOS system tarball for ${system} - ${stdenv.hostPlatform.platform.name}";
+            description = "NixOS system tarball for ${system} - ${stdenv.hostPlatform.linux-kernel.name}";
             maintainers = map (x: lib.maintainers.${x}) maintainers;
           };
           inherit config;
@@ -105,7 +105,7 @@ let
         modules = makeModules module {};
       };
       build = configEvaled.config.system.build;
-      kernelTarget = configEvaled.pkgs.stdenv.hostPlatform.platform.kernelTarget;
+      kernelTarget = configEvaled.pkgs.stdenv.hostPlatform.linux-kernel.target;
     in
       pkgs.symlinkJoin {
         name = "netboot";

--- a/pkgs/applications/audio/virtual-ans/default.nix
+++ b/pkgs/applications/audio/virtual-ans/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   startScript = if stdenv.isx86_32 then "START_LINUX_X86"
     else        if stdenv.isx86_64 then "START_LINUX_X86_64"
     #else        if stdenv.isDarwin then "START_MACOS.app" # disabled because I cannot test on Darwin
-    else abort "Unsupported platform: ${stdenv.platform.kernelArch}.";
+    else abort "Unsupported platform: ${stdenv.hostPlatform.linuxArch}.";
 
   linuxExecutable = if stdenv.isx86_32 then "pixilang_linux_x86"
     else            if stdenv.isx86_64 then "pixilang_linux_x86_64"

--- a/pkgs/applications/virtualization/crosvm/default.nix
+++ b/pkgs/applications/virtualization/crosvm/default.nix
@@ -75,7 +75,7 @@ in
 
     CROSVM_CARGO_TEST_KERNEL_BINARY =
       lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform)
-        "${linux}/${stdenv.hostPlatform.platform.kernelTarget}";
+        "${linux}/${stdenv.hostPlatform.linux-kernel.target}";
 
     passthru = {
       inherit adhdSrc;

--- a/pkgs/applications/virtualization/vpcs/default.nix
+++ b/pkgs/applications/virtualization/vpcs/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''(
     cd src
-    ./mk.sh ${stdenv.buildPlatform.platform.kernelArch}
+    ./mk.sh ${stdenv.buildPlatform.linuxArch}
   )'';
 
   installPhase = ''

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -190,7 +190,7 @@ stdenv.mkDerivation {
       else if targetPlatform.isRiscV then "lriscv"
       else throw "unknown emulation for platform: ${targetPlatform.config}";
     in if targetPlatform.useLLVM or false then ""
-       else targetPlatform.platform.bfdEmulation or (fmt + sep + arch);
+       else targetPlatform.bfdEmulation or (fmt + sep + arch);
 
   strictDeps = true;
   depsTargetTargetPropagated = extraPackages;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -403,31 +403,31 @@ stdenv.mkDerivation {
     # discrepency (x86_64 vs. x86-64), so we provide an "arch" arg in
     # that case.
     + optionalString ((targetPlatform ? platform.gcc.arch) &&
-                      isGccArchSupported targetPlatform.platform.gcc.arch) ''
-      echo "-march=${targetPlatform.platform.gcc.arch}" >> $out/nix-support/cc-cflags-before
+                      isGccArchSupported targetPlatform.gcc.arch) ''
+      echo "-march=${targetPlatform.gcc.arch}" >> $out/nix-support/cc-cflags-before
     ''
 
     # -mcpu is not very useful. You should use mtune and march
     # instead. It’s provided here for backwards compatibility.
     + optionalString (targetPlatform ? platform.gcc.cpu) ''
-      echo "-mcpu=${targetPlatform.platform.gcc.cpu}" >> $out/nix-support/cc-cflags-before
+      echo "-mcpu=${targetPlatform.gcc.cpu}" >> $out/nix-support/cc-cflags-before
     ''
 
     # -mfloat-abi only matters on arm32 but we set it here
     # unconditionally just in case. If the abi specifically sets hard
     # vs. soft floats we use it here.
     + optionalString (targetPlatform ? platform.gcc.float-abi) ''
-      echo "-mfloat-abi=${targetPlatform.platform.gcc.float-abi}" >> $out/nix-support/cc-cflags-before
+      echo "-mfloat-abi=${targetPlatform.gcc.float-abi}" >> $out/nix-support/cc-cflags-before
     ''
     + optionalString (targetPlatform ? platform.gcc.fpu) ''
-      echo "-mfpu=${targetPlatform.platform.gcc.fpu}" >> $out/nix-support/cc-cflags-before
+      echo "-mfpu=${targetPlatform.gcc.fpu}" >> $out/nix-support/cc-cflags-before
     ''
     + optionalString (targetPlatform ? platform.gcc.mode) ''
-      echo "-mmode=${targetPlatform.platform.gcc.mode}" >> $out/nix-support/cc-cflags-before
+      echo "-mmode=${targetPlatform.gcc.mode}" >> $out/nix-support/cc-cflags-before
     ''
     + optionalString (targetPlatform ? platform.gcc.tune &&
-                      isGccArchSupported targetPlatform.platform.gcc.tune) ''
-      echo "-mtune=${targetPlatform.platform.gcc.tune}" >> $out/nix-support/cc-cflags-before
+                      isGccArchSupported targetPlatform.gcc.tune) ''
+      echo "-mtune=${targetPlatform.gcc.tune}" >> $out/nix-support/cc-cflags-before
     ''
 
     # TODO: categorize these and figure out a better place for them

--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -56,13 +56,13 @@ in
 , prepend ? []
 
 # Whether to wrap the initramfs in a u-boot image.
-, makeUInitrd ? stdenvNoCC.hostPlatform.platform.kernelTarget == "uImage"
+, makeUInitrd ? stdenvNoCC.hostPlatform.linux-kernel.target == "uImage"
 
 # If generating a u-boot image, the architecture to use. The default
 # guess may not align with u-boot's nomenclature correctly, so it can
 # be overridden.
 # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L81-106 for a list.
-, uInitrdArch ? stdenvNoCC.hostPlatform.kernelArch
+, uInitrdArch ? stdenvNoCC.hostPlatform.linuxArch
 
 # The name of the compression, as recognised by u-boot.
 # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L195-204 for a list.

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1,6 +1,6 @@
 { pkgs
 , kernel ? pkgs.linux
-, img ? pkgs.stdenv.hostPlatform.platform.kernelTarget
+, img ? pkgs.stdenv.hostPlatform.linux-kernel.target
 , storeDir ? builtins.storeDir
 , rootModules ?
     [ "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_balloon" "virtio_rng" "ext4" "unix" "9p" "9pnet_virtio" "crc32c_generic" ]

--- a/pkgs/development/compilers/gcc/common/platform-flags.nix
+++ b/pkgs/development/compilers/gcc/common/platform-flags.nix
@@ -1,7 +1,7 @@
 { lib, targetPlatform }:
 
 let
-  p =  targetPlatform.platform.gcc or {}
+  p =  targetPlatform.gcc or {}
     // targetPlatform.parsed.abi;
 in lib.concatLists [
   (lib.optional (!targetPlatform.isx86_64 && p ? arch) "--with-arch=${p.arch}") # --with-arch= is unknown flag on x86_64

--- a/pkgs/development/compilers/julia/1.0.nix
+++ b/pkgs/development/compilers/julia/1.0.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
     let
       arch = stdenv.lib.head (stdenv.lib.splitString "-" stdenv.system);
       march = {
-        x86_64 = stdenv.hostPlatform.platform.gcc.arch or "x86-64";
+        x86_64 = stdenv.hostPlatform.gcc.arch or "x86-64";
         i686 = "pentium4";
         aarch64 = "armv8-a";
       }.${arch}

--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     let
       arch = head (splitString "-" stdenv.system);
       march = {
-        x86_64 = stdenv.hostPlatform.platform.gcc.arch or "x86-64";
+        x86_64 = stdenv.hostPlatform.gcc.arch or "x86-64";
         i686 = "pentium4";
         aarch64 = "armv8-a";
       }.${arch}

--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     let
       arch = head (splitString "-" stdenv.system);
       march = {
-        x86_64 = stdenv.hostPlatform.platform.gcc.arch or "x86-64";
+        x86_64 = stdenv.hostPlatform.gcc.arch or "x86-64";
         i686 = "pentium4";
         aarch64 = "armv8-a";
       }.${arch}

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation ({
       "--enable-kernel=3.2.0" # can't get below with glibc >= 2.26
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       (lib.flip lib.withFeature "fp"
-         (stdenv.hostPlatform.platform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft"))
+         (stdenv.hostPlatform.gcc.float or (stdenv.hostPlatform.parsed.abi.float or "hard") == "soft"))
       "--with-__thread"
     ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform && stdenv.hostPlatform.isAarch32) [
       "--host=arm-linux-gnueabi"

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -88,7 +88,7 @@ qtModule {
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
     # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
     "-Wno-class-memaccess"
-  ] ++ lib.optionals (stdenv.hostPlatform.platform.gcc.arch or "" == "sandybridge") [
+  ] ++ lib.optionals (stdenv.hostPlatform.gcc.arch or "" == "sandybridge") [
     # it fails when compiled with -march=sandybridge https://github.com/NixOS/nixpkgs/pull/59148#discussion_r276696940
     # TODO: investigate and fix properly
     "-march=westmere"

--- a/pkgs/development/tools/poetry2nix/poetry2nix/pep425.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/pep425.nix
@@ -73,9 +73,9 @@ let
         if isLinux
         then
           (
-            x: x.platform == "manylinux1_${stdenv.platform.kernelArch}"
-              || x.platform == "manylinux2010_${stdenv.platform.kernelArch}"
-              || x.platform == "manylinux2014_${stdenv.platform.kernelArch}"
+            x: x.platform == "manylinux1_${stdenv.hostPlatform.linuxArch}"
+              || x.platform == "manylinux2010_${stdenv.hostPlatform.linuxArch}"
+              || x.platform == "manylinux2014_${stdenv.hostPlatform.linuxArch}"
               || x.platform == "any"
           )
         else (x: hasInfix "macosx" x.platform || x.platform == "any");

--- a/pkgs/development/tools/poetry2nix/poetry2nix/pep508.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/pep508.nix
@@ -95,7 +95,7 @@ let
           else if stdenv.isDarwin then "darwin"
           else throw "Unsupported platform"
         );
-        platform_machine = stdenv.platform.kernelArch;
+        platform_machine = stdenv.hostPlatform.linuxArch;
         platform_python_implementation =
           let
             impl = python.passthru.implementation;

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -60,18 +60,17 @@ in
 
     configureFlags = let
       isCross = stdenv.hostPlatform != stdenv.buildPlatform;
-      host = stdenv.hostPlatform.platform;
-      isAarch32 = stdenv.hostPlatform.isAarch32;
+      inherit (stdenv.hostPlatform) gcc isArch32;
     in sharedConfigureFlags ++ [
       "--without-dtrace"
     ] ++ (optionals isCross [
       "--cross-compiling"
       "--without-intl"
       "--without-snapshot"
-    ]) ++ (optionals (isCross && isAarch32 && hasAttr "fpu" host.gcc) [
-      "--with-arm-fpu=${host.gcc.fpu}"
-    ]) ++ (optionals (isCross && isAarch32 && hasAttr "float-abi" host.gcc) [
-      "--with-arm-float-abi=${host.gcc.float-abi}"
+    ]) ++ (optionals (isCross && isAarch32 && hasAttr "fpu" gcc) [
+      "--with-arm-fpu=${gcc.fpu}"
+    ]) ++ (optionals (isCross && isAarch32 && hasAttr "float-abi" gcc) [
+      "--with-arm-float-abi=${gcc.float-abi}"
     ]) ++ (optionals (isCross && isAarch32) [
       "--dest-cpu=arm"
     ]) ++ extraConfigFlags;

--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "ARCH=${stdenv.hostPlatform.platform.kernelArch}"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -7,7 +7,7 @@ let
     pname = "linux-headers";
     inherit version;
 
-    ARCH = stdenvNoCC.hostPlatform.platform.kernelArch or stdenvNoCC.hostPlatform.kernelArch;
+    ARCH = stdenvNoCC.hostPlatform.linuxArch;
 
     # It may look odd that we use `stdenvNoCC`, and yet explicit depend on a cc.
     # We do this so we have a build->build, not build->host, C compiler.

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -42,7 +42,7 @@
   # symbolic name and `patch' is the actual patch.  The patch may
   # optionally be compressed with gzip or bzip2.
   kernelPatches ? []
-, ignoreConfigErrors ? stdenv.hostPlatform.platform.name != "pc" ||
+, ignoreConfigErrors ? stdenv.hostPlatform.linux-kernel.name != "pc" ||
                        stdenv.hostPlatform != stdenv.buildPlatform
 , extraMeta ? {}
 
@@ -51,10 +51,10 @@
 , isLibre    ? false
 , isHardened ? false
 
-# easy overrides to stdenv.hostPlatform.platform members
-, autoModules ? stdenv.hostPlatform.platform.kernelAutoModules
-, preferBuiltin ? stdenv.hostPlatform.platform.kernelPreferBuiltin or false
-, kernelArch ? stdenv.hostPlatform.platform.kernelArch
+# easy overrides to stdenv.hostPlatform.linux-kernel members
+, autoModules ? stdenv.hostPlatform.linux-kernel.autoModules
+, preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false
+, kernelArch ? stdenv.hostPlatform.linuxArch
 
 , ...
 }:
@@ -87,7 +87,7 @@ let
   intermediateNixConfig = configfile.moduleStructuredConfig.intermediateNixConfig
     # extra config in legacy string format
     + extraConfig
-    + lib.optionalString (stdenv.hostPlatform.platform ? kernelExtraConfig) stdenv.hostPlatform.platform.kernelExtraConfig;
+    + stdenv.hostPlatform.linux-kernel.extraConfig or "";
 
   structuredConfigFromPatches =
         map ({extraStructuredConfig ? {}, ...}: {settings=extraStructuredConfig;}) kernelPatches;
@@ -113,11 +113,11 @@ let
     nativeBuildInputs = [ perl gmp libmpc mpfr ]
       ++ lib.optionals (lib.versionAtLeast version "4.16") [ bison flex ];
 
-    platformName = stdenv.hostPlatform.platform.name;
+    platformName = stdenv.hostPlatform.linux-kernel.name;
     # e.g. "defconfig"
-    kernelBaseConfig = if defconfig != null then defconfig else stdenv.hostPlatform.platform.kernelBaseConfig;
+    kernelBaseConfig = if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig;
     # e.g. "bzImage"
-    kernelTarget = stdenv.hostPlatform.platform.kernelTarget;
+    kernelTarget = stdenv.hostPlatform.linux-kernel.target;
 
     prePatch = kernel.prePatch + ''
       # Patch kconfig to print "###" after every question so that

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -64,10 +64,10 @@ let
 
   commonMakeFlags = [
     "O=$(buildRoot)"
-  ] ++ lib.optionals (stdenv.hostPlatform.platform ? kernelMakeFlags)
-    stdenv.hostPlatform.platform.kernelMakeFlags;
+  ] ++ lib.optionals (stdenv.hostPlatform.linux-kernel ? makeFlags)
+    stdenv.hostPlatform.linux-kernel.makeFlags;
 
-  drvAttrs = config_: platform: kernelPatches: configfile:
+  drvAttrs = config_: kernelConf: kernelPatches: configfile:
     let
       config = let attrName = attr: "CONFIG_" + attr; in {
         isSet = attr: hasAttr (attrName attr) config;
@@ -171,7 +171,7 @@ let
 
       buildFlags = [
         "KBUILD_BUILD_VERSION=1-NixOS"
-        platform.kernelTarget
+        kernelConf.target
         "vmlinux"  # for "perf" and things like that
       ] ++ optional isModular "modules";
 
@@ -186,16 +186,16 @@ let
       '';
 
       # Some image types need special install targets (e.g. uImage is installed with make uinstall)
-      installTargets = [ (
-        if platform ? kernelInstallTarget then platform.kernelInstallTarget
-        else if platform.kernelTarget == "uImage" then "uinstall"
-        else if platform.kernelTarget == "zImage" || platform.kernelTarget == "Image.gz" then "zinstall"
-        else "install"
-      ) ];
+      installTargets = [
+        (kernelConf.installTarget or (
+          /**/ if kernelConf.target == "uImage" then "uinstall"
+          else if kernelConf.target == "zImage" || kernelConf.target == "Image.gz" then "zinstall"
+          else "install"))
+      ];
 
       postInstall = (optionalString installsFirmware ''
         mkdir -p $out/lib/firmware
-      '') + (if (platform ? kernelDTB && platform.kernelDTB) then ''
+      '') + (if (kernelConf.DTB or false) then ''
         make $makeFlags "''${makeFlagsArray[@]}" dtbs dtbs_install INSTALL_DTBS_PATH=$out/dtbs
       '' else "") + (if isModular then ''
         mkdir -p $dev
@@ -300,7 +300,7 @@ in
 assert (lib.versionAtLeast version "4.14" && lib.versionOlder version "5.8") -> libelf != null;
 assert lib.versionAtLeast version "5.8" -> elfutils != null;
 
-stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches configfile) // {
+stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPatches configfile) // {
   pname = "linux";
   inherit version;
 
@@ -308,7 +308,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk zstd ]
-      ++ optional  (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
+      ++ optional  (stdenv.hostPlatform.linux-kernel.target == "uImage") buildPackages.ubootTools
       ++ optional  (lib.versionAtLeast version "4.14" && lib.versionOlder version "5.8") libelf
       # Removed util-linuxMinimal since it should not be a dependency.
       ++ optionals (lib.versionAtLeast version "4.16") [ bison flex ]
@@ -322,10 +322,10 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches
   makeFlags = commonMakeFlags ++ [
     "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
     "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
-    "ARCH=${stdenv.hostPlatform.platform.kernelArch}"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 
-  karch = stdenv.hostPlatform.platform.kernelArch;
+  karch = stdenv.hostPlatform.linuxArch;
 })

--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -25,11 +25,11 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" "stackprotector" ];
 
   makeFlags = commonMakeFlags ++ [
-    "KLIBCARCH=${stdenv.hostPlatform.platform.kernelArch}"
+    "KLIBCARCH=${stdenv.hostPlatform.linuxArch}"
     "KLIBCKERNELSRC=${linuxHeaders}"
   ] # TODO(@Ericson2314): We now can get the ABI from
     # `stdenv.hostPlatform.parsed.abi`, is this still a good idea?
-    ++ lib.optional (stdenv.hostPlatform.platform.kernelArch == "arm") "CONFIG_AEABI=y"
+    ++ lib.optional (stdenv.hostPlatform.linuxArch == "arm") "CONFIG_AEABI=y"
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
 
   # Install static binaries as well.

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ nukeReferences ];
 
   makeFlags = [
-    "ARCH=${stdenv.hostPlatform.platform.kernelArch}" # Normally not needed, but the Makefile sets ARCH in a broken way.
+    "ARCH=${stdenv.hostPlatform.linuxArch}" # Normally not needed, but the Makefile sets ARCH in a broken way.
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" # Makefile uses $(uname -r); breaks us.
   ];
 

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   makeFlags = [
-    "ARCH=${stdenv.hostPlatform.platform.kernelArch}"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     ("CONFIG_PLATFORM_I386_PC=" + (if (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) then "y" else "n"))

--- a/pkgs/os-specific/linux/uclibc/default.nix
+++ b/pkgs/os-specific/linux/uclibc/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
     cat << EOF | parseconfig
     ${nixConfig}
     ${extraConfig}
-    ${stdenv.hostPlatform.platform.uclibc.extraConfig or ""}
+    ${stdenv.hostPlatform.uclibc.extraConfig or ""}
     EOF
     ( set +o pipefail; yes "" | make oldconfig )
   '';

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -279,7 +279,7 @@ in rec {
         } // lib.optionalAttrs (hardeningDisable != [] || hardeningEnable != []) {
           NIX_HARDENING_ENABLE = enabledHardeningOptions;
         } // lib.optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? platform.gcc.arch) {
-          requiredSystemFeatures = attrs.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.platform.gcc.arch}" ];
+          requiredSystemFeatures = attrs.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.gcc.arch}" ];
         } // lib.optionalAttrs (stdenv.buildPlatform.isDarwin) {
           inherit __darwinAllowLocalNetworking;
           # TODO: remove lib.unique once nix has a list canonicalization primitive

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19284,7 +19284,7 @@ in
     buildPhase = ''
       set -x
       make \
-        ARCH=${stdenv.hostPlatform.kernelArch} \
+        ARCH=${stdenv.hostPlatform.linuxArch} \
         HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc \
         ${makeTarget}
     '';


### PR DESCRIPTION
###### Motivation for this change

The `platform` field is pointless nesting: it's just stuff that happens to be defined together, and that should be an implementation detail.

This instead makes `linux-kernel` and `gcc` top level fields in platform configs. They join `rustc` there [all are optional], which was put there and not in `platform` in anticipation of a change like this.

`linux-kernel.arch` in particular also becomes `linuxArch`, to match the other `*Arch`es.

The next step after is this to combine the *specific* machines from `lib.systems.platforms` with `lib.systems.examples`, keeping just the "multiplatform" ones for defaulting.

Progress on #34274

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).