### PR TITLE
hedgedoc: 1.7.0 -> 1.7.1 (fixes CVE-2020-26286 and CVE-2020-26287)

### DIFF
--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -3,13 +3,13 @@
 
 mkYarnPackage rec {
   name = "hedgedoc";
-  version = "1.7.0";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner  = "hedgedoc";
     repo   = "hedgedoc";
     rev    = version;
-    sha256 = "1zz5ni9cp1dhcvcrzks13pww5qm2wna2hh0k59pfz7c897rs1l7v";
+    sha256 = "0axad5581v25pynfj6pgy0h1xp92dyllnc7mk42z6hxbs4sgkrw1";
   };
 
   nativeBuildInputs = [ which makeWrapper ];

--- a/pkgs/servers/web-apps/hedgedoc/package.json
+++ b/pkgs/servers/web-apps/hedgedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HedgeDoc",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "The best platform to write and share markdown.",
   "main": "app.js",
   "license": "AGPL-3.0",
@@ -43,6 +43,7 @@
     "express": ">=4.14",
     "express-session": "^1.14.2",
     "file-saver": "^1.3.3",
+    "file-type": "^16.1.0",
     "flowchart.js": "^1.6.4",
     "fork-awesome": "^1.1.3",
     "formidable": "^1.0.17",
@@ -111,6 +112,7 @@
     "readline-sync": "^1.4.7",
     "request": "^2.88.0",
     "reveal.js": "^3.9.2",
+    "rimraf": "^3.0.2",
     "scrypt-async": "^2.0.1",
     "scrypt-kdf": "^2.0.1",
     "select2": "^3.5.2-browserify",

--- a/pkgs/servers/web-apps/hedgedoc/yarn.lock
+++ b/pkgs/servers/web-apps/hedgedoc/yarn.lock
@@ -106,6 +106,11 @@
   resolved "https://registry.yarnpkg.com/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz#4c0df069e2ec9262791b9ef1e23320c1d73bdb74"
   integrity sha512-2KhFjtPueJG6xVj2HnqXt9BlANOfYCVLyu+pXYjPGBDT8yk+vQwc/6tsceIj+mayKcoxMau2JimggXRPHgoc8w==
 
+"@tokenizer/token@^0.1.0", "@tokenizer/token@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
+  integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -125,6 +130,11 @@
   integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
   dependencies:
     "@types/node" "*"
+
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
 "@types/express-serve-static-core@*":
   version "4.17.13"
@@ -219,7 +229,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/readable-stream@^2.3.5":
+"@types/readable-stream@^2.3.5", "@types/readable-stream@^2.3.9":
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-2.3.9.tgz#40a8349e6ace3afd2dd1b6d8e9b02945de4566a9"
   integrity sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==
@@ -837,9 +847,9 @@ atob@^2.1.2:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sdk@^2.521.0:
-  version "2.815.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.815.0.tgz#515ead6d0d242f603171faf30c49142fd53a53d9"
-  integrity sha512-BXL3Og97rOY9jE7OeYQdKftMAZ3SneFg/rBslyog+W0dTDKq3NBuM3fBWhc3POf26kHcFjsnLIWScM8bWhD4AA==
+  version "2.817.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.817.0.tgz#3a97b690b0ec494cf8ee927affb3973cf26abcc8"
+  integrity sha512-DZIdWpkcqbqsCz0MEskHsyFaqc6Tk9XIFqXAg1AKHbOgC8nU45bz+Y2osX77pU01JkS/G7OhGtGmlKDrOPvFwg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -4266,6 +4276,16 @@ file-saver@^1.3.3:
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
   integrity sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==
 
