### PR TITLE
xdot: fix tests

### DIFF
--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k
-, wrapGAppsHook, gobject-introspection, pygobject3, graphviz, gtk3 }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k, python3, xvfb_run, stdenv
+, wrapGAppsHook, gobject-introspection, pygobject3, graphviz, gtk3, numpy }:
 
 buildPythonPackage rec {
   pname = "xdot";
@@ -11,9 +11,16 @@ buildPythonPackage rec {
   };
 
   disabled = !isPy3k;
-
   nativeBuildInputs = [ wrapGAppsHook ];
-  propagatedBuildInputs = [ gobject-introspection pygobject3 graphviz gtk3 ];
+  propagatedBuildInputs = [ gobject-introspection pygobject3 graphviz gtk3 numpy ];
+  checkInputs = [ xvfb_run ];
+
+  checkPhase = ''
+    xvfb-run -s '-screen 0 800x600x24' ${python3.interpreter} nix_run_setup test
+  '';
+
+  # https://github.com/NixOS/nixpkgs/pull/107872#issuecomment-752175866
+  doCheck = stdenv.isLinux;
 
   meta = with lib; {
     description = "An interactive viewer for graphs written in Graphviz's dot";


### PR DESCRIPTION
`nix-shell -p xdot` was failing, with an error like:

    builder for '/nix/store/n3yjqssn531c52sbkmpqvczmy5c0lm8n-python3.8-xdot-1.2.drv' failed with exit code 1; last 10 log lines:
          import numpy
      ModuleNotFoundError: No module named 'numpy'

Adding numpy uncovered another error, about not being able to initialize gtk:

    error: Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
    error: --- Error -------------------------------------------------------------------------------------------------------------------------------------------- nix-shell
    builder for '/nix/store/brz6q1ri12z51z3l2p5d6ny2jsf3qkjg-python3.8-xdot-1.2.drv' failed with exit code 1; last 10 log lines:
          raise RuntimeError(
      RuntimeError: Gtk couldn't be initialized. Use Gtk.init_check() if you want to handle this case.

---

Changes based on: pkgs/applications/networking/flent/default.nix

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I tried to use the package with `nix-shell -p xdot`, and it didn't work.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
