### PR TITLE
dnsx: init at 1.0.1

### DIFF
--- a/pkgs/tools/security/dnsx/default.nix
+++ b/pkgs/tools/security/dnsx/default.nix
@@ -1,0 +1,31 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "dnsx";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "projectdiscovery";
+    repo = "dnsx";
+    rev = "v${version}";
+    sha256 = "1pgq21pbnz2dm272zrhd455njj5vg4kywpd230acj675nlgir6y1";
+  };
+
+  vendorSha256 = "0j2cqvskzxbyfrvsv4gm4qwfjm0digizcg157z5iignnknddajax";
+
+  meta = with stdenv.lib; {
+    description = "Fast and multi-purpose DNS toolkit";
+    longDescription = ''
+      dnsx is a fast and multi-purpose DNS toolkit allow to run multiple
+      probers using retryabledns library, that allows you to perform
+      multiple DNS queries of your choice with a list of user supplied
+      resolvers.
+    '';
+    homepage = "https://github.com/projectdiscovery/dnsx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3379,6 +3379,8 @@ in
 
   dnstop = callPackage ../tools/networking/dnstop { };
 
+  dnsx = callPackage ../tools/security/dnsx { };
+
   dhcp = callPackage ../tools/networking/dhcp { };
 
   dhcpdump = callPackage ../tools/networking/dhcpdump { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
dnsx is a fast and multi-purpose DNS toolkit allow to run multiple
probers using retryabledns library, that allows you to perform
multiple DNS queries of your choice with a list of user supplied
resolvers.

https://github.com/projectdiscovery/dnsx

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
