### PR TITLE
cc-wrapper: fix wrapper tests and building for darwin on staging-next

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -30,6 +30,10 @@ cppInclude=1
 cInclude=1
 setDynamicLinker=1
 
+if [[ "@isdarwin@" = "1" ]]; then
+    setDynamicLinker=0
+fi
+
 expandResponseParams "$@"
 declare -i n=0
 nParams=${#params[@]}

--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -30,10 +30,6 @@ cppInclude=1
 cInclude=1
 setDynamicLinker=1
 
-if [[ "@isdarwin@" = "1" ]]; then
-    setDynamicLinker=0
-fi
-
 expandResponseParams "$@"
 declare -i n=0
 nParams=${#params[@]}
@@ -149,6 +145,12 @@ extraAfter=($NIX_CFLAGS_COMPILE_@suffixSalt@)
 extraBefore=(${hardeningCFlags[@]+"${hardeningCFlags[@]}"} $NIX_CFLAGS_COMPILE_BEFORE_@suffixSalt@)
 
 if [ "$dontLink" != 1 ]; then
+
+    # Disable the -dynamic-linker flag if NIX_DYNAMIC_LINKER is the special darwin
+    # value. -dynamic-linker is not supported on darwin systems.
+    if [[ "$NIX_DYNAMIC_LINKER_@suffixSalt@" = "darwin" ]]; then
+        setDynamicLinker=0
+    fi
 
     # Add the flags that should only be passed to the compiler when
     # linking.

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -62,7 +62,6 @@ let
     else "";
 
   useGccForLibs = isClang
-    && libcxx == null
     && !(stdenv.targetPlatform.useLLVM or false)
     && !(stdenv.targetPlatform.useAndroidPrebuilt or false)
     && gccForLibs != null;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -154,6 +154,7 @@ stdenv.mkDerivation {
         local dst="$1"
         local wrapper="$2"
         export prog="$3"
+        export isdarwin="${toString targetPlatform.isDarwin or false}"
         substituteAll "$wrapper" "$out/bin/$dst"
         chmod +x "$out/bin/$dst"
       }

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -36,6 +36,7 @@ in rec {
     export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
     export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
+    export NIX_DYNAMIC_LINKER="darwin"
     unset SDKROOT
 
     export MACOSX_DEPLOYMENT_TARGET=${macosVersionMin}


### PR DESCRIPTION
###### Motivation for this change
Fix darwin builds and the cc-wrapper-libcxx tests for staging-next. Opening as draft since I am not sure the first commit is the correct fix for this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
