### PR TITLE
beam-modules: add fetch-mix-deps

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -33,6 +33,7 @@ let
         buildRebar3 = callPackage ./build-rebar3.nix {};
         buildHex = callPackage ./build-hex.nix {};
         buildErlangMk = callPackage ./build-erlang-mk.nix {};
+        fetchMixDeps = callPackage ./fetch-mix-deps.nix { };
         buildMix = callPackage ./build-mix.nix {};
 
         # BEAM-based languages.

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -1,0 +1,41 @@
+{ stdenvNoCC, elixir, hex, rebar, rebar3, cacert }:
+
+{ name, version, sha256, src, mixEnv ? "prod", debug ? false, meta ? { } }:
+
+with stdenvNoCC.lib;
+
+stdenvNoCC.mkDerivation ({
+  name = "mix-deps-${name}-${version}";
+
+  phases = [ "configurePhase" "downloadPhase" ];
+
+  nativeBuildInputs = [ elixir hex cacert ];
+
+  inherit src;
+
+  MIX_ENV = mixEnv;
+  MIX_REBAR = "${rebar}/bin/rebar";
+  MIX_REBAR3 = "${rebar3}/bin/rebar3";
+  MIX_DEBUG = if debug then 1 else 0;
+
+  configurePhase = ''
+    mkdir -p $out/deps
+    mkdir -p $out/.hex
+    export HEX_HOME="$out/.hex";
+    export MIX_HOME="$TEMPDIR/.mix";
+    export MIX_DEPS_PATH="$out/deps";
+  '';
+
+  downloadPhase = ''
+    ln -s ${src}/mix.exs ./mix.exs
+    ln -s ${src}/mix.lock ./mix.lock
+    mix deps.get --only ${mixEnv}
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = sha256;
+
+  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  inherit meta;
+})

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -1,13 +1,9 @@
-{ stdenvNoCC, elixir, hex, rebar, rebar3, cacert, git }:
+{ stdenvNoCC, lib, elixir, hex, rebar, rebar3, cacert, git }:
 
 { name, version, sha256, src, mixEnv ? "prod", debug ? false, meta ? { } }:
 
-with stdenvNoCC.lib;
-
 stdenvNoCC.mkDerivation ({
   name = "mix-deps-${name}-${version}";
-
-  phases = [ "configurePhase" "downloadPhase" ];
 
   nativeBuildInputs = [ elixir hex cacert git ];
 
@@ -29,9 +25,9 @@ stdenvNoCC.mkDerivation ({
     export REBAR_CACHE_DIR="$TMPDIR/rebar3.cache"
   '';
 
-  downloadPhase = ''
-    ln -s ${src}/mix.exs ./mix.exs
-    ln -s ${src}/mix.lock ./mix.lock
+  dontBuild = true;
+
+  installPhase = ''
     mix deps.get --only ${mixEnv}
   '';
 
@@ -39,6 +35,6 @@ stdenvNoCC.mkDerivation ({
   outputHashMode = "recursive";
   outputHash = sha256;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
   inherit meta;
 })

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation ({
   configurePhase = ''
     mkdir -p $out/deps
     mkdir -p $out/.hex
-    export HEX_HOME="$out/.hex";
+    export HEX_HOME="$TEMPDIR/.hex";
     export MIX_HOME="$TEMPDIR/.mix";
     export MIX_DEPS_PATH="$out/deps";
   '';

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -14,16 +14,19 @@ stdenvNoCC.mkDerivation ({
   inherit src;
 
   MIX_ENV = mixEnv;
-  MIX_REBAR = "${rebar}/bin/rebar";
-  MIX_REBAR3 = "${rebar3}/bin/rebar3";
   MIX_DEBUG = if debug then 1 else 0;
+  DEBUG = if debug then 1 else 0; # for rebar3
 
   configurePhase = ''
-    mkdir -p $out/deps
-    mkdir -p $out/.hex
     export HEX_HOME="$TEMPDIR/.hex";
     export MIX_HOME="$TEMPDIR/.mix";
-    export MIX_DEPS_PATH="$out/deps";
+    export MIX_DEPS_PATH="$out";
+
+    # Rebar
+    mix local.rebar rebar "${rebar}/bin/rebar"
+    mix local.rebar rebar3 "${rebar3}/bin/rebar3"
+    export REBAR_GLOBAL_CONFIG_DIR="$TMPDIR/rebar3"
+    export REBAR_CACHE_DIR="$TMPDIR/rebar3.cache"
   '';
 
   downloadPhase = ''

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, elixir, hex, rebar, rebar3, cacert }:
+{ stdenvNoCC, elixir, hex, rebar, rebar3, cacert, git }:
 
 { name, version, sha256, src, mixEnv ? "prod", debug ? false, meta ? { } }:
 
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation ({
 
   phases = [ "configurePhase" "downloadPhase" ];
 
-  nativeBuildInputs = [ elixir hex cacert ];
+  nativeBuildInputs = [ elixir hex cacert git ];
 
   inherit src;
 


### PR DESCRIPTION
###### Motivation for this change
First step in making elixir a first class citizen of Nix
For more informations see https://github.com/NixOS/nixpkgs/issues/105002

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

##### Details

This is a first pass at it, would love to have comments

I've based this off of
https://github.com/hauleth/nix-elixir/blob/master/lib/fetch-mix-deps.nix
and 
https://github.com/cw789/elixir_nix_seed/blob/master/default.nix
Both repos are amazing

##### Decisions that could be controversial

- I've kept the .hex folder in the derivations since it contains the tar files downloaded. The idea on that is to enable reuse of those files. Keeping the .hex in TEMPDIR would destroy those files (as I understand it)

##### Questions that remains

- should we include the version of the program in the dependency derivivation name? I've seen it in some places in the nix ecosystem, not really sure of the for and against on this?
- I'm still not completly sure how we can take advantage of caching so that dependencies for a new version, don't need to be re-downloaded if they were part of a previous version.

#### testing
in order to test you can use this
(assuming the folder link to nixpkgs points to the right location on your local environment)
(the nix_demo repo is basically just a new phoenix project)
```
with import ../../nixpkgs { };

let
  packages = beam.packagesWith beam.interpreters.erlang;
  name = "whatever_floats_your_boat";
  mixEnv = "prod";
  mixSha256 = "0000000000000000000000000000000000000000000000000000";
  version = "0.0.1";
  src = builtins.fetchGit {
    url = "ssh://git@github.com/happysalada/nix_demo";
    rev = "5128e8356d5f58eef495da6ffe40240f3e9324c2";
  };
  mixDeps = packages.fetchMixDeps {
    inherit src name mixEnv version;
    sha256 = mixSha256;
  };

in mixDeps
```

##### Helpful links

[mix docs](https://hexdocs.pm/mix/Mix.html)
