### PR TITLE
python3Packages.dulwich: 0.20.14 -> 0.20.15

### DIFF
--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-CLK1gJj/YX0RVAVsefinC+7Rj3z6cQvKI6ByGWkQ1bQ=";
+    sha256 = "1d6m21lijwm04g50nwgsgj7x3vhblzw7jv05ah8psqgzk20bbch8";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -39,8 +39,14 @@ buildPythonPackage rec {
   # No tests in archive
   doCheck = false;
 
-  meta = {
-    description = "A simple, correct PEP517 package builder";
-    license = lib.licenses.mit;
+  meta = with lib; {
+    description = "Simple, correct PEP517 package builder";
+    longDescription = ''
+      build will invoke the PEP 517 hooks to build a distribution package. It
+      is a simple build tool and does not perform any dependency management.
+    '';
+    homepage = "https://github.com/pypa/build";
+    maintainers = with maintainers; [ fab ];
+    license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://www.dulwich.io/";
     changelog = "https://github.com/dulwich/dulwich/blob/dulwich-${version}/NEWS";
-    license = licenses.gpl2Plus;
+    license = with licenses; [ asl20 gpl2Plus];
     maintainers = with maintainers; [ koral ];
   };
 }

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -4,12 +4,12 @@
 , git, glibcLocales }:
 
 buildPythonPackage rec {
-  version = "0.20.14";
+  version = "0.20.15";
   pname = "dulwich";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "21d6ee82708f7c67ce3fdcaf1f1407e524f7f4f7411a410a972faa2176baec0d";
+    sha256 = "1248942fr12av2rkzpm2fq0qn6rajvv2lcgq65h8kby27qvp65zv";
   };
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/development/python-modules/dulwich/default.nix
+++ b/pkgs/development/python-modules/dulwich/default.nix
@@ -23,7 +23,12 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Simple Python implementation of the Git file formats and protocols";
-    homepage = "https://samba.org/~jelmer/dulwich/";
+    longDescription = ''
+      Dulwich is a Python implementation of the Git file formats and protocols, which
+      does not depend on Git itself. All functionality is available in pure Python.
+    '';
+    homepage = "https://www.dulwich.io/";
+    changelog = "https://github.com/dulwich/dulwich/blob/dulwich-${version}/NEWS";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ koral ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.20.15

Additionally:

- Update the `homepage` entry to metadata
- Add `changelog` entry to metadata
- Clarify the licensing (see https://www.dulwich.io/ -> Licensing) or `COPYING`:
  ```text
  Dulwich may be used under the conditions of either of two licenses,
  the Apache License (version 2.0 or later) or the GNU General Public License,
  version 2.0 or later.
  ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
