### PR TITLE
vmTools.debClosureGenerator: Fix non-determinism in dependency graph

### DIFF
--- a/pkgs/build-support/vm/deb/deb-closure.pl
+++ b/pkgs/build-support/vm/deb/deb-closure.pl
@@ -50,7 +50,7 @@ sub getDeps {
 # virtual dependencies.
 my %provides;
 
-foreach my $cdata (values %packages) {
+foreach my $cdata (sort {$a->{Package} cmp $b->{Package}} (values %packages)) {
     if (defined $cdata->{Provides}) {
         my @provides = getDeps(Dpkg::Deps::deps_parse($cdata->{Provides}));
         foreach my $name (@provides) {


### PR DESCRIPTION
###### Motivation for this change

By default, Perl versions since 5.8.1 use randomization to make hashes resistant to complexity attacks.

That randomization makes building VM images such as `ubuntu1804x86_64` non-deterministic because the (imported) derivations built by `deb/deb-closure.pl` are not stable.

This can easily be observed by repeating the following sequence of commands and noting the path of the image's `.drv` file:

```sh
nix-instantiate -E '(import <nixpkgs> {}).vmTools.diskImageFuns.ubuntu1804x86_64 {}'
nix-store --delete /nix/store/*ubuntu-18.04-bionic-amd64.nix
```

One source of non-determinism is the handling of `Provides`/`Replaces`, which depends on the order of iteration over `%packages`.  Here is a diff showing the corresponding change in output:

```diff
 >>> awk
-virtual awk: using original-awk
-    original-awk: libc6 (>= 2.14)
+virtual awk: using mawk
+    mawk: libc6 (>= 2.14)
 [...]
-    mawk: libc6 (>= 2.14)
->>> libc6
```

This patch sorts packages by name for `Provides`/`Replaces` processing, which seems to result in stable output.

(If the above turns out not to be sufficient, one could also set the `PERL_HASH_SEED` and `PERL_PERTURB_KEYS` environment variables, documented in `perlrun`, to disable Perl's built-in randomization.  Complexity attacks are not an issue as we control and trust all inputs.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - `nixos/tests/os-prober.nix`
  - `nixos/tests/virtualbox.nix`
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - (None?)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
  - (None?)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
