### PR TITLE
Kicad: 5.1.8 -> 5.1.9

### DIFF
--- a/pkgs/applications/science/electronics/kicad/update.sh
+++ b/pkgs/applications/science/electronics/kicad/update.sh
@@ -144,7 +144,7 @@ for version in "${all_versions[@]}"; do
           for lib in "${libs[@]}"; do
             echo "Checking ${lib}" >&2
             url="${gitlab}/libraries/kicad-${lib}.git"
-            lib_rev="$(${get_rev} "${url}" "${version}" | cut -f1 | head -n1)"
+            lib_rev="$(${get_rev} "${url}" "${version}" | cut -f1 | tail -n1)"
             has_rev="$(grep -sm 1 "\"${pname}\"" -A 19 "${file}" | grep -sm 1 "${lib_rev}" || true)"
             has_hash="$(grep -sm 1 "\"${pname}\"" -A 20 "${file}" | grep -sm 1 "${lib}.sha256" || true)"
             if [[ -n ${has_rev} && -n ${has_hash} && -z ${clean} ]]; then
@@ -173,8 +173,8 @@ printf "}\n"
 } > "${tmp}"
 
 if grep '""' "${tmp}"; then
-	echo "empty value detected, out of space?" >&2
-	exit "1"
+  echo "empty value detected, out of space?" >&2
+  exit "1"
 fi
 
 mv "${tmp}" "${file}"

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,19 +3,19 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"5.1.8";
+      version =			"5.1.9";
       src = {
-        rev =			"db9833491010954bc27fac92c83d2864bd95c23c";
-        sha256 =		"08ni9j2lw2hjc1csk6rkydcxwdal6da17ch60zkjij5vfsif2hix";
+        rev =			"73d0e3b20dec05c4350efa5b69916eb29a7bfcb5";
+        sha256 =		"1cqh3bc9y140hbryfk9qavs2y3lj5sm9q0qjxcf4mm472afzckky";
       };
     };
     libVersion = {
-      version =			"5.1.8";
+      version =			"5.1.9";
       libSources = {
-        i18n.rev =		"78adcd19e7ed53f4889d6db65a33dd8ec2d323e9";
-        i18n.sha256 =		"0x0w2m6d3xfm22y4anp5j2j67iwzby149ynj6qjlw2kcsi8kwk1j";
-        symbols.rev =		"bf475af94877e8fd9cf80e667578ff61835e02bb";
-        symbols.sha256 =	"1ii3r813653ng2ycggnknqx4g3ja7dbm4qyxrf9aq48ws0xkvhx3";
+        i18n.rev =		"04f3231f60d55400cb81564b2cd465a57d5192d5";
+        i18n.sha256 =		"04jq1dcag6i2ljjfqrib65mn4wg4c4nmi7i946l3bywc0rkqsx1f";
+        symbols.rev =		"6dec5004b6a2679c19d4857bda2f90c5ab3a5726";
+        symbols.sha256 =	"0n25rq32jwyigfw26faqraillwv6zbi2ywy26dkz5zqlf5xp56ad";
         templates.rev =		"1ccbaf3704e8ff4030d0915f71e051af621ef7d7";
         templates.sha256 =	"1a8xfcbdbb4ylrb5m7n2jjk9kwvgmlx1pmnn2cwj327a2b3m4jjs";
         footprints.rev =	"302ac78bac21825532f970fb92714fa5973ad79b";

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -27,25 +27,25 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2020-12-01";
+      version =			"2020-12-23";
       src = {
-        rev =			"3c521942ed52e83482c82d426170b4fbf327f846";
-        sha256 =		"sha256:09qab69sy3n44kjlzxxx7gbksyr1kg8n14kz0zf8n71zfcqagci4";
+        rev =			"912657dd238ad78cfc5d9d5e426ea850d5554fb3";
+        sha256 =		"1p5kr4d4zpajwdmya1f351y1ix8qmvsx1hrnvhzh7yc3g72kgxah";
       };
     };
     libVersion = {
-      version =			"2020-12-01";
+      version =			"2020-12-23";
       libSources = {
         i18n.rev =		"e89d9a89bec59199c1ade56ee2556591412ab7b0";
-        i18n.sha256 =		"sha256:04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
+        i18n.sha256 =		"04zaqyhj3qr4ymyd3k5vjpcna64j8klpsygcgjcv29s3rdi8glfl";
         symbols.rev =		"e538abb015b4f289910a6f26b2f1b9cb8bf2efdb";
-        symbols.sha256 =	"sha256:117y4cm46anlrnw6y6mdjgl1a5gab6h6m7cwx3q7qb284m9bs5gi";
+        symbols.sha256 =	"117y4cm46anlrnw6y6mdjgl1a5gab6h6m7cwx3q7qb284m9bs5gi";
         templates.rev =		"32a4f6fab863976fdcfa232e3e08fdcf3323a954";
-        templates.sha256 =	"sha256:13r94dghrh9slpj7nkzv0zqv5hk49s6pxm4q5ndqx0y8037ivmhk";
+        templates.sha256 =	"13r94dghrh9slpj7nkzv0zqv5hk49s6pxm4q5ndqx0y8037ivmhk";
         footprints.rev =	"15ffd67e01257d4d8134dbd6708cb58977eeccbe";
-        footprints.sha256 =	"sha256:1ad5k3wh2zqfibrar7pd3g363jk2q51dvraxnq3zlxa2x4znh7mw";
+        footprints.sha256 =	"1ad5k3wh2zqfibrar7pd3g363jk2q51dvraxnq3zlxa2x4znh7mw";
         packages3d.rev =	"d8b7e8c56d535f4d7e46373bf24c754a8403da1f";
-        packages3d.sha256 =	"sha256:0dh8ixg0w43wzj5h3164dz6l1vl4llwxhi3qcdgj1lgvrs28aywd";
+        packages3d.sha256 =	"0dh8ixg0w43wzj5h3164dz6l1vl4llwxhi3qcdgj1lgvrs28aywd";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change
new stable version tagged

###### Things done
fixed update.sh to handle multiple responses from `git ls-remote --heads --tags` (taking the last rather than the first response)
run update.sh to update stable and unstable

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 - `8 packages updated:
kicad-with-packages3d (5.1.8 → 5.1.9) kicad (5.1.8 → 5.1.9) python39Packages.kicad (5.1.8 → 5.1.9) python38Packages.kicad (5.1.8 → 5.1.9) python37Packages.kicad (5.1.8 → 5.1.9) kicad-small (5.1.8 → 5.1.9) kicad-unstable (2020-12-01 → 2020-12-23) kicad-unstable-small (2020-12-01 → 2020-12-23)`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - stable: `6347308864 -> 6764336248`
  - unstable: `6925383008 -> 6926087408`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
