### PR TITLE
[20.09] qtwebkit: unbreak

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -10,6 +10,7 @@ let
   withCD = config.clementine.cd or true;
   withCloud = config.clementine.cloud or true;
 
+  # On the update after all 1.4rc, qt5.15 will be supported.
   version = "1.4.0rc1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/graphics/freecad/stable.nix
+++ b/pkgs/applications/graphics/freecad/stable.nix
@@ -34,12 +34,17 @@ in mkDerivation rec {
     matplotlib pycollada shiboken2 pyside2 pyside2-tools pivy python boost
   ]);
 
-  # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
-  # remove in versions >= 0.19
   patches = [
+    # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
+    # remove in versions >= 0.19
     (fetchpatch {
       url = "https://github.com/FreeCAD/FreeCAD/commit/c4d2a358ca125d51d059dfd72dcbfba326196dfc.patch";
       sha256 = "0yqc9zrxgi2c2xcidm8wh7a9yznkphqvjqm9742qm5fl20p8gl4h";
+    })
+    # Fix build with Qt >= 5.15
+    (fetchpatch {
+      url = "https://github.com/FreeCAD/FreeCAD/commit/b2882c699b1444efadd9faee36855a965ac6a215.patch";
+      sha256 = "sha256:1fs43a5aaqziaa1iicppfjd68kklmk9qrcncxs8hx2dl429z2lzv";
     })
   ];
 

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -31,9 +31,15 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Fix version in qtikz.pro
     (fetchpatch {
       url = "https://github.com/fhackenberger/ktikz/commit/972685a406517bb85eb561f2c8e26f029eacd7db.patch";
       sha256 = "13z40rcd4m4n088v7z2ns17lnpn0z3rzp31lsamic3qdcwjwa5k8";
+    })
+    # Fix missing qt5.15 QPainterPath include
+    (fetchpatch {
+      url = "https://github.com/fhackenberger/ktikz/commit/ebe4dfb72ac8a137b475ef688b9f7ac3e5c7f242.patch";
+      sha256 = "GIgPh+iUBPftHKIpZR3a0FxmLhMLuPUapF/t+bCuqMs=";
     })
   ];
 

--- a/pkgs/applications/networking/irc/konversation/default.nix
+++ b/pkgs/applications/networking/irc/konversation/default.nix
@@ -28,24 +28,14 @@
 , phonon
 }:
 
-let
+mkDerivation rec {
   pname = "konversation";
-  version = "1.7.5";
-in mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "1.7.7";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0h098yhlp36ls6pdvs2r93ig8dv4fys62m0h6wxccprb0qrpbgv0";
+    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
+    sha256 = "R+wWHBOFmBqLmdKMQZ6Iskgj3AG2j7FiOJSBiXTCGKc=";
   };
-
-  patches = [
-    # Delete this patch for konversation > 1.7.5
-    (fetchpatch {
-      url = "https://cgit.kde.org/konversation.git/patch/?id=4d0036617becc26a76fd021138c98aceec4c7b53";
-      sha256 = "17hdj6zyln3n93b71by26mrwbgyh4k052ck5iw1drysx5dyd5l6y";
-    })
-  ];
 
   buildInputs = [
     kbookmarks

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -32,6 +32,12 @@ stdenv.mkDerivation rec {
     sha256 = "1f46h0hv7fk35zg4iczlp7ib7h2jmh8m4r5klw3g2558ib9134qq";
   };
 
+  patches = [
+    # Couldn't find an upstream version of this patch
+    # https://build.opensuse.org/package/view_file/openSUSE:Factory/vlc/fix-missing-includes-with-qt-5.15.patch?expand=1
+    ./fix-missing-includes-with-qt-5.15.patch
+  ];
+
   # VLC uses a *ton* of libraries for various pieces of functionality, many of
   # which are not included here for no other reason that nobody has mentioned
   # needing them
@@ -99,6 +105,5 @@ stdenv.mkDerivation rec {
     homepage = "http://www.videolan.org/vlc/";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    broken = if qtbase != null then versionAtLeast qtbase.version "5.15" else false;
   };
 }

