### PR TITLE
azure-cli: 2.16.0 -> 2.17.0, bump azure python packages

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-cdn";
-  version = "5.2.0";
+  version = "6.0.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "3e470ba07918a4f97dadb6f50c6f64068da423b735fad38d31d9535c56f06881";
+    sha256 = "590cd35c9f1556a2d93d93a88b5c5661f716de094f22db30f4d05dc58a131c84";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-databoxedge/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-databoxedge/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi
+, msrestazure
+, azure-common
+}:
+
+buildPythonPackage rec {
+  pname = "azure-mgmt-databoxedge";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "g8BtUpIGOse8Jrws48gQ/o7sgymlgX0XIxl1ThHS3XA=";
+  };
+
+  propagatedBuildInputs = [
+    msrestazure
+    azure-common
+  ];
+
+  # no tests in pypi tarball
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.mgmt.databoxedge" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Databoxedge Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
@@ -7,16 +7,17 @@
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
+, azure-mgmt-core
 }:
 
 buildPythonPackage rec {
   pname = "azure-mgmt-loganalytics";
-  version = "2.0.0";
+  version = "7.0.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "947cada6e52fea6ecae7011d7532cf8edbe90250753a58749c473b863331fcc6";
+    sha256 = "e603f9fc61b8d2f93d8814bcca012a8b425cf0c0320ddf1e84462929cf34d1af";
   };
 
   propagatedBuildInputs = [
@@ -24,6 +25,7 @@ buildPythonPackage rec {
     msrestazure
     azure-common
     azure-mgmt-nspkg
+    azure-mgmt-core
   ];
 
   pythonNamespaces = [ "azure.mgmt" ];

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-mgmt-recoveryservices";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "3c90e6b2e358dbe6d5c6d7204955bdf52c3e977c6f8b727cbbb8811427d7fd52";
+    sha256 = "203ebbd6b698a99975092a72d6d47285646a0264b9085fecef1e7b7c98c5d52e";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-synapse-artifacts/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-artifacts/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "azure-synapse-artifacts";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "0p43zmw96fh3wp75phf3fcqdfb36adqvxfc945yfda6fi555nw1a";
+    sha256 = "09fd9cf8c25c901d2daf7e436062065ada866f212f371f9d66f394d39ccaa23b";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-synapse-spark/default.nix
+++ b/pkgs/development/python-modules/azure-synapse-spark/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "azure-synapse-spark";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "fcfe559e30a2e159f07e371af28d18dc635dc55174fb3457be7210ce8e7e7559";
+    sha256 = "7f5881fda4108363c8c6fdee0494fa067ba81e60f038883859d23fc197f5f286";
     extension = "zip";
   };
 

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, python3, fetchFromGitHub, installShellFiles }:
 
 let
-  version = "2.16.0";
+  version = "2.17.0";
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "azure-cli";
     rev = "azure-cli-${version}";
-    sha256 = "wuHPNpt5pizgAwxRxJpRBiX6keJpKRpHu6M5BpFUyeY=";
+    sha256 = "2QLPtZYZZ+W5xZH2hxFnjox31v3My3zocouqLWGWSYI=";
   };
 
   # put packages that needs to be overriden in the py package scope
@@ -67,6 +67,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
     azure-mgmt-containerregistry
     azure-mgmt-containerservice
     azure-mgmt-cosmosdb
+    azure-mgmt-databoxedge
     azure-mgmt-datalake-analytics
     azure-mgmt-datalake-store
     azure-mgmt-datamigration

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -125,8 +125,8 @@ let
         '';
       };
 
-      azure-batch = overrideAzureMgmtPackage super.azure-batch "9.0.0" "zip"
-        "112d73gxjqng348mcvi36ska6pxyg8qc3qswvhf5x4a0lr86zjj7";
+      azure-batch = overrideAzureMgmtPackage super.azure-batch "10.0.0" "zip"
+        "83d7a2b0be42ca456ac2b56fa3dc6ce704c130e888d37d924072c1d3718f32d0";
 
       azure-mgmt-apimanagement = overrideAzureMgmtPackage super.azure-mgmt-apimanagement "0.2.0" "zip"
         "0whx3s8ri9939r3pdvjf8iqcslas1xy6cnccidmp10r5ng0023vr";
@@ -158,8 +158,8 @@ let
       azure-mgmt-cognitiveservices = overrideAzureMgmtPackage super.azure-mgmt-cognitiveservices "6.3.0" "zip"
         "059lhbxqx1r1717s8xz5ahpxwphq5fgy0h7k6b63cahm818rs0hx";
 
