### PR TITLE
WIP: matrix-registration: init 1.0.0.dev4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -518,6 +518,7 @@
   ./services/misc/mame.nix
   ./services/misc/matrix-appservice-discord.nix
   ./services/misc/matrix-appservice-irc.nix
+  ./services/misc/matrix-registration.nix
   ./services/misc/matrix-synapse.nix
   ./services/misc/mautrix-telegram.nix
   ./services/misc/mbpfan.nix

--- a/nixos/modules/services/misc/matrix-registration.nix
+++ b/nixos/modules/services/misc/matrix-registration.nix
@@ -1,0 +1,225 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  dataDir = "/var/lib/matrix-registration";
+  cfg = config.services.matrix-registration;
+  format = pkgs.formats.yaml { };
+
+  matrix-registration-config =
+    format.generate "config.yaml" cfg.settings;
+  matrix-registration-cli-wrapper = pkgs.stdenv.mkDerivation {
+    name = "matrix-registration-cli-wrapper";
+    buildInputs = [ pkgs.makeWrapper ];
+    buildCommand = ''
+      mkdir -p $out/bin
+      makeWrapper ${pkgs.matrix-registration}/bin/matrix-registration "$out/bin/matrix-registration" \
+        --add-flags "--config-path='${matrix-registration-config}'"
+    '';
+  };
+  serviceDependencies = optional config.services.matrix-synapse.enable "matrix-synapse.service";
+
+  synapse_port = (lists.findFirst
+    (
+      listener: lists.any
+        (
+          resource: (builtins.elem "client" resource.names)
+        )
+        listener.resources
+    ) 0
+    config.services.matrix-synapse.listeners).port;
+
+in
+{
+  options.services.matrix-registration = {
+    enable = mkEnableOption "matrix-registration";
+
+    settings = mkOption {
+      default = { };
+      description = "matrix-registration configuration.";
+      type = types.submodule {
+        freeformType = format.type;
+
+        options = {
+          server_location = mkOption {
+            type = types.str;
+            description = ''
+              The client base URL.
+              It is necessary that `/_synapse/admin/v1/register` is reachable.
+              Using a local address is recommended.
+            '';
+            example = "https://matrix.example.tld";
+            default = optionalString (synapse_port > 0)
+              "http://localhost:${builtins.toString synapse_port}";
+          };
+          server_name = mkOption {
+            type = types.str;
+            description = "The server name of your homeserver.";
+            example = "example.tld";
+            default = optionalString config.services.matrix-synapse.enable
+              config.services.matrix-synapse.server_name;
+          };
+          registration_shared_secret = mkOption {
+            type = types.str;
+            default = "";
+            description = ''
+              The registration secret shared with the synapse configuration.
+              This option is discouraged, use the <literal>credentialsFile</literal> option if possible instead.
+            '';
+            example = "RegistrationSharedSecret";
+          };
+          admin_api_shared_secret = mkOption {
+            type = types.str;
+            default = "APIAdminPassword";
+            description = ''
+              The admin secret to access the API.
+              This option is discouraged, use the <literal>credentialsFile</literal> option if possible instead.
+            '';
+            example = "APIAdminPassword";
+          };
+          base_url = mkOption {
+            type = types.str;
+            description = "A prefix for all endpoints.";
+            default = "";
+          };
+          client_redirect = mkOption {
+            type = types.str;
+            description =
+              "The client instance to redirect after succesful registration.";
+            default = "https://app.element.io/#/login";
+          };
+          client_logo = mkOption {
+            type = types.path;
+            description = "The client logo to display.";
+            default =
+              "${pkgs.matrix-registration}/lib/python3.8/site-packages/matrix_registration/static/images/element-logo.png";
+          };
+          db = mkOption {
+            type = types.str;
+            default = "sqlite:///${dataDir}/db.sqlite3";
+            description = "Database URL.";
+          };
+          host = mkOption {
+            type = types.str;
+            default = "localhost";
+            description = "Which host to listen on.";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 5000;
+            description = "Which port to listen on.";
+          };
+          rate_limit = mkOption {
+            type = types.listOf types.str;
+            default = [ "100 per day" "10 per minute" ];
+            description =
+              "How often is one IP allowed to access matrix-registration.";
+          };
+          allow_cors = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Allow Cross Origin Resource Sharing.";
+          };
+          ip_logging = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Associate IPs to tokens used in the database.";
+          };
+          logging = mkOption {
+            type = types.attrs;
+            description = "Python logging configuration.";
+            default = {
+              disable_existing_loggers = false;
+              version = 1;
+              root = {
+                level = "DEBUG";
+                handlers = [ "console" ];
+              };
+              formatters = {
+                brief = { format = "%(name)s - %(levelname)s - %(message)s"; };
+              };
+              handlers = {
+                console = {
+                  class = "logging.StreamHandler";
+                  level = "INFO";
+                  formatter = "brief";
+                  stream = "ext://sys.stdout";
+                };
+              };
+            };
+          };
+          password.min_length = mkOption {
+            type = types.ints.positive;
+            default = 8;
+            description = "Minimum password length for the registered user.";
+          };
+        };
+      };
+    };
+
+    credentialsFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        File containing variables to be passed to the matrix-registration service,
+        in which secret tokens can be specified securely by defining values for:
+        <literal>registration_shared_secret</literal>,
+        <literal>admin_api_shared_secret</literal>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.matrix-registration = {
+      description =
+        "matrix-registration, a token based matrix registration api.";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ] ++ serviceDependencies;
+      after = [ "network-online.target" ] ++ serviceDependencies;
+
+      preStart = ''
+        # run automatic database init and migration scripts
+        ${pkgs.matrix-registration.alembic}/bin/alembic -x config='${matrix-registration-config}' upgrade head
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+
+        DynamicUser = true;
+        PrivateTmp = true;
+        WorkingDirectory =
+          pkgs.matrix-registration; # necessary for the database migration scripts to be found
+        StateDirectory = baseNameOf dataDir;
+        UMask = 27;
+
+        LoadCredential = mkIf (cfg.credentialsFile != null) "secrets:${cfg.credentialsFile}";
+
+        ExecStart = ''
+          ${pkgs.matrix-registration}/bin/matrix-registration \
+            --config-path="${matrix-registration-config}" \
+            serve
+        '';
+      };
+    };
+
+    environment.systemPackages = [ matrix-registration-cli-wrapper ];
+
+    assertions = [
+      {
+        assertion = cfg.settings.server_location != "";
+        message = "can't find server location automatically, "
+          + "please set `config.services.matrix-registration.settings.server_location`";
+      }
+    ];
+  };
+
+  meta.maintainers = with maintainers; [ zeratax ];
+}

