### PR TITLE
properties-cpp: move cmake, pkg-config to nativeBuildInputs, clean up

### DIFF
--- a/pkgs/development/libraries/properties-cpp/default.nix
+++ b/pkgs/development/libraries/properties-cpp/default.nix
@@ -1,27 +1,35 @@
-{ stdenv, fetchurl, cmake, pkgconfig, gtest, doxygen
-, graphviz, lcov }:
+{ stdenv
+, fetchurl
+, cmake
+, pkg-config
+, gtest
+, doxygen
+, graphviz
+, lcov
+}:
 
 stdenv.mkDerivation rec {
   pname = "properties-cpp";
   version = "0.0.1";
 
-  src = let srcver = version+"+14.10.20140730"; in
-  fetchurl {
-    url = "https://launchpad.net/ubuntu/+archive/primary/+files/${pname}_${srcver}.orig.tar.gz";
-    sha256 = "08vjyv7ibn6jh2ikj5v48kjpr3n6hlkp9qlvdn8r0vpiwzah0m2w";
-  };
+  src = let srcver = "${version}+14.10.20140730"; in
+    fetchurl {
+      url = "https://launchpad.net/ubuntu/+archive/primary/+files/${pname}_${srcver}.orig.tar.gz";
+      sha256 = "08vjyv7ibn6jh2ikj5v48kjpr3n6hlkp9qlvdn8r0vpiwzah0m2w";
+    };
 
-  buildInputs = [ cmake gtest doxygen pkgconfig graphviz lcov ];
-
-  patchPhase = ''
+  postPatch = ''
     sed -i "/add_subdirectory(tests)/d" CMakeLists.txt
   '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ gtest doxygen graphviz lcov ];
 
   meta = with stdenv.lib; {
     homepage = "https://launchpad.net/properties-cpp";
     description = "A very simple convenience library for handling properties and signals in C++11";
-    license = licenses.lgpl3;
+    license = licenses.lgpl3Only;
     maintainers = with maintainers; [ edwtjo ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
