### PR TITLE
sympy: 1.6.2 -> 1.7.1

### DIFF
--- a/pkgs/applications/science/math/sage/patches/sympy-1.7-update.patch
+++ b/pkgs/applications/science/math/sage/patches/sympy-1.7-update.patch
@@ -1,0 +1,25 @@
+diff --git a/src/sage/interfaces/sympy.py b/src/sage/interfaces/sympy.py
+index cc35a42a9f..6e577d5d8d 100644
+--- a/src/sage/interfaces/sympy.py
++++ b/src/sage/interfaces/sympy.py
+@@ -397,7 +397,7 @@ def _sympysage_rf(self):
+         sage: from sympy import Symbol, rf
+         sage: _ = var('x, y')
+         sage: rfxy = rf(Symbol('x'), Symbol('y'))
+-        sage: assert rising_factorial(x,y)._sympy_() == rfxy.rewrite('gamma')
++        sage: assert rising_factorial(x,y)._sympy_() == rfxy.rewrite('gamma', piecewise=False)
+         sage: assert rising_factorial(x,y) == rfxy._sage_()
+     """
+     from sage.arith.all import rising_factorial
+diff --git a/src/sage/symbolic/expression.pyx b/src/sage/symbolic/expression.pyx
+index 7c18ec1efa..c2619ac42d 100644
+--- a/src/sage/symbolic/expression.pyx
++++ b/src/sage/symbolic/expression.pyx
+@@ -955,6 +955,6 @@ cdef class Expression(CommutativeRingElement):
+             sage: unicode_art(13 - I)
+             13 - ⅈ
+             sage: unicode_art(1.3 - I)
+-            1.3 - 1.0⋅ⅈ
++            1.3 - ⅈ
+             sage: unicode_art(cos(I))
+             cosh(1)

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -103,6 +103,9 @@ stdenv.mkDerivation rec {
 
     # adapt sage's Image class to pillow 8.0.1 (https://trac.sagemath.org/ticket/30971)
     ./patches/pillow-update.patch
+
+    # fix test output with sympy 1.7 (https://trac.sagemath.org/ticket/30985)
+    ./patches/sympy-1.7-update.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "sympy";
-  version = "1.6.2";
+  version = "1.7.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cfadcc80506e4b793f5b088558ca1fcbeaec24cd6fc86f1fdccaa3ee1d48708";
+    sha256 = "sha256-o96SYel1Nbg7uGB7DaLH0DEmZQ+v6isniWV7Ipwkay4=";
   };
 
   checkInputs = [ glibcLocales ];


### PR DESCRIPTION
###### Motivation for this change

Required by Mathics (https://github.com/NixOS/nixpkgs/pull/107652).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
