### PR TITLE
mathics: init at 1.1.1

### DIFF
--- a/pkgs/applications/science/math/mathics/default.nix
+++ b/pkgs/applications/science/math/mathics/default.nix
@@ -1,0 +1,53 @@
+{ lib, fetchFromGitHub, buildPythonApplication, isPy3k
+, sympy, numpy, pint, django_3, mpmath, dateutil, llvmlite, requests
+, palettable, setuptools, wordcloud, scikitimage, python
+}:
+
+let
+  deps = [
+    sympy numpy pint django_3 mpmath dateutil llvmlite requests
+    palettable setuptools wordcloud scikitimage
+  ];
+  pythonEnv = python.withPackages (p: deps);
+in
+  buildPythonApplication rec {
+    pname = "mathics";
+    version = "1.1.1";
+
+    src = fetchFromGitHub {
+      owner = "mathics";
+      repo = "Mathics";
+      rev = version;
+      sha256 = "sha256-6VCz/pd2kRUkezCoXjqvPYhbzHojHQZ7y//NAFrPHas=";
+    };
+
+    propagatedBuildInputs = deps;
+
+    postPatch = ''
+      substituteInPlace mathics/server.py \
+        --replace "sys.executable, " ""
+    '';
+
+    # We run tests at the `postInstall` stage. This also installs documentation.
+    doCheck = false;
+
+    postInstall = ''
+      rm $out/bin/dmathics*
+
+      # the purpose of the following command is to generate documentation
+      SANDBOX=true python mathics/test.py --keep-going
+
+      for manage in $(find $out -name manage.py); do
+        chmod +x $manage
+        wrapProgram $manage --set PYTHONPATH "$PYTHONPATH:${pythonEnv}/${pythonEnv.sitePackages}"
+      done
+    '';
+
+    disabled = !isPy3k;
+    meta = with lib; {
+      description = "A free, light-weight alternative to Mathematica";
+      homepage = "https://mathics.github.io/";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [ suhr ];
+    };
+  }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -374,7 +374,6 @@ mapAliases ({
   marathon = throw "marathon has been removed from nixpkgs, as it's unmaintained"; # added 2020-08-15
   mariadb-client = hiPrio mariadb.client; #added 2019.07.28
   matcha = throw "matcha was renamed to matcha-gtk-theme"; # added 2020-05-09
-  mathics = throw "mathics has been removed from nixpkgs, as it's unmaintained"; # added 2020-08-15
   matrique = spectral; # added 2020-01-27
   mbedtls_1_3 = throw "mbedtls_1_3 is end of life, see https://tls.mbed.org/kb/how-to/upgrade-2.0"; # added 2019-12-08
   mess = mame; # added 2019-10-30

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27951,6 +27951,8 @@ in
   mathematica10 = callPackage ../applications/science/math/mathematica/10.nix { };
   mathematica11 = callPackage ../applications/science/math/mathematica/11.nix { };
 
+  mathics = python3Packages.callPackage ../applications/science/math/mathics { };
+
   metis = callPackage ../development/libraries/science/math/metis {};
 
   nauty = callPackage ../applications/science/math/nauty {};


### PR DESCRIPTION
###### Motivation for this change

Mathics is back. This PR adds mathics at version [1.1.1](https://github.com/mathics/Mathics/releases/tag/1.1.1), released just three days ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
