### PR TITLE
lib/systems: add emulator for mmix

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -124,6 +124,8 @@ rec {
         then "${qemu-user}/bin/qemu-${final.qemuArch}"
         else if final.isWasi
         then "${pkgs.wasmtime}/bin/wasmtime"
+        else if final.isMmix
+        then "${pkgs.mmixware}/bin/mmix"
         else throw "Don't know how to run ${final.config} executables.";
 
     } // mapAttrs (n: v: v final.parsed) inspect.predicates


### PR DESCRIPTION
###### Motivation for this change
Would be a good example to show when the emulators feature is documented (#106375). Try it out by creating a `test.nix` file at nixpkgs root with the following contents

```nix
{ pkgs ? import ./. {}}:
with pkgs;

let
  hello-cross = pkgsCross.mmix.hello;
  emul = pkgsCross.mmix.stdenv.hostPlatform.emulator pkgs;
in
rec {
  runit = writeScript "runit" ''
    #!/usr/bin/env sh
    ${emul} ${hello-cross}/bin/hello
  '';
}
```

then run

```ShellSession
$ nix-build test.nix -A runit && ./result
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
