### PR TITLE
mopidy-tunein: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/applications/audio/mopidy/tunein.nix
+++ b/pkgs/applications/audio/mopidy/tunein.nix
@@ -2,20 +2,17 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mopidy-tunein";
-  version = "1.0.0";
+  version = "1.0.2";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "Mopidy-TuneIn";
-    sha256 = "0insasf4w8ajsqjh5zmax7pkzmrk1p245vh4y8ddicldj45p6qfj";
+    sha256 = "1mvfhka8wi835yk9869yn3b6mdkfwqkylp14vpjkbm42d0kj4lkc";
   };
 
   propagatedBuildInputs = [
     mopidy
   ];
-
-  # tests fail with "ValueError: Namespace Gst not available" in mopidy itself
-  doCheck = false;
 
   pythonImportsCheck = [ "mopidy_tunein.tunein" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/kingosticks/mopidy-tunein/releases/tag/v1.0.1
https://github.com/kingosticks/mopidy-tunein/releases/tag/v1.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
