### PR TITLE
remarkable-linux-client: init at unstable-2017-10-27

### DIFF
--- a/pkgs/applications/office/remarkable-linux-client/default.nix
+++ b/pkgs/applications/office/remarkable-linux-client/default.nix
@@ -1,0 +1,39 @@
+{ mkDerivation, stdenv, fetchurl, glibc, qtbase, qtdeclarative,
+  qtsvg, qtwebsockets, qtquickcontrols, qtquickcontrols2,
+  qtgraphicaleffects, libsForQt512, libGLU, libGL }:
+
+mkDerivation rec {
+  pname = "reMarkable-linux-client";
+  version = "unstable-2017-10-27";
+
+  src = fetchurl {
+    url = "https://remarkable.engineering/remarkable-linux-client-0.0.5-16-1408-g7eca2b66.tgz";
+    sha256 = "1305scjyi4b1wh4vr8ccszz11dvgwyka9hivyzv5j8ynqsnij58s";
+  };
+
+  buildInputs = [ stdenv.cc.cc.lib libGLU libGL libsForQt512.karchive
+                  qtbase qtdeclarative qtsvg qtbase qtwebsockets
+                  qtquickcontrols qtquickcontrols2 qtgraphicaleffects ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib}
+    cp reMarkable $out/bin
+    cp libpdfium.so.1 $out/lib
+
+    patchelf --set-interpreter \
+      "${glibc}/lib/ld-linux-x86-64.so.2" \
+      "$out/bin/reMarkable"
+
+    patchelf \
+      --set-rpath \
+      "$out/lib:${libsForQt512.karchive}/lib:${qtdeclarative}/lib:${qtsvg}/lib:${qtbase.out}/lib:${qtwebsockets}/lib:${libGLU}/lib:${stdenv.cc.cc.lib}/lib:${libGL}/lib" \
+      "$out/bin/reMarkable"
+  '';
+  meta = with stdenv.lib; {
+    description = "Linux client for interacting with reMarkable cloud";
+    homepage = "https://remarkable.engineering";
+    license = licenses.unfree; # no source or license in tarball
+    maintainers = with maintainers; [ siraben ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6977,6 +6977,8 @@ in
 
   reftools = callPackage ../development/tools/reftools { };
 
+  remarkable-linux-client = qt5.callPackage ../applications/office/remarkable-linux-client { };
+
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };
 
   reptyr = callPackage ../os-specific/linux/reptyr {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
