### PR TITLE
python38: 3.8.6 -> 3.8.7, python39: 3.9.0 -> 3.9.1

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.8/no-ldconfig.patch
+++ b/pkgs/development/interpreters/python/cpython/3.8/no-ldconfig.patch
@@ -1,18 +1,9 @@
-From 597e73f2a4b2f0b508127931b36d5540d6941823 Mon Sep 17 00:00:00 2001
-From: Frederik Rietdijk <fridh@fridh.nl>
-Date: Mon, 28 Aug 2017 09:24:06 +0200
-Subject: [PATCH] Don't use ldconfig
-
----
- Lib/ctypes/util.py | 70 ++----------------------------------------------------
- 1 file changed, 2 insertions(+), 68 deletions(-)
-
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 5e8b31a854..7b45ce6c15 100644
+index 0c2510e161..79635a8e97 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
-@@ -94,46 +94,7 @@ elif os.name == "posix":
-     import re, tempfile
+@@ -100,54 +100,7 @@ elif os.name == "posix":
+             return thefile.read(4) == elf_header
  
      def _findLib_gcc(name):
 -        # Run GCC's linker with the -t (aka --trace) option and examine the
@@ -51,15 +42,23 @@ index 5e8b31a854..7b45ce6c15 100644
 -                # Raised if the file was already removed, which is the normal
 -                # behaviour of GCC if linking fails
 -                pass
--        res = re.search(expr, trace)
+-        res = re.findall(expr, trace)
 -        if not res:
 -            return None
--        return os.fsdecode(res.group(0))
+-
+-        for file in res:
+-            # Check if the given file is an elf file: gcc can report
+-            # some files that are linker scripts and not actual
+-            # shared objects. See bpo-41976 for more details
+-            if not _is_elf(file):
+-                continue
+-            return os.fsdecode(file)
+-
 +        return None
  
- 
      if sys.platform == "sunos5":
-@@ -255,34 +216,7 @@ elif os.name == "posix":
+         # use /usr/ccs/bin/dump on solaris
+@@ -268,34 +221,7 @@ elif os.name == "posix":
      else:
  
          def _findSoname_ldconfig(name):
@@ -95,6 +94,3 @@ index 5e8b31a854..7b45ce6c15 100644
  
          def _findLib_ld(name):
              # See issue #9998 for why this is needed
--- 
-2.15.0
-

--- a/pkgs/development/interpreters/python/cpython/3.9/no-ldconfig.patch
+++ b/pkgs/development/interpreters/python/cpython/3.9/no-ldconfig.patch
@@ -1,18 +1,9 @@
-From 597e73f2a4b2f0b508127931b36d5540d6941823 Mon Sep 17 00:00:00 2001
-From: Frederik Rietdijk <fridh@fridh.nl>
-Date: Mon, 28 Aug 2017 09:24:06 +0200
-Subject: [PATCH] Don't use ldconfig
-
----
- Lib/ctypes/util.py | 70 ++----------------------------------------------------
- 1 file changed, 2 insertions(+), 68 deletions(-)
-
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 5e8b31a854..7b45ce6c15 100644
+index 0c2510e161..79635a8e97 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
-@@ -94,46 +94,7 @@ elif os.name == "posix":
-     import re, tempfile
+@@ -100,54 +100,7 @@ elif os.name == "posix":
+             return thefile.read(4) == elf_header
  
      def _findLib_gcc(name):
 -        # Run GCC's linker with the -t (aka --trace) option and examine the
@@ -51,15 +42,23 @@ index 5e8b31a854..7b45ce6c15 100644
 -                # Raised if the file was already removed, which is the normal
 -                # behaviour of GCC if linking fails
 -                pass
--        res = re.search(expr, trace)
+-        res = re.findall(expr, trace)
 -        if not res:
 -            return None
--        return os.fsdecode(res.group(0))
+-
+-        for file in res:
+-            # Check if the given file is an elf file: gcc can report
+-            # some files that are linker scripts and not actual
+-            # shared objects. See bpo-41976 for more details
+-            if not _is_elf(file):
+-                continue
+-            return os.fsdecode(file)
+-
 +        return None
  
- 
      if sys.platform == "sunos5":
-@@ -255,34 +216,7 @@ elif os.name == "posix":
+         # use /usr/ccs/bin/dump on solaris
+@@ -268,34 +221,7 @@ elif os.name == "posix":
      else:
  
          def _findSoname_ldconfig(name):
@@ -95,6 +94,3 @@ index 5e8b31a854..7b45ce6c15 100644
  
          def _findLib_ld(name):
              # See issue #9998 for why this is needed
--- 
-2.15.0
-

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -154,10 +154,10 @@ in {
     sourceVersion = {
       major = "3";
       minor = "8";
-      patch = "6";
+      patch = "7";
       suffix = "";
     };
-    sha256 = "qeC3nSeqBW65zOjWOkJ7X5urFGXe4/lC3P2yWoL0q4o=";
+    sha256 = "sha256-3cwd8Wu1uHqkLsXSCluQLy0IjKommyjgFZD5enmOxQo=";
     inherit (darwin) configd;
     inherit passthruFun;
   };
@@ -167,10 +167,10 @@ in {
     sourceVersion = {
       major = "3";
       minor = "9";
-      patch = "0";
+      patch = "1";
       suffix = "";
     };
-    sha256 = "0m18z05nlmqm1zjw9s0ifgrn1jvjn3jwjg0bpswhjmw5k4yfcwww";
+    sha256 = "1zq3k4ymify5ig739zyvx9s2ainvchxb1zpy139z74krr653y74r";
     inherit (darwin) configd;
     inherit passthruFun;
   };


### PR DESCRIPTION
This fixes #105038.

###### Motivation for this change

The versions of Python 3.8 and 3.9 in trunk are broken on macOS Big Sur. Upstream fixes have been published in 3.8.7 and 3.9.1.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
