### PR TITLE
pythonPackages.docx2python: init at unstable-2020-11-15

### DIFF
--- a/pkgs/development/python-modules/docx2python/default.nix
+++ b/pkgs/development/python-modules/docx2python/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "docx2python";
+  version = "unstable-2020-11-15";
+
+  # Pypi does not contain tests
+  src = fetchFromGitHub {
+    owner = "ShayHill";
+    repo = pname;
+    rev = "21b2edafc0a01a6cfb73aefc61747a65917e2cad";
+    sha256 = "1nwg17ziwm9a2x7yxsscj8zgc1d383ifsk5w7qa2fws6gf627kyi";
+  };
+
+  preCheck = "cd test"; # Tests require the `test/resources` folder to be accessible
+  checkInputs = [ pytestCheckHook ];
+  disabledTests = [ # asserts related to file deletions fail
+    "test_docx2python.py"
+    "test_docx_context.py"
+    "test_google_docs.py"
+  ];
+  pythonImportsCheck = [ "docx2python" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/ShayHill/docx2python";
+    description = "Extract docx headers, footers, (formatted) text, footnotes, endnotes, properties, and images";
+    maintainers = [ maintainers.ivar ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1820,6 +1820,8 @@ in {
 
   docutils = callPackage ../development/python-modules/docutils { };
 
+  docx2python = callPackage ../development/python-modules/docx2python { };
+
   dodgy = callPackage ../development/python-modules/dodgy { };
 
   dogpile_cache = callPackage ../development/python-modules/dogpile.cache { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wasn't sure if i should pull Pypi or Github sources, as Pypi doesn't contain test but Github doesn't have tagged releases.

Ended up using the latest git commit, which is a bit newer anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 107299"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review pr 107299` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>python37Packages.docx2python</li>
    <li>python38Packages.docx2python</li>
    <li>python39Packages.docx2python</li>
  </ul>
</details>

