### PR TITLE
dconf: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -15,12 +15,15 @@
 , docbook-xsl-nons
 , docbook_xml_dtd_42
 }:
-
+let
+  isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
+in
 stdenv.mkDerivation rec {
   pname = "dconf";
   version = "0.38.0";
 
-  outputs = [ "out" "lib" "dev" "devdoc" ];
+  outputs = [ "out" "lib" "dev" ]
+    ++ stdenv.lib.optional (!isCross) "devdoc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -30,27 +33,26 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    vala
     pkg-config
     python3
     libxslt
     libxml2
     glib
-    gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_42
-  ];
+  ] ++ stdenv.lib.optional (!isCross) gtk-doc;
 
   buildInputs = [
     glib
     bash-completion
     dbus
-  ];
+  ] ++ stdenv.lib.optional (!isCross) vala;
+  # Vala cross compilation is broken. For now, build dconf without vapi when cross-compiling.
 
   mesonFlags = [
     "--sysconfdir=/etc"
-    "-Dgtk_doc=true"
-  ];
+    "-Dgtk_doc=${stdenv.lib.boolToString (!isCross)}" # gtk-doc does do some gobject introspection, which doesn't yet cross-compile.
+  ] ++ stdenv.lib.optional isCross "-Dvapi=false";
 
   doCheck = !stdenv.isAarch32 && !stdenv.isAarch64 && !stdenv.isDarwin;
 

--- a/pkgs/development/libraries/dconf/default.nix
+++ b/pkgs/development/libraries/dconf/default.nix
@@ -10,7 +10,6 @@
 , bash-completion
 , dbus
 , gnome3
-, libxml2
 , gtk-doc
 , docbook-xsl-nons
 , docbook_xml_dtd_42
@@ -36,7 +35,6 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     libxslt
-    libxml2
     glib
     docbook-xsl-nons
     docbook_xml_dtd_42


### PR DESCRIPTION
Vala doesn't yet cross-compile, and gtk-doc uses some
gobject-introspection bits (and gobject-introspection doesn't
cross-compile either).

###### Motivation for this change
Cross-compiled NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
