### PR TITLE
consul: rewrite nixos module

### DIFF
--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -3,6 +3,7 @@
 with lib;
 let
   cfg = config.services.consul;
+  json = pkgs.formats.json { };
   settings = {
     data_dir = "/var/lib/consul";
   } // cfg.settings;
@@ -113,7 +114,7 @@ in
     mkMerge [
       {
         environment = {
-          etc."consul.json".source = json.generate settings;
+          etc."consul.json".source = json.generate "consul.json" settings;
           systemPackages = [ cfg.package ];
         };
 

--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -3,7 +3,7 @@
 with lib;
 let
   cfg = config.services.consul;
-  json = pkgs.formats.json { };
+  format = pkgs.formats.json { };
   settings = {
     data_dir = "/var/lib/consul";
   } // cfg.settings;
@@ -114,7 +114,7 @@ in
     mkMerge [
       {
         environment = {
-          etc."consul.json".source = json.generate "consul.json" settings;
+          etc."consul.json".source = format.generate "consul.json" settings;
           systemPackages = [ cfg.package ];
         };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a major simplification of the `consul` service exposed in nixos.

The primary motivation was to match the systemd unit settings provided by Hashicorp [here](https://learn.hashicorp.com/tutorials/consul/deployment-guide#configure-systemd).

Additionally, this service was previously discovering host IP addresses in an unnecessarily complex way, when Consul supports using [`go-sockaddr`](https://github.com/hashicorp/go-sockaddr) templates in configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
