### PR TITLE
nixos/pipewire: install gstreamer plugins

### DIFF
--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -84,6 +84,10 @@ in {
       pulse = {
         enable = mkEnableOption "PulseAudio server emulation";
       };
+
+      gstreamer = {
+        enable = mkEnableOption "GStreamer plugins";
+      };
     };
   };
 
@@ -103,7 +107,10 @@ in {
 
     services.pipewire.sessionManager = mkDefault "${cfg.package}/bin/pipewire-media-session";
 
+    services.pipewire.gstreamer.enable = mkDefault true;
+
     environment.systemPackages = [ cfg.package ]
+                                 ++ lib.optional cfg.gstreamer.enable cfg.package.gstreamer
                                  ++ lib.optional cfg.jack.enable jack-libs;
 
     systemd.packages = [ cfg.package ]

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation rec {
     "lib"
     "pulse"
     "jack"
+    "gstreamer"
     "dev"
     "doc"
     "installedTests"
@@ -119,6 +120,7 @@ stdenv.mkDerivation rec {
     moveToOutput "share/systemd/user/pipewire-pulse.*" "$pulse"
     moveToOutput "lib/systemd/user/pipewire-pulse.*" "$pulse"
     moveToOutput "bin/pipewire-pulse" "$pulse"
+    moveToOutput "lib/gstreamer-1.0/*" "$gstreamer"
   '';
 
   passthru.tests = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Install gstreamer plugins by default so that they're found by `gst-launch`, etc.  (which will look in `/run/current-system/sw`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
