### PR TITLE
nixos/libinput: Make every option optional

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -335,6 +335,13 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
        official documentation</link> of the json_exporter.
      </para>
    </listitem>
+   <listitem>
+     <para>
+       All options inside <varname>services.xserver.libinput</varname> module now accepts <literal>null</literal>.
+       When set to <literal>null</literal> the option is not available in the resulting <literal>40-libinput.conf</literal>, using the default from X.org itself and allowing override using <xref linkend="opt-services.xserver.extraConfig" /> or <xref linkend="opt-services.xserver.inputClassSections" />.
+       Most options now defaults to <literal>null</literal>, so the behavior of libinput devices may be different from previous releases.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -24,8 +24,8 @@ in {
       };
 
       accelProfile = mkOption {
-        type = types.enum [ "flat" "adaptive" ];
-        default = "adaptive";
+        type = types.nullOr (types.enum [ "flat" "adaptive" ]);
+        default = null;
         example = "flat";
         description =
           ''
@@ -83,13 +83,13 @@ in {
       };
 
       leftHanded = mkOption {
-        type = types.bool;
-        default = false;
+        type = types.nullOr types.bool;
+        default = null;
         description = "Enables left-handed button orientation, i.e. swapping left and right buttons.";
       };
 
       middleEmulation = mkOption {
-        type = types.bool;
+        type = types.nullOr types.bool;
         default = true;
         description =
           ''
@@ -99,8 +99,8 @@ in {
       };
 
       naturalScrolling = mkOption {
-        type = types.bool;
-        default = false;
+        type = types.nullOr types.bool;
+        default = null;
         description = "Enables or disables natural scrolling behavior.";
       };
 
@@ -116,8 +116,8 @@ in {
       };
 
       scrollMethod = mkOption {
-        type = types.enum [ "twofinger" "edge" "button" "none" ];
-        default = "twofinger";
+        type = types.nullOr (types.enum [ "twofinger" "edge" "button" "none" ]);
+        default = null;
         example = "edge";
         description =
           ''
@@ -127,7 +127,7 @@ in {
       };
 
       horizontalScrolling = mkOption {
-        type = types.bool;
+        type = types.nullOr types.bool;
         default = true;
         description =
           ''
@@ -138,8 +138,8 @@ in {
       };
 
       sendEventsMode = mkOption {
-        type = types.enum [ "disabled" "enabled" "disabled-on-external-mouse" ];
-        default = "enabled";
+        type = types.nullOr (types.enum [ "disabled" "enabled" "disabled-on-external-mouse" ]);
+        default = null;
         example = "disabled";
         description =
           ''
@@ -149,7 +149,7 @@ in {
       };
 
       tapping = mkOption {
-        type = types.bool;
+        type = types.nullOr types.bool;
         default = true;
         description =
           ''
@@ -158,7 +158,7 @@ in {
       };
 
       tappingDragLock = mkOption {
-        type = types.bool;
+        type = types.nullOr types.bool;
         default = true;
         description =
           ''
@@ -169,8 +169,8 @@ in {
       };
 
       disableWhileTyping = mkOption {
-        type = types.bool;
-        default = false;
+        type = types.nullOr types.bool;
+        default = null;
         description =
           ''
             Disable input method while typing.
@@ -220,21 +220,21 @@ in {
           Identifier "libinputConfiguration"
           MatchDriver "libinput"
           ${optionalString (cfg.dev != null) ''MatchDevicePath "${cfg.dev}"''}
-          Option "AccelProfile" "${cfg.accelProfile}"
+          ${optionalString (cfg.accelProfile != null) ''Option "AccelProfile" "${cfg.accelProfile}"''}
           ${optionalString (cfg.accelSpeed != null) ''Option "AccelSpeed" "${cfg.accelSpeed}"''}
           ${optionalString (cfg.buttonMapping != null) ''Option "ButtonMapping" "${cfg.buttonMapping}"''}
           ${optionalString (cfg.calibrationMatrix != null) ''Option "CalibrationMatrix" "${cfg.calibrationMatrix}"''}
           ${optionalString (cfg.clickMethod != null) ''Option "ClickMethod" "${cfg.clickMethod}"''}
-          Option "LeftHanded" "${xorgBool cfg.leftHanded}"
-          Option "MiddleEmulation" "${xorgBool cfg.middleEmulation}"
-          Option "NaturalScrolling" "${xorgBool cfg.naturalScrolling}"
+          ${optionalString (cfg.leftHanded != null) ''Option "LeftHanded" "${xorgBool cfg.leftHanded}"''}
+          ${optionalString (cfg.middleEmulation != null) ''Option "MiddleEmulation" "${xorgBool cfg.middleEmulation}"''}
+          ${optionalString (cfg.naturalScrolling != null) ''Option "NaturalScrolling" "${xorgBool cfg.naturalScrolling}"''}
           ${optionalString (cfg.scrollButton != null) ''Option "ScrollButton" "${toString cfg.scrollButton}"''}
-          Option "ScrollMethod" "${cfg.scrollMethod}"
-          Option "HorizontalScrolling" "${xorgBool cfg.horizontalScrolling}"
-          Option "SendEventsMode" "${cfg.sendEventsMode}"
-          Option "Tapping" "${xorgBool cfg.tapping}"
-          Option "TappingDragLock" "${xorgBool cfg.tappingDragLock}"
-          Option "DisableWhileTyping" "${xorgBool cfg.disableWhileTyping}"
+          ${optionalString (cfg.scrollMethod != null) ''Option "ScrollMethod" "${cfg.scrollMethod}"''}
+          ${optionalString (cfg.horizontalScrolling != null) ''Option "HorizontalScrolling" "${xorgBool cfg.horizontalScrolling}"''}
+          ${optionalString (cfg.sendEventsMode != null) ''Option "SendEventsMode" "${cfg.sendEventsMode}"''}
+          ${optionalString (cfg.tapping != null) ''Option "Tapping" "${xorgBool cfg.tapping}"''}
+          ${optionalString (cfg.tappingDragLock != null) ''Option "TappingDragLock" "${xorgBool cfg.tappingDragLock}"''}
+          ${optionalString (cfg.disableWhileTyping != null) ''Option "DisableWhileTyping" "${xorgBool cfg.disableWhileTyping}"''}
           ${cfg.additionalOptions}
         EndSection
       '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The libinput module nowadays set some options as optional (i.e.: accepts null) and other options as required (i.e.: if not set it will be set with a default).

However, this module, since PR #73785, applies to all input devices. And this is an issue since many of the options here only make sense to touchpad (for example, NaturalScrolling). Worse than that, once any option is in this configuration it cannot be overriden by any of the existing mechanisms to override, like:

- `services.xserver.extraConfig`
- `services.xserver.inputClassSections`

The only one that works is `services.xserver.libinput.additionalOptions`, but this one does not support applying options to many targets. You can set `additionalOptions` with `MatchIsTouchpad "on"`, for example, but now you cannot apply options in other target unless you use one of the options above.

So what this PR does is convert every option to optional, and also setting to `null` any option that is already default in libinput itself. This way, most options will be available to override using
`services.xserver.extraConfig` or `services.xserver.inputClassSections`.

Closes https://github.com/NixOS/nixpkgs/issues/75007.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
