### PR TITLE
wad: init at 0.4.6

### DIFF
--- a/pkgs/tools/security/wad/default.nix
+++ b/pkgs/tools/security/wad/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, mock
+, pytestCheckHook
+, six
+}:
+
+buildPythonApplication rec {
+  pname = "wad";
+  version = "0.4.6";
+
+  src = fetchPypi {
+    inherit pname;
+    inherit version;
+    sha256 = "02jq77h6g9v7n4qqq7qri6wmhggy257983dwgmpjsf4qsagkgwy8";
+  };
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    mock
+  ];
+
+  pythonImportsCheck = [ "wad" ];
+
+  meta = with lib; {
+    description = "Tool for detecting technologies used by web applications";
+    longDescription = ''
+      WAD lets you analyze given URL(s) and detect technologies used by web
+      application behind that URL, from the OS and web server level, to the
+      programming platform and frameworks, as well as server- and client-side
+      applications, tools and libraries.
+    '';
+    homepage = "https://github.com/CERN-CERT/WAD";
+    # wad is GPLv3+, wappalyzer source is MIT
+    license = with licenses; [ gpl3Plus mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24821,6 +24821,8 @@ in
 
   vym = qt5.callPackage ../applications/misc/vym { };
 
+  wad = python3Packages.callPackage ../tools/security/wad { };
+
   waon = callPackage ../applications/audio/waon { };
 
   w3m = callPackage ../applications/networking/browsers/w3m { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
WAD lets you analyze given URL(s) and detect technologies used by web
application behind that URL, from the OS and web server level, to the
programming platform and frameworks, as well as server- and client-side
applications, tools and libraries.

https://github.com/CERN-CERT/WAD

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
