### PR TITLE
Cleanups for waffle

### DIFF
--- a/pkgs/development/libraries/waffle/default.nix
+++ b/pkgs/development/libraries/waffle/default.nix
@@ -1,7 +1,8 @@
 { stdenv
 , fetchFromGitLab
 , lib
-, cmake
+, meson
+, ninja
 , libGL
 , libglvnd
 , makeWrapper
@@ -9,6 +10,7 @@
 , wayland
 , libxcb
 , libX11
+, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -32,12 +34,16 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cmake
+    meson
+    ninja
     makeWrapper
     pkg-config
+    python3
   ];
 
-  cmakeFlags = [ "-Dplatforms=x11,wayland" ];
+  mesonFlags = [
+    "-Dgbm=disabled"
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/wflinfo \


### PR DESCRIPTION
###### Motivation for this change

There are two changes here:
1) use the newer meson build system. Cmake is semi-deprecated, and will likely be fully deprecated at some point in the future.
2) Fix building on OSes other than Linux. Waffle is designed to be useful on non-linux OSes including windows and macOS, but the current functionality prevents that by requiring x11 and wayland. Making these changes additionally allows the use of gbm, surfaceless_egl, and x11_egl support. gbm is particularly useful as it's the most popular way to run piglit. 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
