### PR TITLE
ocamlPackages.syslog-message: init at 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/syslog-message/default.nix
+++ b/pkgs/development/ocaml-modules/syslog-message/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildDunePackage, fetchurl
+, astring, ptime, rresult, qcheck
+}:
+
+buildDunePackage rec {
+  pname = "syslog-message";
+  version = "1.1.0";
+
+  minimumOCamlVersion = "4.03";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/verbosemode/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "0vy4dkl2q2fa6rzyfsvjyc9r1b9ymfqd6j35z2kp5vdc4r87053g";
+  };
+
+  propagatedBuildInputs = [
+    astring
+    ptime
+    rresult
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    qcheck
+  ];
+
+  meta = with lib; {
+    description = "Syslog message parser";
+    homepage = "https://github.com/verbosemode/syslog-message";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -708,6 +708,8 @@ let
 
     syslog = callPackage ../development/ocaml-modules/syslog { };
 
+    syslog-message = callPackage ../development/ocaml-modules/syslog-message { };
+
     ocaml_text = callPackage ../development/ocaml-modules/ocaml-text { };
 
     ocaml-version = callPackage ../development/ocaml-modules/ocaml-version { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
