### PR TITLE
ruby_3_0: init 3.0.0

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -27,6 +27,7 @@ let
     ver = version;
     tag = ver.gitTag;
     atLeast27 = lib.versionAtLeast ver.majMin "2.7";
+    atLeast30 = lib.versionAtLeast ver.majMin "3.0";
     baseruby = self.override {
       useRailsExpress = false;
       docSupport = false;
@@ -109,7 +110,9 @@ let
           (import ./patchsets.nix {
             inherit patchSet useRailsExpress ops fetchpatch;
             patchLevel = ver.patchLevel;
-          }).${ver.majMinTiny};
+          }).${ver.majMinTiny}
+          ++ op atLeast27 ./do-not-regenerate-revision.h.patch
+          ++ op (atLeast30 && useRailsExpress) ./do-not-update-gems-baseruby.patch;
 
         postUnpack = opString rubygemsSupport ''
           rm -rf $sourceRoot/{lib,test}/rubygems*
@@ -121,16 +124,11 @@ let
           sed -i configure.ac -e '/config.guess/d'
           cp --remove-destination ${config}/config.guess tool/
           cp --remove-destination ${config}/config.sub tool/
+        '' + opString (!atLeast30) ''
           # Make the build reproducible for ruby <= 2.7
           # See https://github.com/ruby/io-console/commit/679a941d05d869f5e575730f6581c027203b7b26#diff-d8422f096931c58d4463e2489f62a228b0f24f0492950ba88c8c89a0d741cfe6
           sed -i ext/io/console/io-console.gemspec -e '/s\.date/d'
         '';
-
-        # Force the revision.h generation. Somehow `revision.tmp` is an empty
-        # file and because we don't add `git` to buildInputs, hence the check is
-        # always true.
-        # https://github.com/ruby/ruby/commit/97a5af62a318fcd93a4e5e4428d576c0280ddbae
-        buildFlags = lib.optionals atLeast27 [ "REVISION_LATEST=0" ];
 
         configureFlags = ["--enable-shared" "--enable-pthread" "--with-soname=ruby-${version}"]
           ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"
@@ -149,6 +147,10 @@ let
 
         preConfigure = opString docSupport ''
           configureFlagsArray+=("--with-ridir=$devdoc/share/ri")
+
+          # rdoc creates XDG_DATA_DIR (defaulting to $HOME/.local/share) even if
+          # it's not going to be used.
+          export HOME=$TMPDIR
         '';
 
         # fails with "16993 tests, 2229489 assertions, 105 failures, 14 errors, 89 skips"
@@ -259,6 +261,14 @@ in {
     sha256 = {
       src = "1m63461mxi3fg4y3bspbgmb0ckbbb1ldgf9xi0piwkpfsk80cmvf";
       git = "0kbgznf1yprfp9645k31ra5f4757b7fichzi0hdg6nxkj90853s0";
+    };
+  };
+
+  ruby_3_0 = generic {
+    version = rubyVersion "3" "0" "0" "";
+    sha256 = {
+      src = "0a4fmxafxvkg1m738g2lmkhipwnmd96kzqy1m9kvk3n1l50x2gm1";
+      git = "0fvnxv97m94nridlc5nvvrlg53pr5g042dkfc5ysd327s7xj4cjp";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/do-not-regenerate-revision.h.patch
+++ b/pkgs/development/interpreters/ruby/do-not-regenerate-revision.h.patch
@@ -1,0 +1,23 @@
+Do not regenerate revision.h
+
+Ruby's makefile compares the shipped version with the git revision to regenerate
+revision.h [1], but since we don't include git in buildInputs, this comparison
+fails and it can't find $(REVISION_H).
+
+[1] https://github.com/ruby/ruby/commit/97a5af62a318fcd93a4e5e4428d576c0280ddbae
+
+diff -Naur ruby.old/defs/gmake.mk ruby.new/defs/gmake.mk
+--- ruby.old/defs/gmake.mk
++++ ruby.new/defs/gmake.mk
+@@ -325,11 +325,9 @@
+ 
+ REVISION_IN_HEADER := $(shell sed -n 's/^\#define RUBY_FULL_REVISION "\(.*\)"/\1/p' $(srcdir)/revision.h 2>/dev/null)
+ REVISION_LATEST := $(shell $(CHDIR) $(srcdir) && git log -1 --format=%H 2>/dev/null)
+-ifneq ($(REVISION_IN_HEADER),$(REVISION_LATEST))
+ # GNU make treat the target as unmodified when its dependents get
+ # updated but it is not updated, while others may not.
+ $(srcdir)/revision.h: $(REVISION_H)
+-endif
+ 
+ # Query on the generated rdoc
+ #

--- a/pkgs/development/interpreters/ruby/do-not-update-gems-baseruby.patch
+++ b/pkgs/development/interpreters/ruby/do-not-update-gems-baseruby.patch
@@ -1,0 +1,14 @@
+Do not update gems when building with base ruby
+
+diff -Naur ruby.old/defs/gmake.mk ruby.new/defs/gmake.mk
+--- ruby.old/common.mk
++++ ruby.new/common.mk
+@@ -1298,7 +1298,7 @@ update-config_files: PHONY
+ 	    config.guess config.sub
+ 
+ refresh-gems: update-bundled_gems prepare-gems
+-prepare-gems: $(HAVE_BASERUBY:yes=update-gems) $(HAVE_BASERUBY:yes=extract-gems)
++prepare-gems:
+ 
+ update-gems$(gnumake:yes=-nongnumake): PHONY
+ 	$(ECHO) Downloading bundled gem files...

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,11 +1,6 @@
 { patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
-  "2.5.8" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.5/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
-    "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"
-  ];
   "2.6.6" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -16,4 +16,8 @@
     "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
+  "3.0.0" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch"
+  ];
 }

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "e2f4b82e47aeaf2a3b894da3b46ba6f0ca92cbb6";
-  sha256 = "059mvf8jcjrfplr8hv2y6ibc41id979k0zwfh6zdnb7dynym4bsg";
+  rev    = "28c6469ce841ff3033c376e78a7043009a3bdc5c";
+  sha256 = "0kh08hahrwif61sq0qlvgyqiymxi8c8h2dw4s3ln4aq696k4gba9";
 }

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -129,6 +129,12 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     runHook postUnpack
   '';
 
+  # As of ruby 3.0, ruby headers require -fdeclspec when building with clang
+  # Introduced in https://github.com/ruby/ruby/commit/0958e19ffb047781fe1506760c7cbd8d7fe74e57
+  NIX_CFLAGS_COMPILE = lib.optionals (stdenv.cc.isClang && lib.versionAtLeast ruby.version.major "3") [
+    "-fdeclspec"
+  ];
+
   buildPhase = attrs.buildPhase or ''
     runHook preBuild
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11561,13 +11561,15 @@ in
     bison = buildPackages.bison_3_5;
   })
     ruby_2_6
-    ruby_2_7;
+    ruby_2_7
+    ruby_3_0;
 
   ruby = ruby_2_6;
   rubyPackages = rubyPackages_2_6;
 
   rubyPackages_2_6 = recurseIntoAttrs ruby_2_6.gems;
   rubyPackages_2_7 = recurseIntoAttrs ruby_2_7.gems;
+  rubyPackages_3_0 = recurseIntoAttrs ruby_3_0.gems;
 
   mruby = callPackage ../development/compilers/mruby { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
