### PR TITLE
mcrypt: patch to include stdlib.h instead of malloc.h to build on darwin

### DIFF
--- a/pkgs/tools/misc/mcrypt/default.nix
+++ b/pkgs/tools/misc/mcrypt/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     ./overflow_CVE-2012-4409.patch
     ./segv.patch
     ./sprintf_CVE-2012-4527.patch
+    ./malloc_to_stdlib.patch
   ];
 
   buildInputs = [ libmcrypt libmhash ];

--- a/pkgs/tools/misc/mcrypt/default.nix
+++ b/pkgs/tools/misc/mcrypt/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       ever-wider range of algorithms and modes.
     '';
     homepage = "http://mcrypt.sourceforge.net";
-    license = stdenv.lib.licenses.gpl2;
+    license = stdenv.lib.licenses.gpl3Only;
     platforms = stdenv.lib.platforms.all;
     maintainers = [ stdenv.lib.maintainers.qknight ];
   };

--- a/pkgs/tools/misc/mcrypt/malloc_to_stdlib.patch
+++ b/pkgs/tools/misc/mcrypt/malloc_to_stdlib.patch
@@ -1,0 +1,26 @@
+From e295844e8ef5c13487996ab700e5f12a7fadb1a6 Mon Sep 17 00:00:00 2001
+From: Nima Vasseghi <nmv@fb.com>
+Date: Wed, 30 Dec 2020 16:06:46 -0800
+Subject: [PATCH] malloc.h to stdlib.h in rfc2440.c
+
+The malloc.h is deprecated and should not be used
+---
+ src/rfc2440.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rfc2440.c b/src/rfc2440.c
+index 5a1f296..4d6a5db 100644
+--- a/src/rfc2440.c
++++ b/src/rfc2440.c
+@@ -23,7 +23,7 @@
+ #include <zlib.h>
+ #endif
+ #include <stdio.h>
+-#include <malloc.h>
++#include <stdlib.h>
+ 
+ #include "xmalloc.h"
+ #include "keys.h"
+-- 
+2.13.5
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package does not compile on macOS.
malloc.h is non-portable and deprecated. macOS doesn't work with it.
The mcrypt dev site is pretty stale with a ticket about this opened in 2009 (https://sourceforge.net/p/mcrypt/bugs/36/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS https://gist.github.com/nima2007/1d2f70b52ef4d4f92d9ae89d23d58b0f
   - [X] other Linux distributions https://gist.github.com/nima2007/cb7f5e51bceba62445813aedc054bfd6
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) See pastes
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
