### PR TITLE
ocamlPackages.cppo: 1.6.{5,6} → 1.6.7

### DIFF
--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -1,56 +1,65 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, dune }:
+{ stdenv, fetchurl, fetchFromGitHub, ocaml, findlib, ocamlbuild
+, buildDunePackage
+}:
+
 let
   pname = "cppo";
-  webpage = "https://github.com/ocaml-community/${pname}";
-in
-assert stdenv.lib.versionAtLeast ocaml.version "3.12";
-
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then
-   (if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
-    version = "1.6.6";
-    sha256 = "1smcc0l6fh2n0y6bp96c69j5nw755jja99w0b206wx3yb2m4w2hs";
-   } else {
-    version = "1.6.5";
-    sha256 = "03c0amszy28shinvz61hm340jz446zz5763a1pdqlza36kwcj0p0";
-   }) // {
-    buildInputs = [ dune ];
-    extra = {
-      inherit (dune) installPhase;
-    };
-  } else {
-    version = "1.5.0";
-    sha256 = "1xqldjz9risndnabvadw41fdbi5sa2hl4fnqls7j9xfbby1izbg8";
-    extra = {
-      createFindlibDestdir = true;
-      makeFlags = [ "PREFIX=$(out)" ];
-      preBuild = ''
-        mkdir $out/bin
-      '';
-    };
-  }
-; in
-
-stdenv.mkDerivation ({
-
-  name = "${pname}-${param.version}";
-
-  src = fetchFromGitHub {
-    owner = "mjambon";
-    repo = pname;
-    rev = "v${param.version}";
-    inherit (param) sha256;
-  };
-
-  buildInputs = [ ocaml findlib ocamlbuild ] ++ (param.buildInputs or []);
 
   meta = with stdenv.lib; {
     description = "The C preprocessor for OCaml";
     longDescription = ''
       Cppo is an equivalent of the C preprocessor targeted at the OCaml language and its variants.
     '';
-    homepage = webpage;
+    homepage = "https://github.com/ocaml-community/${pname}";
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;
   };
-} // param.extra)
+
+in
+
+if stdenv.lib.versionAtLeast ocaml.version "4.02" then
+
+buildDunePackage rec {
+  inherit pname;
+  version = "1.6.7";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-community/cppo/releases/download/v${version}/cppo-v${version}.tbz";
+    sha256 = "17ajdzrnmnyfig3s6hinb56mcmhywbssxhsq32dz0v90dhz3wmfv";
+  };
+
+  doCheck = true;
+
+  inherit meta;
+}
+
+else
+
+let version = "1.5.0"; in
+
+stdenv.mkDerivation {
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "mjambon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xqldjz9risndnabvadw41fdbi5sa2hl4fnqls7j9xfbby1izbg8";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+
+  inherit meta;
+
+  createFindlibDestdir = true;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preBuild = ''
+    mkdir $out/bin
+  '';
+
+}

--- a/pkgs/development/tools/ocaml/cppo/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/cppo/ocamlbuild.nix
@@ -1,0 +1,17 @@
+{ lib, buildDunePackage, cppo, ocamlbuild }:
+
+if !lib.versionAtLeast (lib.getVersion cppo) "1.6"
+then cppo
+else
+
+buildDunePackage rec {
+  pname = "cppo_ocamlbuild";
+
+  inherit (cppo) version useDune2 src;
+
+  propagatedBuildInputs = [ ocamlbuild ];
+
+  meta = cppo.meta // {
+    description = "Plugin to use cppo with ocamlbuild";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -159,6 +159,8 @@ let
 
     cppo = callPackage ../development/tools/ocaml/cppo { };
 
+    cppo_ocamlbuild = callPackage ../development/tools/ocaml/cppo/ocamlbuild.nix { };
+
     cpu = callPackage ../development/ocaml-modules/cpu { };
 
     cpuid = callPackage ../development/ocaml-modules/cpuid { };


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2
Support for OCaml 4.02 and 4.12.0~α: https://github.com/ocaml-community/cppo/releases/tag/v1.6.7

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
