### PR TITLE
yakuake: add missing kwayland dependency

### DIFF
--- a/pkgs/applications/kde/yakuake.nix
+++ b/pkgs/applications/kde/yakuake.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, kdoctools, extra-cmake-modules,
   karchive, kcrash, kdbusaddons, ki18n, kiconthemes, knewstuff, knotifications,
-  knotifyconfig, konsole, kparts, kwindowsystem, qtx11extras
+  knotifyconfig, konsole, kparts, kwayland, kwindowsystem, qtx11extras
 }:
 
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
 
   buildInputs = [
     karchive kcrash kdbusaddons ki18n kiconthemes knewstuff knotifications
-    knotifyconfig kparts kwindowsystem qtx11extras
+    knotifyconfig kparts kwayland kwindowsystem qtx11extras
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
The optional dependeny kwayland was missing, CMake complained about it.
It might be helpful once a Wayland Plasma5 session becomes reality.
See also: https://github.com/NixOS/nixpkgs/pull/100057

###### Motivation for this change
Ensure all applications are ready with full Wayland support once #100057 is merged.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] (N/A)) Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
