### PR TITLE
pavucontrol: dropdown patch for wayland support

### DIFF
--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -1,5 +1,5 @@
-{ fetchurl, stdenv, pkgconfig, intltool, libpulseaudio, gtkmm3
-, libcanberra-gtk3, gnome3, wrapGAppsHook }:
+{ fetchurl, fetchpatch, stdenv, pkgconfig, intltool, libpulseaudio,
+gtkmm3 , libcanberra-gtk3, gnome3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "pavucontrol";
@@ -9,6 +9,15 @@ stdenv.mkDerivation rec {
     url = "https://freedesktop.org/software/pulseaudio/${pname}/${pname}-${version}.tar.xz";
     sha256 = "1qhlkl3g8d7h72xjskii3g1l7la2cavwp69909pzmbi2jyn5pi4g";
   };
+
+  patches = [
+    # Can be removed with the next version bump
+    # https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/merge_requests/20
+    (fetchpatch {
+      name = "streamwidget-fix-drop-down-wayland.patch";
+      url = "https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/commit/ae278b8643cf1089f66df18713c8154208d9a505.patch";
+      sha256 = "066vhxjz6gmi2sp2n4pa1cdsxjnq6yml5js094g5n7ld34p84dpj";
+  })];
 
   buildInputs = [ libpulseaudio gtkmm3 libcanberra-gtk3
                   gnome3.adwaita-icon-theme ];


### PR DESCRIPTION
###### Motivation for this change
Pavucontrol employed a button with a popup instead of a dropdown menu
for its dropdown menus. These were rendered offset to the window and
maybe even offscreen from the window. Add the upstream patch which fixes
this issue.

Fixes https://github.com/NixOS/nixpkgs/issues/87446

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
