### PR TITLE
glibc: fix Darwin cross compilation for 2.32

### DIFF
--- a/pkgs/development/libraries/glibc/darwin-cross-build.patch
+++ b/pkgs/development/libraries/glibc/darwin-cross-build.patch
@@ -3,10 +3,8 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
 * use host version of ar, which is given by environment variable
 * build system uses stamp.os and stamp.oS files, which only differ in case;
   this fails on macOS, so replace .oS with .o_S
-* libintl.h does not exist (and is not needed) on macOS
-
---- glibc-2.27/Makefile.in	2018-02-01 17:17:18.000000000 +0100
-+++ glibc-2.27/Makefile.in	2019-02-15 17:38:27.022965553 +0100
+--- glibc-2.32/Makefile.in	2018-02-01 17:17:18.000000000 +0100
++++ glibc-2.32/Makefile.in	2020-12-27 18:21:30.000000000 +0100
 @@ -6,9 +6,11 @@
  .PHONY: all install bench
  
@@ -20,9 +18,9 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  	LC_ALL=C; export LC_ALL; \
  	$(MAKE) -r PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
  
---- glibc-2.27/Makerules	2018-02-01 17:17:18.000000000 +0100
-+++ glibc-2.27/Makerules	2019-02-15 17:43:11.196039000 +0100
-@@ -915,8 +915,8 @@
+--- glibc-2.32/Makerules	2018-02-01 17:17:18.000000000 +0100
++++ glibc-2.32/Makerules	2020-12-27 18:21:30.000000000 +0100
+@@ -847,8 +847,8 @@
  ifndef objects
  
  # Create the stamp$o files to keep the parent makefile happy.
@@ -33,7 +31,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  	$(make-target-directory)
  	rm -f $@; > $@
  else
-@@ -927,7 +927,7 @@
+@@ -859,7 +859,7 @@
  # The parent will then actually add them all to the archive in the
  # archive rule, below.
  define o-iterator-doit
@@ -42,7 +40,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  endef
  define do-stamp
  $(make-target-directory)
-@@ -943,14 +943,14 @@
+@@ -875,14 +875,14 @@
  # on the stamp files built above.
  define o-iterator-doit
  $(common-objpfx)$(patsubst %,$(libtype$o),c): \
@@ -59,7 +57,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  ifndef subdir
  $(subdirs-stamps): subdir_lib;
  endif
-@@ -961,7 +961,7 @@
+@@ -893,7 +893,7 @@
  # This makes all the object files.
  .PHONY: objects objs libobjs extra-objs
  objects objs: libobjs extra-objs
@@ -68,7 +66,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  extra-objs: $(addprefix $(objpfx),$(extra-objs))
  
  # Canned sequence for building an extra library archive.
-@@ -1615,7 +1615,7 @@
+@@ -1499,7 +1499,7 @@
  	$(rmobjs)
  define rmobjs
  $(foreach o,$(object-suffixes-for-libc),
@@ -77,27 +75,3 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  endef
  
  # Also remove the dependencies and generated source files.
---- glibc-2.27/sunrpc/rpc_main.c	2019-02-15 17:32:43.710244513 +0100
-+++ glibc-2.27/sunrpc/rpc_main.c	2019-02-15 17:23:57.139617796 +0100
-@@ -38,7 +38,9 @@
- #include <stdio.h>
- #include <string.h>
- #include <unistd.h>
-+#ifndef __APPLE__
- #include <libintl.h>
-+#endif
- #include <locale.h>
- #include <ctype.h>
- #include <sys/types.h>
---- glibc-2.27/sunrpc/rpc_scan.c	2019-02-15 17:32:54.845490606 +0100
-+++ glibc-2.27/sunrpc/rpc_scan.c	2019-02-15 17:24:54.288066644 +0100
-@@ -37,7 +37,9 @@
- #include <stdio.h>
- #include <ctype.h>
- #include <string.h>
-+#ifndef __APPLE__
- #include <libintl.h>
-+#endif
- #include "rpc_scan.h"
- #include "rpc_parse.h"
- #include "rpc_util.h"


### PR DESCRIPTION
This PR fixes cross compilation on Darwin: some parts of the current patch are no longer needed. For the rest, I updated the line numbers so patch applies cleanly again.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
