### PR TITLE
bash-completion: fix sha256 hash

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "scop";
     repo = "bash-completion";
     rev = version;
-    sha256 = "0m3brd5jx7w07h8vxvvcmbyrlnadrx6hra3cvx6grzv6rin89liv";
+    sha256 = "1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change
When building from source, this currently fails

```
trying https://github.com/scop/bash-completion/archive/2.11.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   126  100   126    0     0    281      0 --:--:-- --:--:-- --:--:--   281
100  349k    0  349k    0     0   258k      0 --:--:--  0:00:01 --:--:-- -5575
unpacking source archive /private/var/folders/1c/pv33w80d0_n7w14hwrj92p30000xbj/T/nix-build-source.drv-0/2.11.tar.gz
hash mismatch in fixed-output derivation '/opt/facebook/nix/store/mcll1q71rick2kpk0pldabmfby6c9jr6-source':
  wanted: sha256:0m3brd5jx7w07h8vxvvcmbyrlnadrx6hra3cvx6grzv6rin89liv
  got:    sha256:1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87
```

Confirming with nix-prefetch-git you can see that the hash is indeed different

```
mseeger@mseeger-mbp ~ % nix-shell -p nix-prefetch-git
these paths will be fetched (1.40 MiB download, 6.37 MiB unpacked):
  /nix/store/a3gnmvpalpa8xy4ravxzdymxxqk3wibj-nix-2.3.9-man
  /nix/store/l7afg8w5c647ackdib6sjkl1sg0wjal3-nix-prefetch-git
  /nix/store/rhar968059hphm65x1snpp95qhfzj4dw-nix-2.3.9
copying path '/nix/store/a3gnmvpalpa8xy4ravxzdymxxqk3wibj-nix-2.3.9-man' from 'https://cache.nixos.org'...
copying path '/nix/store/rhar968059hphm65x1snpp95qhfzj4dw-nix-2.3.9' from 'https://cache.nixos.org'...
copying path '/nix/store/l7afg8w5c647ackdib6sjkl1sg0wjal3-nix-prefetch-git' from 'https://cache.nixos.org'...

[nix-shell:~]$ nix-prefetch-git https://github.com/scop/bash-completion 2.11
Initialized empty Git repository in /private/tmp/git-checkout-tmp-O9EBQo1o/bash-completion/.git/
remote: Enumerating objects: 1404, done.
remote: Counting objects: 100% (1404/1404), done.
remote: Compressing objects: 100% (1164/1164), done.
remote: Total 1404 (delta 686), reused 369 (delta 173), pack-reused 0
Receiving objects: 100% (1404/1404), 501.41 KiB | 1.93 MiB/s, done.
Resolving deltas: 100% (686/686), done.
From https://github.com/scop/bash-completion
 * tag               2.11       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...

git revision is b12639a6becec13a0a2c06173ba40fb3bbe972e1
path is /nix/store/bv8p05zsilary8lylwfmqw1bc6bhwmrl-bash-completion
git human-readable version is -- none --
Commit date is 2020-07-25 11:25:49 +0300
hash is 1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87
{
  "url": "https://github.com/scop/bash-completion",
  "rev": "b12639a6becec13a0a2c06173ba40fb3bbe972e1",
  "date": "2020-07-25T11:25:49+03:00",
  "path": "/nix/store/bv8p05zsilary8lylwfmqw1bc6bhwmrl-bash-completion",
  "sha256": "1kyj62wp4sd8629r1gx5ggnkkjfkwvggj98d6cwlx14y3iri0l87",   <---------- Here
  "fetchSubmodules": false,
  "deepClone": false,
  "leaveDotGit": false
}
```

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
