### PR TITLE
python3Packages.daphne: 2.5.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/daphne/default.nix
+++ b/pkgs/development/python-modules/daphne/default.nix
@@ -4,7 +4,7 @@
 }:
 buildPythonPackage rec {
   pname = "daphne";
-  version = "2.5.0";
+  version = "3.0.1";
 
   disabled = !isPy3k;
 
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     owner = "django";
     repo = pname;
     rev = version;
-    sha256 = "0qkhmblj3a5s3z65cgz46xsvq1b6x4m3kr6aljjnxnv7hcwib02n";
+    sha256 = "1bkxhzvaqwz760c11nhaiwvsq1d1csmk5dz2a1j1ynypjprhvhsk";
   };
 
   nativeBuildInputs = [ pytestrunner ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.0.1

Changelog: https://github.com/django/daphne/blob/master/CHANGELOG.txt

Should fix the build issue that came up during update for msgpack.

```text
  ERROR: Could not find a version that satisfies the requirement daphne<4,>=3.0 (from channels)
  ERROR: No matching distribution found for daphne<4,>=3.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
