### PR TITLE
apacheHttpd, nixos/httpd: set lua paths

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -126,6 +126,13 @@ let
     </IfModule>
   '';
 
+  luaSetPaths = ''
+    <IfModule mod_lua.c>
+      LuaPackageCPath ${cfg.package.lua5}/lib/lua/${cfg.package.lua5.lua.luaversion}/?.so
+      LuaPackagePath  ${cfg.package.lua5}/share/lua/${cfg.package.lua5.lua.luaversion}/?.lua
+    </IfModule>
+  '';
+
   mkVHostConf = hostOpts:
     let
       adminAddr = if hostOpts.adminAddr != null then hostOpts.adminAddr else cfg.adminAddr;
@@ -325,6 +332,8 @@ let
     TraceEnable off
 
     ${sslConf}
+
+    ${if cfg.package.luaSupport then luaSetPaths else ""}
 
     # Fascist default - deny access to everything.
     <Directory />

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit apr aprutil sslSupport proxySupport ldapSupport;
+    inherit apr aprutil sslSupport proxySupport ldapSupport luaSupport lua5;
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Without this, lua script handlers do not find the packages that are provided with the lua package.
Note that, since the `luaSupport` argument of the `apacheHttpd` derivation defaults to `false`, this wont change the generated config file unless the derivation is built with lua support enabled.

More information on the used apache directives is here:
  https://httpd.apache.org/docs/trunk/mod/mod_lua.html#luapackagepath
  https://httpd.apache.org/docs/trunk/mod/mod_lua.html#luapackagecpath
  

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
