### PR TITLE
openmolcas: fix fallout from #83888

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -72,7 +72,7 @@ in stdenv.mkDerivation {
     homepage = "https://gitlab.com/Molcas/OpenMolcas";
     maintainers = [ maintainers.markuskowa ];
     license = licenses.lgpl21;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }
 

--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -1,10 +1,8 @@
 { stdenv, fetchFromGitLab, cmake, gfortran, perl
-, openblas, blas, lapack, hdf5-cpp, python3, texlive
+, openblas, hdf5-cpp, python3, texlive
 , armadillo, openmpi, globalarrays, openssh
 , makeWrapper, fetchpatch
 } :
-
-assert blas.implementation == "openblas" && lapack.implementation == "openblas";
 
 let
   version = "20.10";


### PR DESCRIPTION
###### Motivation for this change
Removed non-functional lines.
Openmolcas does not build with the blas/lapack switching mechanism

CC @matthewbauer 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
