### PR TITLE
Fix nixUnstable cross compilation

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -199,13 +199,13 @@ in rec {
 
   nixUnstable = lib.lowPrio (callPackage common rec {
     name = "nix-2.4${suffix}";
-    suffix = "pre20201201_5a6ddb3";
+    suffix = "pre20201228_abbf9df";
 
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "5a6ddb3de14a1684af6c793d663764d093fa7846";
-      sha256 = "0qhd3nxvqzszzsfvh89xhd239ycqb0kq2n0bzh9br78pcb60vj3g";
+      rev = "abbf9df7b1c4219d5a6d3234d9149204208be7de";
+      sha256 = "1bsdmy98j7hmp9r28plfx0745g69m1pcmrrzcby7r8wk0fpscvq1";
     };
 
     inherit storeDir stateDir confDir boehmgc;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -37,7 +37,7 @@ common =
 
       VERSION_SUFFIX = suffix;
 
-      outputs = [ "out" "dev" "man" "doc" ];
+      outputs = [ "out" "dev" ] ++ lib.optionals (!(is24 && stdenv.hostPlatform != stdenv.buildPlatform)) [ "man" "doc" ];
 
       nativeBuildInputs =
         [ pkgconfig ]
@@ -54,7 +54,7 @@ common =
           brotli boost editline
         ]
         ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-        ++ lib.optionals is24 [ libarchive gmock ]
+        ++ lib.optionals is24 [ libarchive gmock lowdown ]
         ++ lib.optional withLibseccomp libseccomp
         ++ lib.optional withAWS
             ((aws-sdk-cpp.override {
@@ -122,7 +122,8 @@ common =
             stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform ? nix && stdenv.hostPlatform.nix ? system
         ) ''--with-system=${stdenv.hostPlatform.nix.system}''
            # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
-        ++ lib.optional (!withLibseccomp) "--disable-seccomp-sandboxing";
+        ++ lib.optional (!withLibseccomp) "--disable-seccomp-sandboxing"
+        ++ lib.optional (is24 && stdenv.hostPlatform != stdenv.buildPlatform) "--disable-doc-gen";
 
       makeFlags = [ "profiledir=$(out)/etc/profile.d" ]
         ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "PRECOMPILE_HEADERS=0";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Bump nixUnstable to latest
- Fix cross compilation by disabling documentation generation.

###### Things done

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
