### PR TITLE
vault: Support secure config file

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -486,6 +486,11 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
      The option's description was incorrect regarding ownership management and has been simplified greatly.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <package>vault</package> can now use a configuration file outside the Nix store in order to protect sensitive configuration like database passwords. See <xref linkend="opt-services.vault.configPath"/>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/tests/vault.nix
+++ b/nixos/tests/vault.nix
@@ -8,6 +8,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     environment.systemPackages = [ pkgs.vault ];
     environment.variables.VAULT_ADDR = "http://127.0.0.1:8200";
     services.vault.enable = true;
+    virtualisation.memorySize = 512;
   };
 
   testScript =


### PR DESCRIPTION

###### Motivation for this change

* use a configuration file outside the Nix store in order to protect sensitive configuration like database passwords.
* fix vm test oom (unrelated)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
