### PR TITLE
pythonPackages.python-tado: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/python-tado/default.nix
+++ b/pkgs/development/python-modules/python-tado/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, fetchFromGitHub, lib, pytestCheckHook, pythonOlder, requests }:
+
+buildPythonPackage rec {
+  pname = "python-tado";
+  version = "0.9.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "wmalgadey";
+    repo = "PyTado";
+    rev = version;
+    sha256 = "0cr5sxdvjgdrrlhl32rs8pwyay8liyi6prm37y66dn00b41cb5l3";
+  };
+
+  propagatedBuildInputs = [ requests ];
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description =
+      "Python binding for Tado web API. Pythonize your central heating!";
+    homepage = "https://github.com/wmalgadey/PyTado";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -811,7 +811,7 @@
     "system_health" = ps: with ps; [ aiohttp-cors ];
     "system_log" = ps: with ps; [ aiohttp-cors ];
     "systemmonitor" = ps: with ps; [ psutil ];
-    "tado" = ps: with ps; [ ]; # missing inputs: python-tado
+    "tado" = ps: with ps; [ python-tado ];
     "tag" = ps: with ps; [ ];
     "tahoma" = ps: with ps; [ ]; # missing inputs: tahoma-api
     "tank_utility" = ps: with ps; [ ]; # missing inputs: tank_utility

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4683,6 +4683,8 @@ in {
 
   python-openems = callPackage ../development/python-modules/python-openems { };
 
+  python-tado = callPackage ../development/python-modules/python-tado { };
+
   pkutils = callPackage ../development/python-modules/pkutils { };
 
   plac = callPackage ../development/python-modules/plac { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Support `tado` integration in Home Assistant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
