### PR TITLE
ocamlPackages.merlin: 3.4.0 → 3.4.2

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -4,7 +4,7 @@
 buildDunePackage rec {
   pname = "merlin";
 
-  inherit (dot-merlin-reader) src version;
+  inherit (dot-merlin-reader) src version useDune2;
 
   minimumOCamlVersion = "4.02.3";
 

--- a/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
+++ b/pkgs/development/tools/ocaml/merlin/dot-merlin-reader.nix
@@ -4,13 +4,15 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "dot-merlin-reader";
-  version = "3.4.0";
+  version = "3.4.2";
+
+  useDune2 = true;
 
   minimumOCamlVersion = "4.02.1";
 
   src = fetchurl {
     url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
-    sha256 = "048rkpbvayksv8mgmkgi17vv0y9xplv7v2ww4d1hs7bkm5zzsvg2";
+    sha256 = "109ai1ggnkrwbzsl1wdalikvs1zx940m6n65jllxj68in6bvidz1";
   };
 
   buildInputs = [ yojson csexp result ];


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://github.com/ocaml/merlin/blob/v3.4.2/CHANGES.md

Use dune 2.

cc maintainer @hongchangwu

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
