### PR TITLE
Ceph bluestore

### DIFF
--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -3,6 +3,7 @@ import ./make-test-python.nix ({pkgs, lib, ...}:
 let
   cfg = {
     clusterId = "066ae264-2a5d-4729-8001-6ad265f50b03";
+    adminKey = "AQBEEJNac00kExAAXEgy943BGyOpVH1LLlHafQ==";
     monA = {
       name = "a";
       ip = "192.168.1.1";
@@ -14,13 +15,9 @@ let
     };
     osd1 = {
       name = "1";
-      key = "AQBEEJNac00kExAAXEgy943BGyOpVH1LLlHafQ==";
-      uuid = "5e97a838-85b6-43b0-8950-cb56d554d1e5";
     };
     osd2 = {
       name = "2";
-      key = "AQAdyhZeIaUlARAAGRoidDAmS6Vkp546UFEf5w==";
-      uuid = "ea999274-13d0-4dd5-9af9-ad25a324f72f";
     };
   };
   generateCephConfig = { daemonConfig }: {
@@ -86,8 +83,11 @@ let
     # Bootstrap ceph-mon daemon
     monA.succeed(
         "sudo -u ceph ceph-authtool --create-keyring /tmp/ceph.mon.keyring --gen-key -n mon. --cap mon 'allow *'",
-        "sudo -u ceph ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'",
+        "sudo -u ceph ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --add-key ${cfg.adminKey} -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'",
+        "sudo -u ceph mkdir /var/lib/ceph/bootstrap-osd",
+        "sudo -u ceph ceph-authtool --create-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring --gen-key -n client.bootstrap-osd --cap mon 'profile bootstrap-osd' --cap mgr 'allow r'",
         "sudo -u ceph ceph-authtool /tmp/ceph.mon.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring",
+        "sudo -u ceph ceph-authtool /tmp/ceph.mon.keyring --import-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring",
         "monmaptool --create --add ${cfg.monA.name} ${cfg.monA.ip} --fsid ${cfg.clusterId} /tmp/monmap",
         "sudo -u ceph ceph-mon --mkfs -i ${cfg.monA.name} --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring",
         "sudo -u ceph touch /var/lib/ceph/mon/ceph-${cfg.monA.name}/done",
@@ -110,34 +110,27 @@ let
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
 
     # Bootstrap OSDs
+
+    # Bootstrap osd0 as a filestore, manually without lvm
     monA.succeed(
         "mkfs.xfs /dev/vdb",
-        "mkfs.xfs /dev/vdc",
-        "mkfs.xfs /dev/vdd",
         "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd0.name}",
         "mount /dev/vdb /var/lib/ceph/osd/ceph-${cfg.osd0.name}",
-        "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd1.name}",
-        "mount /dev/vdc /var/lib/ceph/osd/ceph-${cfg.osd1.name}",
-        "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd2.name}",
-        "mount /dev/vdd /var/lib/ceph/osd/ceph-${cfg.osd2.name}",
         "ceph-authtool --create-keyring /var/lib/ceph/osd/ceph-${cfg.osd0.name}/keyring --name osd.${cfg.osd0.name} --add-key ${cfg.osd0.key}",
-        "ceph-authtool --create-keyring /var/lib/ceph/osd/ceph-${cfg.osd1.name}/keyring --name osd.${cfg.osd1.name} --add-key ${cfg.osd1.key}",
-        "ceph-authtool --create-keyring /var/lib/ceph/osd/ceph-${cfg.osd2.name}/keyring --name osd.${cfg.osd2.name} --add-key ${cfg.osd2.key}",
         'echo \'{"cephx_secret": "${cfg.osd0.key}"}\' | ceph osd new ${cfg.osd0.uuid} -i -',
-        'echo \'{"cephx_secret": "${cfg.osd1.key}"}\' | ceph osd new ${cfg.osd1.uuid} -i -',
-        'echo \'{"cephx_secret": "${cfg.osd2.key}"}\' | ceph osd new ${cfg.osd2.uuid} -i -',
-    )
-
-    # Initialize the OSDs with regular filestore
-    monA.succeed(
         "ceph-osd -i ${cfg.osd0.name} --mkfs --osd-uuid ${cfg.osd0.uuid}",
-        "ceph-osd -i ${cfg.osd1.name} --mkfs --osd-uuid ${cfg.osd1.uuid}",
-        "ceph-osd -i ${cfg.osd2.name} --mkfs --osd-uuid ${cfg.osd2.uuid}",
         "chown -R ceph:ceph /var/lib/ceph/osd",
         "systemctl start ceph-osd-${cfg.osd0.name}",
+    )
+
+    # Bootstrap osd 2 and 3 as bluestore, using ceph-volume
+    monA.succeed(
+        "ceph-volume lvm create --no-systemd --data /dev/vdc",
+        "ceph-volume lvm create --no-systemd --data /dev/vdd",
         "systemctl start ceph-osd-${cfg.osd1.name}",
         "systemctl start ceph-osd-${cfg.osd2.name}",
     )
+
     monA.wait_until_succeeds("ceph osd stat | grep -e '3 osds: 3 up[^,]*, 3 in'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -3,7 +3,6 @@ import ./make-test-python.nix ({pkgs, lib, ...}:
 let
   cfg = {
     clusterId = "066ae264-2a5d-4729-8001-6ad265f50b03";
-    adminKey = "AQBEEJNac00kExAAXEgy943BGyOpVH1LLlHafQ==";
     monA = {
       name = "a";
       ip = "192.168.1.1";
@@ -83,10 +82,10 @@ let
     # Bootstrap ceph-mon daemon
     monA.succeed(
         "sudo -u ceph ceph-authtool --create-keyring /tmp/ceph.mon.keyring --gen-key -n mon. --cap mon 'allow *'",
-        "sudo -u ceph ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --add-key ${cfg.adminKey} -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'",
+        "sudo -u ceph ceph-authtool --create-keyring /etc/ceph/ceph.client.admin.keyring --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'",
+        "sudo -u ceph ceph-authtool /tmp/ceph.mon.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring",
         "sudo -u ceph mkdir /var/lib/ceph/bootstrap-osd",
         "sudo -u ceph ceph-authtool --create-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring --gen-key -n client.bootstrap-osd --cap mon 'profile bootstrap-osd' --cap mgr 'allow r'",
-        "sudo -u ceph ceph-authtool /tmp/ceph.mon.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring",
         "sudo -u ceph ceph-authtool /tmp/ceph.mon.keyring --import-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring",
         "monmaptool --create --add ${cfg.monA.name} ${cfg.monA.ip} --fsid ${cfg.clusterId} /tmp/monmap",
         "sudo -u ceph ceph-mon --mkfs -i ${cfg.monA.name} --monmap /tmp/monmap --keyring /tmp/ceph.mon.keyring",

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -31,7 +31,7 @@ let
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
       memorySize = 512;
-      emptyDiskImages = [ 20480 20480 20480 ];
+      emptyDiskImages = [ 20480 20480 20480 1024 ];
       vlans = [ 1 ];
     };
 
@@ -124,8 +124,8 @@ let
 
     # Bootstrap osd 2 and 3 as bluestore, using ceph-volume
     monA.succeed(
-        "ceph-volume lvm create --no-systemd --data /dev/vdc",
-        "ceph-volume lvm create --no-systemd --data /dev/vdd",
+        "ceph-volume lvm create --no-systemd --bluestore --data /dev/vdc",
+        "ceph-volume lvm create --no-systemd --filestore --data /dev/vdd --journal /dev/vde",
         "systemctl start ceph-osd-${cfg.osd1.name}",
         "systemctl start ceph-osd-${cfg.osd2.name}",
     )


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Test Ceph's Bluestore on NixOS and include necessary setup for `ceph-volume` to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
