### PR TITLE
nixos/yubikey-agent: add udev rules

### DIFF
--- a/nixos/modules/services/security/yubikey-agent.nix
+++ b/nixos/modules/services/security/yubikey-agent.nix
@@ -51,6 +51,9 @@ in
       path = [ pkgs.pinentry.${pinentryFlavor} ];
     };
 
+    # add so that yubikey's are automatically loaded
+    services.udev.packages = [ pkgs.libu2f-host.udev-rules ];
+
     environment.extraInit = ''
       if [ -z "$SSH_AUTH_SOCK" -a -n "$XDG_RUNTIME_DIR" ]; then
         export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/yubikey-agent/yubikey-agent.sock"

--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, json_c, hidapi }:
+{ stdenv, callPackage, fetchurl, fetchpatch, pkgconfig, json_c, hidapi }:
 
+let
+  # expose udev rules without needing to have a full build of libu2f-host
+  udev-rules = callPackage ./udev-rules.nix { };
+in
 stdenv.mkDerivation rec {
   pname = "libu2f-host";
   version = "1.1.10";
@@ -22,6 +26,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ json_c hidapi ];
 
   doCheck = true;
+
+  passthru = {
+    inherit udev-rules;
+  };
 
   meta = with stdenv.lib; {
     homepage = "https://developers.yubico.com/libu2f-host";

--- a/pkgs/development/libraries/libu2f-host/udev-rules.nix
+++ b/pkgs/development/libraries/libu2f-host/udev-rules.nix
@@ -1,0 +1,21 @@
+{ stdenvNoCC
+, libu2f-host
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "libu2f-host-udev-rules";
+
+  inherit (libu2f-host) version src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/etc/udev/rules.d/
+    cp *.rules $out/etc/udev/rules.d/
+  '';
+
+  meta = libu2f-host.meta // {
+    Description = "Yubikey udev rules";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Had trouble getting my yubikey autodetected. Translated https://support.yubico.com/hc/en-us/articles/360013708900-Using-Your-U2F-YubiKey-with-Linux into nixos modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
[11:47:31] jon@jon-desktop /home/jon/projects/nixpkgs (yubikey-udev)
$ nix path-info -Sh $(nix-build -A libu2f-host.udev-rules)
/nix/store/n2kzljlgd97pf6srxcwndvblbwq1gdc1-libu2f-host-udev-rules-1.1.10	   4.6K
```