### PR TITLE
xfce: update src to use new git repository

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad/default.nix
+++ b/pkgs/desktops/xfce/applications/mousepad/default.nix
@@ -4,6 +4,7 @@ mkXfceDerivation {
   category = "apps";
   pname = "mousepad";
   version = "0.4.2";
+  odd-unstable = false;
 
   sha256 = "0a35vaq4l0d8vzw7hqpvbgkr3wj1sqr2zvj7bc5z4ikz2cppqj7p";
 

--- a/pkgs/desktops/xfce/core/xfwm4/default.nix
+++ b/pkgs/desktops/xfce/core/xfwm4/default.nix
@@ -5,9 +5,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfwm4";
-  version = "4.14.5";
+  version = "4.14.6";
 
-  sha256 = "0xxprhs8g00ysrl25y6z9agih6wb7n29v5f5m2icaz7yjvj1k9iv";
+  sha256 = "1ml5b4nn8laqhjihfqqsbjn66525abhin5d32bplh1k9yfxw4xi4";
 
   nativeBuildInputs = [ exo librsvg ];
 

--- a/pkgs/desktops/xfce/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce/mkXfceDerivation.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools, hicolor-icon-theme, xfce, wrapGAppsHook }:
+{ stdenv, fetchFromGitLab, pkgconfig, xfce4-dev-tools, hicolor-icon-theme, xfce, wrapGAppsHook }:
 
 { category
 , pname
@@ -29,8 +29,10 @@ let
     buildInputs = [ hicolor-icon-theme ];
     configureFlags = [ "--enable-maintainer-mode" ];
 
-    src = fetchgit {
-      url = "git://git.xfce.org/${category}/${pname}";
+    src = fetchFromGitLab {
+      domain = "gitlab.xfce.org";
+      owner = category;
+      repo = pname;
       inherit rev sha256;
     };
 
@@ -41,11 +43,11 @@ let
 
     passthru.updateScript = xfce.updateScript {
       inherit pname version attrPath rev-prefix odd-unstable patchlevel-unstable;
-      versionLister = xfce.gitLister src.url;
+      versionLister = xfce.gitLister src.meta.homepage;
     };
 
     meta = with stdenv.lib; {
-      homepage = "https://git.xfce.org/${category}/${pname}/about";
+      homepage = "https://gitlab.xfce.org/${category}/${pname}/about";
       license = licenses.gpl2; # some libraries are under LGPLv2+
       platforms = platforms.linux;
     };

--- a/pkgs/desktops/xfce/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce/mkXfceDerivation.nix
@@ -23,7 +23,7 @@ let
     zipAttrsWithNames (filterAttrNames isList (head attrsets)) (_: concatLists) attrsets;
 
   template = rec {
-    name = "${pname}-${version}";
+    inherit pname version;
 
     nativeBuildInputs = [ pkgconfig xfce4-dev-tools wrapGAppsHook ];
     buildInputs = [ hicolor-icon-theme ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
@@ -1,29 +1,36 @@
-{ stdenv, pkgconfig, fetchFromGitHub, python2, vala_0_40
-, gtk2, libwnck, libxfce4util, xfce4-panel, wafHook }:
+{ stdenv, pkgconfig, fetchFromGitHub, python2, vala_0_46
+, gtk3, libwnck3, libxfce4util, xfce4-panel, wafHook, xfce }:
 
 stdenv.mkDerivation rec {
-  ver = "0.3.1";
-  rev = "07a23b3";
-  name = "xfce4-namebar-plugin-${ver}";
+  pname = "xfce4-namebar-plugin";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "TiZ-EX1";
-    repo = "xfce4-namebar-plugin";
-    rev = rev;
-    sha256 = "1sl4qmjywfvv53ch7hyfysjfd91zl38y7gdw2y3k69vkzd3h18ad";
+    owner = "HugLifeTiZ";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0l70f6mzkscsj4wr43wp5c0l2qnf85vj24cv02bjrh3bzz6wkak8";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ python2 vala_0_40 gtk2 libwnck libxfce4util xfce4-panel ];
+  nativeBuildInputs = [ pkgconfig vala_0_46 wafHook ];
+  buildInputs = [ gtk3 libwnck3 libxfce4util xfce4-panel ];
 
   postPatch = ''
-    substituteInPlace src/preferences.vala --replace 'Environment.get_system_data_dirs()' "{ \"$out/share\" }"
-    substituteInPlace src/namebar.vala     --replace 'Environment.get_system_data_dirs()' "{ \"$out/share\" }"
+    for f in src/preferences.vala src/namebar.vala; do
+      substituteInPlace $f --replace 'var dirs = Environment.get_system_data_dirs()' "string[] dirs = { \"$out/share\" }"
+    done
   '';
 
+  passthru.updateScript = xfce.updateScript {
+    inherit pname version;
+    attrPath = "xfce.${pname}";
+    versionLister = xfce.gitLister src.meta.homepage;
+    rev-prefix = "v";
+  };
+
   meta = with stdenv.lib; {
-    homepage = "https://github.com/TiZ-EX1/xfce4-namebar-plugin";
-    description = "A plugins which integrates titlebar and window controls into the xfce4-panel";
+    homepage = "https://github.com/HugLifeTiZ/xfce4-namebar-plugin";
+    description = "Plugin which integrates titlebar and window controls into the xfce4-panel";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.volth ];

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin/default.nix
@@ -5,6 +5,7 @@ mkXfceDerivation {
   pname = "xfce4-whiskermenu-plugin";
   version = "2.4.6";
   rev-prefix = "v";
+  odd-unstable = false;
   sha256 = "03asfaxqbhawzb3870az7qgid5y7cg3ip8h6r4z8kavcd0b7x4ii";
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

upd.xfce xfce.xfce4-namebar-plugin = 0.3.1 -> 1.0.0
xfce.xfwm4: 4.14.5 -> 4.14.6
xfce.xfce4-whiskermenu-plugin: odd versions are not unstable
xfce.mousepad: odd versions are not unstable
xfce.orage: do not use mkXfceDerivation
xfce: use pname
xfce: update src to use new git repository


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
