### PR TITLE
Add Nix packages for Grafana plugins and allow declarative installation

### DIFF
--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -5,10 +5,11 @@ with lib;
 let
   cfg = config.services.grafana;
   opt = options.services.grafana;
+  declarativePlugins = pkgs.linkFarm "grafana-plugins" (builtins.map (pkg: { name = pkg.pname; path = pkg; }) cfg.declarativePlugins);
 
   envOptions = {
     PATHS_DATA = cfg.dataDir;
-    PATHS_PLUGINS = "${cfg.dataDir}/plugins";
+    PATHS_PLUGINS = if builtins.isNull cfg.declarativePlugins then "${cfg.dataDir}/plugins" else declarativePlugins;
     PATHS_LOGS = "${cfg.dataDir}/log";
 
     SERVER_PROTOCOL = cfg.protocol;
@@ -259,6 +260,12 @@ in {
       default = pkgs.grafana;
       defaultText = "pkgs.grafana";
       type = types.package;
+    };
+    declarativePlugins = mkOption {
+      type = with types; nullOr (listOf path);
+      default = null;
+      description = "If non-null, then a list of packages containing Grafana plugins to install. If set, plugins cannot be manually installed.";
+      example = literalExample "with pkgs.grafanaPlugins; [ grafana-piechart-panel ]";
     };
 
     dataDir = mkOption {

--- a/pkgs/servers/monitoring/grafana/plugins/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/default.nix
@@ -1,0 +1,7 @@
+{ newScope, pkgs }:
+
+let
+  callPackage = newScope (pkgs // plugins);
+  plugins = import ./plugins.nix { inherit callPackage; };
+in
+  plugins

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-clock-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-clock-panel/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin rec {
+  pname = "grafana-clock-panel";
+  version = "1.1.1";
+  zipHash = "sha256-SvZyg7r+XG6i7jqYwxpPn6ZzJc7qmtfPtyphYppURDk=";
+  meta = with lib; {
+    description = "Clock panel for Grafana";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-piechart-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-piechart-panel/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin rec {
+  pname = "grafana-piechart-panel";
+  version = "1.6.1";
+  zipHash = "sha256-64K/efoBKuBFp8Jw79hTdMyTurTZsL0qfgPDcUWz2jg=";
+  meta = with lib; {
+    description = "Pie chart panel for Grafana";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-plugin.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-plugin.nix
@@ -1,0 +1,28 @@
+{ stdenvNoCC, fetchurl, unzip }:
+
+{ pname, version, zipHash, meta ? {}, passthru ? {}, ... }@args:
+stdenvNoCC.mkDerivation ({
+  inherit pname version;
+
+  src = fetchurl {
+    name = "${pname}-${version}.zip";
+    url = "https://grafana.com/api/plugins/${pname}/versions/${version}/download";
+    hash = zipHash;
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    cp -R "." "$out"
+    chmod -R a-w "$out"
+    chmod u+w "$out"
+  '';
+
+  passthru = {
+    updateScript = [ ./update-grafana-plugin.sh pname ];
+  } // passthru;
+
+  meta = {
+    homepage = "https://grafana.com/grafana/plugins/${pname}";
+  } // meta;
+} // (builtins.removeAttrs args [ "pname" "version" "sha256" "meta" ]))

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-polystat-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-polystat-panel/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin rec {
+  pname = "grafana-polystat-panel";
+  version = "1.2.2";
+  zipHash = "sha256-HWQdhstnrDuXPithZ8kOG2ZtSeAT215MJ1ftMCt6/tc=";
+  meta = with lib; {
+    description = "Hexagonal multi-stat panel for Grafana";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-worldmap-panel/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-worldmap-panel/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin rec {
+  pname = "grafana-worldmap-panel";
+  version = "0.3.2";
+  zipHash = "sha256-MGAJzS9X91x6wt305jH1chLoW3zd7pIYDwRnPg9qrgE=";
+  meta = with lib; {
+    description = "World Map panel for Grafana";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -7,4 +7,5 @@
   grafana-clock-panel = callPackage ./grafana-clock-panel { };
   grafana-piechart-panel = callPackage ./grafana-piechart-panel { };
   grafana-polystat-panel = callPackage ./grafana-polystat-panel { };
+  grafana-worldmap-panel = callPackage ./grafana-worldmap-panel { };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+{
+  inherit callPackage;
+
+  grafanaPlugin = callPackage ./grafana-plugin.nix { };
+}

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -5,4 +5,5 @@
   grafanaPlugin = callPackage ./grafana-plugin.nix { };
 
   grafana-clock-panel = callPackage ./grafana-clock-panel { };
+  grafana-piechart-panel = callPackage ./grafana-piechart-panel { };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -3,4 +3,6 @@
   inherit callPackage;
 
   grafanaPlugin = callPackage ./grafana-plugin.nix { };
+
+  grafana-clock-panel = callPackage ./grafana-clock-panel { };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -6,4 +6,5 @@
 
   grafana-clock-panel = callPackage ./grafana-clock-panel { };
   grafana-piechart-panel = callPackage ./grafana-piechart-panel { };
+  grafana-polystat-panel = callPackage ./grafana-polystat-panel { };
 }

--- a/pkgs/servers/monitoring/grafana/plugins/update-grafana-plugin.sh
+++ b/pkgs/servers/monitoring/grafana/plugins/update-grafana-plugin.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -eu -o pipefail
+
+readonly plugin_name="$1"
+readonly latest_version="$(curl "https://grafana.com/api/plugins/${plugin_name}" | jq -r .version)"
+update-source-version "grafanaPlugins.${plugin_name}" "$latest_version"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17164,6 +17164,7 @@ in
   gofish = callPackage ../servers/gopher/gofish { };
 
   grafana = callPackage ../servers/monitoring/grafana { };
+  grafanaPlugins = dontRecurseIntoAttrs (callPackage ../servers/monitoring/grafana/plugins { });
 
   grafana-loki = callPackage ../servers/monitoring/loki { };
 


### PR DESCRIPTION
###### Motivation for this change

I want to have my system state specified in Nix, and in particular I'd also like to have the installed set of Grafana plugins specified declaratively.

This adds a smattering of some of the Grafana plugins published by the Grafana Labs folks, as well as including an updateScript for keeping them up to date automatically.

The nixos/grafana module is then extended with support for declaratively specifying the set of plugins to install, and a new NixOS test added to check that this functionality works.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
