### PR TITLE
chiaki: 1.3.0 -> 2.0.1 & touchpad support

### DIFF
--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -1,21 +1,20 @@
-{ lib, mkDerivation, fetchFromGitHub
-, cmake, ffmpeg, libopus, qtbase, qtmultimedia, qtsvg, pkgconfig, protobuf
+{ lib, mkDerivation, fetchgit
+, cmake, ffmpeg, libopus, qtbase, qtmultimedia, qtsvg, pkg-config, protobuf
 , python3Packages, SDL2 }:
 
 mkDerivation rec {
   pname = "chiaki";
-  version = "1.3.0";
+  version = "2.0.1";
 
-  src = fetchFromGitHub {
+  src = fetchgit {
+    url = "https://git.sr.ht/~thestr4ng3r/chiaki";
     rev = "v${version}";
-    owner = "thestr4ng3r";
-    repo = "chiaki";
     fetchSubmodules = true;
-    sha256 = "07w7srxxr8zjp91p5n1sqf4j8lljfrm78lz1m15s2nzlm579015h";
+    sha256 = "0l532i9j6wmzbxqx7fg69kgfd1zy1r1wlw6f756vpxpgswivi892";
   };
 
   nativeBuildInputs = [
-    cmake pkgconfig protobuf python3Packages.python python3Packages.protobuf
+    cmake pkg-config protobuf python3Packages.python python3Packages.protobuf
   ];
   buildInputs = [ ffmpeg libopus qtbase qtmultimedia qtsvg protobuf SDL2 ];
 

--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -1,7 +1,8 @@
 { lib, mkDerivation, fetchgit
-, cmake, ffmpeg, libopus, qtbase, qtmultimedia, qtsvg, pkg-config, protobuf
-, python3Packages, SDL2 }:
+, cmake, ffmpeg, libevdev, libopus, udev, qtbase, qtmultimedia
+, qtsvg , pkg-config, protobuf , python3Packages, SDL2, stdenv }:
 
+with stdenv.lib;
 mkDerivation rec {
   pname = "chiaki";
   version = "2.0.1";
@@ -16,7 +17,8 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake pkg-config protobuf python3Packages.python python3Packages.protobuf
   ];
-  buildInputs = [ ffmpeg libopus qtbase qtmultimedia qtsvg protobuf SDL2 ];
+  buildInputs = [ ffmpeg libopus qtbase qtmultimedia qtsvg protobuf SDL2 ]
+    ++ optionals stdenv.hostPlatform.isLinux [ libevdev udev];
 
   doCheck = true;
   installCheckPhase = "$out/bin/chiaki --help";

--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchgit
-, cmake, ffmpeg, libevdev, libopus, udev, qtbase, qtmultimedia
+, cmake, ffmpeg, libevdev, libopus, udev, qtbase, qtmacextras, qtmultimedia
 , qtsvg , pkg-config, protobuf , python3Packages, SDL2, stdenv }:
 
 with stdenv.lib;
@@ -18,7 +18,8 @@ mkDerivation rec {
     cmake pkg-config protobuf python3Packages.python python3Packages.protobuf
   ];
   buildInputs = [ ffmpeg libopus qtbase qtmultimedia qtsvg protobuf SDL2 ]
-    ++ optionals stdenv.hostPlatform.isLinux [ libevdev udev];
+    ++ optionals stdenv.hostPlatform.isLinux [ libevdev udev]
+    ++ optionals (stdenv.isDarwin) [ qtmacextras ];
 
   doCheck = true;
   installCheckPhase = "$out/bin/chiaki --help";


### PR DESCRIPTION
###### Motivation for this change
Version bump & DualShock4 touchpad support under Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
