### PR TITLE
task-spooler: init at 1.0.1

### DIFF
--- a/pkgs/tools/system/task-spooler/default.nix
+++ b/pkgs/tools/system/task-spooler/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, fetchurl, fetchpatch
+# The Debian patches rename the task-spooler binary from 'ts' to 'tsp', to not
+# conflict with the 'ts' binary from the moreutils package.
+, applyDebianPatches ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "task-spooler";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://vicerveza.homeunix.net/~viric/soft/ts/ts-${version}.tar.gz";
+    sha256 = "0y32sm2i2jxs88c307h76449fynk75p9qfw1k11l5ixrn03z67pl";
+  };
+
+  patches = lib.optionals applyDebianPatches [
+    # rename executable and man page to tsp
+    (fetchpatch {
+       url = "https://sources.debian.org/data/main/t/task-spooler/1.0.1+dfsg1-1/debian/patches/tsp.patch";
+       sha256 = "1jfrgb62j5dz48jsfqkrzmfw1s52zwnmimm4mqmjpx3n4d32japl";
+     })
+
+    # minor fixes to man page
+    (fetchpatch {
+       url = "https://sources.debian.org/data/main/t/task-spooler/1.0.1+dfsg1-1/debian/patches/manpage.patch";
+       sha256 = "0f28r77l39y8vdmaci3z3pfmawpdr7pg803d29r6swlwvymz5k8b";
+     })
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Unix batch system where the tasks spooled run one after the other";
+    homepage = "http://viric.name/soft/ts/";
+    longDescription = ''
+      Task spooler is a Unix batch system where the tasks spooled run one after
+      the other. Each user in each system has his own job queue. The tasks are
+      run in the correct context (that of enqueue) from any shell/process, and
+      its output/results can be easily watched. It is very useful when you know
+      that your commands depend on a lot of RAM, a lot of disk use, give a lot
+      of output, or for whatever reason it's better not to run them at the same
+      time.
+    '';
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.bjornf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2678,6 +2678,8 @@ in
     libmaxminddb = null;
   };
 
+  task-spooler = callPackage ../tools/system/task-spooler {};
+
   xmlsort = perlPackages.XMLFilterSort;
 
   xmousepasteblock = callPackage ../tools/X11/xmousepasteblock { };


### PR DESCRIPTION
###### Motivation for this change
Add Task spooler, which is a Unix batch system where the tasks spooled run one
after the other. Useful tool! I wish I knew about it earlier.

Homepage: http://viric.name/soft/ts/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
