### PR TITLE
libmesode: 0.9.3 -> 0.10.1

### DIFF
--- a/pkgs/development/libraries/libmesode/default.nix
+++ b/pkgs/development/libraries/libmesode/default.nix
@@ -1,32 +1,32 @@
-{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, libtool, openssl, expat, pkgconfig, check }:
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, libtool
+, openssl
+, expat
+, pkg-config
+, check
+}:
 
 stdenv.mkDerivation rec {
   pname = "libmesode";
-  version = "0.9.3";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
-    owner = "boothj5";
+    owner = "profanity-im";
     repo = "libmesode";
     rev = version;
-    sha256 = "0xzfg1xx88cn36352nnjlb1p7xyw32yqkhjzq10px88iaaqz1vv0";
+    sha256 = "1bxnkhrypgv41qyy1n545kcggmlw1hvxnhwihijhhcf2pxd2s654";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-ssl-certificate-verification.diff";
-      url = "https://github.com/profanity-im/libmesode/commit/532ed1e9d3e71e5bea0752e03dbacd4139d750d1.diff";
-      sha256 = "140jp7xzskik0sb6aqjsw7z477a124cxl7dkm80m2nyzjng4pzg5";
-    })
-  ];
-
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ openssl expat libtool check ];
 
   dontDisableStatic = true;
 
   doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Fork of libstrophe (https://github.com/strophe/libstrophe) for use with Profanity XMPP Client";
     longDescription = ''
       Reasons for forking:
@@ -39,9 +39,10 @@ stdenv.mkDerivation rec {
       Whilst Profanity will run against libstrophe, libmesode provides extra
       TLS functionality such as manual SSL certificate verification.
     '';
-    homepage = "https://github.com/boothj5/libmesode/";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    homepage = "https://github.com/profanity-im/libmesode/";
+    license = with licenses; [ gpl3Only mit];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ devhell ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
