### PR TITLE
libschrift: init at 0.9.1

### DIFF
--- a/pkgs/development/libraries/libschrift/default.nix
+++ b/pkgs/development/libraries/libschrift/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "libschrift";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "tomolt";
+    repo = pname;
+    rev = "c6d20460d6e602e8829d3a227fd7be4c4c3cda86";
+    hash = "sha256-BuTmWaWFZ0DXujlbhbmK3Woit8fR9F4DWmKszHX6gOI=";
+  };
+
+  postPatch = ''
+    substituteInPlace config.mk \
+      --replace "PREFIX = /usr/local" "PREFIX = $out"
+  '';
+
+  makeFlags = [ "libschrift.a" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/tomolt/libschrift";
+    description = "A lightweight TrueType font rendering library";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14608,6 +14608,8 @@ in
 
   libs3 = callPackage ../development/libraries/libs3 { };
 
+  libschrift = callPackage ../development/libraries/libschrift { };
+
   libsearpc = callPackage ../development/libraries/libsearpc { };
 
   libsigcxx = callPackage ../development/libraries/libsigcxx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/tomolt/libschrift>


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
