### PR TITLE
XMonad: configured recompile

### DIFF
--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -103,6 +103,7 @@ in {
         example = ''
           import XMonad
           import XMonad.Util.EZConfig (additionalKeys)
+          import Control.Monad (when)
           import Text.Printf (printf)
           import System.Posix.Process (executeFile)
           import System.Info (arch,os)

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -84,13 +84,13 @@ in {
           This setup is then analogous to other (non-NixOS) linux distributions.
 
           If you do set this option, you likely want to use "launch" as your
-          entry point for xmonad (as in the example), to avoid xmonads
+          entry point for xmonad (as in the example), to avoid xmonad's
           recompilation logic on startup. Doing so will render the default
           "mod+q" restart key binding dysfunctional though, because that attempts
           to call your binary with the "--restart" command line option, unless
           you implement that yourself. You way mant to bind "mod+q" to
           <literal>(restart "xmonad" True)</literal> instead, which will just restart
-          xmonad from PATH. This allows e.g. switching to the new xmonad binary,
+          xmonad from PATH. This allows e.g. switching to the new xmonad binary
           after rebuilding your system with nixos-rebuild.
 
           If you actually want to run xmonad with a config specified here, but

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -27,6 +27,7 @@ let
       pkgs.runCommandLocal "xmonad" {
         nativeBuildInputs = [ pkgs.makeWrapper ];
       } ''
+        install -D ${xmonadEnv}/share/man/man1/xmonad.1.gz $out/share/man/man1/xmonad.1.gz
         makeWrapper ${configured}/bin/xmonad $out/bin/xmonad \
           --set NIX_GHC "${xmonadEnv}/bin/ghc" \
           --set XMONAD_XMESSAGE "${pkgs.xorg.xmessage}/bin/xmessage"

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -111,16 +111,21 @@ in {
 
           compiledConfig = printf "xmonad-%s-%s" arch os
 
-          compileRestart = whenX (recompile True) . catchIO $ do
-              dir  <- getXMonadDataDir
-              args <- getArgs
-              executeFile (dir </> compiledConfig) False args Nothing
+          compileRestart resume =
+            whenX (recompile True) $
+              when resume writeStateToFile
+                *> catchIO
+                  ( do
+                      dir <- getXMonadDataDir
+                      args <- getArgs
+                      executeFile (dir </> compiledConfig) False args Nothing
+                  )
 
           main = launch defaultConfig
               { modMask = mod4Mask -- Use Super instead of Alt
               , terminal = "urxvt" }
               `additionalKeys`
-              [ ( (mod4Mask,xK_r), writeStateToFile >> compileRestart )
+              [ ( (mod4Mask,xK_r), compileRestart True)
               , ( (mod4Mask,xK_q), restart "xmonad" True ) ]
         '';
       };

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -120,7 +120,7 @@ in {
               { modMask = mod4Mask -- Use Super instead of Alt
               , terminal = "urxvt" }
               `additionalKeys`
-              [ ( (mod4Mask,xK_r), compileRestart )
+              [ ( (mod4Mask,xK_r), writeStateToFile >> compileRestart )
               , ( (mod4Mask,xK_q), restart "xmonad" True ) ]
         '';
       };

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -35,7 +35,7 @@ let
 
   xmonad = if (cfg.config != null) then xmonad-config else xmonad-vanilla;
 in {
-  meta.maintainers = with maintainers; [ lassulus xaverdh ];
+  meta.maintainers = with maintainers; [ lassulus xaverdh ivanbrennan ];
 
   options = {
     services.xserver.windowManager.xmonad = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In `services.xserver.windowManager.xmonad`, the xmonad binary was only given the ability to recompile from a local config (e.g. ~/.xmonad/xmonad.hs) if the `config` option was left unset. There was no clean way to set `config` and maintain the ability to recompile from a local config, making it difficult to try out xmonad config changes without a nixos-rebuild.

Adding ghc with the necessary packages (xmonad, xmonad-contrib, etc.) to `environment.systemPackages`, is undesirable because it places both ghc and an _unconfigured_ xmonad on `PATH`:
```
$ ls -l $(which xmonad ghc)
lrwxrwxrwx ... /run/current-system/sw/bin/ghc -> /nix/store/...-ghc-8.10.2-with-packages/bin/ghc
lrwxrwxrwx ... /run/current-system/sw/bin/xmonad -> /nix/store/...-ghc-8.10.2-with-packages/bin/xmonad
```
The xmonad on `PATH` would differ from the one run by the NixOS module, and restarting xmonad would dump the user into the unconfigured version. If no local config was found, they'd be left in an unconfigured state.

###### Things done

Give xmonad runtime access to ghc even if the `config` option is set. This allows users to switch between the system config and a local config while avoiding the pitfalls of exposing ghc globally. (Additionally, include xmonad man page, which was previously only included if config was left unset.)

Since the xmonad on `PATH` is the same one run by the NixOS module, there's no danger a user will unwittingly restart into an unconfigured version, and because xmonad will refuse to recompile if no local config exists, there's no danger a user will unwittingly recompile into an unconfigured version.
___

If a local config exists, the recompile/restart behavior depends on two factors:
- which entry point is used
  * `XMonad.xmonad` (default)
  * `XMonad.launch` (recommended in "config" option description)
- what operation is triggered (i.e. via mod+q)
  * `spawn "xmonad --recompile && xmonad --restart"` (default)
  * `restart "xmonad" True`
  * custom function

If the default `XMonad.xmonad` entrypoint and default mod+q operation are used, hitting mod+q will compile and exec the local config, which will remain in use until next time the display manager is restarted.

If the entrypoint is changed to `XMonad.launch` and mod+q bound to `restart "xmonad" True`, hitting mod+q will restart from the system config. Another key can be bound to a custom function, e.g. `compileRestart` as show in the "config" option example, to compile and exec a local config. The user can use these two keys to switch between the system and local config at will.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
