### PR TITLE
akonadi: add missing kaccounts deps

### DIFF
--- a/pkgs/applications/kde/akonadi/default.nix
+++ b/pkgs/applications/kde/akonadi/default.nix
@@ -1,8 +1,9 @@
 {
   mkDerivation, lib, kdepimTeam,
-  extra-cmake-modules, shared-mime-info, qtbase,
-  boost, kcompletion, kconfigwidgets, kcrash, kdbusaddons, kdesignerplugin,
-  ki18n, kiconthemes, kio, kitemmodels, kwindowsystem, mysql, qttools,
+  extra-cmake-modules, shared-mime-info, qtbase, accounts-qt,
+  boost, kaccounts-integration, kcompletion, kconfigwidgets, kcrash, kdbusaddons,
+  kdesignerplugin, ki18n, kiconthemes, kio, kitemmodels, kwindowsystem, mysql, qttools,
+  signond,
 }:
 
 mkDerivation {
@@ -19,8 +20,8 @@ mkDerivation {
   ];
   nativeBuildInputs = [ extra-cmake-modules shared-mime-info ];
   buildInputs = [
-    kcompletion kconfigwidgets kcrash kdbusaddons kdesignerplugin ki18n
-    kiconthemes kio kwindowsystem qttools
+    kaccounts-integration kcompletion kconfigwidgets kcrash kdbusaddons kdesignerplugin
+    ki18n kiconthemes kio kwindowsystem accounts-qt qttools signond
   ];
   propagatedBuildInputs = [ boost kitemmodels ];
   outputs = [ "out" "dev" ];

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -88,6 +88,7 @@ let
       gwenview = callPackage ./gwenview.nix {};
       incidenceeditor = callPackage ./incidenceeditor.nix {};
       k3b = callPackage ./k3b.nix {};
+      kaccounts-integration = callPackage ./kaccounts-integration.nix {};
       kaddressbook = callPackage ./kaddressbook.nix {};
       kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};

--- a/pkgs/applications/kde/kaccounts-integration.nix
+++ b/pkgs/applications/kde/kaccounts-integration.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, lib, extra-cmake-modules, kdoctools, kcmutils, kcoreaddons, kwallet, accounts-qt, signond }:
+
+mkDerivation {
+  name = "kaccounts-integration";
+  meta = with lib; {
+    homepage = "https://community.kde.org/KTp/Setting_up_KAccounts";
+    description = "Online accounts integration";
+    maintainers = with maintainers; [ freezeboy ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+  buildInputs = [
+    kcmutils
+    kcoreaddons
+    kdoctools
+    kwallet
+    accounts-qt
+    signond
+  ];
+}

--- a/pkgs/development/libraries/accounts-qt/default.nix
+++ b/pkgs/development/libraries/accounts-qt/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitLab, doxygen, glib, libaccounts-glib, pkgconfig, qtbase, qmake }:
+{ mkDerivation, lib, fetchFromGitLab, doxygen, glib, libaccounts-glib, pkgconfig, qmake }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "accounts-qt";
   version = "1.16";
 
@@ -11,17 +11,13 @@ stdenv.mkDerivation rec {
     owner = "accounts-sso";
   };
 
-  buildInputs = [ glib libaccounts-glib qtbase ];
+  propagatedBuildInputs = [ glib libaccounts-glib ];
   nativeBuildInputs = [ doxygen pkgconfig qmake ];
-
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags LIBDIR=$out/lib CMAKE_CONFIG_PATH=$out/lib/cmake"
-  '';
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Qt library for accessing the online accounts database";
     homepage = "https://gitlab.com/accounts-sso";
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/signond/default.nix
+++ b/pkgs/development/libraries/signond/default.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, lib, fetchFromGitLab, qmake, doxygen }:
+
+mkDerivation rec {
+  pname = "signond";
+  version = "8.60";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = pname;
+    rev = "VERSION_${version}";
+    sha256 = "pFpeJ13ut5EoP37W33WrYL2LzkX/k7ZKJcRpPO5l8i4=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    doxygen
+  ];
+
+  preConfigure = ''
+    substituteInPlace src/signond/signond.pro \
+      --replace "/etc" "@out@/etc"
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/accounts-sso/signond";
+    description = "Signon Daemon for Qt";
+    maintainers = with maintainers; [ freezeboy  ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15817,6 +15817,8 @@ in
     # Not a library, but we do want it to be built for every qt version there
     # is, to allow users to choose the right build if needed.
     sddm = callPackage ../applications/display-managers/sddm { };
+
+    signond = callPackage ../development/libraries/signond {};
   };
 
   qtEnv = qt5.env;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15667,9 +15667,9 @@ in
 
     inherit (kdeApplications.override { libsForQt5 = self; })
       libkdcraw libkexiv2 libkipi libkomparediff2 libksane libkcddb akonadi-contacts
-      akonadi-calendar akonadi-notes akonadi-search kidentitymanagement kontactinterface
-      kldap akonadi akregator ark bomber bovo dolphin dragon elisa ffmpegthumbs filelight
-      granatier gwenview k3b kaddressbook kalzium kapptemplate kapman kate katomic
+      akonadi-calendar akonadi-notes akonadi-search kaccounts-integration kidentitymanagement
+      kontactinterface kldap akonadi akregator ark bomber bovo dolphin dragon elisa ffmpegthumbs
+      filelight granatier gwenview k3b kaddressbook kalzium kapptemplate kapman kate katomic
       kblackbox kblocks kbounce kcachegrind kcalc kcharselect kcolorchooser
       kdenlive kdf kdialog kdiamond keditbookmarks kfind kfloppy kget kgpg khelpcenter
       kig kigo killbots kitinerary kleopatra klettres klines kmag kmail kmines kmix kmplot


### PR DESCRIPTION
###### Motivation for this change
Enable the [KAccounts Integration](https://invent.kde.org/network/kaccounts-integration) for Akonadi

###### Things done

 As required by 757661745c55c9b5a667c596b989c1ac16101327 I pulled in ce16b0a9280, ab4bda4c456 and 8e4c0493ed5 from #98212 as per https://github.com/NixOS/nixpkgs/pull/98212#issuecomment-752349410

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
