### PR TITLE
arduino: use gtk3

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -11,7 +11,8 @@
 , ncurses
 , readline
 , withGui ? false
-, gtk2 ? null
+, gtk3 ? null
+, wrapGAppsHook
 , withTeensyduino ? false
   /* Packages needed for Teensyduino */
 , upx
@@ -29,7 +30,7 @@
 , udev
 }:
 
-assert withGui -> gtk2 != null;
+assert withGui -> gtk3 != null && wrapGAppsHook != null;
 assert withTeensyduino -> withGui;
 let
   externalDownloads = import ./downloads.nix {
@@ -55,7 +56,7 @@ let
     gcc.cc.lib
     gdk-pixbuf
     glib
-    gtk2
+    gtk3
     libpng12
     libusb-compat-0_1
     pango
@@ -111,6 +112,7 @@ stdenv.mkDerivation rec {
   };
 
 
+  nativeBuildInputs = [ wrapGAppsHook ];
   buildInputs = [
     jdk
     ant
@@ -149,7 +151,7 @@ stdenv.mkDerivation rec {
 
   # This will be patched into `arduino` wrapper script
   # Java loads gtk dynamically, so we need to provide it using LD_LIBRARY_PATH
-  dynamicLibraryPath = lib.makeLibraryPath [ gtk2 ];
+  dynamicLibraryPath = lib.makeLibraryPath [ gtk3 ];
   javaPath = lib.makeBinPath [ jdk ];
 
   # Everything else will be patched into rpath


### PR DESCRIPTION
###### Motivation for this change

Tested both with a regular arduino patch and with an esp32 module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).