### PR TITLE
sourcetrail: fix hash for SourceTrailPythonIndexer

### DIFF
--- a/pkgs/development/tools/sourcetrail/python.nix
+++ b/pkgs/development/tools/sourcetrail/python.nix
@@ -64,5 +64,7 @@ stdenv.mkDerivation rec {
     description = "Python indexer for Sourcetrail";
     homepage = "https://github.com/CoatiSoftware/SourcetrailPythonIndexer";
     license = licenses.gpl3;
+    broken = stdenv.isDarwin;
+    # https://github.com/NixOS/nixpkgs/pull/107533#issuecomment-751063675
   };
 }

--- a/pkgs/development/tools/sourcetrail/python.nix
+++ b/pkgs/development/tools/sourcetrail/python.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "CoatiSoftware";
     repo = pname;
     rev = version;
-    sha256 = "05hlpd3am029pv1wi6mys3q0ggp64axmg8bdf1fabl9cl9jffscq";
+    sha256 = "01jaigxigq6dvfwq018gn9qw7i6p4jm0y71lqzschfv9vwf6ga45";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix build of sourcetrail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @midchildan 