### PR TITLE
aerc: 0.4.0 -> 0.5.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -6,15 +6,15 @@
 
 buildGoModule rec {
   pname = "aerc";
-  version = "0.4.0";
+  version = "0.5.2";
 
   src = fetchurl {
     url = "https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz";
-    sha256 = "05qy14k9wmyhsg1hiv4njfx1zn1m9lz4d1p50kc36v7pq0n4csfk";
+    sha256 = "h7kiRA5TuZ8mDSMymWU33stFLIOMd06TQLYzKW+faO4=";
   };
 
   runVend = true;
-  vendorSha256 = "13zs5113ip85yl6sw9hzclxwlnrhy18d39vh9cwbq97dgnh9rz89";
+  vendorSha256 = "9PXdUH0gu8PGaKlRJCUF15W1/LxA+sv3Pwl2UnjYxWY=";
 
   doCheck = false;
 

--- a/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
+++ b/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
@@ -29,7 +29,7 @@ diff --git a/config/config.go b/config/config.go
 index 32d07fc..8ffd3e8 100644
 --- a/config/config.go
 +++ b/config/config.go
-@@ -355,6 +355,11 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
+@@ -472,6 +472,11 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
  			return nil, err
  		}
  	}
@@ -41,10 +41,11 @@ index 32d07fc..8ffd3e8 100644
  	file.NameMapper = mapName
  	config := &AercConfig{
  		Bindings: BindingConfig{
-@@ -423,6 +428,9 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
+@@ -546,6 +428,9 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
  	if err = config.LoadConfig(file); err != nil {
  		return nil, err
  	}
+
 +	for i, filter := range config.Filters {
 +		config.Filters[i].Command = strings.ReplaceAll(filter.Command, "@SHAREDIR@", sharedir)
 +	}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
