### PR TITLE
erlang: make systemdSupport overridable

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -5,7 +5,7 @@
 , unixODBC ? null # odbcSupport
 , libGL ? null, libGLU ? null, wxGTK ? null, wxmac ? null, xorg ? null # wxSupport
 , parallelBuild ? false
-, withSystemd ? stdenv.isLinux, systemd # systemd support in epmd
+, systemd
 }:
 
 { baseName ? "erlang"
@@ -20,6 +20,7 @@
 , enableKernelPoll ? true
 , javacSupport ? false, javacPackages ? [ openjdk8 ]
 , odbcSupport ? false, odbcPackages ? [ unixODBC ]
+, withSystemd ? stdenv.isLinux # systemd support in epmd
 , wxSupport ? true, wxPackages ? [ libGL libGLU wxGTK xorg.libX11 ]
 , preUnpack ? "", postUnpack ? ""
 , patches ? [], patchPhase ? "", prePatch ? "", postPatch ? ""


### PR DESCRIPTION
###### Motivation for this change
systemd is a pretty large dependency, and it would be nice to have a "minimal" erlang closure for some scenarios like docker images.

cc @NobbZ 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
$ nix path-info -Sh ./result # master
/nix/store/787qlzbhx2zr8mdpw7w3mjq2yid5wmb1-erlang-22.3	 415.9M
$ nix path-info -Sh ./result # This PR
/nix/store/s38hj41hxivrghypgrvr3fiz9krvicdy-erlang-22.3	 305.9M