### PR TITLE
ocamlPackages.ounit(2): 2.2.3 -> 2.2.4

### DIFF
--- a/pkgs/development/ocaml-modules/ounit2/default.nix
+++ b/pkgs/development/ocaml-modules/ounit2/default.nix
@@ -1,17 +1,20 @@
-{ lib, buildDunePackage, fetchurl, stdlib-shims }:
+{ lib, ocaml, buildDunePackage, fetchurl, stdlib-shims, ncurses }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.04";
 
   pname = "ounit2";
-  version = "2.2.3";
+  version = "2.2.4";
 
   src = fetchurl {
     url = "https://github.com/gildor478/ounit/releases/download/v${version}/ounit-v${version}.tbz";
-    sha256 = "1naahh24lbyxmrnzpfz8karniqbf1nknivf96mrvsr6zlx5ad072";
+    sha256 = "0i9kiqbf2dp12c4qcvbn4abdpdp6h4g5z54ycsh0q8jpv6jnkh5m";
   };
 
   propagatedBuildInputs = [ stdlib-shims ];
+
+  doCheck = true;
+  checkInputs = lib.optional (lib.versionOlder ocaml.version "4.07") ncurses;
 
   meta = with lib; {
     homepage = "https://github.com/gildor478/ounit";


### PR DESCRIPTION
also enable tests

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/gildor478/ounit/releases/tag/v2.2.4>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
