### PR TITLE
pythonPackages.progressbar2: fix build

### DIFF
--- a/pkgs/development/python-modules/progressbar2/default.nix
+++ b/pkgs/development/python-modules/progressbar2/default.nix
@@ -2,15 +2,7 @@
 , python
 , buildPythonPackage
 , fetchPypi
-, pytest
 , python-utils
-, sphinx
-, flake8
-, pytest-flakes
-, pytestcov
-, pytestcache
-, pytestrunner
-, freezegun
 }:
 
 buildPythonPackage rec {
@@ -23,17 +15,12 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ python-utils ];
-  nativeBuildInputs = [ pytestrunner ];
-  checkInputs = [
-    pytest sphinx flake8 pytest-flakes pytestcov
-    pytestcache freezegun
-  ];
-  # ignore tests on the nix wrapped setup.py
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} setup.py test
-    runHook postCheck
-  '';
+
+  # depends on unmaintained pytest-pep8
+  # https://github.com/WoLpH/python-progressbar/issues/241
+  doCheck = false;
+
+  pythonImportsCheck = [ "progressbar" ];
 
   meta = with stdenv.lib; {
     homepage = "https://progressbar-2.readthedocs.io/en/latest/";


### PR DESCRIPTION
build failed because tests depend on pytest-pep8 which is unmaintained
and therefore not worth packaging. it's probably better to wait for
upstream to resolve the linked issue.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
