### PR TITLE
[20.09] docs: add -L to remaining curl install commands

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.
     - If you installed Nix using the install script (https://nixos.org/nix/install),
       it is safe to upgrade by running it again:
 
-          curl https://nixos.org/nix/install | sh
+          curl -L https://nixos.org/nix/install | sh
 
     For more information, please see the NixOS release notes at
     https://nixos.org/nixos/manual or locally at

--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -47,7 +47,7 @@
     Short version:
    </para>
 <screen>
-<prompt>$ </prompt>curl https://nixos.org/nix/install | sh
+<prompt>$ </prompt>curl -L https://nixos.org/nix/install | sh
 <prompt>$ </prompt>. $HOME/.nix-profile/etc/profile.d/nix.sh # …or open a fresh shell</screen>
    <para>
     More details in the

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -173,7 +173,7 @@
      <listitem>
       <para>
        For users of a daemon-less Nix installation on Linux or macOS, you can
-       upgrade Nix by running <command>curl https://nixos.org/nix/install |
+       upgrade Nix by running <command>curl -L https://nixos.org/nix/install |
        sh</command>, or prior to doing a channel update, running
        <command>nix-env -iA nix</command>.
       </para>


### PR DESCRIPTION

###### Motivation for this change
(cherry picked from commit 6ed65d9b5f5f40af285edb73577d2ec690d40237)

so that people looking at the stable version of the manual can install it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
