### PR TITLE
wineStaging: fix mingwSupport

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, pkgArches, callPackage,
   name, version, src, mingwGccs, monos, geckos, platforms,
-  pkgconfig, fontforge, makeWrapper, flex, bison,
+  bison, flex, fontforge, makeWrapper, pkg-config,
+  autoconf, hexdump, perl,
   supportFlags,
   patches,
   buildScript ? null, configureFlags ? []
@@ -18,16 +19,24 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   inherit name src configureFlags;
 
   # Fixes "Compiler cannot create executables" building wineWow with mingwSupport
-  # FIXME Breaks wineStaging builds
-  strictDeps = supportFlags.mingwSupport;
+  strictDeps = true;
 
   nativeBuildInputs = [
-    pkgconfig fontforge makeWrapper flex bison
+    bison
+    flex
+    fontforge
+    makeWrapper
+    pkg-config
+
+    # Required by staging
+    autoconf
+    hexdump
+    perl
   ]
   ++ lib.optionals supportFlags.mingwSupport mingwGccs;
 
   buildInputs = toBuildInputs pkgArches (with supportFlags; (pkgs:
-  [ pkgs.freetype ]
+  [ pkgs.freetype pkgs.perl pkgs.xorg.libX11 ]
   ++ lib.optional stdenv.isLinux         pkgs.libcap
   ++ lib.optional pngSupport             pkgs.libpng
   ++ lib.optional jpegSupport            pkgs.libjpeg
@@ -72,8 +81,7 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ])
   ++ lib.optionals stdenv.isLinux  (with pkgs.xorg; [
      libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext
-  ])
-  ++ [ pkgs.xorg.libX11 pkgs.perl ]));
+  ])));
 
   patches = [ ] ++ patches';
 


### PR DESCRIPTION
###### Motivation for this change
Fix mingwSupport for staging builds of wine. See #103102.

@mweinelt I was able to get WoW running with:
```nix
wineWowPackages.full.override {
  wineRelease = "staging";
  mingwSupport = true;
}
```

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@avnik @bendlas @7c6f434c @cawilliamson