### PR TITLE
licenses: Mark unclear GPL licenses explicitly deprecated

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -817,14 +817,54 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
   };
 } // {
   # TODO: remove legacy aliases
-  agpl3 = lib.licenses.agpl3Only;
-  fdl11 = lib.licenses.fdl11Only;
-  fdl12 = lib.licenses.fdl12Only;
-  fdl13 = lib.licenses.fdl13Only;
-  gpl1 = lib.licenses.gpl1Only;
-  gpl2 = lib.licenses.gpl2Only;
-  gpl3 = lib.licenses.gpl3Only;
-  lgpl2 = lib.licenses.lgpl2Only;
-  lgpl21 = lib.licenses.lgpl21Only;
-  lgpl3 = lib.licenses.lgpl3Only;
+  agpl3 = spdx {
+    spdxId = "AGPL-3.0";
+    fullName = "GNU Affero General Public License v3.0";
+    deprecated = true;
+  };
+  fdl11 = spdx {
+    spdxId = "GFDL-1.1";
+    fullName = "GNU Free Documentation License v1.1";
+    deprecated = true;
+  };
+  fdl12 = spdx {
+    spdxId = "GFDL-1.2";
+    fullName = "GNU Free Documentation License v1.2";
+    deprecated = true;
+  };
+  fdl13 = spdx {
+    spdxId = "GFDL-1.3";
+    fullName = "GNU Free Documentation License v1.3";
+    deprecated = true;
+  };
+  gpl1 = spdx {
+    spdxId = "GPL-1.0";
+    fullName = "GNU General Public License v1.0";
+    deprecated = true;
+  };
+  gpl2 = spdx {
+    spdxId = "GPL-2.0";
+    fullName = "GNU General Public License v2.0";
+    deprecated = true;
+  };
+  gpl3 = spdx {
+    spdxId = "GPL-3.0";
+    fullName = "GNU General Public License v3.0";
+    deprecated = true;
+  };
+  lgpl2 = spdx {
+    spdxId = "LGPL-2.0";
+    fullName = "GNU Library General Public License v2";
+    deprecated = true;
+  };
+  lgpl21 = spdx {
+    spdxId = "LGPL-2.1";
+    fullName = "GNU Lesser General Public License v2.1";
+    deprecated = true;
+  };
+  lgpl3 = spdx {
+    spdxId = "LGPL-3.0";
+    fullName = "GNU Lesser General Public License v3.0";
+    deprecated = true;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
﻿We recently switched to more explicit GPL license names in line with the SPDX change and GNU Foundation recommendations: https://www.gnu.org/licenses/identify-licenses-clearly.html

This followed up older change to use the recommended SPDX ID https://github.com/NixOS/nixpkgs/commit/18a5e8c36b2681f5fc4aecd79f4cc723365d2d94 but using the `-only` variant for these deprecated licenses too makes it harder to check for them automatically.

Let’s switch to the appropriate SPDX ID again.

Fixes: https://github.com/jtojnar/nixpkgs-hammering/issues/4

cc @Supersandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
