### PR TITLE
microplane: init at 0.0.25

### DIFF
--- a/pkgs/tools/misc/microplane/default.nix
+++ b/pkgs/tools/misc/microplane/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "microplane";
+  version = "0.0.25";
+
+  src = fetchFromGitHub {
+    owner = "Clever";
+    repo = "microplane";
+    rev = "v${version}";
+    sha256 = "0vynkv3d70q8d079kgdmwbavyyrjssqnd223dl1rikyy7sd5sli8";
+  };
+
+  goPackagePath = "github.com/Clever/microplane";
+
+  subPackages = ["."];
+
+  # Regenerate deps.nix with the following steps:
+  # git clone git@github.com:Clever/microplane.git
+  # cd microplane
+  # git checkout v<version>
+  # dep2nix
+
+  goDeps = ./deps.nix;
+
+  buildFlagsArray = ''
+    -ldflags="-s -w -X main.version=v${version}"
+  '';
+
+  postInstall = ''
+    ln -s $out/bin/microplane $out/bin/mp
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A CLI tool to make git changes across many repos";
+    homepage = "https://github.com/Clever/microplane";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dbirks ];
+  };
+}

--- a/pkgs/tools/misc/microplane/deps.nix
+++ b/pkgs/tools/misc/microplane/deps.nix
@@ -1,0 +1,228 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev =  "1d903dcb749992f3741d744c0f8376b4bd7eb3e1";
+      sha256 = "1p1ncq4vv244w9v144vplsb2vbl3369wdxn4gc7xbfafkjwn8bxc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/facebookgo/errgroup";
+    fetch = {
+      type = "git";
+      url = "https://github.com/facebookgo/errgroup";
+      rev =  "779c8d7ef069c522bc72ee5f31a98d89a37f3fb6";
+      sha256 = "1kyqrnvr158f5lgb1pbianjd8xnmxxvpgz7qilmp7zvr69gykbas";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "570b54cabe6b8eb0bc2dfce68d964677d63b5260";
+      sha256 = "1hw9hgkfzbzqjhy29pqpk20xggxaqjv45wx8yn69488mw5ph7khh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "130e6b02ab059e7b717a096f397c5b60111cae74";
+      sha256 = "0zk4d7gcykig9ld8f5h86fdxshm2gs93a2xkpf52jd5m4z59q26s";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/go-github";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-github";
+      rev =  "e881974953e6ab6d1a6a1610e98ed6401a3aa1ba";
+      sha256 = "0qaxcm2p655r1jd59rv1hd58driadw5hxlfy7h53c7pzcsmf2546";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/go-querystring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-querystring";
+      rev =  "53e6ce116135b80d037921a7fdd5138cf32d7a8a";
+      sha256 = "0lkbm067nhmxk66pyjx59d77dbjjzwyi43gdvzyx2f8m1942rq7f";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/juju/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/juju/errors";
+      rev =  "c7d06af17c68cd34c835053720b21f6549d9b0ee";
+      sha256 = "1dmj8wkpmkw4z4c7wmnscs4ykrcv7p8lgwb75g5akahwqjaf9zcp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "0360b2af4f38e8d38c7fce2a9f4e702702d73a39";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/nathanleiby/diffparser";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nathanleiby/diffparser";
+      rev =  "936553ce5db1b73e63cbcd7546416d13538e8d85";
+      sha256 = "0qlxkbda4l1glwxdy52fhk3bqkyyc55si4xplf54jpi2x9khi2v4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev =  "4048872b16cc0fc2c5fd9eacf0ed2c2fedaa0c8c";
+      sha256 = "17zg26ia43c8axrxp5q2bxh1asiqfhin4ah7h5d8ibil6pv7xbx4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "7b2c5ac9fc04fc5efafb60700713d4fa609b777b";
+      sha256 = "0k4xswdfd2ridj7m48ijb4klq9mxpw03g8h2rvq99yddi8vmlbvn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "e57e3eeb33f795204c1ca35f56c44f83227c6e66";
+      sha256 = "13mhx4i913jil32j295m3a36jzvq1y64xig0naadiz7q9ja011r2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "69483b4bd14f5845b5a1e55bca19e954e827f1d0";
+      sha256 = "11lzrwkdzdd8yyag92akncc008h2f9d1bpc489mxiwp0jrmz4ivb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xanzy/go-gitlab";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xanzy/go-gitlab";
+      rev =  "ee3313ca5478c4786248d63dd75e4cd8e1fad2db";
+      sha256 = "0xbn94rb9ihpw1g698xbz9vdl7393z9zbb0lck52nxs838gkr4mb";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "5c72a883971a4325f8c62bf07b6d38c20ea47a6a";
+      sha256 = "1cimmqpajys001x6yq8ycklc4w34y7iwrksv7ayv7m7fgzhcjn3d";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "aabf50738bcdd9b207582cbe796b59ed65d56680";
+      sha256 = "0gq60lfzbyc6ggp5v3vbl6li818nmv0n32l9qf80ckpqpqkknkh5";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "bb50c06baba3d0c76f9d125c0719093e315b5b44";
+      sha256 = "19fkbykwjhwa0833cqcphv7sfwc1538ad5wlsdkgdwr59qb9d32i";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev =  "6e8e738ad208923de99951fe0b48239bfd864f28";
+      sha256 = "1avk27pszd5l5df6ff7j78wgla46ir1hhy2jwfl9a3c0ys602yx9";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "28a7276518d399b9634904daad79e18b44d481bc";
+      sha256 = "0qsj394qyy27iaf8srl7bkbsx7sp4aifrv3z2xllkydya8y18rv8";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "150dc57a1b433e64154302bdc40b6bb8aefa313a";
+      sha256 = "0w3knznv39k8bm85ri62f83czcrxknql7dv6p9hk1a5jx3xljgxq";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "eb3733d160e74a9c7e442f435eb3bea458e1d19f";
+      sha256 = "1srhvcaa9db3a6xj29mkjr5kg33y71pclrlx4vcwz5m1lgb5c7q6";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5743,6 +5743,8 @@ in
 
   microdnf = callPackage ../tools/package-management/microdnf { };
 
+  microplane = callPackage ../tools/misc/microplane { };
+
   microserver = callPackage ../servers/microserver { };
 
   midisheetmusic = callPackage ../applications/audio/midisheetmusic { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Wanted to add `microplane` since I'm looking in to using it. 

Some notes:

Using buildGoPackage instead of buildGoModile, as this project uses dep, so it looks like I need `goDeps` that buildGoPackage provides.

Using `subPackages = ["."];` because I noticed a binary named `demo` was being built, and I just wanted the `microplane` binary.

I'm renaming the binary to `mp` because that's [how the Makefile has it](https://github.com/Clever/microplane/blob/master/Makefile#L23). And I had trouble giving `-o $out/bin/mp` as a Go build flag, since it would complain that the directory didn't exist, so I just opted to rename it afterwards.

There doesn't seem to be a `-v` flag or `version` subcommand :confused: , so I'm not sure how to confirm that the version is correct.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
