### PR TITLE
vimix-cursors init at 1.0

### DIFF
--- a/pkgs/data/icons/vimix-cursors/default.nix
+++ b/pkgs/data/icons/vimix-cursors/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchFromGitHub, fetchpatch, xcursorgen, python3Packages, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "vimix-cursors";
+  version = "2020-02-24";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "Vimix-cursors";
+    rev = version;
+    sha256 = "0bij0x916lbxph28i3d4hz5l6mzk5fa68mf21jnl7y9rpxx07xsd";
+  };
+
+  nativeBuildInputs = [ python3Packages.cairosvg xcursorgen ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/vinceliuice/Vimix-cursors/commit/b39d0b41e296cdd0c540078aeda72e9711f0406e.patch";
+      sha256 = "1gh4prb8n5i5njdifgz71pgj4nw45xc23iggnlf9r5n1y3n0w6vc";
+    })
+    (fetchpatch {
+      url = "https://github.com/vinceliuice/Vimix-cursors/commit/a4e5d9d98e855db903629cf9ff9e56138d0aef96.patch";
+      sha256 = "1wcz6m3jjzx47qh6m571bn6fpbqqc7kmxd0j8iimj850gavip28w";
+    })
+    (fetchpatch {
+      url = "https://github.com/vinceliuice/Vimix-cursors/commit/89d75d3d942a07c90b04404bb8dd5a346e2261fe.patch";
+      sha256 = "0qklgdhsp1lvscx1kf0rgqa7k2h5fiwgjkyj44mq6vkr0770zlb9";
+    })
+    (fetchpatch {
+      url = "https://github.com/vinceliuice/Vimix-cursors/commit/bc42481f3a7b412c8ef792fac39af560c6064f99.patch";
+      sha256 = "1gx7gqnbq0xphbm8g68b7skiwsjxsca07n1w986b24bywv0f1kav";
+    })
+    (fetchpatch {
+      url = "https://github.com/vinceliuice/Vimix-cursors/commit/bcc7a56c2b02ee1a13214e654f97fb7ec2d5b7d9.patch";
+      sha256 = "1fp4qqy925c2i4zjka23hi506f2f3naq9v5jnnd93fzyzmfyq47h";
+    })
+  ];
+
+  buildPhase = ''
+    HOME=$TMP ${bash}/bin/bash ./build.sh
+  '';
+
+  installPhase = ''
+    install -dm 0755 $out/share/icons
+    cp -pr dist $out/share/icons/Vimix-cursors
+    cp -pr dist-white $out/share/icons/Vimix-cursors-white
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Vimix cursors";
+    homepage = "https://github.com/vinceliuice/Vimix-cursors";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20244,6 +20244,8 @@ in
 
   victor-mono = callPackage ../data/fonts/victor-mono { };
 
+  vimix-cursors = callPackage ../data/icons/vimix-cursors { };
+
   vimix-gtk-themes = callPackage ../data/themes/vimix {};
 
   vistafonts = callPackage ../data/fonts/vista-fonts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the GTK cursor theme 'Vimix Cursors'. Nixpkgs already provides vimix GTK themes from the same author.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
