### PR TITLE
python3Packages.pyftdi: 0.51.2 -> 0.52.0

### DIFF
--- a/pkgs/development/python-modules/pyftdi/default.nix
+++ b/pkgs/development/python-modules/pyftdi/default.nix
@@ -25,9 +25,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyftdi" ];
 
-  meta = {
+  meta = with lib; {
     description = "User-space driver for modern FTDI devices";
+    longDescription = ''
+      PyFtdi aims at providing a user-space driver for popular FTDI devices.
+      This includes UART, GPIO and multi-serial protocols (SPI, I2C, JTAG)
+      bridges.
+    '';
     homepage = "https://github.com/eblot/pyftdi";
-    license = lib.licenses.bsd3;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/pyftdi/default.nix
+++ b/pkgs/development/python-modules/pyftdi/default.nix
@@ -1,18 +1,27 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pyusb, pyserial }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pythonOlder
+, pyusb
+}:
 
 buildPythonPackage rec {
   pname = "pyftdi";
-  version = "0.51.2";
+  version = "0.52.0";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "eblot";
     repo = pname;
     rev = "v${version}";
-    sha256 = "14mkwk44bgm6s4kqagz7nm6p6gsygmksl2628jaqh7ppblxca9as";
+    sha256 = "0nm4z7v9qcb9mxqbl21jgzica4faldnpy5qmbkrc6scnx55pxfm9";
   };
 
   propagatedBuildInputs = [ pyusb pyserial ];
+
+  # tests requires access to the serial port
+  doCheck = false;
 
   pythonImportsCheck = [ "pyftdi" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.52.0

Disable the tests as they require access to the serial port and fail.

```bash
======================================================================
ERROR: protocol_unix (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: protocol_unix
Traceback (most recent call last):
  File "/nix/store/m7080pw0ryjk0jhljp55rq1hd2qy8gki-python3-3.8.6/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/build/source/pyftdi/serialext/protocol_unix.py", line 32, in <module>
    from serial import (SerialBase, SerialException, portNotOpenError,
ImportError: cannot import name 'portNotOpenError' from 'serial' (/nix/store/ivmwqcnbzarm1gh430hwhbwy3bpb34yy-python3.8-pyserial-3.5/lib/python3.8/site-packages/serial/__init__.py)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
