### PR TITLE
.github/workflows/editorconfig.yml: use api for list of changed files

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -8,13 +8,22 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'NixOS'
     steps:
+    - name: Get list of changed files from PR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo 'PR_DIFF<<EOF' >> $GITHUB_ENV
+        gh api \
+          repos/NixOS/nixpkgs/pulls/${{github.event.number}}/files --paginate \
+          | jq '.[] | select(.status != "removed") | .filename' \
+          >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: technote-space/get-diff-action@v4.0.0
+      if: env.PR_DIFF
     - name: Fetch editorconfig-checker
-      if: env.GIT_DIFF
+      if: env.PR_DIFF
       env:
         ECC_VERSION: "2.2.0"
         ECC_URL: "https://github.com/editorconfig-checker/editorconfig-checker/releases/download"
@@ -23,7 +32,6 @@ jobs:
         tar xzf ec-linux-amd64.tar.gz && \
         mv ./bin/ec-linux-amd64 ./bin/editorconfig-checker
     - name: Checking EditorConfig
-      if: env.GIT_DIFF
+      if: env.PR_DIFF
       run: |
-        ./bin/editorconfig-checker -disable-indent-size \
-        ${{ env.GIT_DIFF }}
+        echo "$PR_DIFF" | xargs ./bin/editorconfig-checker -disable-indent-size


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
