### PR TITLE
Update Haskell package set to Stackage Nightly 2021-01-01 (plus other fixes)

### DIFF
--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -185,7 +185,7 @@ stdenv.mkDerivation (rec {
   strictDeps = true;
 
   # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.
-	dontAddExtraLibs = true;
+  dontAddExtraLibs = true;
 
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -95,12 +95,12 @@ let
 
 in
 stdenv.mkDerivation (rec {
-  version = "9.0.0.20200925";
+  version = "9.0.0.20201227";
   name = "${targetPrefix}ghc-${version}";
 
   src = fetchurl {
-    url = "https://downloads.haskell.org/ghc/9.0.1-alpha1/ghc-${version}-src.tar.xz";
-    sha256 = "1c6vgic0bx0c4c6gszq7znvc5gxf0lgh630283mivbs1lyiqj88l";
+    url = "https://downloads.haskell.org/ghc/9.0.1-rc1/ghc-${version}-src.tar.xz";
+    sha256 = "1kg227fzg9qq2p7r8xqr99vvnx7ind4clxkydikyzf3vqvaacjfy";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/ghc/9.0.1.nix
+++ b/pkgs/development/compilers/ghc/9.0.1.nix
@@ -6,6 +6,7 @@
 , bash
 
 , libiconv ? null, ncurses
+, glibcLocales ? null
 
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
@@ -109,6 +110,9 @@ stdenv.mkDerivation (rec {
 
   postPatch = "patchShebangs .";
 
+  # GHC needs the locale configured during the Haddock phase.
+  LANG = "en_US.UTF-8";
+
   # GHC is a bit confused on its cross terminology.
   preConfigure = ''
     for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
@@ -129,6 +133,8 @@ stdenv.mkDerivation (rec {
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+  '' + stdenv.lib.optionalString (stdenv.isLinux) ''
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -130,7 +130,8 @@ self: super: {
   ABList = dontCheck super.ABList;
 
   # sse2 flag due to https://github.com/haskell/vector/issues/47.
-  vector = if pkgs.stdenv.isi686 then appendConfigureFlag super.vector "--ghc-options=-msse2" else super.vector;
+  # Jailbreak is necessary for QuickCheck dependency.
+  vector = doJailbreak (if pkgs.stdenv.isi686 then appendConfigureFlag super.vector "--ghc-options=-msse2" else super.vector);
 
   conduit-extra = if pkgs.stdenv.isDarwin
     then super.conduit-extra.overrideAttrs (drv: { __darwinAllowLocalNetworking = true; })

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -216,11 +216,7 @@ self: super: {
   # building of the executable has been disabled for ghc < 8.10 in hnix.
   # Generating the completions should be activated again, once we default to
   # ghc 8.10.
-  hnix = dontCheck (super.hnix.override {
-    # 2020-09-18: Those packages are all needed by hnix at versions newer than on stackage
-    prettyprinter = self.prettyprinter_1_7_0; # at least 1.7
-
-  });
+  hnix = dontCheck super.hnix;
 
   # Fails for non-obvious reasons while attempting to use doctest.
   search = dontCheck super.search;
@@ -396,7 +392,6 @@ self: super: {
   xsd = dontCheck super.xsd;
   zip-archive = dontCheck super.zip-archive;  # https://github.com/jgm/zip-archive/issues/57
 
-  random_1_2_0 = super.random_1_2_0.override ({ splitmix = self.splitmix_0_1_0_3; });
   # These test suites run for ages, even on a fast machine. This is nuts.
   Random123 = dontCheck super.Random123;
   systemd = dontCheck super.systemd;
@@ -1532,8 +1527,7 @@ self: super: {
   yesod-core = dontCheck super.yesod-core;
 
   # Add ApplicationServices on darwin
-  # use 0.4.5 instead of 0.4.4 to fix build with glibc >= 2.32
-  apecs-physics = addPkgconfigDepends super.apecs-physics_0_4_5
+  apecs-physics = addPkgconfigDepends super.apecs-physics
     (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.ApplicationServices);
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1538,4 +1538,8 @@ self: super: {
   # https://github.com/haskell/attoparsec/pull/168
   attoparsec = doJailbreak super.attoparsec;
 
+  # Break out of overspecified constraint on QuickCheck.
+  # https://github.com/Gabriel439/Haskell-Nix-Derivation-Library/pull/10
+  nix-derivation = doJailbreak super.nix-derivation;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1531,4 +1531,7 @@ self: super: {
   apecs-physics = addPkgconfigDepends super.apecs-physics
     (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.ApplicationServices);
 
+  # Break out of overspecified constraint on QuickCheck.
+  psqueues = doJailbreak super.psqueues;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1528,9 +1528,6 @@ self: super: {
   # 2020-12-06: Restrictive upper bounds w.r.t. pandoc-types (https://github.com/owickstrom/pandoc-include-code/issues/27)
   pandoc-include-code = doJailbreak super.pandoc-include-code;
 
-  # https://github.com/jgm/pandoc/issues/6961
-  pandoc = dontCheck super.pandoc;
-
   # https://github.com/yesodweb/yesod/issues/1714
   yesod-core = dontCheck super.yesod-core;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1531,11 +1531,6 @@ self: super: {
   # https://github.com/jgm/pandoc/issues/6961
   pandoc = dontCheck super.pandoc;
 
-  # Update pandoc dependencies to fix the build.
-  doctemplates = self.doctemplates_0_9;
-  skylighting = self.skylighting_0_10_2;
-  skylighting-core = self.skylighting-core_0_10_2;
-
   # https://github.com/yesodweb/yesod/issues/1714
   yesod-core = dontCheck super.yesod-core;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1532,8 +1532,14 @@ self: super: {
     (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.ApplicationServices);
 
   # Break out of overspecified constraint on QuickCheck.
+  algebraic-graphs = dontCheck super.algebraic-graphs;
   attoparsec = doJailbreak super.attoparsec;      # https://github.com/haskell/attoparsec/pull/168
   cassava = doJailbreak super.cassava;
+  filepath-bytestring = doJailbreak super.filepath-bytestring;
+  ghc-source-gen = doJailbreak super.ghc-source-gen;
+  haddock-library = doJailbreak super.haddock-library;
+  HsYAML = doJailbreak super.HsYAML;
+  http-api-data = doJailbreak super.http-api-data;
   lzma = doJailbreak super.lzma;
   psqueues = doJailbreak super.psqueues;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -863,8 +863,7 @@ self: super: {
   swagger2 = if (pkgs.stdenv.hostPlatform.isAarch32 || pkgs.stdenv.hostPlatform.isAarch64) then dontHaddock (dontCheck super.swagger2) else super.swagger2;
 
   # hledger-lib requires the latest version of pretty-simple
-  hledger-lib = super.hledger-lib.override { pretty-simple = self.pretty-simple_4_0_0_0; };
-  pretty-simple_4_0_0_0 = super.pretty-simple_4_0_0_0.overrideScope (self: super: { prettyprinter = self.prettyprinter_1_7_0; });
+  hledger-lib = super.hledger-lib.override { pretty-simple = self.pretty-simple; };
 
   # Copy hledger man pages from data directory into the proper place. This code
   # should be moved into the cabal2nix generator.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -64,7 +64,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "1l2syrslba4mrxjzj0iblflz72siw3ibqri6p5hf59fk7rmm30a8";
+      sha256 = "0w71kbz127fcli24sxsvd48l5xamwamjwhr18x9alam5cldqkkz1";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1532,11 +1532,10 @@ self: super: {
     (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.ApplicationServices);
 
   # Break out of overspecified constraint on QuickCheck.
+  attoparsec = doJailbreak super.attoparsec;      # https://github.com/haskell/attoparsec/pull/168
+  cassava = doJailbreak super.cassava;
+  lzma = doJailbreak super.lzma;
   psqueues = doJailbreak super.psqueues;
-
-  # Break out of overspecified constraint on QuickCheck.
-  # https://github.com/haskell/attoparsec/pull/168
-  attoparsec = doJailbreak super.attoparsec;
 
   # Break out of overspecified constraint on QuickCheck.
   # https://github.com/Gabriel439/Haskell-Nix-Derivation-Library/pull/10

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1534,4 +1534,8 @@ self: super: {
   # Break out of overspecified constraint on QuickCheck.
   psqueues = doJailbreak super.psqueues;
 
+  # Break out of overspecified constraint on QuickCheck.
+  # https://github.com/haskell/attoparsec/pull/168
+  attoparsec = doJailbreak super.attoparsec;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -363,9 +363,6 @@ self: super: {
   punycode = dontCheck super.punycode;
   pwstore-cli = dontCheck super.pwstore-cli;
   quantities = dontCheck super.quantities;
-  QuickCheck_2_14_2 = super.QuickCheck_2_14_2.override( {
-    splitmix = self.splitmix_0_1_0_3;
-  });
   redis-io = dontCheck super.redis-io;
   rethinkdb = dontCheck super.rethinkdb;
   Rlang-QQ = dontCheck super.Rlang-QQ;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -98,4 +98,10 @@ self: super: {
 
   # Break out of "Cabal < 3.2" constraint.
   stylish-haskell = doJailbreak super.stylish-haskell;
+
+  # Agda 2.6.1.2 only declares a transformers dependency for ghc < 8.10.3.
+  Agda = appendPatch super.Agda (pkgs.fetchpatch {
+    url = "https://github.com/agda/agda/commit/76278c23d447b49f59fac581ca4ac605792aabbc.patch";
+    sha256 = "1g34g8a09j73h89pk4cdmri0nb0qg664hkff45amcr9kyz14a9f3";
+  });
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -100,6 +100,7 @@ self: super: {
   stylish-haskell = doJailbreak super.stylish-haskell;
 
   # Agda 2.6.1.2 only declares a transformers dependency for ghc < 8.10.3.
+  # https://github.com/agda/agda/issues/5109
   Agda = appendPatch super.Agda (pkgs.fetchpatch {
     url = "https://github.com/agda/agda/commit/76278c23d447b49f59fac581ca4ac605792aabbc.patch";
     sha256 = "1g34g8a09j73h89pk4cdmri0nb0qg664hkff45amcr9kyz14a9f3";

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -83,12 +83,6 @@ self: super: {
     sha256 = "0rgzrq0513nlc1vw7nw4km4bcwn4ivxcgi33jly4a7n3c1r32v1f";
   });
 
-  # Version 4.7.2 is broken by the bytestring library shipped by ghc-8.10.3.
-  ListLike = appendPatch super.ListLike (pkgs.fetchpatch {
-    url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/master/patches/ListLike-4.7.2.patch";
-    sha256 = "1v392a74w0sxyn6x0bqixpmjbgla0i2b5hxzkcn1vaa3gaya7ag4";
-  });
-
   # hnix 0.9.0 does not provide an executable for ghc < 8.10, so define completions here for now.
   hnix = generateOptparseApplicativeCompletion "hnix"
     (overrideCabal super.hnix (drv: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -59,6 +59,7 @@ self: super: {
   # Jailbreaks & Version Updates
   async = doJailbreak super.async;
   ChasingBottoms = markBrokenVersion "1.3.1.9" super.ChasingBottoms;
+  data-fix = doJailbreak super.data-fix;
   dec = doJailbreak super.dec;
   ed25519 = doJailbreak super.ed25519;
   hashable = overrideCabal (doJailbreak (dontCheck super.hashable)) (drv: { postPatch = "sed -i -e 's,integer-gmp .*<1.1,integer-gmp < 2,' hashable.cabal"; });
@@ -66,14 +67,15 @@ self: super: {
   integer-logarithms = overrideCabal (doJailbreak super.integer-logarithms) (drv: { postPatch = "sed -i -e 's,integer-gmp <1.1,integer-gmp < 2,' integer-logarithms.cabal"; });
   lukko = doJailbreak super.lukko;
   parallel = doJailbreak super.parallel;
+  primitive = doJailbreak (dontCheck super.primitive);
   regex-posix = doJailbreak super.regex-posix;
   resolv = doJailbreak super.resolv;
   singleton-bool = doJailbreak super.singleton-bool;
   split = doJailbreak super.split;
   tar = doJailbreak super.tar;
   time-compat = doJailbreak super.time-compat;
-  primitive = doJailbreak (dontCheck super.primitive);
   vector = doJailbreak (dontCheck super.vector);
+  vector-binary-instances = doJailbreak super.vector-binary-instances;
   zlib = doJailbreak super.zlib;
 
   # Apply patches from head.hackage.

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -76,6 +76,7 @@ self: super: {
   time-compat = doJailbreak super.time-compat;
   vector = doJailbreak (dontCheck super.vector);
   vector-binary-instances = doJailbreak super.vector-binary-instances;
+  vector-th-unbox = doJailbreak super.vector-th-unbox;
   zlib = doJailbreak super.zlib;
 
   # Apply patches from head.hackage.

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -72,6 +72,7 @@ self: super: {
   split = doJailbreak super.split;
   tar = doJailbreak super.tar;
   time-compat = doJailbreak super.time-compat;
+  primitive = doJailbreak (dontCheck super.primitive);
   vector = doJailbreak (dontCheck super.vector);
   zlib = doJailbreak super.zlib;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -93,7 +93,6 @@ self: super: {
     url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/master/patches/language-haskell-extract-0.2.4.patch";
     sha256 = "0rgzrq0513nlc1vw7nw4km4bcwn4ivxcgi33jly4a7n3c1r32v1f";
   });
-  QuickCheck = super.QuickCheck_2_14_2;
   regex-base = appendPatch (doJailbreak super.regex-base) (pkgs.fetchpatch {
     url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/master/patches/regex-base-0.94.0.0.patch";
     sha256 = "0k5fglbl7nnhn8400c4cpnflxcbj9p3xi5prl9jfmszr31jwdy5d";

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -70,7 +70,6 @@ self: super: {
   resolv = doJailbreak super.resolv;
   singleton-bool = doJailbreak super.singleton-bool;
   split = doJailbreak super.split;
-  splitmix = self.splitmix_0_1_0_3;
   tar = doJailbreak super.tar;
   time-compat = doJailbreak super.time-compat;
   vector = doJailbreak (dontCheck super.vector);

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4362,6 +4362,7 @@ broken-packages:
   - currency-convert
   - curry-frontend
   - CurryDB
+  - curryer-rpc
   - cursedcsv
   - cursor-fuzzy-time-gen
   - curves
@@ -5260,6 +5261,7 @@ broken-packages:
   - foscam-filename
   - foscam-sort
   - Foster
+  - fp-ieee
   - fpco-api
   - fplll
   - fpnla-examples
@@ -6593,6 +6595,7 @@ broken-packages:
   - Hs2lib
   - hs2ps
   - hsaml2
+  - hsautogui
   - hsay
   - hsbackup
   - hsbc
@@ -7904,6 +7907,7 @@ broken-packages:
   - minst-idx
   - mios
   - MIP
+  - MIP-glpk
   - mirror-tweet
   - miso
   - miso-action-logger
@@ -9480,6 +9484,7 @@ broken-packages:
   - rosso
   - rotating-log
   - rounded
+  - rounded-hw
   - rounding
   - roundtrip-aeson
   - roundtrip-xml

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -76,7 +76,7 @@ default-package-overrides:
   # haskell-language-server 0.5.0.0 doesn't accept newer versions
   - fourmolu ==0.2.*
   - refinery ==0.2.*
-  # Stackage Nightly 2020-12-14
+  # Stackage Nightly 2021-01-01
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -109,7 +109,7 @@ default-package-overrides:
   - al ==0.1.4.2
   - alarmclock ==0.7.0.5
   - alerts ==0.1.2.0
-  - alex ==3.2.5
+  - alex ==3.2.6
   - alg ==0.2.13.1
   - algebraic-graphs ==0.5
   - Allure ==0.9.5.0
@@ -215,18 +215,19 @@ default-package-overrides:
   - ansi-terminal ==0.10.3
   - ansi-wl-pprint ==0.6.9
   - ANum ==0.2.0.2
+  - ap-normalize ==0.1.0.0
   - apecs ==0.9.2
   - apecs-gloss ==0.2.4
-  - apecs-physics ==0.4.4
+  - apecs-physics ==0.4.5
   - api-field-json-th ==0.1.0.2
-  - ap-normalize ==0.1.0.0
+  - api-maker ==0.1.0.0
+  - app-settings ==0.2.0.12
   - appar ==0.1.8
   - appendmap ==0.1.5
   - apply-refact ==0.8.2.1
   - apportionment ==0.0.0.3
   - approximate ==0.3.2
   - approximate-equality ==1.1.0.2
-  - app-settings ==0.2.0.12
   - arbor-lru-cache ==0.1.1.1
   - arbor-postgres ==0.0.5
   - arithmoi ==0.11.0.1
@@ -235,12 +236,12 @@ default-package-overrides:
   - ascii ==1.0.0.2
   - ascii-case ==1.0.0.2
   - ascii-char ==1.0.0.2
-  - asciidiagram ==1.3.3.3
   - ascii-group ==1.0.0.2
   - ascii-predicates ==1.0.0.2
   - ascii-progress ==0.3.3.0
   - ascii-superset ==1.0.0.2
   - ascii-th ==1.0.0.2
+  - asciidiagram ==1.3.3.3
   - asif ==6.0.4
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
@@ -268,14 +269,20 @@ default-package-overrides:
   - authenticate ==1.3.5
   - authenticate-oauth ==1.6.0.1
   - auto ==0.4.3.1
-  - autoexporter ==1.1.19
   - auto-update ==0.1.6
+  - autoexporter ==1.1.19
   - avers ==0.0.17.1
   - avro ==0.5.2.0
   - aws-cloudfront-signed-cookies ==0.2.0.6
+  - backprop ==0.2.6.4
   - backtracking ==0.1.0
   - bank-holidays-england ==0.2.0.6
   - barbies ==2.0.2.0
+  - base-compat ==0.11.2
+  - base-compat-batteries ==0.11.2
+  - base-orphans ==0.8.4
+  - base-prelude ==1.4
+  - base-unicode-symbols ==0.2.4.2
   - base16 ==0.3.0.1
   - base16-bytestring ==0.1.1.7
   - base16-lens ==0.1.3.0
@@ -289,12 +296,7 @@ default-package-overrides:
   - base64-bytestring-type ==1.0.1
   - base64-lens ==0.3.0
   - base64-string ==0.2
-  - base-compat ==0.11.2
-  - base-compat-batteries ==0.11.2
   - basement ==0.0.11
-  - base-orphans ==0.8.4
-  - base-prelude ==1.4
-  - base-unicode-symbols ==0.2.4.2
   - basic-prelude ==0.7.0
   - bazel-runfiles ==0.12
   - bbdb ==0.8
@@ -305,16 +307,15 @@ default-package-overrides:
   - benchpress ==0.2.2.15
   - between ==0.11.0.0
   - bibtex ==0.1.0.6
-  - bifunctors ==5.5.8
+  - bifunctors ==5.5.9
   - bimap ==0.4.0
-  - bimaps ==0.1.0.2
   - bimap-server ==0.1.0.1
+  - bimaps ==0.1.0.2
   - bin ==0.1
   - binary-conduit ==1.3.1
-  - binaryen ==0.0.5.0
   - binary-ext ==2.0.4
   - binary-ieee754 ==0.1.0.0
-  - binary-instances ==1.0.0.1
+  - binary-instances ==1.0.1
   - binary-list ==1.1.1.2
   - binary-orphans ==1.0.1
   - binary-parser ==0.5.6
@@ -322,6 +323,7 @@ default-package-overrides:
   - binary-search ==1.0.0.3
   - binary-shared ==0.8.3
   - binary-tagged ==0.3
+  - binaryen ==0.0.5.0
   - bindings-DSL ==1.0.25
   - bindings-GLFW ==3.3.2.0
   - bindings-libzip ==1.0.1
@@ -329,8 +331,8 @@ default-package-overrides:
   - bins ==0.1.2.0
   - bitarray ==0.0.1.1
   - bits ==0.5.2
-  - bitset-word8 ==0.1.1.2
   - bits-extra ==0.0.2.0
+  - bitset-word8 ==0.1.1.2
   - bitvec ==1.0.3.0
   - bitwise-enum ==1.0.0.2
   - blake2 ==0.3.0
@@ -345,7 +347,7 @@ default-package-overrides:
   - blaze-svg ==0.3.6.1
   - blaze-textual ==0.2.1.0
   - bmp ==1.2.6.3
-  - BNFC ==2.8.4
+  - BNFC ==2.9.0
   - board-games ==0.3
   - boltzmann-samplers ==0.1.1.0
   - Boolean ==0.2.4
@@ -356,12 +358,12 @@ default-package-overrides:
   - boring ==0.1.3
   - both ==0.1.1.1
   - bound ==2.0.2
-  - BoundedChan ==1.0.3.0
   - bounded-queue ==1.0.0
+  - BoundedChan ==1.0.3.0
   - boundingboxes ==0.2.3
   - bower-json ==1.0.0.1
   - boxes ==0.1.5
-  - brick ==0.57.1
+  - brick ==0.58.1
   - broadcast-chan ==0.2.1.1
   - bsb-http-chunked ==0.0.0.4
   - bson ==0.4.0.1
@@ -375,10 +377,10 @@ default-package-overrides:
   - butcher ==1.3.3.2
   - bv ==0.5
   - bv-little ==1.1.1
-  - byteable ==0.1.1
   - byte-count-reader ==0.10.1.2
-  - bytedump ==1.0
   - byte-order ==0.1.2.0
+  - byteable ==0.1.1
+  - bytedump ==1.0
   - byteorder ==1.0.4
   - bytes ==0.17
   - byteset ==0.1.1.0
@@ -394,7 +396,7 @@ default-package-overrides:
   - bzlib-conduit ==0.3.0.2
   - c14n ==0.1.0.1
   - c2hs ==0.28.7
-  - cabal-debian ==5.1
+  - ca-province-codes ==1.0.0.0
   - cabal-doctest ==1.0.8
   - cabal-file ==0.1.1
   - cabal-flatpak ==0.1.0.2
@@ -405,13 +407,12 @@ default-package-overrides:
   - calendar-recycling ==0.0.0.1
   - call-stack ==0.2.0
   - can-i-haz ==0.3.1.0
-  - ca-province-codes ==1.0.0.0
   - cardano-coin-selection ==1.0.1
   - carray ==0.1.6.8
   - casa-client ==0.0.1
   - casa-types ==0.0.1
-  - cased ==0.1.0.0
   - case-insensitive ==1.2.1.0
+  - cased ==0.1.0.0
   - cases ==0.1.4
   - casing ==0.1.4.1
   - cassava ==0.5.2.0
@@ -453,6 +454,7 @@ default-package-overrides:
   - cipher-des ==0.0.6
   - cipher-rc4 ==0.1.4
   - circle-packing ==0.1.0.6
+  - circular ==0.3.1.1
   - clash-ghc ==1.2.5
   - clash-lib ==1.2.5
   - clash-prelude ==1.2.5
@@ -471,12 +473,12 @@ default-package-overrides:
   - cmark-gfm ==0.2.2
   - cmark-lucid ==0.1.0.0
   - cmdargs ==0.10.20
-  - codec-beam ==0.2.0
-  - codec-rpm ==0.2.2
-  - code-page ==0.2
   - co-log ==0.4.0.1
   - co-log-concurrent ==0.5.0.0
   - co-log-core ==0.2.1.1
+  - code-page ==0.2
+  - codec-beam ==0.2.0
+  - codec-rpm ==0.2.2
   - Color ==0.3.0
   - colorful-monoids ==0.2.1.3
   - colorize-haskell ==1.0.1
@@ -486,7 +488,7 @@ default-package-overrides:
   - comfort-array ==0.4
   - comfort-graph ==0.0.3.1
   - commutative ==0.0.2
-  - comonad ==5.0.6
+  - comonad ==5.0.8
   - comonad-extras ==4.0.1
   - compactmap ==0.1.4.2.1
   - compensated ==0.8.1
@@ -522,8 +524,8 @@ default-package-overrides:
   - conferer-hspec ==0.4.0.1
   - conferer-source-json ==0.4.0.1
   - conferer-warp ==0.4.0.1
-  - ConfigFile ==1.1.4
   - config-ini ==0.2.4.0
+  - ConfigFile ==1.1.4
   - configurator ==0.3.0.0
   - configurator-export ==0.1.0.1
   - configurator-pg ==0.2.5
@@ -531,10 +533,10 @@ default-package-overrides:
   - connection-pool ==0.2.2
   - console-style ==0.0.2.1
   - constraint ==0.1.4.0
-  - constraints ==0.12
   - constraint-tuples ==0.1.2
+  - constraints ==0.12
   - construct ==0.3
-  - contravariant ==1.5.2
+  - contravariant ==1.5.3
   - contravariant-extras ==0.3.5.2
   - control-bool ==0.2.1
   - control-monad-free ==0.6.2
@@ -559,8 +561,13 @@ default-package-overrides:
   - cron ==0.7.0
   - crypto-api ==0.13.3
   - crypto-cipher-types ==0.0.9
-  - cryptocompare ==0.1.2
   - crypto-enigma ==0.1.1.6
+  - crypto-numbers ==0.2.7
+  - crypto-pubkey ==0.2.8
+  - crypto-pubkey-types ==0.4.3
+  - crypto-random ==0.0.9
+  - crypto-random-api ==0.2.0
+  - cryptocompare ==0.1.2
   - cryptohash ==0.11.9
   - cryptohash-cryptoapi ==0.1.4
   - cryptohash-md5 ==0.11.100.1
@@ -569,11 +576,6 @@ default-package-overrides:
   - cryptonite ==0.27
   - cryptonite-conduit ==0.2.2
   - cryptonite-openssl ==0.7
-  - crypto-numbers ==0.2.7
-  - crypto-pubkey ==0.2.8
-  - crypto-pubkey-types ==0.4.3
-  - crypto-random ==0.0.9
-  - crypto-random-api ==0.2.0
   - csp ==1.4.0
   - css-syntax ==0.1.0.0
   - css-text ==0.1.3.0
@@ -610,7 +612,6 @@ default-package-overrides:
   - data-default-instances-dlist ==0.0.1
   - data-default-instances-old-locale ==0.0.1
   - data-diverse ==4.7.0.0
-  - datadog ==0.2.5.0
   - data-dword ==0.3.2
   - data-endian ==0.1.1
   - data-fix ==0.3.0
@@ -629,12 +630,12 @@ default-package-overrides:
   - data-reify ==0.6.3
   - data-serializer ==0.3.4.1
   - data-textual ==0.3.0.3
+  - datadog ==0.2.5.0
   - dataurl ==0.1.0.0
   - DAV ==1.3.4
   - DBFunctor ==0.1.1.1
-  - dbus ==1.2.16
+  - dbus ==1.2.17
   - dbus-hslogger ==0.1.0.1
-  - debian ==4.0.2
   - debian-build ==0.10.2.0
   - debug-trace-var ==0.2.0
   - dec ==0.0.3
@@ -643,52 +644,52 @@ default-package-overrides:
   - deepseq-generics ==0.2.0.0
   - deepseq-instances ==0.1.0.1
   - deferred-folds ==0.9.15
-  - dejafu ==2.4.0.0
+  - dejafu ==2.4.0.1
   - dense-linear-algebra ==0.1.0.0
   - depq ==0.4.1.0
   - deque ==0.4.3
-  - deriveJsonNoPrefix ==0.1.0.1
   - derive-topdown ==0.0.2.2
+  - deriveJsonNoPrefix ==0.1.0.1
   - deriving-aeson ==0.2.6
   - deriving-compat ==0.5.10
   - derulo ==1.0.9
-  - dhall ==1.37.0
+  - dhall ==1.37.1
   - dhall-bash ==1.0.35
   - dhall-json ==1.7.4
   - dhall-lsp-server ==1.0.12
   - dhall-yaml ==1.2.4
+  - di-core ==1.0.4
+  - di-monad ==1.3.1
   - diagrams-solve ==0.1.2
   - dialogflow-fulfillment ==0.1.1.3
-  - di-core ==1.0.4
   - dictionary-sharing ==0.1.0.0
   - Diff ==0.4.0
   - digest ==0.0.1.2
   - digits ==0.3.1
   - dimensional ==1.3
-  - di-monad ==1.3.1
-  - directory-tree ==0.12.1
   - direct-sqlite ==2.3.26
-  - dirichlet ==0.1.0.0
+  - directory-tree ==0.12.1
+  - dirichlet ==0.1.0.2
   - discount ==0.1.1
   - disk-free-space ==0.1.0.1
   - distributed-closure ==0.4.2.0
   - distribution-opensuse ==1.1.1
-  - distributive ==0.6.2
+  - distributive ==0.6.2.1
   - dl-fedora ==0.7.5
   - dlist ==0.8.0.8
   - dlist-instances ==0.1.1.1
   - dlist-nonempty ==0.1.1
   - dns ==4.0.1
+  - do-list ==1.0.1
+  - do-notation ==0.1.0.2
   - dockerfile ==0.2.0
   - doclayout ==0.3
-  - doctemplates ==0.8.3
+  - doctemplates ==0.9
   - doctest ==0.16.3
   - doctest-discover ==0.2.0.0
   - doctest-exitcode-stdio ==0.0
   - doctest-lib ==0.1
   - doldol ==0.4.1.2
-  - do-list ==1.0.1
-  - do-notation ==0.1.0.2
   - dotenv ==0.8.0.7
   - dotgen ==0.4.3
   - dotnet-timespan ==0.0.1.0
@@ -705,7 +706,6 @@ default-package-overrides:
   - dyre ==0.8.12
   - eap ==0.9.0.2
   - earcut ==0.1.0.4
-  - Earley ==0.13.0.1
   - easy-file ==0.2.2
   - Ebnf2ps ==1.0.15
   - echo ==0.1.3
@@ -727,24 +727,24 @@ default-package-overrides:
   - elerea ==2.9.0
   - elf ==0.30
   - eliminators ==0.7
-  - elm2nix ==0.2.1
   - elm-bridge ==0.6.1
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
-  - elynx ==0.5.0
-  - elynx-markov ==0.5.0
-  - elynx-nexus ==0.5.0
-  - elynx-seq ==0.5.0
-  - elynx-tools ==0.5.0
-  - elynx-tree ==0.5.0
+  - elm2nix ==0.2.1
+  - elynx ==0.5.0.1
+  - elynx-markov ==0.5.0.1
+  - elynx-nexus ==0.5.0.1
+  - elynx-seq ==0.5.0.1
+  - elynx-tools ==0.5.0.1
+  - elynx-tree ==0.5.0.1
   - email-validate ==2.3.2.13
   - emojis ==0.1
   - enclosed-exceptions ==1.0.3
   - ENIG ==0.0.1.0
   - entropy ==0.4.1.6
+  - enum-subset-generate ==0.1.0.0
   - enummapset ==0.6.0.3
   - enumset ==0.0.5
-  - enum-subset-generate ==0.1.0.0
   - envelope ==0.2.2.0
   - envparse ==0.4.1
   - envy ==2.1.0.0
@@ -754,7 +754,7 @@ default-package-overrides:
   - equational-reasoning ==0.6.0.3
   - equivalence ==0.3.5
   - erf ==2.0.0.0
-  - error-or ==0.1.1.0
+  - error-or ==0.1.2.0
   - error-or-utils ==0.1.1
   - errors ==2.3.0
   - errors-ext ==0.4.2
@@ -766,29 +766,30 @@ default-package-overrides:
   - essence-of-live-coding-quickcheck ==0.2.4
   - etc ==0.4.1.0
   - eve ==0.1.9.0
+  - event-list ==0.1.2
   - eventful-core ==0.2.0
   - eventful-test-helpers ==0.2.0
-  - event-list ==0.1.2
   - eventstore ==1.4.1
   - every ==0.0.1
   - exact-combinatorics ==0.2.0.9
   - exact-pi ==0.5.0.1
   - exception-hierarchy ==0.1.0.4
   - exception-mtl ==0.4.0.1
-  - exceptions ==0.10.4
   - exception-transformers ==0.4.0.9
   - exception-via ==0.1.0.0
+  - exceptions ==0.10.4
   - executable-path ==0.0.3.1
   - exit-codes ==1.0.0
   - exomizer ==1.0.0
+  - exp-pairs ==0.2.1.0
+  - experimenter ==0.1.0.4
   - expiring-cache-map ==0.0.6.1
   - explicit-exception ==0.1.10
-  - exp-pairs ==0.2.1.0
   - express ==0.1.3
   - extended-reals ==0.2.4.0
   - extensible-effects ==5.0.0.1
   - extensible-exceptions ==0.1.1.4
-  - extra ==1.7.8
+  - extra ==1.7.9
   - extractable-singleton ==0.0.1
   - extrapolate ==0.4.2
   - fail ==4.9.0.0
@@ -810,10 +811,10 @@ default-package-overrides:
   - fgl ==5.7.0.3
   - file-embed ==0.0.13.0
   - file-embed-lzma ==0
-  - filelock ==0.1.1.5
-  - filemanip ==0.3.6.3
   - file-modules ==0.1.2.4
   - file-path-th ==0.1.0.0
+  - filelock ==0.1.1.5
+  - filemanip ==0.3.6.3
   - filepattern ==0.1.2
   - fileplow ==0.1.0.0
   - filtrable ==0.1.4.0
@@ -843,8 +844,8 @@ default-package-overrides:
   - fn ==0.3.0.2
   - focus ==1.0.2
   - focuslist ==0.1.0.2
-  - foldable1 ==0.1.0.0
   - fold-debounce ==0.2.0.9
+  - foldable1 ==0.1.0.0
   - foldl ==1.4.10
   - folds ==0.7.5
   - follow-file ==0.0.3
@@ -856,12 +857,12 @@ default-package-overrides:
   - format-numbers ==0.1.0.1
   - formatting ==6.3.7
   - foundation ==0.0.25
-  - free ==5.1.4
+  - free ==5.1.5
   - free-categories ==0.2.0.2
+  - free-vl ==0.1.4
   - freenect ==1.2.1
   - freer-simple ==1.2.1.1
   - freetype2 ==0.2.0
-  - free-vl ==0.1.4
   - friendly-time ==0.4.1
   - from-sum ==0.2.3.0
   - frontmatter ==0.1.0.2
@@ -877,8 +878,8 @@ default-package-overrides:
   - fuzzcheck ==0.1.1
   - fuzzy ==0.1.0.0
   - fuzzy-dates ==0.1.1.2
-  - fuzzyset ==0.2.0
   - fuzzy-time ==0.1.0.0
+  - fuzzyset ==0.2.0
   - gauge ==0.2.5
   - gd ==3000.7.3
   - gdp ==0.0.3.0
@@ -893,8 +894,8 @@ default-package-overrides:
   - generic-lens-core ==2.0.0.0
   - generic-monoid ==0.1.0.1
   - generic-optics ==2.0.0.0
-  - GenericPretty ==1.2.2
   - generic-random ==1.3.0.1
+  - GenericPretty ==1.2.2
   - generics-sop ==0.5.1.0
   - generics-sop-lens ==0.2.0.1
   - geniplate-mirror ==0.7.7
@@ -926,14 +927,11 @@ default-package-overrides:
   - ghc-byteorder ==4.11.0.0.10
   - ghc-check ==0.5.0.3
   - ghc-core ==0.5.6
-  - ghc-events ==0.14.0
+  - ghc-events ==0.15.1
   - ghc-exactprint ==0.6.3.3
-  - ghcid ==0.8.7
-  - ghci-hexcalc ==0.1.1.0
-  - ghcjs-codemirror ==0.0.0.2
-  - ghc-lib ==8.10.2.20200916
-  - ghc-lib-parser ==8.10.2.20200916
-  - ghc-lib-parser-ex ==8.10.0.16
+  - ghc-lib ==8.10.3.20201220
+  - ghc-lib-parser ==8.10.3.20201220
+  - ghc-lib-parser-ex ==8.10.0.17
   - ghc-parser ==0.2.2.0
   - ghc-paths ==0.1.0.12
   - ghc-prof ==1.4.1.7
@@ -945,6 +943,9 @@ default-package-overrides:
   - ghc-typelits-knownnat ==0.7.3
   - ghc-typelits-natnormalise ==0.7.2
   - ghc-typelits-presburger ==0.3.0.1
+  - ghci-hexcalc ==0.1.1.0
+  - ghcid ==0.8.7
+  - ghcjs-codemirror ==0.0.0.2
   - ghost-buster ==0.1.1.0
   - gi-atk ==2.0.22
   - gi-cairo ==1.0.24
@@ -962,18 +963,18 @@ default-package-overrides:
   - gi-gtk ==3.0.36
   - gi-gtk-hs ==0.3.9
   - gi-harfbuzz ==0.0.3
+  - gi-pango ==1.0.23
+  - gi-xlib ==2.0.9
   - ginger ==0.10.1.0
   - gingersnap ==0.3.1.0
-  - gi-pango ==1.0.23
   - githash ==0.1.5.0
   - github ==0.26
   - github-release ==1.3.5
   - github-rest ==1.0.3
   - github-types ==0.2.1
   - github-webhooks ==0.15.0
-  - gitlab-haskell ==0.2.3
+  - gitlab-haskell ==0.2.4
   - gitrev ==1.3.1
-  - gi-xlib ==2.0.9
   - gl ==0.9
   - glabrous ==2.0.2
   - GLFW-b ==3.3.0.0
@@ -988,11 +989,11 @@ default-package-overrides:
   - gothic ==0.1.5
   - gpolyline ==0.1.0.1
   - graph-core ==0.3.0.0
+  - graph-wrapper ==0.2.6.0
   - graphite ==0.10.0.1
   - graphql-client ==1.1.0
   - graphs ==0.7.1
   - graphviz ==2999.20.1.0
-  - graph-wrapper ==0.2.6.0
   - gravatar ==0.8.0
   - groom ==0.1.2.1
   - group-by-date ==0.1.0.3
@@ -1000,9 +1001,11 @@ default-package-overrides:
   - gtk-sni-tray ==0.1.6.0
   - gtk-strut ==0.1.3.0
   - guarded-allocation ==0.0.1
+  - H ==0.9.0.1
   - hackage-db ==2.1.0
   - hackage-security ==0.6.0.1
   - haddock-library ==1.9.0
+  - hadolint ==1.19.0
   - hadoop-streaming ==0.2.0.3
   - hakyll-convert ==0.3.0.3
   - half ==0.3
@@ -1050,13 +1053,13 @@ default-package-overrides:
   - heap ==1.0.4
   - heaps ==0.3.6.1
   - hebrew-time ==0.1.2
-  - hedgehog ==1.0.3
+  - hedgehog ==1.0.4
   - hedgehog-classes ==0.2.5.1
   - hedgehog-corpus ==0.2.0
   - hedgehog-fakedata ==0.0.1.3
   - hedgehog-fn ==1.0
   - hedgehog-quickcheck ==0.1.1
-  - hedis ==0.13.1
+  - hedis ==0.14.0
   - hedn ==0.3.0.2
   - here ==1.2.13
   - heredoc ==0.2.0.0
@@ -1070,9 +1073,9 @@ default-package-overrides:
   - hgeometry ==0.11.0.0
   - hgeometry-combinatorial ==0.11.0.0
   - hgrev ==0.2.6
-  - hidapi ==0.1.5
-  - hie-bios ==0.7.1
   - hi-file-parser ==0.1.0.0
+  - hidapi ==0.1.5
+  - hie-bios ==0.7.2
   - higher-leveldb ==0.6.0.0
   - highlighting-kate ==0.6.4
   - hinfo ==0.0.3.0
@@ -1085,6 +1088,7 @@ default-package-overrides:
   - hlibgit2 ==0.18.0.16
   - hlibsass ==0.1.10.1
   - hmatrix ==0.20.1
+  - hmatrix-backprop ==0.1.3.0
   - hmatrix-gsl ==0.19.0.1
   - hmatrix-gsl-stats ==0.4.1.8
   - hmatrix-morpheus ==0.1.1.2
@@ -1110,15 +1114,16 @@ default-package-overrides:
   - hpc-lcov ==1.0.1
   - hprotoc ==2.4.17
   - hruby ==0.3.8
-  - hsass ==0.8.0
   - hs-bibutils ==6.10.0.0
+  - hs-functors ==0.1.7.1
+  - hs-GeoIP ==0.3
+  - hs-php-session ==0.0.9.3
+  - hsass ==0.8.0
   - hsc2hs ==0.68.7
   - hscolour ==1.24.4
   - hsdns ==1.8
   - hsebaysdk ==0.4.1.0
   - hsemail ==2.2.1
-  - hs-functors ==0.1.7.1
-  - hs-GeoIP ==0.3
   - hsini ==0.5.1.2
   - hsinstall ==2.6
   - HSlippyMap ==3.0.1
@@ -1151,7 +1156,6 @@ default-package-overrides:
   - hspec-tables ==0.0.1
   - hspec-wai ==0.10.1
   - hspec-wai-json ==0.10.1
-  - hs-php-session ==0.0.9.3
   - hsshellscript ==3.4.5
   - HStringTemplate ==0.8.7
   - HSvm ==0.1.1.3.22
@@ -1164,7 +1168,6 @@ default-package-overrides:
   - html-entities ==1.1.4.3
   - html-entity-map ==0.1.0.0
   - htoml ==1.0.0.3
-  - http2 ==2.0.5
   - HTTP ==4000.3.15
   - http-api-data ==0.4.1.1
   - http-client ==0.6.4.1
@@ -1176,13 +1179,14 @@ default-package-overrides:
   - http-date ==0.0.10
   - http-directory ==0.1.8
   - http-download ==0.2.0.0
-  - httpd-shed ==0.4.1.1
   - http-link-header ==1.0.3.1
   - http-media ==0.8.0.0
   - http-query ==0.1.0
   - http-reverse-proxy ==0.6.0
   - http-streams ==0.8.7.2
   - http-types ==0.12.3
+  - http2 ==2.0.5
+  - httpd-shed ==0.4.1.1
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.1.0
   - HUnit-approx ==1.1.1.1
@@ -1195,7 +1199,6 @@ default-package-overrides:
   - hw-conduit-merges ==0.2.1.0
   - hw-diagnostics ==0.0.1.0
   - hw-dsv ==0.4.1.0
-  - hweblib ==0.6.3
   - hw-eliasfano ==0.1.2.0
   - hw-excess ==0.2.3.0
   - hw-fingertree ==0.1.2.0
@@ -1220,6 +1223,7 @@ default-package-overrides:
   - hw-string-parse ==0.0.0.4
   - hw-succinct ==0.1.0.1
   - hw-xml ==0.5.1.0
+  - hweblib ==0.6.3
   - hxt ==9.3.1.18
   - hxt-charproperties ==9.4.0.0
   - hxt-css ==0.1.0.3
@@ -1247,12 +1251,13 @@ default-package-overrides:
   - immortal-queue ==0.1.0.1
   - inbox ==0.1.0
   - include-file ==0.1.0.4
-  - incremental-parser ==0.5
+  - incremental-parser ==0.5.0.1
   - indents ==0.5.0.1
   - indexed ==0.1.3
   - indexed-containers ==0.1.0.2
   - indexed-list-literals ==0.2.1.3
   - indexed-profunctors ==0.1
+  - indexed-traversable ==0.1.1
   - infer-license ==0.2.0
   - inflections ==0.4.0.6
   - influxdb ==1.9.0
@@ -1260,6 +1265,7 @@ default-package-overrides:
   - inj ==1.0
   - inline-c ==0.9.1.3
   - inline-c-cpp ==0.4.0.2
+  - inline-r ==0.10.4
   - inliterate ==0.1.0
   - input-parsers ==0.1.0.1
   - insert-ordered-containers ==0.2.3.1
@@ -1301,13 +1307,13 @@ default-package-overrides:
   - iso3166-country-codes ==0.20140203.8
   - iso639 ==0.1.0.3
   - iso8601-time ==0.1.5
-  - iterable ==3.0
   - it-has ==0.2.0.0
+  - iterable ==3.0
+  - ix-shapable ==0.1.0
   - ixset-typed ==0.5
   - ixset-typed-binary-instance ==0.1.0.2
   - ixset-typed-conversions ==0.1.2.0
   - ixset-typed-hashable-instance ==0.1.0.2
-  - ix-shapable ==0.1.0
   - jack ==0.7.1.4
   - jalaali ==1.0.0.0
   - jira-wiki-markup ==1.3.2
@@ -1318,9 +1324,9 @@ default-package-overrides:
   - js-flot ==0.8.3
   - js-jquery ==3.3.1
   - json-feed ==1.0.11
-  - jsonpath ==0.2.0.0
   - json-rpc ==1.0.3
   - json-rpc-generic ==0.2.1.5
+  - jsonpath ==0.2.0.0
   - JuicyPixels ==3.3.5
   - JuicyPixels-blurhash ==0.1.0.3
   - JuicyPixels-extra ==0.4.1
@@ -1331,11 +1337,13 @@ default-package-overrides:
   - kan-extensions ==5.2.1
   - kanji ==3.4.1
   - katip ==0.8.5.0
+  - katip-logstash ==0.1.0.0
   - kawhi ==0.3.0
   - kazura-queue ==0.1.0.4
   - kdt ==0.2.4
   - keycode ==0.2.2
   - keys ==3.12.3
+  - ki ==0.2.0.1
   - kind-apply ==0.3.2.0
   - kind-generics ==0.4.1.0
   - kind-generics-th ==0.2.2.1
@@ -1396,9 +1404,9 @@ default-package-overrides:
   - libyaml ==0.1.2
   - LibZip ==1.0.1
   - life-sync ==1.1.1.0
+  - lift-generics ==0.2
   - lifted-async ==0.10.1.2
   - lifted-base ==0.2.3.12
-  - lift-generics ==0.2
   - line ==4.0.1
   - linear ==1.21.3
   - linear-circuit ==0.1.0.2
@@ -1407,11 +1415,10 @@ default-package-overrides:
   - linux-namespaces ==0.1.3.0
   - liquid-fixpoint ==0.8.10.2
   - List ==0.6.2
-  - ListLike ==4.7.2
   - list-predicate ==0.1.0.1
-  - listsafe ==0.1.0.1
   - list-singleton ==1.0.0.4
   - list-t ==1.0.4
+  - listsafe ==0.1.0.1
   - ListTree ==0.2.3
   - little-logger ==0.3.1
   - little-rio ==0.2.2
@@ -1429,6 +1436,7 @@ default-package-overrides:
   - logging-facade ==0.3.0
   - logging-facade-syslog ==1
   - logict ==0.7.0.3
+  - logstash ==0.1.0.1
   - loop ==0.3.0
   - lrucache ==1.2.0.1
   - lrucaching ==0.3.3
@@ -1443,20 +1451,20 @@ default-package-overrides:
   - machines ==0.7.1
   - magic ==1.1
   - magico ==0.0.2.1
-  - mainland-pretty ==0.7.0.1
   - main-tester ==0.2.0.1
+  - mainland-pretty ==0.7.0.1
   - makefile ==1.1.0.0
   - managed ==1.0.8
   - MapWith ==0.2.0.0
   - markdown ==0.1.17.4
-  - markdown-unlit ==0.5.0
+  - markdown-unlit ==0.5.1
   - markov-chain ==0.0.3.4
-  - massiv ==0.5.8.0
+  - massiv ==0.5.9.0
   - massiv-io ==0.4.0.0
-  - massiv-test ==0.1.5
-  - mathexpr ==0.3.0.0
+  - massiv-test ==0.1.6
   - math-extras ==0.1.1.0
   - math-functions ==0.3.4.1
+  - mathexpr ==0.3.0.0
   - matplotlib ==0.7.5
   - matrices ==0.5.0
   - matrix ==0.3.6.1
@@ -1466,11 +1474,11 @@ default-package-overrides:
   - maximal-cliques ==0.1.1
   - mbox ==0.3.4
   - mbox-utility ==0.0.3.1
-  - mcmc ==0.3.0
+  - mcmc ==0.4.0.0
   - mcmc-types ==1.0.3
+  - med-module ==0.1.2.1
   - medea ==1.2.0
   - median-stream ==0.7.0.0
-  - med-module ==0.1.2.1
   - megaparsec ==9.0.1
   - megaparsec-tests ==9.0.1
   - membrain ==0.0.0.2
@@ -1492,19 +1500,19 @@ default-package-overrides:
   - microlens-process ==0.2.0.2
   - microlens-th ==0.4.3.8
   - microspec ==0.2.1.3
-  - microstache ==1.0.1.1
+  - microstache ==1.0.1.2
   - midair ==0.2.0.1
   - midi ==0.2.2.2
   - mighty-metropolis ==2.0.0
   - mime-mail ==0.5.0
   - mime-mail-ses ==0.4.3
   - mime-types ==0.1.0.9
+  - min-max-pqueue ==0.1.0.2
   - mini-egison ==1.0.0
   - minimal-configuration ==0.1.4
   - minimorph ==0.3.0.0
   - minio-hs ==1.5.3
   - miniutter ==0.5.1.1
-  - min-max-pqueue ==0.1.0.2
   - mintty ==0.1.2
   - missing-foreign ==0.1.1
   - MissingH ==1.4.3.0
@@ -1516,9 +1524,9 @@ default-package-overrides:
   - mmark-ext ==0.2.1.2
   - mmorph ==1.1.3
   - mnist-idx ==0.1.2.8
-  - mockery ==0.3.5
   - mock-time ==0.1.0
-  - mod ==0.1.2.0
+  - mockery ==0.3.5
+  - mod ==0.1.2.1
   - model ==0.5
   - modern-uri ==0.3.3.0
   - modular ==0.1.0.8
@@ -1527,36 +1535,37 @@ default-package-overrides:
   - monad-control-aligned ==0.0.1.1
   - monad-coroutine ==0.9.0.4
   - monad-extras ==0.6.0
-  - monadic-arrays ==0.2.2
   - monad-journal ==0.8.1
-  - monadlist ==0.0.2
   - monad-logger ==0.3.36
   - monad-logger-json ==0.1.0.0
+  - monad-logger-logstash ==0.1.0.0
   - monad-logger-prefix ==0.1.12
   - monad-loops ==0.4.3
   - monad-memo ==0.5.3
   - monad-metrics ==0.2.2.0
   - monad-par ==0.3.5
-  - monad-parallel ==0.7.2.3
   - monad-par-extras ==0.3.3
+  - monad-parallel ==0.7.2.3
   - monad-peel ==0.2.1.2
   - monad-primitive ==0.1
   - monad-products ==4.0.1
-  - MonadPrompt ==1.0.0.5
-  - MonadRandom ==0.5.2
   - monad-resumption ==0.1.4.0
   - monad-skeleton ==0.1.5
   - monad-st ==0.2.4.1
-  - monads-tf ==0.1.0.3
   - monad-time ==0.3.1.0
   - monad-unlift ==0.2.0
   - monad-unlift-ref ==0.2.1
+  - monadic-arrays ==0.2.2
+  - monadlist ==0.0.2
+  - MonadPrompt ==1.0.0.5
+  - MonadRandom ==0.5.2
+  - monads-tf ==0.1.0.3
   - mongoDB ==2.7.0.0
-  - monoid-subclasses ==1.0.1
-  - monoid-transformer ==0.0.4
   - mono-traversable ==1.0.15.1
   - mono-traversable-instances ==0.1.1.0
   - mono-traversable-keys ==0.1.0
+  - monoid-subclasses ==1.0.1
+  - monoid-transformer ==0.0.4
   - more-containers ==0.2.2.0
   - morpheus-graphql ==0.16.0
   - morpheus-graphql-client ==0.16.0
@@ -1569,14 +1578,14 @@ default-package-overrides:
   - mpi-hs-cereal ==0.1.0.0
   - mtl-compat ==0.2.2
   - mtl-prelude ==2.0.3.1
-  - multiarg ==0.30.0.10
   - multi-containers ==0.1.1
+  - multiarg ==0.30.0.10
   - multimap ==1.2.1
   - multipart ==0.2.1
   - multiset ==0.3.4.3
   - multistate ==0.8.0.3
-  - murmur3 ==1.0.4
   - murmur-hash ==0.1.0.9
+  - murmur3 ==1.0.4
   - MusicBrainz ==0.4.1
   - mustache ==2.3.1
   - mutable-containers ==0.3.4
@@ -1624,20 +1633,20 @@ default-package-overrides:
   - nicify-lib ==1.0.1
   - NineP ==0.0.2.1
   - nix-paths ==1.0.1
+  - no-value ==1.0.0.0
+  - non-empty ==0.3.2
+  - non-empty-sequence ==0.2.0.4
+  - non-negative ==0.1.2
   - nonce ==1.0.7
   - nondeterminism ==1.4
-  - non-empty ==0.3.2
   - nonempty-containers ==0.3.4.1
-  - nonemptymap ==0.0.6.0
-  - non-empty-sequence ==0.2.0.4
   - nonempty-vector ==0.2.1.0
-  - non-negative ==0.1.2
+  - nonemptymap ==0.0.6.0
   - not-gloss ==0.7.7.0
-  - no-value ==1.0.0.0
   - nowdoc ==0.1.1.0
   - nqe ==0.6.3
-  - nri-env-parser ==0.1.0.2
-  - nri-prelude ==0.2.0.0
+  - nri-env-parser ==0.1.0.3
+  - nri-prelude ==0.3.0.0
   - nsis ==0.3.3
   - numbers ==3000.2.0.2
   - numeric-extras ==0.1
@@ -1649,9 +1658,9 @@ default-package-overrides:
   - nvim-hs ==2.1.0.4
   - nvim-hs-contrib ==2.0.0.0
   - nvim-hs-ghcid ==2.0.0.0
+  - o-clock ==1.2.0
   - oauthenticated ==0.2.1.0
   - ObjectName ==1.1.0.1
-  - o-clock ==1.2.0
   - odbc ==0.2.2
   - oeis2 ==1.0.4
   - ofx ==0.4.4.0
@@ -1664,9 +1673,9 @@ default-package-overrides:
   - Only ==0.1
   - oo-prototypes ==0.1.0.0
   - opaleye ==0.7.1.0
+  - open-browser ==0.2.1.0
   - OpenAL ==1.7.0.5
   - openapi3 ==3.0.1.0
-  - open-browser ==0.2.1.0
   - openexr-write ==0.1.0.2
   - OpenGL ==3.0.3.0
   - OpenGLRaw ==3.3.4.0
@@ -1728,12 +1737,12 @@ default-package-overrides:
   - pathtype ==0.8.1.1
   - pathwalk ==0.3.1.2
   - pattern-arrows ==0.0.2
-  - pava ==0.1.0.0
+  - pava ==0.1.1.0
   - pcg-random ==0.1.3.7
   - pcre-heavy ==1.0.0.2
   - pcre-light ==0.4.1.0
   - pcre-utils ==0.1.8.1.1
-  - pdfinfo ==1.5.4
+  - pcre2 ==1.1.3.1
   - peano ==0.1.0.1
   - pem ==0.2.4
   - percent-format ==0.0.1
@@ -1742,19 +1751,20 @@ default-package-overrides:
   - persist ==0.1.1.5
   - persistable-record ==0.6.0.5
   - persistable-types-HDBC-pg ==0.0.3.5
-  - persistent ==2.10.5.3
+  - persistent ==2.11.0.2
   - persistent-documentation ==0.1.0.2
   - persistent-mtl ==0.2.0.0
-  - persistent-mysql ==2.10.2.3
+  - persistent-mysql ==2.10.3.1
   - persistent-pagination ==0.1.1.2
-  - persistent-postgresql ==2.10.1.2
+  - persistent-postgresql ==2.11.0.1
   - persistent-qq ==2.9.2.1
-  - persistent-sqlite ==2.10.6.2
-  - persistent-template ==2.8.2.3
-  - persistent-typed-db ==0.1.0.1
+  - persistent-sqlite ==2.11.0.0
+  - persistent-template ==2.9.1.0
+  - persistent-test ==2.0.3.5
+  - persistent-typed-db ==0.1.0.2
   - pg-harness-client ==0.6.0
-  - pgp-wordlist ==0.1.0.3
   - pg-transact ==0.3.1.1
+  - pgp-wordlist ==0.1.0.3
   - phantom-state ==0.2.1.2
   - pid1 ==0.1.2.0
   - pinboard ==0.10.2.0
@@ -1793,6 +1803,7 @@ default-package-overrides:
   - port-utils ==0.2.1.0
   - posix-paths ==0.2.1.6
   - possibly ==1.0.0.0
+  - post-mess-age ==0.2.1.0
   - postgres-options ==0.2.0.0
   - postgresql-binary ==0.12.3.3
   - postgresql-libpq ==0.9.4.3
@@ -1801,28 +1812,27 @@ default-package-overrides:
   - postgresql-simple ==0.6.3
   - postgresql-typed ==0.6.1.2
   - postgrest ==7.0.1
-  - post-mess-age ==0.2.1.0
   - pptable ==0.3.0.0
   - pqueue ==1.4.1.3
   - prairie ==0.0.1.0
   - prefix-units ==0.2.0
   - prelude-compat ==0.0.0.2
   - prelude-safeenum ==0.1.1.2
-  - prettyclass ==1.0.0.0
   - pretty-class ==1.0.1.1
   - pretty-diff ==0.2.0.3
   - pretty-hex ==1.1
-  - prettyprinter ==1.6.2
+  - pretty-relative-time ==0.2.0.0
+  - pretty-show ==1.10
+  - pretty-simple ==4.0.0.0
+  - pretty-sop ==0.2.0.3
+  - pretty-terminal ==0.1.0.0
+  - prettyclass ==1.0.0.0
+  - prettyprinter ==1.7.0
   - prettyprinter-ansi-terminal ==1.1.2
-  - prettyprinter-compat-annotated-wl-pprint ==1
+  - prettyprinter-compat-annotated-wl-pprint ==1.1
   - prettyprinter-compat-ansi-wl-pprint ==1.0.1
   - prettyprinter-compat-wl-pprint ==1.0.0.1
   - prettyprinter-convert-ansi-wl-pprint ==1.1.1
-  - pretty-relative-time ==0.2.0.0
-  - pretty-show ==1.10
-  - pretty-simple ==3.3.0.0
-  - pretty-sop ==0.2.0.3
-  - pretty-terminal ==0.1.0.0
   - primes ==0.2.1.0
   - primitive ==0.7.1.0
   - primitive-addr ==0.1.0.2
@@ -1831,19 +1841,24 @@ default-package-overrides:
   - primitive-unlifted ==0.1.3.0
   - print-console-colors ==0.1.0.0
   - probability ==0.2.7
-  - process-extras ==0.7.4
   - product-isomorphic ==0.0.3.3
   - product-profunctors ==0.11.0.1
   - profiterole ==0.1
   - profunctors ==5.5.2
-  - projectroot ==0.2.0.1
   - project-template ==0.2.1.0
+  - projectroot ==0.2.0.1
   - prometheus ==2.2.2
   - prometheus-client ==1.0.1
   - prometheus-wai-middleware ==1.0.1.0
   - promises ==0.3
   - prompt ==0.1.1.2
   - prospect ==0.1.0.0
+  - proto-lens ==0.7.0.0
+  - proto-lens-optparse ==0.1.1.7
+  - proto-lens-protobuf-types ==0.7.0.0
+  - proto-lens-protoc ==0.7.0.0
+  - proto-lens-runtime ==0.7.0.0
+  - proto-lens-setup ==0.4.0.4
   - proto3-wire ==1.1.0
   - protobuf ==0.2.1.3
   - protobuf-simple ==0.1.1.0
@@ -1851,13 +1866,6 @@ default-package-overrides:
   - protocol-buffers-descriptor ==2.4.17
   - protocol-radius ==0.0.1.1
   - protocol-radius-test ==0.1.0.1
-  - proto-lens ==0.7.0.0
-  - proto-lens-arbitrary ==0.1.2.9
-  - proto-lens-optparse ==0.1.1.7
-  - proto-lens-protobuf-types ==0.7.0.0
-  - proto-lens-protoc ==0.7.0.0
-  - proto-lens-runtime ==0.7.0.0
-  - proto-lens-setup ==0.4.0.4
   - protolude ==0.3.0
   - proxied ==0.3.1
   - psqueues ==0.2.7.2
@@ -1875,13 +1883,13 @@ default-package-overrides:
   - qrcode-juicypixels ==0.8.2
   - quadratic-irrational ==0.1.1
   - QuasiText ==0.1.2.6
-  - QuickCheck ==2.13.2
+  - QuickCheck ==2.14.2
   - quickcheck-arbitrary-adt ==0.3.1.0
   - quickcheck-assertions ==0.3.0
   - quickcheck-classes ==0.6.4.0
   - quickcheck-classes-base ==0.6.1.0
   - quickcheck-higherorder ==0.1.0.0
-  - quickcheck-instances ==0.3.23
+  - quickcheck-instances ==0.3.25.1
   - quickcheck-io ==0.2.0
   - quickcheck-simple ==0.1.1.1
   - quickcheck-special ==0.1.0.6
@@ -1889,6 +1897,7 @@ default-package-overrides:
   - quickcheck-transformer ==0.3.1.1
   - quickcheck-unicode ==1.0.1.0
   - quiet ==0.2
+  - quote-quot ==0.1.0.0
   - radius ==0.7.1.0
   - rainbow ==0.34.2.2
   - rainbox ==0.26.0.0
@@ -1903,37 +1912,38 @@ default-package-overrides:
   - random-source ==0.3.0.8
   - random-tree ==0.6.0.5
   - range ==0.3.0.2
-  - Ranged-sets ==0.4.0
   - range-set-list ==0.1.3.1
+  - Ranged-sets ==0.4.0
   - rank1dynamic ==0.4.1
   - rank2classes ==1.4.1
   - Rasterific ==0.7.5.3
   - rasterific-svg ==0.3.3.2
-  - ratel ==1.0.12
   - rate-limit ==1.4.2
+  - ratel ==1.0.12
   - ratel-wai ==1.1.3
   - rattle ==0.2
+  - raw-strings-qq ==1.1
   - rawfilepath ==0.2.4
   - rawstring-qm ==0.2.3.0
-  - raw-strings-qq ==1.1
   - rcu ==0.2.4
   - rdf ==0.1.0.4
   - rdtsc ==1.3.0.1
   - re2 ==0.3
-  - readable ==0.3.1
   - read-editor ==0.1.0.2
   - read-env-var ==1.0.0.0
+  - readable ==0.3.1
   - reanimate ==1.1.2.1
   - reanimate-svg ==0.13.0.0
   - rebase ==1.6.1
   - record-dot-preprocessor ==0.2.7
   - record-hasfield ==1.0
-  - records-sop ==0.1.0.3
   - record-wrangler ==0.1.1.0
+  - records-sop ==0.1.0.3
   - recursion-schemes ==5.2.1
   - reducers ==3.12.3
-  - refact ==0.3.0.2
   - ref-fd ==0.4.0.2
+  - ref-tf ==0.4.0.2
+  - refact ==0.3.0.2
   - refined ==0.6.1
   - reflection ==2.1.6
   - reform ==0.2.7.4
@@ -1941,7 +1951,6 @@ default-package-overrides:
   - reform-hamlet ==0.0.5.3
   - reform-happstack ==0.2.5.4
   - RefSerialize ==0.4.0
-  - ref-tf ==0.4.0.2
   - regex ==1.1.0.0
   - regex-applicative ==0.3.4
   - regex-applicative-text ==0.1.0.1
@@ -1999,15 +2008,15 @@ default-package-overrides:
   - runmemo ==1.0.0.1
   - rvar ==0.2.0.6
   - safe ==0.3.19
-  - safecopy ==0.10.3
   - safe-decimal ==0.2.0.0
   - safe-exceptions ==0.1.7.1
   - safe-foldable ==0.1.0.0
-  - safeio ==0.0.5.0
-  - safe-json ==1.1.1
+  - safe-json ==1.1.1.1
   - safe-money ==0.9
-  - SafeSemaphore ==0.10.1
   - safe-tensor ==0.2.1.0
+  - safecopy ==0.10.3
+  - safeio ==0.0.5.0
+  - SafeSemaphore ==0.10.1
   - salak ==0.3.6
   - salak-yaml ==0.3.5.3
   - saltine ==0.1.1.0
@@ -2043,10 +2052,10 @@ default-package-overrides:
   - semialign-indexed ==1.1
   - semialign-optics ==1.1
   - semigroupoid-extras ==5
-  - semigroupoids ==5.3.4
+  - semigroupoids ==5.3.5
   - semigroups ==0.19.1
-  - semirings ==0.5.4
   - semiring-simple ==1.0.0.1
+  - semirings ==0.5.4
   - semver ==0.4.0.1
   - sendfile ==0.7.11.1
   - seqalign ==0.2.0.4
@@ -2092,9 +2101,9 @@ default-package-overrides:
   - shared-memory ==0.2.0.0
   - shell-conduit ==5.0.0
   - shell-escape ==0.2.0
+  - shell-utility ==0.1
   - shellmet ==0.0.3.1
   - shelltestrunner ==1.9
-  - shell-utility ==0.1
   - shelly ==1.9.0
   - shikensu ==0.3.11
   - should-not-typecheck ==2.1.0
@@ -2104,7 +2113,7 @@ default-package-overrides:
   - silently ==1.2.5.1
   - simple-affine-space ==0.1.1
   - simple-cabal ==0.1.3
-  - simple-cmd ==0.2.2
+  - simple-cmd ==0.2.3
   - simple-cmd-args ==0.1.6
   - simple-log ==0.9.12
   - simple-reflect ==0.3.3
@@ -2123,12 +2132,12 @@ default-package-overrides:
   - skein ==1.0.9.4
   - skews ==0.1.0.3
   - skip-var ==0.1.1.0
-  - skylighting ==0.10.1
-  - skylighting-core ==0.10.1
+  - skylighting ==0.10.2
+  - skylighting-core ==0.10.2
   - slack-api ==0.12
   - slack-progressbar ==0.1.0.1
   - slist ==0.1.1.0
-  - slynx ==0.5.0
+  - slynx ==0.5.0.1
   - smallcheck ==1.2.0
   - smash ==0.1.1.0
   - smash-aeson ==0.1.0.0
@@ -2161,21 +2170,21 @@ default-package-overrides:
   - splice ==0.6.1.1
   - splint ==1.0.1.2
   - split ==0.2.3.4
-  - splitmix ==0.0.5
+  - splitmix ==0.1.0.3
   - spoon ==0.3.1
   - spreadsheet ==0.1.3.8
+  - sql-words ==0.1.6.4
   - sqlcli ==0.2.2.0
   - sqlcli-odbc ==0.2.0.1
   - sqlite-simple ==0.4.18.0
-  - sql-words ==0.1.6.4
   - squeal-postgresql ==0.7.0.1
-  - squeather ==0.4.0.0
+  - squeather ==0.6.0.0
   - srcloc ==0.5.1.2
   - stache ==2.2.0
-  - stackcollapse-ghc ==0.0.1.3
   - stack-templatizer ==0.1.0.2
+  - stackcollapse-ghc ==0.0.1.3
   - stateref ==0.3
-  - StateVar ==1.2
+  - StateVar ==1.2.1
   - static-text ==0.2.0.6
   - statistics ==0.15.2.0
   - status-notifier-item ==0.3.0.5
@@ -2188,15 +2197,15 @@ default-package-overrides:
   - stm-extras ==0.1.0.3
   - stm-hamt ==1.2.0.4
   - stm-lifted ==2.5.0.0
-  - STMonadTrans ==0.4.4
   - stm-split ==0.0.2.1
+  - STMonadTrans ==0.4.5
   - stopwatch ==0.1.0.6
   - storable-complex ==0.2.3.0
   - storable-endian ==0.2.6
   - storable-record ==0.0.5
   - storable-tuple ==0.0.3.3
   - storablevector ==0.2.13.1
-  - store ==0.7.8
+  - store ==0.7.9
   - store-core ==0.4.4.4
   - store-streaming ==0.2.0.3
   - stratosphere ==0.59.1
@@ -2210,7 +2219,6 @@ default-package-overrides:
   - strict-list ==0.1.5
   - strict-tuple ==0.1.4
   - strict-tuple-lens ==0.1.0.1
-  - stringbuilder ==0.5.1
   - string-class ==0.1.7.0
   - string-combinators ==0.6.0.5
   - string-conv ==0.1.2
@@ -2218,8 +2226,9 @@ default-package-overrides:
   - string-interpolate ==0.3.0.2
   - string-qq ==0.0.4
   - string-random ==0.1.3.0
-  - stringsearch ==0.3.6.6
   - string-transform ==1.1.1
+  - stringbuilder ==0.5.1
+  - stringsearch ==0.3.6.6
   - stripe-concepts ==1.0.2.4
   - stripe-core ==2.6.2
   - stripe-haskell ==2.6.2
@@ -2244,14 +2253,14 @@ default-package-overrides:
   - symmetry-operations-symbols ==0.0.2.1
   - sysinfo ==0.1.1
   - system-argv0 ==0.1.1
-  - systemd ==2.3.0
   - system-fileio ==0.3.16.4
   - system-filepath ==0.4.14
   - system-info ==0.5.1
+  - systemd ==2.3.0
   - tabular ==0.2.2.8
   - taffybar ==3.2.3
   - tagchup ==0.4.1.1
-  - tagged ==0.8.6
+  - tagged ==0.8.6.1
   - tagged-binary ==0.2.0.1
   - tagged-identity ==0.1.3
   - tagged-transformer ==0.8.1
@@ -2264,22 +2273,22 @@ default-package-overrides:
   - tardis ==0.4.1.0
   - tasty ==1.2.3
   - tasty-ant-xml ==1.1.7
-  - tasty-dejafu ==2.0.0.6
+  - tasty-dejafu ==2.0.0.7
   - tasty-discover ==4.2.2
   - tasty-expected-failure ==0.11.1.2
+  - tasty-focus ==1.0.1
   - tasty-golden ==2.3.3.2
   - tasty-hedgehog ==1.0.0.2
   - tasty-hspec ==1.1.6
-  - tasty-hunit ==0.10.0.2
-  - tasty-hunit-compat ==0.2
+  - tasty-hunit ==0.10.0.3
+  - tasty-hunit-compat ==0.2.0.1
   - tasty-kat ==0.0.3
   - tasty-leancheck ==0.0.1
   - tasty-lua ==0.2.3.1
   - tasty-program ==1.0.5
-  - tasty-quickcheck ==0.10.1.1
+  - tasty-quickcheck ==0.10.1.2
   - tasty-rerun ==1.1.18
-  - tasty-silver ==3.1.15
-  - tasty-smallcheck ==0.8.1
+  - tasty-smallcheck ==0.8.2
   - tasty-test-reporter ==0.1.1.4
   - tasty-th ==0.1.7
   - tasty-wai ==0.1.1.1
@@ -2303,8 +2312,8 @@ default-package-overrides:
   - test-framework-smallcheck ==0.2
   - test-fun ==0.1.0.0
   - testing-type-modifiers ==0.1.0.1
-  - texmath ==0.12.0.3
-  - text-ansi ==0.1.0.1
+  - texmath ==0.12.1
+  - text-ansi ==0.1.0.2
   - text-binary ==0.2.1.1
   - text-builder ==0.6.6.1
   - text-conversions ==0.3.1
@@ -2312,7 +2321,6 @@ default-package-overrides:
   - text-icu ==0.7.0.1
   - text-latin1 ==0.3.1
   - text-ldap ==0.1.1.13
-  - textlocal ==0.1.0.5
   - text-manipulate ==0.2.0.1
   - text-metrics ==0.3.0
   - text-postgresql ==0.0.3.1
@@ -2323,19 +2331,16 @@ default-package-overrides:
   - text-show ==3.9
   - text-show-instances ==3.8.4
   - text-zipper ==0.10.1
-  - tfp ==1.0.1.1
+  - textlocal ==0.1.0.5
   - tf-random ==0.5
-  - th-abstraction ==0.4.1.0
+  - tfp ==1.0.1.1
+  - th-abstraction ==0.4.2.0
   - th-bang-compat ==0.0.1.0
   - th-compat ==0.1
   - th-constraint-compat ==0.0.1.0
   - th-data-compat ==0.1.0.0
   - th-desugar ==1.11
   - th-env ==0.1.0.2
-  - these ==1.1.1.1
-  - these-lens ==1.0.1.1
-  - these-optics ==1.0.1.1
-  - these-skinny ==0.7.4
   - th-expand-syns ==0.4.6.0
   - th-extras ==0.0.0.4
   - th-lift ==0.8.2
@@ -2343,33 +2348,37 @@ default-package-overrides:
   - th-nowq ==0.1.0.5
   - th-orphans ==0.13.11
   - th-printf ==0.7
-  - thread-hierarchy ==0.3.0.2
-  - thread-local-storage ==0.2
-  - threads ==0.5.1.6
-  - thread-supervisor ==0.2.0.0
-  - threepenny-gui ==0.9.0.0
   - th-reify-compat ==0.0.1.5
   - th-reify-many ==0.1.9
-  - throttle-io-stream ==0.2.0.1
-  - through-text ==0.1.0.0
-  - throwable-exceptions ==0.1.0.9
   - th-strict-compat ==0.1.0.1
   - th-test-utils ==1.1.0
   - th-utilities ==0.2.4.1
+  - these ==1.1.1.1
+  - these-lens ==1.0.1.1
+  - these-optics ==1.0.1.1
+  - these-skinny ==0.7.4
+  - thread-hierarchy ==0.3.0.2
+  - thread-local-storage ==0.2
+  - thread-supervisor ==0.2.0.0
+  - threads ==0.5.1.6
+  - threepenny-gui ==0.9.0.0
+  - throttle-io-stream ==0.2.0.1
+  - through-text ==0.1.0.0
+  - throwable-exceptions ==0.1.0.9
   - thyme ==0.3.5.5
   - tidal ==1.6.1
   - tile ==0.3.0.0
   - time-compat ==1.9.5
-  - timeit ==2.0
-  - timelens ==0.2.0.2
   - time-lens ==0.4.0.2
   - time-locale-compat ==0.1.1.5
   - time-locale-vietnamese ==1.0.0.0
   - time-manager ==0.0.0
   - time-parsers ==0.1.2.1
-  - timerep ==2.0.1.0
-  - timer-wheel ==0.3.0
   - time-units ==1.0.0
+  - timeit ==2.0
+  - timelens ==0.2.0.2
+  - timer-wheel ==0.3.0
+  - timerep ==2.0.1.0
   - timezone-olson ==0.2.0
   - timezone-series ==0.1.9
   - tinylog ==0.15.0
@@ -2378,7 +2387,7 @@ default-package-overrides:
   - tls ==1.5.4
   - tls-debug ==0.4.8
   - tls-session-manager ==0.0.4
-  - tlynx ==0.5.0
+  - tlynx ==0.5.0.1
   - tmapchan ==0.0.3
   - tmapmvar ==0.0.4
   - tmp-postgres ==1.34.1.0
@@ -2404,13 +2413,10 @@ default-package-overrides:
   - ttl-hashtables ==1.4.1.0
   - ttrie ==0.1.2.1
   - tuple ==0.3.0.2
-  - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
+  - tuples-homogenous-h98 ==0.1.1.0
   - turtle ==1.5.20
-  - TypeCompose ==0.9.14
-  - typed-process ==0.2.6.0
-  - typed-uuid ==0.0.0.2
   - type-equality ==1
   - type-errors ==0.2.0.0
   - type-errors-pretty ==0.0.1.1
@@ -2424,8 +2430,11 @@ default-package-overrides:
   - type-of-html ==1.6.1.2
   - type-of-html-static ==0.1.0.2
   - type-operators ==0.2.0.0
-  - typerep-map ==0.3.3.0
   - type-spec ==0.4.0.0
+  - TypeCompose ==0.9.14
+  - typed-process ==0.2.6.0
+  - typed-uuid ==0.0.0.2
+  - typerep-map ==0.3.3.0
   - tzdata ==0.2.20201021.0
   - ua-parser ==0.7.5.1
   - uglymemo ==0.1.0.1
@@ -2459,7 +2468,7 @@ default-package-overrides:
   - universe-instances-trans ==1.1
   - universe-reverse-instances ==1.1
   - universe-some ==1.2
-  - universum ==1.7.1
+  - universum ==1.5.0
   - unix-bytestring ==0.3.7.3
   - unix-compat ==0.5.2
   - unix-time ==0.4.7
@@ -2508,7 +2517,7 @@ default-package-overrides:
   - vector-instances ==3.4
   - vector-mmap ==0.0.3
   - vector-rotcev ==0.1.0.0
-  - vector-sized ==1.4.3
+  - vector-sized ==1.4.3.1
   - vector-space ==0.16
   - vector-split ==1.0.0.2
   - vector-th-unbox ==0.2.1.7
@@ -2557,24 +2566,24 @@ default-package-overrides:
   - websockets ==0.12.7.2
   - websockets-snap ==0.10.3.1
   - weigh ==0.0.16
-  - wide-word ==0.1.1.1
+  - wide-word ==0.1.1.2
   - wikicfp-scraper ==0.1.0.11
   - Win32 ==2.6.1.0
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
   - witch ==0.0.0.4
-  - witherable-class ==0
-  - within ==0.2.0.1
   - with-location ==0.1.0
   - with-utf8 ==1.0.2.1
+  - witherable-class ==0
+  - within ==0.2.0.1
   - wizards ==1.0.3
   - wl-pprint-annotated ==0.1.0.1
   - wl-pprint-console ==0.1.0.2
   - wl-pprint-text ==1.2.0.1
-  - word24 ==2.0.1
-  - word8 ==0.1.3
   - word-trie ==0.3.0
   - word-wrap ==0.4.1
+  - word24 ==2.0.1
+  - word8 ==0.1.3
   - world-peace ==1.0.2.0
   - wrap ==0.0.0
   - wreq ==0.5.3.2
@@ -2595,22 +2604,22 @@ default-package-overrides:
   - xdg-desktop-entry ==0.1.1.1
   - xdg-userdirs ==0.1.0.2
   - xeno ==0.4.2
-  - xls ==0.1.3
   - xlsx ==0.8.2
   - xlsx-tabular ==0.2.2.1
   - xml ==1.3.14
   - xml-basic ==0.1.3.1
   - xml-conduit ==1.9.0.0
   - xml-conduit-writer ==0.1.1.2
-  - xmlgen ==0.6.2.2
   - xml-hamlet ==0.5.0.1
   - xml-helpers ==1.0.0
+  - xml-html-qq ==0.1.0.1
   - xml-indexed-cursor ==0.1.1.0
   - xml-lens ==0.2
   - xml-picklers ==0.3.6
   - xml-to-json ==2.0.1
   - xml-to-json-fast ==2.0.0
   - xml-types ==0.3.8
+  - xmlgen ==0.6.2.2
   - xmonad ==0.15
   - xmonad-contrib ==0.16
   - xmonad-extras ==0.15.2
@@ -2618,11 +2627,13 @@ default-package-overrides:
   - xxhash-ffi ==0.2.0.0
   - yaml ==0.11.5.0
   - yamlparse-applicative ==0.1.0.2
+  - yes-precure5-command ==5.5.3
   - yesod ==1.6.1.0
   - yesod-auth ==1.6.10.1
   - yesod-auth-hashdb ==1.7.1.5
+  - yesod-auth-oauth2 ==0.6.1.7
   - yesod-bin ==1.6.0.6
-  - yesod-core ==1.6.18.7
+  - yesod-core ==1.6.18.8
   - yesod-fb ==0.6.1
   - yesod-form ==1.6.7
   - yesod-gitrev ==0.2.1
@@ -2632,9 +2643,8 @@ default-package-overrides:
   - yesod-persistent ==1.6.0.5
   - yesod-sitemap ==1.6.0
   - yesod-static ==1.6.1.0
-  - yesod-test ==1.6.11
+  - yesod-test ==1.6.12
   - yesod-websockets ==0.3.0.2
-  - yes-precure5-command ==5.5.3
   - yi-rope ==0.11
   - yjsvg ==0.2.0.1
   - yjtools ==0.9.18
@@ -2649,9 +2659,9 @@ default-package-overrides:
   - zio ==0.1.0.2
   - zip ==1.6.0
   - zip-archive ==0.4.1
+  - zip-stream ==0.2.0.1
   - zipper-extra ==0.1.3.2
   - zippers ==0.3
-  - zip-stream ==0.2.0.1
   - zlib ==0.6.2.2
   - zlib-bindings ==0.1.1.5
   - zlib-lens ==0.1.2.1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5453,7 +5453,6 @@ broken-packages:
   - geolite-csv
   - geom2d
   - GeomPredicates-SSE
-  - geos
   - Get
   - getemx
   - getflag

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -550,7 +550,6 @@ self: super: builtins.intersectAttrs super {
 
   # Break infinite recursion cycle between QuickCheck and splitmix.
   splitmix = dontCheck super.splitmix;
-  splitmix_0_1_0_3 = dontCheck super.splitmix_0_1_0_3;
 
   # Break infinite recursion cycle between tasty and clock.
   clock = dontCheck super.clock;


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2021-01-01 20:00 +01:00. You can watch this live on Twitch at https://www.twitch.tv/peti343. In addition to the chat features offered by Twitch, there is also a voice conference at https://discord.gg/YTEa3XR that viewers can use to chat with me and with each other.