### PR TITLE
gpodder: 3.10.16 -> 3.10.17

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -5,14 +5,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gpodder";
-  version = "3.10.16";
+  version = "3.10.17";
   format = "other";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "0pbpaasd7kj6y25nm45y1qyb9sxd4570f7g6zkfcpf6pa3nx7qkq";
+    sha256 = "0wrk8d4q6ricbcjzlhk10vrk1qg9hi323kgyyd0c8nmh7a82h8pd";
   };
 
   patches = [


### PR DESCRIPTION
Upstream release notes:

> This release restores Youtube-DL function. It also includes a lot of fixes and improvements since last release.
>
> Notably: feed update errors now only produce a single notification. See feeds in error via a warning icon next to their title. You'll get the error message in the description (also in settings for the feed in error).

Running this release since weeks, so I can confirm that indeed it's working and also fixes youtube-dl functionality of course.