### PR TITLE
Firmware and kernel patch for Realtek RTL8761b

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -48,6 +48,7 @@ in {
         rtl8192su-firmware
         rt5677-firmware
         rtl8723bs-firmware
+        rtl8761b-firmware
         rtlwifi_new-firmware
         zd1211fw
         alsa-firmware

--- a/pkgs/os-specific/linux/firmware/rtl8761b-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8761b-firmware/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  name = "rtl8761b-firmware";
+
+  src = fetchFromGitHub {
+    owner = "Realtek-OpenSource";
+    repo = "android_hardware_realtek";
+    rev = "rtk1395";
+    sha256 = "sha256-vd9sZP7PGY+cmnqVty3sZibg01w8+UNinv8X85B+dzc=";
+  };
+
+  installPhase = ''
+    install -D -pm644 \
+      bt/rtkbt/Firmware/BT/rtl8761b_fw \
+      $out/lib/firmware/rtl_bt/rtl8761b_fw.bin
+
+    install -D -pm644 \
+      bt/rtkbt/Firmware/BT/rtl8761b_config \
+      $out/lib/firmware/rtl_bt/rtl8761b_config.bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for Realtek RTL8761b";
+    license = licenses.unfreeRedistributableFirmware;
+    maintainers = with maintainers; [ edibopp ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -76,6 +76,13 @@
     };
   };
 
+  # Adapted for Linux 5.4 from:
+  # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=04896832c94aae4842100cafb8d3a73e1bed3a45
+  rtl8761b_support =
+    { name = "rtl8761b-support";
+      patch = ./rtl8761b-support.patch;
+    };
+
   export_kernel_fpu_functions = {
     "4.14" = {
       name = "export_kernel_fpu_functions";

--- a/pkgs/os-specific/linux/kernel/rtl8761b-support.patch
+++ b/pkgs/os-specific/linux/kernel/rtl8761b-support.patch
@@ -1,0 +1,33 @@
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+index 67f4bc21e7c5..3a9afc905f24 100644
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -130,12 +130,19 @@  static const struct id_table ic_id_table[] = {
+ 	  .cfg_name = "rtl_bt/rtl8821c_config" },
+
+ 	/* 8761A */
+-	{ IC_MATCH_FL_LMPSUBV, RTL_ROM_LMP_8761A, 0x0,
++	{ IC_INFO(RTL_ROM_LMP_8761A, 0xa),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8761a_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8761a_config" },
+
++	/* 8761B */
++	{ IC_INFO(RTL_ROM_LMP_8761A, 0xb),
++	  .config_needed = false,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8761b_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8761b_config" },
++
+	/* 8822C with USB interface */
+	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc),
+	  .config_needed = false,
+@@ -251,6 +258,7 @@  static int rtlbt_parse_firmware(struct hci_dev *hdev,
+ 		{ RTL_ROM_LMP_8723B, 9 },	/* 8723D */
+ 		{ RTL_ROM_LMP_8821A, 10 },	/* 8821C */
+ 		{ RTL_ROM_LMP_8822B, 13 },	/* 8822C */
++		{ RTL_ROM_LMP_8761A, 14 },	/* 8761B */
+ 	};
+
+ 	min_size = sizeof(struct rtl_epatch_header) + sizeof(extension_sig) + 3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19135,6 +19135,8 @@ in
 
   rtl8723bs-firmware = callPackage ../os-specific/linux/firmware/rtl8723bs-firmware { };
 
+  rtl8761b-firmware = callPackage ../os-specific/linux/firmware/rtl8761b-firmware { };
+
   rtlwifi_new-firmware = callPackage ../os-specific/linux/firmware/rtlwifi_new-firmware { };
 
   s3ql = callPackage ../tools/backup/s3ql { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18378,6 +18378,7 @@ in
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.request_key_helper
+      kernelPatches.rtl8761b_support
       kernelPatches.export_kernel_fpu_functions."5.3"
     ];
   };


### PR DESCRIPTION
###### Motivation for this change

Proprietary firmware is required to get the Bluetooth controller chip Realtek RTL8761b to work on Linux. Support was added to Linux [in this commit][linux-commit]. However, the Linux kernel versions in nixpkgs including this commit (5.9 and 5.10) seem to have [another Bluetooth bug](https://bugzilla.kernel.org/show_bug.cgi?id=210453) that keeps this from being useful.

I backported [the commit][linux-commit] to Linux 5.4, as the surrounding code was not compatible with directly including the commit. The firmware package is based on an [AUR package](https://aur.archlinux.org/packages/rtl8761b-fw/). I tested this on my NixOS x86_64 system using a USB Bluetooth controller with a RTL8761b chip.

[linux-commit]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=04896832c94aae4842100cafb8d3a73e1bed3a45


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