-      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "14.0.0" "zip"
-        "0bvqv56plcgmnfyj0apphlbsn2vfm1a22idvy8y5npbfjz4zwja9";
+      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "18.0.0" "zip"
+        "34815c91193640ad8ff0c4dad7f2d997548c853d2e8b10250329ed516e55879e";
 
       azure-mgmt-consumption = overrideAzureMgmtPackage super.azure-mgmt-consumption "2.0.0" "zip"
         "12ai4qps73ivawh0yzvgb148ksx02r30pqlvfihx497j62gsi1cs";
@@ -206,8 +206,8 @@ let
       azure-mgmt-loganalytics = overrideAzureMgmtPackage super.azure-mgmt-loganalytics "0.7.0" "zip"
         "18n2lqvrhq40gdqhlzzg8mc03571i02c7qq7jv771lc58rqpzysh";
 
-      azure-mgmt-network = overrideAzureMgmtPackage super.azure-mgmt-network "13.0.0" "zip"
-        "02ac54fs4wqdwy986j9qyx6fbl5zmpkh1sykr9r6mqk1xx9l4jq8";
+      azure-mgmt-network = overrideAzureMgmtPackage super.azure-mgmt-network "17.0.0" "zip"
+        "3694f2675e152afccb1588a6cc7bb4b4795d442a4e5d7082cdf1f4e32a779199";
 
       azure-mgmt-media = overrideAzureMgmtPackage super.azure-mgmt-media "2.1.0" "zip"
         "1py0hch0wghzfxazdrrs7p0kln2zn9jh3fmkzwd2z8qggj38q6gm";
@@ -230,8 +230,8 @@ let
       azure-mgmt-search = overrideAzureMgmtPackage super.azure-mgmt-search "2.0.0" "zip"
         "14v8ja8har2xrb00v98610pqvakcdvnzw8hkd6wbr1np3f3dxi8f";
 
-      azure-mgmt-security = overrideAzureMgmtPackage super.azure-mgmt-security "0.4.1" "zip"
-        "08gf401d40bd1kn9wmpxcjxqdh84cd9hxm8rdjd0918483sqs71r";
+      azure-mgmt-security = overrideAzureMgmtPackage super.azure-mgmt-security "0.6.0" "zip"
+        "9f37d0151d730801222af111f0830905634795dbfd59ad1b89c35197421e74d3";
 
       azure-mgmt-signalr = overrideAzureMgmtPackage super.azure-mgmt-signalr "0.4.0" "zip"
         "09n12ligh301z4xwixl50n8f1rgd2k6lpsxqzr6n6jvgkpdds0v5";
@@ -260,8 +260,8 @@ let
       azure-mgmt-cdn = overrideAzureMgmtPackage super.azure-mgmt-cdn "5.2.0" "zip"
         "10b8y1b5qlyr666x7yimnwis9386ciphrxdnmmyzk90qg6h0niry";
 
-      azure-mgmt-containerregistry = overrideAzureMgmtPackage super.azure-mgmt-containerregistry "3.0.0rc15" "zip"
-        "1fnmdl3m7kdn6c2ws5vrm7nwadcbq9mgc6g5bg4s1a4xjb23q6vb";
+      azure-mgmt-containerregistry = overrideAzureMgmtPackage super.azure-mgmt-containerregistry "3.0.0rc16" "zip"
+        "eT5gH0K4q2Qr1lEpuqjxQhOUrA6bEsAktj+PKsfMXTo=";
 
       azure-mgmt-monitor = overrideAzureMgmtPackage super.azure-mgmt-monitor "0.11.0" "zip"
         "05jhn66d4sl1qi6w34rqd8wl500jndismiwhdmzzmprdvn1zxqf6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -597,6 +597,8 @@ in {
 
   azure-mgmt-cosmosdb = callPackage ../development/python-modules/azure-mgmt-cosmosdb { };
 
+  azure-mgmt-databoxedge = callPackage ../development/python-modules/azure-mgmt-databoxedge { };
+
   azure-mgmt-datafactory = callPackage ../development/python-modules/azure-mgmt-datafactory { };
 
   azure-mgmt-datalake-analytics = callPackage ../development/python-modules/azure-mgmt-datalake-analytics { };


### PR DESCRIPTION
###### Motivation for this change
closes: #107905

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/107996

13 packages built:
azure-cli python37Packages.azure-mgmt-cdn python37Packages.azure-mgmt-databoxedge python37Packages.azure-mgmt-loganalytics python37Packages.azure-mgmt-recoveryservices python37Packages.azure-synapse-artifacts python37Packages.azure-synapse-spark python38Packages.azure-mgmt-cdn python38Packages.azure-mgmt-databoxedge python38Packages.azure-mgmt-loganalytics python38Packages.azure-mgmt-recoveryservices python38Packages.azure-synapse-artifacts python38Packages.azure-synapse-spark
```
