### PR TITLE
duckstation: init at unstable-2020-12-28

### DIFF
--- a/pkgs/misc/emulators/duckstation/default.nix
+++ b/pkgs/misc/emulators/duckstation/default.nix
@@ -1,0 +1,34 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkg-config, SDL2, qtbase
+, wrapQtAppsHook, qttools, ninja, gtk3 }:
+mkDerivation rec {
+  pname = "duckstation";
+  version = "unstable-2020-12-29";
+
+  src = fetchFromGitHub {
+    owner = "stenzek";
+    repo = pname;
+    rev = "f8dcfabc44ff8391b2d41eab2e883dc8f21a88b7";
+    sha256 = "0v6w4di4yj1hbxpqqrcw8rbfjg18g9kla8mnb3b5zgv7i4dyzykw";
+  };
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook qttools ];
+
+  buildInputs = [ SDL2 qtbase gtk3 pkg-config ];
+
+  installPhase = ''
+    mkdir -p $out/
+    mv bin $out/
+  '';
+
+  # TODO:
+  # - vulkan graphics backend (OpenGL works).
+  # - default sound backend (cubeb) does not work, but SDL does.
+  meta = with lib; {
+    description =
+      "PlayStation 1 emulator focusing on playability, speed and long-term maintainability";
+    homepage = "https://github.com/stenzek/duckstation";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.guibou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12815,6 +12815,8 @@ in
 
   duckdb = callPackage ../development/libraries/duckdb {};
 
+  duckstation = libsForQt5.callPackage ../misc/emulators/duckstation {};
+
   easyloggingpp = callPackage ../development/libraries/easyloggingpp {};
 
   eccodes = callPackage ../development/libraries/eccodes {


### PR DESCRIPTION
###### Motivation for this change

`duckstation` is a nice playstation one emulator with more features than pcsxr or epsxe available in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions (with OpenGL fixs)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
