### PR TITLE
kinit: increase environment limit

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kinit/0004-start_kdeinit-environ-hard-limit.patch
+++ b/pkgs/development/libraries/kde-frameworks/kinit/0004-start_kdeinit-environ-hard-limit.patch
@@ -17,7 +17,7 @@ index f2db3e9..4ff2602 100644
                      if (read(0, &len, sizeof(unsigned)) == sizeof(unsigned)
 -                            && len && len < (1 << 12)) {
 +                            && len) {
-+                        if (len >= (1 << 14)) {
++                        if (len >= (1 << 20)) {
 +                            fprintf(stderr, "%s: exceeded environment length limit", argv[0]);
 +                            return 1;
 +                        }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Limit is already increased for standard xorg plasma distribution to
start, but with wayland, even more libraries being added

Increasing this limit to 1 << 20 (1M) seems to be enough (For me
length is 80K), and not so much for regular desktops

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
