### PR TITLE
home-assistant: 2020.12.1 -> 2020.12.2

### DIFF
--- a/pkgs/development/python-modules/HAP-python/default.nix
+++ b/pkgs/development/python-modules/HAP-python/default.nix
@@ -1,16 +1,16 @@
 { lib, buildPythonPackage, fetchFromGitHub, isPy3k, curve25519-donna, ed25519
-, cryptography, ecdsa, zeroconf, pytest }:
+, cryptography, ecdsa, zeroconf, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "HAP-python";
-  version = "3.0.0";
+  version = "3.1.0";
 
   # pypi package does not include tests
   src = fetchFromGitHub {
     owner = "ikalchev";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07s1kjm9cz4m4ksj506la1ks3dq2b5mk412rjj9rpj98b0mxrr84";
+    sha256 = "1qg38lfjby2xfm09chzc40a7i3b84kgyfs7g4xq8f5m8s39hg6d7";
   };
 
   disabled = !isPy3k;
@@ -23,20 +23,20 @@ buildPythonPackage rec {
     zeroconf
   ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
 
-  #disable tests needing network
-  checkPhase = ''
-    pytest -k 'not test_persist \
-    and not test_setup_endpoints \
-    and not test_auto_add_aid_mac \
-    and not test_service_callbacks \
-    and not test_send_events \
-    and not test_not_standalone_aid \
-    and not test_start_stop_async_acc \
-    and not test_external_zeroconf \
-    and not test_start_stop_sync_acc'
-  '';
+  disabledTests = [
+    #disable tests needing network
+    "test_persist"
+    "test_setup_endpoints"
+    "test_auto_add_aid_mac"
+    "test_service_callbacks"
+    "test_send_events"
+    "test_not_standalone_aid"
+    "test_start_stop_async_acc"
+    "test_external_zeroconf"
+    "test_start_stop_sync_acc"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/ikalchev/HAP-python";

--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -1,24 +1,28 @@
 { lib, buildPythonPackage, fetchFromGitHub, isPy27, requests, netifaces
-, pytest, testtools, requests-mock }:
+, pytestCheckHook, testtools, requests-mock }:
 
 buildPythonPackage rec {
   pname = "denonavr";
-  version = "0.9.3";
+  version = "0.9.9";
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "scarface-4711";
     repo = "denonavr";
     rev = version;
-    sha256 = "0s8v918n6xn44r2mrq5hqbf0znpz64clq7a1jakkgz9py8bi6vnn";
+    sha256 = "08zh8rdadmxcgr707if6g5k5j2xz21s6jrn4kxh1c7xqpgdfggd9";
   };
 
-  propagatedBuildInputs = [ requests netifaces ];
+  propagatedBuildInputs = [
+    requests
+    netifaces
+  ];
 
-  doCheck = !isPy27;
-  checkInputs = [ pytest testtools requests-mock ];
-  checkPhase = ''
-    pytest tests
-  '';
+  checkInputs = [
+    pytestCheckHook
+    testtools
+    requests-mock
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/scarface-4711/denonavr";

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2020.12.1";
+  version = "2020.12.2";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -62,7 +62,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2020.12.1";
+  hassVersion = "2020.12.2";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2020.12.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
