### PR TITLE
yarn2nix: Handle codeload.github.com tarballs

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/urlToName.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/urlToName.js
@@ -7,9 +7,17 @@ const path = require('path')
 // - https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz
 // - git+https://github.com/srghma/node-shell-quote.git
 // - git+https://1234user:1234pass@git.graphile.com/git/users/1234user/postgraphile-supporter.git
+// - https://codeload.github.com/Gargron/emoji-mart/tar.gz/934f314fd8322276765066e8a2a6be5bac61b1cf
 
 function urlToName(url) {
-  if (url.startsWith('git+')) {
+
+  // Yarn generates `codeload.github.com` tarball URLs, where the final
+  // path component (file name) is the git hash. See #111.
+  // See also https://github.com/yarnpkg/yarn/blob/989a7406/src/resolvers/exotics/github-resolver.js#L24-L26
+  let isCodeloadGitTarballUrl =
+    url.startsWith('https://codeload.github.com/') && url.includes('/tar.gz/')
+
+  if (url.startsWith('git+') || isCodeloadGitTarballUrl) {
     return path.basename(url)
   }
 


### PR DESCRIPTION
This was submitted originally in https://github.com/nix-community/yarn2nix/pull/130


I find it very confusing, that there is a yarn2nix repo in the nix-community project and the same code is duplicated inside nixpkgs. Especially if these code bases diverge, Maybe it would be cooler to have them in just one location (nixpkgs?)