### PR TITLE
bash-completion: Update GitHub hash

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "scop";
     repo = "bash-completion";
     rev = version;
-    sha256 = "0m3brd5jx7w07h8vxvvcmbyrlnadrx6hra3cvx6grzv6rin89liv";
+    sha256 = "1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
To fix checksum failures when building from source

There is a hash mismatch error when building this derivation without binary cache because the sha256 hash no longer matches the github repo hash.

Proof of hash change:
```
sur@surs-MacBook-Pro lib % nix-prefetch-git https://github.com/scop/bash-completion 2.11
Initialized empty Git repository in /private/var/folders/7b/5z_1chpx7w5b6t75rt3px5y80000gn/T/git-checkout-tmp-XlyyFBc9/bash-completion/.git/
remote: Enumerating objects: 1404, done.
remote: Counting objects: 100% (1404/1404), done.
remote: Compressing objects: 100% (1164/1164), done.
remote: Total 1404 (delta 686), reused 366 (delta 173), pack-reused 0
Receiving objects: 100% (1404/1404), 501.36 KiB | 6.60 MiB/s, done.
Resolving deltas: 100% (686/686), done.
From https://github.com/scop/bash-completion
 * tag               2.11       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...

git revision is b12639a6becec13a0a2c06173ba40fb3bbe972e1
path is /nix/store/bv8p05zsilary8lylwfmqw1bc6bhwmrl-bash-completion
git human-readable version is -- none --
Commit date is 2020-07-25 11:25:49 +0300
hash is 1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87
{
  "url": "https://github.com/scop/bash-completion",
  "rev": "b12639a6becec13a0a2c06173ba40fb3bbe972e1",
  "date": "2020-07-25T11:25:49+03:00",
  "path": "/nix/store/bv8p05zsilary8lylwfmqw1bc6bhwmrl-bash-completion",
  "sha256": "1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87",
  "fetchSubmodules": false,
  "deepClone": false,
  "leaveDotGit": false
}
```


###### Things done
Update the fetchFromGitHub sha256 hash

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
