### PR TITLE
pythonPackages.demjson: fix tests, enable on Python 3.x

### DIFF
--- a/pkgs/development/python-modules/demjson/default.nix
+++ b/pkgs/development/python-modules/demjson/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+{ stdenv, python, buildPythonPackage, fetchPypi, isPy3k }:
 
 buildPythonPackage rec {
   pname = "demjson";
   version = "2.2.4";
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0ygbddpnvp5lby6mr5kz60la3hkvwwzv3wwb3z0w9ngxl0w21pii";
   };
 
-  doCheck = false;
-  pythonImportsCheck = [ "demjson" ];
+  checkPhase = stdenv.lib.optionalString isPy3k ''
+    ${python.interpreter} -m lib2to3 -w test/test_demjson.py
+  '' + ''
+    ${python.interpreter} test/test_demjson.py
+  '';
 
   meta = with stdenv.lib; {
     description = "Encoder/decoder and lint/validator for JSON (JavaScript Object Notation)";


### PR DESCRIPTION
In commit 6ba044c1667a4966a69debe73940972307225301, the demjson package was
disabled on Python 3.x with the comment that it doesn't seem to support any
Python 3.x versions.  But looking at the upstream repository, they do seem to
attempt to support Python 3 -- it turns out the failure on our end was caused by
some issue with trying to run `setup.py test` on a 2to3-using codebase with no
test suite (?).

In any case, this package's test suite doesn't seem to use the setuptools
mechanism, so in this commit I override the checkPhase to run the upstream tests
in the correct way.  This fixes the build on all Python versions.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Our expression for `demjson` is broken on Python 3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
