### PR TITLE
python3.pkgs.wordcloud: 1.6.0 -> 1.8.1

### DIFF
--- a/pkgs/development/python-modules/wordcloud/default.nix
+++ b/pkgs/development/python-modules/wordcloud/default.nix
@@ -3,30 +3,41 @@
 , mock
 , numpy
 , pillow
-, pytest
+, cython
 , pytestcov
+, pytest
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "word_cloud";
-  version = "1.6.0";
+  version = "1.8.1";
 
   # tests are not included in pypi tarball
   src = fetchFromGitHub {
     owner = "amueller";
     repo = pname;
     rev = version;
-    sha256 = "1ncjr90m3w3b4zi23kw6ai11gxahdyah96x8jb2yn2x4573022x2";
+    sha256 = "sha256-4EFQfv+Jn9EngUAyDoJP0yv9zr9Tnbrdwq1YzDacB9Q=";
   };
 
+  nativeBuildInputs = [ cython ];
   propagatedBuildInputs = [ matplotlib numpy pillow ];
 
   # Tests require extra dependencies
   checkInputs = [ mock pytest pytestcov ];
-  # skip tests which make assumptions about installation
+
   checkPhase = ''
-    pytest -k 'not cli_as_executable'
+    PATH=$out/bin:$PATH pytest test
   '';
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/amueller/word_cloud/pull/616
+      url = "https://github.com/amueller/word_cloud/commit/858a8ac4b5b08494c1d25d9e0b35dd995151a1e5.patch";
+      sha256 = "sha256-+aDTMPtOibVwjPrRLxel0y4JFD5ERB2bmJi4zRf/asg=";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A little word cloud generator in Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
