### PR TITLE
[staging-next] llvmPackages_8.llvm: fix build with gcc 10

### DIFF
--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetch
+, fetchpatch
 , cmake
 , python3
 , libffi
@@ -54,6 +55,14 @@ in stdenv.mkDerivation ({
     ++ optional enablePFM libpfm; # exegesis
 
   propagatedBuildInputs = [ ncurses zlib ];
+
+  patches = [
+    # Fix missing includes for GCC 10
+    (fetchpatch {
+      url = "https://bugs.gentoo.org/attachment.cgi?id=612792";
+      sha256 = "0rwx6jpqq4xnf4mvfm8v2d4r34y1yi05am0mx5k2d5bha9j64lqg";
+    })
+  ];
 
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \


### PR DESCRIPTION
Applies a patch from the gentoo bugtracker: https://bugs.gentoo.org/732094

Builds `llvmPackages_8.llvm` and dependee `ccls`, as reported broken in https://github.com/NixOS/nixpkgs/pull/89793#issuecomment-751768575

cc @MetaDark @FRidh 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
