### PR TITLE
phd2: add GApps wrapper to fix breakage on non-nixos wayland systems

### DIFF
--- a/pkgs/applications/science/astronomy/phd2/default.nix
+++ b/pkgs/applications/science/astronomy/phd2/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, pkg-config, cmake, gtk3,
-  wxGTK30-gtk3, curl, gettext, glib, indilib, libnova }:
+{ stdenv, fetchFromGitHub, pkg-config, cmake, gtk3, wxGTK30-gtk3,
+  curl, gettext, glib, indilib, libnova, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "phd2";
@@ -12,12 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "1ih7m9lilh12xbhmwm9kkicaqy72mi3firl6df7m5x38n2zj3zm4";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
   buildInputs = [ gtk3 wxGTK30-gtk3 curl gettext glib indilib libnova ];
 
   cmakeFlags = [
     "-DOPENSOURCE_ONLY=1"
   ];
+
+  # Fix broken wrapped name scheme by moving wrapped binary to where wrapper expects it
+  postFixup = ''
+    mv $out/bin/.phd2.bin-wrapped $out/bin/.phd2-wrapped.bin
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://openphdguiding.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
As a gtk application, phd2 should include wrapGAppsHook as a native build input to prevent breakage on some system configurations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
