### PR TITLE
haskellPackages.Agda: Fix build for ghc 8.10.2 → 8.10.3 upgrade

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -98,4 +98,10 @@ self: super: {
 
   # Break out of "Cabal < 3.2" constraint.
   stylish-haskell = doJailbreak super.stylish-haskell;
+
+  # Agda 2.6.1.2 only declares a transformers dependency for ghc < 8.10.3.
+  Agda = appendPatch super.Agda (pkgs.fetchpatch {
+    url = "https://github.com/agda/agda/commit/76278c23d447b49f59fac581ca4ac605792aabbc.patch";
+    sha256 = "1g34g8a09j73h89pk4cdmri0nb0qg664hkff45amcr9kyz14a9f3";
+  });
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -100,6 +100,7 @@ self: super: {
   stylish-haskell = doJailbreak super.stylish-haskell;
 
   # Agda 2.6.1.2 only declares a transformers dependency for ghc < 8.10.3.
+  # https://github.com/agda/agda/issues/5109
   Agda = appendPatch super.Agda (pkgs.fetchpatch {
     url = "https://github.com/agda/agda/commit/76278c23d447b49f59fac581ca4ac605792aabbc.patch";
     sha256 = "1g34g8a09j73h89pk4cdmri0nb0qg664hkff45amcr9kyz14a9f3";


### PR DESCRIPTION
###### Motivation for this change

Commit 1998b95adc6b5a9aef336e45955a01575bd898f1 “haskellPackages: update default compiler from ghc 8.10.2 to version 8.10.3” broke Agda because Agda.cabal incorrectly declares a transformers dependency only for ghc < 8.10.3:

    if impl(ghc >= 8.6.4) && impl(ghc < 8.10.3)
      build-depends: transformers == 0.5.6.2

    if impl(ghc >= 8.4) && impl(ghc < 8.6.4)
      build-depends: transformers == 0.5.5.0

    if impl(ghc < 8.4)
      build-depends: transformers == 0.5.2.0

leading to this error:

    src/full/Agda/Utils/Maybe.hs:13:1: error:
    Could not load module ‘Control.Monad.Trans.Maybe’
    It is a member of the hidden package ‘transformers-0.5.6.2’.
    Perhaps you need to add ‘transformers’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
       |
    13 | import Control.Monad.Trans.Maybe
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
