### PR TITLE
Allow customizing config.gateway.json for Unifi

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -13,6 +13,21 @@ in
 {
 
   options = {
+    services.unifi.sites = mkOption {
+      description = "Site configuration";
+      default = {};
+      example = { default = { system.conntrack.timeout.tcp.close = "20"; }; };
+      type = with types; attrsOf (submodule {
+        options = {
+          configGateway = mkOption {
+            type = types.either types.str types.attrs;
+            description = ''
+              The gateway configuration as per https://help.ui.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration-Using-config-gateway-json.
+            '';
+          };
+        };
+      });
+    };
 
     services.unifi.enable = mkOption {
       type = types.bool;

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -33,6 +33,9 @@ let
             description = ''
                 The gateway configuration as per https://help.ui.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration-Using-config-gateway-json as nix path to a JSON file.
             '';
+            example = ''
+               { config.services.unifi.sites.default.configGatewayFile = ./config.gateway.json; }
+            '';
         };
     };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Unifi allows configuring hardware outside the Web UI by providing a config.gateway.json file per site:

https://help.ui.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration-Using-config-gateway-json


###### Things done

Added a simple option `services.unifi.sites.<site-id>.configGateway` to declaratively allow customizing this file.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
