### PR TITLE
steamPackages.steam: 1.0.0.61 -> 1.0.0.68

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -55,6 +55,14 @@ let
     export STEAM_LD_LIBRARY_PATH="$STEAM_LD_LIBRARY_PATH''${STEAM_LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
   '';
 
+  # bootstrap.tar.xz has 444 permissions, which means that simple deletes fail
+  # and steam will not be able to start
+  fixBootstrap = ''
+    if [ -r $HOME/.local/share/Steam/bootstrap.tar.xz ]; then
+      chmod +w $HOME/.local/share/Steam/bootstrap.tar.xz
+    fi
+  '';
+
   setupSh = writeScript "setup.sh" ''
     #!${runtimeShell}
   '';
@@ -264,6 +272,7 @@ in buildFHSUserEnv rec {
       fi
     fi
     ${lib.optionalString (!nativeOnly) exportLDPath}
+    ${fixBootstrap}
     exec steam "$@"
   '';
 
@@ -290,6 +299,7 @@ in buildFHSUserEnv rec {
       fi
       shift
       ${lib.optionalString (!nativeOnly) exportLDPath}
+      ${fixBootstrap}
       exec -- "$run" "$@"
     '';
   };

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -229,7 +229,7 @@ in buildFHSUserEnv rec {
     mkdir -p $out/share/applications
     ln -s ${steam}/share/icons $out/share
     ln -s ${steam}/share/pixmaps $out/share
-    sed "s,/usr/bin/steam,steam,g" ${steam}/share/applications/steam.desktop > $out/share/applications/steam.desktop
+    ln -s ${steam}/share/applications/steam.desktop $out/share/applications/steam.desktop
   '';
 
   profile = ''

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -2,7 +2,7 @@
 
 let
   traceLog = "/tmp/steam-trace-dependencies.log";
-  version = "1.0.0.61";
+  version = "1.0.0.68";
 
 in stdenv.mkDerivation {
   pname = "steam-original";
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://repo.steampowered.com/steam/pool/steam/s/steam/steam_${version}.tar.gz";
-    sha256 = "0c5xy57gwr14vp3wy3jpqi5dl6y7n01p2dy4jlgl9bf9x7616r6n";
+    sha256 = "sha256-ZeiCYjxnH0Ath5bB20QHmE8R3wU4/3RiAw2NUhrrKNM=";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
@@ -26,14 +26,16 @@ in stdenv.mkDerivation {
       EOF
       chmod +x $out/bin/steamdeps
     ''}
-    install -d $out/lib/udev/rules.d
-    install -m644 lib/udev/rules.d/*.rules $out/lib/udev/rules.d
+
+    # this just installs a link, "steam.desktop -> /lib/steam/steam.desktop"
+    rm $out/share/applications/steam.desktop
+    sed -e 's,/usr/bin/steam,steam,g' steam.desktop > $out/share/applications/steam.desktop
   '';
 
   meta = with stdenv.lib; {
     description = "A digital distribution platform";
     homepage = "http://store.steampowered.com/";
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ jagajaga ];
+    maintainers = with maintainers; [ jagajaga jonringer ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
was trying to hack around and make NixOS work with the latest proton runtime... but just settled for updating the package today. And doing some minor cleanups

udev rules are no longer shipped with steam, so I removed the related logic
fixed the desktop file inside the unwrapped steam package, instead of the wrapper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
