### PR TITLE
libstrophe: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/development/libraries/libstrophe/default.nix
+++ b/pkgs/development/libraries/libstrophe/default.nix
@@ -1,11 +1,10 @@
 { stdenv
 , fetchFromGitHub
-, pkg-config
-, automake
-, autoconf
+, autoreconfHook
 , libtool
 , openssl
 , expat
+, pkg-config
 , check
 }:
 
@@ -17,15 +16,13 @@ stdenv.mkDerivation rec {
     owner = "strophe";
     repo = pname;
     rev = version;
-    sha256 = "sha256-6byg7hE0DN/cbf9NHpK/2DhXZyuelYAp+SA7vVUgo4U=";
+    sha256 = "11d341avsfr0z4lq15cy5dkmff6qpy91wkgzdpfdy31l27pa1g79";
   };
 
-  nativeBuildInputs = [ automake autoconf pkg-config libtool check ];
-  buildInputs = [ openssl expat ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ openssl expat libtool check ];
 
   dontDisableStatic = true;
-
-  preConfigure = "mkdir m4 && sh bootstrap.sh";
 
   doCheck = true;
 
@@ -37,8 +34,10 @@ stdenv.mkDerivation rec {
       runs well on both Linux, Unix, and Windows based platforms.
     '';
     homepage = "https://strophe.im/libstrophe/";
-    license = with licenses; [ gpl3 mit ];
+    license = with licenses; [ gpl3Only mit ];
     platforms = platforms.unix;
+    broken = stdenv.isDarwin;
     maintainers = with maintainers; [ devhell flosse ];
   };
 }
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
