### PR TITLE
disfetch: init at 1.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9374,6 +9374,12 @@
       fingerprint = "4D23 ECDF 880D CADF 5ECA  4458 874B D6F9 16FA A742";
     }];
   };
+  vel = {
+    email = "llathasa@outlook.com";
+    github = "llathasa-veleth";
+    githubId = 61933599;
+    name = "vel";
+  };
   velovix = {
     email = "xaviosx@gmail.com";
     github = "velovix";

--- a/pkgs/tools/misc/disfetch/default.nix
+++ b/pkgs/tools/misc/disfetch/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, lib
+, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "disfetch";
+  version = "1.12";
+
+  src = fetchFromGitHub {
+    owner = "llathasa-veleth";
+    repo = "disfetch";
+    rev = version;
+    sha256 = "1zm8q0fx695x28zg8ihzk3w41439v47n68cw6k551x31mls939yn";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 -t $out/bin disfetch
+  '';
+
+  meta = with lib; {
+    description = "Yet another *nix distro fetching program, but less complex";
+    homepage = "https://github.com/llathasa-veleth/disfetch";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.vel ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2003,6 +2003,8 @@ in
 
   discocss = callPackage ../tools/misc/discocss { };
 
+  disfetch = callPackage ../tools/misc/disfetch { };
+
   disk-filltest = callPackage ../tools/system/disk-filltest { };
 
   diskscan = callPackage ../tools/misc/diskscan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Disfetch is another *nix distro fetching program, but less complex. It is based on several principles
+ less code, more efficiency, more readability
+ simplicity
+ logos must be only 8 rows
+ using only coreutils, other built-ins, bash and nothing third-party
+ showing only main and needed system information

https://github.com/llathasa-veleth/disfetch

I am sorry for messing pull request up with force push.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
