### PR TITLE
clojure-lsp: 20201207T142850 -> 20201228T020543

### DIFF
--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,23 +1,25 @@
-{ stdenv, fetchurl, jre }:
+{ stdenv, fetchurl, jre, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "clojure-lsp";
-  version = "20201207T142850";
+  version = "20201228T020543";
 
   src = fetchurl {
-    url = "https://github.com/snoe/clojure-lsp/releases/download/release-${version}/${pname}";
-    sha256 = "0fxplldpxslm7f5xxazkl09gsj0ysppaal72hmlqbdj6rbgxlrnk";
+    url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/release-${version}/${pname}.jar";
+    sha256 = "0jkpw7dx7976p63c08bp43fiwk6f2h2nxj9vv1zr103hgywpplri";
   };
 
   dontUnpack = true;
 
-  installPhase = ''
-    install -Dm755 $src $out/bin/clojure-lsp
-    sed -i -e '1 s!java!${jre}/bin/java!' $out/bin/clojure-lsp
-  '';
+  buildInputs = [ makeWrapper ];
 
-  # verify shebang patch
-  installCheckPhase = "PATH= clojure-lsp --version";
+  installPhase = ''
+    install -Dm644 $src $out/share/java/${pname}.jar
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $out/share/java/${pname}.jar" \
+      --add-flags "-Xmx2g" \
+      --add-flags "-server"
+  '';
 
   meta = with stdenv.lib; {
     description = "Language Server Protocol (LSP) for Clojure";
@@ -26,5 +28,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.ericdallo ];
     platforms = jre.meta.platforms;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Multiple updates: https://github.com/clojure-lsp/clojure-lsp

Switch to the new repository. Also, switch to packaging uberjar instead of rewriting the lein-bin file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
