### PR TITLE
mutagen: install agents bundle

### DIFF
--- a/pkgs/tools/misc/mutagen/default.nix
+++ b/pkgs/tools/misc/mutagen/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, fetchzip }:
 
 buildGoModule rec {
   pname = "mutagen";
@@ -13,9 +13,25 @@ buildGoModule rec {
 
   vendorSha256 = "0szs9yc49fyh55ra1wf8zj76kdah0x49d45cgivk3gqh2hl17j6l";
 
+  agents = fetchzip {
+    name = "mutagen-agents-${version}";
+    # The package architecture does not matter since all packages contain identical mutagen-agents.tar.gz.
+    url = "https://github.com/mutagen-io/mutagen/releases/download/v${version}/mutagen_linux_amd64_v${version}.tar.gz";
+    stripRoot = false;
+    extraPostFetch = ''
+      rm $out/mutagen # Keep only mutagen-agents.tar.gz.
+    '';
+    sha256 = "0k8iif09kvxfxx6qm5qmkf3lr7ar6i98ivkndimj680ah9v1hkj8";
+  };
+
   doCheck = false;
 
   subPackages = [ "cmd/mutagen" "cmd/mutagen-agent" ];
+
+  postInstall = ''
+    install -d $out/libexec
+    ln -s ${agents}/mutagen-agents.tar.gz $out/libexec/
+  '';
 
   meta = with lib; {
     description = "Make remote development work with your local tools";


### PR DESCRIPTION
###### Motivation for this change

Fixes #81219

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
