### PR TITLE
kwin: allow using wrapper for qpa

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/0001-follow-symlinks.patch
+++ b/pkgs/desktops/plasma-5/kwin/0001-follow-symlinks.patch
@@ -1,17 +1,17 @@
-From 449896c45b23f50c168d8d2789832024c906ec36 Mon Sep 17 00:00:00 2001
+From af569c9ed8079169b524b31461e2789baa09ef7a Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Mon, 27 Jan 2020 05:31:13 -0600
-Subject: [PATCH 1/2] follow symlinks
+Subject: [PATCH 1/3] follow symlinks
 
 ---
  plugins/kdecorations/aurorae/src/aurorae.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/plugins/kdecorations/aurorae/src/aurorae.cpp b/plugins/kdecorations/aurorae/src/aurorae.cpp
-index fd723a8..fb95633 100644
+index 5242cb7..2e4ddae 100644
 --- a/plugins/kdecorations/aurorae/src/aurorae.cpp
 +++ b/plugins/kdecorations/aurorae/src/aurorae.cpp
-@@ -211,7 +211,7 @@ void Helper::init()
+@@ -201,7 +201,7 @@ void Helper::init()
      // so let's try to locate our plugin:
      QString pluginPath;
      for (const QString &path : m_engine->importPathList()) {
@@ -21,5 +21,5 @@ index fd723a8..fb95633 100644
              it.next();
              QFileInfo fileInfo = it.fileInfo();
 -- 
-2.23.1
+2.29.2
 

--- a/pkgs/desktops/plasma-5/kwin/0002-xwayland.patch
+++ b/pkgs/desktops/plasma-5/kwin/0002-xwayland.patch
@@ -1,17 +1,17 @@
-From d584b075d71c4486710c0bbed6d44038f2ff5075 Mon Sep 17 00:00:00 2001
+From 5c90dd84f541bd4789525f12f12ad24411b99018 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Mon, 27 Jan 2020 05:31:23 -0600
-Subject: [PATCH 2/2] xwayland
+Subject: [PATCH 2/3] xwayland
 
 ---
  xwl/xwayland.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/xwl/xwayland.cpp b/xwl/xwayland.cpp
-index 5f17d39..b4b69ba 100644
+index 57efdde..a211a58 100644
 --- a/xwl/xwayland.cpp
 +++ b/xwl/xwayland.cpp
-@@ -145,7 +145,7 @@ void Xwayland::init()
+@@ -124,7 +124,7 @@ void Xwayland::start()
  
      m_xwaylandProcess = new Process(this);
      m_xwaylandProcess->setProcessChannelMode(QProcess::ForwardedErrorChannel);
@@ -21,5 +21,5 @@ index 5f17d39..b4b69ba 100644
      env.insert("WAYLAND_SOCKET", QByteArray::number(wlfd));
      env.insert("EGL_PLATFORM", QByteArrayLiteral("DRM"));
 -- 
-2.23.1
+2.29.2
 

--- a/pkgs/desktops/plasma-5/kwin/0003-plugins-qpa-allow-using-nixos-wrapper.patch
+++ b/pkgs/desktops/plasma-5/kwin/0003-plugins-qpa-allow-using-nixos-wrapper.patch
@@ -1,0 +1,26 @@
+From 8d49f5ef8692c352a62f4f8b1bc68e6e210bbee6 Mon Sep 17 00:00:00 2001
+From: Yaroslav  Bolyukin <iam@lach.pw>
+Date: Wed, 23 Dec 2020 18:02:14 +0300
+Subject: [PATCH 3/3] plugins/qpa: allow using nixos wrapper
+
+Signed-off-by: Yaroslav  Bolyukin <iam@lach.pw>
+---
+ plugins/qpa/main.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/qpa/main.cpp b/plugins/qpa/main.cpp
+index efd236b..a69c046 100644
+--- a/plugins/qpa/main.cpp
++++ b/plugins/qpa/main.cpp
+@@ -23,7 +23,7 @@ public:
+ QPlatformIntegration *KWinIntegrationPlugin::create(const QString &system, const QStringList &paramList)
+ {
+     Q_UNUSED(paramList)
+-    if (!QCoreApplication::applicationFilePath().endsWith(QLatin1String("kwin_wayland")) && !qEnvironmentVariableIsSet("KWIN_FORCE_OWN_QPA")) {
++    if (!QCoreApplication::applicationFilePath().endsWith(QLatin1String("kwin_wayland")) && !QCoreApplication::applicationFilePath().endsWith(QLatin1String(".kwin_wayland-wrapped")) && !qEnvironmentVariableIsSet("KWIN_FORCE_OWN_QPA")) {
+         // Not KWin
+         return nullptr;
+     }
+-- 
+2.29.2
+

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -37,6 +37,7 @@ mkDerivation {
   patches = [
     ./0001-follow-symlinks.patch
     ./0002-xwayland.patch
+    ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
   ];
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/43757#issuecomment-618710712

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