--- a/pkgs/applications/video/vlc/fix-missing-includes-with-qt-5.15.patch
+++ b/pkgs/applications/video/vlc/fix-missing-includes-with-qt-5.15.patch
@@ -1,0 +1,37 @@
+Index: vlc-3.0.8/modules/gui/qt/util/timetooltip.hpp
+===================================================================
+--- vlc-3.0.8.orig/modules/gui/qt/util/timetooltip.hpp
++++ vlc-3.0.8/modules/gui/qt/util/timetooltip.hpp
+@@ -25,6 +25,7 @@
+ #include "qt.hpp"
+ 
+ #include <QWidget>
++#include <QPainterPath>
+ 
+ class TimeTooltip : public QWidget
+ {
+Index: vlc-3.0.8/modules/gui/qt/components/playlist/views.cpp
+===================================================================
+--- vlc-3.0.8.orig/modules/gui/qt/components/playlist/views.cpp
++++ vlc-3.0.8/modules/gui/qt/components/playlist/views.cpp
+@@ -27,6 +27,7 @@
+ #include "input_manager.hpp"                      /* THEMIM */
+ 
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QRect>
+ #include <QStyleOptionViewItem>
+ #include <QFontMetrics>
+Index: vlc-3.0.8/modules/gui/qt/dialogs/plugins.cpp
+===================================================================
+--- vlc-3.0.8.orig/modules/gui/qt/dialogs/plugins.cpp
++++ vlc-3.0.8/modules/gui/qt/dialogs/plugins.cpp
+@@ -53,6 +53,7 @@
+ #include <QListView>
+ #include <QListWidget>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QStyleOptionViewItem>
+ #include <QKeyEvent>
+ #include <QPushButton>
+

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -84,11 +84,17 @@ let
       })
     ]
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
-    qtwebkit = [ ./qtwebkit.patch ]
-      ++ optionals stdenv.isDarwin [
-        ./qtwebkit-darwin-no-readline.patch
-        ./qtwebkit-darwin-no-qos-classes.patch
-      ];
+    qtwebkit = [
+      (fetchpatch {
+        name = "qtwebkit-bison-3.7-build.patch";
+        url = "https://github.com/qtwebkit/qtwebkit/commit/d92b11fea65364fefa700249bd3340e0cd4c5b31.patch";
+        sha256 = "0h8ymfnwgkjkwaankr3iifiscsvngqpwb91yygndx344qdiw9y0n";
+      })
+      ./qtwebkit.patch
+    ] ++ optionals stdenv.isDarwin [
+      ./qtwebkit-darwin-no-readline.patch
+      ./qtwebkit-darwin-no-qos-classes.patch
+    ];
     qttools = [ ./qttools.patch ];
   };
 

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -72,7 +72,6 @@ qtModule {
   preFixup = ''rm -rf "$(pwd)" && mkdir "$(pwd)" '';
 
   meta = {
-    broken = lib.versionAtLeast qtbase.version "5.15";
     maintainers = with stdenv.lib.maintainers; [ abbradar periklis ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -228,6 +228,7 @@ in
 
   archiver = callPackage ../applications/misc/archiver { };
 
+  # It segfaults if it uses qt5.15
   digitalbitbox = libsForQt514.callPackage ../applications/misc/digitalbitbox { };
 
   grsync = callPackage ../applications/misc/grsync { };
@@ -5714,7 +5715,7 @@ in
   inherit (callPackage ../servers/nextcloud {})
     nextcloud17 nextcloud18 nextcloud19 nextcloud20;
 
-  nextcloud-client = libsForQt514.callPackage ../applications/networking/nextcloud-client { };
+  nextcloud-client = libsForQt5.callPackage ../applications/networking/nextcloud-client { };
 
   nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };
 
@@ -6511,7 +6512,7 @@ in
 
   qr-filetransfer = callPackage ../tools/networking/qr-filetransfer { };
 
-  qtikz = libsForQt514.callPackage ../applications/graphics/ktikz { };
+  qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
   quickjs = callPackage ../development/interpreters/quickjs { };
 
@@ -21480,7 +21481,7 @@ in
 
   kondo = callPackage ../applications/misc/kondo { };
 
-  konversation = libsForQt514.callPackage ../applications/networking/irc/konversation { };
+  konversation = libsForQt5.callPackage ../applications/networking/irc/konversation { };
 
   kotatogram-desktop = libsForQt514.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop { };
 
@@ -22761,7 +22762,7 @@ in
 
   qsstv = qt5.callPackage ../applications/radio/qsstv { };
 
-  qsyncthingtray = libsForQt514.callPackage ../applications/misc/qsyncthingtray { };
+  qsyncthingtray = libsForQt5.callPackage ../applications/misc/qsyncthingtray { };
 
   qstopmotion = libsForQt5.callPackage ../applications/video/qstopmotion {
     guvcview = guvcview.override {
@@ -23770,7 +23771,7 @@ in
 
   vkeybd = callPackage ../applications/audio/vkeybd {};
 
-  vlc = libsForQt514.callPackage ../applications/video/vlc {};
+  vlc = libsForQt5.callPackage ../applications/video/vlc {};
 
   vlc_qt5 = vlc;
 


### PR DESCRIPTION
###### Motivation for this change

Fix Qt Webkit on the release branch.

See also: #104474

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
