### PR TITLE
carps-cups: init at unstable-2018-03-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2863,6 +2863,12 @@
     githubId = 30512529;
     name = "Evils";
   };
+  ewok = {
+    email = "ewok@ewok.ru";
+    github = "ewok";
+    githubId = 454695;
+    name = "Artur Taranchiev";
+  };
   exfalso = {
     email = "0slemi0@gmail.com";
     github = "exfalso";

--- a/pkgs/misc/cups/drivers/carps-cups/default.nix
+++ b/pkgs/misc/cups/drivers/carps-cups/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cups
+}:
+
+stdenv.mkDerivation {
+  pname = "carps-cups";
+  version = "unstable-2018-03-05";
+
+  src = fetchFromGitHub {
+    owner = "ondrej-zary";
+    repo = "carps-cups";
+    rev = "18d80d1d6f473dd9132e4b6d8b5c592c74982f17";
+    sha256 = "0mjj9hs5lqxi0qamgb4sxfz4fvf7ggi66bxd37bkz3fl0g9xff70";
+  };
+
+  preBuild = ''
+    export CUPS_DATADIR="${cups}/share/cups"
+  '';
+
+  installPhase = ''
+    CUPSDIR="$out/lib/cups"
+    CUPSDATADIR="$out/share/cups"
+
+    mkdir -p "$CUPSDIR/filter" "$CUPSDATADIR/drv" "$CUPSDATADIR/usb"
+
+    install -s rastertocarps $CUPSDIR/filter
+    install -m 644 carps.drv $CUPSDATADIR/drv/
+    install -m 644 carps.usb-quirks $CUPSDATADIR/usb/
+  '';
+
+  buildInputs = [ cups ];
+
+  meta = with lib; {
+    description = "CUPS Linux drivers for Canon printers";
+    homepage = "https://www.canon.com/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [
+      ewok
+    ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27609,6 +27609,8 @@ in
 
   gutenprintBin = callPackage ../misc/drivers/gutenprint/bin.nix { };
 
+  carps-cups = callPackage ../misc/cups/drivers/carps-cups { };
+
   cups-bjnp = callPackage ../misc/cups/drivers/cups-bjnp { };
 
   cups-brother-hl1110 = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1110 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding support for old Canon printers(from project page):
Printer | Status
-|- 
MF5730 | works
MF5750 | works
MF5770 | should work
MF5630 | works
MF5650 | should work
MF3110 | works
imageCLASS D300 | works
LASERCLASS 500 | should work
FP-L170/MF350/L380/L398 | should work
LC310/L390/L408S | works
PC-D300/FAX-L400/ICD300 | works
L180/L380S/L398S | works


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
