### PR TITLE
tensorflow1: disable sysctl.h in hwloc

### DIFF
--- a/pkgs/development/python-modules/tensorflow/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow/1/default.nix
@@ -258,6 +258,11 @@ let
 
       substituteInPlace tensorflow/tools/pip_package/setup.py \
         --replace "numpy >= 1.16.0, < 1.19.0" "numpy >= 1.16.0"
+
+      # glibc 2.31+ does not have sys/sysctl.h
+      # see https://github.com/tensorflow/tensorflow/issues/45861
+      substituteInPlace third_party/hwloc/BUILD.bazel\
+        --replace "#define HAVE_SYS_SYSCTL_H 1" "#undef HAVE_SYS_SYSCTL_H"
     '';
 
     preConfigure = let


### PR DESCRIPTION
We need to override tensorflow's hwloc configuration, since it forces
sysctl.h usage which is removed since glibc 2.31. This does not appear
to effect tensorflow2.

See also https://github.com/tensorflow/tensorflow/issues/45861

Fixes #104801

###### Things done

- Built on platform(s)
   - [x] NixOS
