### PR TITLE
qt514.qtwebkit: Fix patch applying

### DIFF
--- a/pkgs/development/libraries/qt-5/5.14/qtwebkit-darwin-no-readline.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtwebkit-darwin-no-readline.patch
@@ -28,18 +28,3 @@ diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
  #define HAVE_SYS_TIMEB_H 1
  
  #if !PLATFORM(GTK) && !PLATFORM(QT)
-diff --git a/Source/WTF/wtf/PlatformMac.cmake b/Source/WTF/wtf/PlatformMac.cmake
---- a/Source/WTF/wtf/PlatformMac.cmake
-+++ b/Source/WTF/wtf/PlatformMac.cmake
-@@ -2,11 +2,9 @@ set(WTF_LIBRARY_TYPE SHARED)
- 
- find_library(COCOA_LIBRARY Cocoa)
- find_library(COREFOUNDATION_LIBRARY CoreFoundation)
--find_library(READLINE_LIBRARY Readline)
- list(APPEND WTF_LIBRARIES
-     ${COREFOUNDATION_LIBRARY}
-     ${COCOA_LIBRARY}
--    ${READLINE_LIBRARY}
-     libicucore.dylib
- )
- 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