--- a/pkgs/servers/matrix-registration/default.nix
+++ b/pkgs/servers/matrix-registration/default.nix
@@ -1,0 +1,68 @@
+{ pkgs, lib, fetchFromGitHub, python3Packages }:
+
+with python3Packages;
+
+let
+  # officially supported database drivers
+  dbDrivers = [
+    psycopg2
+    # sqlite driver is already shipped with python by default
+  ];
+
+in
+buildPythonPackage rec {
+  pname = "matrix-registration";
+  version = "1.0.0.dev4";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ZerataX";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "00ky8gqs7860yy1mx7rfcdrmph4s9cqqg887sxxn5vjf3a6nhwnx";
+  };
+
+  postPatch = ''
+    sed -i -e '/alembic>/d' setup.py
+    sed -i -e 's/~=/>=/' setup.py
+  '';
+
+  propagatedBuildInputs = [
+    appdirs
+    flask
+    flask-babel
+    flask-cors
+    flask-httpauth
+    flask-limiter
+    flask_sqlalchemy
+    python-dateutil
+    pyyaml
+    requests
+    waitress
+    wtforms
+  ] ++ dbDrivers;
+
+  checkInputs = [
+    flake8
+    parameterized
+  ];
+
+  # `alembic` (a database migration tool) is only needed for the initial setup,
+  # and not needed during the actual runtime. However `alembic` requires `matrix-registration`
+  # in its environment to create a database schema from all models.
+  #
+  # Hence we need to patch away `alembic` from `matrix-registration` and create an `alembic`
+  # which has `matrix-registration` in its environment.
+  passthru.alembic = alembic.overrideAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ dbDrivers ++ [
+      pkgs.matrix-registration
+    ];
+  });
+
+  meta = with lib; {
+    homepage = https://github.com/ZerataX/matrix-registration/;
+    description = "a token based matrix registration api";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zeratax ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6364,6 +6364,8 @@ in
 
   mathpix-snipping-tool = callPackage ../tools/misc/mathpix-snipping-tool { };
 
+  matrix-registration = callPackage ../servers/matrix-registration { };
+
   /* Python 3.8 is currently broken with matrix-synapse since `python38Packages.bleach` fails
     (https://github.com/NixOS/nixpkgs/issues/76093) */
   matrix-synapse = callPackage ../servers/matrix-synapse { /*python3 = python38;*/ };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

added my python module [matrix-registration](https://github.com/ZerataX/matrix-registration/) to nixos.

Since systemd 247 is merged I tried to set secrets securely via `credentialsFile`, but I am not sure if I understand this [mechanism](https://github.com/systemd/systemd/pull/16568/).
Currently setting it will fail with: 
```
matrix-registration.service: Failed to set up mount namespacing: /run/systemd/unit-root/run/credentials/matrix-registration.service: No such file or directory
matrix-registration.service: Failed at step NAMESPACE spawning /nix/store/9lbym293mblc59gfjr21ypvlcn377hgc-unit-script-matrix-registration-pre-start/bin/matrix-registration-pre-start: No such file or directory
```

As long as this setting is not set it should work.

A configuration like this
```nix
services.matrix-registration = {
  enable = true;
  settings = {
    admin_secret = "verysecuresecret";
    server_location = "http://localhost:8008";
    registration_shared_secret = config.services.matrix-registration.registration_shared_secret;
  };
  # credentialsFile = /etc/nixos/secrets;
};

services.matrix-synapse = {
  enable = true;

  database_type = "sqlite3";
  registration_shared_secret = "testsecret";

  listeners = [
    {
      port = 8008;
      bind_address = "::1";
      type = "http";
      tls = false;
      x_forwarded = true;
      resources = [
        {
          names = [ "client" "federation" ];
          compress = false;
        }
      ];
    }
  ];
};
```

should allow to create a token with:
```console
$ matrix-registration generate
DoubleWizardSky
```

and then to create an account either per webbrowser at localhost:5000/register
or per curl:
```console
curl -X POST \
     -F 'username=test' \
     -F 'password=verysecure' \
     -F 'confirm=verysecure' \
     -F 'token=DoubleWizardSki' \
     http://localhost:5000/register
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
