### PR TITLE
ocamlPackages.csv: use Dune 2

### DIFF
--- a/pkgs/development/ocaml-modules/csv/default.nix
+++ b/pkgs/development/ocaml-modules/csv/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "csv";
 	version = "2.4";
 
+	useDune2 = true;
+
 	src = fetchurl {
 		url = "https://github.com/Chris00/ocaml-${pname}/releases/download/${version}/csv-${version}.tbz";
 		sha256 = "13m9n8mdss6jfbiw7d5bybxn4n85vmg4zw7dc968qrgjfy0w9zhk";

--- a/pkgs/development/ocaml-modules/csv/lwt.nix
+++ b/pkgs/development/ocaml-modules/csv/lwt.nix
@@ -6,7 +6,7 @@ else
 
 buildDunePackage {
   pname = "csv-lwt";
-  inherit (csv) src version meta;
+  inherit (csv) src version useDune2 meta;
 
   propagatedBuildInputs = [ csv ocaml_lwt ];
 


### PR DESCRIPTION
###### Motivation for this change

Fix build with OCaml 4.12

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
