### PR TITLE
qjackctl: 0.6.3 -> 0.9.0

### DIFF
--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, mkDerivation, fetchurl
-, pkg-config, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras
+{ stdenv, mkDerivation, fetchFromGitHub
+, pkg-config, cmake, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras
 # Enable jack session support
 , jackSession ? false
 }:
 
 mkDerivation rec {
-  version = "0.6.3";
+  version = "0.9.0";
   pname = "qjackctl";
 
   # some dependencies such as killall have to be installed additionally
 
-  src = fetchurl {
-    url = "mirror://sourceforge/qjackctl/${pname}-${version}.tar.gz";
-    sha256 = "0zbb4jlx56qvcqyhx34mbagkqf3wbxgj84hk0ppf5cmcrxv67d4x";
+  src = fetchFromGitHub {
+    owner = "rncbc";
+    repo = "qjackctl";
+    rev = "${pname}_${stdenv.lib.replaceChars ["."] ["_"] version}";
+    sha256 = "044kgwk7pfywad4myza0s2kvfkl21zkqq5wgny7n3c43qlcgs3zr";
   };
 
   buildInputs = [
@@ -24,16 +26,19 @@ mkDerivation rec {
     dbus
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  configureFlags = [
-    "--enable-jack-version"
-    (stdenv.lib.strings.enableFeature jackSession "jack-session")
+  cmakeFlags = [
+    "-DCONFIG_JACK_VERSION=1"
+    "-DCONFIG_JACK_SESSION=${toString jackSession}"
   ];
 
   meta = with stdenv.lib; {
     description = "A Qt application to control the JACK sound server daemon";
-    homepage = "http://qjackctl.sourceforge.net/";
+    homepage = "https://github.com/rncbc/qjackctl";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
