### PR TITLE
terrascan: init at 1.2.0

### DIFF
--- a/pkgs/tools/security/terrascan/default.nix
+++ b/pkgs/tools/security/terrascan/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "terrascan";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "accurics";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kjis0ylvmv1gvzp5qvi9a7x4611bjv8yx5mb6nkc0a8lscwb4c3";
+  };
+
+  vendorSha256 = "0yfybzwjvnan4qf5w25k22iwh5hp9v8si93p4jv9bx25rw91swws";
+
+  # tests want to download a vulnerable Terraform project
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Detect compliance and security violations across Infrastructure";
+    longDescription = ''
+      Detect compliance and security violations across Infrastructure as Code to
+      mitigate risk before provisioning cloud native infrastructure. It contains
+      500+ polices and support for Terraform and Kubernetes.
+    '';
+    homepage = "https://github.com/accurics/terrascan";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12186,6 +12186,8 @@ in
 
   terraformer = callPackage ../development/tools/misc/terraformer { };
 
+  terrascan = callPackage ../tools/security/terrascan { };
+
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };
   texinfo4 = texinfo413;
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.2.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Detect compliance and security violations across Infrastructure as Code to
mitigate risk before provisioning cloud native infrastructure. It contains
500+ polices and support for Terraform and Kubernetes.

https://github.com/accurics/terrascan

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
