### PR TITLE
openbabel: 2.4 -> 3.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2031,6 +2031,12 @@
     githubId = 23366017;
     name = "Dan Haraj";
   };
+  danielbarter = {
+    email = "danielbarter@gmail.com";
+    github = "danielbarter";
+    githubId = 8081722;
+    name = "Daniel Barter";
+  };
   danieldk = {
     email = "me@danieldk.eu";
     github = "danieldk";

--- a/pkgs/applications/science/chemistry/avogadro/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro/default.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Molecule editor and visualizer";
-    maintainers = [ ];
-    platforms = lib.platforms.mesaPlatforms;
+    maintainers = with maintainers; [ danielbarter ];
+    platforms = platforms.mesaPlatforms;
   };
 }

--- a/pkgs/development/libraries/openbabel/2.nix
+++ b/pkgs/development/libraries/openbabel/2.nix
@@ -1,0 +1,31 @@
+{stdenv, lib, fetchurl, fetchpatch, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "openbabel";
+  version = "2.4.1";
+
+  src = fetchurl {
+    url = "https://github.com/openbabel/openbabel/archive/openbabel-${stdenv.lib.replaceStrings ["."] ["-"] version}.tar.gz";
+    sha256 = "0xm7y859ivq2cp0q08mwshfxm0jq31xkyr4x8s0j6l7khf57yk2r";
+  };
+
+  patches = [
+    # ARM / AArch64 fixes.
+    (fetchpatch {
+      url = "https://github.com/openbabel/openbabel/commit/ee11c98a655296550710db1207b294f00e168216.patch";
+      sha256 = "0wjqjrkr4pfirzzicdvlyr591vppydk572ix28jd2sagnfnf566g";
+    })
+  ];
+
+  buildInputs = [ zlib libxml2 eigen python cairo pcre ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = with lib; {
+    description = "A toolbox designed to speak the many languages of chemical data";
+    homepage = "http://openbabel.org";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ danielbarter ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -1,34 +1,45 @@
-{stdenv, fetchurl, fetchpatch, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkgconfig }:
+{stdenv, lib, fetchurl, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkg-config, swig, rapidjson }:
 
 stdenv.mkDerivation rec {
   pname = "openbabel";
-  version = "2.4.1";
+  version = "3.1.1";
 
   src = fetchurl {
     url = "https://github.com/openbabel/openbabel/archive/openbabel-${stdenv.lib.replaceStrings ["."] ["-"] version}.tar.gz";
-    sha256 = "0xm7y859ivq2cp0q08mwshfxm0jq31xkyr4x8s0j6l7khf57yk2r";
+    sha256 = "c97023ac6300d26176c97d4ef39957f06e68848d64f1a04b0b284ccff2744f02";
   };
 
-  patches = [
-    # ARM / AArch64 fixes.
-    (fetchpatch {
-      url = "https://github.com/openbabel/openbabel/commit/ee11c98a655296550710db1207b294f00e168216.patch";
-      sha256 = "0wjqjrkr4pfirzzicdvlyr591vppydk572ix28jd2sagnfnf566g";
-    })
+
+  buildInputs = [ zlib libxml2 eigen python cairo pcre swig rapidjson ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  pythonMajorMinor = "${python.sourceVersion.major}.${python.sourceVersion.minor}";
+
+  cmakeFlags = [
+    "-DRUN_SWIG=ON"
+    "-DPYTHON_BINDINGS=ON"
   ];
 
-  # TODO : perl & python bindings;
-  # TODO : wxGTK: I have no time to compile
-  # TODO : separate lib and apps
-  buildInputs = [ zlib libxml2 eigen python cairo pcre ];
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  postFixup = ''
+    cat <<EOF > $out/lib/python$pythonMajorMinor/site-packages/setup.py
+    from distutils.core import setup
 
-  meta = {
+    setup(
+        name = 'pyopenbabel',
+        version = '${version}',
+        packages = ['openbabel'],
+        package_data = {'openbabel' : ['_openbabel.so']}
+    )
+    EOF
+    '';
+
+  meta = with lib; {
     description = "A toolbox designed to speak the many languages of chemical data";
     homepage = "http://openbabel.org";
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ ];
-    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = platforms.all;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ danielbarter ];
   };
 }

--- a/pkgs/development/python-modules/openbabel-bindings/default.nix
+++ b/pkgs/development/python-modules/openbabel-bindings/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, openbabel, python, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "openbabel";
+  version = "3.1.1";
+
+  src = "${openbabel}/lib/python${python.sourceVersion.major}.${python.sourceVersion.minor}/site-packages";
+
+  nativeBuildInputs = [ openbabel ];
+
+  # these env variables are used by the bindings to find libraries
+  # they need to be included explicitly in your nix-shell for
+  # some functionality to work (inparticular, pybel).
+  # see https://openbabel.org/docs/dev/Installation/install.html
+  BABEL_LIBDIR = "${openbabel}/lib/openbabel/3.1.0";
+  LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:${openbabel}/lib";
+
+  doCheck = false;
+  pythonImportsCheck = [ "openbabel" ];
+
+  meta = with lib; {
+    homepage = "http://openbabel.org/wiki/Main_Page";
+    description = "Python bindings for openbabel";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ danielbarter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15779,7 +15779,11 @@ in
   };
   openal = openalSoft;
 
-  openbabel = callPackage ../development/libraries/openbabel { };
+  openbabel = openbabel3;
+
+  openbabel2 = callPackage ../development/libraries/openbabel/2.nix { };
+
+  openbabel3 = callPackages ../development/libraries/openbabel { };
 
   opencascade = callPackage ../development/libraries/opencascade {
     inherit (darwin.apple_sdk.frameworks) OpenCL Cocoa;
@@ -27344,6 +27348,7 @@ in
   ### SCIENCE/CHEMISTY
 
   avogadro = callPackage ../applications/science/chemistry/avogadro {
+    openbabel = openbabel2;
     eigen = eigen2;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4458,6 +4458,10 @@ in {
 
   openapi-spec-validator = callPackage ../development/python-modules/openapi-spec-validator { };
 
+  openbabel-bindings = callPackage ../development/python-modules/openbabel-bindings {
+      openbabel = (callPackage ../development/libraries/openbabel { python = self.python; });
+  };
+
   opencv3 = toPythonModule (pkgs.opencv3.override {
     enablePython = true;
     pythonPackages = self;


### PR DESCRIPTION
###### Motivation for this change

In my current job, openbabel is used quite heavily. The current nixpkgs version is out of date, and doesn't include the python bindings which are heavily used in theoretical chemistry (in pymatgen, for example). I felt like my openbabel nix expressions might be useful for others.

###### Things done

- Bumped openbabel to latest version (3.1.1)
- Build the python bindings. It would be relatively easy to include an argument `pythonBindings ? True`, but as far as I am aware, openbabel is predominantly used as a python module these days. Moreover, there is no appreciable difference in compile time.
- `from openbabel import openbabel` is working correctly, but `from openbabel import pybel` needs some environment variables to be set as in `openbabel-bindings/default.nix`. I have been working around this by setting them explicitly in my working shell.nix. Fixing this would probably require a patch to openbabel itself.

This is my first PR to nixpkgs, so any feedback and suggestions would be be greatly appreciated! 

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
