### PR TITLE
ocamlPackages.mirage: reintroduce dev output

### DIFF
--- a/pkgs/development/ocaml-modules/mirage/default.nix
+++ b/pkgs/development/ocaml-modules/mirage/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, alcotest
+{ lib, buildDunePackage, ocaml, alcotest
 , functoria, mirage-runtime, bos
 , ipaddr, astring, logs, stdlib-shims
 }:
@@ -27,6 +27,12 @@ buildDunePackage rec {
   checkInputs = [
     alcotest
   ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix=$out --libdir=$dev/lib/ocaml/${ocaml.version}/site-lib/ ${pname}
+    runHook postInstall
+  '';
 
   meta = mirage-runtime.meta // {
     description = "The MirageOS library operating system";


### PR DESCRIPTION
The changed dune install directive to install libraries to the dev
output was removed by mistake. cc @vbgl

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
