### PR TITLE
Colmap: 3.5 -> 3.6 and fix colmapWithCuda build

### DIFF
--- a/pkgs/applications/science/misc/colmap/default.nix
+++ b/pkgs/applications/science/misc/colmap/default.nix
@@ -7,21 +7,14 @@ assert !cudaSupport || cudatoolkit != null;
 let boost_static = boost17x.override { enableStatic = true; };
 in
 mkDerivation rec {
-  version = "3.5";
+  version = "3.6";
   pname = "colmap";
   src = fetchFromGitHub {
      owner = "colmap";
      repo = "colmap";
      rev = version;
-     sha256 = "1vnb62p0y2bnga173wmjs0lnyqdjikv0fkcxjzxm8187khk2lly8";
+     sha256 = "1kfivdmhpmdxjjf30rr57y2iy7xmdpg4h8aw3qgacv8ckfpgda3n";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/colmap/colmap/commit/6af3d8b0048cecc3b9fc6f4e78c3214dd038180b.patch";
-      sha256 = "1zv5girmv4hv78w1xn131v8njwhpbyylc1m15731lnhrs8bri0jq";
-    })
-  ];
 
   buildInputs = [
     boost_static ceres-solver eigen

--- a/pkgs/applications/science/misc/colmap/default.nix
+++ b/pkgs/applications/science/misc/colmap/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchpatch, fetchFromGitHub, cmake, boost17x, ceres-solver, eigen,
+{ mkDerivation, lib, fetchFromGitHub, cmake, boost17x, ceres-solver, eigen,
   freeimage, glog, libGLU, glew, qtbase,
   cudaSupport ? false, cudatoolkit ? null }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8949,7 +8949,7 @@ in
   colm = callPackage ../development/compilers/colm { };
 
   colmap = libsForQt514.callPackage ../applications/science/misc/colmap { };
-  colmapWithCuda = colmap.override { cudaSupport = true; };
+  colmapWithCuda = colmap.override { cudaSupport = true; cudatoolkit = cudatoolkit_11; };
 
   chickenPackages_4 = callPackage ../development/compilers/chicken/4 { };
   chickenPackages_5 = callPackage ../development/compilers/chicken/5 { };


### PR DESCRIPTION
###### Motivation for this change

#99098 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
