### PR TITLE
[20.09] Revert "xwallpaper: remove libseccomp dependency"

### DIFF
--- a/pkgs/tools/X11/xwallpaper/default.nix
+++ b/pkgs/tools/X11/xwallpaper/default.nix
@@ -5,6 +5,7 @@
 , pixman
 , xcbutil
 , xcbutilimage
+, libseccomp
 , libjpeg
 , libpng
 , libXpm
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
   preConfigure = "./autogen.sh";
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
-  buildInputs = [ pixman xcbutilimage xcbutil libjpeg libpng libXpm ];
+  buildInputs = [ pixman xcbutilimage xcbutil libseccomp libjpeg libpng libXpm ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/stoeckmann/xwallpaper";


### PR DESCRIPTION
(cherry picked from commit 84e1b7f96929c7e7fda42e64cbee129fb7f68513)

###### Motivation for this change
Original PR: #107661 
cc @SuperSandro2000 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
