### PR TITLE
pythonPackages.advantage_air: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/advantage-air/default.nix
+++ b/pkgs/development/python-modules/advantage-air/default.nix
@@ -1,0 +1,26 @@
+{ aiohttp, buildPythonPackage, fetchPypi, lib, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "advantage_air";
+  version = "0.2.2";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "04q2sjw9r50c00m4sfv98w9cwmmr970830c97m32p5j8ijb10j5x";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # No tests
+  doCheck = false;
+  pythonImportsCheck = [ "advantage_air" ];
+
+  meta = with lib; {
+    description = "API helper for Advantage Air's MyAir and e-zone API";
+    homepage = "https://github.com/Bre77/advantage_air";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -11,7 +11,7 @@
     "actiontec" = ps: with ps; [ ];
     "adguard" = ps: with ps; [ adguardhome ];
     "ads" = ps: with ps; [ pyads ];
-    "advantage_air" = ps: with ps; [ ]; # missing inputs: advantage_air
+    "advantage_air" = ps: with ps; [ advantage_air ];
     "aftership" = ps: with ps; [ pyaftership ];
     "agent_dvr" = ps: with ps; [ ]; # missing inputs: agent-py
     "air_quality" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -169,7 +169,9 @@ in {
 
   addic7ed-cli = callPackage ../development/python-modules/addic7ed-cli { };
 
-  adguardhome= callPackage ../development/python-modules/adguardhome { };
+  adguardhome = callPackage ../development/python-modules/adguardhome { };
+
+  advantage-air = callPackage ../development/python-modules/advantage-air { };
 
   aenum = callPackage ../development/python-modules/aenum { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Support the `advantage_air` component in Home Assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
