### PR TITLE
pythonPackages.{backports_unittest-mock,pytest-black,pytest-mypy,setuptools-scm-git-archive}: Disable tests

### DIFF
--- a/pkgs/development/python-modules/backports_unittest-mock/default.nix
+++ b/pkgs/development/python-modules/backports_unittest-mock/default.nix
@@ -13,9 +13,14 @@ buildPythonPackage rec {
 
   buildInputs = [ setuptools_scm ];
 
+  # does not contain tests
+  doCheck = false;
+  pythonImportsCheck = [ "backports.unittest_mock" ];
+
   meta = with stdenv.lib; {
     description = "Provides a function install() which makes the mock module";
     homepage = "https://github.com/jaraco/backports.unittest_mock";
     license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/development/python-modules/pytest-black/default.nix
+++ b/pkgs/development/python-modules/pytest-black/default.nix
@@ -18,6 +18,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ black pytest toml ];
 
+  # does not contain tests
+  doCheck = false;
   pythonImportsCheck = [ "pytest_black" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pytest-mypy/default.nix
+++ b/pkgs/development/python-modules/pytest-mypy/default.nix
@@ -17,7 +17,12 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
+
   propagatedBuildInputs = [ pytest mypy filelock ];
+
+  # does not contain tests
+  doCheck = false;
+  pythonImportsCheck = [ "pytest_mypy" ];
 
   meta = with lib; {
     description = "Mypy static type checker plugin for Pytest";

--- a/pkgs/development/python-modules/setuptools-scm-git-archive/default.nix
+++ b/pkgs/development/python-modules/setuptools-scm-git-archive/default.nix
@@ -14,6 +14,9 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest ];
 
+  doCheck = false;
+  pythonImportsCheck = [ "setuptools_scm_git_archive" ];
+
   meta = with stdenv.lib; {
     description = "setuptools_scm plugin for git archives";
     homepage = "https://github.com/Changaco/setuptools_scm_git_archive";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#105198

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
