### PR TITLE
gitjacker: init at 0.0.2

### DIFF
--- a/pkgs/tools/security/gitjacker/default.nix
+++ b/pkgs/tools/security/gitjacker/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "gitjacker";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "liamg";
+    repo = "gitjacker";
+    rev = "v${version}";
+    sha256 = "0fg95i2y8sj7dsvqj8mx0k5pps7d0h1i4a3lk85l8jjab4kxx8h9";
+  };
+
+  vendorSha256 = null;
+
+  propagatedBuildInputs = [ git ];
+
+  checkInputs = [ git ];
+
+  doCheck = !stdenv.isDarwin;
+
+  preCheck = ''
+    export PATH=$TMPDIR/usr/bin:$PATH
+  '';
+
+  meta = with lib; {
+    description = "Leak git repositories from misconfigured websites";
+    longDescription = ''
+      Gitjacker downloads git repositories and extracts their contents
+      from sites where the .git directory has been mistakenly uploaded.
+      It will still manage to recover a significant portion of a repository
+      even where directory listings are disabled.
+    '';
+    homepage = "https://github.com/liamg/gitjacker";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2232,6 +2232,8 @@ in
 
   gist = callPackage ../tools/text/gist { };
 
+  gitjacker = callPackage ../tools/security/gitjacker { };
+
   gixy = callPackage ../tools/admin/gixy { };
 
   glpaper = callPackage ../development/tools/glpaper { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Gitjacker downloads git repositories and extracts their contents
from sites where the .git directory has been mistakenly uploaded.
It will still manage to recover a significant portion of a repository
even where directory listings are disabled.

https://github.com/liamg/gitjacker

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
