### PR TITLE
KDE Applications 20.08.3

### DIFF
--- a/pkgs/applications/kde/akonadi-calendar.nix
+++ b/pkgs/applications/kde/akonadi-calendar.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi-calendar";
+  pname = "akonadi-calendar";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadi-contacts.nix
+++ b/pkgs/applications/kde/akonadi-contacts.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi-contacts";
+  pname = "akonadi-contacts";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadi-import-wizard.nix
+++ b/pkgs/applications/kde/akonadi-import-wizard.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi-import-wizard";
+  pname = "akonadi-import-wizard";
   meta = {
     license = with lib.licenses; [ gpl2Plus lgpl21Plus fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadi-mime.nix
+++ b/pkgs/applications/kde/akonadi-mime.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi-mime";
+  pname = "akonadi-mime";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadi-notes.nix
+++ b/pkgs/applications/kde/akonadi-notes.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi-notes";
+  pname = "akonadi-notes";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadi-search.nix
+++ b/pkgs/applications/kde/akonadi-search.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi-search";
+  pname = "akonadi-search";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "akonadi";
+  pname = "akonadi";
   meta = {
     license = [ lib.licenses.lgpl21 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akonadiconsole.nix
+++ b/pkgs/applications/kde/akonadiconsole.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "akonadiconsole";
+  pname = "akonadiconsole";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/akregator.nix
+++ b/pkgs/applications/kde/akregator.nix
@@ -10,7 +10,7 @@
 }:
 
 mkDerivation {
-  name = "akregator";
+  pname = "akregator";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/ark/default.nix
+++ b/pkgs/applications/kde/ark/default.nix
@@ -20,7 +20,7 @@ let
 in
 
 mkDerivation {
-  name = "ark";
+  pname = "ark";
   meta = {
     description = "Graphical file compression/decompression utility";
     license = with lib.licenses;

--- a/pkgs/applications/kde/baloo-widgets.nix
+++ b/pkgs/applications/kde/baloo-widgets.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "baloo-widgets";
+  pname = "baloo-widgets";
   meta = {
     license = [ lib.licenses.lgpl21 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/bomber.nix
+++ b/pkgs/applications/kde/bomber.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "bomber";
+  pname = "bomber";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.bomber";
     description = "A single player arcade game";

--- a/pkgs/applications/kde/bovo.nix
+++ b/pkgs/applications/kde/bovo.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "bovo";
+  pname = "bovo";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.bovo";
     description = "Five in a row application";

--- a/pkgs/applications/kde/calendarsupport.nix
+++ b/pkgs/applications/kde/calendarsupport.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam, fetchpatch,
   extra-cmake-modules, kdoctools,
   akonadi, akonadi-calendar, akonadi-mime, akonadi-notes, kcalutils, kdepim-apps-libs,
   kholidays, kidentitymanagement, kmime, pimcommon, qttools,
@@ -11,6 +11,13 @@ mkDerivation {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };
+  patches = [
+    # Patch for Qt 5.15.2 until version 20.12.0
+    (fetchpatch {
+      url = "https://invent.kde.org/pim/calendarsupport/-/commit/b4193facb223bd5b73a65318dec8ced51b66adf7.patch";
+      sha256 = "sha256:1da11rqbxxrl06ld3avc41p064arz4n6w5nxq8r008v8ws3s64dy";
+    })
+  ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     akonadi akonadi-mime akonadi-notes kcalutils kdepim-apps-libs kholidays pimcommon qttools

--- a/pkgs/applications/kde/calendarsupport.nix
+++ b/pkgs/applications/kde/calendarsupport.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "calendarsupport";
+  pname = "calendarsupport";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -35,15 +35,13 @@ let
 
   mkDerivation = args:
     let
-      inherit (args) name;
-      sname = args.sname or name;
-      inherit (srcs.${sname}) src version;
+      inherit (args) pname;
+      inherit (srcs.${pname}) src version;
       mkDerivation =
         libsForQt5.callPackage ({ mkDerivation }: mkDerivation) {};
     in
       mkDerivation (args // {
-        pname = name;
-        inherit src version;
+        inherit pname version src;
 
         outputs = args.outputs or [ "out" ];
 

--- a/pkgs/applications/kde/dolphin-plugins.nix
+++ b/pkgs/applications/kde/dolphin-plugins.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "dolphin-plugins";
+  pname = "dolphin-plugins";
   meta = {
     license = [ lib.licenses.gpl2 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/dolphin.nix
+++ b/pkgs/applications/kde/dolphin.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "dolphin";
+  pname = "dolphin";
   meta = {
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/dragon.nix
+++ b/pkgs/applications/kde/dragon.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "dragon";
+  pname = "dragon";
   meta = {
     license = with lib.licenses; [ gpl2 fdl12 ];
     description = "A simple media player for KDE";

--- a/pkgs/applications/kde/elisa.nix
+++ b/pkgs/applications/kde/elisa.nix
@@ -19,7 +19,7 @@
 }:
 
 mkDerivation rec {
-  name = "elisa";
+  pname = "elisa";
 
   buildInputs = [ libvlc ];
 

--- a/pkgs/applications/kde/eventviews.nix
+++ b/pkgs/applications/kde/eventviews.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "eventviews";
+  pname = "eventviews";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=(http://download.kde.org/stable/release-service/20.08.2/src)
+WGET_ARGS=( http://download.kde.org/stable/release-service/20.08.2/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.kde.org/stable/release-service/20.08.2/src -A '*.tar.xz' )
+WGET_ARGS=( http://download.kde.org/stable/release-service/20.08.3/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/ffmpegthumbs.nix
+++ b/pkgs/applications/kde/ffmpegthumbs.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "ffmpegthumbs";
+  pname = "ffmpegthumbs";
   meta = {
     license = with lib.licenses; [ gpl2 bsd3 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/filelight.nix
+++ b/pkgs/applications/kde/filelight.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "filelight";
+  pname = "filelight";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ fridh vcunat ];

--- a/pkgs/applications/kde/granatier.nix
+++ b/pkgs/applications/kde/granatier.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "granatier";
+  pname = "granatier";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.granatier";
     description = "Clone of the classic Bomberman game";

--- a/pkgs/applications/kde/grantleetheme/default.nix
+++ b/pkgs/applications/kde/grantleetheme/default.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "grantleetheme";
+  pname = "grantleetheme";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/gwenview.nix
+++ b/pkgs/applications/kde/gwenview.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "gwenview";
+  pname = "gwenview";
   meta = {
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/incidenceeditor.nix
+++ b/pkgs/applications/kde/incidenceeditor.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "incidenceeditor";
+  pname = "incidenceeditor";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/k3b.nix
+++ b/pkgs/applications/kde/k3b.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "k3b";
+  pname = "k3b";
   meta = with lib; {
     license = with licenses; [ gpl2Plus ];
     maintainers = with maintainers; [ sander phreedom ];

--- a/pkgs/applications/kde/kaddressbook.nix
+++ b/pkgs/applications/kde/kaddressbook.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, kdepimTeam,
+  mkDerivation, lib, kdepimTeam, fetchpatch,
   extra-cmake-modules, kdoctools,
   akonadi, akonadi-search, grantlee, grantleetheme, kcmutils, kcompletion,
   kcrash, kdbusaddons, kdepim-apps-libs, ki18n, kontactinterface, kparts,
@@ -13,6 +13,13 @@ mkDerivation {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };
+  patches = [
+    # Patch for Qt 5.15.2 until version 20.12.0
+    (fetchpatch {
+      url = "https://invent.kde.org/pim/kaddressbook/-/commit/8aee8d40ae2a1c920d3520163d550d3b49720226.patch";
+      sha256 = "sha256:0dsy119cd5w9khiwgk6fb7xnjzmj94rfphf327k331lf15zq4853";
+    })
+  ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     akonadi akonadi-search grantlee grantleetheme kcmutils kcompletion kcrash

--- a/pkgs/applications/kde/kaddressbook.nix
+++ b/pkgs/applications/kde/kaddressbook.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "kaddressbook";
+  pname = "kaddressbook";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kalarm.nix
+++ b/pkgs/applications/kde/kalarm.nix
@@ -16,7 +16,7 @@
 }:
 
 mkDerivation {
-  name = "kalarm";
+  pname = "kalarm";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.rittelle ];

--- a/pkgs/applications/kde/kalarmcal.nix
+++ b/pkgs/applications/kde/kalarmcal.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kalarmcal";
+  pname = "kalarmcal";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kalzium.nix
+++ b/pkgs/applications/kde/kalzium.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, openbabel, avogadro, qtscript, kparts, kplotting, kunitconversion }:
 
 mkDerivation {
-  name = "kalzium";
+  pname = "kalzium";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kalzium";
     description = "Program that shows you the Periodic Table of Elements";

--- a/pkgs/applications/kde/kapman.nix
+++ b/pkgs/applications/kde/kapman.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "kapman";
+  pname = "kapman";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kapman";
     description = "Clone of the well known game Pac-Man";

--- a/pkgs/applications/kde/kapptemplate.nix
+++ b/pkgs/applications/kde/kapptemplate.nix
@@ -8,7 +8,7 @@
 }:
 mkDerivation {
 
-  name = "kapptemplate";
+  pname = "kapptemplate";
 
   nativeBuildInputs = [ extra-cmake-modules cmake  ];
 

--- a/pkgs/applications/kde/kate.nix
+++ b/pkgs/applications/kde/kate.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "kate";
+  pname = "kate";
   meta = {
     license = with lib.licenses; [ gpl3 lgpl3 lgpl2 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/katomic.nix
+++ b/pkgs/applications/kde/katomic.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames, knewstuff }:
 
 mkDerivation {
-  name = "katomic";
+  pname = "katomic";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.katomic";
     description = "Fun educational game built around molecular geometry";

--- a/pkgs/applications/kde/kblackbox.nix
+++ b/pkgs/applications/kde/kblackbox.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "kblackbox";
+  pname = "kblackbox";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kblackbox";
     description = "Game of hide and seek played on a grid of boxes";

--- a/pkgs/applications/kde/kblocks.nix
+++ b/pkgs/applications/kde/kblocks.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "kblocks";
+  pname = "kblocks";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kblocks";
     description = "Classic falling blocks game";

--- a/pkgs/applications/kde/kbounce.nix
+++ b/pkgs/applications/kde/kbounce.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, libkdegames, kconfig, kcrash, kio, ki18n }:
 
 mkDerivation {
-  name = "kbounce";
+  pname = "kbounce";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kbounce";
     description = "Single player arcade game with the elements of puzzle";

--- a/pkgs/applications/kde/kbreakout.nix
+++ b/pkgs/applications/kde/kbreakout.nix
@@ -10,7 +10,7 @@
 }:
 
 mkDerivation {
-  name = "kbreakout";
+  pname = "kbreakout";
   meta.license = with lib.licenses; [ lgpl21 gpl3 ];
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [

--- a/pkgs/applications/kde/kcachegrind.nix
+++ b/pkgs/applications/kde/kcachegrind.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kcachegrind";
+  pname = "kcachegrind";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ orivej ];

--- a/pkgs/applications/kde/kcalc.nix
+++ b/pkgs/applications/kde/kcalc.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kcalc";
+  pname = "kcalc";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.fridh ];

--- a/pkgs/applications/kde/kcalutils.nix
+++ b/pkgs/applications/kde/kcalutils.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kcalutils";
+  pname = "kcalutils";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kcharselect.nix
+++ b/pkgs/applications/kde/kcharselect.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kcharselect";
+  pname = "kcharselect";
   meta = {
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.schmittlauch ];

--- a/pkgs/applications/kde/kcolorchooser.nix
+++ b/pkgs/applications/kde/kcolorchooser.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kcolorchooser";
+  pname = "kcolorchooser";
   meta = {
     license = with lib.licenses; [ mit ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/kdebugsettings.nix
+++ b/pkgs/applications/kde/kdebugsettings.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kdebugsettings";
+  pname = "kdebugsettings";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.rittelle ];

--- a/pkgs/applications/kde/kdeconnect-kde.nix
+++ b/pkgs/applications/kde/kdeconnect-kde.nix
@@ -26,7 +26,7 @@
 }:
 
 mkDerivation {
-  name = "kdeconnect-kde";
+  pname = "kdeconnect-kde";
 
   buildInputs = [
     kcmutils

--- a/pkgs/applications/kde/kdeconnect-kde.nix
+++ b/pkgs/applications/kde/kdeconnect-kde.nix
@@ -28,14 +28,6 @@
 mkDerivation {
   name = "kdeconnect-kde";
 
-  patches = [
-    # https://invent.kde.org/network/kdeconnect-kde/-/merge_requests/328
-    (fetchpatch {
-      url = "https://invent.kde.org/network/kdeconnect-kde/-/commit/6101ef3ad07d865958d58a3d2736f5536f1c5719.diff";
-      sha256 = "17mr7k13226vzcgxlmfs6q2mdc5j7vwp4iri9apmh6xlf6r591ac";
-    })
-  ];
-
   buildInputs = [
     kcmutils
     kconfigwidgets

--- a/pkgs/applications/kde/kdegraphics-mobipocket.nix
+++ b/pkgs/applications/kde/kdegraphics-mobipocket.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdegraphics-mobipocket";
+  pname = "kdegraphics-mobipocket";
   meta = {
     license = [ lib.licenses.gpl2Plus ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/kdegraphics-thumbnailers.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "kdegraphics-thumbnailers";
+  pname = "kdegraphics-thumbnailers";
   meta = {
     license = [ lib.licenses.lgpl21 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/kdenetwork-filesharing.nix
+++ b/pkgs/applications/kde/kdenetwork-filesharing.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdenetwork-filesharing";
+  pname = "kdenetwork-filesharing";
   meta = {
     license = [ lib.licenses.gpl2 lib.licenses.lgpl21 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/kdenlive.nix
+++ b/pkgs/applications/kde/kdenlive.nix
@@ -35,7 +35,7 @@
 }:
 
 mkDerivation {
-  name = "kdenlive";
+  pname = "kdenlive";
   nativeBuildInputs = [
     extra-cmake-modules
     kdoctools

--- a/pkgs/applications/kde/kdepim-addons.nix
+++ b/pkgs/applications/kde/kdepim-addons.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "kdepim-addons";
+  pname = "kdepim-addons";
   meta = {
     license = with lib.licenses; [ gpl2Plus lgpl21Plus ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kdepim-apps-libs/default.nix
+++ b/pkgs/applications/kde/kdepim-apps-libs/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kdepim-apps-libs";
+  pname = "kdepim-apps-libs";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "kdepim-runtime";
+  pname = "kdepim-runtime";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kdf.nix
+++ b/pkgs/applications/kde/kdf.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdf";
+  pname = "kdf";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.peterhoeg ];

--- a/pkgs/applications/kde/kdialog.nix
+++ b/pkgs/applications/kde/kdialog.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdialog";
+  pname = "kdialog";
 
   meta = {
     license = with lib.licenses; [ gpl2 fdl12 ];

--- a/pkgs/applications/kde/kdiamond.nix
+++ b/pkgs/applications/kde/kdiamond.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames, kconfig, knotifyconfig }:
 
 mkDerivation {
-  name = "kdiamond";
+  pname = "kdiamond";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kdiamond";
     description = "A single player puzzle game";

--- a/pkgs/applications/kde/keditbookmarks.nix
+++ b/pkgs/applications/kde/keditbookmarks.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "keditbookmarks";
+  pname = "keditbookmarks";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kio kparts kwindowsystem ];
   meta = with lib; {

--- a/pkgs/applications/kde/kfind.nix
+++ b/pkgs/applications/kde/kfind.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kfind";
+  pname = "kfind";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.iblech ];

--- a/pkgs/applications/kde/kfloppy.nix
+++ b/pkgs/applications/kde/kfloppy.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, kcompletion, kxmlgui }:
 
 mkDerivation {
-  name = "kfloppy";
+  pname = "kfloppy";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kfloppy";
     description = "Utility to format 3.5\" and 5.25\" floppy disks";

--- a/pkgs/applications/kde/kgeography.nix
+++ b/pkgs/applications/kde/kgeography.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kgeography";
+  pname = "kgeography";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.globin ];

--- a/pkgs/applications/kde/kget.nix
+++ b/pkgs/applications/kde/kget.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kget";
+  pname = "kget";
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
 

--- a/pkgs/applications/kde/kgpg.nix
+++ b/pkgs/applications/kde/kgpg.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kgpg";
+  pname = "kgpg";
   nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
   buildInputs = [
     akonadi-contacts gnupg karchive kcodecs kcontacts kcoreaddons kcrash

--- a/pkgs/applications/kde/khelpcenter.nix
+++ b/pkgs/applications/kde/khelpcenter.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "khelpcenter";
+  pname = "khelpcenter";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     grantlee kcmutils kconfig kcoreaddons kdbusaddons kdelibs4support khtml

--- a/pkgs/applications/kde/kidentitymanagement.nix
+++ b/pkgs/applications/kde/kidentitymanagement.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kidentitymanagement";
+  pname = "kidentitymanagement";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kig.nix
+++ b/pkgs/applications/kde/kig.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kig";
+  pname = "kig";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ raskin ];

--- a/pkgs/applications/kde/kigo.nix
+++ b/pkgs/applications/kde/kigo.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames, knewstuff }:
 
 mkDerivation {
-  name = "kigo";
+  pname = "kigo";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kigo";
     description = "An open-source implementation of the popular Go game";

--- a/pkgs/applications/kde/killbots.nix
+++ b/pkgs/applications/kde/killbots.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "killbots";
+  pname = "killbots";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.killbots";
     description = "A game where you avoid robots";

--- a/pkgs/applications/kde/kimap.nix
+++ b/pkgs/applications/kde/kimap.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kimap";
+  pname = "kimap";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kio-extras.nix
+++ b/pkgs/applications/kde/kio-extras.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kio-extras";
+  pname = "kio-extras";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/kipi-plugins.nix
+++ b/pkgs/applications/kde/kipi-plugins.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name    = "kipi-plugins";
+  pname    = "kipi-plugins";
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [

--- a/pkgs/applications/kde/kitinerary.nix
+++ b/pkgs/applications/kde/kitinerary.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kitinerary";
+  pname = "kitinerary";
   meta = {
     license = with lib.licenses; [ lgpl21 ];
     maintainers = [ lib.maintainers.bkchr ];

--- a/pkgs/applications/kde/kldap.nix
+++ b/pkgs/applications/kde/kldap.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kldap";
+  pname = "kldap";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kleopatra.nix
+++ b/pkgs/applications/kde/kleopatra.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kleopatra";
+  pname = "kleopatra";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/klettres.nix
+++ b/pkgs/applications/kde/klettres.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, phonon, knewstuff }:
 
 mkDerivation {
-  name = "klettres";
+  pname = "klettres";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.klettres";
     description = "An application specially designed to help the user to learn an alphabet";

--- a/pkgs/applications/kde/klines.nix
+++ b/pkgs/applications/kde/klines.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "klines";
+  pname = "klines";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.klines";
     description = "A simple but highly addictive one player game";

--- a/pkgs/applications/kde/kmag.nix
+++ b/pkgs/applications/kde/kmag.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio }:
 
 mkDerivation {
-  name = "kmag";
+  pname = "kmag";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kmag";
     description = "A small Linux utility to magnify a part of the screen";

--- a/pkgs/applications/kde/kmahjongg.nix
+++ b/pkgs/applications/kde/kmahjongg.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "kmahjongg";
+  pname = "kmahjongg";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kdeclarative libkmahjongg knewstuff libkdegames ];
   meta = {

--- a/pkgs/applications/kde/kmail-account-wizard.nix
+++ b/pkgs/applications/kde/kmail-account-wizard.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kmail-account-wizard";
+  pname = "kmail-account-wizard";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -11,7 +11,7 @@
 }:
 
 mkDerivation {
-  name = "kmail";
+  pname = "kmail";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kmailtransport.nix
+++ b/pkgs/applications/kde/kmailtransport.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kmailtransport";
+  pname = "kmailtransport";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kmbox.nix
+++ b/pkgs/applications/kde/kmbox.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kmbox";
+  pname = "kmbox";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kmime.nix
+++ b/pkgs/applications/kde/kmime.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kmime";
+  pname = "kmime";
   meta = {
     license = [ lib.licenses.lgpl21 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kmines.nix
+++ b/pkgs/applications/kde/kmines.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, libkdegames, kconfig, kcrash, kdoctools, ki18n, kio }:
 
 mkDerivation {
-  name = "kmines";
+  pname = "kmines";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kmines";
     description = "A classic Minesweeper game";

--- a/pkgs/applications/kde/kmix.nix
+++ b/pkgs/applications/kde/kmix.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kmix";
+  pname = "kmix";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = [ lib.maintainers.rongcuid ];

--- a/pkgs/applications/kde/kmplot.nix
+++ b/pkgs/applications/kde/kmplot.nix
@@ -3,7 +3,7 @@
 }:
 
 mkDerivation {
-  name = "kmplot";
+  pname = "kmplot";
   meta = {
     license = with lib.licenses; [ gpl2Plus fdl12 ];
     maintainers = [ lib.maintainers.orivej ];

--- a/pkgs/applications/kde/knavalbattle.nix
+++ b/pkgs/applications/kde/knavalbattle.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames, kdnssd }:
 
 mkDerivation {
-  name = "knavalbattle";
+  pname = "knavalbattle";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.knavalbattle";
     description = "Naval Battle is a ship sinking game";

--- a/pkgs/applications/kde/knetwalk.nix
+++ b/pkgs/applications/kde/knetwalk.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "knetwalk";
+  pname = "knetwalk";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.knetwalk";
     description = "A single player logic game";

--- a/pkgs/applications/kde/knights.nix
+++ b/pkgs/applications/kde/knights.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, kplotting, plasma-framework, libkdegames }:
 
 mkDerivation {
-  name = "knights";
+  pname = "knights";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.knights";
     description = "A chess game";

--- a/pkgs/applications/kde/knotes.nix
+++ b/pkgs/applications/kde/knotes.nix
@@ -13,7 +13,7 @@
 }:
 
 mkDerivation {
-  name = "knotes";
+  pname = "knotes";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kcompletion kconfig kconfigwidgets kcoreaddons kcrash

--- a/pkgs/applications/kde/kolf.nix
+++ b/pkgs/applications/kde/kolf.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kolf";
+  pname = "kolf";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ libkdegames kio ktextwidgets ];
   meta = {

--- a/pkgs/applications/kde/kollision.nix
+++ b/pkgs/applications/kde/kollision.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames }:
 
 mkDerivation {
-  name = "kollision";
+  pname = "kollision";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kollision";
     description = "A casual game";

--- a/pkgs/applications/kde/kolourpaint.nix
+++ b/pkgs/applications/kde/kolourpaint.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kolourpaint";
+  pname = "kolourpaint";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kdelibs4support libkexiv2 ];
   meta = {

--- a/pkgs/applications/kde/kompare.nix
+++ b/pkgs/applications/kde/kompare.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kompare";
+  pname = "kompare";
   meta = { license = with lib.licenses; [ gpl2 ]; };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/applications/kde/konqueror.nix
+++ b/pkgs/applications/kde/konqueror.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "konqueror";
+  pname = "konqueror";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kdelibs4support kcmutils khtml kdesu

--- a/pkgs/applications/kde/konquest.nix
+++ b/pkgs/applications/kde/konquest.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "konquest";
+  pname = "konquest";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kdelibs4support libkdegames qtquickcontrols ];
   meta = {

--- a/pkgs/applications/kde/konsole.nix
+++ b/pkgs/applications/kde/konsole.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "konsole";
+  pname = "konsole";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = with lib.maintainers; [ ttuegel turion ];

--- a/pkgs/applications/kde/kontact.nix
+++ b/pkgs/applications/kde/kontact.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "kontact";
+  pname = "kontact";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kontactinterface.nix
+++ b/pkgs/applications/kde/kontactinterface.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kontactinterface";
+  pname = "kontactinterface";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/korganizer.nix
+++ b/pkgs/applications/kde/korganizer.nix
@@ -11,7 +11,7 @@
 }:
 
 mkDerivation {
-  name = "korganizer";
+  pname = "korganizer";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kpat.nix
+++ b/pkgs/applications/kde/kpat.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "kpat";
+  pname = "kpat";
   nativeBuildInputs = [
     extra-cmake-modules
     shared-mime-info

--- a/pkgs/applications/kde/kpimtextedit.nix
+++ b/pkgs/applications/kde/kpimtextedit.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kpimtextedit";
+  pname = "kpimtextedit";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kpkpass.nix
+++ b/pkgs/applications/kde/kpkpass.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "kpkpass";
+  pname = "kpkpass";
   meta = {
     license = with lib.licenses; [ lgpl21 ];
     maintainers = [ lib.maintainers.bkchr ];

--- a/pkgs/applications/kde/kqtquickcharts.nix
+++ b/pkgs/applications/kde/kqtquickcharts.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kqtquickcharts";
+  pname = "kqtquickcharts";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/krdc.nix
+++ b/pkgs/applications/kde/krdc.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "krdc";
+  pname = "krdc";
   nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
   buildInputs = [
     kcmutils kcompletion kconfig kdnssd knotifyconfig kwallet kwidgetsaddons

--- a/pkgs/applications/kde/kreversi.nix
+++ b/pkgs/applications/kde/kreversi.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, libkdegames, kdeclarative }:
 
 mkDerivation {
-  name = "kreversi";
+  pname = "kreversi";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kreversi";
     description = "A simple one player strategy game played against the computer";

--- a/pkgs/applications/kde/krfb.nix
+++ b/pkgs/applications/kde/krfb.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "krfb";
+  pname = "krfb";
   meta = {
     license = with lib.licenses; [ gpl2 fdl12 ];
     maintainers = with lib.maintainers; [ jerith666 ];

--- a/pkgs/applications/kde/kruler.nix
+++ b/pkgs/applications/kde/kruler.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kruler";
+  pname = "kruler";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = [ lib.maintainers.vandenoever ];

--- a/pkgs/applications/kde/kshisen.nix
+++ b/pkgs/applications/kde/kshisen.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, libkdegames, libkmahjongg }:
 
 mkDerivation {
-  name = "kshisen";
+  pname = "kshisen";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.kshisen";
     description = "A solitaire-like game played using the standard set of Mahjong tiles";

--- a/pkgs/applications/kde/ksmtp/default.nix
+++ b/pkgs/applications/kde/ksmtp/default.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "ksmtp";
+  pname = "ksmtp";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/kspaceduel.nix
+++ b/pkgs/applications/kde/kspaceduel.nix
@@ -10,10 +10,10 @@
 }:
 
 mkDerivation {
-  name = "kspaceduel";
+  pname = "kspaceduel";
   meta.license = with lib.licenses; [ lgpl21 gpl3 ];
   outputs = [ "out" "dev" ];
-  nativeBuildInputs = [ 
+  nativeBuildInputs = [
     cmake extra-cmake-modules
   ];
   propagatedBuildInputs = [

--- a/pkgs/applications/kde/ksquares.nix
+++ b/pkgs/applications/kde/ksquares.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, libkdegames, kconfig, kcrash, kxmlgui }:
 
 mkDerivation {
-  name = "ksquares";
+  pname = "ksquares";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/games/org.kde.ksquares";
     description = "A game of Dots and Boxes";

--- a/pkgs/applications/kde/ksudoku.nix
+++ b/pkgs/applications/kde/ksudoku.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "ksudoku";
+  pname = "ksudoku";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ libGLU kdeclarative libkdegames ];
   meta = {

--- a/pkgs/applications/kde/ksystemlog.nix
+++ b/pkgs/applications/kde/ksystemlog.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "ksystemlog";
+  pname = "ksystemlog";
 
   nativeBuildInputs = [ extra-cmake-modules gettext kdoctools ];
   propagatedBuildInputs = [ karchive kconfig kio ];

--- a/pkgs/applications/kde/kteatime.nix
+++ b/pkgs/applications/kde/kteatime.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kconfig, kcrash, kiconthemes, knotifyconfig }:
 
 mkDerivation {
-  name = "kteatime";
+  pname = "kteatime";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kteatime";
     description = "A handy timer for steeping tea";

--- a/pkgs/applications/kde/ktimer.nix
+++ b/pkgs/applications/kde/ktimer.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio }:
 
 mkDerivation {
-  name = "ktimer";
+  pname = "ktimer";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.ktimer";
     description = "A little tool to execute programs after some time";

--- a/pkgs/applications/kde/ktnef.nix
+++ b/pkgs/applications/kde/ktnef.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "ktnef";
+  pname = "ktnef";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/ktouch.nix
+++ b/pkgs/applications/kde/ktouch.nix
@@ -9,7 +9,7 @@
 
 
   mkDerivation {
-    name = "ktouch";
+    pname = "ktouch";
     meta = {
       license = lib.licenses.gpl2;
       maintainers = [ lib.maintainers.schmittlauch ];

--- a/pkgs/applications/kde/kturtle.nix
+++ b/pkgs/applications/kde/kturtle.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kdoctools, ki18n, kio, knewstuff }:
 
 mkDerivation {
-  name = "kturtle";
+  pname = "kturtle";
   meta = with lib; {
     homepage = "https://kde.org/applications/en/utilities/org.kde.kturtle";
     description = "An educational programming environment for learning how to program";

--- a/pkgs/applications/kde/kwalletmanager.nix
+++ b/pkgs/applications/kde/kwalletmanager.nix
@@ -13,7 +13,7 @@
 }:
 
 mkDerivation {
-  name = "kwalletmanager";
+  pname = "kwalletmanager";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ fridh ];

--- a/pkgs/applications/kde/kwave.nix
+++ b/pkgs/applications/kde/kwave.nix
@@ -3,7 +3,7 @@
 , libogg, libmad, libopus, libvorbis, fftw, librsvg, qtbase }:
 
 mkDerivation {
-  name = "kwave";
+  pname = "kwave";
 
   meta = with lib; {
     homepage = "https://kde.org/applications/en/multimedia/org.kde.kwave";

--- a/pkgs/applications/kde/libgravatar.nix
+++ b/pkgs/applications/kde/libgravatar.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "libgravatar";
+  pname = "libgravatar";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/libkcddb.nix
+++ b/pkgs/applications/kde/libkcddb.nix
@@ -3,7 +3,7 @@
 , libmusicbrainz5 }:
 
 mkDerivation {
-  name = "libkcddb";
+  pname = "libkcddb";
   meta = with lib; {
     license = with licenses; [ gpl2 lgpl21 bsd3 ];
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/kde/libkdcraw.nix
+++ b/pkgs/applications/kde/libkdcraw.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, libraw, qtbase }:
 
 mkDerivation {
-  name = "libkdcraw";
+  pname = "libkdcraw";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 bsd3 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/libkdegames.nix
+++ b/pkgs/applications/kde/libkdegames.nix
@@ -13,7 +13,7 @@
 }:
 
 mkDerivation {
-  name = "libkdegames";
+  pname = "libkdegames";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kdelibs4support qtdeclarative kdeclarative kdnssd knewstuff openal libsndfile

--- a/pkgs/applications/kde/libkdepim.nix
+++ b/pkgs/applications/kde/libkdepim.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "libkdepim";
+  pname = "libkdepim";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/libkexiv2.nix
+++ b/pkgs/applications/kde/libkexiv2.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, exiv2, extra-cmake-modules, qtbase }:
 
 mkDerivation {
-  name = "libkexiv2";
+  pname = "libkexiv2";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 bsd3 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/libkgapi.nix
+++ b/pkgs/applications/kde/libkgapi.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "libkgapi";
+  pname = "libkgapi";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/libkipi.nix
+++ b/pkgs/applications/kde/libkipi.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, kconfig, ki18n, kservice, kxmlgui }:
 
 mkDerivation {
-  name = "libkipi";
+  pname = "libkipi";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 bsd3 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/libkleo.nix
+++ b/pkgs/applications/kde/libkleo.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "libkleo";
+  pname = "libkleo";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/libkmahjongg.nix
+++ b/pkgs/applications/kde/libkmahjongg.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "libkmahjongg";
+  pname = "libkmahjongg";
   meta = {
     license = with lib.licenses; [ gpl2 ];
     maintainers = with lib.maintainers; [ ];

--- a/pkgs/applications/kde/libkomparediff2.nix
+++ b/pkgs/applications/kde/libkomparediff2.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, ki18n, kxmlgui, kcodecs, kio }:
 
 mkDerivation {
-  name = "libkomparediff2";
+  pname = "libkomparediff2";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ kcodecs ki18n kxmlgui kio ];
 }

--- a/pkgs/applications/kde/libksane.nix
+++ b/pkgs/applications/kde/libksane.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "libksane";
+  pname = "libksane";
   meta = with lib; {
     license = licenses.gpl2;
     maintainers = with maintainers; [ pshendry ];

--- a/pkgs/applications/kde/libksieve.nix
+++ b/pkgs/applications/kde/libksieve.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "libksieve";
+  pname = "libksieve";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/mailcommon.nix
+++ b/pkgs/applications/kde/mailcommon.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "mailcommon";
+  pname = "mailcommon";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/mailimporter.nix
+++ b/pkgs/applications/kde/mailimporter.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "mailimporter";
+  pname = "mailimporter";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/marble.nix
+++ b/pkgs/applications/kde/marble.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "marble";
+  pname = "marble";
   meta.license = with lib.licenses; [ lgpl21 gpl3 ];
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools perl ];

--- a/pkgs/applications/kde/mbox-importer.nix
+++ b/pkgs/applications/kde/mbox-importer.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "mbox-importer";
+  pname = "mbox-importer";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/messagelib.nix
+++ b/pkgs/applications/kde/messagelib.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "messagelib";
+  pname = "messagelib";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/minuet.nix
+++ b/pkgs/applications/kde/minuet.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "minuet";
+  pname = "minuet";
   meta = with lib; {
     license = with licenses; [ lgpl21 gpl3 ];
     maintainers = with maintainers; [ peterhoeg HaoZeke ];

--- a/pkgs/applications/kde/okular.nix
+++ b/pkgs/applications/kde/okular.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "okular";
+  pname = "okular";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     breeze-icons discount djvulibre ebook_tools kactivities karchive kbookmarks

--- a/pkgs/applications/kde/picmi.nix
+++ b/pkgs/applications/kde/picmi.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "picmi";
+  pname = "picmi";
   meta = with lib; {
     description = "Nonogram game";
     longDescription = ''The goal is to reveal the hidden pattern in the board by coloring or

--- a/pkgs/applications/kde/pim-data-exporter.nix
+++ b/pkgs/applications/kde/pim-data-exporter.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "pim-data-exporter";
+  pname = "pim-data-exporter";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/pim-sieve-editor.nix
+++ b/pkgs/applications/kde/pim-sieve-editor.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "pim-sieve-editor";
+  pname = "pim-sieve-editor";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/pimcommon.nix
+++ b/pkgs/applications/kde/pimcommon.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "pimcommon";
+  pname = "pimcommon";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;

--- a/pkgs/applications/kde/print-manager.nix
+++ b/pkgs/applications/kde/print-manager.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "print-manager";
+  pname = "print-manager";
   meta = {
     license = [ lib.licenses.gpl2 ];
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/applications/kde/rocs.nix
+++ b/pkgs/applications/kde/rocs.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "rocs";
+  pname = "rocs";
 
   meta = with lib; {
     homepage = "https://edu.kde.org/rocs/";

--- a/pkgs/applications/kde/spectacle.nix
+++ b/pkgs/applications/kde/spectacle.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "spectacle";
+  pname = "spectacle";
   meta = with lib; { maintainers = with maintainers; [ ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1731 +4,1731 @@
 
 {
   akonadi = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-20.08.2.tar.xz";
-      sha256 = "d3a4b3b3f543734ad5428ca0e573b8dbf9e05f42d51e1aab39b5b5266c16be7d";
-      name = "akonadi-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-20.08.3.tar.xz";
+      sha256 = "1hwaan45cyw2nmfmdp5pbhvm00xdxy9la68ms3sa8a67zcsfljhl";
+      name = "akonadi-20.08.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-calendar-20.08.2.tar.xz";
-      sha256 = "20173d00dc764f6a1e8e0b433d96b982ceadcb17e9bd067caf2967fd5440eb51";
-      name = "akonadi-calendar-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-calendar-20.08.3.tar.xz";
+      sha256 = "18rwvn5i6i4ng335rxpwx3a2m4vyq96w9m3fa1gvmr8ls7vkaqrk";
+      name = "akonadi-calendar-20.08.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-calendar-tools-20.08.2.tar.xz";
-      sha256 = "2069cc3a12f0da3f10181c13d19b1048d8f2e0c0f4a4e14309a7e6f08aa74ab9";
-      name = "akonadi-calendar-tools-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-calendar-tools-20.08.3.tar.xz";
+      sha256 = "1pnm3xi26bnbjmnv9zwi9w5rkr1pdry50hzy3gxw7b0g11zz036w";
+      name = "akonadi-calendar-tools-20.08.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadiconsole-20.08.2.tar.xz";
-      sha256 = "dc03a1986b6e7af0d26af927009d567da1e1835cc2bb5cc1b5732ffca3ecde9d";
-      name = "akonadiconsole-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadiconsole-20.08.3.tar.xz";
+      sha256 = "061r0p9pj22x0hiz6piz4vramll3w5xy92sx8nfhcp2gmnvj9890";
+      name = "akonadiconsole-20.08.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-contacts-20.08.2.tar.xz";
-      sha256 = "e4a2696e0e0cf69926d34f160a4581131a1da8244355787564b75dec06db1b30";
-      name = "akonadi-contacts-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-contacts-20.08.3.tar.xz";
+      sha256 = "18n9x41fmh4q9q9lfv882iwk6j1hvgpl11y4qn873vwr9sdrcf4s";
+      name = "akonadi-contacts-20.08.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-import-wizard-20.08.2.tar.xz";
-      sha256 = "639d72ae3d32f681ddb046a87d625871b485785602cf35b817e89004def4dc5e";
-      name = "akonadi-import-wizard-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-import-wizard-20.08.3.tar.xz";
+      sha256 = "0gny0rxvyks5w4rdb73ly06lyvz7kcfvff1268bn6i96xr83kmim";
+      name = "akonadi-import-wizard-20.08.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-mime-20.08.2.tar.xz";
-      sha256 = "5699a1d44a9812c9530bc61af5822ff34a573b168d72230cd8261c05065c06e3";
-      name = "akonadi-mime-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-mime-20.08.3.tar.xz";
+      sha256 = "12ps633y64mj72iryd9z2nmrf7lxbkqj7xnzj28549cvg6jizgl7";
+      name = "akonadi-mime-20.08.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-notes-20.08.2.tar.xz";
-      sha256 = "4897ca92d6b68f75254e1c419438275a94fa678c9f062dcd91c0267129886ca7";
-      name = "akonadi-notes-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-notes-20.08.3.tar.xz";
+      sha256 = "1z90r37lqc7ydmily730idd4s8rcbr6i3a8x9m647snbala16z36";
+      name = "akonadi-notes-20.08.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akonadi-search-20.08.2.tar.xz";
-      sha256 = "618400950fa44f0c578ab51c3b311a47e0b2df47203f754e50bcc363201a9fc7";
-      name = "akonadi-search-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akonadi-search-20.08.3.tar.xz";
+      sha256 = "0izpkvjybp6r79rai0p5j74bm0f8ksgsl3z34ggb51j6vj9rla7h";
+      name = "akonadi-search-20.08.3.tar.xz";
     };
   };
   akregator = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/akregator-20.08.2.tar.xz";
-      sha256 = "4de4bd31dede5c09e0eb9e14d1da1d1979409eb1e28df5f95963086d4a49edc9";
-      name = "akregator-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/akregator-20.08.3.tar.xz";
+      sha256 = "1gqh820s5by3r9lz7r16r0krh916idsks6sgy26hcrwfmva45wn5";
+      name = "akregator-20.08.3.tar.xz";
     };
   };
   analitza = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/analitza-20.08.2.tar.xz";
-      sha256 = "2fad01bf48199e3671559ec9a619f0d590af331922899c793f96fc90860ec487";
-      name = "analitza-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/analitza-20.08.3.tar.xz";
+      sha256 = "16s6kjyclj73lq8z8mvrbsl75h1nrnv7syp6wpip6gvfs5ynai90";
+      name = "analitza-20.08.3.tar.xz";
     };
   };
   ark = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ark-20.08.2.tar.xz";
-      sha256 = "ec061ac07687b5a3541af293e3bc2aa7bedcfe0ef38ba6e57e2704068a726ffc";
-      name = "ark-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ark-20.08.3.tar.xz";
+      sha256 = "03kwjp2nj570k9ph8bgj042sjj4x0h9jwv8nwx0pfpcxkgxv5pzy";
+      name = "ark-20.08.3.tar.xz";
     };
   };
   artikulate = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/artikulate-20.08.2.tar.xz";
-      sha256 = "66545d85e25aa67816deea4b2b89b485181458a5bc117dad9588671d8b48b41c";
-      name = "artikulate-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/artikulate-20.08.3.tar.xz";
+      sha256 = "0bx97qi6zi7jmlzm3g7qamnzg0966g4w9xpskbxbr4cgjr312x19";
+      name = "artikulate-20.08.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/audiocd-kio-20.08.2.tar.xz";
-      sha256 = "5f38c549fe8c3a4659ac8291c223327b765834e7668bc15a96047e20cdb11f01";
-      name = "audiocd-kio-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/audiocd-kio-20.08.3.tar.xz";
+      sha256 = "01n4nyda7l7by1nyx2sgxdl8qkdfndk0w6hj0qc6a7fllcfj5cpb";
+      name = "audiocd-kio-20.08.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/baloo-widgets-20.08.2.tar.xz";
-      sha256 = "e1d14b8dba911ebc1cee76dbcd44fa200418ba959d86ce567093b5fc3b700a07";
-      name = "baloo-widgets-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/baloo-widgets-20.08.3.tar.xz";
+      sha256 = "0ciidrsvwc3ppxhw7w5116q4lfbsvij9jsvyzm292pmjln2vikrg";
+      name = "baloo-widgets-20.08.3.tar.xz";
     };
   };
   blinken = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/blinken-20.08.2.tar.xz";
-      sha256 = "c6e74033ab8ece83618c5cda0ab3cf327514b8e2e6b0e9daf484ce88f671a65e";
-      name = "blinken-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/blinken-20.08.3.tar.xz";
+      sha256 = "1gfw0w66nm3sx81bnr0p0yz1bhjj63lvd3cr86x3b2pny5rcw1da";
+      name = "blinken-20.08.3.tar.xz";
     };
   };
   bomber = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/bomber-20.08.2.tar.xz";
-      sha256 = "27c226b31bcdbbda0c9e304e428ca7451614c397a038e830f8052c381dae7215";
-      name = "bomber-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/bomber-20.08.3.tar.xz";
+      sha256 = "1nw1a9cf0nqgk00hvzcqch3bl97lx6bih0wsax5q0z1kzwlz0kgr";
+      name = "bomber-20.08.3.tar.xz";
     };
   };
   bovo = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/bovo-20.08.2.tar.xz";
-      sha256 = "936cab24a13900765f0c5a5afb6f155cb5a05bdb067f86b77e33af5f0e4c37d2";
-      name = "bovo-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/bovo-20.08.3.tar.xz";
+      sha256 = "06pbivyvfgjx6zkadvwfwnrg9vjy4rf52k2a74qjcnl2ms16sr1g";
+      name = "bovo-20.08.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/calendarsupport-20.08.2.tar.xz";
-      sha256 = "83bcdd36689f762363a95b688b9377a3335b4fd58ad1d5efad36ad2b0cf7cc10";
-      name = "calendarsupport-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/calendarsupport-20.08.3.tar.xz";
+      sha256 = "09w06n745764fs440nh0piy5sahfn50kh3zrljhgzadcij6165vd";
+      name = "calendarsupport-20.08.3.tar.xz";
     };
   };
   cantor = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/cantor-20.08.2.tar.xz";
-      sha256 = "aca92b6e40a9e05282eae2b55f7cc6bf88612ffa9b3dde1a239648be8e5bdc59";
-      name = "cantor-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/cantor-20.08.3.tar.xz";
+      sha256 = "1njqycx0v3zq5mdcvfdfgxs8vgl01v80s27qgapsxxrgr9hgxbhl";
+      name = "cantor-20.08.3.tar.xz";
     };
   };
   cervisia = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/cervisia-20.08.2.tar.xz";
-      sha256 = "b3444ecd1078b92fad9b00297496dd3d92366a9c0bb56cfa138f28cc15db1389";
-      name = "cervisia-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/cervisia-20.08.3.tar.xz";
+      sha256 = "1bsc72kxcmzx25408ngzqzj4a0168vqfr3a2gvmm6d8klbgpm3gv";
+      name = "cervisia-20.08.3.tar.xz";
     };
   };
   dolphin = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/dolphin-20.08.2.tar.xz";
-      sha256 = "bd13574610fc2108b9b04249cff70ca99958fe57a42fbf260ed16e5e377071bc";
-      name = "dolphin-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/dolphin-20.08.3.tar.xz";
+      sha256 = "107n763qix95b1hgy86hddpj9x2clzhaiw8q8yjn9lzj1rz5facx";
+      name = "dolphin-20.08.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/dolphin-plugins-20.08.2.tar.xz";
-      sha256 = "7eabeb295ae2932958992bf7273afcb8164fbe90a2574064983fb2ecbc57eeaf";
-      name = "dolphin-plugins-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/dolphin-plugins-20.08.3.tar.xz";
+      sha256 = "0fmay0sycfj9s7zyxbldgcal5lj2psi0n9zrgq812s5qr4rb5c8c";
+      name = "dolphin-plugins-20.08.3.tar.xz";
     };
   };
   dragon = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/dragon-20.08.2.tar.xz";
-      sha256 = "cf7cce288fdeb12a0c86739741c6b901859e9b36d8fc9e7478c46f53cc74dd6c";
-      name = "dragon-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/dragon-20.08.3.tar.xz";
+      sha256 = "14qsb7h8w58i9jsh1gpcj8pwjgy7y3mqfy51hca82yrd82z5b9rn";
+      name = "dragon-20.08.3.tar.xz";
     };
   };
   elisa = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/elisa-20.08.2.tar.xz";
-      sha256 = "6c04377dfd5e82b2b67b3a43cc3ffd3b206f24ab75c3fe18298ec80876dcc268";
-      name = "elisa-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/elisa-20.08.3.tar.xz";
+      sha256 = "0893nbj0jsapnfd09cp961k2m7lq6sjvzynpa4hfp9ch1jbc912c";
+      name = "elisa-20.08.3.tar.xz";
     };
   };
   eventviews = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/eventviews-20.08.2.tar.xz";
-      sha256 = "ecac9ac6e6a6ed835b28048d8bfc09bac9a1e7a57c5dd0eba6f4360301b32af9";
-      name = "eventviews-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/eventviews-20.08.3.tar.xz";
+      sha256 = "158j5g3i0wbbxpg9jmr50dvbpms4c4vgcnpmn3b3vfbszzwsy6rg";
+      name = "eventviews-20.08.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ffmpegthumbs-20.08.2.tar.xz";
-      sha256 = "af5b3de86487d3ddccda34c5165a34427ef97fe1090108781eb38babc101740f";
-      name = "ffmpegthumbs-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ffmpegthumbs-20.08.3.tar.xz";
+      sha256 = "186hpq949r3xx2a64nqjy4pcn67d6kdvsy80zr238lgb9qqcqygi";
+      name = "ffmpegthumbs-20.08.3.tar.xz";
     };
   };
   filelight = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/filelight-20.08.2.tar.xz";
-      sha256 = "65f5f90d56d3449722647286324f8aae54754ec2a46c9aaa2e3bad92bae3433e";
-      name = "filelight-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/filelight-20.08.3.tar.xz";
+      sha256 = "1jljsnjdhnqphh1kanj6hi2rswq3i9119iah1j33jy5pladcyf5q";
+      name = "filelight-20.08.3.tar.xz";
     };
   };
   granatier = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/granatier-20.08.2.tar.xz";
-      sha256 = "bb79b84b485bb194bf4edaa833e7705ec9fc0275301c70df78498b872de9ee57";
-      name = "granatier-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/granatier-20.08.3.tar.xz";
+      sha256 = "195bc2rcz11v76c0cwa9mb7rfixjn7sb0a52wrzz0sf9624m0rcs";
+      name = "granatier-20.08.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/grantlee-editor-20.08.2.tar.xz";
-      sha256 = "353b2c58d169e8b3c91367a7ce8939ede39c289036e3617da019ae1045a81c7b";
-      name = "grantlee-editor-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/grantlee-editor-20.08.3.tar.xz";
+      sha256 = "1k2rdicd68jdk3pazyn3q0vj99n0vnkpzkrnacpymkjy85cjgrv9";
+      name = "grantlee-editor-20.08.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/grantleetheme-20.08.2.tar.xz";
-      sha256 = "8cb4d2f698cf7f44bf70322669809f07900021f215175c8db120abc0f2debf62";
-      name = "grantleetheme-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/grantleetheme-20.08.3.tar.xz";
+      sha256 = "07b7v5v2vyz3vyj1jjzryzaak8bbqg8a2caxwb6s7cwhy19y6my5";
+      name = "grantleetheme-20.08.3.tar.xz";
     };
   };
   gwenview = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/gwenview-20.08.2.tar.xz";
-      sha256 = "580df49eb6852db4b1229f0326372dc7da7a08140d552da59a62ece08b03cc9d";
-      name = "gwenview-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/gwenview-20.08.3.tar.xz";
+      sha256 = "09mwp3z97hgd7c15w0hz8k61qn5icb81rj27nxzy877ph1xnrixc";
+      name = "gwenview-20.08.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/incidenceeditor-20.08.2.tar.xz";
-      sha256 = "e9c24390b5951ef9f504a4dc432fea52ed7487288c424f073446e6c07e70c69a";
-      name = "incidenceeditor-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/incidenceeditor-20.08.3.tar.xz";
+      sha256 = "15kkl8z1nig9qyxfrq54c3sqh1xs1lzlbm5rphj34y0yb8dbn8kx";
+      name = "incidenceeditor-20.08.3.tar.xz";
     };
   };
   juk = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/juk-20.08.2.tar.xz";
-      sha256 = "b19f59ad8c80c4c335469fbddde6db92112e286b1699964eab39a3d826c7ec60";
-      name = "juk-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/juk-20.08.3.tar.xz";
+      sha256 = "1jvj0r4grm55cnck4apnh4fh44mv1ycm0pprrkh57iwj1dlf7kif";
+      name = "juk-20.08.3.tar.xz";
     };
   };
   k3b = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/k3b-20.08.2.tar.xz";
-      sha256 = "6370be558e93fed4605b7870b1d7ea324713c5a52370eab9c05d85fc3b76acd5";
-      name = "k3b-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/k3b-20.08.3.tar.xz";
+      sha256 = "0qg2p6gdg0clgv6qab5vr0i451m9hqqmpwq335w8m9nwb6wg30cx";
+      name = "k3b-20.08.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kaccounts-integration-20.08.2.tar.xz";
-      sha256 = "6678ee7d394b69a37e6a220a6cba3804f999997da5803da4bab1d8f329ff30fe";
-      name = "kaccounts-integration-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kaccounts-integration-20.08.3.tar.xz";
+      sha256 = "006cglw5ai274a1r5jbk109mdrvw8v6fp3cdyi1kbrq7lp3123a2";
+      name = "kaccounts-integration-20.08.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kaccounts-providers-20.08.2.tar.xz";
-      sha256 = "c719d7840ab118ff591e75e12869afc3118e5cdeb5c0415eba5b1f6993664c90";
-      name = "kaccounts-providers-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kaccounts-providers-20.08.3.tar.xz";
+      sha256 = "1vpv366bzj0sk7dqyxrq06a8ixgaaqi125mf2gmybvhj5yvrn3fp";
+      name = "kaccounts-providers-20.08.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kaddressbook-20.08.2.tar.xz";
-      sha256 = "8d2e5849dd8878806e8566ce43c139633c37f027f677603600c8acc0d0d41198";
-      name = "kaddressbook-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kaddressbook-20.08.3.tar.xz";
+      sha256 = "00mia1jh2c5rcnsyx3wizjdg65pvpazfb8ayppjzv4rrc2nhr9nn";
+      name = "kaddressbook-20.08.3.tar.xz";
     };
   };
   kajongg = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kajongg-20.08.2.tar.xz";
-      sha256 = "1eb534ac6d1d3ca14b73bd6e5b626b988acafc30b168f54d48a493adc715ecde";
-      name = "kajongg-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kajongg-20.08.3.tar.xz";
+      sha256 = "0wr045xqm1q03vy0jbgrldpdc9k3lgnhd39yhi574la367ayffpa";
+      name = "kajongg-20.08.3.tar.xz";
     };
   };
   kalarm = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kalarm-20.08.2.tar.xz";
-      sha256 = "e783c041ac4b162cf5254e37e53854835eda6c61ef3ae2358466000a8650a4da";
-      name = "kalarm-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kalarm-20.08.3.tar.xz";
+      sha256 = "0194rapyvnpmhkba0rgclrai1ywx9anr8dski0j6z1yg0kgav8df";
+      name = "kalarm-20.08.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kalarmcal-20.08.2.tar.xz";
-      sha256 = "0398a37f412eb03b5cbf2488ce7e0c38a069f1806bda4ea9bfce4fc67311a9a6";
-      name = "kalarmcal-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kalarmcal-20.08.3.tar.xz";
+      sha256 = "1i9hi3y4j2pmdmlj13kl13vfplxrh8w23fxz0mmawi1wn533fp66";
+      name = "kalarmcal-20.08.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kalgebra-20.08.2.tar.xz";
-      sha256 = "c934dc8d92917e31c17efa5b64dbec4795439a5f26762e2f214b49028bfe264d";
-      name = "kalgebra-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kalgebra-20.08.3.tar.xz";
+      sha256 = "0k7miil5ilrw68j6xl9g6cf3zfw7g52h0gfwd5j248nx2nxr150c";
+      name = "kalgebra-20.08.3.tar.xz";
     };
   };
   kalzium = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kalzium-20.08.2.tar.xz";
-      sha256 = "474f74cbb478d3f5f69b5785711ed969ac15d5e92aee5308c6118a9d12611016";
-      name = "kalzium-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kalzium-20.08.3.tar.xz";
+      sha256 = "1r80bnpdrybsdwcblpj7cg32dv90l79gs0i42gpm6inilfr3vp5n";
+      name = "kalzium-20.08.3.tar.xz";
     };
   };
   kamera = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kamera-20.08.2.tar.xz";
-      sha256 = "ba28cab34267ce203b4b70f4a2c2b6a75849aec83dd2d73f6903894c5c125fdf";
-      name = "kamera-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kamera-20.08.3.tar.xz";
+      sha256 = "06fwxdgbyywdrf1r0w17w3chfr0s8jhqswz9chmdfds9f2bb45cr";
+      name = "kamera-20.08.3.tar.xz";
     };
   };
   kamoso = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kamoso-20.08.2.tar.xz";
-      sha256 = "e7d0af2781ff077261886a1683aff1d518a17f9b6d83f84fa95a7633a00f1516";
-      name = "kamoso-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kamoso-20.08.3.tar.xz";
+      sha256 = "0zhl3va65ajz3hdggg0jvvgvj14s461pjw9adw9bnfcbs4jzkl2y";
+      name = "kamoso-20.08.3.tar.xz";
     };
   };
   kanagram = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kanagram-20.08.2.tar.xz";
-      sha256 = "3f3f961aa847f26ac875104e82b8e7e73bbc049f20460117f849df91ba9b42e2";
-      name = "kanagram-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kanagram-20.08.3.tar.xz";
+      sha256 = "1cyx8yq03xaw34ic69ghz9gafk8l30qinp0kkp9a1wh4pry8rnxf";
+      name = "kanagram-20.08.3.tar.xz";
     };
   };
   kapman = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kapman-20.08.2.tar.xz";
-      sha256 = "932bd697f2ca0e44af6be983dae3e13df9435642b91f0e1ebba7fd50291c2cbd";
-      name = "kapman-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kapman-20.08.3.tar.xz";
+      sha256 = "0nh1f0v026rib5ahj1mhvs99yabrgdq71bis465vfpm4favnirzy";
+      name = "kapman-20.08.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kapptemplate-20.08.2.tar.xz";
-      sha256 = "3bda6d9f6127e19357f071ca6f9f05890c35a6aaf86e54bce39381f0045b6b0c";
-      name = "kapptemplate-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kapptemplate-20.08.3.tar.xz";
+      sha256 = "1r98ym9sazjzknxfw58hjiyxhmi49fyhrdn02v0b8fm711vprxab";
+      name = "kapptemplate-20.08.3.tar.xz";
     };
   };
   kate = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kate-20.08.2.tar.xz";
-      sha256 = "718e8230edfa16f93f54380c4e214a0f25f8a398fe74ad23f12b7dcffae419d0";
-      name = "kate-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kate-20.08.3.tar.xz";
+      sha256 = "1m7ximinknc0l9zqv4p25ybn6zysz59l4vvdb9xkhjp53aqskdz9";
+      name = "kate-20.08.3.tar.xz";
     };
   };
   katomic = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/katomic-20.08.2.tar.xz";
