### PR TITLE
gtk4: init at 4.0.2

### DIFF
--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -1,0 +1,232 @@
+{ lib
+, stdenv
+, fetchurl
+, pkg-config
+, gettext
+, graphene
+, docbook-xsl-nons
+, docbook_xml_dtd_43
+, gtk-doc
+, meson
+, ninja
+, python3
+, makeWrapper
+, shared-mime-info
+, isocodes
+, glib
+, cairo
+, pango
+, pandoc
+, gdk-pixbuf
+, gobject-introspection
+, fribidi
+, xorg
+, epoxy
+, json-glib
+, libxkbcommon
+, libxml2
+, librest
+, libsoup
+, ffmpeg
+, gmp
+, gnome3
+, gsettings-desktop-schemas
+, gst_all_1
+, sassc
+, trackerSupport ? stdenv.isLinux
+, tracker
+, x11Support ? stdenv.isLinux
+, waylandSupport ? stdenv.isLinux
+, mesa
+, vulkan-loader
+, vulkan-headers
+, wayland
+, wayland-protocols
+, xineramaSupport ? stdenv.isLinux
+, cupsSupport ? stdenv.isLinux
+, withGtkDoc ? stdenv.isLinux
+, cups ? null
+, AppKit
+, Cocoa
+, broadwaySupport ? true
+}:
+
+assert cupsSupport -> cups != null;
+
+stdenv.mkDerivation rec {
+  pname = "gtk4";
+  version = "4.0.2";
+
+  outputs = [ "out" "dev" ] ++ lib.optional withGtkDoc "devdoc";
+  outputBin = "dev";
+
+  setupHooks = [
+    ./hooks/gtk4-clean-immodules-cache.sh
+    ./hooks/drop-icon-theme-cache.sh
+  ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
+    sha256 = "115w3mzwm1xsi1q85qvwfm2yxpsjs2rcajgddzbnwhjicyn0frv2";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    gobject-introspection
+    makeWrapper
+    meson
+    ninja
+    pkg-config
+    python3
+    sassc
+  ] ++ setupHooks ++ lib.optionals withGtkDoc [
+    pandoc
+    docbook_xml_dtd_43
+    docbook-xsl-nons
+    gtk-doc
+    # For xmllint
+    libxml2
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    epoxy
+    json-glib
+    isocodes
+    vulkan-headers
+    librest
+    libsoup
+    ffmpeg
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+    fribidi
+  ] ++ (with xorg; [
+    libICE
+    libSM
+    libXcomposite
+    libXcursor
+    libXi
+    libXrandr
+    libXrender
+  ]) ++ lib.optionals stdenv.isDarwin [
+    AppKit
+  ] ++ lib.optionals trackerSupport [
+    tracker
+  ] ++ lib.optionals waylandSupport [
+    mesa
+    wayland
+    wayland-protocols
+  ] ++ lib.optionals xineramaSupport [
+    xorg.libXinerama
+  ] ++ lib.optionals cupsSupport [
+    cups
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+  ];
+  #TODO: colord?
+
+  propagatedBuildInputs = [
+    # Required by pkg-config files.
+    cairo
+    gdk-pixbuf
+    glib
+    graphene
+    pango
+    vulkan-loader # TODO: Possibly not used on Darwin
+
+    # Required for GSettings schemas at runtime.
+    # Will be picked up by wrapGAppsHook.
+    gsettings-desktop-schemas
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=${lib.boolToString withGtkDoc}"
+    "-Dtests=false"
+    "-Dtracker3=${lib.boolToString trackerSupport}"
+    "-Dbroadway_backend=${lib.boolToString broadwaySupport}"
+  ];
+
+  doCheck = false; # needs X11
+
+  separateDebugInfo = stdenv.isLinux;
+
+  # These are the defines that'd you'd get with --enable-debug=minimum (default).
+  # See: https://developer.gnome.org/gtk3/stable/gtk-building.html#extra-configuration-options
+  NIX_CFLAGS_COMPILE = "-DG_ENABLE_DEBUG -DG_DISABLE_CAST_CHECKS";
+
+  postPatch = ''
+    files=(
+      build-aux/meson/post-install.py
+      demos/gtk-demo/geninclude.py
+      gdk/broadway/gen-c-array.py
+      gdk/gen-gdk-gresources-xml.py
+      gtk/gen-gtk-gresources-xml.py
+      gtk/gentypefuncs.py
+      docs/reference/gtk/gtk-markdown-to-docbook
+    )
+
+    chmod +x ''${files[@]}
+    patchShebangs ''${files[@]}
+  '';
+
+  postBuild =  lib.optionalString withGtkDoc ''
+    # Meson not building `custom_target`s passed to `custom_files` argument of `gnome.gtkdoc` function
+    # as part of the `install` target. We have to build the docs manually first.
+    # https://github.com/mesonbuild/meson/issues/2831
+    ninja g{t,d,s}k4-doc
+  '';
+
+  preInstall = ''
+    OLD_PATH="$PATH"
+    PATH="$PATH:$dev/bin" # so the install script finds gtk4-update-icon-cache
+  '';
+
+  postInstall = ''
+    PATH="$OLD_PATH"
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    # The updater is needed for nixos env and it's tiny.
+    moveToOutput bin/gtk4-update-icon-cache "$out"
+    # Launcher
+    moveToOutput bin/gtk-launch "$out"
+
+    # TODO: patch glib directly
+    for f in $dev/bin/gtk4-encode-symbolic-svg; do
+      wrapProgram $f --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+    done
+  '';
+
+  # Wrap demos
+  postFixup =  lib.optionalString (!stdenv.isDarwin) ''
+    demos=(gtk4-demo gtk4-demo-application gtk4-icon-browser gtk4-widget-factory)
+
+    for program in ''${demos[@]}; do
+      wrapProgram $dev/bin/$program \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${pname}-${version}"
+    done
+  '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gtk";
+      attrPath = "gtk4";
+    };
+  };
+
+  meta = with lib; {
+    description = "A multi-platform toolkit for creating graphical user interfaces";
+    longDescription = ''
+      GTK is a highly usable, feature rich toolkit for creating
+      graphical user interfaces which boasts cross platform
+      compatibility and an easy to use API.  GTK it is written in C,
+      but has bindings to many other popular programming languages
+      such as C++, Python and C# among others.  GTK is licensed
+      under the GNU LGPL 2.1 allowing development of both free and
+      proprietary software with GTK without any license fees or
+      royalties.
+    '';
+    homepage = "https://www.gtk.org/";
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [ raskin vcunat lethalman worldofpeace ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/gtk/hooks/gtk4-clean-immodules-cache.sh
+++ b/pkgs/development/libraries/gtk/hooks/gtk4-clean-immodules-cache.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+fixupOutputHooks+=(_gtk4CleanComments)
+
+# Clean comments that link to generator of the file
+_gtk4CleanComments() {
+    local f="${prefix:?}/lib/gtk-4.0/4.0.0/immodules.cache"
+    if [ -f "$f" ]; then
+        sed 's|Created by .*bin/gtk-query-|Created by bin/gtk-query-|' -i "$f"
+    fi
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13939,6 +13939,11 @@ in
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };
 
+  gtk4 = callPackage ../development/libraries/gtk/4.x.nix {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
+  };
+
+
   # On darwin gtk uses cocoa by default instead of x11.
   gtk3-x11 = gtk3.override {
     cairo = cairo.override { x11Support = true; };


### PR DESCRIPTION
###### Motivation for this change
This is some initial work for getting GTK4 to compile as I wanted to get
a rough feeling how much effort it is.

https://gitlab.gnome.org/GNOME/gtk/-/blob/4.0.0/NEWS
https://blog.gtk.org/2020/12/16/gtk-4-0/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
