### PR TITLE
evillimiter: init at 1.5.0

### DIFF
--- a/pkgs/tools/networking/evillimiter/default.nix
+++ b/pkgs/tools/networking/evillimiter/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, colorama
+, iproute2
+, iptables
+, netaddr
+, netifaces
+, scapy
+, terminaltables
+, tqdm
+}:
+
+buildPythonApplication rec {
+  pname = "evillimiter";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "bitbrute";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1l0acd4a36wzz1gyc6mcw3zpagyi2mc425c6d4c6anq3jxwm3847";
+  };
+
+  propagatedBuildInputs = [
+    colorama
+    iproute2
+    iptables
+    netaddr
+    netifaces
+    scapy
+    terminaltables
+    tqdm
+  ];
+
+  # no tests present
+  doCheck = false;
+
+  pythonImportsCheck = [ "evillimiter.evillimiter" ];
+
+  meta = with lib; {
+    description = "Tool that monitors, analyzes and limits the bandwidth";
+    longDescription = ''
+      A tool to monitor, analyze and limit the bandwidth (upload/download) of
+      devices on your local network without physical or administrative access.
+      evillimiter employs ARP spoofing and traffic shaping to throttle the
+      bandwidth of hosts on the network.
+    '';
+    homepage = "https://github.com/bitbrute/evillimiter";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3796,6 +3796,8 @@ in
 
   eventstat = callPackage ../os-specific/linux/eventstat { };
 
+  evillimiter = python3Packages.callPackage ../tools/networking/evillimiter { };
+
   evtest = callPackage ../applications/misc/evtest { };
 
   evtest-qt = libsForQt5.callPackage ../applications/misc/evtest-qt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A tool to monitor, analyze and limit the bandwidth (upload/download) of
devices on your local network without physical or administrative access.
evillimiter employs ARP spoofing and traffic shaping to throttle the
bandwidth of hosts on the network.

https://github.com/bitbrute/evillimiter

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
