### PR TITLE
emacs: slash-terminate comp-eln-load-path

### DIFF
--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -159,7 +159,7 @@ in stdenv.mkDerivation (lib.optionalAttrs nativeComp {
   '' + lib.optionalString nativeComp ''
     mkdir -p $out/share/emacs/native-lisp
     $out/bin/emacs --batch \
-      --eval "(add-to-list 'comp-eln-load-path \"$out/share/emacs/native-lisp\")" \
+      --eval "(add-to-list 'comp-eln-load-path \"$out/share/emacs/native-lisp/\")" \
       -f batch-native-compile $out/share/emacs/site-lisp/site-start.el
   '';
 

--- a/pkgs/build-support/emacs/setup-hook.sh
+++ b/pkgs/build-support/emacs/setup-hook.sh
@@ -18,7 +18,7 @@ addEmacsVars () {
   addToEmacsLoadPath "$1/share/emacs/site-lisp"
 
   if [ -n "${addEmacsNativeLoadPath:-}" ]; then
-    addToEmacsNativeLoadPath "$1/share/emacs/native-lisp"
+    addToEmacsNativeLoadPath "$1/share/emacs/native-lisp/"
   fi
 
   # Add sub paths to the Emacs load path if it is a directory

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -182,7 +182,7 @@ runCommand
       substitute ${./wrapper.sh} $out/bin/$progname \
         --subst-var-by bash ${emacs.stdenv.shell} \
         --subst-var-by wrapperSiteLisp "$deps/share/emacs/site-lisp" \
-        --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp:" \
+        --subst-var-by wrapperSiteLispNative "$deps/share/emacs/native-lisp/:" \
         --subst-var prog
       chmod +x $out/bin/$progname
     done
@@ -206,7 +206,7 @@ runCommand
 
       makeWrapper $emacs/Applications/Emacs.app/Contents/MacOS/Emacs $out/Applications/Emacs.app/Contents/MacOS/Emacs \
         --suffix EMACSLOADPATH ":" "$deps/share/emacs/site-lisp:" \
-        --suffix EMACSNATIVELOADPATH ":" "$deps/share/emacs/native-lisp:"
+        --suffix EMACSNATIVELOADPATH ":" "$deps/share/emacs/native-lisp/:"
     fi
 
     mkdir -p $out/share


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Emacs just concatenates the version and hash to the string provided in `comp-eln-load-path` (see https://github.com/emacs-mirror/emacs/blob/feature/native-comp/src/comp.c#L4088), so directories must end with a slash (@AndreaCorallo, is this intended?). Otherwise, we get paths like "/nix/store/akx3lh6h8vyj63xgi396mylbhn3lmc4p-emacs-gcc-20201217.0/share/emacs/native-lisp28.0.50-x86_64-pc-linux-gnu-c50f2f5ede36309a94931f324ed27b53".

See https://github.com/nix-community/emacs-overlay/issues/74

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [x] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
