### PR TITLE
printrun: unstable-2015-03-10 -> 1.6.0

### DIFF
--- a/pkgs/applications/misc/printrun/default.nix
+++ b/pkgs/applications/misc/printrun/default.nix
@@ -1,13 +1,14 @@
 { stdenv, python27Packages, fetchFromGitHub }:
 
 python27Packages.buildPythonApplication rec {
-  name = "printrun-20150310";
+  pname = "printrun";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "kliment";
     repo = "Printrun";
-    rev = name;
-    sha256 = "09ijv8h4k5h15swg64s7igamvynawz7gdi7hiymzrzywdvr0zwsa";
+    rev = "${pname}-${version}";
+    sha256 = "0nhcx1bi1hals0a6d6994y0kcwsfqx3hplwbmn9136hgrplg0l2l";
   };
 
   propagatedBuildInputs = with python27Packages; [


### PR DESCRIPTION
###### Motivation for this change

From unstable git to latest release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
