### PR TITLE
.github/workflows: add rebase-staging.yml

### DIFF
--- a/.github/workflows/rebase-staging.yml
+++ b/.github/workflows/rebase-staging.yml
@@ -1,0 +1,56 @@
+on:
+  issue_comment:
+    types:
+      - created
+
+# This action allows people with write access to the repo to rebase a PRs base branch from
+# master to staging by commenting `/rebase-staging` on the PR while avoiding CODEOWNER notifications.
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'NixOS' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase-staging')
+    steps:
+      - uses: scherermichael-oss/action-has-permission@1.0.6
+        id: check-write-access
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check base branch is master
+        if: steps.check-write-access.outputs.has-permission
+        run: |
+          if [ "$(curl https://api.github.com/repos/NixOS/nixpkgs/pulls/${{ github.event.issue.number }} | jq -r '.base.ref')" != "master" ]; then
+            echo "This action only works when the current base branch is master."
+            exit 1
+          fi
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        if: steps.check-write-access.outputs.has-permission
+      - name: rebase pull request
+        if: steps.check-write-access.outputs.has-permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ github.event.issue.number }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git fetch origin
+          gh pr checkout "$PULL_REQUEST"
+          git rebase \
+            --onto="$(git merge-base origin/master origin/staging)" \
+            "HEAD~$(git rev-list --count HEAD ^master)"
+          git push --force
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -d '{ "base": "staging" }' \
+            "https://api.github.com/repos/NixOS/nixpkgs/pulls/$PULL_REQUEST"
+      - uses: peter-evans/create-or-update-comment@v1
+        if: ${{ failure() }}
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            [Failed to rebase on `staging`](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
This allows committers to rebase PRs to staging without CODEOWNER notification spam or running git commands manually.

cc @FRidh @jonringer @zimbatm 