### PR TITLE
knightos-kimg: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/knightos/kimg/default.nix
+++ b/pkgs/development/tools/knightos/kimg/default.nix
@@ -1,27 +1,25 @@
-{ stdenv, fetchFromGitHub, cmake, asciidoc, pkg-config, imagemagick }:
+{ stdenv, fetchFromGitHub, cmake, asciidoc }:
 
 stdenv.mkDerivation rec {
   pname = "kimg";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "KnightOS";
     repo = "kimg";
     rev = version;
-    sha256 = "00gj420m0jvhgm8kkslw8r69nl7r73bxrh6gqs2mx16ymcpkanpk";
+    sha256 = "040782k3rh2a5mhbfgr9gnbfis0wgxvi27vhfn7l35vrr12sw1l3";
   };
 
-  nativeBuildInputs = [ cmake asciidoc pkg-config ];
-
-  buildInputs = [ imagemagick ];
+  nativeBuildInputs = [ cmake asciidoc ];
 
   hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {
     homepage    = "https://knightos.org/";
-    description = "Converts image formats supported by ImageMagick to the KnightOS image format";
+    description = "Converts image formats supported by stb_image to the KnightOS image format";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
-    platforms   = platforms.unix;
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9737,7 +9737,6 @@ in
 
   knightos-kimg = callPackage ../development/tools/knightos/kimg {
     asciidoc = asciidoc-full;
-    imagemagick = imagemagick7Big;
   };
 
   knightos-kpack = callPackage ../development/tools/knightos/kpack { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
