### PR TITLE
hdf4: fix invalid rpath on darwin

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchpatch
 , fetchurl
+, fixDarwinDylibNames
 , cmake
 , libjpeg
 , zlib
@@ -17,6 +18,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
   ];
 
   buildInputs = [


### PR DESCRIPTION
CMake changes in hdf4 v4.15.2 broke library paths on macOS, linking
using an invalid rpath rather than an absolute path.

Before this commit:
```
otool -L result/lib/libhdf.dylib
result/lib/libhdf.dylib:
	@rpath/libhdf.4.dylib (compatibility version 4.0.0, current version 4.15.2)
```

After:
```
otool -L result/lib/libhdf.dylib
result/lib/libhdf.dylib:
	/nix/store/bz52b2gwci0k8rwd0llsi555s1hx166j-hdf-4.2.15/lib/libhdf.4.15.2.dylib (compatibility version 4.0.0, current version 4.15.2)
```

###### Motivation for this change

This broke an out-of-tree derivation for [isce2](https://github.com/isce-framework/isce2) I've been using locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
