### PR TITLE
mdctags: init at unstable-2020-06-11

### DIFF
--- a/pkgs/development/tools/misc/mdctags/default.nix
+++ b/pkgs/development/tools/misc/mdctags/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage {
+  pname = "mdctags";
+  version = "unstable-2020-06-11"; # v0.1.0 does not build with our rust version
+
+  src = fetchFromGitHub {
+    owner = "wsdjeg";
+    repo = "mdctags.rs";
+    rev = "0ed9736ea0c77e6ff5b560dda46f5ed0a983ed82";
+    sha256 = "14gryhgh9czlkfk75ml0620c6v8r74i6h3ykkkmc7gx2z8h1jxrb";
+  };
+
+  cargoSha256 = "01ap2w755vbr01nfqc5185mr2w9y32g0d4ahc3lw2x3m8qv0bh6x";
+
+  meta = {
+    description = "tags for markdown file";
+    homepage = "https://github.com/wsdjeg/mdctags.rs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14987,6 +14987,8 @@ in
 
   mbedtls = callPackage ../development/libraries/mbedtls { };
 
+  mdctags = callPackage ../development/tools/misc/mdctags { };
+
   mdds = callPackage ../development/libraries/mdds { };
 
   mediastreamer = callPackage ../development/libraries/mediastreamer { };


### PR DESCRIPTION
###### Motivation for this change

This creates a package for [mdctags], a ctags generator for markdown files.

[mdctags]: https://github.com/wsdjeg/mdctags.rs


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### How to test

test.md:
```md
# Some big title

## Some other title
```

```sh
nix-build -A mdctags && ./result/bin/mdctags test.md
```

This extracts ctags:
```
!_...
Some big title	/home/kea/src/nixpkgs/test.md	/^# Some big title$/;"	a	line:1	
Some other title	/home/kea/src/nixpkgs/test.md	/^## Some other title$/;"	b	line:3	h1:Some big title
```

The program can be used with the [tagbar] Vim plugin: https://github.com/wsdjeg/mdctags.rs#config-mdctags-for-tagbar
I'm using it and it's working fine so far.

[tagbar]: https://github.com/preservim/tagbar