### PR TITLE
libquotient: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/neochat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/neochat/default.nix
@@ -26,13 +26,13 @@
 
 mkDerivation rec {
   pname = "neochat";
-  version = "v1.0";
+  version = "1.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "network";
     repo = pname;
-    rev = version;
+    rev = "v${version}";
     sha256 = "1r9n83kvc5v215lzmzh6hyc5q9i3w6znbf508qk0mdwdzxz4zry9";
   };
 
@@ -61,6 +61,7 @@ mkDerivation rec {
     description = "A client for matrix, the decentralized communication protocol.";
     homepage = "https://apps.kde.org/en/neochat";
     license = licenses.gpl3Only;
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -5,13 +5,13 @@
 
 mkDerivation rec {
   pname = "quaternion";
-  version = "0.0.9.4e";
+  version = "0.0.9.5-beta2";
 
   src = fetchFromGitHub {
     owner = "QMatrixClient";
     repo = "Quaternion";
     rev = version;
-    sha256 = "0hqhg7l6wpkdbzrdjvrbqymmahziri07ba0hvbii7dd2p0h248fv";
+    sha256 = "sha256-K4SMB5kL0YO2OIeNUu4hWqU4E4n4vZDRRsJVYmCZqvM=";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "libquotient";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "quotient-im";
     repo = "libQuotient";
     rev = version;
-    sha256 = "1721cy6zaq086nrwh9x4d7k1jiaygg1wkvyx486i9bj9z53lc3wd";
+    sha256 = "sha256-RYEcFClRdAippG0kspNi9QZIzZAuU4++9LOQTZcqpVc=";
   };
 
   buildInputs = [ qtbase qtmultimedia ];
@@ -18,7 +18,7 @@ mkDerivation rec {
   meta = with lib; {
     description = "A Qt5 library to write cross-platfrom clients for Matrix";
     homepage = "https://matrix.org/docs/projects/sdk/quotient";
-    maintainers = with maintainers; [ colemickens ];
     license = licenses.lgpl21;
+    maintainers = with maintainers; [ colemickens ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream update but adding on a few minor changes:

1. fix neochat's version tag
2. add maintainer to neochat (@mjlbach - I didn't want to just add you without your consent)
2. upgrade quaternion to the latest beta. Yes, we normally don't do that but:
  1. it is needed to compile against libquotient v0.6+
  1. quaternion is still a young product without a stable v1.0 release so this version isn't necessarily any less stable than the previous
  2. I have been using the beta2 version since release without any issues


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