-      sha256 = "bb94e81cb1122b57d2601f701bc51ff8fa27ac07a5de34e5c49928d50d46ed85";
-      name = "katomic-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/katomic-20.08.3.tar.xz";
+      sha256 = "1v31x6371r9ccvc676vq5dlpkp4829xf0r37dnvdxlfm22mgsdnk";
+      name = "katomic-20.08.3.tar.xz";
     };
   };
   kbackup = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kbackup-20.08.2.tar.xz";
-      sha256 = "bb97dd10a64c42ae80c9c87442d3a06d3c18f4f5997bd3b6d1460dec655b3e0a";
-      name = "kbackup-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kbackup-20.08.3.tar.xz";
+      sha256 = "1sayzvj46ckhn5zgp7qi6zmrmd7bjh5mg05mcl5pfwv4dcvxkrng";
+      name = "kbackup-20.08.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kblackbox-20.08.2.tar.xz";
-      sha256 = "714a8749a49d1a7938b74372138ae3e5bafef50de61207e63a6d2c60b6bfded2";
-      name = "kblackbox-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kblackbox-20.08.3.tar.xz";
+      sha256 = "0vka2pswbza1z8f97nhxcjrczx4w1x0qyjpzs9ycn9a14smqpsrh";
+      name = "kblackbox-20.08.3.tar.xz";
     };
   };
   kblocks = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kblocks-20.08.2.tar.xz";
