### PR TITLE
ocamlPackages.dns*: add missing related packages

### DIFF
--- a/pkgs/development/ocaml-modules/dns/certify.nix
+++ b/pkgs/development/ocaml-modules/dns/certify.nix
@@ -1,0 +1,33 @@
+{ buildDunePackage, dns, dns-tsig, dns-mirage, randomconv, x509
+, mirage-random, mirage-time, mirage-clock, mirage-stack
+, logs, mirage-crypto-pk, mirage-crypto-rng, tls, lwt
+}:
+
+buildDunePackage {
+  pname = "dns-certify";
+
+  inherit (dns) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    dns
+    dns-tsig
+    dns-mirage
+    randomconv
+    x509
+    mirage-random
+    mirage-time
+    mirage-clock
+    mirage-stack
+    logs
+    mirage-crypto-pk
+    mirage-crypto-rng
+    tls
+    lwt
+  ];
+
+  doCheck = true;
+
+  meta = dns.meta // {
+    description = "MirageOS let's encrypt certificate retrieval";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/cli.nix
+++ b/pkgs/development/ocaml-modules/dns/cli.nix
@@ -1,0 +1,48 @@
+{ buildDunePackage, dns, dns-tsig, dns-client, dns-server, dns-certify
+, rresult, bos, cmdliner, fpath, x509, mirage-crypto, mirage-crypto-pk
+, mirage-crypto-rng, hex, ptime, mtime, logs, fmt, ipaddr, lwt
+, randomconv, alcotest
+}:
+
+buildDunePackage {
+  pname = "dns-cli";
+
+  minimumOCamlVersion = "4.08";
+
+  inherit (dns) version src useDune2;
+
+  # no need to propagate as this is primarily
+  # an executable package
+  buildInputs = [
+    dns
+    dns-tsig
+    dns-client
+    dns-server
+    dns-certify
+    rresult
+    bos
+    cmdliner
+    fpath
+    x509
+    mirage-crypto
+    mirage-crypto-pk
+    mirage-crypto-rng
+    hex
+    ptime
+    mtime
+    logs
+    fmt
+    ipaddr
+    lwt
+    randomconv
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+  ];
+
+  meta = dns.meta // {
+    description = "Unix command line utilities using uDNS";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/mirage.nix
+++ b/pkgs/development/ocaml-modules/dns/mirage.nix
@@ -1,0 +1,18 @@
+{ buildDunePackage, dns, mirage-stack, ipaddr, lwt }:
+
+buildDunePackage {
+  pname = "dns-mirage";
+
+  inherit (dns) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    dns
+    mirage-stack
+    ipaddr
+    lwt
+  ];
+
+  meta = dns.meta // {
+    description = "An opinionated Domain Name System (DNS) library";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/resolver.nix
+++ b/pkgs/development/ocaml-modules/dns/resolver.nix
@@ -1,0 +1,32 @@
+{ buildDunePackage, dns, dns-server, dns-mirage, lru, duration
+, randomconv, lwt, mirage-time, mirage-clock, mirage-random
+, alcotest
+}:
+
+buildDunePackage {
+  pname = "dns-resolver";
+
+  inherit (dns) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    dns
+    dns-server
+    dns-mirage
+    lru
+    duration
+    randomconv
+    lwt
+    mirage-time
+    mirage-clock
+    mirage-random
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+  ];
+
+  meta = dns.meta // {
+    description = "DNS resolver business logic";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/server.nix
+++ b/pkgs/development/ocaml-modules/dns/server.nix
@@ -1,0 +1,34 @@
+{ buildDunePackage, dns, dns-mirage, randomconv, duration, lwt
+, mirage-time, mirage-clock, mirage-stack, metrics
+, alcotest, mirage-crypto-rng, dns-tsig, base64
+}:
+
+buildDunePackage {
+  pname = "dns-server";
+
+  inherit (dns) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    dns
+    dns-mirage
+    randomconv
+    duration
+    lwt
+    mirage-time
+    mirage-clock
+    mirage-stack
+    metrics
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    mirage-crypto-rng
+    dns-tsig
+    base64
+  ];
+
+  meta = dns.meta // {
+    description = "DNS server, primary and secondary";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/stub.nix
+++ b/pkgs/development/ocaml-modules/dns/stub.nix
@@ -1,0 +1,33 @@
+{ buildDunePackage, dns, dns-client, dns-mirage, dns-resolver, dns-tsig
+, dns-server, duration, randomconv, lwt, mirage-time, mirage-clock
+, mirage-random, mirage-stack, metrics
+}:
+
+buildDunePackage {
+  pname = "dns-stub";
+
+  inherit (dns) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    dns
+    dns-client
+    dns-mirage
+    dns-resolver
+    dns-tsig
+    dns-server
+    duration
+    randomconv
+    lwt
+    mirage-time
+    mirage-clock
+    mirage-random
+    mirage-stack
+    metrics
+  ];
+
+  doCheck = true;
+
+  meta = dns.meta // {
+    description = "DNS stub resolver";
+  };
+}

--- a/pkgs/development/ocaml-modules/dns/tsig.nix
+++ b/pkgs/development/ocaml-modules/dns/tsig.nix
@@ -1,0 +1,22 @@
+{ buildDunePackage, dns, mirage-crypto, base64, alcotest }:
+
+buildDunePackage {
+  pname = "dns-tsig";
+
+  inherit (dns) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    mirage-crypto
+    dns
+    base64
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+  ];
+
+  meta = dns.meta // {
+    description = "TSIG support for DNS";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -205,7 +205,21 @@ let
 
     dns =  callPackage ../development/ocaml-modules/dns { };
 
+    dns-certify =  callPackage ../development/ocaml-modules/dns/certify.nix { };
+
+    dns-cli =  callPackage ../development/ocaml-modules/dns/cli.nix { };
+
     dns-client =  callPackage ../development/ocaml-modules/dns/client.nix { };
+
+    dns-mirage = callPackage ../development/ocaml-modules/dns/mirage.nix { };
+
+    dns-resolver = callPackage ../development/ocaml-modules/dns/resolver.nix { };
+
+    dns-server = callPackage ../development/ocaml-modules/dns/server.nix { };
+
+    dns-stub = callPackage ../development/ocaml-modules/dns/stub.nix { };
+
+    dns-tsig = callPackage ../development/ocaml-modules/dns/tsig.nix { };
 
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#23955

Add

* dns-certify
* dns-cli
* dns-mirage
* dns-resolver
* dns-server
* dns-stub
* dns-tsig


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or opton `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
