### PR TITLE
linuxPackages_latest.evdi: apply patch for kernel >= 5.9

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -11,6 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "1yrny6jj9403z0rxbd3nxf49xc4w0rfpl7xsq03pq32pb3vlbqw7";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/DisplayLink/evdi/pull/228.patch";
+      sha256 = "0kj8wqvw784npa9y8n28xy5fsa9xc037m460rja09x7czyd8sgwa";
+    })
+  ];
+
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildInputs = [ kernel libdrm ];
@@ -33,6 +40,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = with licenses; [ lgpl21 gpl2 ];
     homepage = "https://www.displaylink.com/";
-    broken = with kernel; kernelOlder "5" || kernelAtLeast "5.9" || stdenv.isAarch64;
+    broken = with kernel; kernelOlder "5" || stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
This is a more conservative backport of
https://github.com/NixOS/nixpkgs/pull/107276, only applying the patch to
get it to build with 5.9, which matches linuxPackages_latest on 20.09.

###### Motivation for this change
Get displaylink to work on 20.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @supercoder3000 for testing.