-      sha256 = "c82f8b6e722308a236d0057028d644ebf8105c9c902d799bc2fb3e1c1ff7c188";
-      name = "kblocks-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kblocks-20.08.3.tar.xz";
+      sha256 = "1jc063xn6dphydf49kv0izzy0nv06dr412xxjvkp7vccwv9qd5gf";
+      name = "kblocks-20.08.3.tar.xz";
     };
   };
   kbounce = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kbounce-20.08.2.tar.xz";
-      sha256 = "371fbaf7c1faeacf1c74441ec1a58f1ced862f741e67123d2eb105f1d4f9b8e2";
-      name = "kbounce-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kbounce-20.08.3.tar.xz";
+      sha256 = "0863vlirljvf101mdv6jxprj9axs4cikrnld3wvxrcqw3w2dy6wy";
+      name = "kbounce-20.08.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kbreakout-20.08.2.tar.xz";
-      sha256 = "b58b9dd26eff3960bc664076ddf4d0c81c7dfd5380be1d058b86de2d3f55d2ef";
-      name = "kbreakout-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kbreakout-20.08.3.tar.xz";
+      sha256 = "14nd1dnbdyxv59y8iildhydhxgal38hvj7bk6544glwl8yalak8z";
+      name = "kbreakout-20.08.3.tar.xz";
     };
   };
   kbruch = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kbruch-20.08.2.tar.xz";
