### PR TITLE
ffmpegthumbnailer: enable generation of thumbnailer file

### DIFF
--- a/pkgs/development/libraries/ffmpegthumbnailer/default.nix
+++ b/pkgs/development/libraries/ffmpegthumbnailer/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, ffmpeg_3, cmake, libpng, pkgconfig, libjpeg
+{ fetchFromGitHub, stdenv, ffmpeg_3, cmake, libpng, pkg-config, libjpeg
 }:
 
 stdenv.mkDerivation rec {
@@ -12,13 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "1bakbr714j7yxdal1f5iq0gcl4cxggbbgj227ihdh5kvygqlwich";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ ffmpeg_3 libpng libjpeg ];
+  cmakeFlags = [ "-DENABLE_THUMBNAILER=ON" ];
 
   meta = with stdenv.lib;  {
     homepage = "https://github.com/dirkvdb/ffmpegthumbnailer";
     description = "A lightweight video thumbnailer";
-    longDescription = "FFmpegthumbnailer is a lightweight video 
+    longDescription = "FFmpegthumbnailer is a lightweight video
         thumbnailer that can be used by file managers to create thumbnails
         for your video files. The thumbnailer uses ffmpeg o decode frames
         from the video files, so supported videoformats depend on the
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
         The only dependencies are ffmpeg and libpng.
     ";
     platforms = platforms.linux;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.jagajaga ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

Makes ffmpegthumbnailer usable with desktop environments.

I've specifically used it to get video thumbnailing working on MATE (on 20.09).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
