### PR TITLE
nixos/spacecookie: convert into settings-style service module

### DIFF
--- a/nixos/modules/services/networking/spacecookie.nix
+++ b/nixos/modules/services/networking/spacecookie.nix
@@ -15,6 +15,18 @@ in {
 
       enable = mkEnableOption "spacecookie";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.haskellPackages.spacecookie;
+        example = literalExample ''
+          pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.spacecookie
+        '';
+        description = ''
+          The spacecookie derivation to use. This can be used to
+          override the used package or to use another version.
+        '';
+      };
+
       hostname = mkOption {
         type = types.str;
         default = "localhost";
@@ -62,7 +74,7 @@ in {
 
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${pkgs.haskellPackages.spacecookie}/bin/spacecookie ${configFile}";
+        ExecStart = "${lib.getBin cfg.package}/bin/spacecookie ${configFile}";
         FileDescriptorStoreMax = 1;
 
         DynamicUser = true;

--- a/nixos/modules/services/networking/spacecookie.nix
+++ b/nixos/modules/services/networking/spacecookie.nix
@@ -18,19 +18,28 @@ in {
       hostname = mkOption {
         type = types.str;
         default = "localhost";
-        description = "The hostname the service is reachable via. Clients will use this hostname for further requests after loading the initial gopher menu.";
+        description = ''
+          The hostname the service is reachable via. Clients
+          will use this hostname for further requests after
+          loading the initial gopher menu.
+        '';
       };
 
       port = mkOption {
         type = types.port;
         default = 70;
-        description = "Port the gopher service should be exposed on.";
+        description = ''
+          Port the gopher service should be exposed on. The
+          firewall is not opened automatically.
+        '';
       };
 
       root = mkOption {
         type = types.path;
         default = "/srv/gopher";
-        description = "The root directory spacecookie serves via gopher.";
+        description = ''
+          The root directory spacecookie serves via gopher.
+        '';
       };
     };
   };

--- a/nixos/modules/services/networking/spacecookie.nix
+++ b/nixos/modules/services/networking/spacecookie.nix
@@ -60,6 +60,16 @@ in {
           The root directory spacecookie serves via gopher.
         '';
       };
+
+      address = mkOption {
+        type = types.str;
+        default = "[::]";
+        description = ''
+          Address to listen on. Must be in the
+          <literal>ListenStream=</literal> syntax of
+          <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd.socket.html">systemd.socket(5)</link>.
+        '';
+      };
     };
   };
 
@@ -68,7 +78,7 @@ in {
     systemd.sockets.spacecookie = {
       description = "Socket for the Spacecookie Gopher Server";
       wantedBy = [ "sockets.target" ];
-      listenStreams = [ "[::]:${toString cfg.port}" ];
+      listenStreams = [ "${cfg.address}:${toString cfg.port}" ];
       socketConfig = {
         BindIPv6Only = "both";
       };

--- a/nixos/modules/services/networking/spacecookie.nix
+++ b/nixos/modules/services/networking/spacecookie.nix
@@ -37,12 +37,19 @@ in {
         '';
       };
 
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open the necessary port in the firewall for spacecookie.
+        '';
+      };
+
       port = mkOption {
         type = types.port;
         default = 70;
         description = ''
-          Port the gopher service should be exposed on. The
-          firewall is not opened automatically.
+          Port the gopher service should be exposed on.
         '';
       };
 
@@ -99,6 +106,10 @@ in {
         # AF_INET replaced by BindIPv6Only=both
         RestrictAddressFamilies = "AF_UNIX AF_INET6";
       };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
     };
   };
 }

--- a/nixos/modules/services/networking/spacecookie.nix
+++ b/nixos/modules/services/networking/spacecookie.nix
@@ -29,10 +29,9 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = pkgs.haskellPackages.spacecookie;
-        example = literalExample ''
-          pkgs.haskell.lib.justStaticExecutables pkgs.haskellPackages.spacecookie
-        '';
+        default = pkgs.spacecookie;
+        defaultText = literalExample "pkgs.spacecookie";
+        example = literalExample "pkgs.haskellPackages.spacecookie";
         description = ''
           The spacecookie derivation to use. This can be used to
           override the used package or to use another version.

--- a/nixos/tests/spacecookie.nix
+++ b/nixos/tests/spacecookie.nix
@@ -9,7 +9,6 @@ in
     name = "spacecookie";
     nodes = {
       ${gopherHost} = {
-        networking.firewall.allowedTCPPorts = [ 70 ];
         systemd.services.spacecookie = {
           preStart = ''
             mkdir -p ${gopherRoot}/directory
@@ -21,6 +20,7 @@ in
           enable = true;
           root = gopherRoot;
           hostname = gopherHost;
+          openFirewall = true;
         };
       };
 

--- a/nixos/tests/spacecookie.nix
+++ b/nixos/tests/spacecookie.nix
@@ -18,9 +18,11 @@ in
 
         services.spacecookie = {
           enable = true;
-          root = gopherRoot;
-          hostname = gopherHost;
           openFirewall = true;
+          settings = {
+            root = gopherRoot;
+            hostname = gopherHost;
+          };
         };
       };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18947,6 +18947,9 @@ in
 
   sogo = callPackage ../servers/web-apps/sogo { };
 
+  spacecookie =
+    haskell.lib.justStaticExecutables haskellPackages.spacecookie;
+
   spawn_fcgi = callPackage ../servers/http/spawn-fcgi { };
 
   spring-boot-cli = callPackage ../development/tools/spring-boot-cli { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
