### PR TITLE
detect-secrets: 0.12.4 -> 0.14.3

### DIFF
--- a/pkgs/development/python-modules/pyahocorasick/default.nix
+++ b/pkgs/development/python-modules/pyahocorasick/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pyahocorasick";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "WojciechMula";
+    repo = pname;
+    rev = version;
+    sha256 = "0plm9x2gziayjsl7flsgn1z8qx88c9vqm4fs1wq7dv7fr188liik";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "unittests.py" ];
+  pythonImportsCheck = [ "ahocorasick" ];
+
+  meta = with lib; {
+    description = "Python module implementing Aho-Corasick algorithm";
+    longDescription = ''
+      This Python module is a fast and memory efficient library for exact or
+      approximate multi-pattern string search meaning that you can find multiple
+      key strings occurrences at once in some input text.
+    '';
+    homepage = "https://github.com/WojciechMula/pyahocorasick";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/tools/detect-secrets/default.nix
+++ b/pkgs/development/tools/detect-secrets/default.nix
@@ -1,29 +1,53 @@
-{ lib, buildPythonApplication, fetchFromGitHub, isPy27, pyyaml, unidiff, configparser, enum34, future, functools32, mock, pytest }:
+{ lib
+, buildPythonApplication
+, configparser
+, enum34
+, fetchFromGitHub
+, functools32
+, future
+, isPy27
+, mock
+, pyahocorasick
+, pytestCheckHook
+, pyyaml
+, requests
+, responses
+, unidiff
+}:
 
 buildPythonApplication rec {
   pname = "detect-secrets";
-  version = "0.12.4";
+  version = "0.14.3";
+  disabled = isPy27;
 
   # PyPI tarball doesn't ship tests
   src = fetchFromGitHub {
     owner = "Yelp";
-    repo = "detect-secrets";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "01y5xd0irxxib4wnf5834gwa7ibb81h5y4dl8b26gyzgvm5zfpk1";
+    sha256 = "0c4hxih9ljmv0d3izq5idyspk5zci26gdb6lv9klwcshwrfkvxj0";
   };
 
-  propagatedBuildInputs = [ pyyaml ]
-    ++ lib.optionals isPy27 [ configparser enum34 future functools32 ];
+  propagatedBuildInputs = [
+    pyyaml
+    requests
+  ];
 
-  checkInputs = [ mock pytest unidiff ];
+  checkInputs = [
+    mock
+    pyahocorasick
+    pytestCheckHook
+    responses
+    unidiff
+  ];
 
-  # deselect tests which require git setup
-  checkPhase = ''
-    PYTHONPATH=$PWD:$PYTHONPATH pytest \
-      --deselect tests/main_test.py::TestMain \
-      --deselect tests/pre_commit_hook_test.py::TestPreCommitHook \
-      --deselect tests/core/baseline_test.py::TestInitializeBaseline
-  '';
+  disabledTests = [
+    "TestMain"
+    "TestPreCommitHook"
+    "TestInitializeBaseline"
+  ];
+
+  pythonImportsCheck = [ "detect_secrets" ];
 
   meta = with lib; {
     description = "An enterprise friendly way of detecting and preventing secrets in code";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5125,6 +5125,8 @@ in {
 
   pyaftership = callPackage ../development/python-modules/pyaftership { };
 
+  pyahocorasick = callPackage ../development/python-modules/pyahocorasick { };
+
   pyairvisual = callPackage ../development/python-modules/pyairvisual { };
 
   pyalgotrade = callPackage ../development/python-modules/pyalgotrade { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.14.3

Tests are now requiring [pyahocorasick](https://github.com/WojciechMula/pyahocorasick).

Changelog: https://github.com/Yelp/detect-secrets/blob/master/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
