### PR TITLE
util-linux: removing symfollow

### DIFF
--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig, zlib, shadow
+{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, zlib, shadow
 , ncurses ? null, perl ? null, pam, systemd ? null, minimal ? false }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./rtcwake-search-PATH-for-shutdown.patch
+    # Remove patch below in 2.36.2, see https://github.com/karelzak/util-linux/issues/1193
+    (fetchpatch {
+      url = "https://github.com/karelzak/util-linux/commit/52f730e47869ce630fafb24fd46f755dc7ffc691.patch";
+      sha256 = "1fz3p9127lfvmrdj1j1s8jds0jjz2dzkvmia66555ihv7hcfajbg";
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "man" ];


### PR DESCRIPTION
###### Motivation for this change
linux-utils 2.36.1 breaks user mounts on kernels. A patch is already in master and will be included in 2.36.2. See https://github.com/karelzak/util-linux/issues/1193. This backports the patch already to 2.36.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
