### PR TITLE
fetchurl: strip query from filename

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -536,21 +536,17 @@ rec {
       then parse x
       else x.version or (parse x.name);
 
-  /* Extract name with version from URL. Ask for separator which is
-     supposed to start extension.
+  /* Extract filename from URL, with query component or tailing slash striped.
 
      Example:
-       nameFromURL "https://nixos.org/releases/nix/nix-1.7/nix-1.7-x86_64-linux.tar.bz2" "-"
-       => "nix"
-       nameFromURL "https://nixos.org/releases/nix/nix-1.7/nix-1.7-x86_64-linux.tar.bz2" "_"
-       => "nix-1.7-x86"
-  */
-  nameFromURL = url: sep:
-    let
-      components = splitString "/" url;
-      filename = lib.last components;
-      name = head (splitString sep filename);
-    in assert name != filename; name;
+       nameFromURL "https://bug-220081-attachments.webkit.org/attachment.cgi?id=416707&action=diff&format=raw"
+       => "attachment.cgi"
+       nameFromURL "http://git.savannah.gnu.org/cgit/mailutils.git/patch/?id=37713b42a501892469234b90454731d8d8b7a3e6"
+       => "patch"
+       nameFromURL "http://git.savannah.gnu.org/cgit/mailutils.git/patch/"
+       => "patch"
+  # */
+  nameFromURL = url: baseNameOf (head (splitString "?" url));
 
   /* Create an --{enable,disable}-<feat> string that can be passed to
      standard GNU Autoconf scripts.

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix
@@ -7,10 +7,11 @@ let
   buildPythonPackage = pythonPackages.buildPythonPackage;
 
   xe = buildPythonPackage rec {
-    url = "http://www.blarg.net/%7Esteveha/xe-0.7.4.tar.gz";
-    name = stdenv.lib.nameFromURL url ".tar";
+    pname = "xe";
+    version = "0.7.4";
+
     src = fetchurl {
-      inherit url;
+      url = "http://www.blarg.net/%7Esteveha/${pname}-${version}.tar.gz";
       sha256 = "0v9878cl0y9cczdsr6xjy8v9l139lc23h4m5f86p4kpf2wlnpi42";
     };
 
@@ -26,12 +27,11 @@ let
 in {
 
   pyfeed = (buildPythonPackage rec {
-    url = "http://www.blarg.net/%7Esteveha/pyfeed-0.7.4.tar.gz";
-
-    name = stdenv.lib.nameFromURL url ".tar";
+    pname = "pyfeed";
+    version = "0.7.4";
 
     src = fetchurl {
-      inherit url;
+      url = "http://www.blarg.net/%7Esteveha/${pname}-${version}.tar.gz";
       sha256 = "1h4msq573m7wm46h3cqlx4rsn99f0l11rhdqgf50lv17j8a8vvy1";
     };
 
@@ -48,10 +48,11 @@ in {
   });
 
   wokkel = buildPythonPackage (rec {
-    url = "http://wokkel.ik.nu/releases/0.7.0/wokkel-0.7.0.tar.gz";
-    name = stdenv.lib.nameFromURL url ".tar";
+    pname = "wokkel";
+    version = "0.7.0";
+
     src = fetchurl {
-      inherit url;
+      url = "http://wokkel.ik.nu/releases/${version}/${pname}-${version}.tar.gz";
       sha256 = "0rnshrzw8605x05mpd8ndrx3ri8h6cx713mp8sl4f04f4gcrz8ml";
     };
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -122,7 +122,7 @@ stdenvNoCC.mkDerivation {
   name =
     if showURLs then "urls"
     else if name != "" then name
-    else baseNameOf (toString (builtins.head urls_));
+    else lib.nameFromURL (toString (builtins.head urls_));
 
   builder = ./builder.sh;
 

--- a/pkgs/development/libraries/spdk/default.nix
+++ b/pkgs/development/libraries/spdk/default.nix
@@ -15,6 +15,7 @@
 
 let
   dpdk-compat-patch = fetchurl {
+    name = "dpdk-compat-patch";
     url = "https://review.spdk.io/gerrit/plugins/gitiles/spdk/spdk/+/6acb9a58755856fb9316baf9dbbb7239dc6b9446%5E%21/?format=TEXT";
     sha256 = "18q0956fkjw19r29hp16x4pygkfv01alj9cld2wlqqyfgp41nhn0";
   };

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -576,7 +576,8 @@ self: super:
     old:
     let
       blas = old.passthru.args.blas or pkgs.openblasCompat;
-      blasImplementation = lib.nameFromURL blas.name "-";
+      # FIXME: Could use blas.implementation or base.pname or lib.getName ?
+      blasImplementation = builtins.head (lib.splitString "-" blas.name);
       cfg = pkgs.writeTextFile {
         name = "site.cfg";
         text = (


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
When fetching url like https://bug-220081-attachments.webkit.org/attachment.cgi?id=416707&action=diff&format=raw , the filename contains query separator `&` which is invalid as path name in Nix. In fact, since it's not part of path according to URI syntax, we can simply strip the whole query component.

###### Things done

Manually `fetchpatch` the patch mention above and it works.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
