### PR TITLE
lua5_4: add readline support

### DIFF
--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -15,8 +15,9 @@ let
     lua = self;
     overrides = packageOverrides;
   };
-
-plat = if stdenv.isLinux then "linux"
+luaversion = with sourceVersion; "${major}.${minor}";
+linuxReadlineSuffix = if (lib.versionAtLeast luaversion "5.4") && (readline!=null) then "-readline" else "";
+plat = if stdenv.isLinux then "linux${linuxReadlineSuffix}"
        else if stdenv.isDarwin then "macosx"
        else if stdenv.hostPlatform.isMinGW then "mingw"
        else if stdenv.isFreeBSD then "freebsd"
@@ -27,7 +28,7 @@ plat = if stdenv.isLinux then "linux"
 
 self = stdenv.mkDerivation rec {
   pname = "lua";
-  luaversion = with sourceVersion; "${major}.${minor}";
+  inherit luaversion;
   version = "${luaversion}.${sourceVersion.patch}";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Introduce readline support for `lua5_4`. This makes the handling in the REPL nicer.

The problem with this patch is, that it cannot be disabled. It would be better to put this into `interpreter.nix` so that the `readline` argument can be overriden/disabled. However, that would also affect previous lua versions, which seem to detect readline already.

Also future Lua version probably will need this as well.

CC @raboof since you introduced `lua5_4` initially.

Any thoughts ?

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
