### PR TITLE
tree-sitter: patch out web-ui by default, to drop emscripten

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -2,10 +2,12 @@
 , fetchgit, fetchFromGitHub, fetchurl
 , writeShellScript, runCommand, which
 , rustPlatform, jq, nix-prefetch-git, xe, curl, emscripten
+, Security
 , callPackage
+
 , enableShared ? true
 , enableStatic ? false
-, Security
+, webUISupport ? false
 }:
 
 # TODO: move to carnix or https://github.com/kolloch/crate2nix
@@ -54,20 +56,25 @@ in rustPlatform.buildRustPackage {
   pname = "tree-sitter";
   inherit src version cargoSha256;
 
-  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs =
+    lib.optionals stdenv.isDarwin [ Security ];
+  nativeBuildInputs =
+    [ which ]
+    ++ lib.optionals webUISupport [ emscripten ];
 
-  nativeBuildInputs = [ emscripten which ];
-
-  postPatch = ''
-    # needed for the tests
-    rm -rf test/fixtures/grammars
-    ln -s ${grammars} test/fixtures/grammars
+  postPatch = lib.optionalString (!webUISupport) ''
+    # remove web interface
+    sed -e '/pub mod web_ui/d' \
+        -i cli/src/lib.rs
+    sed -e 's/web_ui,//' \
+        -e 's/web_ui::serve(&current_dir.*$/println!("ERROR: web-ui is not available in this nixpkgs build; enable the webUISupport"); std::process::exit(1);/' \
+        -i cli/src/main.rs
   '';
 
   # Compile web assembly with emscripten. The --debug flag prevents us from
   # minifying the JavaScript; passing it allows us to side-step more Node
   # JS dependencies for installation.
-  preBuild = ''
+  preBuild = lib.optionalString webUISupport ''
     bash ./script/build-wasm --debug
   '';
 


### PR DESCRIPTION
The tree-sitter build closure is pretty lean by default, but the
optional web-ui requires emscripten to compile the web interface
javascript/wasm code.

This is clearly not worth the increase in build closure size, and
since emscripten is broken more often than not, let’s patch it out by
default. If somebody /really/ needs the web-ui, there is a
`webUISupport` flag.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
