### PR TITLE
python3Packages.jsonfield: init at 3.1.0

### DIFF
--- a/pkgs/development/python-modules/jsonfield/default.nix
+++ b/pkgs/development/python-modules/jsonfield/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage, django, pytestCheckHook, pytest-django }:
+
+buildPythonPackage rec {
+  pname = "jsonfield";
+  version = "3.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0yl828cd0m8jsyr4di6hcjdqmi31ijh5vk57mbpfl7p2gmcq8kky";
+  };
+
+  checkInputs = [ pytestCheckHook pytest-django ];
+
+  preCheck = "export DJANGO_SETTINGS_MODULE=tests.settings";
+
+  propagatedBuildInputs = [ django ];
+
+  meta = with stdenv.lib; {
+    description = "Reusable model field that allows you to store validated JSON, automatically handling serialization to and from the database";
+    homepage = "https://github.com/rpkilby/jsonfield/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mrmebelman ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3176,6 +3176,8 @@ in {
 
   jsondiff = callPackage ../development/python-modules/jsondiff { };
 
+  jsonfield = callPackage ../development/python-modules/jsonfield { };
+
   jsonlines = callPackage ../development/python-modules/jsonlines { };
 
   jsonmerge = callPackage ../development/python-modules/jsonmerge { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