-      sha256 = "54c5997a8d6405439448dd929bf16017c9e5db052b30c9bf144c656c6d8b9e0b";
-      name = "kbruch-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kbruch-20.08.3.tar.xz";
+      sha256 = "03s1hl4h8rsx0gn7wqfssi1ga4igx48jb47gpw6f9rfjm8f199vb";
+      name = "kbruch-20.08.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kcachegrind-20.08.2.tar.xz";
-      sha256 = "e6b84a323a21ae7975ccc07154bcdc6eef1bc92818b800cfc5d546ada7f0387c";
-      name = "kcachegrind-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kcachegrind-20.08.3.tar.xz";
+      sha256 = "17j06z9cpj5qhfbp1xgw4qmhi4jckf2i99c9brys4ifb3p0rkbrs";
+      name = "kcachegrind-20.08.3.tar.xz";
     };
   };
   kcalc = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kcalc-20.08.2.tar.xz";
-      sha256 = "76b6c8e44c789090c0155f79878df8f27c96d2df4273443b0f05a42ec81902cf";
-      name = "kcalc-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kcalc-20.08.3.tar.xz";
+      sha256 = "1mk30fkv51w3fqlpkzgm1yj5sp98h26kkphplqkjva5v6s1jzmjy";
+      name = "kcalc-20.08.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kcalutils-20.08.2.tar.xz";
-      sha256 = "fccae5166b627f654412344d0090000ecd270af54b0cedb8648e35af26369cae";
-      name = "kcalutils-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kcalutils-20.08.3.tar.xz";
+      sha256 = "1i2yh4gvdwlylj7f7p32g1z7lzh3p19rrbd96l1gqhy700f2whpw";
+      name = "kcalutils-20.08.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kcharselect-20.08.2.tar.xz";
-      sha256 = "9438e723469b6bf0d87b23965c6d925800ff35b2cc2214a7eeb5fb41009489e0";
-      name = "kcharselect-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kcharselect-20.08.3.tar.xz";
+      sha256 = "1p6rijjfa2jk4vr0ivjn6p5qf2ys5kvhw0cwfyjs45ff7zg0s2ga";
+      name = "kcharselect-20.08.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kcolorchooser-20.08.2.tar.xz";
-      sha256 = "f314c31932704e7136b5fff89efe95e84e4215f3902089f9d838411f0fbc0c72";
-      name = "kcolorchooser-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kcolorchooser-20.08.3.tar.xz";
+      sha256 = "1874qa04whiivyydxfcn0f1xch515ga1af4ym42zqz64j3kq7i47";
+      name = "kcolorchooser-20.08.3.tar.xz";
     };
   };
   kcron = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kcron-20.08.2.tar.xz";
-      sha256 = "ce72bb7c48606b0611cfe46a545224cca131d34a4b678c86d9ac473071833f83";
-      name = "kcron-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kcron-20.08.3.tar.xz";
+      sha256 = "1piwssyg9fvah25gql6w0n8xf634f6gy475cz52gb1bl7rp72q6j";
+      name = "kcron-20.08.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdebugsettings-20.08.2.tar.xz";
-      sha256 = "78502b1a52f9f81ff848e5b210b37a3a74da7c0032de2513f23c1d25cf801283";
-      name = "kdebugsettings-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdebugsettings-20.08.3.tar.xz";
+      sha256 = "11xnvr9qib3hnp48whsw659c724s2114p5dr3fswvhm3hkw1aky7";
+      name = "kdebugsettings-20.08.3.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdeconnect-kde-20.08.2.tar.xz";
-      sha256 = "6d43e38620987de1ddcfdfa7d4e6e31ff383b806139ba02e69a99c3ddfb4ee67";
-      name = "kdeconnect-kde-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdeconnect-kde-20.08.3.tar.xz";
+      sha256 = "0x10ga81qlsahavmv356xzjxyds41y2b4v338rqcyqkxvfmxj01k";
+      name = "kdeconnect-kde-20.08.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kde-dev-scripts-20.08.2.tar.xz";
-      sha256 = "ff1a819991903b09bef3637b579d215e087310e39b98a1a6928e15f193aec056";
-      name = "kde-dev-scripts-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kde-dev-scripts-20.08.3.tar.xz";
+      sha256 = "0x8ba4mlxx17vk674738xln2dy696b148fa3s87za4yb4jj9gc5n";
+      name = "kde-dev-scripts-20.08.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kde-dev-utils-20.08.2.tar.xz";
-      sha256 = "21a4a11e102cbbd9fed955720966d7be2f7a615f57c9bf1dfc94ce973d25ffc3";
-      name = "kde-dev-utils-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kde-dev-utils-20.08.3.tar.xz";
+      sha256 = "0k7zb1km89nnqfi2p1mhp6dvwkhmgbcgw89301acag34yy954dvn";
+      name = "kde-dev-utils-20.08.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdeedu-data-20.08.2.tar.xz";
-      sha256 = "9030c39b92a7500254e8303ce246d2535cd66a203bb96b2670defd5288294ad1";
-      name = "kdeedu-data-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdeedu-data-20.08.3.tar.xz";
+      sha256 = "1k164h4n8r4yjlll5900fz764lr0qiy3q1fpcpkr8f1n7qs7f797";
+      name = "kdeedu-data-20.08.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdegraphics-mobipocket-20.08.2.tar.xz";
-      sha256 = "8972079756633abe8cbfaa39cdff9d56f89958861e6e418738311bcdc52771a5";
-      name = "kdegraphics-mobipocket-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdegraphics-mobipocket-20.08.3.tar.xz";
+      sha256 = "0ifxbwn7pmxr7y4ri617a303b27nqwqa418isgfrfk11jc4yyxhq";
+      name = "kdegraphics-mobipocket-20.08.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdegraphics-thumbnailers-20.08.2.tar.xz";
-      sha256 = "977cf6c40ba00a8a391a951aab80c55d9615927a1ef4a7bb5eea2f6a83373532";
-      name = "kdegraphics-thumbnailers-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdegraphics-thumbnailers-20.08.3.tar.xz";
+      sha256 = "0mbzkw7pxcfmkpb8ivhahnxkkrkjhmbjqy2l9gqx35gp5855gmxf";
+      name = "kdegraphics-thumbnailers-20.08.3.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdenetwork-filesharing-20.08.2.tar.xz";
-      sha256 = "f909ee8433baf906b6c23af4747d83ae3e151e213585abe01282213012228b3a";
-      name = "kdenetwork-filesharing-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdenetwork-filesharing-20.08.3.tar.xz";
+      sha256 = "0id19wmiivdrx10r1hwbwi7bx6g1v9g5lpbhlmfrapvy82ijfmbg";
+      name = "kdenetwork-filesharing-20.08.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdenlive-20.08.2.tar.xz";
-      sha256 = "535df45a148f0f94271e045ef0c93575fded83da7a2b727aeaf90e61e1d7c418";
-      name = "kdenlive-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdenlive-20.08.3.tar.xz";
+      sha256 = "187d5khqq9ckmqp8amd7ghlvig1z97w2jzm9s4zsfhjzyqv3d3wz";
+      name = "kdenlive-20.08.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdepim-addons-20.08.2.tar.xz";
-      sha256 = "f7ab0d9ee2b9351959199f8903c447c6cb82fd58d642b7039cd2b8e324038b01";
-      name = "kdepim-addons-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdepim-addons-20.08.3.tar.xz";
+      sha256 = "17m8pwiig46pc6x4ylvymb3b6c7xcm2df3vjma665kcir1dr0q7p";
+      name = "kdepim-addons-20.08.3.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdepim-apps-libs-20.08.2.tar.xz";
-      sha256 = "8c3ebdf7072d3a5a6ea2921697b28aa27e51ba43db152ea83a07b4b13c282434";
-      name = "kdepim-apps-libs-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdepim-apps-libs-20.08.3.tar.xz";
+      sha256 = "08iw1p9mv4jic7pk6skxc5anp7k46lhcdqxpq1i6wlhbrk6bpsvg";
+      name = "kdepim-apps-libs-20.08.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdepim-runtime-20.08.2.tar.xz";
-      sha256 = "3b475dfd394d5c09991eb4e1f0ddb3e2aa1f586ed75aa7961b159ef712d80132";
-      name = "kdepim-runtime-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdepim-runtime-20.08.3.tar.xz";
+      sha256 = "0zz2zwq3gr177vgkwz6b70q4n2ra4ym58f167pgvi9kxv3884fib";
+      name = "kdepim-runtime-20.08.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdesdk-kioslaves-20.08.2.tar.xz";
-      sha256 = "5e79532675d717d906f6b43eea1cac20fe1513bcf497696251c00fe74e2f0f58";
-      name = "kdesdk-kioslaves-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdesdk-kioslaves-20.08.3.tar.xz";
+      sha256 = "1kwzms0qha058cm92d4f8pr89r3bqaqx5zfw6gz05s6lg892j5in";
+      name = "kdesdk-kioslaves-20.08.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdesdk-thumbnailers-20.08.2.tar.xz";
-      sha256 = "0b6809e2469d7057b6d674d5950fd4f6243a1d3d185452212522880c714c1c63";
-      name = "kdesdk-thumbnailers-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdesdk-thumbnailers-20.08.3.tar.xz";
+      sha256 = "10fc0agpvzpqdxqynd70vzya0g1nbdw0ylbnl9w35n9jhww42jff";
+      name = "kdesdk-thumbnailers-20.08.3.tar.xz";
     };
   };
   kdf = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdf-20.08.2.tar.xz";
