### PR TITLE
mcrl2: 201707 -> 202006

### DIFF
--- a/pkgs/applications/science/logic/mcrl2/default.nix
+++ b/pkgs/applications/science/logic/mcrl2/default.nix
@@ -1,19 +1,16 @@
-{stdenv, fetchurl, cmake, libGLU, libGL, qt5, boost }:
+{ stdenv, fetchurl, cmake, libGLU, libGL, qt5, boost }:
 
 stdenv.mkDerivation rec {
-  version = "202006";
   pname = "mcrl2";
+  version = "202006.0";
 
   src = fetchurl {
-    url = "https://www.mcrl2.org/download/release/mcrl2-${version}.0.tar.gz";
+    url = "https://www.mcrl2.org/download/release/mcrl2-${version}.tar.gz";
     sha256 = "167ryrzk1a2j53c2j198jlxa98amcaym070gkcj730619gymv5zl";
   };
 
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];
   buildInputs = [ cmake libGLU libGL qt5.qtbase boost ];
-
-  enableParallelBuilding = true;
-
 
   meta = with stdenv.lib; {
     description = "A toolset for model-checking concurrent systems and protocols";

--- a/pkgs/applications/science/logic/mcrl2/default.nix
+++ b/pkgs/applications/science/logic/mcrl2/default.nix
@@ -1,18 +1,19 @@
-{stdenv, fetchurl, cmake, libGLU, libGL, qt5, boost}:
+{stdenv, fetchurl, cmake, libGLU, libGL, qt5, boost }:
 
 stdenv.mkDerivation rec {
-  version = "201707";
-  build_nr = "1";
+  version = "202006";
   pname = "mcrl2";
 
   src = fetchurl {
-    url = "https://www.mcrl2.org/download/release/mcrl2-${version}.${build_nr}.tar.gz";
-    sha256 = "1c8h94ja7271ph61zrcgnjgblxppld6v22f7f900prjgzbcfy14m";
+    url = "https://www.mcrl2.org/download/release/mcrl2-${version}.0.tar.gz";
+    sha256 = "167ryrzk1a2j53c2j198jlxa98amcaym070gkcj730619gymv5zl";
   };
 
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
   buildInputs = [ cmake libGLU libGL qt5.qtbase boost ];
 
   enableParallelBuilding = true;
+
 
   meta = with stdenv.lib; {
     description = "A toolset for model-checking concurrent systems and protocols";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I noticed this package was [failing on hydra](https://hydra.nixos.org/build/133435077#tabs-summary), so I tried to update it.

It currently builds successfully, but the Qt GUI programs don't launch correctly.

```
$ /nix/store/3i1n3zvx5ibdp9s2f75aq44cklqqg0zw-mcrl2-202006/bin/mcrl2-gui 
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Aborted (core dumped)
```

This is probably a simple fix with some Qt wrapper, but this is not an area of NixOS that I'm familiar with yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
