### PR TITLE
new-session-manager: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -76,6 +76,12 @@
     githubId = 882455;
     name = "Elliot Cameron";
   };
+  _6AA4FD = {
+    email = "f6442954@gmail.com";
+    github = "6AA4FD";
+    githubId = 12578560;
+    name = "Quinn Bohner";
+  };
   a1russell = {
     email = "adamlr6+pub@gmail.com";
     github = "a1russell";

--- a/pkgs/applications/audio/new-session-manager/default.nix
+++ b/pkgs/applications/audio/new-session-manager/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, meson, pkg-config, ninja, liblo, libjack2, fltk }:
+
+stdenv.mkDerivation rec {
+  pname = "new-session-manager";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxaudio";
+    repo = "new-session-manager";
+    rev = "v${version}";
+    sha256 = "PqOv4tx3NLxL2+GWIUVgL72EQYMyDPIMrAkyby3TZ+0=";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+
+  buildInputs = [ liblo libjack2 fltk ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://linuxaudio.github.io/new-session-manager/";
+    description = "A session manager designed for audio applications.";
+    maintainers = [ maintainers._6AA4FD ];
+    license = licenses.gpl3Plus;
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29028,6 +29028,8 @@ in
     gcc-armhf-embedded = pkgsCross.armhf-embedded.buildPackages.gcc;
   };
 
+  new-session-manager = callPackage ../applications/audio/new-session-manager { };
+
   newlib = callPackage ../development/misc/newlib { };
   newlibCross = callPackage ../development/misc/newlib {
     stdenv = crossLibcStdenv;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
