### PR TITLE
sonata: 1.7b1 -> git-20200822

### DIFF
--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -5,13 +5,13 @@ let
   inherit (python3Packages) buildPythonApplication isPy3k dbus-python pygobject3 mpd2 setuptools;
 in buildPythonApplication rec {
   pname = "sonata";
-  version = "1.7b1";
+  version = "git-20200822";
 
   src = fetchFromGitHub {
     owner = "multani";
     repo = "sonata";
-    rev = "v${version}";
-    sha256 = "1npbxlrg6k154qybfd250nq2p96kxdsdkj9wwnp93gljnii3g8wh";
+    rev = "d6445e21d20f66edd1d2d53d329e654b4dce3cdc";
+    sha256 = "1sqhbwqwiblwf38hljbwnc1163mi8mb5mha65gvmygnc2gij3h38";
   };
 
   disabled = !isPy3k;


### PR DESCRIPTION
###### Motivation for this change

Sonata was failing to run due to a KeyError.
This updates the git revision to fix it.
Upstream issue for release tag: https://github.com/multani/sonata/issues/117

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
