### PR TITLE
libpsm2: 11.2.156 -> 11.2.185

### DIFF
--- a/pkgs/os-specific/linux/libpsm2/default.nix
+++ b/pkgs/os-specific/linux/libpsm2/default.nix
@@ -2,8 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libpsm2";
-  version = "11.2.156";
-  ifs_version = "10_10_2_0_44";
+  version = "11.2.185";
 
   preConfigure= ''
     export UDEVDIR=$out/etc/udev
@@ -14,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ numactl pkgconfig ];
 
-  installFlags = [ 
+  installFlags = [
     "DESTDIR=$(out)"
     "UDEVDIR=/etc/udev"
     "LIBPSM2_COMPAT_CONF_DIR=/etc"
@@ -23,8 +22,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "intel";
     repo = "opa-psm2";
-    rev = "IFS_RELEASE_${ifs_version}";
-    sha256 = "0ckrfzih1ga9yvximxjdh0z05kn9l858ykqiblv18w6ka3gra1xz";
+    rev = "PSM2_${version}";
+    sha256 = "062hg4r6gz7pla9df70nqs5i2a3mp1wszmp4l0g771fykhhrxsjg";
   };
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change
Update. Fixed the release naming scheme. Preparation for openmpi update (4.1.0).

CC @bzizou 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
