### PR TITLE
redis: build with TLS support

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, lua, pkgconfig, systemd, jemalloc, nixosTests }:
+{ stdenv, fetchurl, lua, pkgconfig, systemd, jemalloc, nixosTests
+, tlsSupport ? true, openssl
+}:
 
 stdenv.mkDerivation rec {
   version = "6.0.6";
@@ -18,14 +20,17 @@ stdenv.mkDerivation rec {
     ''}
   '';
 
-  buildInputs = [ lua pkgconfig ] ++ stdenv.lib.optional (stdenv.isLinux && !stdenv.hostPlatform.isMusl) systemd;
+  buildInputs = [ lua pkgconfig ]
+    ++ stdenv.lib.optional (stdenv.isLinux && !stdenv.hostPlatform.isMusl) systemd
+    ++ stdenv.lib.optionals tlsSupport [ openssl ];
   # More cross-compiling fixes.
   # Note: this enables libc malloc as a temporary fix for cross-compiling.
   # Due to hardcoded configure flags in jemalloc, we can't cross-compile vendored jemalloc properly, and so we're forced to use libc allocator.
   # It's weird that the build isn't failing because of failure to compile dependencies, it's from failure to link them!
   makeFlags = [ "PREFIX=$(out)" ]
     ++ stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" "MALLOC=libc" ]
-    ++ stdenv.lib.optional (stdenv.isLinux && !stdenv.hostPlatform.isMusl) ["USE_SYSTEMD=yes"];
+    ++ stdenv.lib.optional (stdenv.isLinux && !stdenv.hostPlatform.isMusl) ["USE_SYSTEMD=yes"]
+    ++ stdenv.lib.optionals tlsSupport [ "BUILD_TLS=yes" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
     ''}
   '';
 
-  buildInputs = [ lua pkgconfig ]
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ lua ]
     ++ stdenv.lib.optional (stdenv.isLinux && !stdenv.hostPlatform.isMusl) systemd
     ++ stdenv.lib.optionals tlsSupport [ openssl ];
   # More cross-compiling fixes.


### PR DESCRIPTION
###### Motivation for this change

Redis 6 optionally supports [tls](https://redis.io/topics/encryption).

###### Things done

This enables it by default with a flag to turn it off if desired.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
