### PR TITLE
Bitwig Studio : 3.2.8 -> 3.3.1

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -1,23 +1,77 @@
-{ fetchurl, bitwig-studio1, pulseaudio, libjack2, xorg }:
+{ stdenv, fetchurl, alsaLib, cairo, dpkg, freetype
+, gdk-pixbuf, glib, gtk3, lib, xorg
+, libglvnd, libjack2, ffmpeg_3
+, libxkbcommon, xdg_utils, zlib, pulseaudio
+, wrapGAppsHook, makeWrapper }:
 
-bitwig-studio1.overrideAttrs (oldAttrs: rec {
-  name = "bitwig-studio-${version}";
-  version = "3.2.8";
+stdenv.mkDerivation rec {
+  pname = "bitwig-studio";
+  version = "3.3.1";
 
   src = fetchurl {
-    url = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "18ldgmnv7bigb4mch888kjpf4abalpiwmlhwd7rjb9qf6p72fhpj";
+    url = "https://downloads.bitwig.com/stable/${version}/${pname}-${version}.deb";
+    sha256 = "0f7xysk0cl48q7i28m25hasmrp30grgm3kah0s7xmkjgm33887pi";
   };
 
-  buildInputs = oldAttrs.buildInputs ++ [ xorg.libXtst ];
+  nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
 
-  runtimeDependencies = [ pulseaudio libjack2 ];
+  unpackCmd = ''
+    mkdir -p root
+    dpkg-deb -x $curSrc root
+  '';
+
+  dontBuild = true;
+  dontWrapGApps = true; # we only want $gappsWrapperArgs here
+
+  buildInputs = with xorg; [
+    alsaLib cairo freetype gdk-pixbuf glib gtk3 libxcb xcbutil xcbutilwm zlib libXtst libxkbcommon pulseaudio libjack2 libX11 libglvnd libXcursor stdenv.cc.cc.lib
+  ];
+
+  binPath = lib.makeBinPath [
+    xdg_utils ffmpeg_3
+  ];
+
+  ldLibraryPath = lib.strings.makeLibraryPath buildInputs;
 
   installPhase = ''
-    ${oldAttrs.installPhase}
-
-    # recover commercial jre
-    rm -f $out/libexec/lib/jre
-    cp -r opt/bitwig-studio/lib/jre $out/libexec/lib
+    mkdir -p $out/bin
+    cp -r opt/bitwig-studio $out/libexec
+    ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
+    cp -r usr/share $out/share
+    substitute usr/share/applications/bitwig-studio.desktop \
+      $out/share/applications/bitwig-studio.desktop \
+      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
   '';
-})
+
+  postFixup = ''
+    # patchelf fails to set rpath on BitwigStudioEngine, so we use
+    # the LD_LIBRARY_PATH way
+
+    find $out -type f -executable \
+      -not -name '*.so.*' \
+      -not -name '*.so' \
+      -not -name '*.jar' \
+      -not -path '*/resources/*' | \
+    while IFS= read -r f ; do
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
+      wrapProgram $f \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix PATH : "${binPath}" \
+        --prefix LD_LIBRARY_PATH : "${ldLibraryPath}"
+    done
+
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A digital audio workstation";
+    longDescription = ''
+      Bitwig Studio is a multi-platform music-creation system for
+      production, performance and DJing, with a focus on flexible
+      editing tools and a super-fast workflow.
+    '';
+    homepage = "https://www.bitwig.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ bfortz michalrus mrVanDalo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20557,9 +20557,8 @@ in
   bitwig-studio2 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio2.nix {
     inherit (pkgs) bitwig-studio1;
   };
-  bitwig-studio3 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio3.nix {
-    inherit (pkgs) bitwig-studio1;
-  };
+  bitwig-studio3 =  callPackage ../applications/audio/bitwig-studio/bitwig-studio3.nix { };
+
   bitwig-studio = bitwig-studio3;
 
   bgpdump = callPackage ../tools/networking/bgpdump { };


### PR DESCRIPTION
###### Motivation for this change

- Version bump
- Made bitwig-studio3.nix independant of bitwig-studio1.nix (allowed some clean up)
- Manuel paching of binary files as autoPatchElf corrupts BitwigStudioEngine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
