### PR TITLE
python3Packages.cloudscraper: init at 1.2.52

### DIFF
--- a/pkgs/development/python-modules/cloudscraper/default.nix
+++ b/pkgs/development/python-modules/cloudscraper/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, isPy3k
+, fetchPypi
+, requests
+, requests-toolbelt
+, pyparsing
+}:
+
+buildPythonPackage rec {
+  pname = "cloudscraper";
+  version = "1.2.52";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07j2nhzimzhcskj2wpxpvpb3dhpci19daw02r2ckkjiq3zifhm6v";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    requests-toolbelt
+    pyparsing
+  ];
+
+  # The tests require several other dependencies, some of which aren't in
+  # nixpkgs yet, and also aren't included in the PyPI bundle.  TODO.
+  doCheck = false;
+
+  pythonImportsCheck = [ "cloudscraper" ];
+
+  meta = with lib; {
+    description = "A Python module to bypass Cloudflare's anti-bot page";
+    homepage = https://github.com/venomous/cloudscraper;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kini ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1294,6 +1294,8 @@ in {
 
   cloudpickle = callPackage ../development/python-modules/cloudpickle { };
 
+  cloudscraper = callPackage ../development/python-modules/cloudscraper { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cma = callPackage ../development/python-modules/cma { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New package. Tests disabled for now since they pull in a lot of stuff. This PR depends on #107791.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
