### PR TITLE
raspberrypi-tools: fix build on x86_64-linux

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/tools.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/tools.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig }:
 
 stdenv.mkDerivation {
   pname = "raspberrypi-tools";
@@ -13,6 +13,14 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
+  patches = [
+    (fetchpatch {
+      # https://github.com/raspberrypi/userland/pull/670
+      url = "https://github.com/raspberrypi/userland/pull/670/commits/37cb44f314ab1209fe2a0a2449ef78893b1e5f62.patch";
+      sha256 = "1fbrbkpc4cc010ji8z4ll63g17n6jl67kdy62m74bhlxn72gg9rw";
+    })
+  ];
+
   preConfigure = ''
     cmakeFlagsArray+=("-DVMCS_INSTALL_PREFIX=$out")
   '' + stdenv.lib.optionalString stdenv.isAarch64 ''
@@ -23,7 +31,7 @@ stdenv.mkDerivation {
     description = "Userland tools for the Raspberry Pi board";
     homepage = "https://github.com/raspberrypi/userland";
     license = licenses.bsd3;
-    platforms = [ "armv6l-linux" "armv7l-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ dezgeg tavyc ];
   };
 }


### PR DESCRIPTION
This allows using tools such as `dtmerge` on x86_64-linux.

Motivated by https://github.com/kwohlfahrt/nixpkgs/commit/7ba456e500addef74ca30f7bcefecbef1f94ae96.

###### Motivation for this change
Use `dtmerge` on x86_64-linux (while cross-compiling raspberry pi images)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
