### PR TITLE
nixos/fprintd: option to inhibit PAM rule creation

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -125,7 +125,7 @@ let
       };
 
       fprintAuth = mkOption {
-        default = config.services.fprintd.enable;
+        default = config.services.fprintd.enable && config.services.fprintd.global;
         type = types.bool;
         description = ''
           If set, fingerprint reader will be used (if exists and

--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -3,25 +3,29 @@
 with lib;
 
 let
-
   cfg = config.services.fprintd;
-
 in
-
-
 {
-
   ###### interface
 
   options = {
-
     services.fprintd = {
-
       enable = mkOption {
         type = types.bool;
         default = false;
         description = ''
-          Whether to enable fprintd daemon and PAM module for fingerprint readers handling.
+          Whether to enable fprintd daemon and PAM module for fingerprint
+          readers handling.
+        '';
+      };
+
+      global = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to create <literal>fprintAuth</literal> PAM rules for all
+          services when <literal>services.fprintd.enable</literal> is
+          <literal>true</literal>.
         '';
       };
 
@@ -33,22 +37,14 @@ in
           fprintd package to use.
         '';
       };
-
     };
-
   };
 
 
   ###### implementation
-
   config = mkIf cfg.enable {
-
-    services.dbus.packages = [ pkgs.fprintd ];
-
-    environment.systemPackages = [ pkgs.fprintd ];
-
+    services.dbus.packages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
-
   };
-
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Currently, `security.pam.services.<name>.fprintAuth`'s default value is the value of `services.fprintd.enable`. 

Since many fingerprint readers are located on laptops in such a way that they may be inaccessible when the laptop lid is closed, it is tedious to undo this default for commonly used services such as `sudo`, while keeping occasional services like login or screen lockers. 

This commit adds the `services.fprintd.global` (default: `true`), that prevents fprintd PAM rules from being created for every service.  By having a default value of `true`, every user's current configs will behave identically to before if they choose to not set this option.

Example:
```
# fprintd is installed, and *can* be used, but isn't by default
$ grep fprint /etc/nixos/configuration.nix
services.fprintd.enable = true;
services.fprintd.global = false;
$ sudo ls
[sudo] password for kyle:

# fprintd is installed, disabled for services by default, but enabled for sudo
$ grep fprint /etc/nixos/configuration.nix
services.fprintd.enable = true;
services.fprintd.global = false;
security.pam.services.sudo.fprintAuth = true;
$ sudo ls
<fingerprint prompt>

# current configuration behavior is unaffected by this change
$ grep fprint /etc/nixos/configuration.nix
services.fprintd.enable = true;
$ sudo ls
<fingerprint prompt>
```

###### Things done
- Added `global` (for lack of a more creative name...suggestions?) option to `services.fprint`
- Cleaned up formatting of `services/fprintd.nix`
- Corrected bug with `package` override only being honored in one reference.

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