-      sha256 = "b33c043c18ae7b80b40e73c0a34759540724fa81815a6afa1e91e3ad44aec27e";
-      name = "kdf-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdf-20.08.3.tar.xz";
+      sha256 = "02k5nhsf1zzkx9cl3r2500pj2zfmvjhlfsb3smgpka6in7iivxyp";
+      name = "kdf-20.08.3.tar.xz";
     };
   };
   kdialog = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdialog-20.08.2.tar.xz";
-      sha256 = "1bb808c2d01680e2396f282b798d9e22d2c1722f992c672eaf7451bf83a5d459";
-      name = "kdialog-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdialog-20.08.3.tar.xz";
+      sha256 = "0knl6176bjazjiacg1qqaldlqcjlb3bi829sliq1sdh4lzzwrbzk";
+      name = "kdialog-20.08.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kdiamond-20.08.2.tar.xz";
-      sha256 = "7bfc2b24d86c663bff719156ba20cd36017f1df647ee6769b5101aa6ab3e3e21";
-      name = "kdiamond-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kdiamond-20.08.3.tar.xz";
+      sha256 = "0ls1kg3wank1al46knq12jilmp8gaa4rn7zbgflcrhgy5gw8l5px";
+      name = "kdiamond-20.08.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/keditbookmarks-20.08.2.tar.xz";
-      sha256 = "87d72e78c907e7829a642364f3a49dd0f0dea0c76e7a5c524a67f957dca94b9b";
-      name = "keditbookmarks-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/keditbookmarks-20.08.3.tar.xz";
+      sha256 = "0m8ap5hvjgldj9hdk6shpkv8xylhhjla2xn1zs86pvj4la3zh4f8";
+      name = "keditbookmarks-20.08.3.tar.xz";
     };
   };
   kfind = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kfind-20.08.2.tar.xz";
-      sha256 = "2381bbe7793a666fa9463aead1246dc4244409f68375f6d75e1423be15b42d74";
-      name = "kfind-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kfind-20.08.3.tar.xz";
+      sha256 = "10i5mw6q2parq5w7pi955kgfvdlw8hwis2p7r9vkvabjdk69nkdr";
+      name = "kfind-20.08.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kfloppy-20.08.2.tar.xz";
-      sha256 = "7f624d03dc3dc5099ac1479148800043195fa6c0e3bb6d7efcb452a76e99e191";
-      name = "kfloppy-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kfloppy-20.08.3.tar.xz";
+      sha256 = "1cp0pwgldscc7va508gk43im3fv0lsxd5sbhpw8kxlzjlpbwlp8v";
+      name = "kfloppy-20.08.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kfourinline-20.08.2.tar.xz";
-      sha256 = "aed2ecdb40b2e3d5452b183a1817216373d32a0aab4eff02f6c823a6f8d801eb";
-      name = "kfourinline-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kfourinline-20.08.3.tar.xz";
+      sha256 = "0h1n44dncr2siw447n7b0gkx3380vajvqjsgjvapkg7m7bmz7nsv";
+      name = "kfourinline-20.08.3.tar.xz";
     };
   };
   kgeography = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kgeography-20.08.2.tar.xz";
-      sha256 = "82c4798f3184c77d0be63aeb5e86c84240c9cb0aa0e66ff57f92c0b5c3748f19";
-      name = "kgeography-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kgeography-20.08.3.tar.xz";
+      sha256 = "1mk5cip55chc8pmh8wfl7an5x076ywisr0i7isqcjaij2cv54283";
+      name = "kgeography-20.08.3.tar.xz";
     };
   };
   kget = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kget-20.08.2.tar.xz";
-      sha256 = "42993095d6325e921b6ed36f4b0a2153ffd5d68cfa3e6d3ced2db09e2a6aabb8";
-      name = "kget-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kget-20.08.3.tar.xz";
+      sha256 = "144ydk8bbfirph464mkkvwpnynj465i2ynhm8n9d330kcrhnaxd0";
+      name = "kget-20.08.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kgoldrunner-20.08.2.tar.xz";
-      sha256 = "4bbcfcf5cf810e0b1f78e1a88d222631c07401187fb327deaa5ab6658483d351";
-      name = "kgoldrunner-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kgoldrunner-20.08.3.tar.xz";
+      sha256 = "101cdl04wb6xbq95b51ax36570y9ahkcy5gccqsyvc307ij9yg7r";
+      name = "kgoldrunner-20.08.3.tar.xz";
     };
   };
   kgpg = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kgpg-20.08.2.tar.xz";
-      sha256 = "fc4ec5c38c3bdb02a399f0eb1e75da356a523ada369d5410c2f4e7f5f14a508f";
-      name = "kgpg-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kgpg-20.08.3.tar.xz";
+      sha256 = "1ip21yal37yxg5i5sfy6lgfb3sz9lld0dwa7a1w4lbddf9w3akd6";
+      name = "kgpg-20.08.3.tar.xz";
     };
   };
   khangman = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/khangman-20.08.2.tar.xz";
-      sha256 = "7ff30ecbab7c9e8f44b7e8c3887ec78a918c919ce902005aeb7fb969ac995b28";
-      name = "khangman-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/khangman-20.08.3.tar.xz";
+      sha256 = "1zwdd2gpjkld3vkawp0lj83il257ryxf8wpmbgzn1wz8sxxi01jj";
+      name = "khangman-20.08.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/khelpcenter-20.08.2.tar.xz";
-      sha256 = "36051a4352a05dd9b74b4e325c0e16e30d6bd8b48d6c3d13980b39a77aab4e2d";
-      name = "khelpcenter-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/khelpcenter-20.08.3.tar.xz";
+      sha256 = "1xan4awwgs08k7ksfy80rfcxqd6bi8i1fjdgy55hh7wshv76zf5r";
+      name = "khelpcenter-20.08.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kidentitymanagement-20.08.2.tar.xz";
-      sha256 = "17a1fd47d91289519cafb12c0d917b4775496ada447cb6f4ba56dc42446152ec";
-      name = "kidentitymanagement-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kidentitymanagement-20.08.3.tar.xz";
+      sha256 = "0vkydvf4yw3qlqrg9m1zdm6j0c1crxdvc7l24yls9fjbj957vbls";
+      name = "kidentitymanagement-20.08.3.tar.xz";
     };
   };
   kig = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kig-20.08.2.tar.xz";
-      sha256 = "401832d384e47ea6daf310f7e823ae6b8a55bc117b7570bd4bf36261d01587f5";
-      name = "kig-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kig-20.08.3.tar.xz";
+      sha256 = "1dvizdfkvl7p7hr4xm4zh51lpr8qr3s5j5zz162s7arr7sws4w8h";
+      name = "kig-20.08.3.tar.xz";
     };
   };
   kigo = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kigo-20.08.2.tar.xz";
-      sha256 = "b9e6edd2e35e57edb3d89bb76f1d7e4a9e7f8fb64644b58012543a367834aa60";
-      name = "kigo-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kigo-20.08.3.tar.xz";
+      sha256 = "0sx3klivzn8h96mpnbkiv2nbi2l6w0j6fclj7q3ql3cm81jh6n15";
+      name = "kigo-20.08.3.tar.xz";
     };
   };
   killbots = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/killbots-20.08.2.tar.xz";
-      sha256 = "332ebd24be6ea62c8621aeaa5b200d6ebf03ae0198a06693b36b2c80cac89d95";
-      name = "killbots-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/killbots-20.08.3.tar.xz";
+      sha256 = "1j41my0brpqpvd8xibv39z4x4kmw1sqz7wy7ibhh0zir3jh64n83";
+      name = "killbots-20.08.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kimagemapeditor-20.08.2.tar.xz";
-      sha256 = "fd8272978a7c3a1d95b20a5ec57ccf00d740a8d6eb483f0a204d03669215309c";
-      name = "kimagemapeditor-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kimagemapeditor-20.08.3.tar.xz";
+      sha256 = "1m9mrksdl08ijmpmx3lhdysnm70mrnqz9rlbcn1h95p2sq0bk8cg";
+      name = "kimagemapeditor-20.08.3.tar.xz";
     };
   };
   kimap = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kimap-20.08.2.tar.xz";
-      sha256 = "bda4f4b4e94481b70cec270655c0fd2888da51106d80c0388ae5c0dc5d36e092";
-      name = "kimap-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kimap-20.08.3.tar.xz";
+      sha256 = "16paglkqgnyzwjydhn02qw7zg0d4casir4bsfch15wdmqv389mrg";
+      name = "kimap-20.08.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kio-extras-20.08.2.tar.xz";
-      sha256 = "9d4b9cb5a4002ad2127c5c5c4d25ff95d53de32ea08348e8dc40fe83d950076e";
-      name = "kio-extras-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kio-extras-20.08.3.tar.xz";
+      sha256 = "0i7k9asc97r9z4lfk5hyf7mcbx0za7j6v4dhqn43j5v4x2i0201c";
+      name = "kio-extras-20.08.3.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kio-gdrive-20.08.2.tar.xz";
-      sha256 = "71047e9f8e5ad9317cc3dbf1de2d121f322b5d968d3685351ef0d2aabe2f46ca";
-      name = "kio-gdrive-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kio-gdrive-20.08.3.tar.xz";
+      sha256 = "0pp0nvsnfdm8vskw194qjfac4agnlsjm44w1704b5sqx6i27dafy";
+      name = "kio-gdrive-20.08.3.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kipi-plugins-20.08.2.tar.xz";
-      sha256 = "89de8f75dd01e2130c1e651bd04717ce4d35768202ae3e825c93c75c8312e583";
-      name = "kipi-plugins-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kipi-plugins-20.08.3.tar.xz";
+      sha256 = "1pplhv8yjfl1ifx9ykf4w2lgma8jvshihmd5c5mz9liqk3lawq15";
+      name = "kipi-plugins-20.08.3.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kirigami-gallery-20.08.2.tar.xz";
-      sha256 = "0b4a5cec32bdfaef42b790f1d249d227c9daf56e0f3c1e302d33ccaa485c28e5";
-      name = "kirigami-gallery-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kirigami-gallery-20.08.3.tar.xz";
+      sha256 = "0l100ng8ai55s0vl8nkpq4vysy2nc6sk1dbisc2mp7br74ykyfp9";
+      name = "kirigami-gallery-20.08.3.tar.xz";
     };
   };
   kiriki = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kiriki-20.08.2.tar.xz";
-      sha256 = "42081e39c045bd830c6a79938a83690ea5641aa9e5437645234441da2d29b053";
-      name = "kiriki-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kiriki-20.08.3.tar.xz";
+      sha256 = "1gddjii84cbz1dg8k0pnd3dyzar4lvj03j9v84vabggjjjbpir0f";
+      name = "kiriki-20.08.3.tar.xz";
     };
   };
   kiten = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kiten-20.08.2.tar.xz";
-      sha256 = "a7285d5880611da2202d0e3f8f2bf860f275932d3da54ff7aecc793225f7ad7d";
-      name = "kiten-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kiten-20.08.3.tar.xz";
+      sha256 = "0n9mq86gcl6s2f45l8lbp4gsdj356l78xjkdvm14f6qlh81vsqlc";
+      name = "kiten-20.08.3.tar.xz";
     };
   };
   kitinerary = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kitinerary-20.08.2.tar.xz";
-      sha256 = "69d8b5f64774860e5098c1dbfb06d274da4379c04383c4f0f0e412481c48fa27";
-      name = "kitinerary-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kitinerary-20.08.3.tar.xz";
+      sha256 = "169pmy5fyjkbya8r2kdkd9s83sim0jplc3lx8bv2xh6r10mvzgm6";
+      name = "kitinerary-20.08.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kjumpingcube-20.08.2.tar.xz";
-      sha256 = "0edba227e24b8aeda4e75bc6c25ad25b50ac624b5319a64ce20d6c3f7691a48a";
-      name = "kjumpingcube-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kjumpingcube-20.08.3.tar.xz";
+      sha256 = "19246jwwd686x8i0jrvz2c8mpkf6qhm7rnskzin59dqzr76xrpgz";
+      name = "kjumpingcube-20.08.3.tar.xz";
     };
   };
   kldap = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kldap-20.08.2.tar.xz";
-      sha256 = "dfc8bd59d837766e741b33cf8486256b7bd5ffc33ff2aab240d47b4766ec8489";
-      name = "kldap-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kldap-20.08.3.tar.xz";
+      sha256 = "1ihaazsnb9r30m2qhzcp2ns9f5fs7l3agsc9f9wxi4cyw73bq0n3";
+      name = "kldap-20.08.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kleopatra-20.08.2.tar.xz";
-      sha256 = "70ffa2d1549b6b4674a9cd92052174002d81fb236cfbf872187c6e3616191ba2";
-      name = "kleopatra-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kleopatra-20.08.3.tar.xz";
+      sha256 = "1r879g7hw3c5cww58z0kvqj47pgzbiq1vpgxz847smrylqajcpyi";
+      name = "kleopatra-20.08.3.tar.xz";
     };
   };
   klettres = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/klettres-20.08.2.tar.xz";
-      sha256 = "9cef7dea479d27644e4812157d4cf3993dc3ee84b847377a17cec305a03a3156";
-      name = "klettres-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/klettres-20.08.3.tar.xz";
+      sha256 = "0irc0f7vjznlsczan30zzprbnvgnbg19vabr97cw9rkkfa28azx9";
+      name = "klettres-20.08.3.tar.xz";
     };
   };
   klickety = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/klickety-20.08.2.tar.xz";
-      sha256 = "90665c5aeda52f55af8dcf3936e557ba431d9e48c6be361eaeb82117b6213a33";
-      name = "klickety-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/klickety-20.08.3.tar.xz";
+      sha256 = "1qsm9grmy0bnalpdghg48xi68zzk6ysmg6n0d74ldmmnirv3r0zf";
+      name = "klickety-20.08.3.tar.xz";
     };
   };
   klines = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/klines-20.08.2.tar.xz";
