### PR TITLE
gdbm: 1.18.1 -> 1.19

### DIFF
--- a/pkgs/development/libraries/gdbm/0001-Remove-duplicate-assignments.patch
+++ b/pkgs/development/libraries/gdbm/0001-Remove-duplicate-assignments.patch
@@ -1,25 +1,0 @@
-From 2c31a95d9e57a4308c5159c50e69b5c9178dee72 Mon Sep 17 00:00:00 2001
-From: Christian Kampka <christian@kampka.net>
-Date: Fri, 13 Nov 2020 16:52:12 +0100
-Subject: [PATCH] Remove duplicate assignments
-
----
- src/parseopt.c | 2 --
- 1 file changed, 2 deletions(-)
-
-diff --git a/src/parseopt.c b/src/parseopt.c
-index 268e080..a4c8576 100644
---- a/src/parseopt.c
-+++ b/src/parseopt.c
-@@ -255,8 +255,6 @@ print_option_descr (const char *descr, size_t lmargin, size_t rmargin)
- }
- 
- char *parseopt_program_name;
--char *parseopt_program_doc;
--char *parseopt_program_args;
- const char *program_bug_address = "<" PACKAGE_BUGREPORT ">";
- void (*parseopt_help_hook) (FILE *stream);
- 
--- 
-2.25.4
-

--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -2,16 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gdbm";
-  version = "1.18.1";
+  version = "1.19";
 
   src = fetchurl {
     url = "mirror://gnu/gdbm/${pname}-${version}.tar.gz";
-    sha256 = "1p4ibds6z3ccy65lkmd6lm7js0kwifvl53r0fd759fjxgr917rl6";
+    sha256 = "sha256-N+0SIUEiuXLhig2UmVA55XdIGRk573QRWx1B2IETZLw=";
   };
 
   doCheck = true; # not cross;
-
-  patches = [ ./0001-Remove-duplicate-assignments.patch ];
 
   # Linking static stubs on cygwin requires correct ordering.
   # Consider upstreaming this.


### PR DESCRIPTION
###### Motivation for this change

Updates gdbm, including the fix that was adressed by the local patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
