### PR TITLE
Add lotide, hitide and service definitions for both

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -880,6 +880,7 @@
   ./services/web-apps/grocy.nix
   ./services/web-apps/hedgedoc.nix
   ./services/web-apps/hledger-web.nix
+  ./services/web-apps/hitide.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix
   ./services/web-apps/ihatemoney

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -887,6 +887,7 @@
   ./services/web-apps/jitsi-meet.nix
   ./services/web-apps/keycloak.nix
   ./services/web-apps/limesurvey.nix
+  ./services/web-apps/lotide.nix
   ./services/web-apps/mattermost.nix
   ./services/web-apps/mediawiki.nix
   ./services/web-apps/miniflux.nix

--- a/nixos/modules/services/web-apps/hitide.nix
+++ b/nixos/modules/services/web-apps/hitide.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.hitide;
+in
+{
+  options.services.hitide = {
+    enable = mkEnableOption "the hitide service";
+
+    backendHost = mkOption {
+      default = "localhost";
+      type = types.str;
+      description = "URL path to lotide.";
+      example = "http://localhost:3333/";
+    };
+
+    port = mkOption {
+      default = 4333;
+      type = types.port;
+      description = "Port number to bind to.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.hitide = {
+      description = "hitide Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ] ++ lib.optional (cfg.backendHost == "localhost") "lotide.service";
+      environment = {
+        BACKEND_HOST = cfg.backendHost;
+        PORT         = builtins.toString cfg.port;
+      };
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = "${pkgs.hitide}/bin/hitide";
+        PrivateTmp = true;
+        Restart = "always";
+        StateDirectory = "hitide";
+        WorkingDirectory = "%S/hitide";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/web-apps/lotide.nix
+++ b/nixos/modules/services/web-apps/lotide.nix
@@ -1,0 +1,99 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lotide;
+in
+{
+  options.services.lotide = {
+    enable = mkEnableOption "the lotide service";
+
+    databaseUrl = mkOption {
+      default = null;
+      type = types.str;
+      description = "Credentials for database connection.";
+      example = "postgresql://user:passwort@somehost:5432/databasename";
+    };
+
+    hostUrlActivityPub = mkOption {
+      default = null;
+      type = types.str;
+      description = "If using the recommended proxy setup, set this to your root address.";
+      example = "https://example.com";
+    };
+
+    hostUrlAPI = mkOption {
+      default = null;
+      type = types.str;
+      description = "URL for API.";
+
+      example = "https://example.com/api";
+    };
+
+    apubProxyRewrites= mkOption {
+      default = false;
+      type = types.bool;
+      description = "Set to `true` to make signatures work with the proxy setup.";
+    };
+
+    allowForwarded = mkOption {
+      default = null;
+      type = types.str;
+      description = "Set to true to make ratelimiting work with the proxy setup.";
+    };
+
+    smtpUrl = mkOption {
+      default = null;
+      type = types.str;
+      description = "URL used to access SMTP server, required for sending email.";
+
+      example = "smtps://username:password@smtp.example.com";
+    };
+
+    smtpFrom = mkOption {
+      default = null;
+      type = types.str;
+      description = "From value used in sent emails, required for sending email.";
+    };
+
+    mediaLocation = mkOption {
+      default = null;
+      type = types.str;
+      description = ''
+        Directory on disk used for storing uploaded images. If not set, image uploads will be disabled.
+        Must be created before this service is started.
+      '';
+
+      example = "/var/lotide/imgs";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.lotide = {
+      description = "lotide Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ];
+      environment = {
+        DATABASE_URL         = cfg.databaseUrl;
+        HOST_URL_ACTIVITYPUB = cfg.hostUrlActivityPub;
+        HOST_URL_API         = cfg.hostUrlAPI;
+        SMTP_URL             = cfg.smtpUrl;
+        SMTP_FROM            = cfg.smtpFrom;
+        MEDIA_LOCATION       = cfg.mediaLocation;
+      }
+      // lib.optional cfg.apubProxyRewrites { APUB_PROXY_REWRITES = "true"; }
+      // lib.optional cfg.allowForwarded    { ALLOW_FORWARDED     = "true"; }
+      ;
+      serviceConfig = {
+        DynamicUser = true;
+        ExecStart = "${pkgs.lotide}/bin/lotide";
+        PrivateTmp = true;
+        Restart = "always";
+        StateDirectory = "lotide";
+        WorkingDirectory = "%S/lotide";
+      };
+    };
+  };
+}
+

--- a/pkgs/servers/hitide/default.nix
+++ b/pkgs/servers/hitide/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, rustPlatform
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hitide";
+  version = "0.8.0";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~vpzom/hitide";
+    rev = "v${version}";
+    sha256 = "0ln41qfw3rsr37yihbjbp3qdp4gc6rhkb9kpzw2hmkaz40r9hybp";
+  };
+
+  cargoSha256 = "0nph97gq151caga45814xw77qljpccv0ac023nmafhrci1if2zmg";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  meta = with stdenv.lib; {
+    description = "A frontend for lotide";
+    homepage = "https://sr.ht/~vpzom/lotide/";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = with platforms; linux;
+  };
+}
+

--- a/pkgs/servers/lotide/default.nix
+++ b/pkgs/servers/lotide/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, rustPlatform
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lotide";
+  version = "0.8.0";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~vpzom/lotide";
+    rev = "v${version}";
+    sha256 = "0qhrr4zfvrizjc0chixfyf71rh0ifxrnzl6hklhbgh6xchknvrgn";
+  };
+
+  cargoSha256 = "10jpzcv83l1xsrpz9n2hqaszw40x6kkp39gm71bi2njnbcn1023q";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  # requires database to be present.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A federated forum / link aggregator using ActivityPub";
+    homepage = "https://sr.ht/~vpzom/lotide/";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = with platforms; linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8934,6 +8934,8 @@ in
 
   hitch = callPackage ../servers/hitch { };
 
+  hitide = callPackage ../servers/hitide { };
+
   venus = callPackage ../tools/misc/venus {
     python = python27;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5621,6 +5621,8 @@ in
 
   lolcat = callPackage ../tools/misc/lolcat { };
 
+  lotide = callPackage ../servers/lotide { };
+
   lottieconverter = callPackage ../tools/misc/lottieconverter { };
 
   lsd = callPackage ../tools/misc/lsd { };


### PR DESCRIPTION
Add lotide, hitide and service definitions for both.

As I do not often write service definitions, please someone have a look at those.
I did not yet test them. I don't know how, tbh. Maybe by rebasing these patches to nixos-stable and then building my system from it? Isn't there a smoother way for that?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
