### PR TITLE
_3proxy: 0.8.13 -> 0.9.3

### DIFF
--- a/pkgs/applications/networking/3proxy/default.nix
+++ b/pkgs/applications/networking/3proxy/default.nix
@@ -2,25 +2,26 @@
 
 stdenv.mkDerivation rec {
   pname = "3proxy";
-  version = "0.8.13";
+  version = "0.9.3";
+
   src = fetchFromGitHub {
     owner = "z3APA3A";
     repo = pname;
     rev = version;
-    sha256 = "1k5rqldiyakhwhplazlhswkgy3psdkpxhn85605ncwaqx49qy8vk";
+    sha256 = "9aopwyz0U2bYTvx5YWLJo9EE8Xfb51IOguHRJodjpm8=";
   };
+
   makeFlags = [
+    "-f Makefile.Linux"
     "INSTALL=${coreutils}/bin/install"
-    "prefix=$(out)"
+    "DESTDIR=${placeholder "out"}"
   ];
-  preConfigure = ''
-    ln -s Makefile.Linux Makefile
-  '';
+
   meta = with lib; {
     description = "Tiny free proxy server";
     homepage = "https://github.com/z3APA3A/3proxy";
-    license = licenses.gpl2;
+    license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.misuzu ];
+    maintainers = with maintainers; [ misuzu ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
