### PR TITLE
wf-recorder-x: init at 20190712

### DIFF
--- a/pkgs/applications/video/wf-recorder-x/default.nix
+++ b/pkgs/applications/video/wf-recorder-x/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkg-config, wayland, scdoc
+, wayland-protocols, ffmpeg, x264, libpulseaudio, ocl-icd, opencl-headers
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wf-recorder-x";
+  version = "20190712";
+
+  src = fetchFromGitHub {
+    owner = "schauveau";
+    repo = pname;
+    rev = "242fe219cc91ccc4aa54f886592b19be26c84856";
+    sha256 = "0ih2ix56fc3wqwilfcb88dvnny6kc9q4df7zbfd6brw7lcyjlamn";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland scdoc ];
+  buildInputs = [
+    wayland-protocols ffmpeg x264 libpulseaudio ocl-icd opencl-headers
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An experimental fork of wf-recorder with FFMpeg filters (libavfilter)";
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ fadenb ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8180,6 +8180,8 @@ in
 
   wf-recorder = callPackage ../applications/video/wf-recorder { };
 
+  wf-recorder-x = callPackage ../applications/video/wf-recorder-x { };
+
   whipper = callPackage ../applications/audio/whipper { };
 
   whois = callPackage ../tools/networking/whois { };


### PR DESCRIPTION
###### Motivation for this change
wf-recorder-x is an experimental fork of wf-recorder with libavfilters. With it one can build more complex recording pipelines.

Both authors of the original wf-recorder and wf-recorder-x stated that the projects will not merge any time soon. Basically by now it is a completely separate application which is why I did not attempted to integrate it in the existing wf-recorder package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
