### PR TITLE
foot: 1.5.1 -> 1.6.2

### DIFF
--- a/pkgs/applications/terminal-emulators/foot/default.nix
+++ b/pkgs/applications/terminal-emulators/foot/default.nix
@@ -1,35 +1,142 @@
-{ stdenv, fetchgit
-, fcft, freetype, pixman, libxkbcommon, fontconfig, wayland
-, meson, ninja, ncurses, scdoc, tllist, wayland-protocols, pkg-config
+{ stdenv
+, lib
+, fetchzip
+, fetchurl
+, runCommandNoCC
+, fcft
+, freetype
+, pixman
+, libxkbcommon
+, fontconfig
+, wayland
+, meson
+, ninja
+, ncurses
+, scdoc
+, tllist
+, wayland-protocols
+, pkg-config
+, allowPgo ? true
+, python3  # for PGO
 }:
 
+let
+  version = "1.6.2";
+
+  # build stimuli file for PGO build and the script to generate it
+  # independently of the foot's build, so we can cache the result
+  # and avoid unnecessary rebuilds as it can take relatively long
+  # to generate
+  stimulusGenerator = stdenv.mkDerivation {
+    pname = "foot-generate-alt-random-writes";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://codeberg.org/dnkl/foot/raw/tag/${version}/scripts/generate-alt-random-writes.py";
+      sha256 = "0pnc5nvqrbgx5618ylrkrs9fyxjh4jcsbryfk6vlnk8x4wyyaibz";
+    };
+
+    dontUnpack = true;
+
+    buildInputs = [ python3 ];
+
+    installPhase = ''
+      install -Dm755 $src $out
+    '';
+  };
+
+  stimuliFile = runCommandNoCC "pgo-stimulus-file" { } ''
+    ${stimulusGenerator} \
+      --rows=67 --cols=135 \
+      --scroll --scroll-region \
+      --colors-regular --colors-bright --colors-256 --colors-rgb \
+      --attr-bold --attr-italic --attr-underline \
+      --sixel \
+      --seed=2305843009213693951 \
+      $out
+  '';
+
+  compilerName =
+    if stdenv.cc.isClang
+    then "clang"
+    else if stdenv.cc.isGNU
+    then "gcc"
+    else "unknown";
+
+  # https://codeberg.org/dnkl/foot/src/branch/master/INSTALL.md#performance-optimized-pgo
+  pgoCflags = {
+    "clang" = "-O3 -Wno-ignored-optimization-argument -Wno-profile-instr-out-of-date -Wno-profile-instr-unprofiled";
+    "gcc" = "-O3 -Wno-missing-profile";
+  }."${compilerName}";
+
+  # ar with lto support
+  ar = {
+    "clang" = "llvm-ar";
+    "gcc" = "gcc-ar";
+    "unknown" = "ar";
+  }."${compilerName}";
+
+  # PGO only makes sense if we are not cross compiling and
+  # using a compiler which foot's PGO build supports (clang or gcc)
+  doPgo = allowPgo && (stdenv.hostPlatform == stdenv.buildPlatform)
+    && compilerName != "unknown";
+in
 stdenv.mkDerivation rec {
   pname = "foot";
-  version = "1.5.1";
+  inherit version;
 
-  src = fetchgit {
-    url = "https://codeberg.org/dnkl/foot.git";
-    rev = version;
-    sha256 = "sha256-GAk2qkrgCNILJOeRcn1NT4t3w+R6WFTZ1goOhBEwKwc=";
+  src = fetchzip {
+    url = "https://codeberg.org/dnkl/${pname}/archive/${version}.tar.gz";
+    sha256 = "08i3jmjky5s2nnc0c95c009cym91rs4sj4876sr4xnlkb7ab4812";
   };
 
   nativeBuildInputs = [
-    meson ninja ncurses scdoc tllist wayland-protocols pkg-config
-  ];
+    meson
+    ninja
+    ncurses
+    scdoc
+    tllist
+    wayland-protocols
+    pkg-config
+  ] ++ lib.optional stdenv.cc.isClang stdenv.cc.cc.llvm;
+
   buildInputs = [
-    fontconfig freetype pixman wayland libxkbcommon fcft
+    fontconfig
+    freetype
+    pixman
+    wayland
+    libxkbcommon
+    fcft
   ];
 
-  # recommended build flags for foot as per INSTALL.md
-  # https://codeberg.org/dnkl/foot/src/branch/master/INSTALL.md#user-content-release-build
+  # recommended build flags for performance optimized foot builds
+  # https://codeberg.org/dnkl/foot/src/branch/master/INSTALL.md#release-build
+  CFLAGS =
+    if !doPgo
+    then "-O3 -fno-plt"
+    else pgoCflags;
+
+  # ar with gcc plugins for lto objects
   preConfigure = ''
-    export CFLAGS+="-O3 -fno-plt"
+    export AR="${ar}"
   '';
 
   mesonFlags = [ "--buildtype=release" "-Db_lto=true" ];
 
-  meta = with stdenv.lib; {
+  # build and run binary generating PGO profiles,
+  # then reconfigure to build the normal foot binary utilizing PGO
+  preBuild = lib.optionalString doPgo ''
+    meson configure -Db_pgo=generate
+    ninja
+    ./pgo ${stimuliFile} ${stimuliFile} ${stimuliFile}
+    meson configure -Db_pgo=use
+  '' + lib.optionalString (doPgo && stdenv.cc.cc.pname == "clang") ''
+    llvm-profdata merge default_*profraw --output=default.profdata
+  '';
+
+  meta = with lib; {
     homepage = "https://codeberg.org/dnkl/foot/";
+    changelog = "https://codeberg.org/dnkl/foot/releases/tag/${version}";
     description = "A fast, lightweight and minimalistic Wayland terminal emulator";
     license = licenses.mit;
     maintainers = [ maintainers.sternenseemann ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[Changelog](https://codeberg.org/dnkl/foot/releases/tag/1.6.0)

* fix build with `clangStdenv`
* support foot's PGO build
  * enable by default if gcc is used (there are some unresolved warnings
    with clang which need to investigated if they are detrimental, but
    it works all in all)
  * build *should* be deterministic with PGO as we use an input file which
    is generated with the same seed everytime.
* apply nixpkgs-fmt


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Supersedes #106529.