### PR TITLE
libvmaf: 1.5.3 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -2,24 +2,28 @@
 
 stdenv.mkDerivation rec {
   pname = "libvmaf";
-  version = "1.5.3";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "netflix";
     repo = "vmaf";
     rev = "v${version}";
-    sha256 = "0x3l3g0hgrrjh3ygmxr1pd3rd5589s07c7id35nvj76ch5b7gy63";
+    sha256 = "0gh4zwz975x9kvqdmzs45f96rk99apay57jc68rc8c2xm7gfis58";
   };
 
   sourceRoot = "source/libvmaf";
 
   nativeBuildInputs = [ meson ninja nasm ];
+
+  mesonFlags = [ "-Denable_avx512=true" ];
+
   outputs = [ "out" "dev" ];
-  doCheck = true;
+  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/Netflix/vmaf";
     description = "Perceptual video quality assessment based on multi-method fusion (VMAF)";
+    changelog = "https://github.com/Netflix/vmaf/blob/v${version}/CHANGELOG.md";
     platforms = platforms.unix;
     license = licenses.bsd2Patent;
     maintainers = [ maintainers.cfsmp3 maintainers.marsam ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
+ https://github.com/Netflix/vmaf/releases/tag/v2.0.0
+ https://github.com/Netflix/vmaf/releases/tag/v2.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