-      sha256 = "8e8b897cdc3c31fada1dd2635da211def507f47c8062c6458f559283ae470edb";
-      name = "klines-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/klines-20.08.3.tar.xz";
+      sha256 = "1l95ph1sjp3r1q065k3rj18lm36krl7bh41zgqh021p692ywc48c";
+      name = "klines-20.08.3.tar.xz";
     };
   };
   kmag = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmag-20.08.2.tar.xz";
-      sha256 = "8e933e8ebbf0ab956e2a251312e3d4e027848dc2f2b4e8a7c7250b8fdf10ca05";
-      name = "kmag-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmag-20.08.3.tar.xz";
+      sha256 = "0y44gz3qn91vl840xz25l5kc5jj82k5qqxkgsvvyld2s99rif84k";
+      name = "kmag-20.08.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmahjongg-20.08.2.tar.xz";
-      sha256 = "98e34794560a062bd22950acc583b77a6f8d1d28aceb863604f5a6c98c6cc80d";
-      name = "kmahjongg-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmahjongg-20.08.3.tar.xz";
+      sha256 = "0wgp9m7xzf5ysmrrnyng4p4jypvzfnqkyw62gknl0qhk531cgq3h";
+      name = "kmahjongg-20.08.3.tar.xz";
     };
   };
   kmail = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmail-20.08.2.tar.xz";
-      sha256 = "ff179b89836236174cd587ce4ea2a4320e58345d45582cb157186cfbb01e58f2";
-      name = "kmail-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmail-20.08.3.tar.xz";
+      sha256 = "0g59s7wl0n4bp8kw559rdlamlqxl47qvwfms9kr9ign35rvs0ghg";
+      name = "kmail-20.08.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmail-account-wizard-20.08.2.tar.xz";
-      sha256 = "7cdb9b60b1a646f0c5c0d0e7dfbe357a9f66bb305afbccbb4b421ee6f6941df8";
-      name = "kmail-account-wizard-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmail-account-wizard-20.08.3.tar.xz";
+      sha256 = "0vama5a02dfgxrl4iz88lbi8dvq3d9b055xil770d90pwp0sljcz";
+      name = "kmail-account-wizard-20.08.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmailtransport-20.08.2.tar.xz";
-      sha256 = "8b12836b1ca0243819680cba73c809c491c5e7a8d1ea9d9dc23e7338aed69a0c";
-      name = "kmailtransport-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmailtransport-20.08.3.tar.xz";
+      sha256 = "07552qj3ngwvyss7f8cy87c0gmzc47agn54wk85qq0v1fwr73n6z";
+      name = "kmailtransport-20.08.3.tar.xz";
     };
   };
   kmbox = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmbox-20.08.2.tar.xz";
-      sha256 = "4fa1ad98368130dcdc8ad71dba3084c489130b1e8fc4a2b119ffc6f56595ba73";
-      name = "kmbox-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmbox-20.08.3.tar.xz";
+      sha256 = "0ipmwcicn3qklybqy9v41lh7byn7j62ja8b0xf06z9nliwkk4b0b";
+      name = "kmbox-20.08.3.tar.xz";
     };
   };
   kmime = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmime-20.08.2.tar.xz";
-      sha256 = "9f23e2814e62ae6c4a67fd3223315ef875776f9d098b4d11c7d06a726a725435";
-      name = "kmime-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmime-20.08.3.tar.xz";
+      sha256 = "1ndbx712vm4v0fi7p8j28d8z35h3bmsixc97z5r9dg03v1kzd36v";
+      name = "kmime-20.08.3.tar.xz";
     };
   };
   kmines = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmines-20.08.2.tar.xz";
-      sha256 = "6b07a812497a665505b6b1e3a84ac0818f1a5e5757146cdbceec55e94bb41753";
-      name = "kmines-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmines-20.08.3.tar.xz";
+      sha256 = "1mn5hip3vnzmkk1hy14glsplp7f5pm56yv0d5mz25icfgw0xa6lp";
+      name = "kmines-20.08.3.tar.xz";
     };
   };
   kmix = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmix-20.08.2.tar.xz";
-      sha256 = "73453f02a72384382fd7449215189e22b5e1600e9ef0c9cc910f3fddd09beb85";
-      name = "kmix-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmix-20.08.3.tar.xz";
+      sha256 = "00gm93faqmqx0hhkxi3k2pn6sq82k2f622vqgk7mwznkpg66mf4k";
+      name = "kmix-20.08.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmousetool-20.08.2.tar.xz";
-      sha256 = "c1f70c172dc2ad7d937db5e6355522082f924ba45e7aac1bbb1c04e230f1d406";
-      name = "kmousetool-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmousetool-20.08.3.tar.xz";
+      sha256 = "09qznykysr42rzz5cmqvhvz91cr8dbzwjd73hwaib2lfs3c2cgbl";
+      name = "kmousetool-20.08.3.tar.xz";
     };
   };
   kmouth = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmouth-20.08.2.tar.xz";
-      sha256 = "d206afecdbe5f063dfbf805956f475e95c7b0fd548fd5f1b4fd7376ea6747e96";
-      name = "kmouth-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmouth-20.08.3.tar.xz";
+      sha256 = "0ajhnl1sjllfb42nyafpirmlgcs6waqp8qxvgsz5dk5zkb8daqmr";
+      name = "kmouth-20.08.3.tar.xz";
     };
   };
   kmplot = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kmplot-20.08.2.tar.xz";
-      sha256 = "c3bc34a2d1bf4620745009b49b6541a16ac64eb3d1e6cf1ba936b14aa5d02e2b";
-      name = "kmplot-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kmplot-20.08.3.tar.xz";
+      sha256 = "0cv7q1wmbb3fkf4s6ns4q1il5zr4q02b3xghpp661ma82d8jhjcy";
+      name = "kmplot-20.08.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/knavalbattle-20.08.2.tar.xz";
-      sha256 = "2cd91ee61193810eee62e47f38f590e81b03287083f31564e0ebfd893d339ac9";
-      name = "knavalbattle-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/knavalbattle-20.08.3.tar.xz";
+      sha256 = "1028i8zl5ynm3vvqajsms2hq8gmmjmjc5dc6r3jyh6r964vxq3nq";
+      name = "knavalbattle-20.08.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/knetwalk-20.08.2.tar.xz";
-      sha256 = "4a97f4b1af463e5e50698e8ac089cf6933fb66f25dd9b0fae3f1b1a51cbca3c0";
-      name = "knetwalk-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/knetwalk-20.08.3.tar.xz";
+      sha256 = "13pspvi2p68irpbr3f2ck78qmvfl3vahm5qjw2fwhidhpindf9nl";
+      name = "knetwalk-20.08.3.tar.xz";
     };
   };
   knights = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/knights-20.08.2.tar.xz";
-      sha256 = "b62dda6e8b5bb85cc814f7244e39806e38c266be1bf3090eb6de59c8141fc1d4";
-      name = "knights-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/knights-20.08.3.tar.xz";
+      sha256 = "0zqb87mr2x085hi3r9cvdrx2kvxmclh4ffi1ajcb8v1f79wiwzin";
+      name = "knights-20.08.3.tar.xz";
     };
   };
   knotes = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/knotes-20.08.2.tar.xz";
-      sha256 = "1e61f2c8b5fe9075f07be16543e3a7310bf533b6c2446f162f7196b41e3e6ecb";
-      name = "knotes-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/knotes-20.08.3.tar.xz";
+      sha256 = "0ysw8js2s6njilg4v4vqrl1bzcmqvk42l68pzvyflr112zviqz28";
+      name = "knotes-20.08.3.tar.xz";
     };
   };
   kolf = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kolf-20.08.2.tar.xz";
-      sha256 = "834c1c6cdc62e650c7b0d36db26387cc4ebe2bb4b2e8fa06c0bf461e3a1e8c64";
-      name = "kolf-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kolf-20.08.3.tar.xz";
+      sha256 = "1ywyny8iq2sxglsvpgw6p3w3w567k6cw6waywfcfy0lcnfarg1n0";
+      name = "kolf-20.08.3.tar.xz";
     };
   };
   kollision = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kollision-20.08.2.tar.xz";
-      sha256 = "9b6829f49d9baa89596ef8649996724db72c3c8eb793b9b6afc80dc0d07c0421";
-      name = "kollision-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kollision-20.08.3.tar.xz";
+      sha256 = "1l8a32bni40jz5jna0ip9ggbx7zp1hhiw2mip7v8f6qc4arbknl8";
+      name = "kollision-20.08.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kolourpaint-20.08.2.tar.xz";
-      sha256 = "fbcd875a4a407d9b1e5a637d4947bacfb50f39e10af3327f30fdbb953528aae0";
-      name = "kolourpaint-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kolourpaint-20.08.3.tar.xz";
+      sha256 = "0d64gnnb553rxscr8710h5bx8ijxd87jrbix07k41y79i5x60irh";
+      name = "kolourpaint-20.08.3.tar.xz";
     };
   };
   kompare = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kompare-20.08.2.tar.xz";
-      sha256 = "4e52cb2c9e35e90fe77bfb23bd10c1931c56b11e3fec06c215730d60c47e8550";
-      name = "kompare-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kompare-20.08.3.tar.xz";
+      sha256 = "0r9m2vcw9hbdkfdy24pfpqs2b5r0jyxh1ma2h66hfv4ycd470ilc";
+      name = "kompare-20.08.3.tar.xz";
     };
   };
   konqueror = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/konqueror-20.08.2.tar.xz";
-      sha256 = "f0622aa67ad0028e28bd6129688aab8946fb49492f0b335f6624ab7d4ef239d7";
-      name = "konqueror-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/konqueror-20.08.3.tar.xz";
+      sha256 = "1ssjj83jcbcq8i7wx5zd12z7crh2zg6awbpy38maq3c7747nqz7k";
+      name = "konqueror-20.08.3.tar.xz";
     };
   };
   konquest = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/konquest-20.08.2.tar.xz";
-      sha256 = "cf97a6961b15b39f5bcdf541e52c137f1d67d0fa5ee259922b4e762edc4491eb";
-      name = "konquest-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/konquest-20.08.3.tar.xz";
+      sha256 = "1wq0j02dzdah6yhx8r2cg191617hid9fs780yr317fprkwkgb8cb";
+      name = "konquest-20.08.3.tar.xz";
     };
   };
   konsole = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/konsole-20.08.2.tar.xz";
-      sha256 = "af08ac7666f1ba7c407205f32aaaf015329621247502e80d8df4abe103148951";
-      name = "konsole-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/konsole-20.08.3.tar.xz";
+      sha256 = "0jjidy756x8n456qbm977a73l8229kk8i489jh52296k8pkh6yjx";
+      name = "konsole-20.08.3.tar.xz";
     };
   };
   kontact = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kontact-20.08.2.tar.xz";
-      sha256 = "232d9880df74ce0c7697f08b53ef9512ac9c11c3b04142ba7ba4b95091cb5396";
-      name = "kontact-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kontact-20.08.3.tar.xz";
+      sha256 = "0qasgxvq7xps0zxk4hf2sizmy90mxyq70m2pq49pq17ij2pa9ynl";
+      name = "kontact-20.08.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kontactinterface-20.08.2.tar.xz";
-      sha256 = "72d53dbea9db0b1f5654e13c18b4da3d256c6b9d08dfe4581cdf73e3552d2a07";
-      name = "kontactinterface-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kontactinterface-20.08.3.tar.xz";
+      sha256 = "1ah2814js08sm49ykarqdw7z03w4fbym5cc4vwmzimcvh2bc78j3";
+      name = "kontactinterface-20.08.3.tar.xz";
     };
   };
   kopete = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kopete-20.08.2.tar.xz";
-      sha256 = "05f5d6236d4c96b9ce7ba5f24f4e06d7263a78cac27368a7e6b3e5075d42fbb1";
-      name = "kopete-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kopete-20.08.3.tar.xz";
+      sha256 = "1lsab66k0xq1g0w0cxcpadmf9kkc09x8wwbv4i8y3aj2mn7849gh";
+      name = "kopete-20.08.3.tar.xz";
     };
   };
   korganizer = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/korganizer-20.08.2.tar.xz";
-      sha256 = "4f719ec12c52fc313997a187439dc6888fd030a4a1b2357db000abc0a19527b2";
-      name = "korganizer-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/korganizer-20.08.3.tar.xz";
+      sha256 = "112h6vn2y9d3q3z62cwg3zrak3xgx9affibc9cvr6fzhp4z0x9ps";
+      name = "korganizer-20.08.3.tar.xz";
     };
   };
   kpat = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kpat-20.08.2.tar.xz";
-      sha256 = "e4aaed4e876212a926a05d252dab9d01f240d829e383c6072e168a4f78e6d446";
-      name = "kpat-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kpat-20.08.3.tar.xz";
+      sha256 = "1id4b9jkphi8pp29gc2vb3n9f0g8kl9yy5v8cnyv3jq673aj0fs9";
+      name = "kpat-20.08.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kpimtextedit-20.08.2.tar.xz";
-      sha256 = "2dfbcdd53669c812234346b4d31b61af9c510bb4cb0b9912decea8d3c4d406a6";
-      name = "kpimtextedit-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kpimtextedit-20.08.3.tar.xz";
+      sha256 = "1m4r5zbhbjvj3za78xfp3dibyf7mp9gan5ir5zd0k2p7adp3i652";
+      name = "kpimtextedit-20.08.3.tar.xz";
     };
   };
   kpkpass = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kpkpass-20.08.2.tar.xz";
-      sha256 = "ed699c75128ef299f06d699c80c69ac9529fa044db6f18a39d54a5e70d85108c";
-      name = "kpkpass-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kpkpass-20.08.3.tar.xz";
+      sha256 = "0zw3xx5mi38za0xbvld97f5bqvwwgyz47kybyrdm7jrhvmmiiiis";
+      name = "kpkpass-20.08.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kqtquickcharts-20.08.2.tar.xz";
-      sha256 = "2ba593a65c143cb56a3030f7ee0cced2df7c7e9431cebf1ae93be51c68b4c3b4";
-      name = "kqtquickcharts-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kqtquickcharts-20.08.3.tar.xz";
+      sha256 = "0l7v8vrc7by0w0yshnh21jaqhspmhkvm5cd0hpay6jc9v2azkcf3";
+      name = "kqtquickcharts-20.08.3.tar.xz";
     };
   };
   krdc = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/krdc-20.08.2.tar.xz";
-      sha256 = "52ddd68bdb1b356be341cf3bc5405cb965f4e4f3da8bf4b28bfb62c7db21ac5f";
-      name = "krdc-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/krdc-20.08.3.tar.xz";
+      sha256 = "1g9lxdldljh5a2s4g7g9b98lij168l99ah0vr6nvdl53n35pfr8n";
+      name = "krdc-20.08.3.tar.xz";
     };
   };
   kreversi = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kreversi-20.08.2.tar.xz";
-      sha256 = "22824dca9c8f07145a6fd9b7386867d8a8efff0fda6752f377230381a1cc71c2";
-      name = "kreversi-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kreversi-20.08.3.tar.xz";
+      sha256 = "0d3y072q61xcik9lf0pz0c9njvarwlvf6hqv5fp5jyqaf2902pmi";
+      name = "kreversi-20.08.3.tar.xz";
     };
   };
   krfb = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/krfb-20.08.2.tar.xz";
-      sha256 = "5e90fb4f3bcf2c48b15ec33634d61464323ab5ce1c156a499f089d862dd041d4";
-      name = "krfb-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/krfb-20.08.3.tar.xz";
+      sha256 = "13nypbcdhh53wq72w59z5q46a09g1w4yyi1pmsjwa8r7jnk8cafk";
+      name = "krfb-20.08.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kross-interpreters-20.08.2.tar.xz";
-      sha256 = "82da0302d2d292e86fa924c8bd1d4effb21f763c42c57affaddeff4777c43951";
-      name = "kross-interpreters-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kross-interpreters-20.08.3.tar.xz";
+      sha256 = "0mr5vpbbcv66s6dyrrypy1ai6ba744z8cn4r0iwys35p6am075qj";
+      name = "kross-interpreters-20.08.3.tar.xz";
     };
   };
   kruler = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kruler-20.08.2.tar.xz";
-      sha256 = "ede45d9cdf1b514fb20ed3a97877689ec75904438b94735706eb638ba01ca778";
-      name = "kruler-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kruler-20.08.3.tar.xz";
+      sha256 = "1vhl8acccdqfdj7lci8r2mig9qf1js4f8v7b4fqljpnc3gdg8749";
+      name = "kruler-20.08.3.tar.xz";
     };
   };
   kshisen = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kshisen-20.08.2.tar.xz";
