### PR TITLE
Fix Darwin native stdenv

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -164,9 +164,9 @@ stdenv.mkDerivation {
     ''
 
     + (if nativeTools then ''
-      echo ${if targetPlatform.isDarwin then cc else nativePrefix} > $out/nix-support/orig-cc
+      echo ${nativePrefix} > $out/nix-support/orig-cc
 
-      ccPath="${if targetPlatform.isDarwin then cc else nativePrefix}/bin"
+      ccPath="${nativePrefix}/bin"
     '' else ''
       echo $cc > $out/nix-support/orig-cc
 

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -137,7 +137,7 @@ let
         substituteInPlace "$out"/lib/perl5/*/*/Config_heavy.pl \
           --replace "${libcInc}" /no-such-path \
           --replace "${
-              if stdenv.hasCC then stdenv.cc.cc else "/no-such-path"
+              if (stdenv.hasCC && (stdenv.cc.cc or null) != null) then stdenv.cc.cc else "/no-such-path"
             }" /no-such-path \
           --replace "${stdenv.cc}" /no-such-path \
           --replace "$man" /no-such-path

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -189,7 +189,7 @@ in rec {
            "__impureHostDeps" "__propagatedImpureHostDeps"
            "sandboxProfile" "propagatedSandboxProfile"])
         // (lib.optionalAttrs (!(attrs ? name) && attrs ? pname && attrs ? version)) {
-          name = "${attrs.pname}-${attrs.version}";
+          name = "${attrs.pname}${if attrs.version != null then "-${attrs.version}" else ""}";
         } // (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix && (attrs ? name || (attrs ? pname && attrs ? version)))) {
           # Fixed-output derivations like source tarballs shouldn't get a host
           # suffix. But we have some weird ones with run-time deps that are

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -17,7 +17,7 @@ let
     (if system == "i686-solaris" then [ "/usr/gnu" ] else []) ++
     (if system == "i686-netbsd" then [ "/usr/pkg" ] else []) ++
     (if system == "x86_64-solaris" then [ "/opt/local/gnu" ] else []) ++
-    ["/" "/usr" "/usr/local"];
+    [ "/usr/local"  "/usr" "/" ];
 
   prehookBase = ''
     # Disable purity tests; it's allowed (even needed) to link to

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -8,7 +8,9 @@ let
   inherit (localSystem) system;
 
   shell =
-    if system == "i686-freebsd" || system == "x86_64-freebsd" then "/usr/local/bin/bash"
+    if system == "i686-freebsd" || system == "x86_64-freebsd" ||
+       # bash 3.x is too old on darwin systems, so we need an externally installed one (at least bash 4)
+       system == "x86_64-darwin" || system == "aarch64-darwin" then "/usr/local/bin/bash"
     else "/bin/bash";
 
   path =


### PR DESCRIPTION
Since we are not quite ready on https://github.com/NixOS/nixpkgs/pull/105026, I wanted to look into getting native darwin stdenv working again. There were quite a few evaluation errors which needed to be fixed.

In testing, I installed coreutils-8.32 and bash-5.1 in /usr/local.