### PR TITLE
nuclei: init at 2.2.0

### DIFF
--- a/pkgs/tools/security/nuclei/default.nix
+++ b/pkgs/tools/security/nuclei/default.nix
@@ -1,0 +1,36 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "nuclei";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "projectdiscovery";
+    repo = "nuclei";
+    rev = "v${version}";
+    sha256 = "0xrvza86aczlnb11x58fiqch5g0q6gvpxwsi5dq3akfi95gk3a3x";
+  };
+
+  vendorSha256 = "1v3ax8l1lgp2vs50gsa2fhdd6bvyfdlkd118akrqmwxahyyyqycv";
+
+  preBuild = ''
+    mv v2/* .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool for configurable targeted scanning";
+    longDescription = ''
+      Nuclei is used to send requests across targets based on a template
+      leading to zero false positives and providing effective scanning
+      for known paths. Main use cases for nuclei are during initial
+      reconnaissance phase to quickly check for low hanging fruits or
+      CVEs across targets that are known and easily detectable.
+    '';
+    homepage = "https://github.com/projectdiscovery/nuclei";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19933,6 +19933,8 @@ in
 
   nuclear = callPackage ../applications/audio/nuclear { };
 
+  nuclei = callPackage ../tools/security/nuclei { };
+
   nullmailer = callPackage ../servers/mail/nullmailer {
     stdenv = gccStdenv;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Nuclei is used to send requests across targets based on a template
leading to zero false positives and providing effective scanning
for known paths. Main use cases for nuclei are during initial
reconnaissance phase to quickly check for low hanging fruits or
CVEs across targets that are known and easily detectable.

https://github.com/projectdiscovery/nuclei

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
