### PR TITLE
python3Packages.mypy: don't use mypyc on 32-bit platforms

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -53,7 +53,8 @@ buildPythonPackage rec {
 
   # Compile mypy with mypyc, which makes mypy about 4 times faster. The compiled
   # version is also the default in the wheels on Pypi that include binaries.
-  MYPY_USE_MYPYC = "1";
+  # is64bit: unfortunately the build would exhaust all possible memory on i686-linux.
+  MYPY_USE_MYPYC = stdenv.buildPlatform.is64bit;
 
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";


### PR DESCRIPTION
###### Motivation for this change

Almost all i686-linux tests got blocked because of this problem:
  https://hydra.nixos.org/eval/1638038#tabs-now-fail
It regressed in PR #105462 (commit ad26cb9ee8).

###### Things done

Now I tested that at least some test got fixed:
  nix build -f nixos/release-combined.nix nixos.tests.knot.i686-linux
This change won't even cause any rebuild on 64-bit platforms,
and using nix booleans seems nicer anyway.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
