### PR TITLE
nixos/amdgpu: add option for Display Core support

### DIFF
--- a/nixos/modules/hardware/video/amdgpu.nix
+++ b/nixos/modules/hardware/video/amdgpu.nix
@@ -6,24 +6,28 @@ let
 
   cfg = config.hardware.amdgpu;
 
-  enabled = elem "amdgpu" config.services.xserver.videoDrivers;
-
 in
 {
   options = {
-    hardware.amdgpu.enableDisplayCore = mkOption {
-      default = true;
-      type = types.bool;
+    hardware.amdgpu.displayCore = mkOption {
+      default = "default";
+      type = types.enum [ "default" "disabled" "enabled"];
       description = ''
-        Enable drm display core (DC) support for amdgpu.
-        Depending on hardware setup this may either solve or cause video output problems.
+        This option controls drm display core (DC) support for amdgpu.
+        Depending on hardware setup, it may either solve or cause video output problems.
+
+        Try toggling this option if you encounter black screen during boot or DP/HDMI compatibility issues.
+
+        By <literal>"default"</literal> it uses kernel's default config where DC support for newer family of cards
+        will not be enabled.
       '';
     };
   };
 
   config = {
     boot.blacklistedKernelModules = mkIf (elem "amdgpu" config.services.xserver.videoDrivers) [ "radeon" ];
-    boot.kernel.features.amdgpu_dc = cfg.enableDisplayCore;
+
+    boot.kernel.features.amdgpu_dc_disabled = cfg.displayCore == "disabled";
+    boot.kernel.features.amdgpu_dc_all = cfg.displayCore == "enabled";
   };
 }
-

--- a/nixos/modules/hardware/video/amdgpu.nix
+++ b/nixos/modules/hardware/video/amdgpu.nix
@@ -1,9 +1,29 @@
 { config, lib, ... }:
 
 with lib;
+
+let
+
+  cfg = config.hardware.amdgpu;
+
+  enabled = elem "amdgpu" config.services.xserver.videoDrivers;
+
+in
 {
-  config = mkIf (elem "amdgpu" config.services.xserver.videoDrivers) {
-    boot.blacklistedKernelModules = [ "radeon" ];
+  options = {
+    hardware.amdgpu.enableDisplayCore = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Enable drm display core (DC) support for amdgpu.
+        Depending on hardware setup this may either solve or cause video output problems.
+      '';
+    };
+  };
+
+  config = {
+    boot.blacklistedKernelModules = mkIf (elem "amdgpu" config.services.xserver.videoDrivers) [ "radeon" ];
+    boot.kernel.features.amdgpu_dc = cfg.enableDisplayCore;
   };
 }
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -247,6 +247,16 @@ let
       DRM_AMDGPU_CIK = whenAtLeast "4.9" yes;
       # Allow device firmware updates
       DRM_DP_AUX_CHARDEV = whenAtLeast "4.6" yes;
+      # amdgpu display core (DC) support; defaults to yes
+      DRM_AMD_DC = mkIf (!features.amdgpu_dc) (whenAtLeast "4.15" no);
+    } // optionalAttrs (features.amdgpu_dc or false) {
+      # DC support for all chipsets
+      DRM_AMD_DC_DCN1_0 = whenBetween "4.15" "5.6" yes;
+      DRM_AMD_DC_PRE_VEGA = whenBetween "4.15" "4.18" yes;
+      DRM_AMD_DC_DCN2_0 = whenBetween "5.3" "5.6" yes;
+      DRM_AMD_DC_DCN2_1 = whenBetween "5.4" "5.6" yes;
+      DRM_AMD_DC_DCN3_0 = whenBetween "5.9" "5.11" yes;
+      DRM_AMD_DC_DCN = whenAtLeast "5.6" yes;
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux") {
       # Intel GVT-g graphics virtualization supports 64-bit only
       DRM_I915_GVT = whenAtLeast "4.16" yes;

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -247,10 +247,10 @@ let
       DRM_AMDGPU_CIK = whenAtLeast "4.9" yes;
       # Allow device firmware updates
       DRM_DP_AUX_CHARDEV = whenAtLeast "4.6" yes;
-      # amdgpu display core (DC) support; defaults to yes
-      DRM_AMD_DC = mkIf (!features.amdgpu_dc) (whenAtLeast "4.15" no);
-    } // optionalAttrs (features.amdgpu_dc or false) {
-      # DC support for all chipsets
+      # amdgpu display core (DC) support; enabled by default
+      DRM_AMD_DC = mkIf (features.amdgpu_dc_disabled or false) (whenAtLeast "4.15" no);
+    } // optionalAttrs (features.amdgpu_dc_all or false) {
+      # amdgpu display core (DC) support for all chipsets
       DRM_AMD_DC_DCN1_0 = whenBetween "4.15" "5.6" yes;
       DRM_AMD_DC_PRE_VEGA = whenBetween "4.15" "4.18" yes;
       DRM_AMD_DC_DCN2_0 = whenBetween "5.3" "5.6" yes;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
My RX6800 cannot detect any outputs unless I enable drm display core support by compiling linux with DRM_AMD_DC_DCN3_0.
I don't know if this is a universal issue of newer AMD cards or just my specific AIB card/MB combination.
I also noticed that many people have issues with DC enabled instead (with older generation of cards).

Anyway I think it is a good idea to have a module option to enable (disable) DC for all supported cards.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
