### PR TITLE
python3Packages.paperspace: mark as broken

### DIFF
--- a/pkgs/development/python-modules/gradient_sdk/default.nix
+++ b/pkgs/development/python-modules/gradient_sdk/default.nix
@@ -21,5 +21,6 @@ buildPythonPackage rec {
     license     = licenses.mit;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ freezeboy ];
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/paperspace/default.nix
+++ b/pkgs/development/python-modules/paperspace/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     license     = licenses.isc;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice ];
+    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
These packages are currently [failing to build](https://hydra.nixos.org/build/130461228) because because they rely out outdated dependencies. But when you look at upstream, it looks like they're hopelessly outdated.

1. https://github.com/Paperspace/gradient-sdk redirects to https://github.com/Paperspace/gradient-utils (project name changed).
2. https://github.com/paperspace/paperspace-python has been archived on github, and they've apparently moved to https://github.com/Paperspace/gradient-cli.
3. I tried for a hot second packing the new versions, and they're a bit of a mess too. They also hardcode strict dependencies on outdated versions of packages like attrs<=19. That might be a project for someone else.

Our `paperspace` package looks like it hasn't been updated since 2018-06-10, has no tests, and aparently is supposed to interact with a cloud service. So it's pretty unlikely it works anyways. I propose to mark them as broken, or perhaps just remove them.

cc maintainers @thoughtpolice @freezeboy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
