### PR TITLE
beam-packages: move wxSupport arg up to package set, add beam_nox 

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -29,6 +29,7 @@ with lib;
     nixpkgs.overlays = singleton (const (super: {
       cairo = super.cairo.override { x11Support = false; };
       dbus = super.dbus.override { x11Support = false; };
+      beam = super.beam_nox;
       networkmanager-fortisslvpn = super.networkmanager-fortisslvpn.override { withGnome = false; };
       networkmanager-iodine = super.networkmanager-iodine.override { withGnome = false; };
       networkmanager-l2tp = super.networkmanager-l2tp.override { withGnome = false; };

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -3,11 +3,10 @@
 # TODO: use jdk https://github.com/NixOS/nixpkgs/pull/89731
 , openjdk8 ? null # javacSupport
 , unixODBC ? null # odbcSupport
-, libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null, wxSupport ? true
+, libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null
 , parallelBuild ? false
-, systemd
+, systemd, wxSupport ? true
 }:
-let defaultWxSupport = wxSupport; in
 { baseName ? "erlang"
 , version
 , sha256 ? null
@@ -21,7 +20,7 @@ let defaultWxSupport = wxSupport; in
 , javacSupport ? false, javacPackages ? [ openjdk8 ]
 , odbcSupport ? false, odbcPackages ? [ unixODBC ]
 , withSystemd ? stdenv.isLinux # systemd support in epmd
-, wxSupport ? defaultWxSupport, wxPackages ? [ libGL libGLU wxGTK xorg.libX11 ]
+, wxPackages ? [ libGL libGLU wxGTK xorg.libX11 ]
 , preUnpack ? "", postUnpack ? ""
 , patches ? [], patchPhase ? "", prePatch ? "", postPatch ? ""
 , configureFlags ? [], configurePhase ? "", preConfigure ? "", postConfigure ? ""

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -3,11 +3,11 @@
 # TODO: use jdk https://github.com/NixOS/nixpkgs/pull/89731
 , openjdk8 ? null # javacSupport
 , unixODBC ? null # odbcSupport
-, libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null # wxSupport
+, libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null, wxSupport ? true
 , parallelBuild ? false
 , systemd
 }:
-
+let defaultWxSupport = wxSupport; in
 { baseName ? "erlang"
 , version
 , sha256 ? null
@@ -21,7 +21,7 @@
 , javacSupport ? false, javacPackages ? [ openjdk8 ]
 , odbcSupport ? false, odbcPackages ? [ unixODBC ]
 , withSystemd ? stdenv.isLinux # systemd support in epmd
-, wxSupport ? true, wxPackages ? [ libGL libGLU wxGTK xorg.libX11 ]
+, wxSupport ? defaultWxSupport, wxPackages ? [ libGL libGLU wxGTK xorg.libX11 ]
 , preUnpack ? "", postUnpack ? ""
 , patches ? [], patchPhase ? "", prePatch ? "", postPatch ? ""
 , configureFlags ? [], configurePhase ? "", preConfigure ? "", postConfigure ? ""

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10980,11 +10980,14 @@ in
   };
 
   beam = callPackage ./beam-packages.nix { };
+  beam_nox = callPackage ./beam-packages.nix { wxSupport = false; };
 
   inherit (beam.interpreters)
     erlang erlangR23 erlangR22 erlangR21 erlangR20 erlangR19 erlangR18
-    erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
+    erlang_odbc erlang_javac erlang_odbc_javac erlang_basho_R16B02
     elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
+
+  erlang_nox = beam_nox.interpreters.erlang;
 
   inherit (beam.packages.erlang)
     rebar rebar3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18163,7 +18163,7 @@ in
 
   rabbitmq-server = callPackage ../servers/amqp/rabbitmq-server {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon Cocoa;
-    elixir = elixir_1_8;
+    elixir = beam_nox.interpreters.elixir_1_8;
     erlang = erlang_nox;
   };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,4 +1,4 @@
-{ callPackage, wxGTK30, openssl_1_0_2, buildPackages }:
+{ callPackage, wxGTK30, openssl_1_0_2, buildPackages, wxSupport ? true }:
 
 rec {
   lib = callPackage ../development/beam-modules/lib.nix { };
@@ -11,7 +11,6 @@ rec {
     erlang_odbc = erlangR23_odbc;
     erlang_javac = erlangR23_javac;
     erlang_odbc_javac = erlangR23_odbc_javac;
-    erlang_nox = erlangR23_nox;
 
     # Standard Erlang versions, using the generic builder.
 
@@ -21,6 +20,7 @@ rec {
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
+      inherit wxSupport;
     };
     erlangR23_odbc = erlangR23.override { odbcSupport = true; };
     erlangR23_javac = erlangR23.override { javacSupport = true; };
@@ -28,7 +28,6 @@ rec {
       javacSupport = true;
       odbcSupport = true;
     };
-    erlangR23_nox = erlangR23.override { wxSupport = false; };
 
     # R22
     erlangR22 = lib.callErlang ../development/interpreters/erlang/R22.nix {
@@ -36,6 +35,7 @@ rec {
       # Can be enabled since the bug has been fixed in https://github.com/erlang/otp/pull/2508
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
+      inherit wxSupport;
     };
     erlangR22_odbc = erlangR22.override { odbcSupport = true; };
     erlangR22_javac = erlangR22.override { javacSupport = true; };
@@ -43,12 +43,12 @@ rec {
       javacSupport = true;
       odbcSupport = true;
     };
-    erlangR22_nox = erlangR22.override { wxSupport = false; };
 
     # R21
     erlangR21 = lib.callErlang ../development/interpreters/erlang/R21.nix {
       wxGTK = wxGTK30;
       autoconf = buildPackages.autoconf269;
+      inherit wxSupport;
     };
     erlangR21_odbc = erlangR21.override { odbcSupport = true; };
     erlangR21_javac = erlangR21.override { javacSupport = true; };
@@ -56,12 +56,12 @@ rec {
       javacSupport = true;
       odbcSupport = true;
     };
-    erlangR21_nox = erlangR21.override { wxSupport = false; };
 
     # R20
     erlangR20 = lib.callErlang ../development/interpreters/erlang/R20.nix {
       wxGTK = wxGTK30;
       autoconf = buildPackages.autoconf269;
+      inherit wxSupport;
     };
     erlangR20_odbc = erlangR20.override { odbcSupport = true; };
     erlangR20_javac = erlangR20.override { javacSupport = true; };
@@ -69,13 +69,13 @@ rec {
       javacSupport = true;
       odbcSupport = true;
     };
-    erlangR20_nox = erlangR20.override { wxSupport = false; };
 
     # R19
     erlangR19 = lib.callErlang ../development/interpreters/erlang/R19.nix {
       wxGTK = wxGTK30;
       openssl = openssl_1_0_2;
       autoconf = buildPackages.autoconf269;
+      inherit wxSupport;
     };
     erlangR19_odbc = erlangR19.override { odbcSupport = true; };
     erlangR19_javac = erlangR19.override { javacSupport = true; };
@@ -83,13 +83,13 @@ rec {
       javacSupport = true;
       odbcSupport = true;
     };
-    erlangR19_nox = erlangR19.override { wxSupport = false; };
 
     # R18
     erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {
       wxGTK = wxGTK30;
       openssl = openssl_1_0_2;
       autoconf = buildPackages.autoconf269;
+      inherit wxSupport;
     };
     erlangR18_odbc = erlangR18.override { odbcSupport = true; };
     erlangR18_javac = erlangR18.override { javacSupport = true; };
@@ -97,12 +97,12 @@ rec {
       javacSupport = true;
       odbcSupport = true;
     };
-    erlangR18_nox = erlangR18.override { wxSupport = false; };
 
     # Basho fork, using custom builder.
     erlang_basho_R16B02 =
       lib.callErlang ../development/interpreters/erlang/R16B02-basho.nix {
         autoconf = buildPackages.autoconf269;
+        inherit wxSupport;
       };
     erlang_basho_R16B02_odbc =
       erlang_basho_R16B02.override { odbcSupport = true; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It turns out that rabbitmq does not build with `environment.noXlibs` set, and neither does epmd. It's a bit tedious to get out the packages built without X support, or to even override it manually. After various iterations, I think an argument to beam-packages.nix is the best solution. This allows us to set `beam = beam_nox` to disable X support on all erlang packages.

cc @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
