### PR TITLE
nixos/gdm: add option to configure monitors.xml

### DIFF
--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -104,6 +104,45 @@ in
         type = types.bool;
       };
 
+      monitorsConfig = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = ''
+          <monitors version="2">
+            <configuration>
+              <logicalmonitor>
+                <x>0</x>
+                <y>0</y>
+                <scale>1</scale>
+                <primary>yes</primary>
+                <monitor>
+                  <monitorspec>
+                    <connector>DP-0</connector>
+                    <vendor>XYZ</vendor>
+                    <product>ABC123</product>
+                    <serial>DEF456</serial>
+                  </monitorspec>
+                  <mode>
+                    <width>2560</width>
+                    <height>1440</height>
+                    <rate>144</rate>
+                  </mode>
+                </monitor>
+              </logicalmonitor>
+            </configuration>
+          </monitors>
+        '';
+        description = let
+          url = "https://wiki.archlinux.org/index.php/GDM#Setup_default_monitor_settings";
+        in ''
+          Monitor config to be placed in
+          <filename>.config/monitors.xml</filename> in the GDM home directory,
+          typically copied from <filename>~/.config/monitors.xml</filename>
+          after setting up in GNOME. See the ArchWiki GDM documentation at
+          <link xlink:href="${url}"/> for more information.
+        '';
+      };
+
     };
 
   };
@@ -151,6 +190,11 @@ in
 
     systemd.tmpfiles.rules = [
       "d /run/gdm/.config 0711 gdm gdm"
+    ] ++ optionals (cfg.gdm.monitorsConfig != null) [
+      (
+        let monitorsXml = pkgs.writeText "gdm-monitors.xml" cfg.gdm.monitorsConfig;
+        in "L+ /run/gdm/.config/monitors.xml - - - - ${monitorsXml}"
+      )
     ] ++ optionals config.hardware.pulseaudio.enable [
       "d /run/gdm/.config/pulse 0711 gdm gdm"
       "L+ /run/gdm/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"


### PR DESCRIPTION
###### Motivation for this change

This option allows users to configure GDM to respect custom monitor
setups, such as those generated by GNOME in `~/.config/monitors.xml`.
See this section of the ArchWiki GDM page regarding monitor settings:
https://wiki.archlinux.org/index.php/GDM#Setup_default_monitor_settings

The GDM home directory in NixOS is a tmpfs at `/run/gdm`, so the config
is persisted in a similar way to the pulseaudio config, by adding a
systemd tmpfiles rule to symlink it from a generated file written to the
nix store.

Relevant discourse thread: https://discourse.nixos.org/t/gdm-monitor-configuration/6356

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
