### PR TITLE
teler: init at 1.0.1

### DIFF
--- a/pkgs/tools/security/teler/default.nix
+++ b/pkgs/tools/security/teler/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "teler";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "kitabisa";
+    repo = "teler";
+    rev = "v${version}";
+    sha256 = "07pfqgms5cj4y6zm984qjmmw1c8j9yjbgrp2spi9vzk96s3k3qn3";
+  };
+
+  vendorSha256 = "06szi2jw3nayd7pljjlww2gsllgnfg8scnjmc6qv5xl6gf797kdz";
+
+  # test require internet access
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Real-time HTTP Intrusion Detection";
+    longDescription = ''
+      teler is an real-time intrusion detection and threat alert
+      based on web log that runs in a terminal with resources that
+      we collect and provide by the community.
+    '';
+    homepage = "https://github.com/kitabisa/teler";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7693,6 +7693,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  teler = callPackage ../tools/security/teler { };
+
   termius = callPackage ../applications/networking/termius { };
 
   termplay = callPackage ../tools/misc/termplay { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
teler is an real-time intrusion detection and threat alert
based on web log that runs in a terminal with resources that
we collect and provide by the community.

https://github.com/kitabisa/teler

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
