### PR TITLE
gpxsee: 7.37 → 8.0

### DIFF
--- a/pkgs/applications/misc/gpxsee/default.nix
+++ b/pkgs/applications/misc/gpxsee/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "gpxsee";
-  version = "7.37";
+  version = "8.0";
 
   src = fetchFromGitHub {
     owner = "tumic0";
     repo = "GPXSee";
     rev = version;
-    sha256 = "0fpb43smh0kwic5pdxs46c0hkqj8g084h72pa024x1my6w12y9b8";
+    sha256 = "01ggakpzmiwkqdzc9xqc93xmynd53kzpwl99q3l9z2hpqyzlnj2a";
   };
 
   patches = (substituteAll {
@@ -37,7 +37,7 @@ mkDerivation rec {
     '';
     homepage = "https://www.gpxsee.org/";
     changelog = "https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ womfoo sikmir ];
     platforms = with platforms; linux ++ darwin;
   };

--- a/pkgs/applications/misc/gpxsee/fix-qttranslations-path.diff
+++ b/pkgs/applications/misc/gpxsee/fix-qttranslations-path.diff
@@ -1,18 +1,18 @@
 diff --git i/src/GUI/app.cpp w/src/GUI/app.cpp
-index 10e84d5..1e0abbe 100644
+index 37e9d3f..d4a065c 100644
 --- i/src/GUI/app.cpp
 +++ w/src/GUI/app.cpp
-@@ -34,11 +34,10 @@ App::App(int &argc, char **argv) : QApplication(argc, argv)
- 	installTranslator(gpxsee);
+@@ -35,11 +35,10 @@ App::App(int &argc, char **argv) : QApplication(argc, argv)
+ 		installTranslator(gpxsee);
  
  	QTranslator *qt = new QTranslator(this);
 -#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
 +#if defined(Q_OS_WIN32)
- 	qt->load(QLocale::system(), "qt", "_", ProgramPaths::translationsDir());
+ 	if (qt->load(QLocale::system(), "qt", "_", ProgramPaths::translationsDir()))
  #else // Q_OS_WIN32 || Q_OS_MAC
--	qt->load(QLocale::system(), "qt", "_", QLibraryInfo::location(
--	  QLibraryInfo::TranslationsPath));
-+	qt->load(QLocale::system(), "qt", "_", QLatin1String("@qttranslations@/translations"));
+-	if (qt->load(QLocale::system(), "qt", "_", QLibraryInfo::location(
+-	  QLibraryInfo::TranslationsPath)))
++	if (qt->load(QLocale::system(), "qt", "_", QLatin1String("@qttranslations@/translations")))
  #endif // Q_OS_WIN32 || Q_OS_MAC
- 	installTranslator(qt);
+ 		installTranslator(qt);
  


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
