### PR TITLE
neochat: re-add kitemmodels and qtgraphicaleffects to build inputs

### DIFF
--- a/pkgs/applications/networking/instant-messengers/neochat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/neochat/default.nix
@@ -7,6 +7,7 @@
 , qttools
 , qtquickcontrols2
 , qtmultimedia
+, qtgraphicaleffects
 , qtkeychain
 , libpulseaudio
 , olm
@@ -14,6 +15,7 @@
 , cmark
 , extra-cmake-modules
 , kirigami2
+, kitemmodels
 , ki18n
 , knotifications
 , kdbusaddons
@@ -40,10 +42,12 @@ mkDerivation rec {
     qtkeychain
     qtquickcontrols2
     qtmultimedia
+    qtgraphicaleffects
     olm
     libsecret
     cmark
     kirigami2
+    kitemmodels
     ki18n
     knotifications
     kdbusaddons


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
During cleanups, kitemmodels and qtgraphicaleffects were removed from the build-inputs, these are needed to launch neochat on non-nixos systems

cc @peterhoeg @SuperSandro2000 @lovesegfault 
```
❯ nixGLNvidia ./result/bin/neochat
Gtk-Message: 14:52:46.544: Failed to load module "canberra-gtk-module"
Gtk-Message: 14:52:46.544: Failed to load module "pk-gtk-module"
Gtk-Message: 14:52:46.545: Failed to load module "canberra-gtk-module"
Gtk-Message: 14:52:46.545: Failed to load module "pk-gtk-module"
QQmlApplicationEngine failed to load component
qrc:/qml/main.qml:19:1: Type Kirigami.ApplicationWindow unavailable
file:///nix/store/1vvhlf5lyc83xapin99qc4vw93nspdf1-kirigami2-5.76.0/lib/qt-5.15.2/qml/org/kde/kirigami.2/styles/org.kde.desktop/ApplicationWindow.qml:12:1: Type Base.ApplicationWindow unavailable
file:///nix/store/1vvhlf5lyc83xapin99qc4vw93nspdf1-kirigami2-5.76.0/lib/qt-5.15.2/qml/org/kde/kirigami.2/ApplicationWindow.qml:10:1: module "QtGraphicalEffects" is not installed

❯ nixGLNvidia ./result/bin/neochat
Gtk-Message: 14:53:10.875: Failed to load module "canberra-gtk-module"
Gtk-Message: 14:53:10.875: Failed to load module "pk-gtk-module"
Gtk-Message: 14:53:10.876: Failed to load module "canberra-gtk-module"
Gtk-Message: 14:53:10.876: Failed to load module "pk-gtk-module"
QQmlApplicationEngine failed to load component
qrc:/qml/main.qml:118:20: Type RoomDrawer unavailable
qrc:/imports/NeoChat/Panel/RoomDrawer.qml:13:1: module "org.kde.kitemmodels" is not installed
```

###### Things done

 re-add kitemmodels and qtgraphicaleffects to build inputs

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
