### PR TITLE
docker-buildx: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3887,6 +3887,12 @@
     githubId = 4458;
     name = "Ivan Kozik";
   };
+  ivan-babrou = {
+    email = "nixpkgs@ivan.computer";
+    name = "Ivan Babrou";
+    github = "bobrik";
+    githubId = 89186;
+  };
   ivan-timokhin = {
     email = "nixpkgs@ivan.timokhin.name";
     name = "Ivan Timokhin";

--- a/pkgs/applications/virtualization/docker/buildx.nix
+++ b/pkgs/applications/virtualization/docker/buildx.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "docker-buildx";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "docker";
+    repo = "buildx";
+    rev = "v${version}";
+    sha256 = "0l03ncs1x4lhgy0kf7bd1zq00md8fi93f8xq6k0ans4400divfzk";
+  };
+
+  vendorSha256 = null;
+
+  installPhase = ''
+    install -D $GOPATH/bin/buildx $out/libexec/docker/cli-plugins/docker-buildx
+  '';
+
+  meta = with lib; {
+    description = "Docker CLI plugin for extended build capabilities with BuildKit";
+    license = licenses.asl20;
+    maintainers = [ maintainers.ivan-babrou ];
+  };
+}

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -1,10 +1,11 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, buildGoPackage
 , makeWrapper, installShellFiles, pkg-config
 , go-md2man, go, containerd, runc, docker-proxy, tini, libtool
-, sqlite, iproute, lvm2, systemd
+, sqlite, iproute, lvm2, systemd, docker-buildx
 , btrfs-progs, iptables, e2fsprogs, xz, util-linux, xfsprogs, git
 , procps, libseccomp
 , nixosTests
+, buildxSupport ? false
 }:
 
 with lib;
@@ -15,7 +16,7 @@ rec {
       , mobyRev, mobySha256
       , runcRev, runcSha256
       , containerdRev, containerdSha256
-      , tiniRev, tiniSha256
+      , tiniRev, tiniSha256, buildxSupport
     } :
   let
     docker-runc = runc.overrideAttrs (oldAttrs: {
@@ -142,7 +143,7 @@ rec {
       makeWrapper
     ] ++ optionals (stdenv.isLinux) [
       sqlite lvm2 btrfs-progs systemd libseccomp
-    ];
+    ] ++ optionals (buildxSupport) [ docker-buildx ];
 
     # Keep eyes on BUILDTIME format - https://github.com/docker/cli/blob/${version}/scripts/build/.variables
     buildPhase = ''
@@ -167,6 +168,9 @@ rec {
       substituteInPlace ./scripts/build/.variables --replace "set -eu" ""
       substituteInPlace ./scripts/docs/generate-man.sh --replace "-v md2man" "-v go-md2man"
       substituteInPlace ./man/md2man-all.sh            --replace md2man go-md2man
+    '' + optionalString buildxSupport ''
+      substituteInPlace ./components/cli/cli-plugins/manager/manager_unix.go --replace /usr/libexec/docker/cli-plugins \
+          ${lib.strings.makeSearchPathOutput "bin" "libexec/docker/cli-plugins" [docker-buildx]}
     '';
 
     outputs = ["out" "man"];
@@ -224,5 +228,6 @@ rec {
     containerdSha256 = "09xvhjg5f8h90w1y94kqqnqzhbhd62dcdd9wb9sdqakisjk6zrl0";
     tiniRev = "de40ad007797e0dcd8b7126f27bb87401d224240"; # v0.19.0
     tiniSha256 = "1h20i3wwlbd8x4jr2gz68hgklh0lb0jj7y5xk1wvr8y58fip1rdn";
+    inherit buildxSupport;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21443,6 +21443,8 @@ in
 
   afterburn = callPackage ../tools/admin/afterburn {};
 
+  docker-buildx = callPackage ../applications/virtualization/docker/buildx.nix { };
+
   amazon-ecr-credential-helper = callPackage ../tools/admin/amazon-ecr-credential-helper { };
 
   docker-credential-gcr = callPackage ../tools/admin/docker-credential-gcr { };


### PR DESCRIPTION
###### Motivation for this change

Installing docker-buildx enables buildx subcommand on the client:

* https://github.com/docker/buildx

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (aarch64)
   - [x] `nixos/nix` docker image (aarch64)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using (n/a)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
