### PR TITLE
bash-completion: fix build on darwin (#107768)

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchurl
 , fetchpatch
 , autoreconfHook
 , perl
@@ -11,11 +11,13 @@ stdenv.mkDerivation rec {
   pname = "bash-completion";
   version = "2.11";
 
-  src = fetchFromGitHub {
-    owner = "scop";
-    repo = "bash-completion";
-    rev = version;
-    sha256 = "0m3brd5jx7w07h8vxvvcmbyrlnadrx6hra3cvx6grzv6rin89liv";
+  # Using fetchurl because fetchGithub or fetchzip will have trouble on
+  # e.g. APFS filesystems (macOS) because of non UTF-8 characters in some of the
+  # test fixtures that are part of the repository.
+  # See discussion in https://github.com/NixOS/nixpkgs/issues/107768
+  src = fetchurl {
+    url = "https://github.com/scop/${pname}/releases/download/${version}/${pname}-${version}.tar.xz";
+    sha256 = "1b0iz7da1sgifx1a5wdyx1kxbzys53v0kyk8nhxfipllmm5qka3k";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

As discussed in https://github.com/NixOS/nixpkgs/issues/107768, macOS APFS and HFS+ seem to have issues extracting some of the test fixtures because of filesystem issues (case sensitivity, binary representation of characters, ...). This means that people currently won't be able to build things from source on macOS.
I'm a bit confused as to how the binary caches with this version got created.


By switching to fetchurl, we will still validate the tarball checksum itself while being able to compile on mac and linux.
It's not the cleanest solution, but it does work.

I tried to look into things like cleanSource / cleanSourceWith, but I'm not 100% sure that would solve the issue at hand.


Comparison:

Grab the new files:
```
% nix-build default.nix -A bash-completion
/nix/store/br1vvv70z4icia58fzlcw1nxid28ww62-bash-completion-2.11
% pushd /nix/store/br1vvv70z4icia58fzlcw1nxid28ww62-bash-completion-2.11; find . > ~/new.txt; popd  
```

Grab the current binary results:
```
% nix-env -i bash-completion
warning: there are multiple derivations named 'bash-completion-2.11'; using the first one
installing 'bash-completion-2.11'
these paths will be fetched (0.14 MiB download, 0.97 MiB unpacked):
  /nix/store/jyniimfqps4b1dgm2ya0hqyilc7g4y8v-bash-completion-2.11
copying path '/nix/store/jyniimfqps4b1dgm2ya0hqyilc7g4y8v-bash-completion-2.11' from 'https://cache.nixos.org'...
building '/nix/store/xbfs4rdn10ir4bjbnqahkzbrc0s6fs5a-user-environment.drv'...
created 257 symlinks in user environment
% pushd /nix/store/jyniimfqps4b1dgm2ya0hqyilc7g4y8v-bash-completion-2.11; find . > ~/binary.txt; popd
/nix/store/jyniimfqps4b1dgm2ya0hqyilc7g4y8v-bash-completion-2.11 ~/workspace/nixpkgs
~/workspace/nixpkgs
```

Compare the filenames:
```
% diff -qs ~/binary.txt ~/new.txt
Files /Users/mseeger/binary.txt and /Users/mseeger/new.txt are identical
```

Sanity check:
```
% head -n 5 ~/binary.txt
.
./etc
./etc/profile.d
./etc/profile.d/bash_completion.sh
./share
% head -n 5 ~/new.txt   
.
./etc
./etc/profile.d
./etc/profile.d/bash_completion.sh
./share
```




###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
