### PR TITLE
herbe: init at 1.0.0

### DIFF
--- a/pkgs/applications/misc/herbe/default.nix
+++ b/pkgs/applications/misc/herbe/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub, libX11, libXft, freetype, patches ? [ ],
+  extraLibs ? [ ] }:
+
+stdenv.mkDerivation rec {
+  pname = "herbe";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dudik";
+    repo = pname;
+    rev = version;
+    sha256 = "0358i5jmmlsvy2j85ij7m1k4ar2jr5lsv7y1c58dlf9710h186cv";
+  };
+
+  inherit patches;
+
+  postPatch = ''
+    sed -i 's_/usr/include/freetype2_${freetype.dev}/include/freetype2_' Makefile
+  '';
+
+  buildInputs = [ libX11 libXft freetype ] ++ extraLibs;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Daemon-less notifications without D-Bus";
+    homepage = "https://github.com/dudik/herbe";
+    license = licenses.mit;
+    # NOTE: Could also work on 'unix'.
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wishfort36 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21939,6 +21939,8 @@ in
 
   heme = callPackage ../applications/editors/heme { };
 
+  herbe = callPackage ../applications/misc/herbe { };
+
   herbstluftwm = callPackage ../applications/window-managers/herbstluftwm {
     asciidoc = asciidoc-full;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This program displays notifications without including a daemon or the whole D-Bus dependency tree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Arch)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