+file-type@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.1.0.tgz#1c8a4458b2103e07d2b49ae7f76384abafe86529"
+  integrity sha512-G4Klqf6tuprtG0pC4r9kni4Wv8XhAAsfHphVqsQGA+YiOlPAO40BZduDqKfv0RFsu9q9ZbFObWfwszY/NqhEZw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.0.3"
+    token-types "^2.0.0"
+    typedarray-to-buffer "^3.1.5"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -5677,7 +5697,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -7962,6 +7982,11 @@ pdfobject@^2.0.201604172:
   resolved "https://registry.yarnpkg.com/pdfobject/-/pdfobject-2.2.4.tgz#ccb3c191129298a471e9ccb59c88a3ee0b7c7530"
   integrity sha512-r6Rw9CQWsrY6uqmKvlgFNoupmuRbSt9EsG0sZhSAy3cIk4WgOXyAVmebFSlLhqj6gA5NIEXL3lSEbwOOYfdUvw==
 
+peek-readable@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.0.tgz#250b08b7de09db8573d7fd8ea475215bbff14348"
+  integrity sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -8776,6 +8801,14 @@ readable-stream@~2.0.0:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
+
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.0.tgz#4ca5408e70471069119d691934141a52de413955"
+  integrity sha512-HNmLb3n0SteGAs8HQlErYPGeO+y7cvL/mVUKtXeUkl0iCZ/2GIgKGrCFHyS7UXFnO8uc9U+0y3pYIzAPsjFfvA==
+  dependencies:
+    "@types/readable-stream" "^2.3.9"
+    readable-stream "^3.6.0"
 
 readdir-glob@^1.0.0:
   version "1.1.1"
@@ -10464,6 +10497,15 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strtok3@^6.0.3:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.4.tgz#ede0d20fde5aa9fda56417c3558eaafccc724694"
+  integrity sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==
+  dependencies:
+    "@tokenizer/token" "^0.1.1"
+    "@types/debug" "^4.1.5"
+    peek-readable "^3.1.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -10767,6 +10809,14 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+token-types@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.0.0.tgz#b23618af744818299c6fbf125e0fdad98bab7e85"
+  integrity sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==
+  dependencies:
+    "@tokenizer/token" "^0.1.0"
+    ieee754 "^1.1.13"
+
 toobusy-js@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/toobusy-js/-/toobusy-js-0.5.1.tgz#5511f78f6a87a6a512d44fdb0efa13672217f659"
@@ -10895,6 +10945,13 @@ type@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz#9bdc22c648cf8cf86dd23d32336a41cfb6475e3f"
   integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6:
   version "0.0.6"

