### PR TITLE
sundials: 5.3.0 -> 5.6.1

### DIFF
--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -15,6 +15,24 @@ stdenv.mkDerivation rec {
   pname = "sundials";
   version = "5.6.1";
 
+  outputs = [ "out" "examples" ];
+
+  src = fetchurl {
+    url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
+    sha256 = "Frd5mex+fyFXqh0Eyh3kojccqBUOBW0klR0MWJZvKoM=";
+  };
+
+  patches = [
+    # Fixing an upstream regression in treating cmake prefix directories:
+    # https://github.com/LLNL/sundials/pull/58
+    (fetchpatch {
+      url = "https://github.com/LLNL/sundials/commit/dd32ff9baa05618f36e44aadb420bbae4236ea1e.patch";
+      sha256 = "kToAuma+2iHFyL1v/l29F3+nug4AdK5cPG6IcXv2afc=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
   buildInputs = [
     python
   ]
@@ -30,22 +48,6 @@ stdenv.mkDerivation rec {
   # [INSTALL_GUIDE.pdf](https://raw.githubusercontent.com/LLNL/sundials/master/INSTALL_GUIDE.pdf)
   ++ stdenv.lib.optionals (kluSupport) [
     suitesparse
-  ];
-  outputs = [ "out" "examples" ];
-
-  nativeBuildInputs = [ cmake ];
-
-  src = fetchurl {
-    url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
-    sha256 = "Frd5mex+fyFXqh0Eyh3kojccqBUOBW0klR0MWJZvKoM=";
-  };
-  patches = [
-    # Fixing an upstream regression in treating cmake prefix directories:
-    # https://github.com/LLNL/sundials/pull/58
-    (fetchpatch {
-      url = "https://github.com/LLNL/sundials/commit/dd32ff9baa05618f36e44aadb420bbae4236ea1e.patch";
-      sha256 = "kToAuma+2iHFyL1v/l29F3+nug4AdK5cPG6IcXv2afc=";
-    })
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , cmake
 , fetchurl
+, fetchpatch
 , python
 , blas
 , lapack
@@ -12,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "sundials";
-  version = "5.3.0";
+  version = "5.6.1";
 
   buildInputs = [
     python
@@ -35,32 +36,35 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
-    sha256 = "19xwi7pz35s2nqgldm6r0jl2k0bs36zhbpnmmzc56s1n3bhzgpw8";
+    sha256 = "Frd5mex+fyFXqh0Eyh3kojccqBUOBW0klR0MWJZvKoM=";
   };
-
   patches = [
-    (fetchurl {
-      # https://github.com/LLNL/sundials/pull/19
-      url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
-      sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
+    # Fixing an upstream regression in treating cmake prefix directories:
+    # https://github.com/LLNL/sundials/pull/58
+    (fetchpatch {
+      url = "https://github.com/LLNL/sundials/commit/dd32ff9baa05618f36e44aadb420bbae4236ea1e.patch";
+      sha256 = "kToAuma+2iHFyL1v/l29F3+nug4AdK5cPG6IcXv2afc=";
     })
   ];
 
   cmakeFlags = [
     "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
   ] ++ stdenv.lib.optionals (lapackSupport) [
-    "-DLAPACK_ENABLE=ON"
+    "-DENABLE_LAPACK=ON"
     "-DLAPACK_LIBRARIES=${lapack}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}"
   ] ++ stdenv.lib.optionals (kluSupport) [
-    "-DKLU_ENABLE=ON"
+    "-DENABLE_KLU=ON"
     "-DKLU_INCLUDE_DIR=${suitesparse.dev}/include"
     "-DKLU_LIBRARY_DIR=${suitesparse}/lib"
-  ] ++ stdenv.lib.optionals (lapackSupport && !lapack.isILP64) [
-    # Use the correct index type according to lapack which is supposed to be
-    # the same index type compatible with blas, thanks to the assertion of
-    # buildInputs
-    "-DSUNDIALS_INDEX_TYPE=int32_t"
-  ]
+  ] ++ [(
+    # Use the correct index type according to lapack and blas used. They are
+    # already supposed to be compatible but we check both for extra safety. 64
+    # should be the default but we prefer to be explicit, for extra safety.
+    if blas.isILP64 then
+      "-DSUNDIALS_INDEX_SIZE=64"
+    else
+      "-DSUNDIALS_INDEX_SIZE=32"
+  )]
   ;
 
   doCheck = true;

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals (kluSupport) [
     suitesparse
   ];
+  outputs = [ "out" "examples" ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -48,7 +49,7 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
+    "-DEXAMPLES_INSTALL_PATH=${placeholder "examples"}/share/examples"
   ] ++ stdenv.lib.optionals (lapackSupport) [
     "-DENABLE_LAPACK=ON"
     "-DLAPACK_LIBRARIES=${lapack}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}"


### PR DESCRIPTION
Update some cmake flags and be more explicit regarding index size.<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update.

###### Things done

Tested `octave` to build with this update.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
