### PR TITLE
haskellPackages.apecs-physics: push to 0.4.5 to unbreak build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1544,7 +1544,8 @@ self: super: {
   yesod-core = dontCheck super.yesod-core;
 
   # Add ApplicationServices on darwin
-  apecs-physics = addPkgconfigDepends super.apecs-physics
+  # use 0.4.5 instead of 0.4.4 to fix build with glibc >= 2.32
+  apecs-physics = addPkgconfigDepends super.apecs-physics_0_4_5
     (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.ApplicationServices);
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3150,9 +3150,6 @@ broken-packages:
   - aos-signature
   - aosd
   - apart
-  - apecs-gloss
-  - apecs-physics
-  - apecs-physics-gloss
   - apecs-stm
   - apelsin
   - api-builder


### PR DESCRIPTION
apecs-physics was broken by the update of glibc to 2.32 due to the
vendored Chipmunk2D using sys/sysctl.h on GNU/Linux. 0.4.5 updates the
vendored version of Chipmunk2D which resolves this issue.

Resolves #107358.

See also #107395 for context.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @siraben for testing