### PR TITLE
wireshark: 3.4.0 -> 3.4.2 (security)

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -10,7 +10,7 @@ assert withQt  -> qt5  != null;
 with stdenv.lib;
 
 let
-  version = "3.4.0";
+  version = "3.4.2";
   variant = if withQt then "qt" else "cli";
   pcap = libpcap.override { withBluez = stdenv.isLinux; };
 
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "1bm8jj2rviis9j9l6nixvhxcfx362y9iphkxssgmiz2kj6yypr37";
+    sha256 = "1i548w6zv6ni5n22rs90a12aakyq811493dxmadlcsj2krr6i66y";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
https://www.wireshark.org/docs/relnotes/wireshark-3.4.1.html
https://www.wireshark.org/docs/relnotes/wireshark-3.4.2.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
Tested wireshark-qt.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).