### PR TITLE
smesh, pythonPackages.{pythonocc-core,cadquery}: Fix building on darwin

### DIFF
--- a/pkgs/development/libraries/smesh/default.nix
+++ b/pkgs/development/libraries/smesh/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, ninja, opencascade }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, ninja, opencascade
+, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "smesh";
@@ -20,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ opencascade ];
+  buildInputs = [ opencascade ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
   meta = with stdenv.lib; {
     description = "Extension to OCE providing advanced meshing features";

--- a/pkgs/development/python-modules/cadquery/default.nix
+++ b/pkgs/development/python-modules/cadquery/default.nix
@@ -1,25 +1,25 @@
 { lib
-  , buildPythonPackage
-  , isPy3k
-  , pythonOlder
-  , pythonAtLeast
-  , fetchFromGitHub
-  , pyparsing
-  , opencascade
-  , stdenv
-  , python
-  , cmake
-  , swig
-  , ninja
-  , smesh
-  , freetype
-  , libGL
-  , libGLU
-  , libX11
-  , six
-  , pytest
-  , makeFontsConf
-  , freefont_ttf
+, buildPythonPackage
+, isPy3k
+, pythonOlder
+, pythonAtLeast
+, fetchFromGitHub
+, pyparsing
+, opencascade
+, stdenv
+, python
+, cmake
+, swig
+, smesh
+, freetype
+, libGL
+, libGLU
+, libX11
+, six
+, pytest
+, makeFontsConf
+, freefont_ttf
+, Cocoa
 }:
 
 let
@@ -38,7 +38,6 @@ let
     nativeBuildInputs = [
       cmake
       swig
-      ninja
     ];
 
     buildInputs = [
@@ -49,7 +48,7 @@ let
       libGL
       libGLU
       libX11
-    ];
+    ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
     propagatedBuildInputs = [
       six

--- a/pkgs/development/python-modules/pythonocc-core/default.nix
+++ b/pkgs/development/python-modules/pythonocc-core/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, python, fetchFromGitHub, cmake, swig, ninja,
-  opencascade, smesh, freetype, libGL, libGLU, libX11 }:
+{ stdenv, python, fetchFromGitHub, cmake, swig, ninja
+, opencascade, smesh, freetype, libGL, libGLU, libX11
+, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "pythonocc-core";
@@ -12,11 +13,17 @@ stdenv.mkDerivation rec {
     sha256 = "1jk4y7f75z9lyawffpfkr50qw5452xzi1imcdlw9pdvf4i0y86k3";
   };
 
-  nativeBuildInputs = [ cmake swig ninja ];
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+    --replace "/usr/X11R6/lib/libGL.dylib" "${libGL}/lib/libGL.dylib" \
+    --replace "/usr/X11R6/lib/libGLU.dylib" "${libGLU}/lib/libGLU.dylib"
+  '';
+
+  nativeBuildInputs = [ cmake swig ];
   buildInputs = [
     python opencascade smesh
     freetype libGL libGLU libX11
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 
   cmakeFlags = [
     "-Wno-dev"

--- a/pkgs/development/python-modules/spyder-kernels/0.x.nix
+++ b/pkgs/development/python-modules/spyder-kernels/0.x.nix
@@ -1,20 +1,19 @@
-{
-  lib
-  , buildPythonPackage
-  , fetchFromGitHub
-  , cloudpickle
-  , ipykernel
-  , wurlitzer
-  , jupyter_client
-  , pyzmq
-  , numpy
-  , pandas
-  , scipy
-  , matplotlib
-  , xarray
-  , pytest
-  , flaky
-  , isPy3k
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cloudpickle
+, ipykernel
+, wurlitzer
+, jupyter_client
+, pyzmq
+, numpy
+, pandas
+, scipy
+, matplotlib
+, xarray
+, pytestCheckHook
+, flaky
+, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -24,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "spyder-ide";
     repo = "spyder-kernels";
-    rev = "v0.5.2";
+    rev = "v${version}";
     sha256 = "1yan589g0470y61bcyjy3wj13i94ndyffckqdyrg97vw2qhfrisb";
   };
 
@@ -45,23 +44,23 @@ buildPythonPackage rec {
     scipy
     matplotlib
     xarray
-    pytest
+    pytestCheckHook
     flaky
   ];
+
+  preCheck = ''
+    export JUPYTER_RUNTIME_DIR=$(mktemp -d)
+  '';
 
   # skipped tests:
   # turtle requires graphics
   # cython test fails, I don't think this can ever access cython?
   # umr pathlist test assumes standard directories, not compatible with nix
-  checkPhase = ''
-    export JUPYTER_RUNTIME_DIR=$(mktemp -d)
-    pytest -x -vv -k '\
-      not test_turtle_launch \
-      and not test_umr_skip_cython \
-      and not test_umr_pathlist' \
-      -W 'ignore::DeprecationWarning' \
-      spyder_kernels
-  '';
+  disabledTests = [
+    "test_turtle_launc"
+    "test_umr_skip_cython"
+    "test_umr_pathlist"
+  ];
 
   meta = with lib; {
     description = "Jupyter kernels for Spyder's console";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7411,7 +7411,9 @@ in
 
   smenu = callPackage ../tools/misc/smenu { };
 
-  smesh = callPackage ../development/libraries/smesh {};
+  smesh = callPackage ../development/libraries/smesh {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   smu = callPackage ../tools/text/smu { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1041,7 +1041,9 @@ in {
 
   cachy = callPackage ../development/python-modules/cachy { };
 
-  cadquery = callPackage ../development/python-modules/cadquery { };
+  cadquery = callPackage ../development/python-modules/cadquery {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   caffe = toPythonModule (pkgs.caffe.override {
     pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6021,8 +6021,10 @@ in {
 
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
-  pythonocc-core =
-    toPythonModule (callPackage ../development/python-modules/pythonocc-core { inherit (pkgs.xorg) libX11; });
+  pythonocc-core = toPythonModule (callPackage ../development/python-modules/pythonocc-core {
+    inherit (pkgs.xorg) libX11;
+    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+  });
 
   python-olm = callPackage ../development/python-modules/python-olm { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#106433

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
