### PR TITLE
pe-parse: init at 1.2.0

### DIFF
--- a/pkgs/development/libraries/pe-parse/default.nix
+++ b/pkgs/development/libraries/pe-parse/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "pe-parse";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "pe-parse";
+    rev = "v${version}";
+    sha256 = "1jvfjaiwddczjlx4xdhpbgwvvpycab7ix35lwp3wfy44hs6qpjqv";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/dump-pe ../test/assets/example.exe
+  '';
+
+  meta = with lib; {
+    description = "A principled, lightweight parser for Windows portable executable files";
+    homepage = "https://github.com/trailofbits/pe-parse";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ arturcygan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15349,6 +15349,8 @@ in
 
   pdf2xml = callPackage ../development/libraries/pdf2xml {} ;
 
+  pe-parse = callPackage ../development/libraries/pe-parse { };
+
   inherit (callPackage ../development/libraries/physfs { })
     physfs_2
     physfs;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
