### PR TITLE
ethminer: fix broken package by switching to clang

### DIFF
--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   opencl-headers,
   cmake,
@@ -16,7 +16,11 @@
   cli11
 }:
 
-stdenv.mkDerivation rec {
+# Note that this requires clang < 9.0 to build, and currently
+# clangStdenv provides clang 7.1 which satisfies the requirement.
+let stdenv = clangStdenv;
+
+in stdenv.mkDerivation rec {
   pname = "ethminer";
   version = "0.18.0";
 
@@ -71,8 +75,5 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ nand0p ];
     license = licenses.gpl2;
-    # Doesn't build with gcc9, and if overlayed to use gcc8 stdenv fails on CUDA issues.
-    broken = true;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `ethminer` has been broken due to the reason that both gcc 8/9 cannot compile it. This PR updated the package to use clang (7.1) instead. Tested locally (NixOS) that the package is successfully built and also tested mining with it smoothly (see below)

```
$ result/bin/ethminer --farm-recheck 200 -U -P stratum://${WALLET_ADDRESS}.Worker@us1.ethermine.org:4444

ethminer 0.18.0
Build: linux/release/clang

 i 22:24:53 .ethminer-wrapp Configured pool us1.ethermine.org:4444
 i 22:24:53 .ethminer-wrapp Selected pool us1.ethermine.org:4444
 i 22:24:53 .ethminer-wrapp Negotiation of EthereumStratum/2.0.0 failed. Trying another ...
 i 22:24:53 .ethminer-wrapp Stratum mode : EthereumStratum/1.0.0 (NiceHash)
 i 22:24:53 .ethminer-wrapp Established connection to us1.ethermine.org [172.65.218.238:4444]
 i 22:24:53 .ethminer-wrapp Spinning up miners...
cu 22:24:53 cuda-0   Using Pci Id : 0d:00.0 GeForce GTX 1080 Ti (Compute 6.1) Memory : 10.91 GB
 i 22:24:53 .ethminer-wrapp Authorized worker 0x5c2816Cd036B29dA9Ba03E0D7c4BEDBbEAA671eA.Worker
 i 22:24:53 .ethminer-wrapp Epoch : 382 Difficulty : 4.29 Gh
 i 22:24:53 .ethminer-wrapp Job: 3d2fcd45… us1.ethermine.org [172.65.218.238:4444]
 i 22:24:55 .ethminer-wrapp Job: 740a5c54… us1.ethermine.org [172.65.218.238:4444]
cu 22:24:55 cuda-0   Generating DAG + Light : 4.05 GB
 i 22:24:55 .ethminer-wrapp Job: 8d14a775… us1.ethermine.org [172.65.218.238:4444]
 m 22:24:58 .ethminer-wrapp 0:00 A0 0.00 h - cu0 0.00
 i 22:24:59 .ethminer-wrapp Job: 158f0d2e… us1.ethermine.org [172.65.218.238:4444]
 i 22:25:03 .ethminer-wrapp Job: f75b49d3… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:03 .ethminer-wrapp 0:00 A0 0.00 h - cu0 0.00
cu 22:25:06 cuda-0   Generated DAG + Light in 11,570 ms. 6.86 GB left.
 i 22:25:07 .ethminer-wrapp Job: c2c26957… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:08 .ethminer-wrapp 0:00 A0 157.09 Kh - cu0 157.09
 i 22:25:11 .ethminer-wrapp Job: 5d9d572a… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:13 .ethminer-wrapp 0:00 A0 32.16 Mh - cu0 32.16
 i 22:25:15 .ethminer-wrapp Job: 3a7bb902… us1.ethermine.org [172.65.218.238:4444]
 i 22:25:17 .ethminer-wrapp Job: 07c29244… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:18 .ethminer-wrapp 0:00 A0 32.21 Mh - cu0 32.21
 i 22:25:19 .ethminer-wrapp Job: 9af3ecc6… us1.ethermine.org [172.65.218.238:4444]
 i 22:25:19 .ethminer-wrapp Job: 3f30f793… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:23 .ethminer-wrapp 0:00 A0 32.20 Mh - cu0 32.20
 i 22:25:23 .ethminer-wrapp Job: 7d7f724d… us1.ethermine.org [172.65.218.238:4444]
 i 22:25:27 .ethminer-wrapp Job: 346888a1… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:28 .ethminer-wrapp 0:00 A0 32.19 Mh - cu0 32.19
 i 22:25:29 .ethminer-wrapp Job: 09005484… us1.ethermine.org [172.65.218.238:4444]
 i 22:25:29 .ethminer-wrapp Job: 56516961… us1.ethermine.org [172.65.218.238:4444]
 m 22:25:33 .ethminer-wrapp 0:00 A0 32.18 Mh - cu0 32.18
...
``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
