### PR TITLE
fish: avoid nontermination in fhs like setups

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -46,8 +46,12 @@ let
     #     source both, but source the more global configuration files earlier
     #     than the more local ones, so that more local configurations inherit
     #     from but override the more global locations.
+    #
+    #     Special care needs to be taken, when fish is called from an FHS user env
+    #     or similar setup, because this configuration file will then be relocated
+    #     to /etc/fish/config.fish, so we test for this case to avoid nontermination.
 
-    if test -f /etc/fish/config.fish
+    if test -f /etc/fish/config.fish && test /etc/fish/config.fish != (status filename)
       source /etc/fish/config.fish
     end
 


### PR DESCRIPTION
###### Motivation for this change

fix https://github.com/NixOS/nixpkgs/issues/59357
fix https://github.com/NixOS/nixpkgs/issues/34656

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