-      sha256 = "d11030b101a409324661adf664d4298f34cc320abff80dba72d112cc3ae2d25d";
-      name = "kshisen-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kshisen-20.08.3.tar.xz";
+      sha256 = "1vy8qh8s60a4ikyw3sh4cbr3p3fk35d4dwdqc263gn4skyrsb1l9";
+      name = "kshisen-20.08.3.tar.xz";
     };
   };
   ksirk = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ksirk-20.08.2.tar.xz";
-      sha256 = "b7766f0976b3cc112d4c599d91c07d321829c9b1e8ef34d3d21ec4964026854a";
-      name = "ksirk-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ksirk-20.08.3.tar.xz";
+      sha256 = "1kxc1b05r8x6pvaiwpvjpgrr88qkm5qs4d3s1ym8rki60c724qpl";
+      name = "ksirk-20.08.3.tar.xz";
     };
   };
   ksmtp = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ksmtp-20.08.2.tar.xz";
-      sha256 = "5f51e0c025b192719709ae763feeac94df893007b62b5a69b7b95ae9f2fdd8ee";
-      name = "ksmtp-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ksmtp-20.08.3.tar.xz";
+      sha256 = "1p9clzvmsym2fijwvs3s0zqx57bk82mlks52j5ni3il6lvklaayc";
+      name = "ksmtp-20.08.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ksnakeduel-20.08.2.tar.xz";
-      sha256 = "b6f0f51f8fad795cd134f9426b1f1ba8ccceb72e304e8ba55e60af471ad282cc";
-      name = "ksnakeduel-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ksnakeduel-20.08.3.tar.xz";
+      sha256 = "03ydbwknn20gadjpwcw0z8zw777hgj8j10w4gvp2dwpb07rdg1pn";
+      name = "ksnakeduel-20.08.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kspaceduel-20.08.2.tar.xz";
-      sha256 = "62b9526c031662c049aa90b06ed3e5e2ce8ae774f271e1f29430f23c1f6cd787";
-      name = "kspaceduel-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kspaceduel-20.08.3.tar.xz";
+      sha256 = "1ii3lnxd11d3ihl8j1abh9qn9q0qq8ra9hbrwjs5df2kk36bnirj";
+      name = "kspaceduel-20.08.3.tar.xz";
     };
   };
   ksquares = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ksquares-20.08.2.tar.xz";
-      sha256 = "e1f9fdfa9a4a8348a65e66d48b7389784a1db6c8799cea453d6da3a2a57aca59";
-      name = "ksquares-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ksquares-20.08.3.tar.xz";
+      sha256 = "1ch7lbylzb9ngdzvpzqq5f30gkm2l4rzk6iqa8xm53rawr7jjqcy";
+      name = "ksquares-20.08.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ksudoku-20.08.2.tar.xz";
-      sha256 = "6fed393f734eb27d6c36ad7516bf29ff648d319f08d9f8bdc17a8030842d8e33";
-      name = "ksudoku-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ksudoku-20.08.3.tar.xz";
+      sha256 = "0hnqbd3krxi3zwj8p4n9ydhwfwhw8wljhjdfv0llv0nhj1wb89p9";
+      name = "ksudoku-20.08.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ksystemlog-20.08.2.tar.xz";
-      sha256 = "63c6a520b63f148de2e3996250a2fef22e1a3ce18e744a699ae21de96a2c4e53";
-      name = "ksystemlog-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ksystemlog-20.08.3.tar.xz";
+      sha256 = "11fc2mn4hkcibpxp7s2gihpp05yix7ws84a0bm6vjiqlidmrk192";
+      name = "ksystemlog-20.08.3.tar.xz";
     };
   };
   kteatime = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kteatime-20.08.2.tar.xz";
-      sha256 = "d8e69fdb124e8689c72e4b9fe39226cc49b1ca990478fbb68e02b37f0cd861ac";
-      name = "kteatime-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kteatime-20.08.3.tar.xz";
+      sha256 = "1vj738s2a7nnrvxi847mdmn1vg79kh9k8gqaflcwnvyxanf6n4f7";
+      name = "kteatime-20.08.3.tar.xz";
     };
   };
   ktimer = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktimer-20.08.2.tar.xz";
-      sha256 = "69293b7296643c6543d0646d14f9c75479f29f129924258957a407b77539a4c2";
-      name = "ktimer-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktimer-20.08.3.tar.xz";
+      sha256 = "1rc1z93s24b7p2ixr4xbpg0sj8ls90gzfijwj9f8b0lrwd905ysv";
+      name = "ktimer-20.08.3.tar.xz";
     };
   };
   ktnef = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktnef-20.08.2.tar.xz";
-      sha256 = "ab73736e386c2b52a14fb56f1184479ed1c83c0571e9e8518d2b94b1dcd2e47d";
-      name = "ktnef-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktnef-20.08.3.tar.xz";
+      sha256 = "1lj93sqyi522k91jiyf7d26vx5sgn5njhyaf8plsfz5rj82dw1m4";
+      name = "ktnef-20.08.3.tar.xz";
     };
   };
   ktouch = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktouch-20.08.2.tar.xz";
-      sha256 = "1b073a92343c9a2c772cfaac4e9fa7b6e85750586e3a57da413e33cdba34b5f4";
-      name = "ktouch-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktouch-20.08.3.tar.xz";
+      sha256 = "1ssxd7f75866rn5k192bnm016d8674q13ibcgmaxqsmr7wqkyd39";
+      name = "ktouch-20.08.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-accounts-kcm-20.08.2.tar.xz";
-      sha256 = "df709ee612ff4c71a43197762b8a9d296b5a43f6e0afe4d9c8d0bd88eef81465";
-      name = "ktp-accounts-kcm-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-accounts-kcm-20.08.3.tar.xz";
+      sha256 = "0039svbzx7fphyk6cw4hb8k4h7l6q31pbwvp6pvls450rycz8i8y";
+      name = "ktp-accounts-kcm-20.08.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-approver-20.08.2.tar.xz";
-      sha256 = "054db02db679d0a4600632700cdd57cae539159a0a8f01f479ea337d33d8a6bd";
-      name = "ktp-approver-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-approver-20.08.3.tar.xz";
+      sha256 = "1kqsdw7vkcd0ka98y2r7qz7dp5hsrr2m8k1xlh3gpj7fdxpla2bh";
+      name = "ktp-approver-20.08.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-auth-handler-20.08.2.tar.xz";
-      sha256 = "a61557efa800d42fd8ed14efdb09d43310212976d737a4fd5272f502bacbc371";
-      name = "ktp-auth-handler-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-auth-handler-20.08.3.tar.xz";
+      sha256 = "0wbhg458ysipwma8sygimasq71sbrzmx3vwqi51ai8y5hwrx04j4";
+      name = "ktp-auth-handler-20.08.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-call-ui-20.08.2.tar.xz";
-      sha256 = "ecd38d8b9f24cf620b8c9c1935328af3142199c6aa87e69c734e43096e492ac5";
-      name = "ktp-call-ui-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-call-ui-20.08.3.tar.xz";
+      sha256 = "1fh8bz9kc6f8v28x12xp3vw19swgcq07zyjzhd6qcnwf1bv6gl7i";
+      name = "ktp-call-ui-20.08.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-common-internals-20.08.2.tar.xz";
-      sha256 = "807fcd6f9c415a0799057435f997e143e9584a94577f9afaa7fcc6a4197e7cb0";
-      name = "ktp-common-internals-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-common-internals-20.08.3.tar.xz";
+      sha256 = "193yx4g1fwlwysy5scb7m24wqmvwmfyyb9sv7arw7zn5czlg480z";
+      name = "ktp-common-internals-20.08.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-contact-list-20.08.2.tar.xz";
-      sha256 = "214d73532dc855a8a4b68730adf5cbd046aae89f2ee2ad5d9a4c25b4eff6acb0";
-      name = "ktp-contact-list-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-contact-list-20.08.3.tar.xz";
+      sha256 = "0093z17r1xqlb1zlgxfayrnrkyl8zmnnasfd8i97dx712wmbbxxa";
+      name = "ktp-contact-list-20.08.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-contact-runner-20.08.2.tar.xz";
-      sha256 = "8e40e4ab7ce2c1c382b109a15f88f5e1c7d147c76ed36ca05ef6d9f3f58d3d45";
-      name = "ktp-contact-runner-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-contact-runner-20.08.3.tar.xz";
+      sha256 = "063jylnq3gm0s0jh1xs6b591a161sb6gdi840l40mqlhhg7i8x55";
+      name = "ktp-contact-runner-20.08.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-desktop-applets-20.08.2.tar.xz";
-      sha256 = "b0884360be80f89dee3852b023055220e3cdab2f422cc3812eda31169fba6298";
-      name = "ktp-desktop-applets-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-desktop-applets-20.08.3.tar.xz";
+      sha256 = "1i69qzfa455phjnd5ycflyggcbq7ycn2cc7a3ni5195isjzq6r6s";
+      name = "ktp-desktop-applets-20.08.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-filetransfer-handler-20.08.2.tar.xz";
-      sha256 = "c2ec5fd2a5746dd8ce1371c503c51feee206d8dfe7ca8cdaa71b8e925636a97c";
-      name = "ktp-filetransfer-handler-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-filetransfer-handler-20.08.3.tar.xz";
+      sha256 = "0a26ziacl3fkd0a0h1579jnwjzjlsz0zymj9k4da4sb60zad5y72";
+      name = "ktp-filetransfer-handler-20.08.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-kded-module-20.08.2.tar.xz";
-      sha256 = "307285b2d4e04c244691a6f2a285aec8ada26e0b01eb1fdbf2bc1da57b05828a";
-      name = "ktp-kded-module-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-kded-module-20.08.3.tar.xz";
+      sha256 = "105vh6b7a0v02arksbwxn30slpcg11cpvb7dqmvf041iyr13sqsv";
+      name = "ktp-kded-module-20.08.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-send-file-20.08.2.tar.xz";
-      sha256 = "6c3fb09112d439ce2f0db3acdbc766e8a914d4dc7cbb6ab709922f8e95f2f0e1";
-      name = "ktp-send-file-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-send-file-20.08.3.tar.xz";
+      sha256 = "08pp3029jplc6rcbav40cgy787gn3jjl312gbgvnwzglxaqvcg4b";
+      name = "ktp-send-file-20.08.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktp-text-ui-20.08.2.tar.xz";
-      sha256 = "0f10612e08bc1ee04fb0a538337d760d7b79b5dac37bb58275998d16dbb5415c";
-      name = "ktp-text-ui-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktp-text-ui-20.08.3.tar.xz";
+      sha256 = "1anxl9wa5ndyi9r9w0kpivx8nv1xpx28xjvkdplkc75cc1wl88sw";
+      name = "ktp-text-ui-20.08.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/ktuberling-20.08.2.tar.xz";
-      sha256 = "f9e4a0de3b92d015f8e7b862badf4bbf11b3ce2727aa607384a009247e7b7fad";
-      name = "ktuberling-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/ktuberling-20.08.3.tar.xz";
+      sha256 = "0q6ynmn6w5q65a77fq8n9vxqswrimln22b1zfgxmb2i3qwnhkrmz";
+      name = "ktuberling-20.08.3.tar.xz";
     };
   };
   kturtle = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kturtle-20.08.2.tar.xz";
-      sha256 = "ca9bf47b2ec34744492f218c922b10d613b19fbbd2c75b6ddba157eef21337c7";
-      name = "kturtle-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kturtle-20.08.3.tar.xz";
+      sha256 = "0riv76vwvz94zixqhhwkxw8sz2r2xqai39yh9hr31d28q9rza384";
+      name = "kturtle-20.08.3.tar.xz";
     };
   };
   kubrick = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kubrick-20.08.2.tar.xz";
-      sha256 = "02fed26a7246feffd668fbda939893295557c0571da64fdf195db93474653224";
-      name = "kubrick-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kubrick-20.08.3.tar.xz";
+      sha256 = "03k73gr33dr3va69vc70fsfcdwkqz70bg87yk2l2j33x8wsgl4wx";
+      name = "kubrick-20.08.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kwalletmanager-20.08.2.tar.xz";
-      sha256 = "7950e250c5351a9b8e3b36165fa2003baa044bb2d3553a32360000a322bddad8";
-      name = "kwalletmanager-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kwalletmanager-20.08.3.tar.xz";
+      sha256 = "1l07vxl2x3jl8553rbvr3p0k3rc95nmrw4vhxxynl3102xshrg5i";
+      name = "kwalletmanager-20.08.3.tar.xz";
     };
   };
   kwave = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kwave-20.08.2.tar.xz";
-      sha256 = "6e15a67022ef96f07b9825139cc7aaacbc6f60729570c31ce6cb25184602b434";
-      name = "kwave-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kwave-20.08.3.tar.xz";
+      sha256 = "0zk8ik03qcc6y0vhpih8sk2jpkxwxalmqmaan2767k9h92grdpc8";
+      name = "kwave-20.08.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/kwordquiz-20.08.2.tar.xz";
-      sha256 = "57aa012f3aad128579f067668db1344306e2e23d6a89b47d413d6eee0da0e238";
-      name = "kwordquiz-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/kwordquiz-20.08.3.tar.xz";
+      sha256 = "1kiqk3xyd0l7kqdxqjqs8mw4drcdbdri9xxi5gcav57ndcinknqb";
+      name = "kwordquiz-20.08.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libgravatar-20.08.2.tar.xz";
-      sha256 = "4c0a2eb073ef42a26813b93bd76aaa9e26a040a966329e6e3cf371d7de1e55f7";
-      name = "libgravatar-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libgravatar-20.08.3.tar.xz";
+      sha256 = "09dvx2rb1j7q4r0gkbhz0vjk8ya3njqprpjqdhwcq7xwc2j9h0hr";
+      name = "libgravatar-20.08.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkcddb-20.08.2.tar.xz";
-      sha256 = "545cf54ac454845c524ba7cd7ec289ac952fa1ce2bbae01411ba71c66a5ed08a";
-      name = "libkcddb-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkcddb-20.08.3.tar.xz";
+      sha256 = "0r36hs79hmq0znsds0d04lj7ffs6l2d866kyn1z1fdwr9b3crirg";
+      name = "libkcddb-20.08.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkcompactdisc-20.08.2.tar.xz";
-      sha256 = "37534f67af69775d6f786917920d2810a5d20f28df57e1a17aee9a7b30bbe302";
-      name = "libkcompactdisc-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkcompactdisc-20.08.3.tar.xz";
+      sha256 = "1nglk3kbx5czqla3cnpnf1fk71pf2cl9h6rgb40ak1xw4z31d456";
+      name = "libkcompactdisc-20.08.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkdcraw-20.08.2.tar.xz";
-      sha256 = "6fbf1a5ca5a439fabb01648cde4b57e1f3de2372b7f3b56ccae03f653490f1b2";
-      name = "libkdcraw-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkdcraw-20.08.3.tar.xz";
+      sha256 = "1806i99qsrmixdg5b0hyi8h55fk00q6wxsnrblbwcmsb268jddp7";
+      name = "libkdcraw-20.08.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkdegames-20.08.2.tar.xz";
-      sha256 = "d9f0ab87dc4671a55ad8d2b7d3a54cbc444201c11ebae436e0107fe7067fb983";
-      name = "libkdegames-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkdegames-20.08.3.tar.xz";
+      sha256 = "1ccbcwwqb53bgqlr1rq9plpw21mipxp8rsi1f7l0p1jzpw054p08";
+      name = "libkdegames-20.08.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkdepim-20.08.2.tar.xz";
-      sha256 = "3558c9af95c22bb4ce0ceeec483fada9e8e9f27de4ac34ffe44a4eb3b6d21101";
-      name = "libkdepim-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkdepim-20.08.3.tar.xz";
+      sha256 = "1v77g02v5sdqprh8psx5xpjgf8v91il60ca59yivm5jvc3hdf3f6";
+      name = "libkdepim-20.08.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkeduvocdocument-20.08.2.tar.xz";
-      sha256 = "ef8e0b359e3cf1b3303da3795add1ced405d230f51895abe10d5a7989be03923";
-      name = "libkeduvocdocument-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkeduvocdocument-20.08.3.tar.xz";
+      sha256 = "0ghkx6x5sn5fl934ybhl32knwv9zky0n1vkjw2w93lpms45xmw76";
+      name = "libkeduvocdocument-20.08.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkexiv2-20.08.2.tar.xz";
-      sha256 = "793c4d11bb1b60beca7b25a2427650b3f358364c55be022dfd4a7ccfd889578d";
-      name = "libkexiv2-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkexiv2-20.08.3.tar.xz";
+      sha256 = "1lh3947w6xgzl2r1wm6m4kd478q6bv89f0c3c38ldv30imfw7rfl";
+      name = "libkexiv2-20.08.3.tar.xz";
     };
   };
   libkgapi = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkgapi-20.08.2.tar.xz";
