### PR TITLE
vector: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -1,18 +1,11 @@
 { stdenv, lib, fetchFromGitHub, rustPlatform, openssl, pkg-config, protobuf
 , Security, libiconv, rdkafka, tzdata
 
-, features ? ((if stdenv.isAarch64 then [
-  "jemallocator"
-  "rdkafka"
-  "rdkafka/dynamic_linking"
-] else [
-  "leveldb"
-  "leveldb/leveldb-sys-2"
-  "jemallocator"
-  "rdkafka"
-  "rdkafka/dynamic_linking"
-]) ++ (lib.optional stdenv.targetPlatform.isUnix "unix")
-  ++ [ "sinks" "sources" "transforms" ]), coreutils, CoreServices }:
+, features ?
+  ((lib.optional (!stdenv.isAarch64) [ "leveldb" "leveldb/leveldb-sys-2" ]
+    ++ [ "jemallocator" "rdkafka" "rdkafka/dynamic_linking" ])
+    ++ (lib.optional stdenv.targetPlatform.isUnix "unix")
+    ++ [ "sinks" "sources" "transforms" ]), coreutils, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "vector";


### PR DESCRIPTION
###### Motivation for this change

upgrade vector

###### Things done

This is more a RFC at this point. @thoughtpolice when you have a moment.

(I've run nixfmt on this, I hope it's not a problem. The only change is version and sha256 corresponding)

Trying to build this, you'll get the 
```
error: failed to sync

Caused by:
  found duplicate version of package `tracing-attributes v0.1.11` vendored from two sources:

        source 1: registry `https://github.com/rust-lang/crates.io-index`
        source 2: https://github.com/tokio-rs/tracing?rev=f470db1b0354b368f62f9ee4d763595d16373231#f470db1b
Traceback (most recent call last):
  File "/nix/store/jfq4wq19ms0m46nkwr9xf3kiv9gqs2jl-cargo-vendor-normalise/bin/.cargo-vendor-normalise-wrapped", line 42, in <module>
    main()
  File "/nix/store/jfq4wq19ms0m46nkwr9xf3kiv9gqs2jl-cargo-vendor-normalise/bin/.cargo-vendor-normalise-wrapped", line 17, in main
    assert list(data.keys()) == ["source"]
AssertionError
```

This is caused by the fact that vector has a dependency on two libraries named tracing with different sources and versions.
https://github.com/timberio/vector/blob/master/Cargo.lock#L6717
and
https://github.com/timberio/vector/blob/master/Cargo.lock#L6727

I'm not sure what's the best way to resolve this?

In this case, vector has all it's dependencies defined clearly in the cargo.lock, is there even a need to run the vendored script?

@symphorien @Mic92 perhaps you have a better idea of how to solve the problem of having two dependencies named exactly the same?


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
