### PR TITLE
steamPackages.steam: add udev rules

### DIFF
--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, runtimeShell, traceDeps ? false}:
+{ stdenv, fetchurl, runtimeShell, traceDeps ? false, bash }:
 
 let
   traceLog = "/tmp/steam-trace-dependencies.log";
@@ -26,6 +26,12 @@ in stdenv.mkDerivation {
       EOF
       chmod +x $out/bin/steamdeps
     ''}
+
+    # install udev rules
+    mkdir -p $out/etc/udev/rules.d/
+    cp ./subprojects/steam-devices/*.rules $out/etc/udev/rules.d/
+    substituteInPlace $out/etc/udev/rules.d/60-steam-input.rules \
+      --replace "/bin/sh" "${bash}/bin/bash"
 
     # this just installs a link, "steam.desktop -> /lib/steam/steam.desktop"
     rm $out/share/applications/steam.desktop


### PR DESCRIPTION
###### Motivation for this change
closes #107446

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
