### PR TITLE
nixos/acme: Backport account missing fixes

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -104,7 +104,12 @@ let
     mkHash = with builtins; val: substring 0 20 (hashString "sha256" val);
     certDir = mkHash hashData;
     domainHash = mkHash "${concatStringsSep " " extraDomains} ${data.domain}";
-    othersHash = mkHash "${toString acmeServer} ${data.keyType}";
+    othersHash = mkHash (
+      "${toString acmeServer} ${data.keyType}"
+      + (
+        optionalString (versionOlder "20.09" config.system.stateVersion) data.email
+      )
+    );
     accountDir = "/var/lib/acme/.lego/accounts/" + othersHash;
 
     protocolOpts = if useDns then (

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -252,7 +252,8 @@ let
         echo '${domainHash}' > domainhash.txt
 
         # Check if we can renew
-        if [ -e 'certificates/${keyName}.key' -a -e 'certificates/${keyName}.crt' ]; then
+        # Certificates and account credentials must exist
+        if [ -e 'certificates/${keyName}.key' -a -e 'certificates/${keyName}.crt' -a "$(ls -1 accounts)" ]; then
 
           # When domains are updated, there's no need to do a full
           # Lego run, but it's likely renew won't work if days is too low.

--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -104,12 +104,7 @@ let
     mkHash = with builtins; val: substring 0 20 (hashString "sha256" val);
     certDir = mkHash hashData;
     domainHash = mkHash "${concatStringsSep " " extraDomains} ${data.domain}";
-    othersHash = mkHash (
-      "${toString acmeServer} ${data.keyType}"
-      + (
-        optionalString (versionOlder "20.09" config.system.stateVersion) data.email
-      )
-    );
+    othersHash = mkHash "${toString acmeServer} ${data.keyType} ${data.email}";
     accountDir = "/var/lib/acme/.lego/accounts/" + othersHash;
 
     protocolOpts = if useDns then (

--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -263,4 +263,28 @@ chmod 400 /var/lib/secrets/certs.secret
    ones.
   </para>
  </section>
+ <section xml:id="module-security-acme-fix-jws">
+  <title>Fixing JWS Verification error</title>
+
+  <para>
+   It is possible that your account credentials file may become corrupt and need
+   to be regnerated. In this scenario lego will produce the error <literal>JWS verification error</literal>.
+   The solution is to simply delete the associated accounts file and
+   re-run the affected service(s).
+  </para>
+
+<programlisting>
+# Find the accounts folder for the certificate
+systemctl cat acme-example.com.service | grep -Po 'accounts/[^:]*'
+export accountdir="$(!!)"
+# Move this folder to some place else
+mv /var/lib/acme/.lego/$accountdir{,.bak}
+# Recreate the folder using systemd-tmpfiles
+systemd-tmpfiles --create
+# Get a new account and reissue certificates
+# Note: Do this for all certs that share the same account email address
+systemctl start acme-example.com.service
+</programlisting>
+
+ </section>
 </chapter>

--- a/nixos/modules/security/acme.xml
+++ b/nixos/modules/security/acme.xml
@@ -268,7 +268,7 @@ chmod 400 /var/lib/secrets/certs.secret
 
   <para>
    It is possible that your account credentials file may become corrupt and need
-   to be regnerated. In this scenario lego will produce the error <literal>JWS verification error</literal>.
+   to be regenerated. In this scenario lego will produce the error <literal>JWS verification error</literal>.
    The solution is to simply delete the associated accounts file and
    re-run the affected service(s).
   </para>


### PR DESCRIPTION
###### Motivation for this change

Backport of #101482

It was requested by at least one user, and the module is still causing issues for users so this will probably not be the last backport of acme-related changes.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
