### PR TITLE
opentabletdriver: init at 0.4.2/add module

### DIFF
--- a/nixos/modules/hardware/opentabletdriver.nix
+++ b/nixos/modules/hardware/opentabletdriver.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.opentabletdriver;
+in
+{
+  options = {
+    hardware.opentabletdriver = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable OpenTabletDriver udev rules, user service and blacklist kernel
+          modules known to conflict with OpenTabletDriver.
+        '';
+      };
+
+      blacklistedKernelModules = mkOption {
+        type = types.listOf types.str;
+        default = [ "hid-uclogic" "wacom" ];
+        description = ''
+          Blacklist of kernel modules known to conflict with OpenTabletDriver.
+        '';
+      };
+
+      daemon = {
+        enable = mkOption {
+          default = true;
+          type = types.bool;
+          description = ''
+            Whether to start OpenTabletDriver daemon as a systemd user service.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [ opentabletdriver ];
+
+    services.udev.packages = with pkgs; [ opentabletdriver ];
+
+    boot.blacklistedKernelModules = cfg.blacklistedKernelModules;
+
+    systemd.user.services.opentabletdriver = with pkgs; mkIf cfg.daemon.enable {
+      description = "Open source, cross-platform, user-mode tablet driver";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${opentabletdriver}/bin/otd-daemon -c ${opentabletdriver}/lib/OpenTabletDriver/Configurations";
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -66,6 +66,7 @@
   ./hardware/tuxedo-keyboard.nix
   ./hardware/usb-wwan.nix
   ./hardware/onlykey.nix
+  ./hardware/opentabletdriver.nix
   ./hardware/wooting.nix
   ./hardware/uinput.nix
   ./hardware/video/amdgpu.nix

--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -1,0 +1,152 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, makeWrapper
+, linkFarmFromDrvs
+, dotnet-netcore
+, dotnet-sdk
+, dotnetPackages
+, dpkg
+, gtk3
+, libX11
+, libXrandr
+, libappindicator
+, libevdev
+, libnotify
+, udev
+, makeDesktopItem
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "OpenTabletDriver";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "InfinityGhost";
+    repo = "OpenTabletDriver";
+    rev = "v${version}";
+    sha256 = "048y7gjlk2yw4vh62px1d9w0va6ap1a0cndcpbirlyj9q6b8jxax";
+  };
+
+  debPkg = fetchurl {
+    url = "https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${version}/OpenTabletDriver.deb";
+    sha256 = "13gg0dhvjy88h9lhcrp30fjiwgb9dzjsgk1k760pi1ki71a5vz2r";
+  };
+
+  nativeBuildInputs = [
+    dotnet-sdk
+    dotnetPackages.Nuget
+    dpkg
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  nugetDeps = linkFarmFromDrvs "${pname}-nuget-deps" (import ./deps.nix {
+    fetchNuGet = { name, version, sha256 }: fetchurl {
+      name = "nuget-${name}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+      inherit sha256;
+    };
+  });
+
+  runtimeDeps = [
+    gtk3
+    libX11
+    libXrandr
+    libappindicator
+    libevdev
+    libnotify
+    udev
+  ];
+
+  configurePhase = ''
+    export HOME=$(mktemp -d)
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+    nuget sources Add -Name nixos -Source "$PWD/nixos"
+    nuget init "$nugetDeps" "$PWD/nixos"
+
+    # FIXME: https://github.com/NuGet/Home/issues/4413
+    mkdir -p $HOME/.nuget/NuGet
+    cp $HOME/.config/NuGet/NuGet.Config $HOME/.nuget/NuGet
+
+    for project in OpenTabletDriver.{Console,Daemon,UX.Gtk}; do
+        dotnet restore --source "$PWD/nixos" $project
+    done
+  '';
+
+  buildPhase = ''
+    for project in OpenTabletDriver.{Console,Daemon,UX.Gtk}; do
+        dotnet build $project \
+            --no-restore \
+            --configuration Release \
+            --framework net5
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/OpenTabletDriver/
+    cp -r ./OpenTabletDriver/Configurations/ $out/lib/OpenTabletDriver/
+
+    for project in OpenTabletDriver.{Console,Daemon,UX.Gtk}; do
+      dotnet publish $project \
+          --no-build \
+          --no-self-contained \
+          --configuration Release \
+          --framework net5 \
+          --output $out/lib
+    done
+
+    # Give a more "*nix" name to the binaries
+    makeWrapper $out/lib/OpenTabletDriver.Console $out/bin/otd \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --set DOTNET_ROOT "${dotnet-netcore}" \
+        --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
+
+    makeWrapper $out/lib/OpenTabletDriver.Daemon $out/bin/otd-daemon \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --set DOTNET_ROOT "${dotnet-netcore}" \
+        --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
+
+    makeWrapper $out/lib/OpenTabletDriver.UX.Gtk $out/bin/otd-gui \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --set DOTNET_ROOT "${dotnet-netcore}" \
+        --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
+
+    mkdir -p $out/share/{applications,pixmaps}
+
+    cp -r $src/OpenTabletDriver.UX/Assets/* $out/share/pixmaps
+
+    cp -r ${makeDesktopItem {
+      desktopName = "OpenTabletDriver";
+      name = "OpenTabletDriver";
+      exec = "otd-gui";
+      icon = "otd";
+      comment = meta.description;
+      type = "Application";
+      categories = "Utility;";
+    }}/share/applications/* $out/share/applications
+
+    # TODO: Ideally this should be build from OpenTabletDriver/OpenTabletDriver-udev instead
+    dpkg-deb --fsys-tarfile ${debPkg} | tar xf - ./usr/lib/udev/rules.d/30-opentabletdriver.rules
+    mkdir -p $out/lib/udev/rules.d
+    cp ./usr/lib/udev/rules.d/* $out/lib/udev/rules.d
+  '';
+
+  dontWrapGApps = true;
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "Open source, cross-platform, user-mode tablet driver";
+    homepage = "https://github.com/InfinityGhost/OpenTabletDriver";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ thiagokokada ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/X11/opentabletdriver/deps.nix
+++ b/pkgs/tools/X11/opentabletdriver/deps.nix
@@ -1,0 +1,462 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    name = "AtkSharp";
+    version = "3.22.25.74";
+    sha256 = "04zjpjrddw5clac0mjpk0q00rbmv45bh1bsqa4s3pc5pb7fm9cd9";
+  })
+  (fetchNuGet {
+    name = "CairoSharp";
+    version = "3.22.25.74";
+    sha256 = "0sx7vmwcrfbkg3g887v051iklcdmdhh43ndp96nk4bccjimmmwl6";
+  })
+  (fetchNuGet {
+    name = "Eto.Forms";
+    version = "2.5.6";
+    sha256 = "035ny8jlanchwq16gcq0xb6ywabjl71c7qbpv26sjwg96na8vz51";
+  })
+  (fetchNuGet {
+    name = "Eto.Platform.Gtk";
+    version = "2.5.6";
+    sha256 = "1ijkjd3lc7x59yk369kxipzgk1zhyr9g6k319wc0n033vij26mwl";
+  })
+  (fetchNuGet {
+    name = "GdkSharp";
+    version = "3.22.25.74";
+    sha256 = "07sdfvqk2jmyjj7fyd0mikhnzsk52zd3g2dhip8kz3006cczqm81";
+  })
+  (fetchNuGet {
+    name = "GioSharp";
+    version = "3.22.25.74";
+    sha256 = "01l4216bm5jxbxypkkq4d2527c6zd68kbywr3h1lr1darc9nf1d1";
+  })
+  (fetchNuGet {
+    name = "GLibSharp";
+    version = "3.22.25.74";
+    sha256 = "0k2p79z4wcswi528v0ykc37rsqfqi6xd6pl0j4csdj9zf19svgx2";
+  })
+  (fetchNuGet {
+    name = "GtkSharp";
+    version = "3.22.25.74";
+    sha256 = "0vazfvkjyzppcynqa1h70s1jmp4vq2j30v5x2scg8n2c5dxaj0k3";
+  })
+  (fetchNuGet {
+    name = "HidSharpCore";
+    version = "1.1.0";
+    sha256 = "122s5j3wrv8hcgnbxrnjqydvcfz7gdm8xq0wlwzrgwdjk44lr45a";
+  })
+  (fetchNuGet {
+    name = "MessagePack.Annotations";
+    version = "2.1.194";
+    sha256 = "1jkhq3hiy4brvzsywl4p4jb9jrnzs3vmgr3s8fxpb1dzafadw8b0";
+  })
+  (fetchNuGet {
+    name = "MessagePack";
+    version = "2.1.194";
+    sha256 = "1v2gyd9sd6hppfhlzngmzzhnpr39b95rwrqq0r9zzp480b6vzaj0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Bcl.AsyncInterfaces";
+    version = "1.1.1";
+    sha256 = "0a1ahssqds2ympr7s4xcxv5y8jgxs7ahd6ah6fbgglj4rki1f1vw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.4.1";
+    sha256 = "0z6d1i6xcf0c00z6rs75rgw4ncs9q2m8amasf6mmbf40fm02ry7g";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.1.1";
+    sha256 = "164wycgng4mi9zqi2pnsf1pq6gccbqvw6ib916mqizgjmd8f44pj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "3.0.0";
+    sha256 = "1bk8r4r3ihmi6322jmcag14jmw11mjqys202azqjzglcx59pxh51";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.1.0";
+    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.VisualStudio.Threading.Analyzers";
+    version = "16.7.56";
+    sha256 = "04v9df0k7bsc0rzgkw4mnvi43pdrh42vk6xdcwn9m6im33m0nnz2";
+  })
+  (fetchNuGet {
+    name = "Microsoft.VisualStudio.Threading";
+    version = "16.7.56";
+    sha256 = "13x0xrsjxd86clf9cjjwmpzlyp8pkrf13riya7igs8zy93zw2qap";
+  })
+  (fetchNuGet {
+    name = "Microsoft.VisualStudio.Validation";
+    version = "15.5.31";
+    sha256 = "1ah99rn922qa0sd2k3h64m324f2r32pw8cn4cfihgvwx4qdrpmgw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.6.0";
+    sha256 = "0i4y782yrqqyx85pg597m20gm0v126w0j9ddk5z7xb3crx4z9f2s";
+  })
+  (fetchNuGet {
+    name = "Nerdbank.Streams";
+    version = "2.6.77";
+    sha256 = "13dnfwxa8syx7vfjmd5pcrqz31k0q8y3mmh6yz6bmljhjri65q5c";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.2";
+    sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.3";
+    sha256 = "17dzl305d835mzign8r15vkmav2hq8l6g7942dfjpnzr17wwl89x";
+  })
+  (fetchNuGet {
+    name = "PangoSharp";
+    version = "3.22.25.74";
+    sha256 = "172i1hjpz4rgqlilir8a57kgmciw9x0shz4zwbhhlr59mndvqbih";
+  })
+  (fetchNuGet {
+    name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "0rwpqngkqiapqc5c2cpkj7idhngrgss5qpnqg0yh40mbyflcxf8i";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "1n06gxwlinhs0w7s8a94r1q3lwqzvynxwd3mp10ws9bg6gck8n4r";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "0404wqrc7f2yc0wxv71y3nnybvqx8v4j9d47hlscxy759a525mc3";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "0zy5r25jppz48i2bkg8b9lfig24xixg6nm3xyr1379zdnqnpm8f6";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.3.0";
+    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "096ch4n4s8k82xga80lfmpimpzahd2ip1mgwdqgar0ywbbl6x438";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "1dm8fifl7rf1gy7lnwln78ch4rw54g0pl5g1c189vawavll7p6rj";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "1m9z1k9kzva9n9kwinqxl97x2vgl79qhqjlv17k9s2ymcyv2bwr6";
+  })
+  (fetchNuGet {
+    name = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "1cpx56mcfxz7cpn57wvj18sjisvzq8b5vd9rw16ihd2i6mcp3wa1";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "15gsm1a8jdmgmf8j5v1slfz8ks124nfdhk2vxs2rw3asrxalg8hi";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "0q0n5q1r1wnqmr5i5idsrd9ywl33k0js4pngkwq9p368mbxp8x1w";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.2";
+    sha256 = "1x0g58pbpjrmj2x2qw17rdwwnrcl0wvim2hdwz48lixvwvp22n9c";
+  })
+  (fetchNuGet {
+    name = "StreamJsonRpc";
+    version = "2.6.121";
+    sha256 = "0xzvpk17w2skndzdg47j7gkrrvw6521db4mv8lc3v8hm97vs9m76";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.3.0";
+    sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.7.1";
+    sha256 = "1nh4nlxfc7lbnbl86wwk1a3jwl6myz5j6hvgh5sp4krim9901hsq";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.3.0";
+    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+  })
+  (fetchNuGet {
+    name = "System.CommandLine";
+    version = "2.0.0-beta1.20253.1";
+    sha256 = "16saf1fm9q80bb624fkqz0ksrwpnbw9617d7xg3jib7a2wgagm2r";
+  })
+  (fetchNuGet {
+    name = "System.CommandLine";
+    version = "2.0.0-beta1.20303.1";
+    sha256 = "0isnz8ipqlqim06hf56zlaq2vnsy5facvf5nvq6kzm5h1dm3l2vn";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Annotations";
+    version = "4.7.0";
+    sha256 = "06x1m46ddxj0ng28d7gry9gjkqdg2kp89jyf480g5gznyybbs49z";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.3.0";
+    sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.3.0";
+    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.3.0";
+    sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.3.0";
+    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.3.0";
+    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.3.0";
+    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+  })
+  (fetchNuGet {
+    name = "System.IO.Pipelines";
+    version = "4.7.2";
+    sha256 = "16v4qaypm72cfsfqr8z3k6yrpzn0m3apgkh6aljfwpycdk150sf9";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.3.0";
+    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.3.0";
+    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.3";
+    sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.4";
+    sha256 = "14gbbs22mcxwggn0fcfs1b062521azb9fbb7c113x0mq6dzq9h6y";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.3.4";
+    sha256 = "0kdp31b8819v88l719j6my0yas6myv9d1viql3qz5577mv819jhl";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.3.0";
+    sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets";
+    version = "4.3.0";
+    sha256 = "1gfj800078kggcgl0xyl00a6y5k4wwh2k2qm69rjy22wbmq7fy4p";
+  })
+  (fetchNuGet {
+    name = "System.Numerics.Vectors";
+    version = "4.5.0";
+    sha256 = "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.6.0";
+    sha256 = "0hry2k6b7kicg4zxnq0hhn0ys52711pxy7l9v5sp7gvp9cicwpgp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.7.0";
+    sha256 = "121l1z2ypwg02yz84dy6gr82phpys0njk7yask3sihgy214w43qp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.3.0";
+    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.3.0";
+    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.3.0";
+    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.2";
+    sha256 = "1vz4275fjij8inf31np78hw50al8nqkngk04p3xv5n4fcmf1grgi";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.7.1";
+    sha256 = "119br3pd85lq8zcgh4f60jzmv1g976q1kdgi3hvqdlhfbw6siz2j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.3.0";
+    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.3.0";
+    sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.3.0";
+    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+  })
+  (fetchNuGet {
+    name = "System.Security.AccessControl";
+    version = "4.6.0";
+    sha256 = "1wl1dyghi0qhpap1vgfhg2ybdyyhy9vc2a7dpm1xb30vfgmlkjmf";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.3.0";
+    sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.3.0";
+    sha256 = "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.3.0";
+    sha256 = "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.3.0";
+    sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.3.0";
+    sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.3.0";
+    sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.6.0";
+    sha256 = "1jmfzfz1n8hp63s5lja5xxpzkinbp6g59l3km9h8avjiisdrg5wm";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Dataflow";
+    version = "4.11.1";
+    sha256 = "09fbfsiay1xcbpvnq2j38b6mb2scvf0s8mpn78bcqsldidg7k2vw";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.5.4";
+    sha256 = "0y6ncasgfcgnjrhynaf0lwpkpkmv4a07sswwkwbwb5h7riisj153";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.3.0";
+    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+  })
+  (fetchNuGet {
+    name = "WaylandNET";
+    version = "0.2.0";
+    sha256 = "1qjpvra08vdqdw4j1gamz6451x5sd5r1j86lsvrl8akq4nymfr8k";
+  })
+]

--- a/pkgs/tools/X11/opentabletdriver/shell.nix
+++ b/pkgs/tools/X11/opentabletdriver/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import ../../../../. {} }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    common-updater-scripts
+    curl
+    dotnetCorePackages.sdk_5_0
+    jq
+  ];
+}

--- a/pkgs/tools/X11/opentabletdriver/update.sh
+++ b/pkgs/tools/X11/opentabletdriver/update.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env nix-shell
+#!nix-shell shell.nix -i bash
+
+set -eo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+deps_file="$(realpath "./deps.nix")"
+
+new_version="$(curl -s "https://api.github.com/repos/InfinityGhost/OpenTabletDriver/releases" | jq -r '.[0].tag_name' | sed 's|[^0-9.]||g')"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "Up to date"
+  [[ "${1}" != "--force" ]] && exit 0
+fi
+
+cd ../../../..
+update-source-version opentabletdriver "$new_version"
+store_src="$(nix-build . -A opentabletdriver.src --no-out-link)"
+src="$(mktemp -d /tmp/opentabletdriver-src.XXX)"
+echo "Temp src dir: $src"
+cp -rT "$store_src" "$src"
+chmod -R +w "$src"
+
+pushd "$src"
+
+# Setup empty nuget package folder to force reinstall.
+mkdir ./nuget_tmp.packages
+cat >./nuget_tmp.config <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="$(realpath ./nuget_tmp.packages)" />
+  </config>
+</configuration>
+EOF
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+for project in OpenTabletDriver.{Console,Daemon,UX.Gtk}; do
+    dotnet restore $project --configfile ./nuget_tmp.config
+done
+
+echo "{ fetchNuGet }: [" >"$deps_file"
+while read pkg_spec; do
+  { read pkg_name; read pkg_version; } < <(
+    # Build version part should be ignored: `3.0.0-beta2.20059.3+77df2220` -> `3.0.0-beta2.20059.3`
+    sed -nE 's/.*<id>([^<]*).*/\1/p; s/.*<version>([^<+]*).*/\1/p' "$pkg_spec")
+  pkg_sha256="$(nix-hash --type sha256 --flat --base32 "$(dirname "$pkg_spec")"/*.nupkg)"
+  cat >>"$deps_file" <<EOF
+  (fetchNuGet {
+    name = "$pkg_name";
+    version = "$pkg_version";
+    sha256 = "$pkg_sha256";
+  })
+EOF
+done < <(find ./nuget_tmp.packages -name '*.nuspec' | sort)
+echo "]" >>"$deps_file"
+
+popd
+rm -r "$src"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23378,6 +23378,11 @@ in
     libtiff = callPackage ../applications/graphics/opentoonz/libtiff.nix { };
   })).callPackage ../applications/graphics/opentoonz { };
 
+  opentabletdriver = callPackage ../tools/X11/opentabletdriver {
+    dotnet-sdk = dotnetCorePackages.sdk_5_0;
+    dotnet-netcore = dotnetCorePackages.net_5_0;
+  };
+
   opentx = libsForQt5.callPackage ../applications/misc/opentx { };
 
   opera = callPackage ../applications/networking/browsers/opera {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/InfinityGhost/OpenTabletDriver

OpenTabletDriver is an open source, cross platform, user mode tablet driver. The goal of OpenTabletDriver is to be cross platform as possible with the highest compatibility in an easily configurable graphical user interface.

It supports multiple tablets that are badly supported in Linux. Even for tablets already supported by other means (i.e.: libinput or xf86-input-wacom), OpenTabletDriver offers a graphical interface, plugins and more customization.

List of supported tablets: https://github.com/InfinityGhost/OpenTabletDriver/projects/4

Closes #107544.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
