### PR TITLE
code-minimap: init at 0.4.3

### DIFF
--- a/pkgs/tools/misc/code-minimap/default.nix
+++ b/pkgs/tools/misc/code-minimap/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "code-minimap";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "wfxr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03azqy4i15kfpd0gzjaw2di9xva4xdf95yb65b93z3y9y5wy4krc";
+  };
+
+  cargoSha256 = "1rxrdavj07i7qa5rf1i3aj7zdcp7c6lrg8yiy75r6lm4g98izzww";
+
+  meta = with stdenv.lib; {
+    description = "A high performance code minimap render";
+    homepage = "https://github.com/wfxr/code-minimap";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ bsima ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1859,6 +1859,8 @@ in
 
   cpulimit = callPackage ../tools/misc/cpulimit { };
 
+  code-minimap = callPackage ../tools/misc/code-minimap { };
+
   codesearch = callPackage ../tools/text/codesearch { };
 
   codec2 = callPackage ../development/libraries/codec2 { };


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit ff0b90414ae7064e1ad37aff865f99e82bbee3e5
Author: Ben Sima <ben@bsima.me>
Date:   Fri Dec 25 00:22:34 2020 -0500

    code-minimap: init at 0.4.3

    Message-Id: <20201225052234.17216-1-ben@bsima.me>
```

You can find the submission in the [archive](https://lists.sr.ht/~andir/nixpkgs-dev/%3C20201225052234.17216-1-ben%40bsima.me%3E).