### PR TITLE
neochat: init at 1.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/neochat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/neochat/default.nix
@@ -1,0 +1,41 @@
+{ mkDerivation, stdenv, fetchFromGitLab
+, pkgconfig, wrapQtAppsHook
+, cmake
+, qtbase, qttools, qtquickcontrols2, qtmultimedia, qtkeychain
+, libpulseaudio
+# Not mentioned but seems needed
+, qtgraphicaleffects
+, qtdeclarative
+, qtmacextras
+, olm, libsecret, cmark, extra-cmake-modules, kirigami2, ki18n, knotifications, kdbusaddons, kconfig, libquotient
+, KQuickImageEdit, kitemmodels
+}:
+
+let
+qtkeychain-qt5 = qtkeychain.override {
+  inherit qtbase qttools;
+  withQt5 = true;
+};
+
+in mkDerivation rec {
+  pname = "neochat";
+  version = "v1.0";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "network";
+    repo = pname;
+    rev = version;
+    sha256 = "1r9n83kvc5v215lzmzh6hyc5q9i3w6znbf508qk0mdwdzxz4zry9";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake extra-cmake-modules wrapQtAppsHook ];
+  buildInputs = [ qtbase qtkeychain-qt5 qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative olm libsecret cmark kirigami2 ki18n knotifications kdbusaddons kconfig libquotient KQuickImageEdit kitemmodels libpulseaudio ];
+
+  meta = with stdenv.lib; {
+    description = "A client for matrix, the decentralized communication protocol.";
+    homepage = "https://apps.kde.org/en/neochat";
+    license = licenses.gpl3;
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/KQuickImageEdit/default.nix
+++ b/pkgs/development/libraries/KQuickImageEdit/default.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, fetchFromGitLab
+, extra-cmake-modules
+, qtbase
+, qtquickcontrols2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "KQuickImageEditor";
+  version = "0.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "libraries";
+    repo = pname;
+    rev = version;
+    sha256 = "0krx9bq6nfmpjjangis8gaz8rx3z35f6m3cpsrcfdwpgpm22fqll";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [ qtbase qtquickcontrols2 ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15653,6 +15653,8 @@ in
 
     kreport = callPackage ../development/libraries/kreport { };
 
+    KQuickImageEdit = callPackage ../development/libraries/KQuickImageEdit { };
+
     ldutils = callPackage ../development/libraries/ldutils { };
 
     libcommuni = callPackage ../development/libraries/libcommuni { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5933,6 +5933,8 @@ in
 
   neo-cowsay = callPackage ../tools/misc/neo-cowsay { };
 
+  neochat = libsForQt5.callPackage ../applications/networking/instant-messengers/neochat { };
+
   neofetch = callPackage ../tools/misc/neofetch { };
 
   nerdfonts = callPackage ../data/fonts/nerdfonts { };


### PR DESCRIPTION
###### Motivation for this change
Neochat is a fork/continuation of spectral and an official KDE project.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
