### PR TITLE
sccache: 0.2.13 -> 0.2.14

### DIFF
--- a/pkgs/development/tools/misc/sccache/default.nix
+++ b/pkgs/development/tools/misc/sccache/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, cargo, rustc, rustPlatform, pkgconfig, glib, openssl, darwin }:
 
 rustPlatform.buildRustPackage rec {
-  version = "0.2.13";
+  version = "0.2.14";
   pname = "sccache";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "sccache";
     rev = version;
-    sha256 = "19z9fdkn3bnr8q33m66h2by6bs6kmhw3a2lq2n8bywmnhrjwhxpw";
+    sha256 = "1ahg3cpb9pbgpdjglnfxm5c8r8qrgwaxwz5s394478ix7f9dxind";
   };
-  cargoSha256 = "1pm7il0x7i9mqx4vsmkcs8nq0dqr5ck3x3x7la6k39igaxn9vkwz";
+  cargoSha256 = "0jphs0frr399iywi9ch8g271igayzv1vi3wa4v3yx19xdxawlgda";
 
   cargoBuildFlags = [ "--features=all" ];
   nativeBuildInputs = [


### PR DESCRIPTION

###### Motivation for this change
https://github.com/mozilla/sccache/issues/875

It seems that there are some incompatibilities with newer rust version and sccache 0.2.13. According to the issue, the fix is in 0.2.14.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
