### PR TITLE
lib/systems/platforms: treat missing cpu version as generic pcBase

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -490,8 +490,9 @@ rec {
 
     # ARM
     else if platform.isAarch32 then let
-      version = platform.parsed.cpu.version or "";
-      in     if lib.versionOlder version "6" then sheevaplug
+      version = platform.parsed.cpu.version or null;
+      in     if version == null then pcBase
+        else if lib.versionOlder version "6" then sheevaplug
         else if lib.versionOlder version "7" then raspberrypi
         else armv7l-hf-multiplatform
     else if platform.isAarch64 then aarch64-multiplatform


### PR DESCRIPTION
###### Motivation for this change

Since 40e7be1 all ARM platforms that didn't have a parsed cpu version
(e.g. arm-none-eabi) would be handled as armv7l-hf-multiplatform which
did break building arm-trusted-platform packages for some targets (e.g.
rk3399).

Using pcBase as fallback, instead of armv7l-hf-multiplatform,
corresponds with the behaviour we had before 40e7be1.




###### Things done


- [X] building `ubootRockPi4` on aarch64-linux works again
