### PR TITLE
xfsprogs: 4.19 -> 5.10

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -169,6 +169,14 @@
     </para>
    </listitem>
    <listitem>
+     <para>
+       xfsprogs was update from 4.19 to 5.10. It now enables reflink support by default on filesystem creation.
+       Support for reflinks was added with an experimental status to kernel 4.9 and deemed stable in kernel 4.16.
+       If you want to be able to mount XFS filesystems created with this release of xfsprogs on kernel releases older than those, you need to format them
+       with <literal>mkfs.xfs -m reflink=0</literal>.
+     </para>
+   </listitem>
+   <listitem>
     <para>
     <package>btc1</package> has been abandoned upstream, and removed.
     </para>

--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -1,22 +1,14 @@
-{ stdenv, buildPackages, fetchpatch, fetchgit, autoconf, automake, gettext, libtool, pkgconfig
-, icu, libuuid, readline
+{ stdenv, buildPackages, fetchpatch, fetchurl, autoconf, automake, gettext, libtool, pkgconfig
+, icu, libuuid, readline, inih
 }:
-
-let
-  gentooPatch = name: sha256: fetchpatch {
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/xfsprogs/files/${name}?id=2517dd766cf84d251631f4324f7ec4bce912abb9";
-    inherit sha256;
-  };
-in
 
 stdenv.mkDerivation rec {
   pname = "xfsprogs";
-  version = "4.19.0";
+  version = "5.10.0";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git";
-    rev = "v${version}";
-    sha256 = "18728hzfxr1bg4bdzqlxjs893ac1zwlfr7nmc2q4a1sxs0sphd1d";
+  src = fetchurl {
+    url = "mirror://kernel/linux/utils/fs/xfs/xfsprogs/${pname}-${version}.tar.xz";
+    sha256 = "1schqzjx836jd54l10pqds7hyli2m77df3snk95xbr23dpj1fh70";
   };
 
   outputs = [ "bin" "dev" "out" "doc" ];
@@ -26,26 +18,24 @@ stdenv.mkDerivation rec {
     autoconf automake libtool gettext pkgconfig
     libuuid # codegen tool uses libuuid
   ];
-  buildInputs = [ readline icu ];
+  buildInputs = [ readline icu inih ];
   propagatedBuildInputs = [ libuuid ]; # Dev headers include <uuid/uuid.h>
 
   enableParallelBuilding = true;
 
-  # Why is all this garbage needed? Why? Why?
-  patches = [
-    (gentooPatch "xfsprogs-4.15.0-sharedlibs.patch" "0bv2naxpiw7vcsg8p1v2i47wgfda91z1xy1kfwydbp4wmb4nbyyv")
-    (gentooPatch "xfsprogs-4.15.0-docdir.patch" "1srgdidvq2ka0rmfdwpqp92fapgh53w1h7rajm4nnby5vp2v8dfr")
-    (gentooPatch "xfsprogs-4.9.0-underlinking.patch" "1r7l8jphspy14i43zbfnjrnyrdm4cpgyfchblascxylmans0gci7")
-  ];
-
+  # @sbindir@ is replaced with /run/current-system/sw/bin to fix dependency cycles
   preConfigure = ''
-    sed -i Makefile -e '/cp include.install-sh/d'
+    for file in scrub/{xfs_scrub_all.cron.in,xfs_scrub@.service.in,xfs_scrub_all.service.in}; do
+      substituteInPlace "$file" \
+        --replace '@sbindir@' '/run/current-system/sw/bin'
+    done
     make configure
+    patchShebangs ./install-sh
   '';
 
   configureFlags = [
     "--disable-lib64"
-    "--enable-readline"
+    "--with-systemd-unit-dir=${placeholder "out"}/lib/systemd/system"
   ];
 
   installFlags = [ "install-dev" ];
@@ -60,6 +50,6 @@ stdenv.mkDerivation rec {
     description = "SGI XFS utilities";
     license = licenses.lgpl21;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ dezgeg ];
+    maintainers = with maintainers; [ dezgeg ajs124 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
xfsprogs was outdated by several years and does not appear to have an (active) maintainer.

Closes #107010

cc @TredwellGit @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
