### PR TITLE
meslo-lgs-nf: init at git-2020-03-22

### DIFF
--- a/pkgs/data/fonts/meslo-lgs-nf/default.nix
+++ b/pkgs/data/fonts/meslo-lgs-nf/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "meslo-lgs-nf";
+  version = "2020-03-22";
+
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "powerlevel10k-media";
+    rev = "32c7d40239c93507277f14522be90b5750f442c9";
+    sha256 = "10hq4whai1rqj495w4n80p0y21am8rihm4rc40xq7241d6dzilrd";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp $src/*.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Meslo Nerd Font patched for Powerlevel10k";
+    homepage = "https://github.com/romkatv/powerlevel10k-media";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bbigras ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19884,6 +19884,8 @@ in
 
   meslo-lg = callPackage ../data/fonts/meslo-lg {};
 
+  meslo-lgs-nf = callPackage ../data/fonts/meslo-lgs-nf {};
+
   migmix = callPackage ../data/fonts/migmix {};
 
   migu = callPackage ../data/fonts/migu {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/romkatv/powerlevel10k#meslo-nerd-font-patched-for-powerlevel10k

cc @hexa

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
