### PR TITLE
libtapi: 1000.10.8 -> 1100.0.11

### DIFF
--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libtapi";
-  version = "1000.10.8"; # determined by looking at VERSION.txt
+  version = "1100.0.11"; # determined by looking at VERSION.txt
 
   src = fetchFromGitHub {
     owner = "tpoechtrager";
     repo = "apple-libtapi";
-    rev = "3cb307764cc5f1856c8a23bbdf3eb49dfc6bea48";
-    sha256 = "1zb10p6xkls8x7wsdwgy9c0v16z97rfkgidii9ffq5rfczgvrhjh";
+    rev = "664b8414f89612f2dfd35a9b679c345aa5389026";
+    sha256 = "1y1yl46msabfy14z0rln333a06087bk14f5h7q1cdawn8nmvbdbr";
   };
 
   sourceRoot = "source/src/llvm";
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
     cmakeFlagsArray+=(-DCMAKE_CXX_FLAGS="$INCLUDE_FIX")
   '';
 
-  buildFlags = [ "clangBasic" "libtapi" ];
+  buildFlags = [ "clangBasic" "libtapi" "tapi" ];
 
-  installTargets = [ "install-libtapi" "install-tapi-headers" ];
+  installTargets = [ "install-libtapi" "install-tapi-headers" "install-tapi" ];
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     install_name_tool -id $out/lib/libtapi.dylib $out/lib/libtapi.dylib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- update libtapi
- build the `tapi` executable (replaces #106348)

From #106348:

> This adds the tapi executable to the libtapi package. The tapi executable can be used to create TBD files, i.e. text-based stubs for macOS dynamic libraries.
>
> The main use I have in mind for this is osxfuse (now macFUSE). The osxfuse library in nixpkgs is currently built from source, but this sadly isn't ideal because the library is closely tied to the osxfuse kernel extension which isn't packaged in nixpkgs. Replacing the current osxfuse library with a TBD would make FUSE packages work more reliably by making it link to the osxfuse library that matches its kernel counterpart.
>
> I also did a quick check to see if I could use this copy of the tapi executable to generate darwin-stubs, but that unfortunately didn't seem to work out well. This version of tapi lacks support for "zippered" binaries (whatever that means), so it couldn't generate a TBD for libSystem.B.dylib.

Version 1100.0.11 supports zippered binaries, so it can generate stubs for macOS preinstalled libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
