### PR TITLE
openocd: unstable-2020-11-11 -> 0.11.0-rc1

### DIFF
--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "openocd";
-  version = "unstable-2020-11-11";
+  version = "0.11.0-rc1";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/openocd/code";
-    rev = "06c7a53f1fff20bcc4be9e63f83ae98664777f34";
-    sha256 = "0g0w7g94r88ylfpwswnhh8czlf5iqvd991ssn4gfcfd725lpdb01";
+    rev = "v${version}";
+    sha256 = "15g8qalyxhdp0imfrg8mxwnp0nimd836fc5laaavajw49gcm65m4";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
0.11.0-rc1 was released, seems like a better thing to have around than a random master branch commit

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
```
2 packages updated:
openocd (2020-11-11 → 0.11.0-rc1) tinygo
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  `179419728 -> 179448152`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
