### PR TITLE
pure-maps: init at 2.6.0

### DIFF
--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -1,0 +1,46 @@
+{ lib, mkDerivation, fetchFromGitHub, wrapQtAppsHook
+, qmake, qttools, kirigami2, qtquickcontrols2, qtlocation, qtsensors
+, nemo-qml-plugin-dbus, mapbox-gl-qml, s2geometry
+, python3, pyotherside, python3Packages
+}:
+
+mkDerivation rec {
+  pname = "pure-maps";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "rinigus";
+    repo = "pure-maps";
+    rev = version;
+    sha256 = "1nviq2pavyxwh9k4kyzqpbzmx1wybwdax4pyd017izh9h6gqnjhs";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ qmake python3 qttools wrapQtAppsHook ];
+  buildInputs = [
+    kirigami2 qtquickcontrols2 qtlocation qtsensors
+    nemo-qml-plugin-dbus pyotherside mapbox-gl-qml s2geometry
+  ];
+  propagatedBuildInputs = with python3Packages; [ gpxpy pyxdg ];
+
+  postPatch = ''
+    substituteInPlace pure-maps.pro \
+      --replace '$$[QT_HOST_BINS]/lconvert' 'lconvert'
+  '';
+
+  qmakeFlags = [ "FLAVOR=kirigami" ];
+
+  dontWrapQtApps = true;
+  postInstall = ''
+    wrapQtApp $out/bin/pure-maps \
+      --prefix PYTHONPATH : "$out/share"
+  '';
+
+  meta = with lib; {
+    description = "Display vector and raster maps, places, routes, and provide navigation instructions with a flexible selection of data and service providers";
+    homepage = "https://github.com/rinigus/pure-maps";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/mapbox-gl-native/default.nix
+++ b/pkgs/development/libraries/mapbox-gl-native/default.nix
@@ -1,0 +1,33 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkg-config
+, qtbase, curl, libuv, glfw3 }:
+
+mkDerivation rec {
+  pname = "mapbox-gl-native";
+  version = "2020.06.07";
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = "mapbox-gl-native";
+    rev = "e18467d755f470b26f61f6893eddd76ecf0816e6";
+    sha256 = "1x271gg9h81jpi70pv63i6lsa1zg6bzja9mbz7bsa4s02fpqy7wh";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ curl libuv glfw3 qtbase ];
+
+  cmakeFlags = [
+    "-DMBGL_WITH_QT=ON"
+    "-DMBGL_WITH_QT_LIB_ONLY=ON"
+    "-DMBGL_WITH_QT_HEADLESS=OFF"
+  ];
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations -Wno-error=type-limits";
+
+  meta = with lib; {
+    description = "Interactive, thoroughly customizable maps in native Android, iOS, macOS, Node.js, and Qt applications, powered by vector tiles and OpenGL";
+    homepage = "https://mapbox.com/mobile";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/mapbox-gl-qml/default.nix
+++ b/pkgs/development/libraries/mapbox-gl-qml/default.nix
@@ -1,0 +1,32 @@
+{ lib, mkDerivation, fetchFromGitHub, qmake, qtbase, qtlocation, mapbox-gl-native }:
+
+mkDerivation rec {
+  pname = "mapbox-gl-qml";
+  version = "1.7.5";
+
+  src = fetchFromGitHub {
+    owner = "rinigus";
+    repo = "mapbox-gl-qml";
+    rev = version;
+    sha256 = "1izwkfqn8jl83vihcxl2b159sqmkn1amxf92zw0h6psls2g9xhwx";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtlocation mapbox-gl-native ];
+
+  postPatch = ''
+    substituteInPlace mapbox-gl-qml.pro \
+      --replace '$$[QT_INSTALL_QML]' $out'/${qtbase.qtQmlPrefix}'
+  '';
+
+  # Package expects qt5 subdirectory of mapbox-gl-native to be in the include path
+  NIX_CFLAGS_COMPILE = "-I${mapbox-gl-native}/include/qt5";
+
+  meta = with lib; {
+    description = "Unofficial Mapbox GL Native bindings for Qt QML";
+    homepage = "https://github.com/rinigus/mapbox-gl-qml";
+    license = licenses.lgpl3Only;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/nemo-qml-plugin-dbus/default.nix
+++ b/pkgs/development/libraries/nemo-qml-plugin-dbus/default.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, lib, fetchFromGitLab, qmake, qtbase }:
+
+mkDerivation rec {
+  pname = "nemo-qml-plugin-dbus";
+  version = "2.1.23";
+
+  src = fetchFromGitLab {
+    domain = "git.sailfishos.org";
+    owner = "mer-core";
+    repo = "nemo-qml-plugin-dbus";
+    rev = version;
+    sha256 = "0ww478ds7a6h4naa7vslj6ckn9cpsgcml0q7qardkzmdmxsrv1ag";
+  };
+
+  nativeBuildInputs = [ qmake ];
+
+  postPatch = ''
+    substituteInPlace dbus.pro --replace ' tests' ""
+    substituteInPlace src/nemo-dbus/nemo-dbus.pro \
+      --replace /usr $out \
+      --replace '$$[QT_INSTALL_LIBS]' $out'/lib'
+    substituteInPlace src/plugin/plugin.pro \
+      --replace '$$[QT_INSTALL_QML]' $out'/${qtbase.qtQmlPrefix}'
+  '';
+
+  meta = with lib; {
+    description = "Nemo DBus plugin for qml";
+    homepage = "https://git.sailfishos.org/mer-core/nemo-qml-plugin-dbus/";
+    license = licenses.lgpl2Only;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/s2geometry/default.nix
+++ b/pkgs/development/libraries/s2geometry/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, openssl, gtest }:
+
+stdenv.mkDerivation rec {
+  pname = "s2geometry";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "s2geometry";
+    rev = "v${version}";
+    sha256 = "1mx61bnn2f6bd281qlhn667q6yfg1pxzd2js88l5wpkqlfzzhfaz";
+  };
+
+  patches = [
+    # Fix build https://github.com/google/s2geometry/issues/165
+    (fetchpatch {
+      url = "https://github.com/google/s2geometry/commit/a4dddf40647c68cd0104eafc31e9c8fb247a6308.patch";
+      sha256 = "0fp3w4bg7pgf5vv4vacp9g06rbqzhxc2fg6i5appp93q6phiinvi";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ openssl gtest ];
+
+  meta = with lib; {
+    description = "Computational geometry and spatial indexing on the sphere";
+    homepage = "http://s2geometry.io/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24603,6 +24603,8 @@ in
 
   puremapping = callPackage ../applications/audio/pd-plugins/puremapping { };
 
+  pure-maps = libsForQt5.callPackage ../applications/misc/pure-maps { };
+
   pwdsafety = callPackage ../tools/security/pwdsafety { };
 
   pybitmessage = callPackage ../applications/networking/instant-messengers/pybitmessage { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15859,6 +15859,8 @@ in
 
   mapbox-gl-native = libsForQt5.callPackage ../development/libraries/mapbox-gl-native { };
 
+  mapbox-gl-qml = libsForQt5.callPackage ../development/libraries/mapbox-gl-qml { };
+
   mapnik = callPackage ../development/libraries/mapnik { };
 
   marisa = callPackage ../development/libraries/marisa {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16657,6 +16657,8 @@ in
 
   rubberband = callPackage ../development/libraries/rubberband { };
 
+  s2geometry = callPackage ../development/libraries/s2geometry { };
+
   /* This package references ghc844, which we no longer have. Unfortunately, I
      have been unable to mark it as "broken" in a way that the ofBorg bot
      recognizes. Since I don't want to merge code into master that generates

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15857,6 +15857,8 @@ in
 
   opencl-clang = callPackage ../development/libraries/opencl-clang { };
 
+  mapbox-gl-native = libsForQt5.callPackage ../development/libraries/mapbox-gl-native { };
+
   mapnik = callPackage ../development/libraries/mapnik { };
 
   marisa = callPackage ../development/libraries/marisa {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16004,6 +16004,8 @@ in
 
   ndpi = callPackage ../development/libraries/ndpi { };
 
+  nemo-qml-plugin-dbus = libsForQt5.callPackage ../development/libraries/nemo-qml-plugin-dbus { };
+
   nifticlib = callPackage ../development/libraries/science/biology/nifticlib { };
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };


### PR DESCRIPTION
###### Motivation for this change
Pure maps is a great navigation application. While it's main focus is mobile devices (I intend to use it on NixOS Mobile), it works pretty well on the desktop too.

Pure maps has multiple GUI 'flavours', Kirigami, QtControls, Sailfish, & Ubuntu Touch: I have just packaged the kirigami version for the sake of simplicity, but we can always add a flag to choose the flavour later if there's interest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
