### PR TITLE
umockdev: 0.13.1 -> 0.15.2

### DIFF
--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -1,33 +1,34 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig
-, gobject-introspection, glib, systemd, libgudev, vala
-, usbutils, which, python3 }:
+{ stdenv
+, docbook_xsl
+, fetchurl
+, glib
+, gobject-introspection
+, gtk-doc
+, libgudev
+, meson
+, ninja
+, pkg-config
+, python3
+, systemd
+, usbutils
+, vala
+, which
+}:
 
 stdenv.mkDerivation rec {
   pname = "umockdev";
-  version = "0.13.1";
+  version = "0.15.2";
 
   outputs = [ "bin" "out" "dev" "doc" ];
 
   src = fetchurl {
     url = "https://github.com/martinpitt/umockdev/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "197a169imiirgm73d9fn9234cx56agyw9d2f47h7f1d8s2d51lla";
+    sha256 = "19f21qb9ckwvlm7yzpnc0vcp092qbkms2yrafc26b9a63v4imj52";
   };
 
-  patches = [
-    ./fix-test-paths.patch
-    # https://github.com/NixOS/nixpkgs/commit/9960a2be9b32a6d868046c5bfa188b9a0dd66682#commitcomment-34734461
-    ./disable-failed-test.patch
-    # https://github.com/martinpitt/umockdev/pull/93
-    (fetchpatch {
-      url = "https://github.com/abbradar/umockdev/commit/ce22f893bf50de0b32760238a3e2cfb194db89e9.patch";
-      sha256 = "01q3qhs30x8hl23iigimsa2ikbiw8y8y0bpmh02mh1my87shpwnx";
-    })
+  mesonFlags = [
+    "-Dgtk_doc=true"
   ];
-
-  # autoreconfHook complains if we try to build the documentation
-  postPatch = ''
-    echo 'EXTRA_DIST =' > docs/gtk-doc.make
-  '';
 
   preCheck = ''
     patchShebangs tests/test-static-code
@@ -35,19 +36,34 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib systemd libgudev ];
 
-  nativeBuildInputs = [ pkgconfig vala gobject-introspection ];
+  nativeBuildInputs = [
+    docbook_xsl
+    gobject-introspection
+    gtk-doc
+    meson
+    ninja
+    pkg-config
+    vala
+  ];
 
   checkInputs = [ python3 which usbutils ];
 
   enableParallelBuilding = true;
 
   # Test fail with libusb 1.0.24
+  # https://github.com/NixOS/nixpkgs/issues/107420
+  # https://github.com/martinpitt/umockdev/issues/115
   doCheck = false;
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/umockdev/
+    mv docs/reference $doc/share/doc/umockdev/
+  '';
 
   meta = with stdenv.lib; {
     description = "Mock hardware devices for creating unit tests";
     license = licenses.lgpl2;
-    maintainers = with maintainers; [];
+    maintainers = with maintainers; [ flokli ];
     platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
This updates umockdev to the latest stable release.

Upstream switched to meson and gtk-doc in the meantime.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
