### PR TITLE
grafana-loki: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -1,36 +1,20 @@
-{ stdenv
-, lib
-, buildGoModule
-, fetchFromGitHub
-, makeWrapper
-, nixosTests
-, systemd
-, fetchpatch
+{ stdenv, lib, buildGoModule, fetchFromGitHub, makeWrapper, nixosTests, systemd
 }:
 
 buildGoModule rec {
-  version = "2.0.0";
+  version = "2.1.0";
   pname = "grafana-loki";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "grafana";
     repo = "loki";
-    sha256 = "09a0mqdmk754vigd1xqijzwazwrmfaqcgdr2c6dz25p7a65568hj";
+    sha256 = "O/3079a67j1i9pgf18SBx0iJcQPVmb0H+K/PzQVBCDQ=";
   };
 
   vendorSha256 = null;
 
   subPackages = [ "..." ];
-
-  patches = [
-    (fetchpatch {
-      # Fix expected return value in Test_validateDropConfig
-      # https://github.com/grafana/loki/issues/2519
-      url = "https://github.com/grafana/loki/commit/1316c0f0c5cda7c272c4873ea910211476fc1db8.patch";
-      sha256 = "06hwga58qpmivbhyjgyqzb75602hy8212a4b5vh99y9pnn6c913h";
-    })
-  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ systemd.dev ];


### PR DESCRIPTION
###### Motivation for this change
upgrade loki to latest version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Here is the result of nix path-info after
`/nix/store/g86z7wl67kq2vr9c25ip5l8sn92qwyw7-grafana-loki-2.1.0    442635888`

@WilliButz  
@globin  @mmahut 
When you have a moment, please check

I've removed the patch as it was for version 1.6 and the issue is now closed

I've used nixfmt so there is a slight change in the format of the topline, I hope that's not a problem