### PR TITLE
python3Packages.pydicom: unbreak

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -1,14 +1,27 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
+, fetchFromGitHub
 , isPy27
 , pytest
-, pytestrunner
 , pytestCheckHook
 , numpy
 , pillow
 }:
+let pydicom-data = buildPythonPackage rec {
+  version = "2020.07.27";
+  pname = "pydicom-data";
 
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = pname;
+    rev = "bbb723879690bb77e077a6d57657930998e92bd5";
+    sha256 = "0fdb3rqjd1s2hjylf1vrlzhhkxnb9837s5cnb2idb95gx6ska8kl";
+  };
+
+  buildInputs = [ pytest ];
+};
+in
 buildPythonPackage rec {
   version = "2.1.1";
   pname = "pydicom";
@@ -21,11 +34,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy pillow ];
 
-  checkInputs = [ pytest pytestrunner pytestCheckHook ];
-  disabledTests = [ "test_invalid_bit_depth_raises" ];
-  # harmless failure; see https://github.com/pydicom/pydicom/issues/1119
+  checkInputs = [ pytestCheckHook pydicom-data ];
+  # This test assumes that the directory for pydicom-data is writable, and
+  # writes to $HOME
+  disabledTests = [ "test_data_manager" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://pydicom.github.io";
     description = "Pure-Python package for working with DICOM files";
     license = licenses.mit;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
pydicom has been [failing on hydra](https://hydra.nixos.org/build/133623012) since c9a189fdf98d. The latest release moved some data required for the tests into a separate github repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