--- a/pkgs/servers/web-apps/hedgedoc/yarn.nix
+++ b/pkgs/servers/web-apps/hedgedoc/yarn.nix
@@ -114,6 +114,14 @@
       };
     }
     {
+      name = "_tokenizer_token___token_0.1.1.tgz";
+      path = fetchurl {
+        name = "_tokenizer_token___token_0.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz";
+        sha1 = "f0d92c12f87079ddfd1b29f614758b9696bc29e3";
+      };
+    }
+    {
       name = "_types_anymatch___anymatch_1.3.1.tgz";
       path = fetchurl {
         name = "_types_anymatch___anymatch_1.3.1.tgz";
@@ -135,6 +143,14 @@
         name = "_types_connect___connect_3.4.33.tgz";
         url  = "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz";
         sha1 = "31610c901eca573b8713c3330abc6e6b9f588546";
+      };
+    }
+    {
+      name = "_types_debug___debug_4.1.5.tgz";
+      path = fetchurl {
+        name = "_types_debug___debug_4.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz";
+        sha1 = "b14efa8852b7768d898906613c23f688713e02cd";
       };
     }
     {
@@ -1010,11 +1026,11 @@
       };
     }
     {
-      name = "aws_sdk___aws_sdk_2.815.0.tgz";
+      name = "aws_sdk___aws_sdk_2.817.0.tgz";
       path = fetchurl {
-        name = "aws_sdk___aws_sdk_2.815.0.tgz";
-        url  = "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.815.0.tgz";
-        sha1 = "515ead6d0d242f603171faf30c49142fd53a53d9";
+        name = "aws_sdk___aws_sdk_2.817.0.tgz";
+        url  = "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.817.0.tgz";
+        sha1 = "3a97b690b0ec494cf8ee927affb3973cf26abcc8";
       };
     }
     {
@@ -4519,6 +4535,14 @@
         name = "file_saver___file_saver_1.3.8.tgz";
         url  = "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz";
         sha1 = "e68a30c7cb044e2fb362b428469feb291c2e09d8";
+      };
+    }
+    {
+      name = "file_type___file_type_16.1.0.tgz";
+      path = fetchurl {
+        name = "file_type___file_type_16.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/file-type/-/file-type-16.1.0.tgz";
+        sha1 = "1c8a4458b2103e07d2b49ae7f76384abafe86529";
       };
     }
     {
@@ -8802,6 +8826,14 @@
       };
     }
     {
+      name = "peek_readable___peek_readable_3.1.0.tgz";
+      path = fetchurl {
+        name = "peek_readable___peek_readable_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.0.tgz";
+        sha1 = "250b08b7de09db8573d7fd8ea475215bbff14348";
+      };
+    }
+    {
       name = "performance_now___performance_now_2.1.0.tgz";
       path = fetchurl {
         name = "performance_now___performance_now_2.1.0.tgz";
@@ -9695,6 +9727,14 @@
         name = "readable_stream___readable_stream_2.0.6.tgz";
         url  = "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz";
         sha1 = "8f90341e68a53ccc928788dacfcd11b36eb9b78e";
+      };
+    }
+    {
+      name = "readable_web_to_node_stream___readable_web_to_node_stream_3.0.0.tgz";
+      path = fetchurl {
+        name = "readable_web_to_node_stream___readable_web_to_node_stream_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.0.tgz";
+        sha1 = "4ca5408e70471069119d691934141a52de413955";
       };
     }
     {
@@ -11402,6 +11442,14 @@
       };
     }
     {
+      name = "strtok3___strtok3_6.0.4.tgz";
+      path = fetchurl {
+        name = "strtok3___strtok3_6.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.4.tgz";
+        sha1 = "ede0d20fde5aa9fda56417c3558eaafccc724694";
+      };
+    }
+    {
       name = "stylehacks___stylehacks_4.0.3.tgz";
       path = fetchurl {
         name = "stylehacks___stylehacks_4.0.3.tgz";
@@ -11698,6 +11746,14 @@
       };
     }
     {
+      name = "token_types___token_types_2.0.0.tgz";
+      path = fetchurl {
+        name = "token_types___token_types_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/token-types/-/token-types-2.0.0.tgz";
+        sha1 = "b23618af744818299c6fbf125e0fdad98bab7e85";
+      };
+    }
+    {
       name = "toobusy_js___toobusy_js_0.5.1.tgz";
       path = fetchurl {
         name = "toobusy_js___toobusy_js_0.5.1.tgz";
@@ -11871,6 +11927,14 @@
         name = "type___type_2.1.0.tgz";
         url  = "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz";
         sha1 = "9bdc22c648cf8cf86dd23d32336a41cfb6475e3f";
+      };
+    }
+    {
+      name = "typedarray_to_buffer___typedarray_to_buffer_3.1.5.tgz";
+      path = fetchurl {
+        name = "typedarray_to_buffer___typedarray_to_buffer_3.1.5.tgz";
+        url  = "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz";
+        sha1 = "a97ee7a9ff42691b9f783ff1bc5112fe3fca9080";
       };
     }
     {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/hedgedoc/hedgedoc/releases/tag/1.7.1
https://github.com/hedgedoc/hedgedoc/security/advisories/GHSA-wcr3-xhv7-8gxc
https://github.com/hedgedoc/hedgedoc/security/advisories/GHSA-g6w6-7xf9-m95p

I think that this should be ported to stable _together_ with the recent rename to hedgedoc and the corresponding changes from #105385. Even though the name and logo changed, the functionality did not, so I don't see any real issue with porting this to 20.09.
I am not sure whether the release notes should just be removed or kept.
(ping @NixOS/nixos-release-managers for opinions)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Successfully deployed to an existing HedgeDoc instance