### PR TITLE
Patch python-gnupg to fix tests on aarch64

### DIFF
--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -1,16 +1,25 @@
-{ stdenv, buildPythonPackage, fetchPypi, gnupg }:
+{ stdenv, buildPythonPackage, fetchpatch, fetchPypi, gnupg }:
 
 buildPythonPackage rec {
   pname   = "python-gnupg";
-  version = "0.4.6";
+  version = "0.4.6"; # Please remove the patch below when >0.4.6
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "3aa0884b3bd414652c2385b9df39e7b87272c2eca1b8fcc3089bc9e58652019a";
   };
 
+  patches = [
+  ] ++ stdenv.lib.optionals (let cutoff = "0.4.6"; in version == cutoff || stdenv.lib.versionOlder version cutoff) [
+    # Remove on next version bump
+    (fetchpatch {
+      url = "https://bitbucket.org/vinay.sajip/python-gnupg/commits/443fc58ed3ce5ea928d90c16d6cfac25e40c05ba/raw";
+      sha256 = "1ppbg944227nj6yylhcxfr6bdrlhzripahmjh1a0c63vxzrcwg4m";
+    })
+  ];
+
   # Let's make the library default to our gpg binary
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace gnupg.py \
     --replace "gpgbinary='gpg'" "gpgbinary='${gnupg}/bin/gpg'"
     substituteInPlace test_gnupg.py \


### PR DESCRIPTION
###### Motivation for this change

For some reason /etc/foo is writable during the nix build on some
systems. I've observed it on an aarch64 Ubuntu 18.04 system.

This patch is also filed as an issues against the upstream package
so once it lands we can remove it here.

See https://bitbucket.org/vinay.sajip/python-gnupg/issues/143/pr-fix-tests-when-etc-foo-is-writable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
