### PR TITLE
ocamlPackages.ppxlib: add ppxlib 0.20.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,21 +1,31 @@
 { lib, fetchFromGitHub, buildDunePackage, ocaml
 , version ? if lib.versionAtLeast ocaml.version "4.07" then "0.15.0" else "0.13.0"
-, ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
+, ocaml-compiler-libs, ppx_derivers, stdio
 , stdlib-shims
+, ocaml-migrate-parsetree-1-8, ocaml-migrate-parsetree-2-1
 }:
 
 let param = {
   "0.8.1" = {
     sha256 = "0vm0jajmg8135scbg0x60ivyy5gzv4abwnl7zls2mrw23ac6kml6";
     max_version = "4.10";
+    ocaml-migrate-parsetree = ocaml-migrate-parsetree-1-8;
   };
   "0.13.0" = {
     sha256 = "0c54g22pm6lhfh3f7s5wbah8y48lr5lj3cqsbvgi99bly1b5vqvl";
+    ocaml-migrate-parsetree = ocaml-migrate-parsetree-1-8;
   };
   "0.15.0" = {
     sha256 = "1p037kqj5858xrhh0dps6vbf4fnijla6z9fjz5zigvnqp4i2xkrn";
     min_version = "4.07";
     useDune2 = true;
+    ocaml-migrate-parsetree = ocaml-migrate-parsetree-1-8;
+  };
+  "0.20.0" = {
+    sha256 = "0nwwvh58hf18wpfh6i5mgsykiaw0rj9vy5id4xmja36s3pm5bcn3";
+    useDune2 = true;
+    min_version = "4.07";
+    ocaml-migrate-parsetree = ocaml-migrate-parsetree-2-1;
   };
 }."${version}"; in
 
@@ -38,7 +48,7 @@ buildDunePackage rec {
   };
 
   propagatedBuildInputs = [
-    ocaml-compiler-libs ocaml-migrate-parsetree ppx_derivers stdio
+    ocaml-compiler-libs param.ocaml-migrate-parsetree ppx_derivers stdio
     stdlib-shims
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add latest version of `ppxlib` to `ocamlPackages`, leave default `ppxlib` version untouched.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
