### PR TITLE
kmod: fix depmod crash on darwin

### DIFF
--- a/pkgs/os-specific/linux/kmod/darwin.patch
+++ b/pkgs/os-specific/linux/kmod/darwin.patch
@@ -121,3 +121,15 @@ index fd2028d..ecb0141 100644
  	if (!cwd)
  		return NULL;
  
+--- a/shared/util.h	2018-01-31 18:10:59.000000000 +0100
++++ b/shared/util.h	2020-12-28 19:48:21.000000000 +0100
+@@ -7,6 +7,9 @@
+ #include <stdio.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#ifdef __APPLE__
++#include <libgen.h>
++#endif
+ 
+ #include <shared/macro.h>
+ 


### PR DESCRIPTION
The `kmod` tools, most importantly `depmod` are needed when cross-compiling a Linux kernel on macOS (Darwin). Currently `depmod` will just segfault and I diagnosed the problem as follows:
* all `kmod` tools are symlinked to one binary
* this binary uses `basename(argv[0])` to determine its personality
* `basename()` requires the `libgen.h` header on Darwin, which is not included
* the return type is thus assumed to be `int`
* this causes the resulting `char *` (the actual return type) to be truncated to 32 bit
* `depmod` crashes

The fix is to include `libgen.h` at a prominent location so that all invocations of `basename()` are covered.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
