### PR TITLE
pythonPackages.r2pipe: Fix build

### DIFF
--- a/pkgs/development/python-modules/r2pipe/default.nix
+++ b/pkgs/development/python-modules/r2pipe/default.nix
@@ -18,10 +18,10 @@ buildPythonPackage rec {
   ''
     # Fix find_library, can be removed after
     # https://github.com/NixOS/nixpkgs/issues/7307 is resolved.
-    substituteInPlace r2pipe/native.py --replace "find_library('r_core')" "'${libr_core}'"
+    substituteInPlace r2pipe/native.py --replace 'find_library("r_core")' "'${libr_core}'"
 
     # Fix the default r2 executable
-    substituteInPlace r2pipe/open_sync.py --replace "r2e = 'radare2'" "r2e = '${radare2}/bin/radare2'"
+    substituteInPlace r2pipe/open_sync.py --replace 'r2e = "radare2"' "r2e = '${radare2}/bin/radare2'"
     substituteInPlace r2pipe/open_base.py --replace 'which("radare2")' "'${radare2}/bin/radare2'"
   '';
 


### PR DESCRIPTION
Regression introduced by 6556711c87f42e064ba01deb4c1e0aa917be8d66.

The string start and end quoting styles have changed in the upstream source code between version 1.4.2 and version 1.5.3, so the `checkPhase` now results in the following error:

```
======================================================================
ERROR: native (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: native
Traceback (most recent call last):
  File ".../unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/build/r2pipe-1.5.3/r2pipe/native.py", line 113, in <module>
    class RCore(Structure):  # 1
  File "/build/r2pipe-1.5.3/r2pipe/native.py", line 125, in RCore
    cmd_str, r_core_cmd_str = register(
  File "/build/r2pipe-1.5.3/r2pipe/native.py", line 108, in register
    method = WrappedRMethod(cname, args, ret)
  File "/build/r2pipe-1.5.3/r2pipe/native.py", line 53, in __init__
    r2 = r2lib()
  File "/build/r2pipe-1.5.3/r2pipe/native.py", line 27, in r2lib
    raise ImportError("No native r_core library")
ImportError: No native r_core library
```