### PR TITLE
xdot: unbreak build

### DIFF
--- a/pkgs/development/python-modules/xdot/default.nix
+++ b/pkgs/development/python-modules/xdot/default.nix
@@ -1,19 +1,25 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k
-, wrapGAppsHook, gobject-introspection, pygobject3, graphviz, gtk3 }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+, wrapGAppsHook, gobject-introspection, pygobject3, graphviz, gtk3
+, numpy, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "xdot";
   version = "1.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3df91e6c671869bd2a6b2a8883fa3476dbe2ba763bd2a7646cf848a9eba71b70";
+  src = fetchFromGitHub {
+    owner = "jrfonseca";
+    repo = "xdot.py";
+    rev = version;
+    sha256 = "0lignsx7yr2pq92q8dgyim7d3xlmmwq1l16waz3qj4p6g2yh8023";
   };
 
   disabled = !isPy3k;
 
   nativeBuildInputs = [ wrapGAppsHook ];
-  propagatedBuildInputs = [ gobject-introspection pygobject3 graphviz gtk3 ];
+  propagatedBuildInputs = [ numpy gobject-introspection pygobject3 graphviz gtk3 ];
+  checkPhase = ''
+    python ./test.py;
+  '';
 
   meta = with lib; {
     description = "An interactive viewer for graphs written in Graphviz's dot";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix xdot [build failure on hydra](https://hydra.nixos.org/job/nixpkgs/trunk/xdot.x86_64-linux). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
