### PR TITLE
nixos/doc/profiles/hardening: update User Namespaces info

### DIFF
--- a/nixos/doc/manual/configuration/profiles/hardened.xml
+++ b/nixos/doc/manual/configuration/profiles/hardened.xml
@@ -14,9 +14,8 @@
   This includes a hardened kernel, and limiting the system information
   available to processes through the <filename>/sys</filename> and
   <filename>/proc</filename> filesystems. It also disables the User Namespaces
-  feature of the kernel, which stops Nix from being able to build anything
-  (this particular setting can be overriden via
-  <xref linkend="opt-security.allowUserNamespaces"/>). See the
+  feature of the kernel for non-root users, which means you need to be root to
+  build anything. See the
   <literal
    xlink:href="https://github.com/nixos/nixpkgs/tree/master/nixos/modules/profiles/hardened.nix">
   profile source</literal> for further detail on which settings are altered.


### PR DESCRIPTION
See commit ad9bfe2254e6205f94baa9c988063b0737911a23, which re-enabled the security.allowUserNamespaces feature, but only for the root user.

Note: This is a quick sketch I made on GitHub, I might clean it up a bit later.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
