### PR TITLE
picocom: 3.1 -> 3.2a

### DIFF
--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -5,8 +5,6 @@
 , IOKit
 }:
 
-assert stdenv.isDarwin -> IOKit != null;
-
 stdenv.mkDerivation rec {
   pname = "picocom";
   # last tagged release is 3.1 but 3.2 is still considered a release

--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , installShellFiles
 , lrzsz
-, IOKit ? null
+, IOKit
 }:
 
 assert stdenv.isDarwin -> IOKit != null;

--- a/pkgs/tools/misc/picocom/default.nix
+++ b/pkgs/tools/misc/picocom/default.nix
@@ -1,36 +1,50 @@
-{ stdenv, fetchFromGitHub, makeWrapper, lrzsz, IOKit }:
+{ stdenv
+, fetchFromGitHub
+, installShellFiles
+, lrzsz
+, IOKit ? null
+}:
 
 assert stdenv.isDarwin -> IOKit != null;
 
-with stdenv.lib;
-
 stdenv.mkDerivation rec {
   pname = "picocom";
-  version = "3.1";
+  # last tagged release is 3.1 but 3.2 is still considered a release
+  version = "3.2a";
 
+  # upstream is quiet as the original author is no longer active since March 2018
   src = fetchFromGitHub {
     owner = "npat-efault";
     repo = "picocom";
-    rev = version;
-    sha256 = "1vvjydqf0ax47nvdyyl67jafw5b3sfsav00xid6qpgia1gs2r72n";
+    rev = "1acf1ddabaf3576b4023c4f6f09c5a3e4b086fb8";
+    sha256 = "sha256-cs2bxqZfTbnY5d+VJ257C5hssaFvYup3tBKz68ROnAo=";
   };
 
-  buildInputs = [ makeWrapper ]
-    ++ optionals stdenv.isDarwin [ IOKit ];
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '.picocom_history' '.cache/picocom_history'
 
-  installPhase = ''
-    mkdir -p $out/bin $out/share/man/man1
-    cp picocom $out/bin
-    cp picocom.1 $out/share/man/man1
-
-    wrapProgram $out/bin/picocom \
-      --prefix PATH ":" "${lrzsz}/bin"
+    substituteInPlace picocom.c \
+      --replace '"rz -vv"' '"${lrzsz}/bin/rz -vv"' \
+      --replace '"sz -vv"' '"${lrzsz}/bin/sz -vv"'
   '';
 
-  meta = {
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin IOKit;
+
+  installPhase = ''
+    install -Dm555 -t $out/bin picocom
+    installManPage picocom.1
+    installShellCompletion --bash bash_completion/picocom
+  '';
+
+  meta = with stdenv.lib; {
     description = "Minimal dumb-terminal emulation program";
     homepage = "https://github.com/npat-efault/picocom/";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream (untagged) release.

Also:
- write history to $HOME/.cache instead of $HOME
- drop wrapper and patch in location of binaries
- add bash completion support
- start using shell helpers instead of manually copying in man page

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
