### PR TITLE
nixos/{networkd,dhcpcd}: remove udev-settle hack

### DIFF
--- a/nixos/doc/manual/configuration/networking.xml
+++ b/nixos/doc/manual/configuration/networking.xml
@@ -15,5 +15,6 @@
  <xi:include href="firewall.xml" />
  <xi:include href="wireless.xml" />
  <xi:include href="ad-hoc-network-config.xml" />
+ <xi:include href="renaming-interfaces.xml" />
 <!-- TODO: OpenVPN, NAT -->
 </chapter>

--- a/nixos/doc/manual/configuration/renaming-interfaces.xml
+++ b/nixos/doc/manual/configuration/renaming-interfaces.xml
@@ -1,0 +1,67 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-rename-ifs">
+ <title>Renaming network interfaces</title>
+
+ <para>
+  NixOS uses the udev
+  <link xlink:href="https://systemd.io/PREDICTABLE_INTERFACE_NAMES/">predictable naming scheme</link>
+  to assign names to network interfaces. This means that by default
+  cards are not given the traditional names like
+  <literal>eth0</literal> or <literal>eth1</literal>, whose order can
+  change unpredictably across reboots. Instead, relying on physical
+  locations and firmware information, the scheme produces names like
+  <literal>ens1</literal>, <literal>enp2s0</literal>, etc.
+ </para>
+
+ <para>
+  These names are predictable but less memorable and not necessarily
+  stable: for example installing new hardware or changing firmware
+  settings can result in a
+  <link xlink:href="https://github.com/systemd/systemd/issues/3715#issue-165347602">name change</link>.
+  If this is undesirable, for example if you have a single ethernet
+  card, you can revert to the traditional scheme by setting
+  <xref linkend="opt-networking.usePredictableInterfaceNames"/> to
+  <literal>false</literal>.
+ </para>
+
+ <section xml:id="sec-custom-ifnames">
+  <title>Assigning custom names</title>
+  <para>
+   In case there are multiple interfaces of the same type, it’s better to
+   assign custom names based on the device hardware address. For
+   example, we assign the name <literal>wan</literal> to the interface
+   with MAC address <literal>52:54:00:12:01:01</literal> using a
+   netword link unit:
+  </para>
+  <programlisting>
+ <link linkend="opt-systemd.network.links">systemd.network.links."10-wan"</link> = {
+   matchConfig.MACAddress = "52:54:00:12:01:01";
+   linkConfig.Name = "wan";
+ };
+  </programlisting>
+  <para>
+   Note that links are directly read by udev, <emphasis>not networkd</emphasis>,
+   and will work even if networkd is disabled.
+  </para>
+  <para>
+   Alternatively, we can use a plain old udev rule:
+  </para>
+  <programlisting>
+ <link linkend="opt-services.udev.initrdRules">services.udev.initrdRules</link> = ''
+  SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", \
+  ATTR{address}=="52:54:00:12:01:01", KERNEL=="eth*", NAME="wan"
+ '';
+  </programlisting>
+
+  <warning><para>
+   The rule must be installed in the initrd using
+   <literal>services.udev.initrdRules</literal>, not the usual
+   <literal>services.udev.extraRules</literal> option. This is to avoid race
+   conditions with other programs controlling the interface.
+  </para></warning>
+ </section>
+
+</section>

--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -91,6 +91,16 @@
   </para>
 
   <itemizedlist>
+   <listitem>
+    <para>
+     If you are using <option>services.udev.extraRules</option> to assign
+     custom names to network interfaces, this may stop working due to a change
+     in the initialisation of dhcpcd and systemd networkd. To avoid this, either
+     move them to <option>services.udev.initrdRules</option> or see the new
+     <link linkend="sec-custom-ifnames">Assigning custom names</link> section
+     of the NixOS manual for an example using networkd links.
+    </para>
+   </listitem>
     <listitem>
       <para>
         <literal>systemd-journal2gelf</literal> no longer parses json and expects the receiving system to handle it. How to achieve this with Graylog is described in this <link xlink:href="https://github.com/parse-nl/SystemdJournal2Gelf/issues/10">GitHub issue</link>.

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -191,9 +191,8 @@ in
       { description = "DHCP Client";
 
         wantedBy = [ "multi-user.target" ] ++ optional (!hasDefaultGatewaySet) "network-online.target";
-        wants = [ "network.target" "systemd-udev-settle.service" ];
+        wants = [ "network.target" ];
         before = [ "network-online.target" ];
-        after = [ "systemd-udev-settle.service" ];
 
         restartTriggers = [ exitHook ];
 

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1553,9 +1553,6 @@ in
         wantedBy = [ "multi-user.target" ];
         aliases = [ "dbus-org.freedesktop.network1.service" ];
         restartTriggers = map (x: x.source) (attrValues unitFiles);
-        # prevent race condition with interface renaming (#39069)
-        requires = [ "systemd-udev-settle.service" ];
-        after = [ "systemd-udev-settle.service" ];
       };
 
       systemd.services.systemd-networkd-wait-online = {


### PR DESCRIPTION
###### Motivation for this change

systemd-udev-settle is a terrible hack[1] and should never[2] ever[3]
used, seriously it's very bad. It was used as a stop-gap solution for
issue #39069, but thanks to PR #79532 it can be removed now.

[1]: https://github.com/systemd/systemd/issues/7293#issuecomment-592941764
[2]: https://github.com/NixOS/nixpkgs/issues/73095
[3]: https://github.com/NixOS/nixpkgs/issues/107341


###### Things done

- Tested via:
  - [x]  `nixosTests.networking.networkd`
  - [x]  `nixosTests.networking.scripted`
  - [x] `nixosTests.predictable-interface-names` 
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
