### PR TITLE
soapyaudio: init at 0.1.1

### DIFF
--- a/pkgs/applications/radio/soapyaudio/default.nix
+++ b/pkgs/applications/radio/soapyaudio/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config
+, hamlib, rtaudio, alsaLib, libpulseaudio, libjack2, libusb1, soapysdr
+} :
+
+stdenv.mkDerivation rec {
+  pname = "soapyaudio";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "pothosware";
+    repo = "SoapyAudio";
+    rev = "soapy-audio-${version}";
+    sha256 = "0minlsc1lvmqm20vn5hb4im7pz8qwklfy7sbr2xr73xkrbqdahc0";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ hamlib rtaudio alsaLib libpulseaudio libjack2 libusb1 soapysdr ];
+
+  cmakeFlags = [
+    "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/"
+    "-DUSE_HAMLIB=ON"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pothosware/SoapyAudio";
+    description = "SoapySDR plugin for amateur radio and audio devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ numinit ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16015,6 +16015,8 @@ in
 
   soapyairspy = callPackage ../applications/radio/soapyairspy { };
 
+  soapyaudio = callPackage ../applications/radio/soapyaudio { };
+
   soapybladerf = callPackage ../applications/radio/soapybladerf { };
 
   soapyhackrf = callPackage ../applications/radio/soapyhackrf { };
@@ -16027,6 +16029,7 @@ in
     extraPackages = [
       limesuite
       soapyairspy
+      soapyaudio
       soapybladerf
       soapyhackrf
       soapyremote


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding audio input plugin for SoapySDR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
