### PR TITLE
kinfocenter: create symlink manually

### DIFF
--- a/pkgs/desktops/plasma-5/kinfocenter.nix
+++ b/pkgs/desktops/plasma-5/kinfocenter.nix
@@ -4,8 +4,9 @@
   qtbase,
   kcmutils, kcompletion, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons,
   kdeclarative, kdelibs4support, ki18n, kiconthemes, kio, kirigami2, kpackage,
-  kservice, kwayland, kwidgetsaddons, kxmlgui, libraw1394, libGLU, pciutils,
-  solid
+  kservice, kwayland, kwidgetsaddons, kxmlgui,
+  systemsettings,
+  libraw1394, libGLU, pciutils, solid,
 }:
 
 mkDerivation {
@@ -17,4 +18,9 @@ mkDerivation {
     kdeclarative kdelibs4support ki18n kiconthemes kio kirigami2 kpackage
     kservice kwayland kwidgetsaddons kxmlgui libraw1394 libGLU pciutils solid
   ];
+
+  # it doesn't detect systemsettings when added to buildInputs so manually symlink it
+  postInstall = ''
+    ln -sf ${systemsettings}/bin/systemsettings5 $out/bin/kinfocenter
+  '';
 }


### PR DESCRIPTION
###### Motivation for this change

`kinfocenter` is not a standalone binary but instead a symlink to `systemsettings5`. *However*, without this PR it's just a dangling symlink as it otherwise expects `systemsettings5` to exist in the same directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
