### PR TITLE
driftnet: 1.1.5 -> 1.3.0

### DIFF
--- a/pkgs/tools/networking/driftnet/default.nix
+++ b/pkgs/tools/networking/driftnet/default.nix
@@ -1,31 +1,64 @@
-{ stdenv, lib, fetchFromGitHub, libpcap, libjpeg , libungif, libpng
-, giflib, glib, gtk2, cairo, pango, gdk-pixbuf, atk
-, pkg-config, autoreconfHook }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, cairo
+, giflib
+, glib
+, gtk2-x11
+, libjpeg
+, libpcap
+, libpng
+, libwebsockets
+, pkg-config
+, libuv
+, openssl
+}:
 
-with lib;
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "driftnet";
-  version = "1.1.5";
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    libpcap libjpeg libungif libpng giflib
-    glib gtk2 glib cairo pango gdk-pixbuf atk autoreconfHook
-  ];
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "deiv";
     repo = "driftnet";
-    rev = "0ae4a91";
-    sha256 = "1sagpx0mw68ggvqd9c3crjhghqmj7391mf2cb6cjw1cpd2hcddsj";
+    rev = "v${version}";
+    sha256 = "0kd22aqb25kf54jjv3ml8wy8xm7lmbf0xz1wfp31m08cbzsbizib";
   };
 
-  meta = {
+  # https://github.com/deiv/driftnet/pull/33
+  # remove on version bump from 1.3.0
+  patches = [
+    (fetchpatch {
+      name = "fix-darwin-build";
+      url = "https://github.com/deiv/driftnet/pull/33/commits/bef5f3509ab5710161e9e21ea960a997eada534f.patch";
+      sha256 = "1b7p9fkgp7dxv965l7q7y632s80h3nnrkaqnak2h0hakwv0i4pvm";
+    })
+  ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  buildInputs = [
+    cairo
+    giflib
+    glib
+    gtk2-x11
+    libjpeg
+    libpcap
+    libpng
+    libwebsockets
+    openssl
+    libuv
+  ];
+
+  meta = with lib; {
     description = "Watches network traffic, and picks out and displays JPEG and GIF images for display";
     homepage = "https://github.com/deiv/driftnet";
     maintainers = with maintainers; [ offline ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = licenses.gpl2;
   };
 }

--- a/pkgs/tools/networking/driftnet/fix-darwin-build.patch
+++ b/pkgs/tools/networking/driftnet/fix-darwin-build.patch
@@ -1,0 +1,61 @@
+diff --git a/src/compat/compat.h b/src/compat/compat.h
+index 6add422..ea80406 100644
+--- a/src/compat/compat.h
++++ b/src/compat/compat.h
+@@ -17,7 +17,7 @@
+     #include <config.h>
+ #endif
+ 
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__APPLE__)
+     #include <sys/types.h>
+ #endif
+ 
+diff --git a/src/network/layer2.c b/src/network/layer2.c
+index 763f0ac..2497b72 100644
+--- a/src/network/layer2.c
++++ b/src/network/layer2.c
+@@ -14,7 +14,7 @@
+ 
+ #include <string.h>
+ 
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__APPLE__)
+ #include <netinet/in_systm.h>
+ #include <netinet/in.h>
+ #else
+@@ -29,7 +29,7 @@
+ /*
+  * Freebsd and Cygwin doesn't define 'ethhdr'
+  */
+-#if defined(__FreeBSD__) || defined(__CYGWIN__)
++#if defined(__FreeBSD__) || defined(__CYGWIN__) || defined(__APPLE__)
+ 
+ #define ETH_ALEN	6			/* Octets in one ethernet addr	 */
+ #define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
+diff --git a/src/network/layer3.c b/src/network/layer3.c
+index 7864126..aae2041 100644
+--- a/src/network/layer3.c
++++ b/src/network/layer3.c
+@@ -15,7 +15,7 @@
+ #include <string.h>
+ #include <assert.h>
+ 
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__APPLE__)
+ #include <netinet/in_systm.h>
+ #include <netinet/in.h>
+ #include <sys/socket.h>
+diff --git a/src/pid.c b/src/pid.c
+index 621834e..94e7dcc 100644
+--- a/src/pid.c
++++ b/src/pid.c
+@@ -14,7 +14,7 @@
+ 
+ #include "compat/compat.h"
+ 
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__APPLE__)
+ #include <sys/stat.h>
+ #endif
+ #include <fcntl.h>


### PR DESCRIPTION
###### Motivation for this change
Would also be good if someone could unbreak the darwin build. Currently fails with log

```
layer2.c:22:14: fatal error: 'netinet/ether.h' file not found
    #include <netinet/ether.h>
             ^~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [Makefile:356: layer2.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/private/tmp/nix-build-driftnet-1.3.0.drv-0/source/src/network'
make[1]: *** [Makefile:456: all-recursive] Error 1
make[1]: Leaving directory '/private/tmp/nix-build-driftnet-1.3.0.drv-0/source/src'
make: *** [Makefile:430: all-recursive] Error 1
builder for '/nix/store/5b9s1wav6arj2vr9fzz1mjsfmh1zhw73-driftnet-1.3.0.drv' failed with exit code 2
error: build of '/nix/store/5b9s1wav6arj2vr9fzz1mjsfmh1zhw73-driftnet-1.3.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
