### PR TITLE
python38Packages.macropy, python39Packages.macropy: mark as broken

### DIFF
--- a/pkgs/development/python-modules/macropy/default.nix
+++ b/pkgs/development/python-modules/macropy/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , python
 , isPy27
+, pythonAtLeast
 , pinqSupport ? false, sqlalchemy
 , pyxlSupport ? false, pyxl3
 }:
@@ -34,5 +35,6 @@ buildPythonPackage rec {
     description = "Macros in Python: quasiquotes, case classes, LINQ and more";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = pythonAtLeast "3.8"; # see https://github.com/lihaoyi/macropy/issues/103
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package is broken for python3.8 and python3.9 (https://hydra.nixos.org/job/nixpkgs/trunk/python38Packages.macropy.x86_64-linux/all, https://hydra.nixos.org/job/nixpkgs/trunk/python39Packages.macropy.x86_64-linux/all) because of an upstream incompatibility. It's unclear to me if this package is still maintained at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
