### PR TITLE
gnome3.iagno: remove stale patch

### DIFF
--- a/pkgs/desktops/gnome-3/games/iagno/default.nix
+++ b/pkgs/desktops/gnome-3/games/iagno/default.nix
@@ -26,15 +26,6 @@ stdenv.mkDerivation rec {
     sha256 = "097dw1l92l73xah9l56ka5mi3dvx48ffpiv33ni5i5rqw0ng7fc4";
   };
 
-  patches = [
-    # Fix build with Meson 0.55
-    # https://gitlab.gnome.org/GNOME/iagno/-/issues/16
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/iagno/commit/0100bab269f2102f24a6e41202b931da1b6e8dc5.patch";
-      sha256 = "ZW75s+bV45ivwA+SKUN7ejSvnXYEo/kYQjDVvFBA/sg=";
-    })
-  ];
-
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing to apply a patch when reviewing another PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
