### PR TITLE
[staging-next] qt514.qtlocation: fix build

### DIFF
--- a/pkgs/development/libraries/qt-5/5.14/qtlocation-fix-int32_t.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtlocation-fix-int32_t.patch
@@ -1,0 +1,12 @@
+diff --git a/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp b/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp
+index 02ec7fe..a71d881 100644
+--- a/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp
++++ b/src/3rdparty/mapbox-gl-native/include/mbgl/util/convert.hpp
+@@ -3,6 +3,7 @@
+ #include <array>
+ #include <type_traits>
+ #include <utility>
++#include <cstdint>
+ 
+ namespace mbgl {
+ namespace util {

--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -1,4 +1,4 @@
-{ stdenv, qtModule, qtbase, qtmultimedia }:
+{ stdenv, lib, qtModule, qtbase, qtmultimedia }:
 
 qtModule {
   name = "qtlocation";
@@ -10,5 +10,7 @@ qtModule {
      # https://libcxx.llvm.org/docs/UsingLibcxx.html#c-17-specific-configuration-macros
      "QMAKE_CXXFLAGS+=-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
   ];
-
+  patches = lib.optionals (lib.versionOlder qtbase.version "5.15") [
+    ../5.14/qtlocation-fix-int32_t.patch
+  ];
 }


### PR DESCRIPTION
###### Motivation for this change
attempt to fix build

related: https://bugreports.qt.io/browse/QTBUG-83225

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
