### PR TITLE
ocamlPackages.lambdaTerm: 2.0.3 → 3.1.0; ocamlPackages.utop: 2.4.3 → 2.6.0

### DIFF
--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, fetchFromGitHub, ocaml, findlib, dune
+{ stdenv, makeWrapper, fetchFromGitHub, ocaml, findlib, dune_2
 , fix, menhir, merlin-extend, ppx_tools_versioned, utop, cppo
 }:
 
@@ -17,13 +17,12 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ menhir merlin-extend ppx_tools_versioned ];
 
-  buildInputs = [ ocaml findlib dune cppo fix utop menhir ];
+  buildInputs = [ ocaml findlib dune_2 cppo fix utop menhir ];
 
   buildFlags = [ "build" ]; # do not "make tests" before reason lib is installed
 
-  inherit (dune) installPhase;
-
-  postInstall = ''
+  installPhase = ''
+    dune install --prefix=$out --libdir=$OCAMLFIND_DESTDIR
     wrapProgram $out/bin/rtop \
       --prefix PATH : "${utop}/bin" \
       --prefix CAML_LD_LIBRARY_PATH : "$CAML_LD_LIBRARY_PATH" \

--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, fetchurl, libev, buildDunePackage, zed, lwt_log, lwt_react }:
+{ lib, fetchFromGitHub, buildDunePackage, zed, lwt_log, lwt_react, mew_vi }:
 
 buildDunePackage rec {
   pname = "lambda-term";
-  version = "2.0.3";
+  version = "3.1.0";
 
-  src = fetchurl {
-    url = "https://github.com/ocaml-community/lambda-term/releases/download/${version}/lambda-term-${version}.tbz";
-    sha256 = "1n1b3ffj41a1lm2315hh870yj9h8gg8g9jcxha6dr3xx8r84np3v";
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "ocaml-community";
+    repo = pname;
+    rev = version;
+    sha256 = "1k0ykiz0vhpyyj9fkss29ajas4fh1xh449j702xkvayqipzj1mkg";
   };
 
-  buildInputs = [ libev ];
-  propagatedBuildInputs = [ zed lwt_log lwt_react ];
+  propagatedBuildInputs = [ zed lwt_log lwt_react mew_vi ];
 
   meta = { description = "Terminal manipulation library for OCaml";
     longDescription = ''
@@ -28,10 +31,10 @@ buildDunePackage rec {
     console applications.
     '';
 
-    homepage = "https://github.com/diml/lambda-term";
-    license = stdenv.lib.licenses.bsd3;
+    inherit (src.meta) homepage;
+    license = lib.licenses.bsd3;
     maintainers = [
-      stdenv.lib.maintainers.gal_bolle
+      lib.maintainers.gal_bolle
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/mew/default.nix
+++ b/pkgs/development/ocaml-modules/mew/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, result, trie
+}:
+
+buildDunePackage rec {
+  pname = "mew";
+  version = "0.1.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "kandu";
+    repo = pname;
+    rev = version;
+    sha256 = "0417xsghj92v3xa5q4dk4nzf2r4mylrx2fd18i7cg3nzja65nia2";
+  };
+
+  propagatedBuildInputs = [ result trie ];
+
+  meta = {
+    inherit (src.meta) homepage;
+    license = lib.licenses.mit;
+    description = "Modal Editing Witch";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/mew_vi/default.nix
+++ b/pkgs/development/ocaml-modules/mew_vi/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, mew, react
+}:
+
+buildDunePackage rec {
+  pname = "mew_vi";
+  version = "0.5.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "kandu";
+    repo = pname;
+    rev = version;
+    sha256 = "0lihbf822k5zasl60w5mhwmdkljlq49c9saayrws7g4qc1j353r8";
+  };
+
+  propagatedBuildInputs = [ mew react ];
+
+  meta = {
+    inherit (src.meta) homepage;
+    license = lib.licenses.mit;
+    description = "Modal Editing Witch, VI interpreter";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/trie/default.nix
+++ b/pkgs/development/ocaml-modules/trie/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchFromGitHub }:
+
+buildDunePackage rec {
+  pname = "trie";
+  version = "1.0.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "kandu";
+    repo = pname;
+    rev = version;
+    sha256 = "0s7p9swjqjsqddylmgid6cv263ggq7pmb734z4k84yfcrgb6kg4g";
+  };
+
+  meta = {
+    inherit (src.meta) homepage;
+    license = lib.licenses.mit;
+    description = "Strict impure trie tree";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, dune
+{ stdenv, fetchurl, ocaml, findlib
 , lambdaTerm, cppo, makeWrapper, buildDunePackage
 }:
 
@@ -8,11 +8,13 @@ else
 
 buildDunePackage rec {
   pname = "utop";
-  version = "2.4.3";
+  version = "2.6.0";
+
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/ocaml-community/utop/releases/download/${version}/utop-${version}.tbz";
-    sha256 = "107al0l3x4a5kkjka7glmhsqlm7pwzzc6shspiv5gsjb49pblc2f";
+    sha256 = "17n9igl74xcvj0mzdh2ybda29f2m48a5lj4yf8lrdqr7vg0982jd";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -545,6 +545,8 @@ let
 
     mew = callPackage ../development/ocaml-modules/mew { };
 
+    mew_vi = callPackage ../development/ocaml-modules/mew_vi { };
+
     mezzo = callPackage ../development/compilers/mezzo { };
 
     minisat = callPackage ../development/ocaml-modules/minisat { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -543,6 +543,8 @@ let
       inherit (pkgs) gnuplot;
     };
 
+    mew = callPackage ../development/ocaml-modules/mew { };
+
     mezzo = callPackage ../development/compilers/mezzo { };
 
     minisat = callPackage ../development/ocaml-modules/minisat { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -976,6 +976,8 @@ let
 
     topkg = callPackage ../development/ocaml-modules/topkg { };
 
+    trie = callPackage ../development/ocaml-modules/trie { };
+
     tsdl = callPackage ../development/ocaml-modules/tsdl { };
 
     twt = callPackage ../development/ocaml-modules/twt { };


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

cc maintainer @FlorentBecker 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
