### PR TITLE
hoogle: set the host to bind on

### DIFF
--- a/nixos/modules/services/development/hoogle.nix
+++ b/nixos/modules/services/development/hoogle.nix
@@ -49,6 +49,11 @@ in {
       default = "https://hoogle.haskell.org";
     };
 
+    host = mkOption {
+      type = types.str;
+      description = "Set the host to bind on.";
+      default = "127.0.0.1";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -59,7 +64,7 @@ in {
 
       serviceConfig = {
         Restart = "always";
-        ExecStart = ''${hoogleEnv}/bin/hoogle server --local --port ${toString cfg.port} --home ${cfg.home}'';
+        ExecStart = ''${hoogleEnv}/bin/hoogle server --local --port ${toString cfg.port} --home ${cfg.home} --host ${cfg.host}'';
 
         DynamicUser = true;
 


### PR DESCRIPTION
I'm forwarding this patch that I received via email:

```
commit dbf9750782d7a9eca40265cf028dd81423498cd5
Author: Ben Sima <ben@bsima.me>
Date:   Tue Dec 29 22:20:48 2020 -0500

    hoogle: set the host to bind on

    Message-Id: <20201230032048.32626-1-ben@bsima.me>
```

You can find the submission in the [archive](https://lists.sr.ht/~andir/nixpkgs-dev/%3C20201230032048.32626-1-ben%40bsima.me%3E).