### PR TITLE
libctemplate: 2.3 -> 2.4

### DIFF
--- a/pkgs/development/libraries/libctemplate/default.nix
+++ b/pkgs/development/libraries/libctemplate/default.nix
@@ -1,20 +1,25 @@
-{ stdenv, fetchurl, python2 }:
+{ stdenv, fetchFromGitHub, python3, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
   pname = "ctemplate";
 
-  version = "2.3";
+  version = "2.4";
 
-  src = fetchurl {
-    url = "https://github.com/OlafvdSpek/ctemplate/archive/ctemplate-${version}.tar.gz";
-    sha256 = "0mi5g2xlws10z1g4x0cj6kd1r673kkav35pgzyqxa1w47xnwprcr";
+
+  src = fetchFromGitHub {
+    owner = "OlafvdSpek";
+    repo = "ctemplate";
+    rev = "ctemplate-${version}";
+    sha256 = "1x0p5yym6vvcx70pm8ihnbxxrl2wnblfp72ih5vjyg8mzkc8cxrr";
   };
 
-  buildInputs = [ python2 ];
+  nativeBuildInputs = [ python3 autoconf automake libtool ];
 
   postPatch = ''
     patchShebangs .
   '';
+
+  preConfigure = "./autogen.sh";
 
   meta = {
     description = "A simple but powerful template language for C++";

--- a/pkgs/development/libraries/libctemplate/default.nix
+++ b/pkgs/development/libraries/libctemplate/default.nix
@@ -2,7 +2,6 @@
 
 stdenv.mkDerivation rec {
   pname = "ctemplate";
-
   version = "2.4";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/libctemplate/default.nix
+++ b/pkgs/development/libraries/libctemplate/default.nix
@@ -5,7 +5,6 @@ stdenv.mkDerivation rec {
 
   version = "2.4";
 
-
   src = fetchFromGitHub {
     owner = "OlafvdSpek";
     repo = "ctemplate";
@@ -19,7 +18,9 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  preConfigure = "./autogen.sh";
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   meta = {
     description = "A simple but powerful template language for C++";


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update to latest version
- Switches to python3
- Can now be cross compiled
- Don't fetch the source tarball from github, use the fetcher instead

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
