### PR TITLE
sqlitebrowser: 3.12.0 -> 3.12.1

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "sqlitebrowser";
-  version = "3.12.0";
+  version = "3.12.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = version;
-    sha256 = "1arv4rzl8s1vjjqzz35l2b1rfzr2b8b23v97fdw1kdxpwvs63l99";
+    rev = "v${version}";
+    sha256 = "0ray6cscx2qil1dfi7hmpijmq3kba49wn430ih1q4fkz9psjvrz1";
   };
 
   # We should be using qscintilla from nixpkgs instead of the vendored version,


### PR DESCRIPTION
###### Motivation for this change
https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.12.1

CC Maintainer @peterhoeg

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
