### PR TITLE
datasette: 0.46 -> 0.53

### DIFF
--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -14,6 +14,7 @@
 , python-baseconv
 , pyyaml
 , uvicorn
+, httpx
 # Check Inputs
 , pytestCheckHook
 , pytestrunner
@@ -26,13 +27,13 @@
 
 buildPythonPackage rec {
   pname = "datasette";
-  version = "0.46";
+  version = "0.53";
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "datasette";
     rev = version;
-    sha256 = "0g4dfq5ykifa9628cb4i7gvx98p8hvb99gzfxk3bkvq1v9p4kcqq";
+    sha256 = "1rsgxkvav1qy2ia2csm1jvabd8klh3ly8719979gdlx2il1cjjkz";
   };
 
   nativeBuildInputs = [ pytestrunner ];
@@ -52,6 +53,8 @@ buildPythonPackage rec {
     pyyaml
     uvicorn
     setuptools
+    httpx
+    asgiref
   ];
 
   checkInputs = [
@@ -59,7 +62,6 @@ buildPythonPackage rec {
     pytest-asyncio
     aiohttp
     beautifulsoup4
-    asgiref
   ];
 
   postConfigure = ''
@@ -75,9 +77,9 @@ buildPythonPackage rec {
 
   # takes 30-180 mins to run entire test suite, not worth the cpu resources, slows down reviews
   # with pytest-xdist, it still takes around 10mins with 32 cores
-  # just run the messages tests, as this should give some indictation of correctness
+  # just run the csv tests, as this should give some indictation of correctness
   pytestFlagsArray = [
-    "tests/test_messages.py"
+    "tests/test_csv.py"
   ];
   disabledTests = [
     "facet"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Unbreak datasette on hydra (https://hydra.nixos.org/build/133682915) by upgrading to latest release.

Checked that the datasette binary works. Verified license is still correct.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
