### PR TITLE
linphone: 4.2.4 -> 4.2.5 and update all major SIP-related dependencies

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -52,7 +52,7 @@
 
 mkDerivation rec {
   pname = "linphone-desktop";
-  version = "4.2.4";
+  version = "4.2.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -175,13 +175,12 @@ mkDerivation rec {
     ln -s ${liblinphone}/share/belr/grammars/* $out/share/belr/grammars/
     mkdir -p $out/share/linphone
     ln -s ${liblinphone}/share/linphone/* $out/share/linphone/
-    mkdir $out/lib # prevent warning
   '';
 
   meta = with lib; {
     homepage = "https://www.linphone.org/";
     description = "Open source SIP phone for voice/video calls and instant messaging";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/bcg729/default.nix
+++ b/pkgs/development/libraries/bcg729/default.nix
@@ -1,34 +1,20 @@
 { stdenv
-, fetchFromGitHub
-, fetchpatch
+, fetchFromGitLab
 , cmake
 }:
 
 stdenv.mkDerivation rec {
   pname = "bcg729";
-  version = "1.0.4";
+  version = "1.1.1";
 
-  src = fetchFromGitHub {
-    owner = "BelledonneCommunications";
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    owner = "public";
+    group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "05s0c5ps3a763y0v34wg5zghj0cdjnq4ch7g81848xxry7q90fwa";
+    sha256 = "1hal6b3w6f8y5r1wa0xzj8sj2jjndypaxyw62q50p63garp2h739";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/BelledonneCommunications/bcg729/commit/a5907daf1b111e4ad7aab4f558f57e2af1e37e55.patch";
-      sha256 = "0445syfwj4w4chh8ak80rq77iqcr27924n1ld5snshk3d21nxd64";
-    })
-    (fetchpatch {
-      url = "https://github.com/BelledonneCommunications/bcg729/commit/697bf6653a8c7421f0e821ee8d42471246e6850f.patch";
-      sha256 = "1h3gf5sj2sg5cs5iv1lcav3lkqmd5jf4agvjzz83l89wd5f5hp5l";
-    })
-    (fetchpatch {
-      url = "https://github.com/BelledonneCommunications/bcg729/commit/d63ce04a93711820d9a6985b1d11d8d91ed8e6b6.patch";
-      sha256 = "1piwf63ci2gma6jd6b4adkvxirysvazf0vklb5pc6vx1g93nkgxs";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -36,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "Opensource implementation of both encoder and decoder of the ITU G729 Annex A/B speech codec";
     homepage = "https://linphone.org/technical-corner/bcg729";
     changelog = "https://gitlab.linphone.org/BC/public/bcg729/raw/${version}/NEWS";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ c0bw3b ];
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bctoolbox";
-  version = "4.4.13";
+  version = "4.4.21";
 
   nativeBuildInputs = [ cmake bcunit ];
   buildInputs = [ mbedtls ];
@@ -30,9 +30,7 @@ stdenv.mkDerivation rec {
     inherit version;
     description = "Utilities library for Linphone";
     homepage = "https://gitlab.linphone.org/BC/public/bctoolbox";
-    # Still using GPLv2 but as the rest of the Linphone projects have switched
-    # to GPLv3, this might too, so check this when bumping the version number.
-    license = licenses.gpl3Only;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ raskin jluttine ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "C++ library to manipulate VCard standard format";
     homepage = "https://gitlab.linphone.org/BC/public/belcard";
-    license = licenses.lgpl21;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "belle-sip";
-  version = "4.4.13";
+  version = "4.4.21";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1ad7sqc5y4f3gc8glwmb3rvfzapnvhg981g13x90cg4nzikjvka0";
+    sha256 = "0ylv1jsqnfhw23i6p3lfqqzw48lwii8zwkq3y34q0hhnngn26iiw";
   };
 
-  nativeBuildInputs = [ cmake antlr3_4 ];
+  nativeBuildInputs = [ antlr3_4 cmake ];
 
   buildInputs = [ zlib ];
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://linphone.org/technical-corner/belle-sip";
     description = "Modern library implementing SIP (RFC 3261) transport, transaction and dialog layers";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -6,17 +6,15 @@
 
 stdenv.mkDerivation rec {
   pname = "belr";
-  # Using master branch for linphone-desktop caused a chain reaction that many
-  # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-09";
+  version = "4.3.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
     repo = pname;
-    rev = "326d030ca9db12525c2a6d2a65f386f36f3c2ed5";
-    sha256 = "1cdblb9smncq3al0crqp5651b02k1g6whlw1ib769p61gad0rs3v";
+    rev = version;
+    sha256 = "1lda0f89vas38xgmc4yvnrigmrbril3dyqxgb5jh1zfx1xczfh1q";
   };
 
   buildInputs = [ bctoolbox ];
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Belledonne Communications' language recognition library";
     homepage = "https://gitlab.linphone.org/BC/public/belr";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bzrtp";
-  version = "4.4.0";
+  version = "4.4.9";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -29,9 +29,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An opensource implementation of ZRTP keys exchange protocol";
     homepage = "https://gitlab.linphone.org/BC/public/bzrtp";
-    # They have switched to GPLv3 on git HEAD so probably the next release will
-    # be GPL3.
-    license = licenses.lgpl21;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://www.linphone.org/technical-corner/liblinphone";
     description = "Library for SIP calls and instant messaging";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A Real-Time Transport Protocol (RFC3550) stack";
     homepage = "https://linphone.org/technical-corner/ortp";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];
   };

--- a/pkgs/os-specific/linux/atop/default.nix
+++ b/pkgs/os-specific/linux/atop/default.nix
@@ -1,22 +1,24 @@
 {stdenv, fetchurl, zlib, ncurses}:
 
 stdenv.mkDerivation rec {
-  version = "2.4.0";
   pname = "atop";
+  version = "2.6.0";
 
   src = fetchurl {
     url = "https://www.atoptool.nl/download/atop-${version}.tar.gz";
-    sha256 = "0s9xlxlzz688a80zxld840zkrmzw998rdkkg6yc7ssq8fw50275y";
+    sha256 = "nsLKOlcWkvfvqglfmaUQZDK8txzCLNbElZfvBIEFj3I=";
   };
 
   buildInputs = [zlib ncurses];
 
   makeFlags = [
-    ''SCRPATH=$out/etc/atop''
-    ''LOGPATH=/var/log/atop''
-    ''INIPATH=$out/etc/rc.d/init.d''
-    ''CRNPATH=$out/etc/cron.d''
-    ''ROTPATH=$out/etc/logrotate.d''
+    "SCRPATH=$out/etc/atop"
+    "LOGPATH=/var/log/atop"
+    "INIPATH=$out/etc/rc.d/init.d"
+    "SYSDPATH=$out/lib/systemd/system"
+    "CRNPATH=$out/etc/cron.d"
+    "DEFPATH=$out/etc/default"
+    "ROTPATH=$out/etc/logrotate.d"
   ];
 
   preConfigure = ''
@@ -28,9 +30,9 @@ stdenv.mkDerivation rec {
     sed -e 's/chmod 04711/chmod 0711/g' -i Makefile
   '';
 
+  installTargets = [ "systemdinstall" ];
   preInstall = ''
     mkdir -p "$out"/{bin,sbin}
-    make systemdinstall $makeFlags
   '';
 
   meta = with stdenv.lib; {
@@ -42,7 +44,7 @@ stdenv.mkDerivation rec {
       Atop is an ASCII full-screen performance monitor that is capable of reporting the activity of all processes (even if processes have finished during the interval), daily logging of system and process activity for long-term analysis, highlighting overloaded system resources by using colors, etc. At regular intervals, it shows system-level activity related to the CPU, memory, swap, disks and network layers, and for every active process it shows the CPU utilization, memory growth, disk utilization, priority, username, state, and exit code.
     '';
     inherit version;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     downloadPage = "http://atoptool.nl/downloadatop.php";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes a crash on incoming calls for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
