### PR TITLE
a52dec: 0.7.4p4 -> 0.7.4

### DIFF
--- a/pkgs/development/libraries/a52dec/default.nix
+++ b/pkgs/development/libraries/a52dec/default.nix
@@ -1,11 +1,12 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "a52dec-0.7.4p4";
+  pname = "a52dec";
+  version = "0.7.4";
 
   src = fetchurl {
-    url = "${meta.homepage}/files/a52dec-0.7.4.tar.gz";
-    sha256 = "0czccp4fcpf2ykp16xcrzdfmnircz1ynhls334q374xknd5747d2";
+    url = "${meta.homepage}/files/${pname}-${version}.tar.gz";
+    sha256 = "oh1ySrOzkzMwGUNTaH34LEdbXfuZdRPu9MJd5shl7DM=";
   };
 
   configureFlags = [
@@ -18,10 +19,10 @@ stdenv.mkDerivation rec {
   # but it's better to disable tests than loose ASLR on i686
   doCheck = !stdenv.isi686;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "ATSC A/52 stream decoder";
-    homepage = "http://liba52.sourceforge.net/";
-    platforms = stdenv.lib.platforms.unix;
-    license = stdenv.lib.licenses.gpl2;
+    homepage = "https://liba52.sourceforge.net/";
+    platforms = platforms.unix;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
