### PR TITLE
cmake: 3.19.1 -> 3.19.2

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkgconfig, fetchpatch
+{ stdenv, lib, fetchurl, pkgconfig
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
 , buildPackages
 # darwin attributes
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
           + lib.optionalString useNcurses "-cursesUI"
           + lib.optionalString withQt5 "-qt5UI"
           + lib.optionalString useQt4 "-qt4UI";
-  version = "3.19.1";
+  version = "3.19.2";
 
   src = fetchurl {
     url = "${meta.homepage}files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
     # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
-    sha256 = "1fisi9rlijw9wd0yjzk1c6j7ljnb2yiq5iqnrz6m1xkflyinw9hx";
+    sha256 = "1w67w0ak6vf37501dlz9yhnzlvvpw1w10n2nm3hi7yxp4cxzvq73";
   };
 
   patches = [
@@ -37,12 +37,6 @@ stdenv.mkDerivation rec {
 
     # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
     ./libuv-application-services.patch
-
-    # Fix namelink failures, can be removed in 3.19.2+
-    (fetchpatch {
-      url = "https://gitlab.kitware.com/cmake/cmake/-/commit/38bcb5c0a3accd2dd29fb7632c6b3bf31b990d82.patch";
-      sha256 = "17yr66wrayhmavsz46b37zfwp2jcwab1zig2xqps39ysndf74qjc";
-    })
 
   ] ++ lib.optional stdenv.isCygwin ./3.2.2-cygwin.patch;
 


### PR DESCRIPTION
###### Motivation for this change
Should fix the build for a number of packages (e.g. gdcm and itk).

Apparently already encountered by @jonringer in https://github.com/awslabs/aws-checksums/pull/40

###### Things done

- [x] Checked that this fixes itk
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
