### PR TITLE
adoptopenjdk-bin, graalvm11-ce, graalvm8-ce, zulu, zulu8: add support for GTK+ Look and Feel

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -4,16 +4,31 @@ sourcePerArch:
 , lib
 , fetchurl
 , autoPatchelfHook
+, makeWrapper
+# minimum dependencies
 , alsaLib
-, freetype
 , fontconfig
-, zlib
-, xorg
+, freetype
 , libffi
+, xorg
+, zlib
+# runtime dependencies
+, cups
+# runtime dependencies for GTK+ Look and Feel
+, gtkSupport ? true
+, cairo
+, glib
+, gtk3
 }:
 
 let
   cpuName = stdenv.hostPlatform.parsed.cpu.name;
+  runtimeDependencies = [
+    cups
+  ] ++ lib.optionals gtkSupport [
+    cairo glib gtk3
+  ];
+  runtimeLibraryPath = lib.makeLibraryPath runtimeDependencies;
 in
 
 let result = stdenv.mkDerivation rec {
@@ -28,11 +43,19 @@ let result = stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    alsaLib freetype fontconfig zlib xorg.libX11 xorg.libXext xorg.libXtst
-    xorg.libXi xorg.libXrender stdenv.cc.cc.lib
+    alsaLib # libasound.so wanted by lib/libjsound.so
+    fontconfig
+    freetype
+    stdenv.cc.cc.lib # libstdc++.so.6
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+    zlib
   ] ++ lib.optional stdenv.isAarch32 libffi;
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
@@ -57,6 +80,13 @@ let result = stdenv.mkDerivation rec {
     cat <<EOF >> "$out/nix-support/setup-hook"
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
+
+    # We cannot use -exec since wrapProgram is a function but not a command.
+    for bin in $( find "$out" -executable -type f ); do
+      if patchelf --print-interpreter "$bin" &> /dev/null; then
+        wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
+      fi
+    done
   '';
 
   preFixup = ''

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -1,7 +1,24 @@
-{ stdenv, lib, fetchurl, unzip, makeWrapper, setJavaClassPath
-, zulu, glib, libxml2, ffmpeg_3, libxslt, libGL, alsaLib
-, fontconfig, freetype, pango, gtk2, cairo, gdk-pixbuf, atk, xorg
-, swingSupport ? true }:
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, unzip
+, makeWrapper
+, setJavaClassPath
+, zulu
+# minimum dependencies
+, alsaLib
+, fontconfig
+, freetype
+, xorg
+# runtime dependencies
+, cups
+# runtime dependencies for GTK+ Look and Feel
+, gtkSupport ? stdenv.isLinux
+, cairo
+, glib
+, gtk3
+}:
 
 let
   version = "8.48.0.53";
@@ -14,14 +31,12 @@ let
   hash = if stdenv.isDarwin then sha256_darwin else sha256_linux;
   extension = if stdenv.isDarwin then "zip" else "tar.gz";
 
-  libraries = [
-    stdenv.cc.libc glib libxml2 ffmpeg_3 libxslt libGL
-    xorg.libXxf86vm alsaLib fontconfig freetype pango
-    gtk2 cairo gdk-pixbuf atk
-  ] ++ (lib.optionals swingSupport (with xorg; [
-    xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp
-    xorg.libXt xorg.libXrender stdenv.cc.cc
-  ]));
+  runtimeDependencies = [
+    cups
+  ] ++ lib.optionals gtkSupport [
+    cairo glib gtk3
+  ];
+  runtimeLibraryPath = lib.makeLibraryPath runtimeDependencies;
 
 in stdenv.mkDerivation {
   inherit version openjdk platform hash extension;
@@ -33,25 +48,27 @@ in stdenv.mkDerivation {
     sha256 = hash;
   };
 
-  buildInputs = [ makeWrapper ] ++ lib.optional stdenv.isDarwin unzip;
+  buildInputs = lib.optionals stdenv.isLinux [
+    alsaLib # libasound.so wanted by lib/libjsound.so
+    fontconfig
+    freetype
+    stdenv.cc.cc # libstdc++.so.6
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXtst
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook makeWrapper
+  ] ++ lib.optionals stdenv.isDarwin [
+    unzip
+  ];
 
   installPhase = ''
     mkdir -p $out
     cp -r ./* "$out/"
-
-    jrePath="$out/jre"
-
-    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/jli
-    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/server
-    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64/xawt
-    rpath=$rpath''${rpath:+:}$jrePath/lib/amd64
-
-    # set all the dynamic linkers
-    find $out -type f -perm -0100 \
-        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "$rpath" {} \;
-
-    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
 
     mkdir -p $out/nix-support
     printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
@@ -60,9 +77,19 @@ in stdenv.mkDerivation {
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
+  '' + lib.optionalString stdenv.isLinux ''
+    # We cannot use -exec since wrapProgram is a function but not a command.
+    for bin in $( find "$out" -executable -type f ); do
+      if patchelf --print-interpreter "$bin" &> /dev/null; then
+        wrapProgram "$bin" --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
+      fi
+    done
   '';
 
-  rpath = lib.strings.makeLibraryPath libraries;
+  preFixup = ''
+    find "$out" -name libfontmanager.so -exec \
+      patchelf --add-needed libfontconfig.so {} \;
+  '';
 
   passthru = {
     home = zulu;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds Swing support and optional GTK+ theme for JDK packages.

See also #106716.

To test the packages, you can use https://github.com/taku0/swing-set-2:

```
for i in adoptopenjdk-hotspot-bin-11 adoptopenjdk-hotspot-bin-8 graalvm11-ce graalvm8-ce zulu zulu8
do
  nix-build -I nixpkgs=. -o "${i}" -A pkgs."${i}"
done

git clone --depth 1 https://github.com/taku0/swing-set-2
nix-build -I nixpkgs=. -o SwingSet2 ./swing-set-2

adoptopenjdk-hotspot-bin-8/bin/java -jar SwingSet2/SwingSet2.jar
# and other JDKs.
```

Then choose `Look & Feel` → `GTK Style Look & Feel` from the menu (Linux only).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
