### PR TITLE
conduktor: init at 2.15.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10247,6 +10247,12 @@
     githubId = 9870613;
     name = "Hubert Mühlhans";
   };
+  trobert = {
+    email = "thibaut.robert@gmail.com";
+    github = "trobert";
+    githubId = 504580;
+    name = "Thibaut Robert";
+  };
   troydm = {
     email = "d.geurkov@gmail.com";
     github = "troydm";

--- a/pkgs/applications/misc/conduktor/default.nix
+++ b/pkgs/applications/misc/conduktor/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, fetchurl, fetchzip, jdk11, unzip, makeWrapper, makeDesktopItem, copyDesktopItems }:
+
+stdenv.mkDerivation rec {
+  pname = "conduktor";
+  version = "2.15.1";
+
+  src = fetchzip {
+    url = "https://github.com/conduktor/builds/releases/download/v${version}/Conduktor-linux-${version}.zip";
+    sha256 = "1kr5yh9piqbl6njsnxgh6jzf3vifw8ja5x4qm4znmzi3r49sw0gx";
+  };
+
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+
+  desktopItems = makeDesktopItem {
+    type = "Application";
+    name = pname;
+    desktopName = "Conduktor";
+    genericName = meta.description;
+    exec = pname;
+    icon = fetchurl {
+      url = "https://github.com/conduktor/builds/raw/v${version}/.github/resources/Conduktor.png";
+      sha256 = "0s7p74qclvac8xj2m22gfxx5m2c7cf0nqpk5sb049p2wvryhn2j4";
+    };
+    comment = "A beautiful and fully-featured desktop client for Apache Kafka";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/applications
+    mv * $out
+    wrapProgram "$out/bin/conduktor" --set JAVA_HOME "${jdk11.home}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Apache Kafka Desktop Client";
+    longDescription = ''
+      Conduktor is a GUI over the Kafka ecosystem, to make the development
+      and management of Apache Kafka clusters as easy as possible.
+    '';
+    homepage = "https://www.conduktor.io/";
+    changelog = "https://www.conduktor.io/changelog/#${version}";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ trobert ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3726,6 +3726,8 @@ in
 
   conda = callPackage ../tools/package-management/conda { };
 
+  conduktor = callPackage ../applications/misc/conduktor { };
+
   console-bridge = callPackage ../development/libraries/console-bridge { };
 
   convbin = callPackage ../tools/misc/convbin { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add conduktor (https://www.conduktor.io/)

Conduktor is a GUI over the Kafka ecosystem, to make the development and management of Apache Kafka clusters as easy as possible.

Free of charge for a single broker.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
