### PR TITLE
darwin.darling.src: fix build on case-sensitive filesystems

### DIFF
--- a/pkgs/os-specific/darwin/darling/default.nix
+++ b/pkgs/os-specific/darwin/darling/default.nix
@@ -8,11 +8,22 @@ stdenv.mkDerivation rec {
     url = "https://github.com/darlinghq/darling/archive/d2cc5fa748003aaa70ad4180fff0a9a85dc65e9b.tar.gz";
     sha256 = "11b51fw47nl505h63bgx5kqiyhf3glhp1q6jkpb6nqfislnzzkrf";
     postFetch = ''
-      # Get rid of case conflict
-      mkdir $out
+      # The archive contains both `src/opendirectory` and `src/OpenDirectory`,
+      # pre-create the directory to choose the canonical case on
+      # case-insensitive filesystems.
+      mkdir -p $out/src/OpenDirectory
+
       cd $out
       tar -xzf $downloadedFile --strip-components=1
       rm -r $out/src/libm
+
+      # If `src/opendirectory` and `src/OpenDirectory` refer to different
+      # things, then combine them into `src/OpenDirectory` to match the result
+      # on case-insensitive filesystems.
+      if [ "$(stat -c %i src/opendirectory)" != "$(stat -c %i src/OpenDirectory)" ]; then
+        mv src/opendirectory/* src/OpenDirectory/
+        rmdir src/opendirectory
+      fi
     '';
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix #91480 as discussed in https://github.com/NixOS/nixpkgs/pull/101799#issuecomment-730722554

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
