### PR TITLE
netperf: fix Darwin build

### DIFF
--- a/pkgs/applications/networking/netperf/default.nix
+++ b/pkgs/applications/networking/netperf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "1wbbgdvhadd3qs3afv6i777argdpcyxkwz4yv6aqp223n8ki6dm8";
   };
 
-  buildInputs = stdenv.lib.optional (stdenv.hostPlatform.isx86) libsmbios;
+  buildInputs = stdenv.lib.optional (with stdenv.hostPlatform; isx86 && isLinux) libsmbios;
   nativeBuildInputs = [ autoreconfHook ];
   autoreconfPhase = ''
     autoreconf -i -I src/missing/m4
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     homepage = "http://www.netperf.org/netperf/";
     license = "Hewlett-Packard BSD-like license";
 
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.mmlb ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This fixes the following build error on Darwin:
```
In file included from ./src/libsmbios_c/common/libsmbios_c_source.h:37:
./src/libsmbios_c/common/select_platform_config.h:16:7: error: "Unknown platform - please report to libsmbios maintainer."
#     error "Unknown platform - please report to libsmbios maintainer."
      ^
1 error generated.
make[1]: *** [Makefile:1728: src/libsmbios_c/common/out_libsmbios_c_la-common.lo] Error 1
```

###### Things done
Per the netperf doc, `libsmbios` is only used on Linux so added a conditional.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
