### PR TITLE
par: fix static build

### DIFF
--- a/pkgs/tools/text/par/default.nix
+++ b/pkgs/tools/text/par/default.nix
@@ -20,9 +20,7 @@ stdenv.mkDerivation {
 
   makefile = "protoMakefile";
   preBuild = ''
-    makeFlagsArray=+( CC="${stdenv.cc.targetPrefix}cc -c" \
-                      LINK1=${stdenv.cc.targetPrefix}cc   \
-                    )
+    makeFlagsArray+=(CC="${stdenv.cc.targetPrefix}cc -c" LINK1=${stdenv.cc.targetPrefix}cc)
   '';
 
   installPhase = ''

--- a/pkgs/tools/text/par/default.nix
+++ b/pkgs/tools/text/par/default.nix
@@ -18,7 +18,12 @@ stdenv.mkDerivation {
     })
   ];
 
-  buildPhase = ''make -f protoMakefile'';
+  makefile = "protoMakefile";
+  preBuild = ''
+    makeFlagsArray=+( CC="${stdenv.cc.targetPrefix}cc -c" \
+                      LINK1=${stdenv.cc.targetPrefix}cc   \
+                    )
+  '';
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).