### PR TITLE
monsoon: init at 0.6.0

### DIFF
--- a/pkgs/tools/security/monsoon/default.nix
+++ b/pkgs/tools/security/monsoon/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "monsoon";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "RedTeamPentesting";
+    repo = "monsoon";
+    rev = "v${version}";
+    sha256 = "01c84s11m645mqaa2vdnbsj0kb842arqjhicgjv0ahb7qdw65zz4";
+  };
+
+  vendorSha256 = "1g84az07hv8w0jha2yl4f5jm0p9nkbawgw9l7cpmn8ckbfa54l7q";
+
+  # tests fails on darwin
+  doCheck = !stdenv.isDarwin;
+
+  meta = with stdenv.lib; {
+    description = "Fast HTTP enumerator";
+    longDescription = ''
+      A fast HTTP enumerator that allows you to execute a large number of HTTP
+      requests, filter the responses and display them in real-time.
+    '';
+    homepage = "https://github.com/RedTeamPentesting/monsoon";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2455,6 +2455,8 @@ in
 
   mons = callPackage ../tools/misc/mons {};
 
+  monsoon = callPackage ../tools/security/monsoon {};
+
   mousetweaks = callPackage ../applications/accessibility/mousetweaks {
     inherit (pkgs.xorg) libX11 libXtst libXfixes;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
monsoon (https://github.com/RedTeamPentesting/monsoon) is a ast HTTP enumerator.

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
