### PR TITLE
go-minimock: init at 3.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8573,6 +8573,12 @@
     githubId = 1040871;
     name = "Mathis Antony";
   };
+  svrana = {
+    email = "shaw@vranix.com";
+    github = "svrana";
+    githubId = 850665;
+    name = "Shaw Vrana";
+  };
   svsdep = {
     email = "svsdep@gmail.com";
     github = "svsdep";

--- a/pkgs/development/tools/go-minimock/default.nix
+++ b/pkgs/development/tools/go-minimock/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-minimock";
+  version = "3.0.8";
+
+  src = fetchFromGitHub {
+    owner = "gojuno";
+    repo = "minimock";
+    rev = "v${version}";
+    sha256 = "0r0krbwvx5w1z0yv2qqi92irbsfhkvwvaigy350cvcz9gmcppj4h";
+  };
+
+  vendorSha256 = "1macwm6hybjinwnx62v146yxydcn5k5r587nxwkf4ffy76s2m3jc";
+
+  doCheck = true;
+
+  subPackages = [ "cmd/minimock" "." ];
+
+  meta = with lib; {
+    homepage = "https://github.com/gojuno/minimock";
+    description = "A golang mock generator from interfaces";
+    license = licenses.mit;
+    maintainers = with maintainers; [ svrana ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18943,6 +18943,8 @@ in
 
   go-bindata-assetfs = callPackage ../development/tools/go-bindata-assetfs { };
 
+  go-minimock = callPackage ../development/tools/go-minimock { };
+
   go-protobuf = callPackage ../development/tools/go-protobuf { };
 
   go-symbols = callPackage ../development/tools/go-symbols { };


### PR DESCRIPTION

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](,nt) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
