### PR TITLE
zchunk: 1.1.6-> 1.1.8 & Add darwin support

### DIFF
--- a/pkgs/development/libraries/zchunk/default.nix
+++ b/pkgs/development/libraries/zchunk/default.nix
@@ -1,15 +1,17 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , pkgconfig
 , meson
 , ninja
 , zstd
 , curl
+, argp-standalone
 }:
 
 stdenv.mkDerivation rec {
   pname = "zchunk";
-  version = "1.1.6";
+  version = "1.1.8";
 
   outputs = [ "out" "lib" "dev" ];
 
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "zchunk";
     repo = pname;
     rev = version;
-    sha256 = "1j05f26xppwbkxrm11895blm75i1a6p9q23x7wlkqw198mpnpbbv";
+    sha256 = "0q1jafxh5nqgn2w5ciljkh8h46xma0qia8a5rj9m0pxixcacqj6q";
   };
 
   nativeBuildInputs = [
@@ -29,7 +31,17 @@ stdenv.mkDerivation rec {
   buildInputs = [
     zstd
     curl
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin argp-standalone;
+
+  # Darwin needs a patch for argp-standalone usage and differing endian.h location on macOS
+  # https://github.com/zchunk/zchunk/pull/35
+  patches = [
+  (fetchpatch {
+    name = "darwin-support.patch";
+    url = "https://github.com/zchunk/zchunk/commit/f7db2ac0a95028a7f82ecb89862426bf53a69232.patch";
+    sha256 = "0cm84gyii4ly6nsmagk15g9kbfa13rw395nqk3fdcwm0dpixlkh4";
+  })
+];
 
   meta = with stdenv.lib; {
     description = "File format designed for highly efficient deltas while maintaining good compression";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Zchunk previously did not compile on macOS, so it had to be disabled in librepo for macOS (#107104). 
With this change, Zchunk will compile on macOS and we will be able to enable Zchunk for librepo.

###### Things done
-Updated version and hash from 1.1.6 to 1.1.8
-Added a patch to use the macOS location of endian if compiling on macOS
-Added argp-standalone as a build input for macOS
-Added a patch to find the arg library if compiling on macOS

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS **via nix-review bc I didn't know how to do it any other way**
   - [X] macOS **On macOS Catalina and Big Sur via nix-build & nix-review. https://pastebin.com/tjxtikkn**
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) **Did not find any related tests**
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` **Ran nixpkgs-review pr successfully but I didn't use that exact command**
- [X] Tested execution of all binary files (usually in `./result/bin/`) **https://pastebin.com/RDQwfGFV**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date **No documentation**
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). **Squashed to a single commit following commit message format**
