### PR TITLE
microdnf: init at 3.6.0,  libdnf: init at 0.55.2

### DIFF
--- a/pkgs/tools/package-management/libdnf/darwin.patch
+++ b/pkgs/tools/package-management/libdnf/darwin.patch
@@ -1,0 +1,35 @@
+--- src/libdnf/hy-iutil.cpp	2020-12-02 07:53:42.000000000 -0800
++++ src/libdnf/hy-iutil.cpp	2020-12-21 14:24:14.000000000 -0800
+@@ -22,7 +22,7 @@
+ #include <errno.h>
+ #include <dirent.h>
+ #include <fcntl.h>
+-#include <linux/limits.h>
++#include <limits.h>
+ #include <pwd.h>
+ #include <unistd.h>
+ #include <stdio.h>
+--- src/libdnf/hy-util.cpp	2020-12-02 07:53:42.000000000 -0800
++++ src/libdnf/hy-util.cpp	2020-12-21 14:23:21.000000000 -0800
+@@ -24,7 +24,20 @@
+ #include <ctype.h>
+ #include <sys/utsname.h>
+ #include <sys/stat.h>
+-#include <sys/auxv.h>
++
++// Darwin compatibility hacks
++typedef int auxv_t;
++#ifndef AT_HWCAP2
++#define AT_HWCAP2 26
++#endif
++#ifndef AT_HWCAP
++#define AT_HWCAP 16
++#endif
++static unsigned long getauxval(unsigned long type)
++{
++  unsigned long ret = 0;
++  return ret;
++}
+ 
+ // hawkey
+ #include "dnf-types.h"

--- a/pkgs/tools/package-management/libdnf/default.nix
+++ b/pkgs/tools/package-management/libdnf/default.nix
@@ -1,0 +1,66 @@
+{ gcc9Stdenv, stdenv, fetchFromGitHub, cmake, gettext, pkg-config, gpgme, libsolv, openssl, check
+, pcre, json_c, libmodulemd, libsmartcols, sqlite, librepo, libyaml, rpm }:
+
+gcc9Stdenv.mkDerivation rec {
+  pname = "libdnf";
+  version = "0.55.2";
+
+  src = fetchFromGitHub {
+    owner = "rpm-software-management";
+    repo = pname;
+    rev = version;
+    sha256 = "0hiydwfa90nsrqk5ffa6ks1g73wnsgjgq7z7gwq9jj76a7gpfbfq";
+  };
+
+  patches = stdenv.lib.optionals stdenv.isDarwin [ ./darwin.patch ];
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+  ];
+
+  buildInputs = [
+    check
+    gpgme
+    openssl
+    json_c
+    libsmartcols
+    libyaml
+    libmodulemd
+  ];
+
+  propagatedBuildInputs = [
+    sqlite
+    libsolv
+    librepo
+    rpm
+  ];
+
+  # See https://github.com/NixOS/nixpkgs/issues/107430
+  prePatch = ''
+    cp ${libsolv}/share/cmake/Modules/FindLibSolv.cmake cmake/modules/
+  '';
+
+  # See https://github.com/NixOS/nixpkgs/issues/107428
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "enable_testing()" "" \
+      --replace "add_subdirectory(tests)" ""
+  '';
+
+  cmakeFlags = [
+    "-DWITH_GTKDOC=OFF"
+    "-DWITH_HTML=OFF"
+    "-DWITH_BINDINGS=OFF"
+    "-DWITH_ZCHUNK=OFF"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Package management library.";
+    homepage = "https://github.com/rpm-software-management/libdnf";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ rb2k ];
+  };
+}

--- a/pkgs/tools/package-management/microdnf/default.nix
+++ b/pkgs/tools/package-management/microdnf/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, gettext, libdnf, pkg-config, glib, libpeas, libsmartcols, help2man }:
+
+stdenv.mkDerivation rec {
+  pname = "microdnf";
+  version = "3.6.0";
+
+  src = fetchFromGitHub {
+    owner = "rpm-software-management";
+    repo = pname;
+    rev = version;
+    sha256 = "0a7lc3qsnblvznzsz3544l3n84184xi85zf7c3m3jhnmpmxsg39h";
+  };
+
+  nativeBuildInputs = [ pkg-config cmake gettext help2man ];
+  buildInputs = [ libdnf glib libpeas libsmartcols ];
+
+  meta = with stdenv.lib; {
+    description = "Lightweight implementation of dnf in C";
+    homepage = "https://github.com/rpm-software-management/microdnf";
+    license = licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ rb2k ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5741,6 +5741,8 @@ in
 
   mgba = libsForQt5.callPackage ../misc/emulators/mgba { };
 
+  microdnf = callPackage ../tools/package-management/microdnf { };
+
   microserver = callPackage ../servers/microserver { };
 
   midisheetmusic = callPackage ../applications/audio/midisheetmusic { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13977,6 +13977,8 @@ in
 
   libdnet = callPackage ../development/libraries/libdnet { };
 
+  libdnf = callPackage ../tools/package-management/libdnf { };
+
   libdrm = callPackage ../development/libraries/libdrm { };
 
   libdv = callPackage ../development/libraries/libdv { };


### PR DESCRIPTION
This PR adds derivations for microdnf and libdnf. Both support darwin and linux.
I split this in two commits. libdnf first, microdnf after.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
