### PR TITLE
[20.09] redmine: wrap rdm-mailhandler.rb for inbound e-mail capabilities

### DIFF
--- a/pkgs/applications/version-management/redmine/default.nix
+++ b/pkgs/applications/version-management/redmine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bundlerEnv, ruby }:
+{ stdenv, fetchurl, bundlerEnv, ruby, makeWrapper }:
 
 let
   version = "4.1.1";
@@ -19,6 +19,7 @@ in
       sha256 = "1nndy5hz8zvfglxf1f3bsb1pkrfwinfxzkdan1vjs3rkckkszyh5";
     };
 
+    nativeBuildInputs = [ makeWrapper ];
     buildInputs = [ rubyEnv rubyEnv.wrappedRuby rubyEnv.bundler ];
 
     # taken from https://www.redmine.org/issues/33784
@@ -31,12 +32,14 @@ in
     '';
 
     installPhase = ''
-      mkdir -p $out/share
+      mkdir -p $out/bin $out/share
       cp -r . $out/share/redmine
       for i in config files log plugins public/plugin_assets public/themes tmp; do
         rm -rf $out/share/redmine/$i
         ln -fs /run/redmine/$i $out/share/redmine/$i
       done
+
+      makeWrapper ${rubyEnv.wrappedRuby}/bin/ruby $out/bin/rdm-mailhandler.rb --add-flags $out/share/redmine/extra/mail_handler/rdm-mailhandler.rb
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
(cherry picked from commit 1288f41c6ee3506654d2f88a204f2f7951b8f664)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Backport of https://github.com/NixOS/nixpkgs/pull/107155. Only adds new functionality, so no impact on existing installs - safe to backport :+1: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
