### PR TITLE
[20.09] Fix webkitgtk and reintroduce epiphany

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -1343,6 +1343,14 @@ CREATE ROLE postgres LOGIN SUPERUSER;
       It was chosen to do this as it has a usability breaking issue (see issue <link xlink:href="https://github.com/NixOS/nixpkgs/issues/98819">#98819</link>)
       that makes it unsuitable to be a default app.
     </para>
+    <note>
+      <para>
+        Issue <link
+        xlink:href="https://github.com/NixOS/nixpkgs/issues/98819">#98819</link>
+        is now fixed and <package>gnome3.epiphany</package> is once
+        again installed by default.
+      </para>
+    </note>
    </listitem>
    <listitem>
      <para>

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -402,9 +402,7 @@ in
         baobab
         cheese
         eog
-        /* Not in good standing on nixos:
-         * https://github.com/NixOS/nixpkgs/issues/98819
-        /* epiphany */
+        epiphany
         gedit
         gnome-calculator
         gnome-calendar

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -19,7 +19,7 @@ let
 
   defaultFavoriteAppsOverride = ''
     [org.gnome.shell]
-    favorite-apps=[ 'org.gnome.Geary.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.Music.desktop', 'org.gnome.Photos.desktop', 'org.gnome.Nautilus.desktop' ]
+    favorite-apps=[ 'org.gnome.Epiphany.desktop', 'org.gnome.Geary.desktop', 'org.gnome.Calendar.desktop', 'org.gnome.Music.desktop', 'org.gnome.Photos.desktop', 'org.gnome.Nautilus.desktop' ]
   '';
 
   nixos-gsettings-desktop-schemas = let

--- a/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
+++ b/pkgs/development/libraries/webkitgtk/fix-bubblewrap-paths.patch
@@ -10,7 +10,7 @@ diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLa
          { SCMP_SYS(move_pages), nullptr },
          { SCMP_SYS(mbind), nullptr },
          { SCMP_SYS(get_mempolicy), nullptr },
-@@ -724,6 +724,10 @@
+@@ -724,6 +724,11 @@
          "--ro-bind-try", "/usr/local/lib64", "/usr/local/lib64",
  
          "--ro-bind-try", PKGLIBEXECDIR, PKGLIBEXECDIR,
@@ -18,6 +18,7 @@ diff -ru old/webkitgtk-2.26.0/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLa
 +        // Nix Directories
 +        "--ro-bind", "@storeDir@", "@storeDir@",
 +        "--ro-bind", "/run/current-system", "/run/current-system",
++        "--ro-bind", "/run/opengl-driver", "/run/opengl-driver",
      };
      // We would have to parse ld config files for more info.
      bindPathVar(sandboxArgs, "LD_LIBRARY_PATH");


### PR DESCRIPTION
###### Motivation for this change
Backport of #107486 and #108107.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
