### PR TITLE
notion: 4.0.1 -> 4.0.2

### DIFF
--- a/pkgs/applications/window-managers/notion/default.nix
+++ b/pkgs/applications/window-managers/notion/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "notion";
-  version = "4.0.1";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "raboof";
     repo = pname;
     rev = version;
-    sha256 = "1s0fyacygvc9iz7b9v3b2cmzzqc02nh4g1p9bfcxbg254iscd502";
+    sha256 = "14swd0yqci8lxn259fkd9w92bgyf4rmjwgvgyqp78wlfix6ai4mv";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper groff ];


### PR DESCRIPTION
###### Motivation for this change

The highlight of this release is fixing the long-standing issue where Firefox popups would sometimes show up in the wrong place on multi-monitor setups (https://github.com/raboof/notion/issue/59), thanks to great detective work by @florolf . Thanks!
    
* Initial implementation of _NET_FRAME_EXTENTS (https://github.com/raboof/notion/pull/303) @florolf/@raboof
* Fix potential livelock in do_timer_set (https://github.com/raboof/notion/pull/302) @dnr
    
Docs:

* Add more docs to cfg_notion.lua (https://github.com/raboof/notion/pull/283) @raboof
    
Under the hood:
    
* Trigger release drafter from github actions (https://github.com/raboof/notion/pull/304) @raboof
* Remove some colorful language (https://github.com/raboof/notion/pull/296) @raboof
    
https://github.com/raboof/notion/releases/tag/4.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).