### PR TITLE
mathematica: 12.1.1 -> 12.2.0

### DIFF
--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -14,24 +14,6 @@ let allVersions = with lib; flip map
       sha256 = "3b6676a203c6adb7e9c418a5484b037974287b5be09c64e7dfea74ddc0e400d7";
     }
     {
-      version = "12.1.1";
-      lang = "en";
-      language = "English";
-      sha256 = "02mk8gmv8idnakva1nc7r7mx8ld02lk7jgsj1zbn962aps3bhixd";
-    }
-    {
-      version = "12.1.0";
-      lang = "en";
-      language = "English";
-      sha256 = "15m9l20jvkxh5w6mbp81ys7mx2lx5j8acw5gz0il89lklclgb8z7";
-    }
-    {
-      version = "12.0.0";
-      lang = "en";
-      language = "English";
-      sha256 = "b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7";
-    }
-    {
       version = "11.3.0";
       lang = "en";
       language = "English";

--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -8,6 +8,12 @@ let allVersions = with lib; flip map
   # N.B. Versions in this list should be ordered from newest to oldest.
   [
     {
+      version = "12.2.0";
+      lang = "en";
+      language = "English";
+      sha256 = "3b6676a203c6adb7e9c418a5484b037974287b5be09c64e7dfea74ddc0e400d7";
+    }
+    {
       version = "12.1.1";
       lang = "en";
       language = "English";


### PR DESCRIPTION
###### Motivation for this change

12.2.0 was released a few days ago.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
