### PR TITLE
xkb-switch-i3: init at 1.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2863,6 +2863,12 @@
     githubId = 30512529;
     name = "Evils";
   };
+  ewok = {
+    email = "ewok@ewok.ru";
+    github = "ewok";
+    githubId = 454695;
+    name = "Artur Taranchiev";
+  };
   exfalso = {
     email = "0slemi0@gmail.com";
     github = "exfalso";

--- a/pkgs/tools/X11/xkb-switch-i3/default.nix
+++ b/pkgs/tools/X11/xkb-switch-i3/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, cmake
+, fetchFromGitHub
+, i3
+, jsoncpp
+, libsigcxx
+, libX11
+, libxkbfile
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xkb-switch-i3";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "Zebradil";
+    repo = "xkb-switch-i3";
+    rev = version;
+    sha256 = "15c19hp0n1k3w15qn97j6wp5b8hbk0mq6x3xjfn6dkkjfz1fl6cn";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ i3 jsoncpp libsigcxx libX11 libxkbfile ];
+
+  meta = with stdenv.lib; {
+    description = "Switch your X keyboard layouts from the command line(i3 edition)";
+    homepage = "https://github.com/Zebradil/xkb-switch-i3";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ewok ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25168,6 +25168,8 @@ in
 
   xkb-switch = callPackage ../tools/X11/xkb-switch { };
 
+  xkb-switch-i3 = callPackage ../tools/X11/xkb-switch-i3 { };
+
   xkblayout-state = callPackage ../applications/misc/xkblayout-state { };
 
   xlife = callPackage ../applications/graphics/xlife { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding xkb-switch with i3 support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
