### PR TITLE
nixos/gitlab: add support for enabling rbtrace

### DIFF
--- a/nixos/modules/services/misc/defaultUnicornConfig.rb
+++ b/nixos/modules/services/misc/defaultUnicornConfig.rb
@@ -49,6 +49,8 @@ before_fork do |server, worker|
 end
 
 after_fork do |server, worker|
+  require 'rbtrace' if ENV['ENABLE_RBTRACE']
+
   # per-process listener ports for debugging/admin/migrations
   # addr = "127.0.0.1:#{9293 + worker.nr}"
   # server.listen(addr, :tries => -1, :delay => 5, :tcp_nopush => true)

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -148,6 +148,7 @@ let
     GITLAB_REDIS_CONFIG_FILE = pkgs.writeText "redis.yml" (builtins.toJSON redisConfig);
     prometheus_multiproc_dir = "/run/gitlab";
     RAILS_ENV = "production";
+    ENABLE_RBTRACE = if cfg.rbtrace then "1" else "0";
   };
 
   gitlab-rake = pkgs.stdenv.mkDerivation {
@@ -537,6 +538,14 @@ in {
 
           This should be a string, not a nix path, since nix paths are
           copied into the world-readable nix store.
+        '';
+      };
+
+      rbtrace = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable rbtrace for the unicorn processes.
         '';
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GitLab added support for using rbtrace with version 11.2.  The gem needs to be required by the unicorn process after the forking happens (see https://gitlab.com/gitlab-org/omnibus-gitlab/-/merge_requests/2672/diffs#diff-content-3fc76569158fe132ae9ac89640c05bcc53c4bfa6).  This change will add that support to the nixpkgs version of GitLab through a new option `services.gitlab.rbtrace = true`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
