### PR TITLE
nixos/auto-upgrade: add persistent option

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1508,6 +1508,14 @@
       </listitem>
       <listitem>
         <para>
+          The auto-upgrade service now accepts persistent (default:
+          true) parameter. By default auto-upgrade will now run
+          immediately if it would have been triggered at least once
+          during the time when the timer was inactive.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           If you are using Wayland you can choose to use the Ozone
           Wayland support in Chrome and several Electron apps by setting
           the environment variable <literal>NIXOS_OZONE_WL=1</literal>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -520,6 +520,10 @@ In addition to numerous new and upgraded packages, this release has the followin
   - Support for older versions of hadoop have been added to the module
   - Overriding and extending site XML files has been made easier
 
+- The auto-upgrade service now accepts persistent (default: true) parameter.
+  By default auto-upgrade will now run immediately if it would have been triggered at least
+  once during the time when the timer was inactive.
+
 - If you are using Wayland you can choose to use the Ozone Wayland support
   in Chrome and several Electron apps by setting the environment variable
   `NIXOS_OZONE_WL=1` (for example via

--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -63,13 +63,16 @@ in {
       };
 
       dates = mkOption {
-        default = "04:40";
         type = types.str;
+        default = "04:40";
+        example = "daily";
         description = ''
-          Specification (in the format described by
+          How often or when upgrade occurs. For most desktop and server systems
+          a sufficient upgrade frequency is once a day.
+
+          The format is described in
           <citerefentry><refentrytitle>systemd.time</refentrytitle>
-          <manvolnum>7</manvolnum></citerefentry>) of the time at
-          which the update will occur.
+          <manvolnum>7</manvolnum></citerefentry>.
         '';
       };
 
@@ -121,6 +124,22 @@ in {
             };
           };
         });
+      };
+
+      persistent = mkOption {
+        default = true;
+        type = types.bool;
+        example = false;
+        description = ''
+          Takes a boolean argument. If true, the time when the service
+          unit was last triggered is stored on disk. When the timer is
+          activated, the service unit is triggered immediately if it
+          would have been triggered at least once during the time when
+          the timer was inactive. Such triggering is nonetheless
+          subject to the delay imposed by RandomizedDelaySec=. This is
+          useful to catch up on missed runs of the service when the
+          system was powered down.
+        '';
       };
 
     };
@@ -217,11 +236,17 @@ in {
       '';
 
       startAt = cfg.dates;
+
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
     };
 
-    systemd.timers.nixos-upgrade.timerConfig.RandomizedDelaySec =
-      cfg.randomizedDelaySec;
-
+    systemd.timers.nixos-upgrade = {
+      timerConfig = {
+        RandomizedDelaySec = cfg.randomizedDelaySec;
+        Persistent = cfg.persistent;
+      };
+    };
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

I am complaining about auto-upgrade not correctly working in laptop environment where laptop is turned on and off unpredictable causing those timers never expire and this service never executed.

Here is my fix.

I think that current situation is making this service unusable on laptops. Since it is auto upgrade that could lead to security issues as user might expect getting automatic updates while he is really not.

One can add this to his configuration.nix: systemd.timers.auto-upgrade.timerConfig.Persistent = true; but it is not apparent for users...

#15689
#75861

#107805

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
