### PR TITLE
webkitgtk: Add `/run/opengl-driver` to bubblewrap bind mounts

### DIFF
--- a/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
+++ b/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
@@ -10,7 +10,7 @@ diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLa
          { SCMP_SYS(move_pages), nullptr },
          { SCMP_SYS(mbind), nullptr },
          { SCMP_SYS(get_mempolicy), nullptr },
-@@ -724,6 +724,10 @@
+@@ -724,6 +724,11 @@
          "--ro-bind-try", "/usr/local/lib64", "/usr/local/lib64",
  
          "--ro-bind-try", PKGLIBEXECDIR, PKGLIBEXECDIR,
@@ -18,6 +18,7 @@ diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLa
 +        // Nix Directories
 +        "--ro-bind", "@storeDir@", "@storeDir@",
 +        "--ro-bind", "/run/current-system", "/run/current-system",
++        "--ro-bind", "/run/opengl-driver", "/run/opengl-driver",
      };
      // We would have to parse ld config files for more info.
      bindPathVar(sandboxArgs, "LD_LIBRARY_PATH");


### PR DESCRIPTION
###### Motivation for this change

Without access to the `/run/opengl-driver` directory, webkit fails to create an EGL context, since it can't identify a suitable EGL
vendor. This results in a blank window and the following error output:

```
Cannot get default EGL display: EGL_BAD_PARAMETER
Cannot create EGL context: invalid display (last error: EGL_SUCCESS)
```

Fixes #98819 and possibly #32580.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
