### PR TITLE
tiramisu: init at 1.0

### DIFF
--- a/pkgs/applications/misc/tiramisu/default.nix
+++ b/pkgs/applications/misc/tiramisu/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkg-config, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "tiramisu";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "Sweets";
+    repo = pname;
+    rev = version;
+    sha256 = "0aw17riwgrhsmcndzh7sw2zw8xvn3d203c2gcrqi9nk5pa7fwp9m";
+  };
+
+  postPatch = ''
+    sed -i 's/printf(element_delimiter)/printf("%s", element_delimiter)/' src/output.c
+  '';
+
+  buildInputs = [ glib ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Desktop notifications, the UNIX way";
+    longDescription = ''
+    tiramisu is a notification daemon based on dunst that outputs notifications
+    to STDOUT in order to allow the user to process notifications any way they
+    prefer.
+    '';
+    homepage = "https://github.com/Sweets/tiramisu";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wishfort36 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22080,6 +22080,8 @@ in
 
   swaylock-effects = callPackage ../applications/window-managers/sway/lock-effects.nix { };
 
+  tiramisu = callPackage ../applications/misc/tiramisu { };
+
   waybar = callPackage ../applications/misc/waybar {};
 
   hikari = callPackage ../applications/window-managers/hikari { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package is a notification daemon that prints notifications to stdout - allowing the user process notifications as they wish, for example by integrating it in their existing statusbar.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Arch)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Note: I've added this:

    postPatch = ''
      sed -i 's/printf(element_delimiter)/printf("%s", element_delimiter)/' src/output.c
    '';

because `gcc` refuses to compile, erroring at line no. 88 in `src/output.c`:

                  printf(element_delimiter);

(Furthermore, this happens on `gcc 9.3.0` (NixOS), but not on `gcc 10.2.0` (Arch), when compiling the normal way.). I'm not sure if this strategy is the best way to make it compile, so if anyone knows a better or more idiomatic way, then please tell!