### PR TITLE
bintools-wrapper: fix inverted link32 check

### DIFF
--- a/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+++ b/pkgs/build-support/bintools-wrapper/ld-wrapper.sh
@@ -145,7 +145,7 @@ then
     done
 fi
 
-if [[ "$link32" = "0" && "$setDynamicLinker" = 1 && -e "@out@/nix-support/dynamic-linker-m32" ]]; then
+if [[ "$link32" = "1" && "$setDynamicLinker" = 1 && -e "@out@/nix-support/dynamic-linker-m32" ]]; then
     # We have an alternate 32-bit linker and we're producing a 32-bit ELF, let's
     # use it.
     extraAfter+=(


### PR DESCRIPTION
###### Motivation for this change
The new skip for the dynamic linker includes a change in behaviour,
previously the $link32 variable was checked using an arithmetic
expression via (( )). This returns zero if the output of the arithmetic
expression if nonzero, i.e. link32=1 would return zero and the if
condition would be executed.
The code refactored this to use "$link32" = "0" which is incorrect in
this case, since we want this if conditional to run if $link32 is 1.

Small shell excerpt for clarity:
```bash
$ export link32=1
$ export cookie=1
$ if [[ "$cookie" = "1" ]] && (( "$link32" )); then echo "do some stuff"; fi;
do some stuff
$ if [[ "$cookie" = "1" && "$link32" = "0" ]]; then echo "do some stuff"; fi;
$
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