-      sha256 = "f3fb015e8b8ac92c138e8a59e8e8b9333500e0ea314180cc1ad14e31248312df";
-      name = "libkgapi-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkgapi-20.08.3.tar.xz";
+      sha256 = "1kmgf9v9rvb67l7aw5xsx7v44l4pz8rl6p09lk26irq7gd4k68la";
+      name = "libkgapi-20.08.3.tar.xz";
     };
   };
   libkgeomap = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkgeomap-20.08.2.tar.xz";
-      sha256 = "7149095aa0df4e3a184bb2a6fb8322e27e3a34eb3bc40cf370a09b21fb2a6ea0";
-      name = "libkgeomap-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkgeomap-20.08.3.tar.xz";
+      sha256 = "14ipksxnvgk2s1sw7a70153iy9aik9mf4i7k8y3pzdr3l3155ayk";
+      name = "libkgeomap-20.08.3.tar.xz";
     };
   };
   libkipi = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkipi-20.08.2.tar.xz";
-      sha256 = "87ffa30b23779313a94953afe57d1b19515c3a2f311a2dea6449c9d96b09e5b1";
-      name = "libkipi-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkipi-20.08.3.tar.xz";
+      sha256 = "1b5qby7xm926qnzrf1zpb89fwx1a2syhqnznmdjxifj499p1jqjb";
+      name = "libkipi-20.08.3.tar.xz";
     };
   };
   libkleo = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkleo-20.08.2.tar.xz";
-      sha256 = "34537b35e22cef85650ae6f9bf197518bb5a59e9614d6d86ba86f085fddd97c4";
-      name = "libkleo-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkleo-20.08.3.tar.xz";
+      sha256 = "1d6dal4qnrikg6ma2ird4b2sdivqqkkhamvd3s1srcxppc3aiq79";
+      name = "libkleo-20.08.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkmahjongg-20.08.2.tar.xz";
-      sha256 = "032ac6d9e96cd9156f5153c01f881d0e442fda9de90398df320846095ba2c40a";
-      name = "libkmahjongg-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkmahjongg-20.08.3.tar.xz";
+      sha256 = "0xabp1vzbzs52m3bb9nzm1d9md1n4j4pr13izn6nv28ja7477nnm";
+      name = "libkmahjongg-20.08.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libkomparediff2-20.08.2.tar.xz";
-      sha256 = "91b0b72d5c4e2ddd863636cca299660bfbb5b7a55773cbc51000fe9c1ca91a98";
-      name = "libkomparediff2-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libkomparediff2-20.08.3.tar.xz";
+      sha256 = "0nk0jkf0jwaz1yqzzp44c6xyjgw42gclkcvw8w61w1f8sdl40wb8";
+      name = "libkomparediff2-20.08.3.tar.xz";
     };
   };
   libksane = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libksane-20.08.2.tar.xz";
-      sha256 = "21bb577d78e020281dfc6c993ab7fe286d648e72c851e45463a32969fbb35aa6";
-      name = "libksane-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libksane-20.08.3.tar.xz";
+      sha256 = "0d2cnmvk16g1vnx9jd7jvp3bpw07ss54khmhqip8iskkvcfll9j0";
+      name = "libksane-20.08.3.tar.xz";
     };
   };
   libksieve = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/libksieve-20.08.2.tar.xz";
-      sha256 = "589e4dc27d1d91d8c16879fa99aab45f3847a74e3e9357e3e037503e5515ee2e";
-      name = "libksieve-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/libksieve-20.08.3.tar.xz";
+      sha256 = "0bhpdqynazssql2iivvpb9l8npa441345gcn59fc0va6barl9sam";
+      name = "libksieve-20.08.3.tar.xz";
     };
   };
   lokalize = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/lokalize-20.08.2.tar.xz";
-      sha256 = "c11616bc02763fb1f3b1abf0b2ba70d0c6c550435c94ff25c5096f9a90375e23";
-      name = "lokalize-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/lokalize-20.08.3.tar.xz";
+      sha256 = "0iab8sd1qh7h0zna7lc3v43z6rcmxba9v4nynhl5miiac4r6ddr8";
+      name = "lokalize-20.08.3.tar.xz";
     };
   };
   lskat = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/lskat-20.08.2.tar.xz";
-      sha256 = "78f152f7af46345f65c3800f9c591fb204e917595c1f803c9c15148ef39c42b8";
-      name = "lskat-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/lskat-20.08.3.tar.xz";
+      sha256 = "1rcmh592w5gd5b69czfxycypidj74y2d91cw92rccariadz9vnjz";
+      name = "lskat-20.08.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/mailcommon-20.08.2.tar.xz";
-      sha256 = "a4170ab9ff7680fb26c61474f42d5424716f4e91c1a5e9275cc1222491c9564d";
-      name = "mailcommon-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/mailcommon-20.08.3.tar.xz";
+      sha256 = "0bhs60cz4qcrqkmw2sm6cd2laq8lzj9vcwi8kjqkajsidh342wdv";
+      name = "mailcommon-20.08.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/mailimporter-20.08.2.tar.xz";
-      sha256 = "a255b60378c1cf77e517919d072cb44bd8c25e8ed8f07429763bb7915b3cc711";
-      name = "mailimporter-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/mailimporter-20.08.3.tar.xz";
+      sha256 = "0w6yfgqx0adlkwx32vmb23kl6n50737jiabmad3pnhqw8rv41h80";
+      name = "mailimporter-20.08.3.tar.xz";
     };
   };
   marble = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/marble-20.08.2.tar.xz";
-      sha256 = "f44ac10de33dc31ce1cb99635131fe2c7bf3f60f09204b2061f81042a725475c";
-      name = "marble-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/marble-20.08.3.tar.xz";
+      sha256 = "1xpxgy724z97k063fdk0l3mrl8i6nvnhj35b4987jqji76i92ffb";
+      name = "marble-20.08.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/mbox-importer-20.08.2.tar.xz";
-      sha256 = "3b3bee33683c534974255616f3b2f3baebf85363b2c24bbee9cc195ddf35ca9a";
-      name = "mbox-importer-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/mbox-importer-20.08.3.tar.xz";
+      sha256 = "1qh0f93df228cqlcqdwc7g6im3g0gkfmzir3ccsmb5iv0ygvjl6f";
+      name = "mbox-importer-20.08.3.tar.xz";
     };
   };
   messagelib = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/messagelib-20.08.2.tar.xz";
-      sha256 = "5cf3a3f2b6473e60a7c2af10aa4eb1cfba25a4786132ee87b657b0dafb9f5028";
-      name = "messagelib-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/messagelib-20.08.3.tar.xz";
+      sha256 = "16amni6qrq96h8jr313gc7k9frwr20d4pk9y2i61a1xm2w3xsqd4";
+      name = "messagelib-20.08.3.tar.xz";
     };
   };
   minuet = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/minuet-20.08.2.tar.xz";
-      sha256 = "24383168e2a0b7b319ecb37e2b1f3b039ad790a7e0f49385657f049565f1ef84";
-      name = "minuet-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/minuet-20.08.3.tar.xz";
+      sha256 = "1l45g7labnyz0pkwcfhjl5a3ypr7cy3bsshr06ab85364yjwazvi";
+      name = "minuet-20.08.3.tar.xz";
     };
   };
   okular = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/okular-20.08.2.tar.xz";
-      sha256 = "6f1885ed8050a55bb2cbf05089b452f555852e003ec7fe89fe472c0dbc92e65b";
-      name = "okular-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/okular-20.08.3.tar.xz";
+      sha256 = "1q59ikcwsfgjc0202daingxv15iarnzba6szdncznzcafd6hhk9z";
+      name = "okular-20.08.3.tar.xz";
     };
   };
   palapeli = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/palapeli-20.08.2.tar.xz";
-      sha256 = "a31b0db2f3e77eac8f527d26f8ed0400fe5bcdb3a3970b925f14886bd1bcd63e";
-      name = "palapeli-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/palapeli-20.08.3.tar.xz";
+      sha256 = "107z3izfznrq7g5aqb5a7r8a4ibaia90g334d7wwvd7prm7hdgfp";
+      name = "palapeli-20.08.3.tar.xz";
     };
   };
   parley = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/parley-20.08.2.tar.xz";
-      sha256 = "cf2f00925730d8baec66d422f058e4b3e979678e79c57898ceffd8650720bda6";
-      name = "parley-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/parley-20.08.3.tar.xz";
+      sha256 = "0wli09zkk5z50y1gzp5wc9k056xjaadlq97j09lf6lqyg6kb56ya";
+      name = "parley-20.08.3.tar.xz";
     };
   };
   picmi = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/picmi-20.08.2.tar.xz";
-      sha256 = "35f2bf3d8375618f97aee01c8f2421521b2cd5c11d7b14fc9a376026d74c82a5";
-      name = "picmi-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/picmi-20.08.3.tar.xz";
+      sha256 = "1lkpazsi9dyb2y9q5bk56d80x7x035rf4hdap25i8qfj3ilykv3w";
+      name = "picmi-20.08.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/pimcommon-20.08.2.tar.xz";
-      sha256 = "cba9e66153d36debe3f046363af7ff40a4ba263f33bfe20c7ec10b5bf9183deb";
-      name = "pimcommon-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/pimcommon-20.08.3.tar.xz";
+      sha256 = "0mpl7li2y5xjzk4hdb85d1x7cz15cicd91c1krlw74q7pbrjinlq";
+      name = "pimcommon-20.08.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/pim-data-exporter-20.08.2.tar.xz";
-      sha256 = "54b09a3f763004c805cc0dce8ab2e665116b7ef29419f22ad413aa250dcb4ac0";
-      name = "pim-data-exporter-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/pim-data-exporter-20.08.3.tar.xz";
+      sha256 = "0f08c16d3730fbdsbrwlr9w5c4l9xcmd1bdbv5m38h5r2ddlkvzr";
+      name = "pim-data-exporter-20.08.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/pim-sieve-editor-20.08.2.tar.xz";
-      sha256 = "e8c590a0fddc5292172115b11fb75c5f847347079100617dbf321875642d7098";
-      name = "pim-sieve-editor-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/pim-sieve-editor-20.08.3.tar.xz";
+      sha256 = "1falzw2a2v912fdzlyljsw9rcy1whrn9ys9ccrskkpvjn8y444x4";
+      name = "pim-sieve-editor-20.08.3.tar.xz";
     };
   };
   poxml = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/poxml-20.08.2.tar.xz";
-      sha256 = "67d260349489e92ebce20253f9a3ccde5bb75eb13eb4d1a08a86c18c82e4a2a9";
-      name = "poxml-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/poxml-20.08.3.tar.xz";
+      sha256 = "0gzg3vbsjrfhs1jg59g7b3gf3b4qajiffkb94njkz8v1f0fadlxp";
+      name = "poxml-20.08.3.tar.xz";
     };
   };
   print-manager = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/print-manager-20.08.2.tar.xz";
-      sha256 = "de21f8c428198b906f4ae438d6ced8d707b12c15578409c2aa2f7b2f73feb990";
-      name = "print-manager-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/print-manager-20.08.3.tar.xz";
+      sha256 = "18nl9gpmzz4g9fqzyvbh858nxz23b2vyi505qacqvcrz13r0l78z";
+      name = "print-manager-20.08.3.tar.xz";
     };
   };
   rocs = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/rocs-20.08.2.tar.xz";
-      sha256 = "2d8efd62b89dd36033bb3d818c82fee67e6efa2d2bb98dda0d4eab13baaee485";
-      name = "rocs-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/rocs-20.08.3.tar.xz";
+      sha256 = "0bd9x7kh2s4z79ff9byd3ly7k040c574zwrrgi8sq21yd531hxhj";
+      name = "rocs-20.08.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/signon-kwallet-extension-20.08.2.tar.xz";
-      sha256 = "a271f4d09511171dcf1ebcdaf0b7205f9ee6a75b20ef0801f36d136f7b4a70dd";
-      name = "signon-kwallet-extension-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/signon-kwallet-extension-20.08.3.tar.xz";
+      sha256 = "1s0syq9aw2q34k1wxrpjqqi12xay1h0vc4s2d8l184hzzg8qq71i";
+      name = "signon-kwallet-extension-20.08.3.tar.xz";
     };
   };
   spectacle = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/spectacle-20.08.2.tar.xz";
-      sha256 = "9a467ea3b05981d588d39573cca375636b825ad8cab8a36ce48dbbc12425ab0d";
-      name = "spectacle-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/spectacle-20.08.3.tar.xz";
+      sha256 = "16dwbsk9hik7gmz9s4x78hibz4x9d1fpx8x2i2giry5hwzknfcw4";
+      name = "spectacle-20.08.3.tar.xz";
     };
   };
   step = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/step-20.08.2.tar.xz";
-      sha256 = "a52e4b6f281ba1a7afd4ab3ac7307080464147c4052ee222399135fe61ac7958";
-      name = "step-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/step-20.08.3.tar.xz";
+      sha256 = "05ljsmgpra1az64yddy8idi46cv3afaf2v4n7d5j81a8vvlz7fj1";
+      name = "step-20.08.3.tar.xz";
     };
   };
   svgpart = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/svgpart-20.08.2.tar.xz";
-      sha256 = "3a46b5bd9acf5372f73b602d155517f0dff47f3337bd8a46a580aae7480dd771";
-      name = "svgpart-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/svgpart-20.08.3.tar.xz";
+      sha256 = "0wwq576dblqmfknr0qs8kskw7nar6hah95fqicdn97xdy4nvzhc6";
+      name = "svgpart-20.08.3.tar.xz";
     };
   };
   sweeper = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/sweeper-20.08.2.tar.xz";
-      sha256 = "0c255ef15c1e32eb561b26f5b73a6c154730be583efbc5ee713aaed17de14091";
-      name = "sweeper-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/sweeper-20.08.3.tar.xz";
+      sha256 = "0i4zvbljdzkj47vh8kizam7vsc9k7mvf8dqd2j6ixr4p0cqvw5a8";
+      name = "sweeper-20.08.3.tar.xz";
     };
   };
   umbrello = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/umbrello-20.08.2.tar.xz";
-      sha256 = "0357b44646c750253e3e7ee323b9e49e854c4c8cdf340eb5a11b2d42edfc4cd7";
-      name = "umbrello-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/umbrello-20.08.3.tar.xz";
+      sha256 = "1hh5gyggb4f3pjip8dfvx00hi83gj65c92jgzkzahj7p35mkplgl";
+      name = "umbrello-20.08.3.tar.xz";
     };
   };
   yakuake = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/yakuake-20.08.2.tar.xz";
-      sha256 = "8a0aa3a97a9fdc781887a6cb6480cba5079cf8aacd3345b63f5eb6be4d91665a";
-      name = "yakuake-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/yakuake-20.08.3.tar.xz";
+      sha256 = "05zd2xm5vgrgz0bxbkh1mpiknlqzpzk5jb74lnd5x7wn5b80ngv0";
+      name = "yakuake-20.08.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "20.08.2";
+    version = "20.08.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/20.08.2/src/zeroconf-ioslave-20.08.2.tar.xz";
-      sha256 = "0ad34f8361ee3ecd669e396265135b534239994d3bec5e9e6a43b7b7bf5c04e4";
-      name = "zeroconf-ioslave-20.08.2.tar.xz";
+      url = "${mirror}/stable/release-service/20.08.3/src/zeroconf-ioslave-20.08.3.tar.xz";
+      sha256 = "1afga0liiy9n98kb0gmxzbb6ckhdgbrdc4ig1x9pwp98wr1fzmcg";
+      name = "zeroconf-ioslave-20.08.3.tar.xz";
     };
   };
 }

--- a/pkgs/applications/kde/yakuake.nix
+++ b/pkgs/applications/kde/yakuake.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "yakuake";
+  pname = "yakuake";
 
   buildInputs = [
     karchive kcrash kdbusaddons ki18n kiconthemes knewstuff knotifications

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.20.4/ )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.20.4/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=(https://download.kde.org/stable/frameworks/5.76/)
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.76/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.12/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.12/fetch.sh
@@ -1,1 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.7/submodules/ )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.7/submodules/ \
+            -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.14/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.14/fetch.sh
@@ -1,1 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.14/5.14.2/submodules/ )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.14/5.14.2/submodules/ \
+            -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.15/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.15/fetch.sh
@@ -1,1 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.15/5.15.2/submodules/ )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.15/5.15.2/submodules/ \
+            -A '*.tar.xz' )


### PR DESCRIPTION
###### Motivation for this change

Update KDE Applications with a scheduled minor release. Fix the derivation names using the `{ pname, version }` convention.

See: #107570.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
