### PR TITLE
xfce.xfce4-namebar-plugin: fix build

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgconfig, fetchFromGitHub, python2, vala_0_46
+{ stdenv, pkgconfig, fetchFromGitHub, python3, vala_0_46
 , gtk3, libwnck3, libxfce4util, xfce4-panel, wafHook, xfce }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0l70f6mzkscsj4wr43wp5c0l2qnf85vj24cv02bjrh3bzz6wkak8";
   };
 
-  nativeBuildInputs = [ pkgconfig vala_0_46 wafHook ];
+  nativeBuildInputs = [ pkgconfig vala_0_46 wafHook python3 ];
   buildInputs = [ gtk3 libwnck3 libxfce4util xfce4-panel ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing to build

```
  configure flags: --prefix=/nix/store/2hxlg20rqh6ksjj4k6amrk0bhg4mq0dz-xfce4-namebar-plugin-1.0.0 configure
  /nix/store/3af4czhg5b9vaawzdwfirlphgg9spxf7-hook/nix-support/setup-hook: line 22: python: command not found
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
