### PR TITLE
gitAndTools.ghr: init at 0.13.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -38,6 +38,8 @@ let
 
   ghq = callPackage ./ghq { };
 
+  ghr = callPackage ./ghr { };
+
   git = appendToName "minimal" gitBase;
 
   git-absorb = callPackage ./git-absorb {

--- a/pkgs/applications/version-management/git-and-tools/ghr/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghr/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "ghr";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "tcnksm";
+    repo = "ghr";
+    rev = "v${version}";
+    sha256 = "1nm5kdjkqayxh06j9nr5daic9sw9nx9w06y9gaqhdrw9byvjpr1a";
+  };
+
+  vendorSha256 = "14avsngzhl1b8a05i43ph6sxh9vj0jls0acxr9j7r0h3f0vpamcj";
+
+  # Tests require a Github API token, and networking
+  doCheck = false;
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/ghr --version
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tcnksm/ghr";
+    description = "Upload multiple artifacts to GitHub Release in parallel";
+    license = licenses.mit;
+    maintainers = [ maintainers.ivar ];
+  };
+}


### PR DESCRIPTION

###### Motivation for this change
Tests didn't seem to work, so I've added a simple check if the binary works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
