### PR TITLE
i3-balance-workspace: init at 1.8.3

### DIFF
--- a/pkgs/applications/window-managers/i3/balance-workspace.nix
+++ b/pkgs/applications/window-managers/i3/balance-workspace.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, i3ipc }:
+
+buildPythonPackage rec {
+  pname = "i3-balance-workspace";
+  version = "1.8.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gndzrwff8gfdqjjxv4zf2h2k0x7y97w1c3mrjpihz8xd0hbnk4d";
+  };
+
+  propagatedBuildInputs = [ i3ipc ];
+
+  doCheck = false;  # project has no test
+  pythonImportsCheck = [ "i3_balance_workspace" ];
+
+  meta = {
+    description = "Balance windows and workspaces in i3wm";
+    homepage = "https://pypi.org/project/i3-balance-workspace/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pacien ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22059,6 +22059,8 @@ in
 
   i3altlayout = callPackage ../applications/window-managers/i3/altlayout.nix { };
 
+  i3-balance-workspace = python3Packages.callPackage ../applications/window-managers/i3/balance-workspace.nix { };
+
   i3-easyfocus = callPackage ../applications/window-managers/i3/easyfocus.nix { };
 
   i3-layout-manager = callPackage ../applications/window-managers/i3/layout-manager.nix { };


### PR DESCRIPTION
###### Motivation for this change

This creates a package for [i3-balance-workspace], a program which re-balances windows and workspaces in the i3 window manager.

[i3-balance-workspace]: https://pypi.org/project/i3-balance-workspace/


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### How to test

You need to use an i3-compatible window manager.

Resize the windows un-evenly, then run:
```sh
nix-build -A i3-workspace-manager
./result/bin/i3_balance_workspace --scope workspace
```

The windows should be resized evenly.

I'm using this with a keybinding; it's working fine for me.