### PR TITLE
cpuset: 1.5.8 -> 1.6

### DIFF
--- a/pkgs/os-specific/linux/cpuset/default.nix
+++ b/pkgs/os-specific/linux/cpuset/default.nix
@@ -1,27 +1,44 @@
 { stdenv
 , fetchFromGitHub
-, python2Packages
+, fetchpatch
+, pythonPackages
 }:
 
-python2Packages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   pname = "cpuset";
-  version = "1.5.8";
+  version = "1.6";
 
-  propagatedBuildInputs = [ ];
+  propagatedBuildInputs = with pythonPackages; [
+    configparser
+    future
+  ];
+
+  # https://github.com/lpechacek/cpuset/pull/36
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/MawKKe/cpuset/commit/a4b6b275d0a43d2794ab9e82922d3431aeea9903.patch";
+      sha256 = "1mi1xrql81iczl67s4dk2rm9r1mk36qhsa19wn7zgryf95krsix2";
+    })
+  ];
 
   makeFlags = [ "prefix=$(out)" ];
 
   src = fetchFromGitHub {
-    owner = "wykurz";
+    owner = "lpechacek";
     repo = "cpuset";
     rev = "v${version}";
-    sha256 = "19fl2sn470yrnm2q508giggjwy5b6r2gd94gvwfbdlhf0r9dsbbm";
+    sha256 = "0ig0ml2zd5542d0989872vmy7cs3qg7nxwa93k42bdkm50amhar4";
   };
+
+  checkPhase = ''
+    cd t
+    make
+  '';
 
   meta = with stdenv.lib; {
     description = "Python application that forms a wrapper around the standard Linux filesystem calls to make using the cpusets facilities in the Linux kernel easier";
-    homepage    = "https://github.com/wykurz/cpuset";
+    homepage    = "https://github.com/lpechacek/cpuset";
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ wykurz ];
+    maintainers = with maintainers; [ thiagokokada wykurz ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18041,7 +18041,9 @@ in
 
   cpufrequtils = callPackage ../os-specific/linux/cpufrequtils { };
 
-  cpuset = callPackage ../os-specific/linux/cpuset { };
+  cpuset = callPackage ../os-specific/linux/cpuset {
+    pythonPackages = python3Packages;
+  };
 
   criu = callPackage ../os-specific/linux/criu { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Switch from wykurz to lpechacek fork, so we can use Python 3 instead of Python 2. However, Python 2 should still works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
