### PR TITLE
mopidy-scrobbler: init at 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3923,6 +3923,12 @@
     githubId = 2179419;
     name = "Arseniy Seroka";
   };
+  jakeisnt = {
+    name = "Jacob Chvatal";
+    email = "jake@isnt.online";
+    github = "jakeisnt";
+    githubId = 29869612;
+  };
   jakelogemann = {
     email = "jake.logemann@gmail.com";
     github = "jakelogemann";

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -14,9 +14,9 @@ let
 
     mopidy-gmusic = callPackage ./gmusic.nix { };
 
-    mopidy-local = callPackage ./local.nix { };
+    mopidy-iris = callPackage ./iris.nix { };
 
-    mopidy-spotify = callPackage ./spotify.nix { };
+    mopidy-local = callPackage ./local.nix { };
 
     mopidy-moped = callPackage ./moped.nix { };
 
@@ -26,20 +26,19 @@ let
 
     mopidy-mpris = callPackage ./mpris.nix { };
 
+    mopidy-musicbox-webclient = callPackage ./musicbox-webclient.nix { };
+
     mopidy-somafm = callPackage ./somafm.nix { };
-
-    mopidy-spotify-tunigo = callPackage ./spotify-tunigo.nix { };
-
-    mopidy-youtube = callPackage ./youtube.nix { };
 
     mopidy-soundcloud = callPackage ./soundcloud.nix { };
 
-    mopidy-musicbox-webclient = callPackage ./musicbox-webclient.nix { };
+    mopidy-spotify = callPackage ./spotify.nix { };
 
-    mopidy-iris = callPackage ./iris.nix { };
+    mopidy-spotify-tunigo = callPackage ./spotify-tunigo.nix { };
 
     mopidy-tunein = callPackage ./tunein.nix { };
 
+    mopidy-youtube = callPackage ./youtube.nix { };
   };
 
 in self

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -28,6 +28,8 @@ let
 
     mopidy-musicbox-webclient = callPackage ./musicbox-webclient.nix { };
 
+    mopidy-scrobbler = callPackage ./scrobbler.nix { };
+
     mopidy-somafm = callPackage ./somafm.nix { };
 
     mopidy-soundcloud = callPackage ./soundcloud.nix { };

--- a/pkgs/applications/audio/mopidy/scrobbler.nix
+++ b/pkgs/applications/audio/mopidy/scrobbler.nix
@@ -1,0 +1,24 @@
+{ stdenv, python3Packages, mopidy }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "Mopidy-Scrobbler";
+  version = "2.0.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "11vxgax4xgkggnq4fr1rh2rcvzspkkimck5p3h4phdj3qpnj0680";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ mopidy pylast ];
+
+  # no tests implemented
+  doCheck = false;
+  pythonImportsCheck = [ "mopidy_scrobbler" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mopidy/mopidy-scrobbler";
+    description = "Mopidy extension for scrobbling played tracks to Last.fm.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jakeisnt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22913,6 +22913,7 @@ in
     mopidy-mpd
     mopidy-mpris
     mopidy-musicbox-webclient
+    mopidy-scrobbler
     mopidy-somafm
     mopidy-soundcloud
     mopidy-spotify


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[Mopidy-Scrobbler](https://github.com/mopidy/mopidy-scrobbler) is a Mopidy extensions maintained by the Mopidy organization. Many other Mopidy extensions maintained by them are already packaged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
