### PR TITLE
gospider: init at 1.1.4

### DIFF
--- a/pkgs/tools/security/gospider/default.nix
+++ b/pkgs/tools/security/gospider/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "gospider";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "jaeles-project";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "03gl8y2047iwa6bhmayyds3li21wy3sw1x4hpp9zgqgi95039q86";
+  };
+
+  vendorSha256 = "0dc4ddi26i38c5rvy9zbal27a7qvn17h64w1yhbig4iyb79b18ym";
+
+  # tests require internet access and API keys
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Fast web spider written in Go";
+    longDescription = ''
+      GoSpider is a fast web crawler that parses sitemap.xml and robots.txt file.
+      It can generate and verify link from JavaScript files, extract URLs from
+      various sources and can detect subdomains from the response source.
+    '';
+    homepage = "https://github.com/jaeles-project/gospider";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1305,6 +1305,8 @@ in
 
   gopass = callPackage ../tools/security/gopass { };
 
+  gospider = callPackage ../tools/security/gospider { };
+
   browserpass = callPackage ../tools/security/browserpass { };
 
   passff-host = callPackage ../tools/security/passff-host { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
GoSpider is a fast web crawler that parses sitemap.xml and robots.txt file.
It can generate and verify link from JavaScript files, extract URLs from 
various sources and can detect subdomains from the response source.

https://github.com/jaeles-project/gospider

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
