### PR TITLE
nixos: fix "nixos-rebuild build-vm-with-bootloader" for EFI systems

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -605,6 +605,10 @@ in
 
     virtualisation.bootDevice = mkDefault (driveDeviceName 1);
 
+    virtualisation.useEFIBoot = mkDefault
+      (config.boot.loader.systemd-boot.enable ||
+       config.boot.loader.efi.canTouchEfiVariables);
+
     virtualisation.pathsInNixDB = [ config.system.build.toplevel ];
 
     # FIXME: Consolidate this one day.

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -9,7 +9,6 @@ with pkgs.lib;
 let
   common = {
     virtualisation.useBootLoader = true;
-    virtualisation.useEFIBoot = true;
     boot.loader.systemd-boot.enable = true;
     boot.loader.efi.canTouchEfiVariables = true;
     environment.systemPackages = [ pkgs.efibootmgr ];


### PR DESCRIPTION
###### Motivation for this change
`nixos-rebuild build-vm-with-bootloader` currently fails with the
default NixOS EFI configuration:

```
  $ cat >configuration.nix <<EOF
  {
    fileSystems."/".device = "/dev/sda1";
    boot.loader.systemd-boot.enable = true;
    boot.loader.efi.canTouchEfiVariables = true;
  }
  EOF

  $ nixos-rebuild build-vm-with-bootloader -I nixos-config=$PWD/configuration.nix -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-20.09.tar.gz
  [...]
  insmod: ERROR: could not insert module /nix/store/1ibmgfr13r8b6xyn4f0wj115819f359c-linux-5.4.83/lib/modules/5.4.83/kernel/fs/efivarfs/efivarfs.ko.xz: No such device
  mount: /sys/firmware/efi/efivars: mount point does not exist.
  [    1.908328] reboot: Power down
  builder for '/nix/store/dx2ycclyknvibrskwmii42sgyalagjxa-nixos-boot-disk.drv' failed with exit code 32
  [...]
```

Fix it by setting `virtualisation.useEFIBoot = true` in qemu-vm.nix, when
efi is neeeded.

And remove the now unneeded configuration in
./nixos/tests/systemd-boot.nix, since it's handled globally.

Before:
* release-20.03: successful build, unsuccessful run
* release-20.09 (and master): unsuccessful build

After:
* Successful build and run.

Fixes https://github.com/NixOS/nixpkgs/issues/107255

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
