### PR TITLE
terraform-provider-vercel: init at 2.1.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -65,6 +65,7 @@ let
     lxd = callPackage ./lxd {};
     shell = callPackage ./shell {};
     vpsadmin = callPackage ./vpsadmin {};
+    vercel = callPackage ./vercel {};
   };
 in
   automated-providers // special-providers

--- a/pkgs/applications/networking/cluster/terraform-providers/vercel/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/vercel/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "terraform-provider-vercel";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ondrejsika";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06lskp3mmax7g0lchq6jaxavycj7snkhip9madzqkr552qvz5cgw";
+  };
+
+  vendorSha256 = "0s0kf1v2217q9hfmc7r2yybcfk33k566dfvs2jiq63kyjnadhb0k";
+
+  postInstall = "mv $out/bin/terraform-provider-vercel{,_v${version}}";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ondrejsika/terraform-provider-vercel";
+    description = "Terraform provider for Vercel";
+    maintainers = with maintainers; [ mmahut ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
