### PR TITLE
buildGoModule: fix cross-compilation with CGO_ENABLED=1

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -46,7 +46,7 @@ with builtins;
 let
   args = removeAttrs args' [ "overrideModAttrs" "vendorSha256" "disabled" ];
 
-  go-modules = if vendorSha256 != null then go.stdenv.mkDerivation (let modArgs = {
+  go-modules = if vendorSha256 != null then stdenv.mkDerivation (let modArgs = {
 
     name = "${name}-go-modules";
 
@@ -119,7 +119,7 @@ let
       }
   ) // overrideModAttrs modArgs) else "";
 
-  package = go.stdenv.mkDerivation (args // {
+  package = stdenv.mkDerivation (args // {
     nativeBuildInputs = [ go ] ++ nativeBuildInputs;
 
     inherit (go) GOOS GOARCH;


### PR DESCRIPTION
When building a go binary that's linking against some .so/.a, while
cross-compiling, we need to pass the correct compiler, otherwise
`go build` will fail with the not-so helpful error message:

```
gcc_arm64.S: Assembler messages:
gcc_arm64.S:28: Error: no such instruction: `stp x29,x30,[sp,'
gcc_arm64.S:32: Error: too many memory references for `mov'
gcc_arm64.S:34: Error: no such instruction: `stp x19,x20,[sp,'
gcc_arm64.S:37: Error: no such instruction: `stp x21,x22,[sp,'
gcc_arm64.S:40: Error: no such instruction: `stp x23,x24,[sp,'
gcc_arm64.S:43: Error: no such instruction: `stp x25,x26,[sp,'
gcc_arm64.S:46: Error: no such instruction: `stp x27,x28,[sp,'
gcc_arm64.S:50: Error: too many memory references for `mov'
gcc_arm64.S:51: Error: too many memory references for `mov'
gcc_arm64.S:52: Error: too many memory references for `mov'
gcc_arm64.S:54: Error: no such instruction: `blr x20'
gcc_arm64.S:55: Error: no such instruction: `blr x19'
gcc_arm64.S:57: Error: no such instruction: `ldp x27,x28,[sp,'
gcc_arm64.S:60: Error: no such instruction: `ldp x25,x26,[sp,'
gcc_arm64.S:63: Error: no such instruction: `ldp x23,x24,[sp,'
gcc_arm64.S:66: Error: no such instruction: `ldp x21,x22,[sp,'
gcc_arm64.S:69: Error: no such instruction: `ldp x19,x20,[sp,'
gcc_arm64.S:72: Error: no such instruction: `ldp x29,x30,[sp],'
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
