### PR TITLE
doc: explain where the "pkgs" comes from in a module

### DIFF
--- a/nixos/doc/manual/configuration/config-file.xml
+++ b/nixos/doc/manual/configuration/config-file.xml
@@ -16,9 +16,10 @@
   The first line (<literal>{ config, pkgs, ... }:</literal>) denotes that this
   is actually a function that takes at least the two arguments
   <varname>config</varname> and <varname>pkgs</varname>. (These are explained
-  later.) The function returns a <emphasis>set</emphasis> of option definitions
-  (<literal>{ <replaceable>...</replaceable> }</literal>). These definitions
-  have the form <literal><replaceable>name</replaceable> =
+  later, in chapter <xref linkend="sec-writing-modules" />) The function returns
+  a <emphasis>set</emphasis> of option definitions (<literal>{
+  <replaceable>...</replaceable> }</literal>). These definitions have the form
+  <literal><replaceable>name</replaceable> =
   <replaceable>value</replaceable></literal>, where
   <replaceable>name</replaceable> is the name of an option and
   <replaceable>value</replaceable> is its value. For example,

--- a/nixos/doc/manual/development/writing-modules.xml
+++ b/nixos/doc/manual/development/writing-modules.xml
@@ -74,7 +74,10 @@ linkend="sec-configuration-syntax"/>, we saw the following structure
    <callout arearefs='module-syntax-1'>
     <para>
      This line makes the current Nix expression a function. The variable
-     <varname>pkgs</varname> contains Nixpkgs, while <varname>config</varname>
+     <varname>pkgs</varname> contains Nixpkgs (by default, it takes the
+     <varname>nixpkgs</varname> entry of <envar>NIX_PATH</envar>, see the <link
+     xlink:href="https://nixos.org/manual/nix/stable/#sec-common-env">Nix
+     manual</link> for further details), while <varname>config</varname>
      contains the full system configuration. This line can be omitted if there
      is no reference to <varname>pkgs</varname> and <varname>config</varname>
      inside the module.


### PR DESCRIPTION
Ahoj! While reading the NixOS manual, I noticed that I didn't really see where "pkgs" is explained. So, I added a link to the "Writing Modules" (which could also be titled "Understanding Modules") chapter, and explained that pkgs is usually taken from the `nixpkgs` entry of the `NIX_PATH` environment variable. For me, this was not at all obvious from reading the manual.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
