### PR TITLE
[staging-next] mesa: fix build on darwin

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -65,6 +65,13 @@ stdenv.mkDerivation {
       url = "https://gitlab.freedesktop.org/mesa/mesa/commit/aebbf819df6d1e.patch";
       sha256 = "17248hyzg43d73c86p077m4lv1pkncaycr3l27hwv9k4ija9zl8q";
     })
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    # Fix for pre macOS SDK 10.13
+    # TODO(r-burns) can be applied unconditionally, at the cost of a mass linux rebuild
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/f4403f70fe5bf2ec41af5546122f0d78caffa984.patch";
+      sha256 = "03j2aj255m7ms848nkb41vj3s3yb72zb5rz3w3fzp5l9wzzargw5";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Latest mesa requires macOS SDK 10.13 - this applies an upstream
patch for compatibility with 10.13

Applied on darwin only to avoid linux rebuilds in staging-next - left a
note that this can be done unconditionally as it has no effect on
non-darwin platforms, if this would be considered more robust.

cc @FRidh 

Have not tested thoroughly beyond `mesa` itself - let me know if there are any dependees in particular I can check.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
