### PR TITLE
credhub-cli: init at 2.9.0

### DIFF
--- a/pkgs/tools/admin/credhub-cli/default.nix
+++ b/pkgs/tools/admin/credhub-cli/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "credhub-cli";
+  version = "2.9.0";
+
+  src = fetchFromGitHub {
+    owner = "cloudfoundry-incubator";
+    repo = "credhub-cli";
+    rev = version;
+    sha256 = "1j0i0b79ph2i52cj0qln8wvp6gwhl73akkn026h27vvmlw9sndc2";
+  };
+
+  # these tests require network access that we're not going to give them
+  postPatch = ''
+    rm commands/api_test.go
+    rm commands/socks5_test.go
+  '';
+  __darwinAllowLocalNetworking = true;
+
+  vendorSha256 = null;
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-s"
+    "-w"
+    "-X code.cloudfoundry.org/credhub-cli/version.Version=${version}"
+  ];
+
+  postInstall = ''
+    ln -s $out/bin/credhub-cli $out/bin/credhub
+  '';
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Provides a command line interface to interact with CredHub servers";
+    homepage = "https://github.com/cloudfoundry-incubator/credhub-cli";
+    maintainers = with maintainers; [ ris ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1880,6 +1880,10 @@ in
 
   cppclean = callPackage ../development/tools/cppclean {};
 
+  credhub-cli = callPackage ../tools/admin/credhub-cli {
+    buildGoModule = buildGo114Module;
+  };
+
   crex = callPackage ../tools/misc/crex { };
 
   cri-tools = callPackage ../tools/virtualization/cri-tools {};


### PR DESCRIPTION
###### Motivation for this change
Add `credhub-cli`, with most tests enabled. Some tests don't compile with go 1.15 right now, so forcing 1.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
