### PR TITLE
python3Packages.channels-redis: 2.4.0 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/channels-redis/default.nix
+++ b/pkgs/development/python-modules/channels-redis/default.nix
@@ -1,50 +1,41 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
-, redis, channels, msgpack, aioredis, hiredis, asgiref
-# , fetchFromGitHub, async_generator, async-timeout, cryptography, pytest, pytest-asyncio
+{ stdenv
+, aioredis
+, asgiref
+, buildPythonPackage
+, channels
+, fetchPypi
+, hiredis
+, msgpack
+, pythonOlder
+, redis
 }:
 
 buildPythonPackage rec {
   pname = "channels-redis";
-  version = "2.4.0";
+  version = "3.2.0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit version;
     pname = "channels_redis";
-    sha256 = "1g4izdf8237pwxn85bv5igc2bajrvck1p2a7q448qmjfznrbrk5p";
+    sha256 = "1rjs9irnq59yr6zwc9k6nnw6xrmr48dakrm25m0gcwskn1iimcrg";
   };
 
   buildInputs = [ redis hiredis ];
 
   propagatedBuildInputs = [ channels msgpack aioredis asgiref ];
 
-  # Fetch from github (no tests files on pypi)
-  # src = fetchFromGitHub {
-  #   rev = version;
-  #   owner = "django";
-  #   repo = "channels_redis";
-  #   sha256 = "05niaqjv790mnrvca26kbnvb50fgnk2zh0k4np60cn6ilp4nl0kc";
-  # };
-  #
-  # checkInputs = [
-  #   async_generator
-  #   async-timeout
-  #   cryptography
-  #   pytest
-  #   pytest-asyncio
-  # ];
-  #
-  # # Fails with : ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 6379)
-  # # (even with a local redis instance running)
-  # checkPhase = ''
-  #   pytest -p no:django tests/
-  # '';
+  # Fails with : ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 6379)
+  # (even with a local Redis instance running)
+  doCheck = false;
 
   postPatch = ''
     sed -i "s/msgpack~=0.6.0/msgpack/" setup.py
     sed -i "s/aioredis~=1.0/aioredis/" setup.py
   '';
+
+  pythonImportsCheck = [ "channels_redis" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/django/channels_redis/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.2.0

Changelog: https://github.com/django/channels_redis/blob/master/CHANGELOG.txt

Should fix the build issue that came up during update for msgpack.

```text
  ERROR: Could not find a version that satisfies the requirement channels~=2.2 (from channels-redis)
  ERROR: No matching distribution found for channels~=2.2exit
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
