### PR TITLE
librepo: enable zchunk support on darwin

### DIFF
--- a/pkgs/tools/package-management/librepo/default.nix
+++ b/pkgs/tools/package-management/librepo/default.nix
@@ -38,9 +38,8 @@ stdenv.mkDerivation rec {
     curl
     check
     gpgme
-  ]
-  # zchunk currently has issues compiling in darwin, fine in linux
-  ++ stdenv.lib.optional stdenv.isLinux zchunk;
+    zchunk
+  ];
 
   # librepo/fastestmirror.h includes curl/curl.h, and pkg-config specfile refers to others in here
   propagatedBuildInputs = [
@@ -49,9 +48,7 @@ stdenv.mkDerivation rec {
     libxml2
   ];
 
-  cmakeFlags = [
-    "-DPYTHON_DESIRED=${stdenv.lib.substring 0 1 python.pythonVersion}"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "-DWITH_ZCHUNK=OFF";
+  cmakeFlags = [ "-DPYTHON_DESIRED=${stdenv.lib.substring 0 1 python.pythonVersion}" ];
 
   postFixup = ''
     moveToOutput "lib/${python.libPrefix}" "$py"


### PR DESCRIPTION
###### Motivation for this change

Thanks to @nima2007 's work in https://github.com/NixOS/nixpkgs/pull/107443, we can now enable zchunk support on Darwin as well.
For Linux, this PR is a noop.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
