### PR TITLE
tmuxPlugins.onedark-theme: fix entrypoint

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -290,6 +290,7 @@ in rec {
 
   onedark-theme = mkDerivation {
     pluginName = "onedark-theme";
+    rtpFilePath = "tmux-onedark-theme.tmux";
     version = "unstable-2020-06-07";
     src = fetchFromGitHub {
       owner = "odedlaz";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently, the resulting target file `/nix/store/zrv5g7p1sy3b59dasxb9sqmr8c9v5lly-tmuxplugin-onedark-theme-unstable-2020-06-07/share/tmux-plugins/onedark-theme.tmux` doesn't exist.

This is because the tmux file name is incorrect.

Current: `onedark-theme.tmux`

Actual: [`tmux-onedark-theme.tmux`](https://github.com/odedlaz/tmux-onedark-theme/blob/master/tmux-onedark-theme.tmux)

CC @sherubthakur @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
