### PR TITLE
ike-scan: init at 1.9.4

### DIFF
--- a/pkgs/tools/security/ike-scan/default.nix
+++ b/pkgs/tools/security/ike-scan/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, autoconf
+, automake
+, autoreconfHook
+, fetchFromGitHub
+, fetchpatch
+, openssl
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ike-scan";
+  version = "1.9.4";
+
+  src = fetchFromGitHub {
+    owner = "royhills";
+    repo = pname;
+    rev = version;
+    sha256 = "01a39bk9ma2lm59q320m9g11909if5gc3qynd8pzn6slqiq5r8kw";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    openssl
+  ];
+
+  configureFlags = [ "--with-openssl=${openssl.dev}" ];
+
+  patches = [
+    # Using the same patches as for the Fedora RPM
+    (fetchpatch {
+      # Memory leaks, https://github.com/royhills/ike-scan/pull/15
+      url = "https://github.com/royhills/ike-scan/pull/15/commits/d864811de08dcddd65ac9b8d0f2acf5d7ddb9dea.patch";
+      sha256 = "0wbrq89dl8js7cdivd0c45hckmflan33cpgc3qm5s3az6r4mjljm";
+    })
+    (fetchpatch {
+      # Unknown vendor IDs,  https://github.com/royhills/ike-scan/pull/18, was merged but not released
+      url = "https://github.com/royhills/ike-scan/pull/18/commits/e065ddbe471880275dc7975e7da235e7a2097c22.patch";
+      sha256 = "13ly01c96nnd5yh7rxrhv636csm264m5xf2a1inprrzxkkri5sls";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Tool to discover, fingerprint and test IPsec VPN servers";
+    longDescription = ''
+      ike-scan is a command-line tool that uses the IKE protocol to discover,
+      fingerprint and test IPsec VPN servers.
+    '';
+    homepage = "https://github.com/royhills/ike-scan";
+    license = with licenses; [ gpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4820,6 +4820,8 @@ in
 
   iruby = callPackage ../applications/editors/jupyter-kernels/iruby { };
 
+  ike-scan = callPackage ../tools/security/ike-scan { };
+
   imapproxy = callPackage ../tools/networking/imapproxy {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ike-scan is a command-line tool that uses the IKE protocol to discover,
fingerprint and test IPsec VPN servers.

Related to #81418


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
