### PR TITLE
insync-v3: init at 3.2.4.40856

### DIFF
--- a/pkgs/applications/networking/insync/v3.nix
+++ b/pkgs/applications/networking/insync/v3.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, lib
+, fetchurl
+, makeWrapper
+, dpkg
+, glibc
+, glib
+, libxcb
+, libGL
+, nss
+, libthai
+, wayland
+, alsaLib
+, qtvirtualkeyboard
+, qtwebchannel
+, qtwebsockets
+, qtlocation
+, qtwebengine
+, autoPatchelfHook
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "insync";
+  version = "3.2.4.40856";
+
+  src = fetchurl {
+    url = "http://s.insynchq.com/builds/${pname}_${version}-focal_amd64.deb";
+    sha256 = "1bvqbbrfn5784nmb2qaflm1rzczqhvghhb6y5zaxrapyhygxbcis";
+  };
+
+  postPatch = ''
+    substituteInPlace usr/bin/insync --replace /usr/lib/insync $out/usr/lib/insync
+  '';
+
+  buildInputs = [
+    alsaLib
+    libGL
+    libthai
+    libxcb
+    nss
+    qtlocation
+    qtvirtualkeyboard
+    qtwebchannel
+    qtwebengine
+    qtwebsockets
+    wayland
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper wrapQtAppsHook ];
+
+  unpackPhase = ''
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib $out/share
+    cp -R usr/* $out/
+    rm $out/lib/insync/libGLX.so.0
+    rm $out/lib/insync/libQt5*
+    sed -i 's|/usr/lib/insync|/lib/insync|' "$out/bin/insync"
+    wrapQtApp "$out/lib/insync/insync"
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  meta = with lib; {
+    platforms = ["x86_64-linux"];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ benley ];
+    homepage = "https://www.insynchq.com";
+    description = "Google Drive sync and backup with multiple account support";
+    longDescription = ''
+     Insync is a commercial application that syncs your Drive files to your
+     computer.  It has more advanced features than Google's official client
+     such as multiple account support, Google Doc conversion, symlink support,
+     and built in sharing.
+
+     There is a 15-day free trial, and it is a paid application after that.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24022,6 +24022,8 @@ in
 
   insync = callPackage ../applications/networking/insync { };
 
+  insync-v3 = libsForQt515.callPackage ../applications/networking/insync/v3.nix { };
+
   libstrangle = callPackage ../tools/X11/libstrangle {
     stdenv = stdenv_32bit;
   };


### PR DESCRIPTION
Fixes #104515 

###### Motivation for this change
Insync 3.0 is a full rewrite with a different feature set than the existing v1 derivation in nixpkgs.  Some users need to stick with the old version, particularly those on headless/non-GUI systems.  There is a headless version of v3, but that will need to be packaged separately.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
