### PR TITLE
esptool: 2.7 -> 3.0, fix #82965

### DIFF
--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -2,17 +2,31 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "esptool";
-  version = "2.7";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    sha256 = "1p5hx0rhs986ffqz78rdxg7jayndsq632399xby39k17kvd3mb31";
+    sha256 = "1y022qlcdgdx5a88lkc3sqavklz494afbfyh100lp7xfk3f2mjln";
   };
 
-  checkInputs = with python3.pkgs; [ flake8 flake8-future-import flake8-import-order openssl ];
-  propagatedBuildInputs = with python3.pkgs; [ pyserial pyaes ecdsa ];
+  checkInputs = with python3.pkgs;
+    [ flake8 flake8-future-import flake8-import-order openssl ];
+  propagatedBuildInputs = with python3.pkgs;
+    [ pyserial pyaes ecdsa reedsolo bitstring cryptography ];
+
+  # wrapPythonPrograms will overwrite esptool.py with a bash script,
+  # but espefuse.py tries to import it. Since we don't add any binary paths,
+  # use patchPythonScript directly.
+  dontWrapPythonPrograms = true;
+  postFixup = ''
+    buildPythonPath "$out $pythonPath"
+    for f in $out/bin/*.py; do
+        echo "Patching $f"
+        patchPythonScript "$f"
+    done
+  '';
 
   meta = with stdenv.lib; {
     description = "ESP8266 and ESP32 serial bootloader utility";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Esptool version 3.0 was released on nov 5. I also fixed #82965.

cc: @wucke13 @dezgeg @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
