### PR TITLE
python3Packages.pydicom: 2.1.1 -> 2.1.2

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -1,29 +1,55 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , isPy27
-, pytest
 , pytestrunner
 , pytestCheckHook
 , numpy
 , pillow
 }:
 
-buildPythonPackage rec {
-  version = "2.1.1";
+let
   pname = "pydicom";
-  disabled = isPy27;
+  version = "2.1.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "72a11086f6a277c1529a552583fde73e03256a912173f15e9bc256e5b28f28f1";
+  src = fetchFromGitHub {
+    owner = "${pname}";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "sha256-iExy+mUs1uqs/u9N6btlqyP6/TvoPVsuOuzs56zZAS8=";
   };
+
+  # Pydicom needs pydicom-data to run some tests. If these files are downloaded
+  # before the package creation, it'll try to download during the checkPhase.
+  test_data = fetchFromGitHub {
+    owner = "${pname}";
+    repo = "${pname}-data";
+    rev = "bbb723879690bb77e077a6d57657930998e92bd5";
+    sha256 = "sha256-dCI1temvpNWiWJYVfQZKy/YJ4ad5B0e9hEKHJnEeqzk=";
+  };
+
+in
+buildPythonPackage {
+  inherit pname version src;
+  disabled = isPy27;
 
   propagatedBuildInputs = [ numpy pillow ];
 
-  checkInputs = [ pytest pytestrunner pytestCheckHook ];
-  disabledTests = [ "test_invalid_bit_depth_raises" ];
-  # harmless failure; see https://github.com/pydicom/pydicom/issues/1119
+  checkInputs = [ pytestrunner pytestCheckHook ];
+
+  # Setting $HOME to prevent pytest to try to create a folder inside
+  # /homeless-shelter which is read-only.
+  # Linking pydicom-data dicom files to $HOME/.pydicom/data
+  preCheck = ''
+    export HOME=$TMP/test-home
+    mkdir -p $HOME/.pydicom/
+    ln -s ${test_data}/data_store/data $HOME/.pydicom/data
+  '';
+
+  # This test try to remove a dicom inside $HOME/.pydicom/data/ and download it again.
+  disabledTests = [
+    "test_fetch_data_files"
+  ];
 
   meta = with stdenv.lib; {
     homepage = "https://pydicom.github.io";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update Pydicom to 2.1.2 and fix https://github.com/NixOS/nixpkgs/issues/106262

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
