### PR TITLE
aiodnsbrute: init at 0.3.2

### DIFF
--- a/pkgs/tools/security/aiodnsbrute/default.nix
+++ b/pkgs/tools/security/aiodnsbrute/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, aiodns
+, click
+, tqdm
+, uvloop
+}:
+
+buildPythonApplication rec {
+  pname = "aiodnsbrute";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "blark";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fs8544kx7vwvc97zpg4rs3lmvnb4vwika5g952rv3bfx4rv3bpg";
+  };
+
+  # https://github.com/blark/aiodnsbrute/pull/8
+  prePatch = ''
+    substituteInPlace setup.py --replace " 'asyncio', " ""
+  '';
+
+  propagatedBuildInputs = [
+     aiodns
+     click
+     tqdm
+     uvloop
+  ];
+
+  # no tests present
+  doCheck = false;
+
+  pythonImportsCheck = [ "aiodnsbrute.cli" ];
+
+  meta = with lib; {
+    description = "DNS brute force utility";
+    homepage = "https://github.com/blark/aiodnsbrute";
+    # https://github.com/blark/aiodnsbrute/issues/5
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -685,6 +685,8 @@ in
 
   aide = callPackage ../tools/security/aide { };
 
+  aiodnsbrute = python3Packages.callPackage ../tools/security/aiodnsbrute { };
+
   aircrack-ng = callPackage ../tools/networking/aircrack-ng { };
 
   airfield = callPackage ../tools/networking/airfield { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A Python 3.5+ tool that uses asyncio to brute force domain names asynchronously.

https://github.com/blark/aiodnsbrute

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
