### PR TITLE
notsodeep: init at 2019.5.29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1957,6 +1957,12 @@
     githubId = 4331004;
     name = "Naoya Hatta";
   };
+  damhiya = {
+    name = "SoonWon Moon";
+    email = "damhiya@gmail.com";
+    github = "damhiya";
+    githubId = 13533446;
+  };
   DamienCassou = {
     email = "damien@cassou.me";
     github = "DamienCassou";

--- a/pkgs/tools/networking/notsodeep/default.nix
+++ b/pkgs/tools/networking/notsodeep/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, stdenv, fetchFromGitHub }:
+with stdenv;
+mkDerivation {
+  # notsodeep doesn't have version number
+  # So I added last commit date instead
+  pname = "notsodeep";
+  version = "2019.5.29";
+  src = fetchFromGitHub {
+    owner = "farukuzun";
+    repo = "notsodeep";
+    rev = "470532243bff92fd8314f3693c4748604078b484";
+    sha256 = "0rzxszvjcv86516cv79zxs65jvd464483y6xv9g6l0bhjvrdr9kv";
+  };
+
+  buildInputs = with pkgs; [ libnetfilter_queue libnfnetlink ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp notsodeep $out/bin
+  '';
+  meta = with lib; {
+    description = "Active DPI circumvention utility for Linux";
+    homepage = "https://github.com/farukuzun/notsodeep";
+    license = licenses.asl20;
+    maintainers = [ maintainers.damhiya ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -699,6 +699,8 @@ in
 
   albert = libsForQt5.callPackage ../applications/misc/albert {};
 
+  notsodeep = callPackage ../tools/networking/notsodeep { };
+
   ### APPLICATIONS/TERMINAL-EMULATORS
 
   alacritty = callPackage ../applications/terminal-emulators/alacritty {
@@ -28966,4 +28968,5 @@ in
   lc3tools = callPackage ../development/tools/lc3tools {};
 
   zktree = callPackage ../applications/misc/zktree {};
+
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`notsodeep` is an active DPI circumvention utility.
Here is the original repository : https://github.com/farukuzun/notsodeep
I wrote a nix expression for `notsodeep` and it seems it works well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
