### PR TITLE
groff: fix static build

### DIFF
--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     "--with-gs=${ghostscript}/bin/gs"
   ] ++ stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "ac_cv_path_PERL=${buildPackages.perl}/bin/perl"
+    "gl_cv_func_signbit=yes"
   ];
 
   makeFlags = stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [


### PR DESCRIPTION
Without manual override following problematic code in generated
"configure" script (line 15918):

  case "$host_os" in
    # Guess yes on glibc systems.
    *-gnu* | gnu*) gl_cv_func_signbit="guessing yes" ;;
    # Guess yes on native Windows.
    mingw*)        gl_cv_func_signbit="guessing yes" ;;
    # If we don't know, assume the worst.
    *)             gl_cv_func_signbit="guessing no" ;;
  esac

results in declaration conflict with gnulib declaring

  int signbit(double)

while system "math.h" providing modern declaration as

  constexpr bool signbit(double)


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).