### PR TITLE
gpy: unbreak on python3.9

### DIFF
--- a/pkgs/development/python-modules/gpy/default.nix
+++ b/pkgs/development/python-modules/gpy/default.nix
@@ -1,5 +1,14 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, numpy, scipy, six, paramz, nose, matplotlib, cython }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, six
+, paramz
+, matplotlib
+, cython
+, nose
+}:
 
 buildPythonPackage rec {
   pname = "GPy";
@@ -10,21 +19,35 @@ buildPythonPackage rec {
     sha256 = "04faf0c24eacc4dea60727c50a48a07ddf9b5751a3b73c382105e2a31657c7ed";
   };
 
-  # running tests produces "ImportError: cannot import name 'linalg_cython'"
-  # even though Cython has run
-  checkPhase = "nosetests -d";
-  doCheck = false;
-
+  buildInputs = [ cython ];
+  propagatedBuildInputs = [ numpy scipy six paramz matplotlib ];
   checkInputs = [ nose ];
 
-  buildInputs = [ cython ];
+  # $ nosetests GPy/testing/*.py
+  # => Ran 483 tests in 112.146s (on 8 cores)
+  # So instead, run shorter set of tests
+  checkPhase = ''
+    nosetests GPy/testing/linalg_test.py
+  '';
 
-  propagatedBuildInputs = [ numpy scipy six paramz matplotlib ];
+  # Rebuild cython-generated .c files since the included
+  # ones were built with an older version of cython that is
+  # incompatible with python3.9
+  preBuild = ''
+    for fn in $(find . -name '*.pyx'); do
+      echo $fn | sed 's/\.\.pyx$/\.c/' | xargs ${cython}/bin/cython -3
+    done
+  '';
+
+  pythonImportsCheck = [
+    "GPy"
+  ];
 
   meta = with stdenv.lib; {
     description = "Gaussian process framework in Python";
     homepage = "https://sheffieldml.github.io/GPy";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
+    broken = stdenv.isDarwin;  # See inscrutable error message here: https://github.com/NixOS/nixpkgs/pull/107653#issuecomment-751527547
   };
 }

--- a/pkgs/development/python-modules/paramz/default.nix
+++ b/pkgs/development/python-modules/paramz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, six, decorator }:
+{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, six, decorator, nose }:
 
 buildPythonPackage rec {
   pname = "paramz";
@@ -10,6 +10,12 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy scipy six decorator ];
+  checkInputs = [ nose ];
+
+  # Ran 113 tests in 3.082s
+  checkPhase = ''
+      nosetests -v paramz/tests
+  '';
 
   meta = with stdenv.lib; {
     description = "Parameterization framework for parameterized model creation and handling";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Gpy is currently not compiling on python3.9 (https://hydra.nixos.org/build/133670737)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
