### PR TITLE
libxkbcommon: 0.10.0 -> 1.0.3

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -1,30 +1,47 @@
-{ stdenv, fetchurl, fetchpatch, meson, ninja, pkgconfig, yacc, xkeyboard_config, libxcb, libX11, doxygen }:
+{ stdenv, fetchurl, meson, ninja, pkg-config, yacc, doxygen
+, xkeyboard_config, libxcb, libxml2
+, python3
+, libX11
+}:
 
 stdenv.mkDerivation rec {
   pname = "libxkbcommon";
-  version = "0.10.0";
+  version = "1.0.3";
 
   src = fetchurl {
     url = "https://xkbcommon.org/download/${pname}-${version}.tar.xz";
-    sha256 = "1wmnl0hngn6vrqrya4r8hvimlkr4jag39yjprls4gyrqvh667hsp";
+    sha256 = "0lmwglj16anhpaq0h830xsl1ivknv75i4lir9bk88aq73s2jy852";
   };
 
   outputs = [ "out" "dev" "doc" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig yacc doxygen ];
-  buildInputs = [ xkeyboard_config libxcb ];
+  nativeBuildInputs = [ meson ninja pkg-config yacc doxygen ];
+  buildInputs = [ xkeyboard_config libxcb libxml2 ];
+  checkInputs = [ python3 ];
 
   mesonFlags = [
-    "-Denable-wayland=false"
     "-Dxkb-config-root=${xkeyboard_config}/etc/X11/xkb"
+    "-Dxkb-config-extra-path=/etc/xkb" # default=$sysconfdir/xkb ($out/etc)
     "-Dx-locale-root=${libX11.out}/share/X11/locale"
+    "-Denable-wayland=false"
+    "-Denable-xkbregistry=false" # Optional, separate library (TODO: Install into extra output)
   ];
 
-  doCheck = false; # fails, needs unicode locale
+  doCheck = true;
+  preCheck = ''
+    patchShebangs ../test/
+  '';
 
   meta = with stdenv.lib; {
     description = "A library to handle keyboard descriptions";
+    longDescription = ''
+      libxkbcommon is a keyboard keymap compiler and support library which
+      processes a reduced subset of keymaps as defined by the XKB (X Keyboard
+      Extension) specification. It also contains a module for handling Compose
+      and dead keys.
+    ''; # and a separate library for listing available keyboard layouts.
     homepage = "https://xkbcommon.org";
+    changelog = "https://github.com/xkbcommon/libxkbcommon/blob/xkbcommon-${version}/NEWS";
     license = licenses.mit;
     maintainers = with maintainers; [ ttuegel ];
     platforms = with platforms; unix;


### PR DESCRIPTION
###### Motivation for this change

This updates `libxkbcommon` from `0.10.0` to latest stable, `1.0.3`.

Fixes #108003.

This is currently a draft since I haven't run `nixpkgs-review` since I'm expecting a huge rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
