### PR TITLE
iptraf-ng: 1.1.4 -> 1.2.1

### DIFF
--- a/pkgs/applications/networking/iptraf-ng/default.nix
+++ b/pkgs/applications/networking/iptraf-ng/default.nix
@@ -1,24 +1,27 @@
-{ stdenv, fetchurl, ncurses }:
+{ stdenv, fetchFromGitHub, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.4";
+  version = "1.2.1";
   pname = "iptraf-ng";
 
-  src = fetchurl {
-    url = "https://fedorahosted.org/releases/i/p/iptraf-ng/${pname}-${version}.tar.gz";
-    sha256 = "02gb8z9h2s6s1ybyikywz7jgb1mafdx88hijfasv3khcgkq0q53r";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1f91w1bjaayr6ld95z2q55ny983bb0m05k1jrw2bcddvcihaiqb1";
   };
 
   buildInputs = [ ncurses ];
 
-  configurePhase = ''
-    ./configure --prefix=$out/usr --sysconfdir=$out/etc \
-                --localstatedir=$out/var --sbindir=$out/bin
-  '';
+  makeFlags = [
+    "DESTDIR=$(out)"
+    "prefix=/usr"
+    "sbindir=/bin"
+  ];
 
   hardeningDisable = [ "format" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A console-based network monitoring utility (fork of iptraf)";
     longDescription = ''
       IPTraf-ng is a console-based network monitoring utility. IPTraf-ng
@@ -38,9 +41,9 @@ stdenv.mkDerivation rec {
       of the Linux kernel, so it can be used on a wide variety of supported
       network cards.
     '';
-    homepage = "https://fedorahosted.org/iptraf-ng/";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.devhell ];
+    homepage = "https://github.com/iptraf-ng/iptraf-ng";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ devhell ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
