### PR TITLE
librepo: Build with zchunk support on darwin

### DIFF
--- a/pkgs/tools/package-management/librepo/default.nix
+++ b/pkgs/tools/package-management/librepo/default.nix
@@ -38,9 +38,8 @@ stdenv.mkDerivation rec {
     curl
     check
     gpgme
-  ]
-  # zchunk currently has issues compiling in darwin, fine in linux
-  ++ stdenv.lib.optional stdenv.isLinux zchunk;
+    zchunk
+  ];
 
   # librepo/fastestmirror.h includes curl/curl.h, and pkg-config specfile refers to others in here
   propagatedBuildInputs = [
@@ -51,7 +50,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DPYTHON_DESIRED=${stdenv.lib.substring 0 1 python.pythonVersion}"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "-DWITH_ZCHUNK=OFF";
+  ];
 
   postFixup = ''
     moveToOutput "lib/${python.libPrefix}" "$py"


### PR DESCRIPTION
Now that zchunk builds on darwin from #107443, we can enable it when building librepo.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS (see below)
   - [X] other Linux distributions. [Ubuntu](https://gist.github.com/nima2007/ed3acee98ef7997b7b973f8750e74c2d)
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Compiling it:
```
oooo@oooos-MacBook-Pro nixpkgs % nix-build default.nix -A librepo
these derivations will be built:
  /nix/store/hk5fdy4snfj5j3sihqffp7yvnvbp3crw-librepo-1.12.1.drv
these paths will be fetched (16.59 MiB download, 74.19 MiB unpacked):
  /nix/store/006k2q228pk597kfhpckzpzxg0441yff-check-0.15.2
  /nix/store/0hlaw36yviwy569psjiwxc7m9zfgx288-source
  /nix/store/3idyy4ns9h7s3cl1cl5q7mrk8yd9x9mv-ps-1003.1-2008
  /nix/store/41xpnbn2pxjvjdg072n2bbwhqdzhk8ng-db-5.3.28
  /nix/store/4i99653dahr75sxiphvw2zdrmv8486gd-glib-2.66.3
  /nix/store/4zyw4gzlydq7zdfm5g7k72k0rcz3da0y-adv_cmds-osx-10.5.8-ps
  /nix/store/5szl4zsvfw74y31nhsar9f89xmly922l-gnupg-2.2.24
  /nix/store/7j8slaypd4zn8nvqg562d2h41w1bq6yb-libffi-3.3-dev
  /nix/store/7nfzpf6kp2igsx8fp2isl6qx4jf40x61-openldap-2.4.56
  /nix/store/943xqz3fhkkrav24xljwcfk28r0znwqj-libxml2-2.9.10-bin
  /nix/store/asskzgd6m78y618gw22b0mbyrl1cvqjw-libgcrypt-1.8.7
  /nix/store/axs6gba5c1p8mq1f4fvh4z6ygkp0s201-cyrus-sasl-2.1.27
  /nix/store/cc4q6c048ii2zmqcdix9w87g4gxbpi63-libassuan-2.5.4-dev
  /nix/store/g96likl5vkl42hfkbvgh0x31jqxj5fij-libusb-1.0.23
  /nix/store/h2vcv6yivwaqwiqbbcn80z0vxzdsy22h-cmake-3.19.1
  /nix/store/i3cpm51zq5f50avic9y2pxkrjk879zr4-libgpg-error-1.38-dev
  /nix/store/ihpg2gn9addfkjrq4wxgqygwaww1k9zr-libuv-1.40.0
  /nix/store/jfy4fchvayrn52bgq5qy11rb4xn0p8j9-glib-2.66.3-dev
  /nix/store/jsz5m6ydmxcn68fgnysnh8ld0vk5xp7d-libksba-1.5.0
  /nix/store/k6qfam8hc5vjwsx76wssz4nyi2cwsfiv-gpgme-1.15.0-dev
  /nix/store/kvwxn5iys1wnlb2hf4lmnak7crxlxbk1-libxml2-2.9.10-dev
  /nix/store/lwiq21zw4lqfdx2wbp0gkr5v5s3fjppv-pth-2.0.7
  /nix/store/m07a5bx6kbvw3vjksasx6lzwgnyv8nmm-libgpg-error-1.38
  /nix/store/n3b4i9xl6j2dd5w0xwzy3lblvmsdh4pd-npth-1.6
  /nix/store/piz64wqz85mkkm6cfajn6zr23ynd5hxw-pinentry-mac-0.9.4
  /nix/store/py6hh8sbp4q6v3hylar7qkh59ginn1dh-libassuan-2.5.4
  /nix/store/rd31qfbqyx2gnmfjzv89c7jksq5bw4l7-gpgme-1.15.0
  /nix/store/spmgdaj9gxbg0aivgy5zijmyafl58kgw-rhash-1.4.0
  /nix/store/v6m5mzw7109s72jany8wr17ch0q2m9ad-glib-2.66.3-bin
  /nix/store/vl7nnfxl420q927gs90gxlcr816qk8ky-libarchive-3.5.0-lib
  /nix/store/zr2jafjyywqm8i76a1482b4m3gxa4y0c-hook
copying path '/nix/store/0hlaw36yviwy569psjiwxc7m9zfgx288-source' from 'https://cache.nixos.org'...
copying path '/nix/store/4zyw4gzlydq7zdfm5g7k72k0rcz3da0y-adv_cmds-osx-10.5.8-ps' from 'https://cache.nixos.org'...
copying path '/nix/store/006k2q228pk597kfhpckzpzxg0441yff-check-0.15.2' from 'https://cache.nixos.org'...
copying path '/nix/store/41xpnbn2pxjvjdg072n2bbwhqdzhk8ng-db-5.3.28' from 'https://cache.nixos.org'...
copying path '/nix/store/4i99653dahr75sxiphvw2zdrmv8486gd-glib-2.66.3' from 'https://cache.nixos.org'...
copying path '/nix/store/axs6gba5c1p8mq1f4fvh4z6ygkp0s201-cyrus-sasl-2.1.27' from 'https://cache.nixos.org'...
copying path '/nix/store/v6m5mzw7109s72jany8wr17ch0q2m9ad-glib-2.66.3-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/zr2jafjyywqm8i76a1482b4m3gxa4y0c-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/vl7nnfxl420q927gs90gxlcr816qk8ky-libarchive-3.5.0-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/7j8slaypd4zn8nvqg562d2h41w1bq6yb-libffi-3.3-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/m07a5bx6kbvw3vjksasx6lzwgnyv8nmm-libgpg-error-1.38' from 'https://cache.nixos.org'...
copying path '/nix/store/jfy4fchvayrn52bgq5qy11rb4xn0p8j9-glib-2.66.3-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/py6hh8sbp4q6v3hylar7qkh59ginn1dh-libassuan-2.5.4' from 'https://cache.nixos.org'...
copying path '/nix/store/asskzgd6m78y618gw22b0mbyrl1cvqjw-libgcrypt-1.8.7' from 'https://cache.nixos.org'...
copying path '/nix/store/i3cpm51zq5f50avic9y2pxkrjk879zr4-libgpg-error-1.38-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/jsz5m6ydmxcn68fgnysnh8ld0vk5xp7d-libksba-1.5.0' from 'https://cache.nixos.org'...
copying path '/nix/store/cc4q6c048ii2zmqcdix9w87g4gxbpi63-libassuan-2.5.4-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/g96likl5vkl42hfkbvgh0x31jqxj5fij-libusb-1.0.23' from 'https://cache.nixos.org'...
copying path '/nix/store/ihpg2gn9addfkjrq4wxgqygwaww1k9zr-libuv-1.40.0' from 'https://cache.nixos.org'...
copying path '/nix/store/943xqz3fhkkrav24xljwcfk28r0znwqj-libxml2-2.9.10-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/n3b4i9xl6j2dd5w0xwzy3lblvmsdh4pd-npth-1.6' from 'https://cache.nixos.org'...
copying path '/nix/store/kvwxn5iys1wnlb2hf4lmnak7crxlxbk1-libxml2-2.9.10-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/7nfzpf6kp2igsx8fp2isl6qx4jf40x61-openldap-2.4.56' from 'https://cache.nixos.org'...
copying path '/nix/store/piz64wqz85mkkm6cfajn6zr23ynd5hxw-pinentry-mac-0.9.4' from 'https://cache.nixos.org'...
copying path '/nix/store/3idyy4ns9h7s3cl1cl5q7mrk8yd9x9mv-ps-1003.1-2008' from 'https://cache.nixos.org'...
copying path '/nix/store/5szl4zsvfw74y31nhsar9f89xmly922l-gnupg-2.2.24' from 'https://cache.nixos.org'...
copying path '/nix/store/lwiq21zw4lqfdx2wbp0gkr5v5s3fjppv-pth-2.0.7' from 'https://cache.nixos.org'...
copying path '/nix/store/rd31qfbqyx2gnmfjzv89c7jksq5bw4l7-gpgme-1.15.0' from 'https://cache.nixos.org'...
copying path '/nix/store/spmgdaj9gxbg0aivgy5zijmyafl58kgw-rhash-1.4.0' from 'https://cache.nixos.org'...
copying path '/nix/store/k6qfam8hc5vjwsx76wssz4nyi2cwsfiv-gpgme-1.15.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/h2vcv6yivwaqwiqbbcn80z0vxzdsy22h-cmake-3.19.1' from 'https://cache.nixos.org'...
building '/nix/store/hk5fdy4snfj5j3sihqffp7yvnvbp3crw-librepo-1.12.1.drv'...
unpacking sources
unpacking source archive /nix/store/0hlaw36yviwy569psjiwxc7m9zfgx288-source
source root is source
patching sources
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/share/doc/librepo -DCMAKE_INSTALL_INFODIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include -DCMAKE_INSTALL_SBINDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/i1mccwrczhhacpk0jn58wmixqiqh1vkb-cctools-binutils-darwin-949.0.1/bin/strip -DCMAKE_RANLIB=/nix/store/i1mccwrczhhacpk0jn58wmixqiqh1vkb-cctools-binutils-darwin-949.0.1/bin/ranlib -DCMAKE_AR=/nix/store/i1mccwrczhhacpk0jn58wmixqiqh1vkb-cctools-binutils-darwin-949.0.1/bin/ar -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1 -DPYTHON_DESIRED=3 
-- The C compiler identification is Clang 7.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/511qa169fbxj18b3k2bjwxffqzxw0fag-clang-wrapper-7.1.0/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Deprecation Warning at CMakeLists.txt:2 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Found PkgConfig: pkg-config (found version "0.29.2") 
-- Checking for module 'glib-2.0'
--   Found glib-2.0, version 2.66.3
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
Package libpcre was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre', required by 'glib-2.0', not found
-- Checking for one of the modules 'libcrypto;openssl'
-- Checking for module 'libxml-2.0'
--   Found libxml-2.0, version 2.9.10
-- Found CURL: /nix/store/v3qbz0ic0kyyc66crssi9khb06wq9nl9-curl-7.73.0/lib/libcurl.dylib (found version "7.73.0")  
-- Found gpgme-config at /nix/store/k6qfam8hc5vjwsx76wssz4nyi2cwsfiv-gpgme-1.15.0-dev/bin/gpgme-config
-- Found gpgme v1.15.0-unknown, checking for flavours...
--  Found flavour 'vanilla', checking whether it's usable...yes
--  Found flavour 'pthread', checking whether it's usable...yes
-- Usable gpgme flavours found:  vanilla pthread
-- Checking for module 'zck>=0.9.11'
--   Found zck, version 1.1.8
Package libzstd was not found in the pkg-config search path.
Perhaps you should add the directory containing `libzstd.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libzstd', required by 'zck', not found
Package libzstd was not found in the pkg-config search path.
Perhaps you should add the directory containing `libzstd.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libzstd', required by 'zck', not found
Package libzstd was not found in the pkg-config search path.
Perhaps you should add the directory containing `libzstd.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libzstd', required by 'zck', not found
Package libzstd was not found in the pkg-config search path.
Perhaps you should add the directory containing `libzstd.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libzstd', required by 'zck', not found
-- Found PythonInterp: /nix/store/c56kq0k3f3rdgkj3s1z5hw0j4ack9gdg-python3-3.8.6/bin/python3 (found suitable exact version "3.8.6") 
-- Found PythonLibs: /nix/store/c56kq0k3f3rdgkj3s1z5hw0j4ack9gdg-python3-3.8.6/lib/libpython3.8.dylib (found version "3.8.6") 
Building for python3
-- Python3 install dir is /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/python3.8/site-packages
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Configuring done
CMake Warning (dev) at doc/CMakeLists.txt:5 (ADD_DEPENDENCIES):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "doc-c" of target "doc" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   librepo

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev):
  Policy CMP0068 is not set: RPATH settings on macOS do not affect
  install_name.  Run "cmake --help-policy CMP0068" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

  For compatibility with older versions of CMake, the install_name fields for
  the following targets are still affected by RPATH settings:

   _librepo
   librepo

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_CXX_COMPILER
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY


-- Build files have been written to: /tmp/nix-build-librepo-1.12.1.drv-0/source/build
cmake: enabled parallel building
building
build flags: -j8 -l8 SHELL=/nix/store/drz9yxh2v1swn9yl88c8w5g0x69b8wk2-bash-4.4-p23/bin/bash
Scanning dependencies of target librepo
[  1%] Building C object librepo/CMakeFiles/librepo.dir/checksum.c.o
[  5%] Building C object librepo/CMakeFiles/librepo.dir/downloader.c.o
[  5%] Building C object librepo/CMakeFiles/librepo.dir/downloadtarget.c.o
[  7%] Building C object librepo/CMakeFiles/librepo.dir/fastestmirror.c.o
[ 11%] Building C object librepo/CMakeFiles/librepo.dir/gpg.c.o
[ 11%] Building C object librepo/CMakeFiles/librepo.dir/lrmirrorlist.c.o
[ 13%] Building C object librepo/CMakeFiles/librepo.dir/handle.c.o
[ 15%] Building C object librepo/CMakeFiles/librepo.dir/metalink.c.o
/tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/downloader.c:1666:15: warning: unused variable 'cm_rc' [-Wunused-variable]
    CURLMcode cm_rc = curl_multi_add_handle(dd->multi_handle, h);
              ^
/tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/handle.c:1231:14: warning: implicit declaration of function 'mkdtemp' is invalid in C99 [-Wimplicit-function-declaration]
        if (!mkdtemp(handle->destdir)) {
             ^
/tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/downloader.c:2340:21: warning: implicit declaration of function 'futimes' is invalid in C99 [-Wimplicit-function-declaration]
                if (futimes(fileno(target->f), tv) == -1)
                    ^
[ 17%] Building C object librepo/CMakeFiles/librepo.dir/metadata_downloader.c.o
[ 19%] Building C object librepo/CMakeFiles/librepo.dir/mirrorlist.c.o
[ 21%] Building C object librepo/CMakeFiles/librepo.dir/package_downloader.c.o
[ 23%] Building C object librepo/CMakeFiles/librepo.dir/rcodes.c.o
[ 25%] Building C object librepo/CMakeFiles/librepo.dir/repoconf.c.o
[ 26%] Building C object librepo/CMakeFiles/librepo.dir/repomd.c.o
[ 28%] Building C object librepo/CMakeFiles/librepo.dir/repoutil_yum.c.o
[ 30%] Building C object librepo/CMakeFiles/librepo.dir/result.c.o
[ 32%] Building C object librepo/CMakeFiles/librepo.dir/url_substitution.c.o
1 warning generated.
[ 34%] Building C object librepo/CMakeFiles/librepo.dir/util.c.o
[ 36%] Building C object librepo/CMakeFiles/librepo.dir/xmlparser.c.o
[ 38%] Building C object librepo/CMakeFiles/librepo.dir/yum.c.o
/tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/util.c:172:10: warning: implicit declaration of function 'mkdtemp' is invalid in C99 [-Wimplicit-function-declaration]
    if (!mkdtemp(template)) {
         ^
1 warning generated.
2 warnings generated.
[ 40%] Linking C shared library librepo.dylib
[ 40%] Built target librepo
Scanning dependencies of target _librepo
Scanning dependencies of target test_main
[ 42%] Building C object tests/CMakeFiles/test_main.dir/fixtures.c.o
[ 44%] Building C object tests/CMakeFiles/test_main.dir/test_checksum.c.o
[ 46%] Building C object tests/CMakeFiles/test_main.dir/test_downloader.c.o
[ 48%] Building C object tests/CMakeFiles/test_main.dir/test_gpg.c.o
[ 50%] Building C object tests/CMakeFiles/test_main.dir/test_handle.c.o
[ 51%] Building C object tests/CMakeFiles/test_main.dir/test_lrmirrorlist.c.o
[ 53%] Building C object tests/CMakeFiles/test_main.dir/test_main.c.o
[ 55%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/downloader-py.c.o
[ 57%] Building C object tests/CMakeFiles/test_main.dir/test_metalink.c.o
[ 59%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/exception-py.c.o
[ 61%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/handle-py.c.o
[ 63%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/librepomodule.c.o
[ 65%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/logging.c.o
[ 67%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/metadatadownloader-py.c.o
[ 69%] Building C object tests/CMakeFiles/test_main.dir/test_mirrorlist.c.o
[ 71%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/metadatatarget-py.c.o
In file included from /tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/python/librepomodule.c:35:
/tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/python/globalstate-py.h:60:1: warning: unused function 'gil_logger_hack_begin' [-Wunused-function]
gil_logger_hack_begin(PyThreadState **state)
^
/tmp/nix-build-librepo-1.12.1.drv-0/source/librepo/python/globalstate-py.h:84:1: warning: unused function 'gil_logger_hack_end' [-Wunused-function]
gil_logger_hack_end(int hack_begin_rc)
^
2 warnings generated.
[ 73%] Building C object tests/CMakeFiles/test_main.dir/test_repo_zck.c.o
[ 75%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/packagetarget-py.c.o
[ 76%] Building C object tests/CMakeFiles/test_main.dir/test_url_substitution.c.o
[ 78%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/result-py.c.o
[ 80%] Building C object tests/CMakeFiles/test_main.dir/test_util.c.o
[ 82%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/typeconversion.c.o
[ 84%] Building C object tests/CMakeFiles/test_main.dir/test_version.c.o
[ 86%] Building C object tests/CMakeFiles/test_main.dir/testsys.c.o
[ 88%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/yum-py.c.o
[ 90%] Building C object tests/CMakeFiles/test_main.dir/test_repomd.c.o
[ 92%] Building C object librepo/python/python3/CMakeFiles/_librepo.dir/__/packagedownloader-py.c.o
[ 94%] Building C object tests/CMakeFiles/test_main.dir/test_repoconf.c.o
/tmp/nix-build-librepo-1.12.1.drv-0/source/tests/test_repoconf.c:37:1: warning: unused function 'repoconf_assert_false' [-Wunused-function]
repoconf_assert_false(LrYumRepoConf *repoconf,
^
[ 96%] Linking C shared library librepo/_librepo.dylib
1 warning generated.
[ 98%] Building C object tests/CMakeFiles/test_main.dir/test_package_downloader.c.o
[ 98%] Built target _librepo
[100%] Linking C executable test_main
[100%] Built target test_main
glibPreInstallPhase
installing
install flags: SHELL=/nix/store/drz9yxh2v1swn9yl88c8w5g0x69b8wk2-bash-4.4-p23/bin/bash gsettingsschemadir=/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/share/gsettings-schemas/librepo-1.12.1/glib-2.0/schemas/ install
[ 40%] Built target librepo
[ 65%] Built target _librepo
[100%] Built target test_main
Install the project...
-- Install configuration: "Release"
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/checksum.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/fastestmirror.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/gpg.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/handle.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/librepo.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/metadata_downloader.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/metalink.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/mirrorlist.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/package_downloader.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/rcodes.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/repoconf.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/repomd.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/repoutil_yum.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/result.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/types.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/url_substitution.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/util.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/version.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/xmlparser.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/yum.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/downloader.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/downloader_internal.h
-- Installing: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/include/librepo/downloadtarget.h
-- Installing: /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/librepo.0.dylib
-- Installing: /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/librepo.dylib
-- Installing: /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/pkgconfig/librepo.pc
-- Installing: /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/python3.8/site-packages/librepo/__init__.py
-- Installing: /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/python3.8/site-packages/librepo/_librepo.dylib
glibPreFixupPhase
post-installation fixup
Moving /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/pkgconfig to /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/lib/pkgconfig
rmdir: failed to remove '/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib': Directory not empty
Patching '/nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/lib/pkgconfig/librepo.pc' includedir to output /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev
strip is /nix/store/i1mccwrczhhacpk0jn58wmixqiqh1vkb-cctools-binutils-darwin-949.0.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib 
strip: can't process non-object and non-archive file: /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/python3.8/site-packages/librepo/__init__.py
patching script interpreter paths in /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1
strip is /nix/store/i1mccwrczhhacpk0jn58wmixqiqh1vkb-cctools-binutils-darwin-949.0.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/lib 
strip: can't process non-object and non-archive file: /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev/lib/pkgconfig/librepo.pc
patching script interpreter paths in /nix/store/x9cz5vy765vcsplrk1za5mlgkn5s8kkp-librepo-1.12.1-dev
find: '/nix/store/8ckpbayvrnzb0v4hnjzm2q1y23qj0jc6-librepo-1.12.1-py': No such file or directory
strip is /nix/store/i1mccwrczhhacpk0jn58wmixqiqh1vkb-cctools-binutils-darwin-949.0.1/bin/strip
Moving /nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib/python3.8 to /nix/store/8ckpbayvrnzb0v4hnjzm2q1y23qj0jc6-librepo-1.12.1-py/lib/python3.8
rmdir: failed to remove '/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1/lib': Directory not empty
/nix/store/88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1
oooo@oooos-MacBook-Pro nixpkgs % echo $?
0
```

Verify that it was built with zchunk (compare to output from #107104):
```
oooo@oooos-MacBook-Pro 88pxr8fdn6w2m05vd6fzyjnaphyj1myh-librepo-1.12.1 % nm -gU lib/librepo.dylib 
000000000000fc20 T _appendFdValue
000000000000fc50 T _appendPath
0000000000010310 T _cleanup
0000000000016d30 T _compare_records
000000000000fd60 T _create_repomd_xml_download_targets
000000000000a340 T _ensure_socket_dir_exists
00000000000181f0 T _error_handling
000000000000fc80 T _fillInvalidationValues
000000000000fce0 T _handle_failure
0000000000016d40 T _hmfcb
0000000000015b90 T _lr_best_checksum
0000000000016680 T _lr_char_handler
00000000000111f0 T _lr_check_packages
00000000000171f0 T _lr_check_repomd_xml_asc_availability
00000000000117b0 T _lr_checksum_error_quark
0000000000003d50 T _lr_checksum_fd
00000000000040c0 T _lr_checksum_fd_cmp
00000000000040e0 T _lr_checksum_fd_compare
0000000000015e10 T _lr_checksum_from_zck_hash
0000000000003b60 T _lr_checksum_type
0000000000003d30 T _lr_checksum_type_to_str
00000000000159c0 T _lr_copy_content
0000000000017000 T _lr_copy_metalink_content
000000000000ea00 T _lr_detect_protocol
0000000000004600 T _lr_download
0000000000010380 T _lr_download_metadata
0000000000011170 T _lr_download_package
0000000000010a30 T _lr_download_packages
0000000000006700 T _lr_download_single_cb
00000000000065c0 T _lr_download_target
0000000000006610 T _lr_download_url
00000000000117d0 T _lr_downloader_error_quark
0000000000008b90 T _lr_downloadtarget_free
00000000000089c0 T _lr_downloadtarget_new
0000000000008b50 T _lr_downloadtarget_reset
0000000000008d10 T _lr_downloadtarget_set_effectiveurl
0000000000008bd0 T _lr_downloadtarget_set_error
0000000000008cf0 T _lr_downloadtarget_set_usedmirror
0000000000008990 T _lr_downloadtargetchecksum_free
0000000000008950 T _lr_downloadtargetchecksum_new
0000000000009e00 T _lr_fastestmirror
0000000000008d60 T _lr_fastestmirror_detailed
00000000000117f0 T _lr_fastestmirror_error_quark
0000000000009f20 T _lr_fastestmirror_sort_internalmirrorlist
0000000000009f60 T _lr_fastestmirror_sort_internalmirrorlists
00000000000153c0 T _lr_free
0000000000017460 T _lr_get_best_checksum
000000000000ae90 T _lr_get_curl_handle
00000000000175a0 T _lr_get_metadata_failure_callback
0000000000016540 T _lr_get_recursive_files
00000000000163c0 T _lr_get_recursive_files_rec
0000000000015450 T _lr_gettmpdir
00000000000153e0 T _lr_gettmpfile
00000000000152a0 T _lr_global_init
000000000000a930 T _lr_gpg_check_signature
000000000000a400 T _lr_gpg_check_signature_fd
0000000000011810 T _lr_gpg_error_quark
000000000000aa90 T _lr_gpg_import_key
0000000000011830 T _lr_handle_error_quark
000000000000b0c0 T _lr_handle_free
000000000000af60 T _lr_handle_free_list
000000000000dd60 T _lr_handle_getinfo
000000000000afc0 T _lr_handle_init
000000000000d920 T _lr_handle_perform
000000000000cc10 T _lr_handle_prepare_internal_mirrorlist
000000000000b330 T _lr_handle_setopt
000000000001fd30 S _lr_interrupt
0000000000015d40 T _lr_is_local_path
0000000000015d90 T _lr_key_file_save_to_file
0000000000015200 T _lr_log_librepo_summary
0000000000008d30 T _lr_lrfastestmirror_free
000000000000ee80 T _lr_lrmirrorlist_append_lrmirrorlist
000000000000ece0 T _lr_lrmirrorlist_append_metalink
000000000000ebc0 T _lr_lrmirrorlist_append_mirrorlist
000000000000ead0 T _lr_lrmirrorlist_append_url
000000000000ea90 T _lr_lrmirrorlist_free
000000000000ef10 T _lr_lrmirrorlist_nth
000000000000ef20 T _lr_lrmirrorlist_nth_url
0000000000015350 T _lr_malloc
0000000000015370 T _lr_malloc0
000000000000faa0 T _lr_metadatatarget_append_error
000000000000fa60 T _lr_metadatatarget_free
000000000000f8d0 T _lr_metadatatarget_new
000000000000f980 T _lr_metadatatarget_new2
0000000000011850 T _lr_metalink_error_quark
000000000000ef50 T _lr_metalink_free
000000000000ef40 T _lr_metalink_init
000000000000f050 T _lr_metalink_parse_file
0000000000011870 T _lr_mirrorlist_error_quark
0000000000010500 T _lr_mirrorlist_free
00000000000104f0 T _lr_mirrorlist_init
0000000000010530 T _lr_mirrorlist_parse_file
00000000000066e0 T _lr_multi_mf_func
0000000000006630 T _lr_multi_progress_func
0000000000015320 T _lr_out_of_memory
0000000000011890 T _lr_package_downloader_error_quark
0000000000010a00 T _lr_packagetarget_free
0000000000010850 T _lr_packagetarget_new
0000000000010950 T _lr_packagetarget_new_v2
0000000000010990 T _lr_packagetarget_new_v3
00000000000109e0 T _lr_packagetarget_reset
00000000000154a0 T _lr_pathconcat
0000000000016d60 T _lr_prepare_repodata_dir
0000000000017150 T _lr_prepare_repomd_xml_file
0000000000015a70 T _lr_prepend_url_protocol
0000000000015390 T _lr_realloc
00000000000159a0 T _lr_remove_dir
0000000000015950 T _lr_remove_dir_cb
00000000000118d0 T _lr_repoconf_error_quark
00000000000118f0 T _lr_repomd_error_quark
0000000000014880 T _lr_repoutil_yum_check_repo
0000000000011910 T _lr_repoutil_yum_error_quark
0000000000014980 T _lr_repoutil_yum_parse_repomd
0000000000014b80 T _lr_result_clear
0000000000011930 T _lr_result_error_quark
0000000000014bd0 T _lr_result_free
0000000000014c20 T _lr_result_getinfo
0000000000014b70 T _lr_result_init
0000000000004330 T _lr_sigint_handler
0000000000016eb0 T _lr_store_mirrorlist_files
0000000000011780 T _lr_strerror
0000000000015b40 T _lr_string_chunk_insert
0000000000015cb0 T _lr_strv_dup
0000000000014fe0 T _lr_url_substitute
0000000000015c20 T _lr_url_without_path
0000000000014f80 T _lr_urlvars_free
0000000000014e60 T _lr_urlvars_set
0000000000004440 T _lr_writecb
0000000000016640 T _lr_xml_parser_data_free
00000000000165d0 T _lr_xml_parser_data_new
00000000000118b0 T _lr_xml_parser_error_quark
00000000000169e0 T _lr_xml_parser_generic
0000000000016910 T _lr_xml_parser_strtoll
00000000000167d0 T _lr_xml_parser_warning
0000000000015b60 T _lr_xml_parser_warning_logger
0000000000018440 T _lr_yum_download_repo
0000000000018300 T _lr_yum_download_repos
0000000000017610 T _lr_yum_download_url
0000000000011950 T _lr_yum_error_quark
0000000000018530 T _lr_yum_perform
0000000000016bd0 T _lr_yum_repo_free
0000000000016bc0 T _lr_yum_repo_init
0000000000016c70 T _lr_yum_repo_path
00000000000120e0 T _lr_yum_repoconf_getinfo
0000000000011fe0 T _lr_yum_repoconf_save
0000000000013070 T _lr_yum_repoconf_setopt
0000000000011a30 T _lr_yum_repoconfs_add_empty_conf
0000000000011980 T _lr_yum_repoconfs_free
0000000000011a20 T _lr_yum_repoconfs_get_list
0000000000011970 T _lr_yum_repoconfs_init
0000000000011e10 T _lr_yum_repoconfs_load_dir
0000000000011b40 T _lr_yum_repoconfs_parse
0000000000011f60 T _lr_yum_repoconfs_save
0000000000013d60 T _lr_yum_repomd_free
0000000000014af0 T _lr_yum_repomd_get_age
0000000000013e40 T _lr_yum_repomd_get_highest_timestamp
0000000000013df0 T _lr_yum_repomd_get_record
0000000000013d30 T _lr_yum_repomd_init
0000000000013eb0 T _lr_yum_repomd_parse_file
0000000000004590 T _lr_zck_clear_header
0000000000015e30 T _lr_zck_hash_from_lr_checksum
0000000000016170 T _lr_zck_init_read
0000000000015e50 T _lr_zck_init_read_base
00000000000162e0 T _lr_zck_valid_header
0000000000016090 T _lr_zck_valid_header_base
0000000000004410 T _lr_zck_writecb
0000000000004340 T _lr_zckheadercb
00000000000177c0 T _prepare_repo_download_std_target
0000000000017a40 T _prepare_repo_download_targets
0000000000017900 T _prepare_repo_download_zck_target
0000000000010150 T _process_repomd_xml
```