### PR TITLE
dbeaver: 7.3.0 -> 7.3.1

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "7.3.0";
+  version = "7.3.1";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,10 +30,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "sha256-JhEF2/97vo2FgzpCFkuc31aLl9qjKHV8RYXO5oBU1no=";
+    sha256 = "sha256-4UVC5lBoGsW99L6AgM+1Rs07LCrvp2qVevBrooTbee4=";
   };
 
   installPhase = ''
+    # remove bundled jre
+    rm -rf jre
+
     mkdir -p $out/
     cp -r . $out/dbeaver
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
New upstream release https://dbeaver.io/2020/12/20/dbeaver-7-3-1/

The upstream archive now contains its own JRE installation, which must be removed for `dbeaver` to run. Otherwise, `./result/bin/dbeaver` immediately terminates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/mi9lbh3zpvbifw03b41x6gbg9amphv7n-dbeaver-ce-7.3.0	 1455757672
/nix/store/k843v61fw73wrh9iiwcd3prdyq31v832-dbeaver-ce-7.3.1	 1456190936
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
