### PR TITLE
nixos/mysql: replace initialDatabases, ensureDatabases, and ensureUsers options with activationScripts option

### DIFF
--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -566,12 +566,15 @@ in
     services.mysql = optionalAttrs mysqlLocal {
       enable = true;
       package = mkDefault pkgs.mariadb;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
-        { name = cfg.database.user;
-          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-        }
-      ];
+      activationScripts.sympa =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == lib.getName pkgs.mariadb) then "unix_socket" else "auth_socket";
+        in ''
+          ( echo "create database if not exists \`${cfg.database.name}\`;"
+            echo "create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};"
+            echo "grant all privileges on \`${cfg.database.name}\`.* to '${cfg.database.user}'@'localhost';"
+          ) | ${config.services.mysql.package}/bin/mysql -N
+        '';
     };
 
     services.postgresql = optionalAttrs pgsqlLocal {

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -220,14 +220,17 @@ in
     services.mysql = optionalAttrs mysqlLocal {
       enable = true;
       package = mkDefault pkgs.mariadb;
-    };
 
-    systemd.services.mysql.postStart = mkAfter (optionalString mysqlLocal ''
-      ( echo "CREATE DATABASE IF NOT EXISTS \`${cfg.database.name}\` CHARACTER SET utf8 COLLATE utf8_bin;"
-        echo "CREATE USER IF NOT EXISTS '${cfg.database.user}'@'localhost' IDENTIFIED WITH ${if (getName config.services.mysql.package == getName pkgs.mariadb) then "unix_socket" else "auth_socket"};"
-        echo "GRANT ALL PRIVILEGES ON \`${cfg.database.name}\`.* TO '${cfg.database.user}'@'localhost';"
-      ) | ${config.services.mysql.package}/bin/mysql -N
-    '');
+      activationScripts.zabbix-server =
+        let
+          unix_socket = if (lib.getName config.services.mysql.package == lib.getName pkgs.mariadb) then "unix_socket" else "auth_socket";
+        in ''
+          ( echo "create database if not exists \`${cfg.database.name}\` character set utf8 collate utf8_bin;"
+            echo "create user if not exists '${cfg.database.user}'@'localhost' identified with ${unix_socket};"
+            echo "grant all privileges on \`${cfg.database.name}\`.* to '${cfg.database.user}'@'localhost';"
+          ) | ${config.services.mysql.package}/bin/mysql -N
+        '';
+    };
 
     services.postgresql = optionalAttrs pgsqlLocal {
       enable = true;
@@ -257,7 +260,7 @@ in
       description = "Zabbix Server";
 
       wantedBy = [ "multi-user.target" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql-activation-scripts.service" ++ optional pgsqlLocal "postgresql.service";
 
       path = [ "/run/wrappers" ] ++ cfg.extraPackages;
       preStart = ''

--- a/nixos/tests/mysql/mysql-autobackup.nix
+++ b/nixos/tests/mysql/mysql-autobackup.nix
@@ -9,7 +9,11 @@ import ./../make-test-python.nix ({ pkgs, lib, ... }:
     {
       services.mysql.enable = true;
       services.mysql.package = pkgs.mysql;
-      services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+      services.mysql.initialScript = pkgs.writeText "mysql-backup.sql" ''
+        create database if not exists testdb;
+        use testdb;
+        ${builtins.readFile ./testdb.sql}
+      '';
 
       services.automysqlbackup.enable = true;
     };

--- a/nixos/tests/mysql/mysql-backup.nix
+++ b/nixos/tests/mysql/mysql-backup.nix
@@ -9,8 +9,12 @@ import ./../make-test-python.nix ({ pkgs, ... } : {
     master = { pkgs, ... }: {
       services.mysql = {
         enable = true;
-        initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
         package = pkgs.mysql;
+        initialScript = pkgs.writeText "mysql-backup.sql" ''
+          create database if not exists testdb;
+          use testdb;
+          ${builtins.readFile ./testdb.sql}
+        '';
       };
 
       services.mysqlBackup = {

--- a/nixos/tests/mysql/mysql-replication.nix
+++ b/nixos/tests/mysql/mysql-replication.nix
@@ -22,7 +22,10 @@ in
         services.mysql.replication.slaveHost = "%";
         services.mysql.replication.masterUser = replicateUser;
         services.mysql.replication.masterPassword = replicatePassword;
-        services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+        services.mysql.activationScripts.mysql-replication = ''
+          ${pkgs.mysql}/bin/mysql -N -e "create database if not exists testdb;"
+          ${pkgs.mysql}/bin/mysql -N testdb < ${./testdb.sql}
+        '';
         networking.firewall.allowedTCPPorts = [ 3306 ];
       };
 

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -12,27 +12,26 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
         users.users.testuser = { };
         users.users.testuser2 = { };
         services.mysql.enable = true;
-        services.mysql.initialDatabases = [
-          { name = "testdb3"; schema = ./testdb.sql; }
-        ];
         # note that using pkgs.writeText here is generally not a good idea,
         # as it will store the password in world-readable /nix/store ;)
         services.mysql.initialScript = pkgs.writeText "mysql-init.sql" ''
           CREATE USER 'testuser3'@'localhost' IDENTIFIED BY 'secure';
           GRANT ALL PRIVILEGES ON testdb3.* TO 'testuser3'@'localhost';
         '';
-        services.mysql.ensureDatabases = [ "testdb" "testdb2" ];
-        services.mysql.ensureUsers = [{
-          name = "testuser";
-          ensurePermissions = {
-            "testdb.*" = "ALL PRIVILEGES";
-          };
-        } {
-          name = "testuser2";
-          ensurePermissions = {
-            "testdb2.*" = "ALL PRIVILEGES";
-          };
-        }];
+        services.mysql.activationScripts.mysql57 = ''
+          ( echo "create database if not exists testdb;"
+            echo "create user if not exists 'testuser'@'localhost' identified with auth_socket;"
+            echo "grant all privileges on testdb.* to 'testuser'@'localhost';"
+
+            echo "create database if not exists testdb2;"
+            echo "create user if not exists 'testuser2'@'localhost' identified with auth_socket;"
+            echo "grant all privileges on testdb2.* to 'testuser2'@'localhost';"
+
+            echo "create database if not exists testdb3;"
+          ) | ${pkgs.mysql57}/bin/mysql -N
+
+          ${pkgs.mysql57}/bin/mysql -N testdb3 < ${./testdb.sql}
+        '';
         services.mysql.package = pkgs.mysql57;
       };
 
@@ -47,27 +46,26 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
         users.users.testuser = { };
         users.users.testuser2 = { };
         services.mysql.enable = true;
-        services.mysql.initialDatabases = [
-          { name = "testdb3"; schema = ./testdb.sql; }
-        ];
         # note that using pkgs.writeText here is generally not a good idea,
         # as it will store the password in world-readable /nix/store ;)
         services.mysql.initialScript = pkgs.writeText "mysql-init.sql" ''
           CREATE USER 'testuser3'@'localhost' IDENTIFIED BY 'secure';
           GRANT ALL PRIVILEGES ON testdb3.* TO 'testuser3'@'localhost';
         '';
-        services.mysql.ensureDatabases = [ "testdb" "testdb2" ];
-        services.mysql.ensureUsers = [{
-          name = "testuser";
-          ensurePermissions = {
-            "testdb.*" = "ALL PRIVILEGES";
-          };
-        } {
-          name = "testuser2";
-          ensurePermissions = {
-            "testdb2.*" = "ALL PRIVILEGES";
-          };
-        }];
+        services.mysql.activationScripts.mysql80 = ''
+          ( echo "create database if not exists testdb;"
+            echo "create user if not exists 'testuser'@'localhost' identified with auth_socket;"
+            echo "grant all privileges on testdb.* to 'testuser'@'localhost';"
+
+            echo "create database if not exists testdb2;"
+            echo "create user if not exists 'testuser2'@'localhost' identified with auth_socket;"
+            echo "grant all privileges on testdb2.* to 'testuser2'@'localhost';"
+
+            echo "create database if not exists testdb3;"
+          ) | ${pkgs.mysql80}/bin/mysql -N
+
+          ${pkgs.mysql80}/bin/mysql -N testdb3 < ${./testdb.sql}
+        '';
         services.mysql.package = pkgs.mysql80;
       };
 
@@ -84,18 +82,16 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
           DELETE FROM mysql.user WHERE user = ''';
           FLUSH PRIVILEGES;
         '';
-        services.mysql.ensureDatabases = [ "testdb" "testdb2" ];
-        services.mysql.ensureUsers = [{
-          name = "testuser";
-          ensurePermissions = {
-            "testdb.*" = "ALL PRIVILEGES";
-          };
-        } {
-          name = "testuser2";
-          ensurePermissions = {
-            "testdb2.*" = "ALL PRIVILEGES";
-          };
-        }];
+        services.mysql.activationScripts.mariadb = ''
+          ( echo "create database if not exists testdb;"
+            echo "create user if not exists 'testuser'@'localhost' identified with unix_socket;"
+            echo "grant all privileges on testdb.* to 'testuser'@'localhost';"
+
+            echo "create database if not exists testdb2;"
+            echo "create user if not exists 'testuser2'@'localhost' identified with unix_socket;"
+            echo "grant all privileges on testdb2.* to 'testuser2'@'localhost';"
+          ) | ${pkgs.mariadb}/bin/mysql -N
+        '';
         services.mysql.settings = {
           mysqld = {
             plugin-load-add = [ "ha_tokudb.so" "ha_rocksdb.so" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I have been ~~brainwashed~~ convinced by @grahamc that the `ensure*` options aren't a good fit for NixOS. I'm seeking to remove these options from both the `mysql` and `postgresql` modules, but still leave other module authors who wish to provision databases with a reasonable way to do so. My plan for `postgresql` and `mysql` was as follows:
- remove the `initialDatabases`, `ensureDatabases` and `ensureUsers` options
- add an `activationScripts` option which module authors (and NixOS users) can use to write idempotent sql statements, via shell code, which will be executed as the `mysql`/`postgresql` super admin user to do things like provision local accounts, databases, etc... (ie. replace the `ensureDatabases` and `ensureUsers` options with a new option that provides the same functionality, but with even more flexibility)
- replace all usage of `initialDatabases`, `ensureDatabases` and `ensureUsers` in NixOS with the new `activationScripts` option
- **strongly** caution NixOS users against carelessly using the `activationScripts` option, very explicitly explaining how it leads to systems which aren't reproducible and why that is bad
- separate the execution of the sql in the `activationScripts` option from the `postgresql`/`mysql` `systemd` service so a full restart of `postgresql`/`mysql` is not required every time someone alters `activationScripts` - which is a **significant** advantage over simply tacking more snippets onto the `.postStart` of the database `systemd` units

You might ask **why should we get rid of the `ensure*` options?**
Aside from promoting systems which aren't reproducible, the `ensure*` options have a few other major problems with `postgresql`, mainly dealing with encoding and extensions. Currently all attempts to extend the `ensureDatabase` options have led to scenarios where a users `configuration.nix` could very easily not match the reality of what the database actually looks like. After investigating what it would take to make the `ensure*` options truly reproducible and actually enforce what they describe I came to the conclusion this is simply a bad idea because any database changes we might make can lead to data corruption and require a backup before making them - something we don't want to do every time the user does a rebuild.

While some will argue that users can simply add sql statements to the `.postStart` of the `mysql`/`postgresql` `systemd` units I do see this as somewhat hacky, providing no documentation, and causes `mysql`/`postgresql` restarts with no easy and user-facing-api friendly way correct that.

NOTE: this is to replace https://github.com/NixOS/nixpkgs/pull/84146 and https://github.com/NixOS/nixpkgs/pull/94048. The `postgresql` variant of this PR will follow shortly after, if this is merged.

NOTE: @aszlig - I didn't provision a separate `systemd` unit for each snippet because I wanted to mimic `system.activationScripts` - I found that to be a reasonable interface with a good set of trade-offs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
