### PR TITLE
ocamlPackages.zarith: 1.10 → 1.11

### DIFF
--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -6,9 +6,9 @@
 let source =
   if stdenv.lib.versionAtLeast ocaml.version "4.02"
   then {
-    version = "1.10";
-    url = "https://github.com/ocaml/Zarith/archive/release-1.10.tar.gz";
-    sha256 = "1qxrl0v2mk9wghc1iix3n0vfz2jbg6k5wpn1z7p02m2sqskb0zhb";
+    version = "1.11";
+    url = "https://github.com/ocaml/Zarith/archive/release-1.11.tar.gz";
+    sha256 = "111n33flg4aq5xp5jfksqm4yyz6mzxx9ps9a4yl0dz8h189az5pr";
   } else {
     version = "1.3";
     url = "http://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz";


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/ocaml/Zarith/releases/tag/release-1.11

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
