### PR TITLE
proxify: init at 0.0.3

### DIFF
--- a/pkgs/tools/networking/proxify/default.nix
+++ b/pkgs/tools/networking/proxify/default.nix
@@ -1,0 +1,31 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "proxify";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "projectdiscovery";
+    repo = "proxify";
+    rev = "v${version}";
+    sha256 = "15j2q9zrs8bdf72jgldkai3xbi4irk69wyjzv48r74rdgf2k49gn";
+  };
+
+  vendorSha256 = "1x78n88ri8kph827k03x1q06zpbbbp7793xsvc376ljda5n6bqig";
+
+  meta = with stdenv.lib; {
+    description = "Proxy tool for HTTP/HTTPS traffic capture";
+    longDescription = ''
+      This tool supports multiple operations such as request/response dump, filtering
+      and manipulation via DSL language, upstream HTTP/Socks5 proxy. Additionally a
+      replay utility allows to import the dumped traffic (request/responses with correct
+      domain name) into other tools by simply setting the upstream proxy to proxify.
+    '';
+    homepage = "https://github.com/projectdiscovery/proxify";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6739,6 +6739,8 @@ in
 
   proxychains = callPackage ../tools/networking/proxychains { };
 
+  proxify = callPackage ../tools/networking/proxify { };
+
   proxytunnel = callPackage ../tools/misc/proxytunnel {
     openssl = openssl_1_0_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This tool supports multiple operations such as request/response dump, filtering
and manipulation via DSL language, upstream HTTP/Socks5 proxy. Additionally a
replay utility allows to import the dumped traffic (request/responses with correct
domain name) into other tools by simply setting the upstream proxy to proxify.

https://github.com/projectdiscovery/proxify

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
