### PR TITLE
nvidia-x11.vulkan_beta: 455.46.02 -> 455.46.04

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -39,10 +39,10 @@ rec {
   # Vulkan developer beta driver
   # See here for more information: https://developer.nvidia.com/vulkan-driver
   vulkan_beta = generic rec {
-    version = "455.46.02";
+    version = "455.46.04";
     persistencedVersion = "455.45.01";
     settingsVersion = "455.45.01";
-    sha256_64bit = "05y4scg62mrhjnj2c8689m5hdyzqnx5p8vqvdqvv76zy970723l7";
+    sha256_64bit = "1iv42w3x1vc00bgn6y4w1hnfsvnh6bvj3vcrq8hw47760sqwa4xa";
     settingsSha256 = "09v86y2c8xas9ql0bqr7vrjxx3if6javccwjzyly11dzffm02h7g";
     persistencedSha256 = "13s4b73il0lq2hs81q03176n16mng737bfsp3bxnxgnrv3whrayz";
     url = "https://developer.nvidia.com/vulkan-beta-${lib.concatStrings (lib.splitString "." version)}-linux";


### PR DESCRIPTION
###### Motivation for this change

```
December 16th, 2020 - Windows 457.67, Linux 455.46.04

    New:
        VK_NV_acquire_winrt_display [Windows]
    Fixes:
        Fixed a crash from vkCreateGraphicsPipelines when certain blend operations were used with scalar outputs from the fragment shader
        Fixed the X driver's composition pipeline (used, e.g., for X desktop rotation, "ForceCompositionPipeline", and some OpenGL Swap Group configurations) to correctly preserve color precision in depth 30 [Linux]
```

Source: https://developer.nvidia.com/vulkan-driver

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
