### PR TITLE
[staging] treewide: cmake buildInputs to nativeBuildInputs, minor cleanups

### DIFF
--- a/pkgs/applications/audio/artyFX/default.nix
+++ b/pkgs/applications/audio/artyFX/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub , cairomm, cmake, libjack2, libpthreadstubs, libXdmcp, libxshmfence, libsndfile, lv2, ntk, pkgconfig }:
+{ stdenv, fetchFromGitHub , cairomm, cmake, libjack2, libpthreadstubs, libXdmcp, libxshmfence, libsndfile, lv2, ntk, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "artyFX";
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0wwg8ivnpyy0235bapjy4g0ij85zq355jwi6c1nkrac79p4z9ail";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cairomm cmake libjack2 libpthreadstubs libXdmcp libxshmfence libsndfile lv2 ntk   ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cairomm libjack2 libpthreadstubs libXdmcp libxshmfence libsndfile lv2 ntk ];
 
   meta = with stdenv.lib; {
     homepage = "http://openavproductions.com/artyfx/";

--- a/pkgs/applications/audio/eq10q/default.nix
+++ b/pkgs/applications/audio/eq10q/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, cmake, fftw, gtkmm2, libxcb, lv2, pkgconfig
+{ stdenv, fetchurl, fetchpatch, cmake, fftw, gtkmm2, libxcb, lv2, pkg-config
 , xorg }:
 stdenv.mkDerivation rec {
   pname = "eq10q";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "16mhcav8gwkp29k9ki4dlkajlcgh1i2wvldabxb046d37dq4qzrk";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fftw gtkmm2 libxcb lv2 xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fftw gtkmm2 libxcb lv2 xorg.libpthreadstubs xorg.libXdmcp xorg.libxshmfence ];
 
   patches = [
     (fetchpatch {

--- a/pkgs/applications/audio/eteroj.lv2/default.nix
+++ b/pkgs/applications/audio/eteroj.lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, libuv, lv2 }:
+{ stdenv, fetchFromGitHub, cmake, pkg-config, libuv, lv2 }:
 
 stdenv.mkDerivation rec {
   pname = "eteroj.lv2";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libuv lv2 ];
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   meta = with stdenv.lib; {
     description = "OSC injection/ejection from/to UDP/TCP/Serial for LV2";

--- a/pkgs/applications/audio/game-music-emu/default.nix
+++ b/pkgs/applications/audio/game-music-emu/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "07857vdkak306d9s5g6fhmjyxk7vijzjhkmqb15s7ihfxx9lx8xb";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     homepage = "https://bitbucket.org/mpyne/game-music-emu/wiki/Home";

--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, pkgconfig, cmake, python3, ffmpeg_3, phonon, automoc4
+, pkg-config, cmake, python3, ffmpeg_3, phonon, automoc4
 , chromaprint, docbook_xml_dtd_45, docbook_xsl, libxslt
 , id3lib, taglib, mp4v2, flac, libogg, libvorbis
 , zlib, readline , qtbase, qttools, qtmultimedia, qtquickcontrols
@@ -15,12 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-WYuEOqMu2VMOv6mkVCRXnmInFER/DWfPNqYuaTJ3vAc=";
   };
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
-  buildInputs = [
-    pkgconfig cmake python3 ffmpeg_3 phonon automoc4
-    chromaprint docbook_xml_dtd_45 docbook_xsl libxslt
-    id3lib taglib mp4v2 flac libogg libvorbis zlib readline
-    qtbase qttools qtmultimedia qtquickcontrols ];
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+  buildInputs = [ python3 ffmpeg_3 phonon automoc4 chromaprint
+    docbook_xml_dtd_45 docbook_xsl libxslt id3lib taglib mp4v2 flac
+    libogg libvorbis zlib readline qtbase qttools qtmultimedia
+    qtquickcontrols ];
 
   cmakeFlags = [ "-DWITH_APPS=Qt;CLI" ];
   NIX_LDFLAGS = "-lm -lpthread";

--- a/pkgs/applications/audio/ncpamixer/default.nix
+++ b/pkgs/applications/audio/ncpamixer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, ncurses, libpulseaudio, pkgconfig }:
+{ stdenv, fetchFromGitHub, cmake, ncurses, libpulseaudio, pkg-config }:
 
 stdenv.mkDerivation rec {
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ncurses libpulseaudio ];
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   configurePhase = ''
     make PREFIX=$out build/Makefile

--- a/pkgs/applications/audio/petrifoo/default.nix
+++ b/pkgs/applications/audio/petrifoo/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, alsaLib, cmake, gtk2, libjack2, libgnomecanvas
 , libpthreadstubs, libsamplerate, libsndfile, libtool, libxml2
-, pkgconfig, openssl }:
+, pkg-config, openssl }:
 
 stdenv.mkDerivation  rec {
   pname = "petri-foo";
@@ -11,10 +11,10 @@ stdenv.mkDerivation  rec {
     sha256 = "0b25iicgn8c42487fdw32ycfrll1pm2zjgy5djvgw6mfcaa4gizh";
   };
 
-  buildInputs =
-   [ alsaLib cmake gtk2 libjack2 libgnomecanvas libpthreadstubs
-     libsamplerate libsndfile libtool libxml2 pkgconfig openssl
-   ];
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ alsaLib gtk2 libjack2 libgnomecanvas libpthreadstubs
+                  libsamplerate libsndfile libtool libxml2 openssl ];
 
   meta = with stdenv.lib; {
     description = "MIDI controllable audio sampler";

--- a/pkgs/applications/audio/sorcer/default.nix
+++ b/pkgs/applications/audio/sorcer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub , boost, cairomm, cmake, libsndfile, lv2, ntk, pkgconfig, python }:
+{ stdenv, fetchFromGitHub , boost, cairomm, cmake, libsndfile, lv2, ntk, pkg-config, python }:
 
 stdenv.mkDerivation rec {
   pname = "sorcer";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1x7pi77nal10717l02qpnhrx6d7w5nqrljkn9zx5w7gpb8fpb3vp";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ boost cairomm cmake libsndfile lv2 ntk python ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ boost cairomm libsndfile lv2 ntk python ];
 
   postPatch = ''
      # Fix build with lv2 1.18: https://github.com/brummer10/guitarix/commit/c0334c72

--- a/pkgs/applications/audio/sorcer/default.nix
+++ b/pkgs/applications/audio/sorcer/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "http://openavproductions.com/sorcer/";
     description = "A wavetable LV2 plugin synth, targeted at the electronic / dubstep genre";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/audio/ympd/default.nix
+++ b/pkgs/applications/audio/ympd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, mpd_clientlib, openssl }:
+{ stdenv, fetchFromGitHub, cmake, pkg-config, mpd_clientlib, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "ympd";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1nvb19jd556v2h2bi7w4dcl507p3p8xvjkqfzrcsy7ccy3502brq";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake mpd_clientlib openssl ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ mpd_clientlib openssl ];
 
   meta = {
     homepage = "https://www.ympd.org";

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, cairo, cmake, libjack2, fftw, fltk13, lash,  libjpeg
-, libXpm, minixml, ntk, pkgconfig, zlib, liblo
+, libXpm, minixml, ntk, pkg-config, zlib, liblo
 }:
 
 stdenv.mkDerivation  rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation  rec {
   };
 
   buildInputs = [ alsaLib cairo libjack2 fftw fltk13 lash libjpeg libXpm minixml ntk zlib liblo ];
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   patchPhase = ''
     substituteInPlace src/Misc/Config.cpp --replace /usr $out

--- a/pkgs/applications/editors/bonzomatic/default.nix
+++ b/pkgs/applications/editors/bonzomatic/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "12mdfjvbhdqz1585772rj4cap8m4ijfci6ib62jysxjf747k41fg";
   };
 
-  buildInputs = [ cmake makeWrapper alsaLib mesa_glu libXcursor libXinerama libXrandr xorgserver ];
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = [ alsaLib mesa_glu libXcursor libXinerama libXrandr xorgserver ];
 
   postFixup = ''
     wrapProgram $out/bin/Bonzomatic --prefix LD_LIBRARY_PATH : "${alsaLib}/lib"

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -583,7 +583,8 @@ let
         };
 
         vterm = super.vterm.overrideAttrs (old: {
-          buildInputs = old.buildInputs ++ [ self.emacs pkgs.cmake pkgs.libvterm-neovim ];
+          nativeBuildInputs = [ pkgs.cmake ];
+          buildInputs = old.buildInputs ++ [ self.emacs pkgs.libvterm-neovim ];
           cmakeFlags = [
             "-DEMACS_SOURCE=${self.emacs.src}"
             "-DUSE_SYSTEM_LIBVTERM=ON"

--- a/pkgs/applications/graphics/autopanosiftc/default.nix
+++ b/pkgs/applications/graphics/autopanosiftc/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
     sha256 = "0dqk8ff82gmy4v5ns5nr9gpzkc1p7c2y8c8fkid102r47wsjk44s";
   };
 
-  buildInputs = [ cmake libpng libtiff libjpeg panotools libxml2 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libpng libtiff libjpeg panotools libxml2 ];
 
   patches = [
     (fetchurl {

--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -27,7 +27,7 @@ in mkDerivation rec {
   ];
 
   buildInputs = [
-    cmake coin3d xercesc ode eigen opencascade-occt gts
+    coin3d xercesc ode eigen opencascade-occt gts
     zlib swig gfortran soqt libf2c makeWrapper mpi vtk hdf5 medfile
     libGLU libXmu qtbase qttools qtwebengine qtxmlpatterns
   ] ++ (with pythonPackages; [

--- a/pkgs/applications/graphics/freepv/default.nix
+++ b/pkgs/applications/graphics/freepv/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation {
     sha256 = "1w19abqjn64w47m35alg7bcdl1p97nf11zn64cp4p0dydihmhv56";
   };
 
-  buildInputs = [ libjpeg libGLU libGL freeglut zlib cmake libX11 libxml2 libpng
-    libXxf86vm ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libjpeg libGLU libGL freeglut zlib libX11 libxml2 libpng libXxf86vm ];
 
   postPatch = ''
     sed -i -e '/GECKO/d' CMakeLists.txt

--- a/pkgs/applications/graphics/pbrt/default.nix
+++ b/pkgs/applications/graphics/pbrt/default.nix
@@ -1,7 +1,6 @@
 {stdenv, fetchFromGitHub, flex, bison, cmake, git, zlib}:
 
 stdenv.mkDerivation {
-
   version = "2018-08-15";
   pname = "pbrt-v3";
 
@@ -18,12 +17,13 @@ stdenv.mkDerivation {
     ./openexr-cmake-3.12.patch
   ];
 
-  buildInputs = [ git flex bison cmake zlib ];
+  nativeBuildInputs = [ flex bison cmake ];
+  buildInputs = [ zlib ];
 
   meta = with stdenv.lib; {
     homepage = "http://pbrt.org";
     description = "The renderer described in the third edition of the book 'Physically Based Rendering: From Theory To Implementation'";
-    platforms = platforms.linux ;
+    platforms = platforms.linux;
     license = licenses.bsd2;
     maintainers = [ maintainers.juliendehos ];
     priority = 10;

--- a/pkgs/applications/graphics/scantailor/default.nix
+++ b/pkgs/applications/graphics/scantailor/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
     sha256 = "1pjx3a6hs16az6rki59bchy3biy7jndjx8r125q01aq7lbf5npgg";
   };
 
-  buildInputs = [ qt4 cmake libjpeg libtiff boost ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 libjpeg libtiff boost ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/graphics/screencloud/default.nix
+++ b/pkgs/applications/graphics/screencloud/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   # for tracking usage.
   consumerKey = "23e747012c68601f27ab69c6de129ed70552d55b6";
   consumerSecret = "4701cb00c1bd357bbcae7c3d713dd216";
-  
+
   src = fetchFromGitHub {
     owner = "olav-st";
     repo = "screencloud";
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "1s0dxa1sa37nvna5nfqdsp294810favj68qb7ghl78qna7zw0cim";
   };
 
-  buildInputs = [ cmake qt4 quazip qt-mobility qxt pythonPackages.python pythonPackages.pycrypto ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 quazip qt-mobility qxt pythonPackages.python pythonPackages.pycrypto ];
 
   patchPhase = ''
     # Required to make the configure script work. Normally, screencloud's
@@ -27,8 +28,6 @@ stdenv.mkDerivation rec {
     # have nice things.
     substituteInPlace "CMakeLists.txt" --replace "set(CMAKE_INSTALL_PREFIX \"/opt\")" ""
   '';
-
-  enableParallelBuilding = true;
 
   # We need to append /opt to our CMAKE_INSTALL_PREFIX, so we tell the Nix not
   # to add the argument for us.

--- a/pkgs/applications/graphics/smartdeblur/default.nix
+++ b/pkgs/applications/graphics/smartdeblur/default.nix
@@ -16,9 +16,8 @@ stdenv.mkDerivation rec {
     cd src
   '';
 
-  enableParallelBuilding = true;
-
-  buildInputs = [ cmake qt4 fftw ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 fftw ];
 
   cmakeFlags = [ "-DUSE_SYSTEM_FFTW=ON" ];
 

--- a/pkgs/applications/misc/apvlv/default.nix
+++ b/pkgs/applications/misc/apvlv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig, pcre, libxkbcommon, epoxy
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkg-config, pcre, libxkbcommon, epoxy
 , gtk3, poppler, freetype, libpthreadstubs, libXdmcp, libxshmfence, wrapGAppsHook
 }:
 
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-I${poppler.dev}/include/poppler";
 
   nativeBuildInputs = [
-    pkgconfig
+    cmake
+    pkg-config
     wrapGAppsHook
   ];
 
   buildInputs = [
-    cmake
     poppler pcre libxkbcommon epoxy
     freetype gtk3
     libpthreadstubs libXdmcp libxshmfence # otherwise warnings in compilation

--- a/pkgs/applications/misc/dfilemanager/default.nix
+++ b/pkgs/applications/misc/dfilemanager/default.nix
@@ -1,18 +1,17 @@
-{ stdenv, mkDerivation, fetchgit, cmake, file, qtbase, qttools, solid }:
+{ stdenv, fetchgit, cmake, file, qtbase, qttools, solid }:
 
-let
-  version = "git-2016-01-10";
-in
-mkDerivation {
+stdenv.mkDerivation {
   pname = "dfilemanager";
-  inherit version;
+  version = "git-2016-01-10";
+
   src = fetchgit {
     url = "git://git.code.sf.net/p/dfilemanager/code";
     rev = "2c5078b05e0ad74c037366be1ab3e6a03492bde4";
     sha256 = "1qwhnlcc2j8sr1f3v63sxs3m7q7w1xy6c2jqsnznjgm23b5h3hxd";
   };
 
-  buildInputs = [ cmake qtbase qttools file solid ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase qttools file solid ];
 
   cmakeFlags = [ "-DQT5BUILD=true" ];
 

--- a/pkgs/applications/misc/keepassx/2.0.nix
+++ b/pkgs/applications/misc/keepassx/2.0.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, libgcrypt, qt4, xorg, ... }:
+{ stdenv, fetchurl, cmake, libgcrypt, qt4, xorg }:
 
 stdenv.mkDerivation rec {
   pname = "keepassx2";
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ia7cqx9ias38mnffsl7da7g1f66bcbjsi23k49sln0c6spb9zr3";
   };
 
-  buildInputs = [ cmake libgcrypt qt4 xorg.libXtst ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libgcrypt qt4 xorg.libXtst ];
 
   meta = {
     description = "Qt password manager compatible with its Win32 and Pocket PC versions";

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig
+{ stdenv, fetchurl, makeWrapper, pkg-config
 , zip, python, zlib, which, icu, libmicrohttpd, lzma, aria2, wget, bc
 , libuuid, libX11, libXext, libXt, libXrender, glib, dbus, dbus-glib
 , gtk2, gdk-pixbuf, pango, cairo, freetype, fontconfig, alsaLib, atk, cmake
@@ -38,7 +38,7 @@ let
       sha256 = "0sqk0vdwjq44jxbbkj1cy8qykrmafs1sickzldb2w2nshsnjshhg";
     };
 
-    buildInputs = [ cmake ];
+    nativeBuildInputs = [ cmake ];
 
     unpackPhase = ''
       # not a nice src archive: all the files are in the root :(
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     sha256 = "0577phhy2na59cpcqjgldvksp0jwczyg0l6c9ghnr19i375l7yqc";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     zip python zlib xapian which icu libmicrohttpd
     lzma zimlib ctpp2 aria2 wget bc libuuid makeWrapper pugixml

--- a/pkgs/applications/misc/lenmus/default.nix
+++ b/pkgs/applications/misc/lenmus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgconfig, fetchFromGitHub, fetchpatch
+{ stdenv, pkg-config, fetchFromGitHub, fetchpatch
 , cmake, boost
 , portmidi, sqlite
 , freetype, libpng, pngpp, zlib
@@ -29,9 +29,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    cmake boost
+    boost
     portmidi sqlite
     freetype libpng pngpp zlib
     wxGTK30 wxsqlite3

--- a/pkgs/applications/misc/opencpn/default.nix
+++ b/pkgs/applications/misc/opencpn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, gtk2, wxGTK30, libpulseaudio, curl,
+{ stdenv, fetchFromGitHub, pkg-config, cmake, gtk2, wxGTK30, libpulseaudio, curl,
   gettext, glib, portaudio }:
 
 stdenv.mkDerivation rec {
@@ -12,16 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "0yiqahkzwcbzgabc5xgxmwlngapkfiaqyva3mwz29xj0c5lg2bdk";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake gtk2 wxGTK30 libpulseaudio curl gettext
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ gtk2 wxGTK30 libpulseaudio curl gettext
                   glib portaudio ];
 
   cmakeFlags = [
     "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
     "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
   ];
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "A concise ChartPlotter/Navigator";

--- a/pkgs/applications/misc/posterazor/default.nix
+++ b/pkgs/applications/misc/posterazor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, unzip, pkgconfig, libXpm, fltk13, freeimage }:
+{ stdenv, fetchurl, cmake, unzip, pkg-config, libXpm, fltk13, freeimage }:
 
 stdenv.mkDerivation {
   name = "posterazor-1.5.1";
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake unzip libXpm fltk13 freeimage ];
+  nativeBuildInputs = [ cmake pkg-config unzip ];
+  buildInputs = [ libXpm fltk13 freeimage ];
 
   unpackPhase = ''
     unzip $src -d posterazor

--- a/pkgs/applications/misc/sqliteman/default.nix
+++ b/pkgs/applications/misc/sqliteman/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1blzyh1646955d580f71slgdvz0nqx0qacryx0jc9w02yrag17cs";
   };
 
-  buildInputs = [ cmake qt4 qscintilla ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 qscintilla ];
 
   prePatch = ''
     sed -i 's,m_file(0),m_file(QString()),' Sqliteman/sqliteman/main.cpp

--- a/pkgs/applications/misc/tellico/default.nix
+++ b/pkgs/applications/misc/tellico/default.nix
@@ -42,7 +42,6 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    cmake
     exempi
     extra-cmake-modules
     karchive

--- a/pkgs/applications/networking/flent/http-getter.nix
+++ b/pkgs/applications/networking/flent/http-getter.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake
-, curl, pkgconfig }:
+{ stdenv, fetchFromGitHub, cmake, curl, pkg-config }:
 
 stdenv.mkDerivation {
   pname = "http-getter";
@@ -12,7 +11,8 @@ stdenv.mkDerivation {
     sha256 = "0plyqqwfm9bysichda0w3akbdxf6279wd4mx8mda0c4mxd4xy9nl";
   };
 
-  buildInputs = [ cmake pkgconfig curl ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ curl ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/tohojo/http-getter";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation {
     sha256 = "02p57fgx8ml00cbrb4f280ak2802svz80836dzk9f1zwm1bcr2qc";
   };
 
-  buildInputs = [ pidgin cmake libxml2 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ pidgin libxml2 ];
 
   preConfigure = ''
     sed -i -e 's|DESTINATION.*PURPLE_PLUGIN_DIR}|DESTINATION lib/purple-2|' CMakeLists.txt

--- a/pkgs/applications/networking/instant-messengers/ring-daemon/restbed.nix
+++ b/pkgs/applications/networking/instant-messengers/ring-daemon/restbed.nix
@@ -19,11 +19,8 @@ stdenv.mkDerivation {
 
   inherit patches;
 
-  buildInputs = [
-    cmake
-    asio
-    openssl
-  ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ asio openssl ];
 
   meta = with stdenv.lib; {
     description = "HTTP framework for building networked applications";

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -54,8 +54,8 @@ in (if !buildClient then stdenv.mkDerivation else mkDerivation) rec {
   # Prevent ``undefined reference to `qt_version_tag''' in SSL check
   NIX_CFLAGS_COMPILE = "-DQT_NO_VERSION_TAGGING=1";
 
-  buildInputs =
-       [ cmake makeWrapper qtbase ]
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = [ qtbase ]
     ++ lib.optionals buildCore [qtscript qca-qt5]
     ++ lib.optionals buildClient [libdbusmenu phonon]
     ++ lib.optionals (buildClient && withKDE) [

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, lib
 , ncurses, openssl, aspell, gnutls, gettext
-, zlib, curl, pkgconfig, libgcrypt
+, zlib, curl, pkg-config, libgcrypt
 , cmake, makeWrapper, libobjc, libresolv, libiconv
 , asciidoctor # manpages
 , guileSupport ? true, guile
@@ -37,7 +37,6 @@ let
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;
 
-      enableParallelBuilding = true;
       cmakeFlags = with stdenv.lib; [
         "-DENABLE_MAN=ON"
         "-DENABLE_DOC=ON"
@@ -48,10 +47,10 @@ let
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins
         ;
 
+      nativeBuildInputs = [ cmake pkg-config makeWrapper asciidoctor ];
       buildInputs = with stdenv.lib; [
-          ncurses openssl aspell gnutls gettext zlib curl pkgconfig
-          libgcrypt makeWrapper cmake asciidoctor
-          ]
+          ncurses openssl aspell gnutls gettext zlib curl
+          libgcrypt ]
         ++ optionals stdenv.isDarwin [ libobjc libresolv ]
         ++ concatMap (p: p.buildInputs) enabledPlugins
         ++ extraBuildInputs;

--- a/pkgs/applications/office/tagainijisho/default.nix
+++ b/pkgs/applications/office/tagainijisho/default.nix
@@ -7,7 +7,8 @@ stdenv.mkDerivation {
     sha256 = "0kmg1940yiqfm4vpifyj680283ids4nsij9s750nrshwxiwwbqvg";
   };
 
-  buildInputs = [ qt4 cmake sqlite ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 sqlite ];
 
   meta = with stdenv.lib; {
     description = "A free, open-source Japanese dictionary and kanji lookup tool";

--- a/pkgs/applications/radio/gnuradio/ais.nix
+++ b/pkgs/applications/radio/gnuradio/ais.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
+{ stdenv, fetchFromGitHub, cmake, pkg-config, boost, gnuradio
 , makeWrapper, cppunit, gr-osmosdr, log4cpp
 , pythonSupport ? true, python, swig
 }:
@@ -17,10 +17,9 @@ stdenv.mkDerivation {
     sha256 = "1b9j0kc74cw12a7jv4lii77dgzqzg2s8ndzp4xmisxksgva1qfvh";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    cmake boost gnuradio makeWrapper cppunit gr-osmosdr log4cpp
-  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+  nativeBuildInputs = [ cmake makeWrapper pkg-config ];
+  buildInputs = [ boost gnuradio cppunit gr-osmosdr log4cpp ]
+             ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do

--- a/pkgs/applications/radio/gnuradio/gsm.nix
+++ b/pkgs/applications/radio/gnuradio/gsm.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio, log4cpp
+{ stdenv, fetchFromGitHub, cmake, pkg-config, boost, gnuradio, log4cpp
 , makeWrapper, cppunit, libosmocore, gr-osmosdr
 , pythonSupport ? true, python, swig
 }:
@@ -16,9 +16,9 @@ stdenv.mkDerivation {
     sha256 = "13nnq927kpf91iqccr8db9ripy5czjl5jiyivizn6bia0bam2pvx";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    cmake boost gnuradio makeWrapper cppunit libosmocore gr-osmosdr log4cpp
+    boost gnuradio makeWrapper cppunit libosmocore gr-osmosdr log4cpp
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''

--- a/pkgs/applications/radio/gnuradio/nacl.nix
+++ b/pkgs/applications/radio/gnuradio/nacl.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio, uhd
+{ stdenv, fetchFromGitHub, cmake, pkg-config, boost, gnuradio, uhd
 , makeWrapper, libsodium, cppunit, log4cpp
 , pythonSupport ? true, python, swig
 }:
@@ -16,9 +16,9 @@ stdenv.mkDerivation {
     sha256 = "018np0qlk61l7mlv3xxx5cj1rax8f1vqrsrch3higsl25yydbv7v";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    cmake boost gnuradio uhd makeWrapper libsodium cppunit log4cpp
+    boost gnuradio uhd makeWrapper libsodium cppunit log4cpp
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''

--- a/pkgs/applications/radio/gnuradio/osmosdr.nix
+++ b/pkgs/applications/radio/gnuradio/osmosdr.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, pkgconfig, makeWrapper
+{ stdenv, fetchgit, cmake, pkg-config, makeWrapper
 , boost
 , pythonSupport ? true, python, swig
 , airspy
@@ -23,10 +23,9 @@ stdenv.mkDerivation rec {
     sha256 = "0bf9bnc1c3c4yqqqgmg3nhygj6rcfmyk6pybi27f7461d2cw1drv";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake makeWrapper pkg-config ];
   buildInputs = [
-    cmake makeWrapper boost log4cpp
-    airspy gnuradio hackrf libbladeRF rtl-sdr uhd
+    boost log4cpp airspy gnuradio hackrf libbladeRF rtl-sdr uhd
   ] ++ stdenv.lib.optionals stdenv.isLinux [ soapysdr-with-plugins ]
     ++ stdenv.lib.optionals pythonSupport [ python swig python.pkgs.cheetah ];
 

--- a/pkgs/applications/radio/gnuradio/rds.nix
+++ b/pkgs/applications/radio/gnuradio/rds.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio, log4cpp
+{ stdenv, fetchFromGitHub, cmake, pkg-config, boost, gnuradio, log4cpp
 , makeWrapper, pythonSupport ? true, python, swig
 }:
 
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "0jkzchvw0ivcxsjhi1h0mf7k13araxf5m4wi5v9xdgqxvipjzqfy";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    cmake boost gnuradio makeWrapper log4cpp
+    boost gnuradio makeWrapper log4cpp
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''

--- a/pkgs/applications/radio/tqsl/default.nix
+++ b/pkgs/applications/radio/tqsl/default.nix
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "00v4n8pvi5qi2psjnrw611w5gg5bdlaxbsny535fsci3smyygpc0";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [
-    cmake
     expat
     openssl
     zlib

--- a/pkgs/applications/science/astronomy/openspace/default.nix
+++ b/pkgs/applications/science/astronomy/openspace/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [
-    makeWrapper cmake
     curl boost gdal glew soil
     libX11 libXi libXxf86vm libXcursor libXrandr libXinerama
   ];

--- a/pkgs/applications/science/biology/cmtk/default.nix
+++ b/pkgs/applications/science/biology/cmtk/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "1nmsga9m7vcc4y4a6zl53ra3mwlgjwdgsq1j291awkn7zr1az6qs";
   };
 
-  buildInputs = [cmake];
+  nativeBuildInputs = [ cmake ];
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-Wno-error=c++11-narrowing";
 

--- a/pkgs/applications/science/biology/somatic-sniper/default.nix
+++ b/pkgs/applications/science/biology/somatic-sniper/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./somatic-sniper.patch ];
 
-  buildInputs = [ cmake zlib ncurses ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib ncurses ];
 
   enableParallelBuilding = false;
 

--- a/pkgs/applications/science/electronics/qfsm/default.nix
+++ b/pkgs/applications/science/electronics/qfsm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4, cmake, graphviz, pkgconfig }:
+{ stdenv, fetchurl, qt4, cmake, graphviz, pkg-config }:
 
 stdenv.mkDerivation rec {
   name = "qfsm-0.54.0";
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0rl7bc5cr29ng67yij4akciyid9z7npal812ys4c3m229vjvflrb";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ qt4 cmake graphviz ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ qt4 graphviz ];
 
   patches = [
     ./drop-hardcoded-prefix.patch
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
   ];
 
   hardeningDisable = [ "format" ];
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "Graphical editor for finite state machines";

--- a/pkgs/applications/science/electronics/qucs/default.nix
+++ b/pkgs/applications/science/electronics/qucs/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
     ./cmakelists.patch
   ];
 
-  buildInputs = [ flex bison qt4 libX11 cmake gperf adms ];
+  nativeBuildInputs = [ cmake flex bison ];
+  buildInputs = [ qt4 libX11 gperf adms ];
 
   meta = {
     description = "Integrated circuit simulator";

--- a/pkgs/applications/science/logic/avy/default.nix
+++ b/pkgs/applications/science/logic/avy/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ cmake zlib boost.out boost.dev ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib boost.out boost.dev ];
   NIX_CFLAGS_COMPILE = toString ([ "-Wno-narrowing" ]
     # Squelch endless stream of warnings on same few things
     ++ stdenv.lib.optionals stdenv.cc.isClang [

--- a/pkgs/applications/science/logic/lean2/default.nix
+++ b/pkgs/applications/science/logic/lean2/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation {
     sha256 = "1xv3j487zhh1zf2b4v19xzw63s2sgjhg8d62a0kxxyknfmdf3khl";
   };
 
-  buildInputs = [ gmp mpfr cmake python gperftools ninja makeWrapper ];
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake makeWrapper ninja ];
+  buildInputs = [ gmp mpfr python gperftools ];
 
   preConfigure = ''
     patchShebangs bin/leantags

--- a/pkgs/applications/science/logic/mcrl2/default.nix
+++ b/pkgs/applications/science/logic/mcrl2/default.nix
@@ -10,9 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1c8h94ja7271ph61zrcgnjgblxppld6v22f7f900prjgzbcfy14m";
   };
 
-  buildInputs = [ cmake libGLU libGL qt5.qtbase boost ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGLU libGL qt5.qtbase boost ];
 
   meta = with stdenv.lib; {
     description = "A toolset for model-checking concurrent systems and protocols";

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -31,7 +31,8 @@ let
   core = stdenv.mkDerivation {
     name = "${pname}-${version}";
     inherit src patches;
-    buildInputs = [ cmake zlib gmp jdk8 ];
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ zlib gmp jdk8 ];
 
     cmakeFlags = [
       "-DBUILD_STATIC=OFF"

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -65,8 +65,9 @@ stdenv.mkDerivation rec {
   CCACHE_DISABLE="1";
   CCACHE_DIR=".ccache";
 
+  nativeBuildInputs = [ cmake ];
   buildInputs = with lib; [
-      blas lapack bzip2 cmake colpack curl ctags eigen hdf5 json_c lp_solve lzma lzo
+      blas lapack bzip2 colpack curl ctags eigen hdf5 json_c lp_solve lzma lzo
       protobuf nlopt snappy swig (libarchive.dev) libxml2 lapack glpk
     ]
     ++ optionals (pythonSupport) (with pythonPackages; [ python ply numpy ])

--- a/pkgs/applications/science/misc/gplates/default.nix
+++ b/pkgs/applications/science/misc/gplates/default.nix
@@ -10,8 +10,9 @@ stdenv.mkDerivation rec {
     sha256 = "1jrcv498vpcs8xklhbsgg12yfa90f96p2mwq6x5sjnrlpf8mh50b";
   };
 
+  nativeBuildInputs = [ cmake ];
   buildInputs = [
-    qt4 qwt6_qt4 libGLU libGL glew gdal cgal proj cmake python2
+    qt4 qwt6_qt4 libGLU libGL glew gdal cgal proj python2
     doxygen graphviz gmp mpfr
     (boost.override {
       enablePython = true;

--- a/pkgs/applications/science/misc/root/5.nix
+++ b/pkgs/applications/science/misc/root/5.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, cmake, pcre, pkgconfig, python2
+{ stdenv, fetchurl, fetchpatch, cmake, pcre, pkg-config, python2
 , libX11, libXpm, libXft, libXext, libGLU, libGL, zlib, libxml2, lz4, lzma, gsl_1, xxHash
 , Cocoa, OpenGL, noSplash ? false }:
 
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ln448lszw4d6jmbdphkr2plwxxlhmjkla48vmmq750xc1lxlfrc";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake pcre python2 zlib libxml2 lz4 lzma gsl_1 xxHash ]
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ pcre python2 zlib libxml2 lz4 lzma gsl_1 xxHash ]
     ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext libGLU libGL ]
     ++ stdenv.lib.optionals (stdenv.isDarwin) [ Cocoa OpenGL ]
     ;

--- a/pkgs/applications/science/misc/vite/default.nix
+++ b/pkgs/applications/science/misc/vite/default.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation {
     ln -sv "${externals}" externals
   '';
 
-  buildInputs = [ cmake qt4 libGLU libGL ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 libGLU libGL ];
 
   NIX_LDFLAGS = "-lGLU";
 

--- a/pkgs/applications/science/programming/scyther/cli.nix
+++ b/pkgs/applications/science/programming/scyther/cli.nix
@@ -6,12 +6,8 @@ stdenv.mkDerivation {
 
   inherit src meta;
 
-  buildInputs = [
-    cmake
-    glibc.static
-    flex
-    bison
-  ];
+  nativeBuildInputs = [ cmake flex bison ];
+  buildInputs = [ glibc.static ];
 
   patchPhase = ''
     # Since we're not in a git dir, the normal command this project uses to create this file wouldn't work

--- a/pkgs/applications/science/robotics/yarp/default.nix
+++ b/pkgs/applications/science/robotics/yarp/default.nix
@@ -11,9 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0mphh899niy30xbjjwi9xpsliq8mladfldbbbjfngdrqfhiray1a";
   };
 
-  buildInputs = [ cmake ace ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ace ];
 
   cmakeFlags = [
     "-DYARP_COMPILE_UNMAINTAINED:BOOL=ON"

--- a/pkgs/applications/version-management/sit/default.nix
+++ b/pkgs/applications/version-management/sit/default.nix
@@ -13,8 +13,9 @@ rustPlatform.buildRustPackage rec {
     sha256 = "06xkhlfix0h6di6cnvc4blbj3mjy90scbh89dvywbx16wjlc79pf";
   };
 
-  buildInputs = [ cmake libzip gnupg ] ++
-    (if stdenv.isDarwin then [ libiconv CoreFoundation Security ] else []);
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libzip gnupg ]
+    ++ (stdenv.lib.optionals stdenv.isDarwin [ libiconv CoreFoundation Security ]);
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -47,7 +47,8 @@ let self = rec {
       sha256 = "1r3gs3c6zczmm66qcxh9mr306clwb3p7ykzb70r3jv5jqggiz199";
     };
 
-    buildInputs = [ cmake kodiPlain libcec_platform tinyxml ];
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ kodiPlain libcec_platform tinyxml ];
   };
 
   mkKodiPlugin = { plugin, namespace, version, sourceDir ? null, ... }@args:
@@ -75,8 +76,8 @@ let self = rec {
 
     dontStrip = true;
 
-    buildInputs = [ cmake kodiPlain kodi-platform libcec_platform ]
-               ++ extraBuildInputs;
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ kodiPlain kodi-platform libcec_platform ] ++ extraBuildInputs;
 
     inherit extraRuntimeDependencies;
 

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -1,5 +1,5 @@
 config:
-{ stdenv, cmake, pkgconfig, which
+{ stdenv, cmake, pkg-config, which
 
 # Xen
 , bison, bzip2, checkpolicy, dev86, figlet, flex, gettext, glib
@@ -66,7 +66,7 @@ stdenv.mkDerivation (rec {
 
   hardeningDisable = [ "stackprotector" "fortify" "pic" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     cmake which
 

--- a/pkgs/data/misc/shared-desktop-ontologies/default.nix
+++ b/pkgs/data/misc/shared-desktop-ontologies/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "shared-desktop-ontologies-0.11.0";
-  
+
   src = fetchurl {
     url = "mirror://sourceforge/oscaf/${name}.tar.bz2";
     sha256 = "1m5vnijg7rnwg41vig2ckg632dlczzdab1gsq51g4x7m9k1fdbw2";
   };
-  
-  buildInputs = [ cmake ];
-  
+
+  nativeBuildInputs = [ cmake ];
+
   meta = with stdenv.lib; {
     homepage = "http://oscaf.sourceforge.net/";
     description = "Ontologies necessary for the Nepomuk semantic desktop";
@@ -23,4 +23,3 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.sander ];
   };
 }
-

--- a/pkgs/development/compilers/dale/default.nix
+++ b/pkgs/development/compilers/dale/default.nix
@@ -1,18 +1,16 @@
 { stdenv
 , fetchFromGitHub
 , cmake
-, pkgconfig
+, pkg-config
 , libffi
 , llvm_6
 , doCheck ? false
 , perl
 }:
 
-let version = "20181024";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "dale";
-  inherit version;
+  version = "20181024";
 
   src = fetchFromGitHub {
     owner = "tomhrr";
@@ -21,15 +19,13 @@ in stdenv.mkDerivation {
     sha256 = "0v4ajrzrqvf279kd7wsd9flrpsav57lzxlwwimk9vnfwh7xpzf9v";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libffi llvm_6 ]
-             ++ stdenv.lib.optional doCheck perl;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libffi llvm_6 ];
 
   inherit doCheck;
+  checkInputs = [ perl ];
 
   checkTarget = "tests";
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Lisp-flavoured C";

--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, pkgconfig, boost, libunwind, libmemcached
+{ stdenv, fetchgit, cmake, pkg-config, boost, libunwind, libmemcached
 , pcre, libevent, gd, curl, libxml2, icu, flex, bison, openssl, zlib, php
 , expat, libcap, oniguruma, libdwarf, libmcrypt, tbb, gperftools, glog, libkrb5
 , bzip2, openldap, readline, libelf, uwimap, binutils, cyrus_sasl, pam, libpng
@@ -18,9 +18,10 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [ cmake pkg-config flex bison ];
   buildInputs =
-    [ cmake pkgconfig boost libunwind libmysqlclient libmemcached pcre gdb git perl
-      libevent gd curl libxml2 icu flex bison openssl zlib php expat libcap
+    [ boost libunwind libmysqlclient libmemcached pcre gdb git perl
+      libevent gd curl libxml2 icu openssl zlib php expat libcap
       oniguruma libdwarf libmcrypt tbb gperftools bzip2 openldap readline
       libelf uwimap binutils cyrus_sasl pam glog libpng libxslt libkrb5
       gmp libyaml libedit libvpx imagemagick fribidi gperf which
@@ -31,7 +32,6 @@ stdenv.mkDerivation rec {
     ./flexible-array-members-gcc6.patch
   ];
 
-  enableParallelBuilding = true;
   dontUseCmakeBuildDir = true;
   NIX_LDFLAGS = "-lpam -L${pam}/lib";
 

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, bison, pkgconfig, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python3, version, sha256, autoconf, libtool, automake, cmake, which
+{ stdenv, fetchurl, bison, pkg-config, glib, gettext, perl, libgdiplus, libX11, callPackage, ncurses, zlib, withLLVM ? false, cacert, Foundation, libobjc, python3, version, sha256, autoconf, libtool, automake, cmake, which
 , gnumake42
 , enableParallelBuilding ? true
 , srcArchiveSuffix ? "tar.bz2"
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
     url = "https://download.mono-project.com/sources/mono/${pname}-${version}.${srcArchiveSuffix}";
   };
 
-  nativeBuildInputs = [ gnumake42 ];
+  nativeBuildInputs = [ automake bison cmake pkg-config which gnumake42 ];
   buildInputs =
-    [ bison pkgconfig glib gettext perl libgdiplus libX11 ncurses zlib python3 autoconf libtool automake cmake which
+    [ glib gettext perl libgdiplus libX11 ncurses zlib python3 autoconf libtool
     ]
     ++ (stdenv.lib.optionals stdenv.isDarwin [ Foundation libobjc ]);
 

--- a/pkgs/development/compilers/mono/llvm.nix
+++ b/pkgs/development/compilers/mono/llvm.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation {
     sha256 = "07wd1cs3fdvzb1lv41b655z5zk34f47j8fgd9ljjimi5j9pj71f7";
   };
 
-  buildInputs = [ perl groff cmake libxml2 python2 libffi ] ++ lib.optional stdenv.isLinux valgrind;
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ perl groff libxml2 python2 libffi ] ++ lib.optional stdenv.isLinux valgrind;
 
   propagatedBuildInputs = [ ncurses zlib ];
 

--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -18,13 +18,13 @@ in clangStdenv.mkDerivation rec {
   };
 
   cmakeFlags = [ "-DUSE_BOOST_WAVE=ON" "-DENABLERTTI=ON" ];
-  enableParallelBuilding = true;
 
   preConfigure = '' patchShebangs src/liboslexec/serialize-bc.bash '';
-  
+
+  nativeBuildInputs = [ cmake boost_static flex bison];
   buildInputs = [
-     cmake zlib openexr openimageio llvm
-     boost_static flex bison partio pugixml
+     zlib openexr openimageio llvm
+     partio pugixml
      util-linux # needed just for hexdump
      python # CMake doesn't check this?
   ];

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation (rec {
     name = "v1.5.0.tar.gz";
   };
 
-  buildInputs = [ makeWrapper which libxml2 cmake z3 ];
+  nativeBuildInputs = [ cmake makeWrapper which ];
+  buildInputs = [ libxml2 z3 ];
   propagatedBuildInputs = [ cc ];
 
   # Sandbox disallows network access, so disabling problematic networking tests

--- a/pkgs/development/compilers/seexpr/default.nix
+++ b/pkgs/development/compilers/seexpr/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
     sha256 = "0a44k56jf6dl36fwgg4zpc252wq5lf9cblg74mp73k82hxw439l4";
   };
 
-  buildInputs = [ cmake libGLU libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGLU libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
   meta = with stdenv.lib; {
     description = "Embeddable expression evaluation engine from Disney Animation";
     homepage = "https://www.disneyanimation.com/technology/seexpr.html";

--- a/pkgs/development/interpreters/proglodyte-wasm/default.nix
+++ b/pkgs/development/interpreters/proglodyte-wasm/default.nix
@@ -14,7 +14,8 @@ let
       # set this to nonempty string to disable default cmake configure
     '';
 
-    buildInputs = [ cmake clang python ];
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ clang python ];
 
     buildPhase = "make clang-debug-no-tests";
 

--- a/pkgs/development/libraries/NSPlist/default.nix
+++ b/pkgs/development/libraries/NSPlist/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "0v4yfiwfd08hmh2ydgy6pnmlzjbd96k78dsla9pfd56ka89aw74r";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     maintainers = with maintainers; [ matthewbauer ];

--- a/pkgs/development/libraries/PlistCpp/default.nix
+++ b/pkgs/development/libraries/PlistCpp/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
     sha256 = "10jn6bvm9vn6492zix2pd724v5h4lccmkqg3lxfw8r0qg3av0yzv";
   };
 
-  buildInputs = [ cmake boost NSPlist pugixml ];
-
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost NSPlist pugixml ];
 
   meta = with stdenv.lib; {
     maintainers = with maintainers; [ matthewbauer ];

--- a/pkgs/development/libraries/alure/default.nix
+++ b/pkgs/development/libraries/alure/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0w8gsyqki21s1qb2s5ac1kj08i6nc937c0rr08xbw9w9wvd6lpj6";
   };
 
-  buildInputs = [ cmake openal ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openal ];
 
   meta = with stdenv.lib; {
     description = "A utility library to help manage common tasks with OpenAL applications";

--- a/pkgs/development/libraries/assimp/default.nix
+++ b/pkgs/development/libraries/assimp/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "00vxzfcrs856qnyk806wqr67nmpjk06mjby0fqmyhm6i1jj2hg1w";
   };
 
-  buildInputs = [ cmake boost zlib ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost zlib ];
 
   meta = with stdenv.lib; {
     description = "A library to import various 3D model formats";

--- a/pkgs/development/libraries/audio/jamomacore/default.nix
+++ b/pkgs/development/libraries/audio/jamomacore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, alsaLib, portaudio, portmidi, libsndfile, cmake, libxml2 }:
+{ stdenv, fetchFromGitHub, pkg-config, alsaLib, portaudio, portmidi, libsndfile, cmake, libxml2 }:
 
 stdenv.mkDerivation rec {
   version = "1.0-beta.1";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1hb9b6qc18rsvzvixgllknn756m6zwcn22c79rdibbyz1bhrcnln";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ alsaLib portaudio portmidi libsndfile cmake libxml2 ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ alsaLib portaudio portmidi libsndfile libxml2 ];
 
   meta = {
     description = "A C++ platform for building dynamic and reflexive systems with an emphasis on audio and media";

--- a/pkgs/development/libraries/audio/libgme/default.nix
+++ b/pkgs/development/libraries/audio/libgme/default.nix
@@ -20,9 +20,7 @@ in stdenv.mkDerivation {
     sha256 = "100ahb4n4pvgcry9xzlf2fr4j57n5h9x7pvyhhxys4dcy8axqqsy";
   };
 
-  buildInputs = [ cmake ];
-
-  nativeBuildInputs = [ removeReferencesTo ];
+  nativeBuildInputs = [ cmake removeReferencesTo ];
 
   # It used to reference it, in the past, but thanks to the postFixup hook, now
   # it doesn't.

--- a/pkgs/development/libraries/avro-c++/default.nix
+++ b/pkgs/development/libraries/avro-c++/default.nix
@@ -11,11 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1ars58bfw83s8f1iqbhnqp4n9wc9cxsph0gs2a8k7r9fi09vja2k";
   };
 
-  buildInputs = [
-    cmake
-    python2
-    boost
-  ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ python2 boost ];
 
   preConfigure = ''
     substituteInPlace test/SchemaTests.cc --replace "BOOST_CHECKPOINT" "BOOST_TEST_CHECKPOINT"

--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, unzip, cmake, libGLU, libGL, freeglut, libX11, xorgproto
-, libXi, pkgconfig }:
+, libXi, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "box2d";
@@ -12,10 +12,8 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "Box2D-${version}/Box2D";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    unzip cmake libGLU libGL freeglut libX11 xorgproto libXi
-  ];
+  nativeBuildInputs = [ cmake unzip pkg-config ];
+  buildInputs = [ libGLU libGL freeglut libX11 xorgproto libXi ];
 
   cmakeFlags = [
     "-DBOX2D_INSTALL=ON"

--- a/pkgs/development/libraries/cegui/default.nix
+++ b/pkgs/development/libraries/cegui/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "067562s71kfsnbp2zb2bmq8zj3jk96g5a4rcc5qc3n8nfyayhldk";
   };
 
-
-  buildInputs = [ cmake ogre freetype boost expat ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ogre freetype boost expat ];
 
   meta = with stdenv.lib; {
     homepage = "http://cegui.org.uk/";

--- a/pkgs/development/libraries/cpp-ipfs-api/default.nix
+++ b/pkgs/development/libraries/cpp-ipfs-api/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1z6gbd7npg4pd9wmdyzcp9h12sg84d7a43c69pp4lzqkyqg8pz1g";
   };
 
-  buildInputs = [ cmake curl ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ curl ];
   propagatedBuildInputs = [ nlohmann_json ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/cpp-netlib/default.nix
+++ b/pkgs/development/libraries/cpp-netlib/default.nix
@@ -12,13 +12,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ cmake boost openssl ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost openssl ];
 
   cmakeFlags = [
     "-DCPP-NETLIB_BUILD_SHARED_LIBS=ON"
   ];
-
-  enableParallelBuilding = true;
 
   # The test driver binary lacks an RPath to the library's libs
   preCheck = ''

--- a/pkgs/development/libraries/cppcms/default.nix
+++ b/pkgs/development/libraries/cppcms/default.nix
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
       sha256 = "0lmcdjzicmzhnr8pa0q3f5lgapz2cnh9w0dr56i4kj890iqwgzhh";
   };
 
-  enableParallelBuilding = true;
-
-  buildInputs = [ cmake pcre zlib python openssl ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ pcre zlib python openssl ];
 
   cmakeFlags = [
     "--no-warn-unused-cli"

--- a/pkgs/development/libraries/cppdb/default.nix
+++ b/pkgs/development/libraries/cppdb/default.nix
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
       sha256 = "0blr1casmxickic84dxzfmn3lm7wrsl4aa2abvpq93rdfddfy3nn";
   };
 
-  enableParallelBuilding = true;
-
-  buildInputs = [ cmake sqlite libmysqlclient postgresql unixODBC ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ sqlite libmysqlclient postgresql unixODBC ];
 
   cmakeFlags = [ "--no-warn-unused-cli" ];
   NIX_CFLAGS_COMPILE = "-I${libmysqlclient}/include/mysql -L${libmysqlclient}/lib/mysql";

--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation {
     rev   = version;
     sha256 = "071magxif5nrdddzk2z34czqmz1dfws4d7dqynb2zpn7cwhwxcpm";
   };
-  buildInputs = [ cmake sfml ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ sfml ];
   cmakeFlags = [ "-DCMAKE_MODULE_PATH=${sfml}/share/SFML/cmake/Modules/" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/ctpp2/default.nix
+++ b/pkgs/development/libraries/ctpp2/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1z22zfw9lb86z4hcan9hlvji49c9b7vznh7gjm95gnvsh43zsgx8";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   patchPhase = ''
     # include <unistd.h> to fix undefined getcwd

--- a/pkgs/development/libraries/curlcpp/default.nix
+++ b/pkgs/development/libraries/curlcpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, curl }: 
+{ stdenv, fetchFromGitHub, cmake, curl }:
 
 stdenv.mkDerivation rec {
   pname = "curlcpp";
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1zx76jcddqk4zkcdb6p7rsmkjbbjm2cj6drj0c8hdd61ms1d0f3n";
   };
 
-  buildInputs = [ cmake curl ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ curl ];
 
   meta = with stdenv.lib; {
     homepage = "https://josephp91.github.io/curlcpp/";
@@ -21,4 +22,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ rszibele ];
   };
 }
-

--- a/pkgs/development/libraries/embree/2.x.nix
+++ b/pkgs/development/libraries/embree/2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, ispc, tbb, glfw,
+{ stdenv, fetchFromGitHub, cmake, pkg-config, ispc, tbb, glfw,
 openimageio, libjpeg, libpng, libpthreadstubs, libX11
 }:
 
@@ -14,11 +14,11 @@ stdenv.mkDerivation {
   };
 
   cmakeFlags = [ "-DEMBREE_TUTORIALS=OFF" ];
-  enableParallelBuilding = true;
-  
-  buildInputs = [ pkgconfig cmake ispc tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ ispc tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ];
   meta = with stdenv.lib; {
-    description = "High performance ray tracing kernels from Intel"; 
+    description = "High performance ray tracing kernels from Intel";
     homepage = "https://embree.github.io/";
     maintainers = with maintainers; [ hodapp ];
     license = licenses.asl20;

--- a/pkgs/development/libraries/flann/default.nix
+++ b/pkgs/development/libraries/flann/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  buildInputs = [ unzip cmake python ];
+  nativeBuildInputs = [ unzip cmake python ];
 
   meta = {
     homepage = "http://people.cs.ubc.ca/~mariusm/flann/";

--- a/pkgs/development/libraries/freeglut/default.nix
+++ b/pkgs/development/libraries/freeglut/default.nix
@@ -12,7 +12,8 @@ in stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ libXi libXrandr libXxf86vm libGL libGLU xlibsWrapper cmake ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libXi libXrandr libXxf86vm libGL libGLU xlibsWrapper ];
 
   cmakeFlags = stdenv.lib.optionals stdenv.isDarwin [
                  "-DOPENGL_INCLUDE_DIR=${libGL}/include"

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
     cd ../build
   '';
 
-  enableParallelBuilding = true;
-  buildInputs = [ cmake vtk_7 ]
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ vtk_7 ]
     ++ stdenv.lib.optional stdenv.isDarwin [
       darwin.apple_sdk.frameworks.ApplicationServices
       darwin.apple_sdk.frameworks.Cocoa

--- a/pkgs/development/libraries/glbinding/default.nix
+++ b/pkgs/development/libraries/glbinding/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, libGLU, xlibsWrapper }:
+
 stdenv.mkDerivation rec {
   pname = "glbinding";
   version = "3.1.0";
@@ -10,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1avd7ssms11xx7h0cm8h4pfpk55f07f1j1ybykxfgsym2chb2z08";
   };
 
-  buildInputs = [ cmake libGLU xlibsWrapper ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGLU xlibsWrapper ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/cginternals/glbinding/";

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, clang-tools, grpc, curl, cmake, pkgconfig, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, fetchurl, openssl, zlib }:
+{ stdenv, clang-tools, grpc, curl, cmake, pkg-config, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, fetchurl, openssl, zlib }:
 let
   googleapis = fetchFromGitHub {
     owner = "googleapis";
@@ -16,7 +16,7 @@ let
       sha256 = "02zkcq2wl831ayd9qy009xvfx7q80pgycx7mzz9vknwd0nn6dd0n";
     };
 
-    nativeBuildInputs = [ cmake pkgconfig ];
+    nativeBuildInputs = [ cmake pkg-config ];
     buildInputs = [ c-ares c-ares.cmake-config grpc openssl protobuf zlib ];
 
     postPatch = ''
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ curl crc32c c-ares c-ares.cmake-config googleapis-cpp-cmakefiles grpc protobuf ];
-  nativeBuildInputs = [ clang-tools cmake pkgconfig doxygen ];
+  nativeBuildInputs = [ clang-tools cmake pkg-config doxygen ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/grantlee/default.nix
+++ b/pkgs/development/libraries/grantlee/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1b501xbimizmbmysl1j5zgnp48qw0r2r7lhgmxvzhzlv9jzhj60r";
   };
 
-  buildInputs = [ cmake qt4 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 ];
 
   meta = {
     description = "Qt4 port of Django template system";

--- a/pkgs/development/libraries/grib-api/default.nix
+++ b/pkgs/development/libraries/grib-api/default.nix
@@ -23,9 +23,8 @@ stdenv.mkDerivation rec {
     substituteInPlace "src/grib_jasper_encoding.c" --replace "image.inmem_    = 1;" ""
   '';
 
-  buildInputs = [ cmake
-                  netcdf
-                  gfortran
+  nativeBuildInputs = [ cmake gfortran ];
+  buildInputs = [ netcdf
                   libpng
                   openjpeg
                 ] ++ stdenv.lib.optionals enablePython [
@@ -41,8 +40,6 @@ stdenv.mkDerivation rec {
                  "-DENABLE_FORTRAN=ON"
                  "-DOPENJPEG_INCLUDE_DIR=${openjpeg.dev}/include/${openjpeg.incDir}"
                ];
-
-  enableParallelBuilding = true;
 
   doCheck = true;
 

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, c-ares, pkgconfig, openssl, protobuf
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, c-ares, pkg-config, openssl, protobuf
 , gflags, abseil-cpp, libnsl
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ zlib c-ares c-ares.cmake-config openssl protobuf gflags abseil-cpp ]
     ++ stdenv.lib.optionals stdenv.isLinux [ libnsl ];
 

--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, boost, cmake, hwloc, gperftools, pkgconfig, python }:
+{ stdenv, fetchFromGitHub, boost, cmake, hwloc, gperftools, pkg-config, python }:
 
 stdenv.mkDerivation rec {
   pname = "hpx";
@@ -12,9 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ boost hwloc gperftools ];
-  nativeBuildInputs = [ cmake pkgconfig python ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config python ];
 
   meta = {
     description = "C++ standard library for concurrency and parallelism";

--- a/pkgs/development/libraries/libLAS/default.nix
+++ b/pkgs/development/libraries/libLAS/default.nix
@@ -4,13 +4,12 @@ stdenv.mkDerivation rec {
   name = "libLAS-1.8.1";
 
   src = fetchurl {
-
     url = "https://download.osgeo.org/liblas/${name}.tar.bz2";
     sha256 = "0xjfxb3ydvr2258ji3spzyf81g9caap19ql2pk91wiivqsc4mnws";
   };
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  buildInputs = [ boost cmake gdal libgeotiff libtiff LASzip2 ];
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  buildInputs = [ boost gdal libgeotiff libtiff LASzip2 ];
 
   cmakeFlags = [
     "-DGDAL_CONFIG=${gdal}/bin/gdal-config"

--- a/pkgs/development/libraries/libbladeRF/default.nix
+++ b/pkgs/development/libraries/libbladeRF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, git, doxygen, help2man, ncurses, tecla
+{ stdenv, lib, fetchFromGitHub, pkg-config, cmake, git, doxygen, help2man, ncurses, tecla
 , libusb1, udev }:
 
 let
@@ -23,9 +23,9 @@ in stdenv.mkDerivation {
     sha256 = "0g89al4kwfbx1l3zjddgb9ay4mhr7zk0ndchca3sm1vq2j47nf4l";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config git doxygen help2man ];
   # ncurses used due to https://github.com/Nuand/bladeRF/blob/ab4fc672c8bab4f8be34e8917d3f241b1d52d0b8/host/utilities/bladeRF-cli/CMakeLists.txt#L208
-  buildInputs = [ cmake git doxygen help2man tecla libusb1 ]
+  buildInputs = [ tecla libusb1 ]
     ++ lib.optionals stdenv.isLinux [ udev ]
     ++ lib.optionals stdenv.isDarwin [ ncurses ];
 

--- a/pkgs/development/libraries/libbluedevil/default.nix
+++ b/pkgs/development/libraries/libbluedevil/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0p4f0brhcz9gfxfd6114fa5x6swfdmgzv350xwncdr0s1qnamk8c";
   };
 
-  buildInputs = [ cmake qt4 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 ];
 
   meta = {
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/libdynd/default.nix
+++ b/pkgs/development/libraries/libdynd/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     "-Wno-error=deprecated-copy"
   ];
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   outputs = [ "out" "dev" ];
   outputDoc = "dev";

--- a/pkgs/development/libraries/libebur128/default.nix
+++ b/pkgs/development/libraries/libebur128/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, speexdsp, pkgconfig }:
+{ stdenv, fetchFromGitHub, cmake, speexdsp, pkg-config }:
 
 stdenv.mkDerivation rec {
   version = "1.2.4";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0n81rnm8dm1zmibkr2v3q79rsd609y0dbbsrbay18njcjva88p0g";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake speexdsp ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ speexdsp ];
 
   meta = with stdenv.lib; {
     description = "Implementation of the EBU R128 loudness standard";

--- a/pkgs/development/libraries/libgroove/default.nix
+++ b/pkgs/development/libraries/libgroove/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./no-warnings-as-errors.patch ];
 
-  buildInputs = [ cmake libav SDL2 chromaprint libebur128 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libav SDL2 chromaprint libebur128 ];
 
   meta = with stdenv.lib; {
     description = "Streaming audio processing library";

--- a/pkgs/development/libraries/libharu/default.nix
+++ b/pkgs/development/libraries/libharu/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
     sha256 = "15s9hswnl3qqi7yh29jyrg0hma2n99haxznvcywmsp8kjqlyg75q";
   };
 
-  buildInputs = [ zlib libpng cmake ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib libpng ];
 
   meta = {
     description = "Cross platform, open source library for generating PDF files";

--- a/pkgs/development/libraries/libjreen/default.nix
+++ b/pkgs/development/libraries/libjreen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, qt4, pkgconfig, gsasl }:
+{ stdenv, fetchurl, cmake, qt4, pkg-config, gsasl }:
 
 stdenv.mkDerivation rec {
   pname = "libjreen";
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "14nwwk40xx8w6x7yaysgcr0lgzhs7l064f7ikp32s5y9a8mmp582";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake qt4 gsasl ];
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ qt4 gsasl ];
 
   meta = {
     description = "C++ Jabber library using Qt framework";

--- a/pkgs/development/libraries/libjson-rpc-cpp/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, jsoncpp, argtable, curl, libmicrohttpd
-, doxygen, catch, pkgconfig
+, doxygen, catch, pkg-config
 }:
 
 stdenv.mkDerivation rec {
@@ -53,8 +53,8 @@ stdenv.mkDerivation rec {
     cp -r Install/* $out
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake jsoncpp argtable curl libmicrohttpd doxygen catch ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ jsoncpp argtable curl libmicrohttpd doxygen catch ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/liblaxjson/default.nix
+++ b/pkgs/development/libraries/liblaxjson/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "01iqbpbhnqfifhv82m6hi8190w5sdim4qyrkss7z1zyv3gpchc5s";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description = "Library for parsing JSON config files";

--- a/pkgs/development/libraries/libmusicbrainz/5.x.nix
+++ b/pkgs/development/libraries/libmusicbrainz/5.x.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, cmake, neon, libdiscid, libxml2, pkgconfig }:
+{ stdenv, fetchFromGitHub, cmake, neon, libdiscid, libxml2, pkg-config }:
 
 stdenv.mkDerivation rec {
   version = "5.1.0";
   pname = "libmusicbrainz";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake neon libdiscid libxml2 ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ neon libdiscid libxml2 ];
 
   src = fetchFromGitHub {
     owner  = "metabrainz";

--- a/pkgs/development/libraries/libmusicbrainz/default.nix
+++ b/pkgs/development/libraries/libmusicbrainz/default.nix
@@ -3,7 +3,8 @@
 stdenv.mkDerivation rec {
   name = "libmusicbrainz-3.0.3";
 
-  buildInputs = [ cmake neon libdiscid ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ neon libdiscid ];
 
   src = fetchurl {
     url = "ftp://ftp.musicbrainz.org/pub/musicbrainz/${name}.tar.gz";

--- a/pkgs/development/libraries/libnabo/default.nix
+++ b/pkgs/development/libraries/libnabo/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "17vxlmszzpm95vvfdxnm98d5p297i10fyblblj6kf0ynq8r2mpsh";
   };
 
-  buildInputs = [cmake eigen boost];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ eigen boost ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libresample/default.nix
+++ b/pkgs/development/libraries/libresample/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation {
   preConfigure = ''
     cat debian/patches/1001_shlib-cmake.patch | patch -p1
   '';
-  buildInputs = [ cmake ];
-  
+  nativeBuildInputs = [ cmake ];
+
   meta = {
     description = "A real-time library for sampling rate conversion library";
     license = stdenv.lib.licenses.lgpl2Plus;

--- a/pkgs/development/libraries/libsnark/default.nix
+++ b/pkgs/development/libraries/libsnark/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, boost, gmp, procps }:
+{ stdenv, fetchFromGitHub, cmake, pkg-config, openssl, boost, gmp, procps }:
 
 let
   rev = "9e6b19ff15bc19fba5da1707ba18e7f160e5ed07";
@@ -7,7 +7,8 @@ in stdenv.mkDerivation rec {
   name = "libsnark-pre${version}";
   version = stdenv.lib.substring 0 8 rev;
 
-  buildInputs = [ cmake pkgconfig openssl boost gmp ] ++ lib.optional stdenv.hostPlatform.isLinux procps;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ openssl boost gmp ] ++ lib.optional stdenv.hostPlatform.isLinux procps;
 
   cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [ "-DWITH_PROCPS=OFF" "-DWITH_SUPERCOP=OFF" ];
 
@@ -18,8 +19,6 @@ in stdenv.mkDerivation rec {
     sha256          = "13f02qp2fmfhvxlp4xi69m0l8r5nq913l2f0zwdk7hl46lprfdca";
     fetchSubmodules = true;
   };
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "C++ library for zkSNARKs";

--- a/pkgs/development/libraries/libtcod/default.nix
+++ b/pkgs/development/libraries/libtcod/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation {
 
   cmakeFlags = [ "-DLIBTCOD_SAMPLES=OFF" ];
 
-  buildInputs = [ cmake SDL libGLU libGL upx zlib ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ SDL libGLU libGL upx zlib ];
 
   meta = {
     description = "API for roguelike games";

--- a/pkgs/development/libraries/libuecc/default.nix
+++ b/pkgs/development/libraries/libuecc/default.nix
@@ -10,9 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sm05aql75sh13ykgsv3ns4x4zzw9lvzid6misd22gfgf6r9n5fs";
   };
 
-  buildInputs = [ cmake ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description = "Very small Elliptic Curve Cryptography library";

--- a/pkgs/development/libraries/liquidfun/default.nix
+++ b/pkgs/development/libraries/liquidfun/default.nix
@@ -1,6 +1,6 @@
 { stdenv, requireFile, cmake, libGLU, libGL, libX11, libXi }:
 
-let 
+let
   sourceInfo = rec {
     version="1.1.0";
     name="liquidfun-${version}";
@@ -16,7 +16,8 @@ stdenv.mkDerivation {
   };
 
   inherit (sourceInfo) name version;
-  buildInputs = [ cmake libGLU libGL libX11 libXi ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGLU libGL libX11 libXi ];
 
   sourceRoot = "liquidfun/Box2D/";
 
@@ -26,10 +27,10 @@ stdenv.mkDerivation {
     sed -i Box2D/Common/b2Settings.h -e 's@b2_maxPolygonVertices .*@b2_maxPolygonVertices 15@'
     substituteInPlace Box2D/CMakeLists.txt --replace "Common/b2GrowableStack.h" "Common/b2GrowableStack.h Common/b2GrowableBuffer.h"
   '';
-      
+
   configurePhase = ''
     mkdir Build
-    cd Build; 
+    cd Build;
     cmake -DBOX2D_INSTALL=ON -DBOX2D_BUILD_SHARED=ON -DCMAKE_INSTALL_PREFIX=$out ..
   '';
 
@@ -45,4 +46,3 @@ stdenv.mkDerivation {
     homepage = "https://google.github.io/liquidfun/";
   };
 }
-

--- a/pkgs/development/libraries/lucene++/default.nix
+++ b/pkgs/development/libraries/lucene++/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [ "-DGTEST_INCLUDE_DIR=${gtest}/include" ];
-  buildInputs = [ cmake boost gtest ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost gtest ];
 
-  enableParallelBuilding = true;
   doCheck = true;
   checkTarget = "test";
 

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, libetpan, icu, cyrus_sasl, libctemplate
-, libuchardet, pkgconfig, glib, html-tidy, libxml2, libuuid, openssl
+, libuchardet, pkg-config, glib, html-tidy, libxml2, libuuid, openssl
 }:
 
 stdenv.mkDerivation rec {
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
     sha256 = "0a69q11z194fdfwyazjyyylx57sqs9j4lz7jwh5qcws8syqgb23z";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    libetpan cmake icu cyrus_sasl libctemplate libuchardet glib
+    libetpan icu cyrus_sasl libctemplate libuchardet glib
     html-tidy libxml2 libuuid openssl
   ];
 

--- a/pkgs/development/libraries/mygui/default.nix
+++ b/pkgs/development/libraries/mygui/default.nix
@@ -1,5 +1,5 @@
 {  stdenv, fetchFromGitHub, libX11, unzip, cmake, ois, freetype, libuuid,
-   boost, pkgconfig, withOgre ? false, ogre ? null, libGL, libGLU ? null } :
+   boost, pkg-config, withOgre ? false, ogre ? null, libGL, libGLU ? null } :
 
 let
   renderSystem = if withOgre then "3" else "4";
@@ -14,11 +14,9 @@ in stdenv.mkDerivation rec {
     sha256 = "0a4zi8w18pjj813n7kmxldl1d9r1jp0iyhkw7pbqgl8f7qaq994w";
   };
 
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libX11 unzip cmake ois freetype libuuid boost ]
-    ++ (if withOgre then [ ogre ] else [libGL libGLU]);
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libX11 unzip ois freetype libuuid boost ]
+    ++ (if withOgre then [ ogre ] else [ libGL libGLU ]);
 
   # Tools are disabled due to compilation failures.
   cmakeFlags = [ "-DMYGUI_BUILD_TOOLS=OFF" "-DMYGUI_BUILD_DEMOS=OFF" "-DMYGUI_RENDERSYSTEM=${renderSystem}" ];

--- a/pkgs/development/libraries/nanoflann/default.nix
+++ b/pkgs/development/libraries/nanoflann/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0lq1zqwjvk8wv15hd7aw57jsqbvv45cwb8ngdh1d2iyw5rvnbhsn";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
     "-DBUILD_EXAMPLES=OFF"

--- a/pkgs/development/libraries/nss_wrapper/default.nix
+++ b/pkgs/development/libraries/nss_wrapper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig }:
+{ stdenv, fetchurl, cmake, pkg-config }:
 
 stdenv.mkDerivation rec {
   name = "nss_wrapper-1.1.11";
@@ -8,8 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1q5l6w69yc71ly8gcbnkrcbnq6b64cbiiv99m0z5vn5lgwp36igv";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake pkg-config ];
 
   meta = with stdenv.lib; {
     description = "A wrapper for the user, group and hosts NSS API";

--- a/pkgs/development/libraries/ogre/1.10.x.nix
+++ b/pkgs/development/libraries/ogre/1.10.x.nix
@@ -2,7 +2,7 @@
 , cmake, libGLU, libGL
 , freetype, freeimage, zziplib, xorgproto, libXrandr
 , libXaw, freeglut, libXt, libpng, boost, ois
-, libX11, libXmu, libSM, pkgconfig
+, libX11, libXmu, libSM, pkg-config
 , libXxf86vm, libICE
 , libXrender
 , withNvidiaCg ? false, nvidia_cg_toolkit
@@ -21,13 +21,12 @@ stdenv.mkDerivation {
            ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
     ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
 
-  enableParallelBuilding = true;
-
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs =
-   [ cmake libGLU libGL
+   [ libGLU libGL
      freetype freeimage zziplib xorgproto libXrandr
      libXaw freeglut libXt libpng boost ois
-     libX11 libXmu libSM pkgconfig
+     libX11 libXmu libSM
      libXxf86vm libICE
      libXrender
    ] ++ lib.optional withNvidiaCg nvidia_cg_toolkit;

--- a/pkgs/development/libraries/ogre/1.9.x.nix
+++ b/pkgs/development/libraries/ogre/1.9.x.nix
@@ -2,7 +2,7 @@
 , cmake, libGLU, libGL
 , freetype, freeimage, zziplib, xorgproto, libXrandr
 , libXaw, freeglut, libXt, libpng, boost, ois
-, libX11, libXmu, libSM, pkgconfig
+, libX11, libXmu, libSM, pkg-config
 , libXxf86vm, libICE
 , libXrender
 , withNvidiaCg ? false, nvidia_cg_toolkit
@@ -24,13 +24,13 @@ stdenv.mkDerivation rec {
            ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
     ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
 
-  enableParallelBuilding = true;
 
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs =
-   [ cmake libGLU libGL
+   [ libGLU libGL
      freetype freeimage zziplib xorgproto libXrandr
      libXaw freeglut libXt libpng boost ois
-     libX11 libXmu libSM pkgconfig
+     libX11 libXmu libSM
      libXxf86vm libICE
      libXrender
    ] ++ lib.optional withNvidiaCg nvidia_cg_toolkit;

--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -2,7 +2,7 @@
 , cmake, libGLU, libGL
 , freetype, freeimage, zziplib, xorgproto, libXrandr
 , libXaw, freeglut, libXt, libpng, boost, ois
-, libX11, libXmu, libSM, pkgconfig
+, libX11, libXmu, libSM, pkg-config
 , libXxf86vm, libICE
 , unzip
 , libXrender
@@ -23,18 +23,16 @@ stdenv.mkDerivation rec {
            ([ "BSP" "OCTREE" "PCZ" "PFX" ] ++ lib.optional withNvidiaCg "CG")
     ++ map (x: "-DOGRE_BUILD_RENDERSYSTEM_${x}=on") [ "GL" ];
 
-  enableParallelBuilding = true;
 
+  nativeBuildInputs = [ cmake unzip pkg-config ];
   buildInputs =
    [ cmake libGLU libGL
      freetype freeimage zziplib xorgproto libXrandr
      libXaw freeglut libXt libpng boost ois
-     libX11 libXmu libSM pkgconfig
+     libX11 libXmu libSM
      libXxf86vm libICE
      libXrender
    ] ++ lib.optional withNvidiaCg nvidia_cg_toolkit;
-
-  nativeBuildInputs = [ unzip ];
 
   meta = {
     description = "A 3D engine";

--- a/pkgs/development/libraries/opencollada/default.nix
+++ b/pkgs/development/libraries/opencollada/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkgconfig, libxml2, pcre
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, libxml2, pcre
 , darwin}:
 
 stdenv.mkDerivation rec {
@@ -13,9 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ym16fxx9qhf952vva71sdzgbm7ifis0h1n5fj1bfdj8zvvkbw5w";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake ]
-    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ AGL ]);
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ AGL ]);
 
   propagatedBuildInputs = [ libxml2 pcre ];
 

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, stdenv, fetchFromGitHub, cmake, pkgconfig, xorg, libGLU
+{ config, lib, stdenv, fetchFromGitHub, cmake, pkg-config, xorg, libGLU
 , libGL, glew, ocl-icd, python3
 , cudaSupport ? config.cudaSupport or false, cudatoolkit
 , darwin
@@ -17,8 +17,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs =
-    [ cmake pkgconfig libGLU libGL python3
+    [ libGLU libGL python3
       # FIXME: these are not actually needed, but the configure script wants them.
       glew xorg.libX11 xorg.libXrandr xorg.libXxf86vm xorg.libXcursor
       xorg.libXinerama xorg.libXi

--- a/pkgs/development/libraries/opentracing-cpp/default.nix
+++ b/pkgs/development/libraries/opentracing-cpp/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "04kw19g8qrv3kd40va3sqbfish7kfczkdpxdwraifk9950wfs3gx";
   };
-  buildInputs = [ cmake ];
+
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "C++ implementation of the OpenTracing API";

--- a/pkgs/development/libraries/portmidi/default.nix
+++ b/pkgs/development/libraries/portmidi/default.nix
@@ -44,7 +44,8 @@ stdenv.mkDerivation rec {
     ln -s libportmidi.so "$out/lib/libporttime.so"
   '';
 
-  buildInputs = [ unzip cmake /*jdk*/ alsaLib ];
+  nativeBuildInputs = [ unzip cmake ];
+  buildInputs = [ alsaLib ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/libraries/properties-cpp/default.nix
+++ b/pkgs/development/libraries/properties-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, gtest, doxygen
+{ stdenv, fetchurl, cmake, pkg-config, gtest, doxygen
 , graphviz, lcov }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "08vjyv7ibn6jh2ikj5v48kjpr3n6hlkp9qlvdn8r0vpiwzah0m2w";
   };
 
-  buildInputs = [ cmake gtest doxygen pkgconfig graphviz lcov ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ gtest doxygen graphviz lcov ];
 
   patchPhase = ''
     sed -i "/add_subdirectory(tests)/d" CMakeLists.txt

--- a/pkgs/development/libraries/ptex/default.nix
+++ b/pkgs/development/libraries/ptex/default.nix
@@ -14,9 +14,8 @@ stdenv.mkDerivation rec
 
   outputs = [ "bin" "dev" "out" "lib" ];
 
-  buildInputs = [ zlib python cmake pkg-config ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib python pkg-config ];
 
   # Can be removed in the next release
   # https://github.com/wdas/ptex/pull/42

--- a/pkgs/development/libraries/qimageblitz/default.nix
+++ b/pkgs/development/libraries/qimageblitz/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation {
     sha256 = "0pnaf3qi7rgkxzs2mssmslb3f9ya4cyx09wzwlis3ppyvf72j0p9";
   };
 
-  buildInputs = [ cmake qt4 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 ];
 
   patches = [ ./qimageblitz-9999-exec-stack.patch ];
 

--- a/pkgs/development/libraries/qjson/default.nix
+++ b/pkgs/development/libraries/qjson/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1f4wnxzx0qdmxzc7hqk28m0sva7z9p9xmxm6aifvjlp0ha6pmfxs";
   };
 
-  buildInputs = [ cmake qt4 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 ];
 
   meta = with stdenv.lib; {
     description = "Lightweight data-interchange format";

--- a/pkgs/development/libraries/rabbitmq-c/default.nix
+++ b/pkgs/development/libraries/rabbitmq-c/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1iv7aww4pam8497s524xjxbbxypyqd01qgrb0b429y3q9x06m4sw";
   };
 
-  buildInputs = [ cmake openssl popt xmlto ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl popt xmlto ];
 
   meta = with stdenv.lib; {
     description = "RabbitMQ C AMQP client library";

--- a/pkgs/development/libraries/rnnoise-plugin/default.nix
+++ b/pkgs/development/libraries/rnnoise-plugin/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "11pwisbcks7g0mdgcrrv49v3ci1l6m26bbb7f67xz4pr1hai5dwc";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
 

--- a/pkgs/development/libraries/science/math/clblas/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/default.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
      "-DBUILD_TEST=OFF"
   ];
 
+  nativeBuildInputs = [ cmake ];
   buildInputs = [
-    cmake
     gfortran
     blas
     python
@@ -52,8 +52,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [
     OpenCL
   ];
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/clMathLibraries/clBLAS";

--- a/pkgs/development/libraries/science/math/metis/default.nix
+++ b/pkgs/development/libraries/science/math/metis/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   cmakeFlags = [ "-DGKLIB_PATH=../GKlib" ];
-  buildInputs = [ unzip cmake ];
+  nativeBuildInputs = [ unzip cmake ];
 
   meta = {
     description = "Serial graph partitioning and fill-reducing matrix ordering";

--- a/pkgs/development/libraries/science/math/parmetis/default.nix
+++ b/pkgs/development/libraries/science/math/parmetis/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0pvfpvb36djvqlcc3lq7si0c5xpb2cqndjg8wvzg35ygnwqs5ngj";
   };
 
-  buildInputs = [ cmake mpi ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ mpi ];
 
   # metis and GKlib are packaged with distribution
   # AUR https://aur.archlinux.org/packages/parmetis/ has reported that

--- a/pkgs/development/libraries/science/math/superlu/default.nix
+++ b/pkgs/development/libraries/science/math/superlu/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qzlb7cd608q62kyppd0a8c65l03vrwqql6gsm465rky23b6dyr8";
   };
 
-  buildInputs = [ cmake gfortran ];
+  nativeBuildInputs = [ cmake gfortran ];
 
   propagatedBuildInputs = [ blas ];
 

--- a/pkgs/development/libraries/science/robotics/ispike/default.nix
+++ b/pkgs/development/libraries/science/robotics/ispike/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchurl, cmake, boost
-}:
+{ stdenv, fetchurl, cmake, boost }:
 
 stdenv.mkDerivation rec {
   pname = "ispike";
@@ -10,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0khrxp43bi5kisr8j4lp9fl4r5marzf7b4inys62ac108sfb28lp";
   };
 
-  buildInputs = [ cmake boost ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
 
   meta = {
     description = "Spiking neural interface between iCub and a spiking neural simulator";
@@ -19,6 +19,4 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.nico202 ];
   };
-
-  
 }

--- a/pkgs/development/libraries/unittest-cpp/default.nix
+++ b/pkgs/development/libraries/unittest-cpp/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0sxb3835nly1jxn071f59fwbdzmqi74j040r81fanxyw3s1azw0i";
   };
 
-  buildInputs = [cmake];
+  nativeBuildInputs = [ cmake ];
 
   doCheck = false;
 

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -21,7 +21,8 @@ in stdenv.mkDerivation rec {
                                 sha256 = "1i1w6smijgb5z8bg9jaq84ccy00k2sxm87s37lgjpyix901gjlgi"; };
     in [ clangPatch ];
 
-  buildInputs = [ boost cmake fftw fftwSinglePrec hdf5 ilmbase libjpeg libpng
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost fftw fftwSinglePrec hdf5 ilmbase libjpeg libpng
                   libtiff numpy openexr python ];
 
   preConfigure = "cmakeFlags+=\" -DVIGRANUMPY_INSTALL_DIR=$out/lib/${python.libPrefix}/site-packages\"";

--- a/pkgs/development/libraries/vrpn/default.nix
+++ b/pkgs/development/libraries/vrpn/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "032q295d68w34rk5q8nfqdd29s55n00bfik84y7xzkjrpspaprlh";
   };
 
-  buildInputs = [ unzip cmake libGLU libGL ];
+  nativeBuildInputs = [ cmake unzip ];
+  buildInputs = [ libGLU libGL ];
 
   doCheck = false; # FIXME: test failure
   checkTarget = "test";

--- a/pkgs/development/libraries/vxl/default.nix
+++ b/pkgs/development/libraries/vxl/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation {
     sha256 = "0xpkwwb93ka6c3da8zjhfg9jk5ssmh9ifdh1by54sz6c7mbp55m8";
   };
 
-  buildInputs = [ cmake unzip libtiff expat zlib libpng libjpeg ];
+  nativeBuildInputs = [ cmake unzip ];
+  buildInputs = [ libtiff expat zlib libpng libjpeg ];
 
   cmakeFlags = [
     # BUILD_OUL wants old linux headers for videodev.h, not available

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, boost, pkgconfig, doxygen, qt48Full, libharu
+{ stdenv, fetchFromGitHub, cmake, boost, pkg-config, doxygen, qt48Full, libharu
 , pango, fcgi, firebird, libmysqlclient, postgresql, graphicsmagick, glew, openssl
 , pcre, harfbuzz
 }:
@@ -19,9 +19,9 @@ let
 
       enableParallelBuilding = true;
 
-      nativeBuildInputs = [ pkgconfig ];
+      nativeBuildInputs = [ cmake pkg-config ];
       buildInputs = [
-        cmake boost doxygen qt48Full libharu
+        boost doxygen qt48Full libharu
         pango fcgi firebird libmysqlclient postgresql graphicsmagick glew
         openssl pcre
       ];

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
 
   inherit (llvm) src;
 
-  buildInputs = [ python cmake ocaml findlib ctypes ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ python ocaml findlib ctypes ];
   propagatedBuildInputs = [ llvm ];
 
   patches = [ (fetchpatch {

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -19,7 +19,7 @@
 
 { lib, fetchurl, writeScript, ruby, kerberos, libxml2, libxslt, python, stdenv, which
 , libiconv, postgresql, v8, clang, sqlite, zlib, imagemagick
-, pkgconfig , ncurses, xapian, gpgme, util-linux, tzdata, icu, libffi
+, pkg-config , ncurses, xapian, gpgme, util-linux, tzdata, icu, libffi
 , cmake, libssh2, openssl, libmysqlclient, darwin, git, perl, pcre, gecode_3, curl
 , msgpack, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
@@ -41,7 +41,7 @@ in
 {
   atk = attrs: {
     dependencies = attrs.dependencies ++ [ "gobject-introspection" ];
-    nativeBuildInputs = [ rake bundler pkgconfig ];
+    nativeBuildInputs = [ rake bundler pkg-config ];
     propagatedBuildInputs = [ gobject-introspection wrapGAppsHook atk ];
   };
 
@@ -61,12 +61,12 @@ in
     };
 
   cairo = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ gtk2 pcre xorg.libpthreadstubs xorg.libXdmcp];
   };
 
   cairo-gobject = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ cairo pcre xorg.libpthreadstubs xorg.libXdmcp ];
   };
 
@@ -75,7 +75,7 @@ in
   };
 
   cld3 = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ protobuf ];
   };
 
@@ -180,12 +180,12 @@ in
   };
 
   ffi = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libffi ];
   };
 
   gdk_pixbuf2 = attrs: {
-    nativeBuildInputs = [ pkgconfig bundler rake ];
+    nativeBuildInputs = [ pkg-config bundler rake ];
     propagatedBuildInputs = [ gobject-introspection wrapGAppsHook gdk-pixbuf ];
   };
 
@@ -195,7 +195,7 @@ in
   };
 
   gio2 = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ gtk2 pcre gobject-introspection ] ++ lib.optionals stdenv.isLinux [ util-linux libselinux libsepol ];
   };
 
@@ -212,13 +212,13 @@ in
   };
 
   glib2 = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ gtk2 pcre ];
   };
 
   gtk2 = attrs: {
     nativeBuildInputs = [
-      binutils pkgconfig
+      binutils pkg-config
     ] ++ lib.optionals stdenv.isLinux [
       util-linux libselinux libsepol
     ];
@@ -238,12 +238,12 @@ in
   };
 
   gobject-introspection = attrs: {
-    nativeBuildInputs = [ pkgconfig pcre ];
+    nativeBuildInputs = [ pkg-config pcre ];
     propagatedBuildInputs = [ gobject-introspection wrapGAppsHook glib ];
   };
 
   grpc = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ openssl ];
     hardeningDisable = [ "format" ];
     NIX_CFLAGS_COMPILE = toString [
@@ -320,7 +320,7 @@ in
       cmake
       bison
       flex
-      pkgconfig
+      pkg-config
       python3
     ];
 
@@ -417,7 +417,7 @@ in
 
   pango = attrs: {
     nativeBuildInputs = [
-      pkgconfig
+      pkg-config
       fribidi
       harfbuzz
       pcre
@@ -475,7 +475,7 @@ in
   };
 
   rmagick = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkg-config ];
     buildInputs = [ imagemagick which ];
   };
 
@@ -484,7 +484,7 @@ in
   };
 
   ruby-libvirt = attrs: {
-    buildInputs = [ libvirt pkgconfig ];
+    buildInputs = [ libvirt pkg-config ];
     buildFlags = [
       "--with-libvirt-include=${libvirt}/include"
       "--with-libvirt-lib=${libvirt}/lib"
@@ -519,8 +519,8 @@ in
   };
 
   rugged = attrs: {
-    nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ which cmake openssl libssh2 zlib ];
+    nativeBuildInputs = [ cmake pkg-config which ];
+    buildInputs = [ openssl libssh2 zlib ];
     dontUseCmakeConfigure = true;
   };
 
@@ -587,7 +587,7 @@ in
   };
 
   tiny_tds = attrs: {
-    nativeBuildInputs = [ pkgconfig openssl ];
+    nativeBuildInputs = [ pkg-config openssl ];
     buildInputs = [ freetds ];
   };
 
@@ -616,7 +616,7 @@ in
   xapian-ruby = attrs: {
     # use the system xapian
     dontBuild = false;
-    nativeBuildInputs = [ rake pkgconfig bundler ];
+    nativeBuildInputs = [ rake pkg-config bundler ];
     buildInputs = [ xapian zlib ];
     postPatch = ''
       cp ${./xapian-Rakefile} Rakefile

--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -27,8 +27,8 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [ cmake ];
   buildInputs = [
-    cmake
     elfutils
     extra-cmake-modules
     kconfigwidgets
@@ -49,8 +49,6 @@ mkDerivation rec {
   postPatch = ''
     mkdir -p 3rdparty/perfparser/.git
   '';
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "A GUI for Linux perf";

--- a/pkgs/development/tools/analysis/ikos/default.nix
+++ b/pkgs/development/tools/analysis/ikos/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "0k3kp1af0qx3l1x6a4sl4fm8qlwchjvwkvs2ck0fhfnc62q2im5f";
   };
 
-  buildInputs = [ cmake boost tbb gmp clang llvm sqlite python
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost tbb gmp clang llvm sqlite python
                   ocamlPackages.apron mpfr ppl doxygen graphviz ];
 
   cmakeFlags = [ "-DAPRON_ROOT=${ocamlPackages.apron}" ];

--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DIWYU_LLVM_ROOT_PATH=${llvmPackages.clang-unwrapped}" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     substituteInPlace $out/bin/iwyu_tool.py \
       --replace "'include-what-you-use'" "'$out/bin/include-what-you-use'"

--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, libpfm, zlib, pkgconfig, python3Packages, which, procps, gdb, capnproto }:
+{ stdenv, fetchFromGitHub, cmake, libpfm, zlib, pkg-config, python3Packages, which, procps, gdb, capnproto }:
 
 stdenv.mkDerivation rec {
   version = "5.4.0";
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
   # see https://github.com/mozilla/rr/issues/2269
   preConfigure = ''substituteInPlace CMakeLists.txt --replace "std=c++11" "std=c++14"'';
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config which ];
   buildInputs = [
-    cmake libpfm zlib python3Packages.python python3Packages.pexpect which procps gdb capnproto
+    libpfm zlib python3Packages.python python3Packages.pexpect procps gdb capnproto
   ];
   propagatedBuildInputs = [ gdb ]; # needs GDB to replay programs at runtime
   cmakeFlags = [
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
   hardeningDisable = [ "fortify" ];
-
-  enableParallelBuilding = true;
 
   # FIXME
   #doCheck = true;

--- a/pkgs/development/tools/build-managers/arpa2cm/default.nix
+++ b/pkgs/development/tools/build-managers/arpa2cm/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "arpa2";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description = "CMake Module library for the ARPA2 project";

--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   pname = "minizinc";
   inherit version;
 
-  buildInputs = [ cmake flex bison ];
+  nativeBuildInputs = [ cmake flex bison ];
 
   src = fetchFromGitHub {
     owner = "MiniZinc";

--- a/pkgs/development/tools/misc/automoc4/default.nix
+++ b/pkgs/development/tools/misc/automoc4/default.nix
@@ -1,15 +1,17 @@
 { stdenv, fetchurl, cmake, qt4 }:
 
 stdenv.mkDerivation rec {
-  name = "automoc4-0.9.88";
-  
+  pname = "automoc4";
+  version = "0.9.88";
+
   src = fetchurl {
-    url = "mirror://kde/stable/automoc4/0.9.88/${name}.tar.bz2";
+    url = "mirror://kde/stable/automoc4/0.9.88/${pname}.tar.bz2";
     sha256 = "0jackvg0bdjg797qlbbyf9syylm0qjs55mllhn11vqjsq3s1ch93";
   };
-  
-  buildInputs = [ cmake qt4 ];
-  
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qt4 ];
+
   meta = with stdenv.lib; {
     homepage = "https://techbase.kde.org/Development/Tools/Automoc4";
     description = "KDE Meta Object Compiler";

--- a/pkgs/development/tools/misc/xc3sprog/default.nix
+++ b/pkgs/development/tools/misc/xc3sprog/default.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     rev = version;
   };
 
-  buildInputs = [ cmake libusb-compat-0_1 libftdi ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libusb-compat-0_1 libftdi ];
 
   meta = with stdenv.lib; {
     description = "Command-line tools for programming FPGAs, microcontrollers and PROMs via JTAG";

--- a/pkgs/development/tools/msgpack-tools/default.nix
+++ b/pkgs/development/tools/msgpack-tools/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, fetchFromGitHub, cmake, unzip }:
+{ stdenv, fetchurl, fetchFromGitHub, cmake }:
+
 stdenv.mkDerivation rec {
   pname = "msgpack-tools";
   version = "0.6";
@@ -32,8 +33,7 @@ stdenv.mkDerivation rec {
     cp ${mpack} $sourceRoot/contrib/mpack-df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz
   '';
 
-
-  buildInputs = [ cmake unzip ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {
     description = "Command-line tools for converting between MessagePack and JSON";

--- a/pkgs/development/tools/rucksack/default.nix
+++ b/pkgs/development/tools/rucksack/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0bcm20hqxqnq1j0zghb9i7z9frri6bbf7rmrv5g8dd626sq07vyv";
   };
 
-  buildInputs = [ cmake liblaxjson freeimage ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ liblaxjson freeimage ];
 
   meta = with stdenv.lib; {
     description = "Texture packer and resource bundler";

--- a/pkgs/development/tools/solarus-quest-editor/default.nix
+++ b/pkgs/development/tools/solarus-quest-editor/default.nix
@@ -1,9 +1,7 @@
-{ lib, mkDerivation, fetchFromGitLab, cmake, luajit,
-  SDL2, SDL2_image, SDL2_ttf, physfs,
-  openal, libmodplug, libvorbis, solarus,
-  qtbase, qttools, glm }:
+{ stdenv, fetchFromGitLab, cmake, luajit, SDL2, SDL2_image, SDL2_ttf, physfs
+, openal, libmodplug, libvorbis, solarus, qtbase, qttools, glm }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "solarus-quest-editor";
   version = "1.6.4";
 
@@ -13,13 +11,13 @@ mkDerivation rec {
     rev = "v${version}";
     sha256 = "1qbc2j9kalk7xqk9j27s7wnm5zawiyjs47xqkqphw683idmzmjzn";
   };
-  
-  buildInputs = [ cmake luajit SDL2
-    SDL2_image SDL2_ttf physfs
-    openal libmodplug libvorbis
-    solarus qtbase qttools glm ];
 
-  meta = with lib; {
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ luajit SDL2 SDL2_image SDL2_ttf physfs openal
+    libmodplug libvorbis solarus qtbase qttools glm ];
+
+  meta = with stdenv.lib; {
     description = "The editor for the Zelda-like ARPG game engine, Solarus";
     longDescription = ''
       Solarus is a game engine for Zelda-like ARPG games written in lua.
@@ -31,5 +29,5 @@ mkDerivation rec {
     maintainers = [ maintainers.Nate-Devv ];
     platforms = platforms.linux;
   };
-  
+
 }

--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -47,8 +47,6 @@ in stdenv.mkDerivation {
       --replace "#if HAVE_LIBCOMPRESSION" "#if 0"
   '';
 
-  enableParallelBuilding = true;
-
   # TODO: instruct cmake not to put it in /usr, rather than cleaning up
   postInstall = ''
     mv $out/usr/* $out
@@ -59,7 +57,8 @@ in stdenv.mkDerivation {
 
   cmakeFlags = [ "-GNinja" ];
 
-  buildInputs = [ cmake zlib libxml2 libpng ninja ]
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ zlib libxml2 libpng ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices CoreGraphics ImageIO ];
 
   meta = with stdenv.lib; {

--- a/pkgs/games/astromenace/default.nix
+++ b/pkgs/games/astromenace/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1rkz6lwjcd5mwv72kf07ghvx6z46kf3xs250mjbmnmjpn7r5sxwv";
   };
 
-  buildInputs = [ cmake xlibsWrapper libGLU libGL SDL openal freealut libogg libvorbis ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ xlibsWrapper libGLU libGL SDL openal freealut libogg libvorbis ];
 
   buildPhase = ''
     cmake ./

--- a/pkgs/games/blobby/default.nix
+++ b/pkgs/games/blobby/default.nix
@@ -1,23 +1,20 @@
-{stdenv, fetchurl, SDL2, SDL2_image, libGLU, libGL, cmake, physfs, boost, zip, zlib
-, pkgconfig, unzip}:
+{ stdenv, fetchurl, SDL2, SDL2_image, libGLU, libGL, cmake, physfs, boost, zip, zlib, pkg-config }:
+
 stdenv.mkDerivation rec {
-  version = "1.0";
   pname = "blobby-volley";
+  version = "1.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/blobby/Blobby%20Volley%202%20%28Linux%29/1.0/blobby2-linux-1.0.tar.gz";
     sha256 = "1qpmbdlyhfbrdsq4vkb6cb3b8mh27fpizb71q4a21ala56g08yms";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [SDL2 SDL2_image libGLU libGL cmake physfs boost zip zlib
-    unzip];
+  nativeBuildInputs = [ cmake pkg-config zip ];
+  buildInputs = [ SDL2 SDL2_image libGLU libGL physfs boost zlib ];
 
   preConfigure=''
     sed -e '1i#include <iostream>' -i src/NetworkMessage.cpp
   '';
-
-  inherit unzip;
 
   postInstall = ''
     cp ../data/Icon.bmp "$out/share/blobby/"
@@ -26,13 +23,12 @@ stdenv.mkDerivation rec {
     chmod a+x "$out/bin/blobby"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = ''A blobby volleyball game'';
-    license = stdenv.lib.licenses.bsd3;
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [raskin];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raskin ];
     homepage = "http://blobby.sourceforge.net/";
     downloadPage = "https://sourceforge.net/projects/blobby/files/Blobby%20Volley%202%20%28Linux%29/";
-    inherit version;
   };
 }

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -14,10 +14,10 @@ mkDerivation rec {
   };
 
   buildInputs = [
-    cmake qtbase qtmultimedia protobuf qttools qtwebsockets
+     qtbase qtmultimedia protobuf qttools qtwebsockets
   ];
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
 
   meta = {
     homepage = "https://github.com/Cockatrice/Cockatrice";

--- a/pkgs/games/holdingnuts/default.nix
+++ b/pkgs/games/holdingnuts/default.nix
@@ -25,7 +25,8 @@ in stdenv.mkDerivation rec {
     substituteInPlace src/system/SysAccess.c --replace /usr/share $out/share
   '';
 
-  buildInputs = [ cmake SDL qt4 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ SDL qt4 ];
 
   meta = with stdenv.lib; {
     homepage    = "http://www.holdingnuts.net/";

--- a/pkgs/games/ja2-stracciatella/default.nix
+++ b/pkgs/games/ja2-stracciatella/default.nix
@@ -30,7 +30,8 @@ stdenv.mkDerivation {
   inherit src;
   inherit version;
 
-  buildInputs = [ cmake SDL2 fltk boost ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ SDL2 fltk boost ];
 
   patches = [
     ./remove-rust-buildstep.patch
@@ -40,8 +41,6 @@ stdenv.mkDerivation {
     sed -i -e 's|rust-stracciatella|${libstracciatella}/lib/libstracciatella.so|g' CMakeLists.txt
     cmakeFlagsArray+=("-DEXTRA_DATA_DIR=$out/share/ja2")
   '';
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "Jagged Alliance 2, with community fixes";

--- a/pkgs/games/mars/default.nix
+++ b/pkgs/games/mars/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchgit, cmake, libGLU, libGL, sfml, fribidi, taglib }:
+{ stdenv, fetchFromGitHub, cmake, libGLU, libGL, sfml, fribidi, taglib }:
 stdenv.mkDerivation rec {
-  name = "mars-${version}-${rev}";
+  pname = "mars";
   version = "0.7.5";
-  rev = "c855d04409";
-  src = fetchgit {
-    url = "https://github.com/thelaui/M.A.R.S..git";
-    inherit rev;
+
+  src = fetchFromGitHub {
+    owner = "thelaui";
+    repo = "M.A.R.S.";
+    rev = "c855d044094a1d92317e38935d81ba938946132e";
     sha256 = "1r4c5gap1z2zsv4yjd34qriqkxaq4lb4rykapyzkkdf4g36lc3nh";
   };
-  buildInputs = [ cmake libGLU libGL sfml fribidi taglib ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libGLU libGL sfml fribidi taglib ];
   patches = [
     ./unbind_fix.patch
     ./fix-gluortho2d.patch

--- a/pkgs/games/megaglest/default.nix
+++ b/pkgs/games/megaglest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, pkgconfig, git, curl, SDL2, xercesc, openal, lua, libvlc
+{ stdenv, cmake, pkg-config, git, curl, SDL2, xercesc, openal, lua, libvlc
 , libjpeg, wxGTK, cppunit, ftgl, glew, libogg, libvorbis, buildEnv, libpng
 , fontconfig, freetype, xorg, makeWrapper, bash, which, gnome3, libGLU, glib
 , fetchFromGitHub
@@ -28,17 +28,17 @@ stdenv.mkDerivation {
     sha256 = "0fb58a706nic14ss89zrigphvdiwy5s9dwvhscvvgrfvjpahpcws";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake git curl SDL2 xercesc openal lua libpng libjpeg libvlc wxGTK
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ git curl SDL2 xercesc openal lua libpng libjpeg libvlc wxGTK
     glib cppunit fontconfig freetype ftgl glew libogg libvorbis makeWrapper libGLU ];
 
-  configurePhase = ''
-    cmake -DCMAKE_INSTALL_PREFIX=$out \
-          -DBUILD_MEGAGLEST=On \
-          -DBUILD_MEGAGLEST_MAP_EDITOR=On \
-          -DBUILD_MEGAGLEST_MODEL_IMPORT_EXPORT_TOOLS=On \
-          -DBUILD_MEGAGLEST_MODEL_VIEWER=On
-  '';
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=$out"
+    "-DBUILD_MEGAGLEST=On"
+    "-DBUILD_MEGAGLEST_MAP_EDITOR=On"
+    "-DBUILD_MEGAGLEST_MODEL_IMPORT_EXPORT_TOOLS=On"
+    "-DBUILD_MEGAGLEST_MODEL_VIEWER=On"
+  ];
 
   postInstall =  ''
     for i in $out/bin/*; do
@@ -48,11 +48,11 @@ stdenv.mkDerivation {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "An entertaining free (freeware and free software) and open source cross-platform 3D real-time strategy (RTS) game";
-    license = stdenv.lib.licenses.gpl3;
+    license = licenses.gpl3;
     homepage = "http://megaglest.org/";
-    maintainers = [ stdenv.lib.maintainers.matejc ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ maintainers.matejc ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/games/ninvaders/default.nix
+++ b/pkgs/games/ninvaders/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1wmwws1zsap4bfc2439p25vnja0hnsf57k293rdxw626gly06whi";
   };
 
-  buildInputs = [ cmake ncurses ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ncurses ];
 
   meta = with stdenv.lib; {
     description = "Space Invaders clone based on ncurses";

--- a/pkgs/games/opendungeons/default.nix
+++ b/pkgs/games/opendungeons/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ogre, cegui, boost, sfml, openal, cmake, ois, pkgconfig }:
+{ stdenv, fetchFromGitHub, ogre, cegui, boost, sfml, openal, cmake, ois, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "opendungeons";
@@ -13,14 +13,14 @@ stdenv.mkDerivation rec {
 
   patches = [ ./cmakepaths.patch ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake ogre cegui boost sfml openal ois ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ ogre cegui boost sfml openal ois ];
   NIX_LDFLAGS = "-lpthread";
 
   meta = with stdenv.lib; {
     description = "An open source, real time strategy game sharing game elements with the Dungeon Keeper series and Evil Genius";
     homepage = "https://opendungeons.github.io";
-    license = [ licenses.gpl3Plus licenses.zlib licenses.mit licenses.cc-by-sa-30 licenses.cc0 licenses.ofl licenses.cc-by-30 ];
+    license = with licenses; [ gpl3Plus zlib mit cc-by-sa-30 cc0 ofl cc-by-30 ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/games/openlierox/default.nix
+++ b/pkgs/games/openlierox/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libX11, xorgproto, gd, SDL, SDL_image, SDL_mixer, zlib
-, libxml2, pkgconfig, curl, cmake, libzip }:
+, libxml2, pkg-config, curl, cmake, libzip }:
 
 stdenv.mkDerivation {
   name = "openlierox-0.58rc3";
@@ -28,8 +28,9 @@ stdenv.mkDerivation {
     cp -R ../share/gamedir/* $out/share/OpenLieroX
   '';
 
+  nativeBuildInputs = [ cmake pkg-config curl ];
   buildInputs = [ libX11 xorgproto gd SDL SDL_image SDL_mixer zlib libxml2
-    pkgconfig curl cmake libzip ];
+    libzip ];
 
   meta = {
     homepage = "http://openlierox.net";

--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, mkDerivationWith, fetchFromGitHub, qtbase, openscenegraph, mygui, bullet, ffmpeg_3
-, boost, cmake, SDL2, unshield, openal, libXt, pkgconfig }:
+{ stdenv, fetchFromGitHub, qtbase, openscenegraph, mygui, bullet, ffmpeg_3
+, boost, cmake, SDL2, unshield, openal, libXt, pkg-config }:
 
 let
   openscenegraph_ = openscenegraph.overrideDerivation (self: {
@@ -10,7 +10,9 @@ let
       sha256 = "0d74hijzmj82nx3jkv5qmr3pkgvplra0b8fbjx1y3vmzxamb0axd";
     };
   });
-in mkDerivationWith stdenv.mkDerivation rec {
+in
+
+stdenv.mkDerivation rec {
   version = "0.46.0";
   pname = "openmw";
 
@@ -23,8 +25,8 @@ in mkDerivationWith stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake boost ffmpeg_3 bullet mygui openscenegraph_ SDL2 unshield openal libXt qtbase ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ boost ffmpeg_3 bullet mygui openscenegraph_ SDL2 unshield openal libXt qtbase ];
 
   cmakeFlags = [
     "-DDESIRED_QT_VERSION:INT=5"
@@ -33,7 +35,7 @@ in mkDerivationWith stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An unofficial open source engine reimplementation of the game Morrowind";
     homepage = "http://openmw.org";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
   };

--- a/pkgs/games/privateer/default.nix
+++ b/pkgs/games/privateer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchsvn, boost, cmake, ffmpeg_3, freeglut, glib,
   gtk2, libjpeg, libpng, libpthreadstubs, libvorbis, libXau, libXdmcp,
-  libXmu, libGLU, libGL, openal, pixman, pkgconfig, python27, SDL }:
+  libXmu, libGLU, libGL, openal, pixman, pkg-config, python27, SDL }:
 
 stdenv.mkDerivation {
   name = "privateer-1.03";
@@ -12,10 +12,11 @@ stdenv.mkDerivation {
     sha256 = "e1759087d4565d3fc95e5c87d0f6ddf36b2cd5befec5695ec56ed5f3cd144c63";
   };
 
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs =
-    [ boost cmake ffmpeg_3 freeglut glib gtk2 libjpeg libpng
+    [ boost ffmpeg_3 freeglut glib gtk2 libjpeg libpng
       libpthreadstubs libvorbis libXau libXdmcp libXmu libGLU libGL openal
-      pixman pkgconfig python27 SDL ];
+      pixman python27 SDL ];
 
   patches = [ ./0001-fix-VSFile-constructor.patch ];
 

--- a/pkgs/games/rigsofrods/default.nix
+++ b/pkgs/games/rigsofrods/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, stdenv, wxGTK30, freeimage, cmake, zziplib, libGLU, libGL, boost,
-  pkgconfig, libuuid, openal, ogre, ois, curl, gtk2, mygui, unzip,
+  pkg-config, libuuid, openal, ogre, ois, curl, gtk2, mygui, unzip,
   angelscript, ogrepaged, mysocketw, libxcb
   }:
 
@@ -25,17 +25,17 @@ stdenv.mkDerivation rec {
     ln -s $out/share/rigsofrods/{RoR,RoRConfig} $out/bin
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ wxGTK30 freeimage cmake zziplib libGLU libGL boost
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ wxGTK30 freeimage zziplib libGLU libGL boost
     libuuid openal ogre ois curl gtk2 mygui unzip angelscript
     ogrepaged mysocketw libxcb ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "3D simulator game where you can drive, fly and sail various vehicles";
     homepage = "http://rigsofrods.sourceforge.net/";
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
     hydraPlatforms = [];
   };
 }

--- a/pkgs/games/stuntrally/default.nix
+++ b/pkgs/games/stuntrally/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, cmake, boost, ogre, mygui, ois, SDL2, libvorbis, pkgconfig
+{ fetchurl, stdenv, cmake, boost, ogre, mygui, ois, SDL2, libvorbis, pkg-config
 , makeWrapper, enet, libXcursor, bullet, openal }:
 
 stdenv.mkDerivation rec {
@@ -26,12 +26,10 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake boost ogre mygui ois SDL2 libvorbis 
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ boost ogre mygui ois SDL2 libvorbis
     makeWrapper enet libXcursor bullet openal
   ];
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Stunt Rally game with Track Editor, based on VDrift and OGRE";

--- a/pkgs/games/trackballs/default.nix
+++ b/pkgs/games/trackballs/default.nix
@@ -1,24 +1,23 @@
 { stdenv, fetchFromGitHub, cmake, SDL2, SDL2_ttf, gettext, zlib, SDL2_mixer, SDL2_image, guile, libGLU, libGL }:
 
-with stdenv.lib;
-
 stdenv.mkDerivation rec {
   pname = "trackballs";
   version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "trackballs";
-    repo = "trackballs";
+    repo = pname;
     rev = "v${version}";
     sha256 = "G+KfQgqk+iI+Beb/ZRul2ArCBcvwYQ/ftEWzdrtwb18=";
   };
 
-  buildInputs = [ cmake zlib SDL2 SDL2_ttf SDL2_mixer SDL2_image guile gettext libGLU libGL ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib SDL2 SDL2_ttf SDL2_mixer SDL2_image guile gettext libGLU libGL ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://trackballs.github.io/";
     description = "3D Marble Madness clone";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2;
+    platforms = platforms.linux;
+    license = licenses.gpl2;
   };
 }

--- a/pkgs/games/xskat/default.nix
+++ b/pkgs/games/xskat/default.nix
@@ -1,37 +1,29 @@
 {stdenv, fetchurl, libX11, imake, gccmakedep}:
 
+stdenv.mkDerivation rec {
+  pname = "xskat";
+  version = "4.0";
 
-let
-  s = # Generated upstream information
-  rec {
-    baseName="xskat";
-    version="4.0";
-    name="${baseName}-${version}";
+  nativeBuildInputs = [ gccmakedep ];
+  buildInputs = [ libX11 imake ];
 
-    url="http://www.xskat.de/xskat-4.0.tar.gz";
-    hash="8ba52797ccbd131dce69b96288f525b0d55dee5de4008733f7a5a51deb831c10";
-    sha256="8ba52797ccbd131dce69b96288f525b0d55dee5de4008733f7a5a51deb831c10";
-  };
-   buildInputs = [ libX11 imake gccmakedep ];
-in
-
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
   src = fetchurl {
-    inherit (s) url sha256;
+    url = "http://www.xskat.de/xskat-${version }.tar.gz";
+    sha256 = "8ba52797ccbd131dce69b96288f525b0d55dee5de4008733f7a5a51deb831c10";
   };
+
   preInstall = ''
     sed -i Makefile \
       -e "s|.* BINDIR .*|   BINDIR = $out/bin|" \
       -e "s|.* MANPATH .*|  MANPATH = $out/man|"
   '';
+
   installTargets = [ "install" "install.man" ];
-  meta = {
-    inherit (s) version;
+
+  meta = with stdenv.lib; {
     description = ''Famous german card game'';
-    platforms = stdenv.lib.platforms.unix;
-    license = stdenv.lib.licenses.free;
+    platforms = platforms.unix;
+    license = licenses.free;
     longDescription = ''Play the german card game Skat against the AI or over IRC.'';
     homepage = "http://www.xskat.de/";
   };

--- a/pkgs/misc/emulators/hatari/default.nix
+++ b/pkgs/misc/emulators/hatari/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   # For pthread_cancel
   cmakeFlags = [ "-DCMAKE_EXE_LINKER_FLAGS=-lgcc_s" ];
 
-  buildInputs = [ zlib SDL cmake ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib SDL ];
 
   meta = {
     homepage = "http://hatari.tuxfamily.org/";

--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -6,15 +6,15 @@
     packageOverrides = pkgs : with pkgs; {
       sdlEnv = pkgs.myEnvFun {
           name = "sdl";
-  nativeBuildInputs = [ pkgconfig ];
-          buildInputs = [ stdenv SDL SDL_image SDL_ttf SDL_gfx cmake SDL_net];
+          nativeBuildInputs = [ cmake pkg-config ];
+          buildInputs = [ stdenv SDL SDL_image SDL_ttf SDL_gfx SDL_net];
       };
     };
   }
 
-  # Then you can install it by:  
+  # Then you can install it by:
   #  $ nix-env -i env-sdl
-  # And you can load it simply calling:  
+  # And you can load it simply calling:
   #  $ load-env-sdl
   # and this will update your env vars to have 'make' and 'gcc' finding the SDL
   # headers and libs.
@@ -29,7 +29,7 @@
     let complicatedMyEnv = { name, buildInputs ? [], cTags ? [], extraCmds ? ""}:
             pkgs.myEnvFun {
               inherit name;
-            buildInputs = buildInputs 
+            buildInputs = buildInputs
                   ++ map (x : sourceWithTagsDerivation
                     ( (addCTaggingInfo x ).passthru.sourceWithTags ) ) cTags;
             extraCmds = ''

--- a/pkgs/misc/screensavers/xss-lock/default.nix
+++ b/pkgs/misc/screensavers/xss-lock/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, docutils, pkgconfig, glib, libpthreadstubs
+{ stdenv, fetchFromGitHub, cmake, docutils, pkg-config, glib, libpthreadstubs
 , libXau, libXdmcp, xcbutil }:
 
 stdenv.mkDerivation {
@@ -11,9 +11,8 @@ stdenv.mkDerivation {
     sha256 = "040nqgfh564frvqkrkmak3x3h0yadz6kzk81jkfvd9vd20a9drh7";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake docutils glib libpthreadstubs libXau
-                  libXdmcp xcbutil ];
+  nativeBuildInputs = [ cmake pkg-config docutils ];
+  buildInputs = [ glib libpthreadstubs libXau libXdmcp xcbutil ];
 
   meta = with stdenv.lib; {
     description = "Use external locker (such as i3lock) as X screen saver";

--- a/pkgs/os-specific/darwin/darling/default.nix
+++ b/pkgs/os-specific/darwin/darling/default.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
     cp src/libaks/include/* $out/include
   '';
 
-  # buildInputs = [ cmake bison flex ];
-
   meta = with lib; {
     maintainers = with maintainers; [ matthewbauer ];
     license = licenses.gpl3;

--- a/pkgs/os-specific/darwin/swift-corelibs/libdispatch.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/libdispatch.nix
@@ -8,5 +8,6 @@ stdenv.mkDerivation rec {
     rev = "f83b5a498bad8e9ff8916183cf6e8ccf677c346b";
     sha256 = "1czkyyc9llq2mnqfp19mzcfsxzas0y8zrk0gr5hg60acna6jkz2l";
   };
-  buildInputs = [ cmake apple_sdk_sierra.sdk xnu-new ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ apple_sdk_sierra.sdk xnu-new ];
 }

--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchurl
-, cmake, pkgconfig, dbus, makeWrapper
+, cmake, pkg-config, dbus, makeWrapper
 , gtest
 , boost
 , libcap
@@ -55,11 +55,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    cmake
+    pkg-config
     makeWrapper
   ];
 
   buildInputs = [
-    cmake pkgconfig dbus boost libcap gtest systemd mesa glib
+    dbus boost libcap gtest systemd mesa glib
     SDL2 SDL2_image protobuf protobufc properties-cpp lxc python
     libGL
   ];

--- a/pkgs/os-specific/linux/libwebcam/default.nix
+++ b/pkgs/os-specific/linux/libwebcam/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , cmake
-, pkgconfig
+, pkg-config
 , libxml2
 }:
 
@@ -19,11 +19,8 @@ stdenv.mkDerivation rec {
     ./uvcdynctrl_symlink_support_and_take_data_dir_from_env.patch
   ];
 
-  buildInputs = [
-    cmake
-    pkgconfig
-    libxml2
-  ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libxml2 ];
 
   postPatch = ''
     substituteInPlace ./uvcdynctrl/CMakeLists.txt \

--- a/pkgs/servers/misc/taskserver/default.nix
+++ b/pkgs/servers/misc/taskserver/default.nix
@@ -4,8 +4,6 @@ stdenv.mkDerivation rec {
   pname = "taskserver";
   version = "1.1.0";
 
-  enableParallelBuilding = true;
-
   src = fetchurl {
     url = "http://www.taskwarrior.org/download/taskd-${version}.tar.gz";
     sha256 = "1d110q9vw8g5syzihxymik7hd27z1592wkpz55kya6lphzk8i13v";
@@ -30,8 +28,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  buildInputs = [ makeWrapper ];
-  nativeBuildInputs = [ cmake libuuid gnutls ];
+  buildInputs = [ libuuid gnutls ];
+  nativeBuildInputs = [ cmake makeWrapper ];
 
   meta = {
     description = "Server for synchronising Taskwarrior clients";

--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchgit, fetchurl, runCommand, git, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, fetchgit, fetchurl, runCommand, git, cmake, pkg-config
 , openssl,  zlib, boost, grpc, c-ares, abseil-cpp, protobuf3_8, libnsl }:
 
 let
@@ -129,7 +129,7 @@ in stdenv.mkDerivation rec {
   hardeningDisable = ["format"];
   cmakeFlags = ["-Dstatic=OFF" "-DBoost_NO_BOOST_CMAKE=ON"];
 
-  nativeBuildInputs = [ pkgconfig cmake git ];
+  nativeBuildInputs = [ pkg-config cmake git ];
   buildInputs = [ openssl openssl.dev boostSharedStatic zlib grpc c-ares c-ares.cmake-config abseil-cpp protobuf3_8 libnsl ];
 
   preConfigure = ''

--- a/pkgs/servers/sql/percona/5.6.x.nix
+++ b/pkgs/servers/sql/percona/5.6.x.nix
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "09qqk02iny7jvngyk6k2j0kk2sspc6gw8sm3i6nn97njbkihi697";
   };
 
-  buildInputs = [ cmake bison ncurses openssl zlib libaio perl ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake bison perl ];
+  buildInputs = [ ncurses openssl zlib libaio ];
 
   cmakeFlags = [
     "-DFEATURE_SET=community"

--- a/pkgs/servers/uhub/default.nix
+++ b/pkgs/servers/uhub/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchpatch, fetchFromGitHub, cmake, openssl, sqlite, pkgconfig, systemd
+{ stdenv, fetchpatch, fetchFromGitHub, cmake, openssl, sqlite, pkg-config, systemd
 , tlsSupport ? false }:
 
 assert tlsSupport -> openssl != null;
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "0zdbxfvw7apmfhqgsfkfp4pn9iflzwdn0zwvzymm5inswfc00pxg";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake sqlite systemd ] ++ stdenv.lib.optional tlsSupport openssl;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ sqlite systemd ] ++ stdenv.lib.optional tlsSupport openssl;
 
   outputs = [ "out"
     "mod_example"

--- a/pkgs/tools/audio/acoustid-fingerprinter/default.nix
+++ b/pkgs/tools/audio/acoustid-fingerprinter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, cmake, pkgconfig, qt4, taglib, chromaprint, ffmpeg }:
+{ stdenv, fetchurl, fetchpatch, cmake, pkg-config, qt4, taglib, chromaprint, ffmpeg }:
 
 stdenv.mkDerivation rec {
   pname = "acoustid-fingerprinter";
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ckglwy95qgqvl2l6yd8ilwpd6qs7yzmj8g7lnxb50d12115s5n0";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake qt4 taglib chromaprint ffmpeg ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ qt4 taglib chromaprint ffmpeg ];
 
   cmakeFlags = [ "-DTAGLIB_MIN_VERSION=${stdenv.lib.getVersion taglib}" ];
 

--- a/pkgs/tools/cd-dvd/cdrkit/default.nix
+++ b/pkgs/tools/cd-dvd/cdrkit/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1nj7iv3xrq600i37na9a5idd718piiiqbs4zxvpjs66cdrsk1h6i";
   };
 
-  buildInputs = [cmake libcap zlib bzip2 perl];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libcap zlib bzip2 perl ];
 
   hardeningDisable = [ "format" ];
 
@@ -36,7 +37,7 @@ stdenv.mkDerivation rec {
       cdrkit is not affiliated with any of these authors; it is now an
       independent project.
     '';
-    
+
     homepage = "http://cdrkit.org/";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/cd-dvd/vobsub2srt/default.nix
+++ b/pkgs/tools/cd-dvd/vobsub2srt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, libtiff, pkgconfig, tesseract }:
+{ stdenv, fetchgit, cmake, libtiff, pkg-config, tesseract }:
 
 let rev = "a6abbd61127a6392d420bbbebdf7612608c943c2";
     shortRev = builtins.substring 0 7 rev;
@@ -12,8 +12,8 @@ stdenv.mkDerivation {
     sha256 = "1rpanrv8bgdh95v2320qbd44xskncvq6y84cbbfc86gw0qxpd9cb";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libtiff ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libtiff ];
   propagatedBuildInputs = [ tesseract ];
 
   meta = {

--- a/pkgs/tools/compression/lzham/default.nix
+++ b/pkgs/tools/compression/lzham/default.nix
@@ -10,9 +10,7 @@ stdenv.mkDerivation {
     sha256 = "14c1zvzmp1ylp4pgayfdfk1kqjb23xj4f7ll1ra7b18wjxc9ja1v";
   };
 
-  buildInputs = [ cmake ];
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -5,9 +5,8 @@
 with stdenv;
 
 {
-  enableParallelBuilding = true;
-
-  buildInputs = [ bzip2 zlib autoconf automake cmake gnumake help2man texinfo libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc kerberos gcc boost libcxx which catch2 ];
+  nativeBuildInputs = [ autoconf automake cmake gnumake help2man texinfo which gcc ];
+  buildInputs = [ bzip2 zlib libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc kerberos boost libcxx catch2 ];
 
   cmakeFlags = [
     "-DIRODS_EXTERNALS_FULLPATH_CLANG=${stdenv.cc}"

--- a/pkgs/tools/filesystems/unionfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/unionfs-fuse/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
       ./prevent-kill-on-shutdown.patch
     ];
 
-  buildInputs = [ cmake fuse ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ fuse ];
 
   # Put the unionfs mount helper in place as mount.unionfs-fuse. This makes it
   # possible to do:

--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, guile,
+{ stdenv, fetchFromGitHub, cmake, boost165, pkg-config, guile,
 eigen, libpng, python, libGLU, qt4, openexr, openimageio,
 opencolorio, xercesc, ilmbase, osl, seexpr, makeWrapper
 }:
@@ -18,10 +18,11 @@ in stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1sq9s0rzjksdn8ayp1g17gdqhp7fqks8v1ddd3i5rsl96b04fqx5";
   };
+  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
   buildInputs = [
-    cmake pkgconfig boost_static guile eigen libpng python
+    boost_static guile eigen libpng python
     libGLU qt4 openexr openimageio opencolorio xercesc
-    osl seexpr makeWrapper
+    osl seexpr
   ];
 
   NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/tools/graphics/gromit-mpx/default.nix
+++ b/pkgs/tools/graphics/gromit-mpx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, pkg-config
 , gtk, glib, pcre, libappindicator, libpthreadstubs, libXdmcp
 , libxkbcommon, epoxy, at-spi2-core, dbus, libdbusmenu
 , wrapGAppsHook
@@ -15,9 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1xn14r7lhay720y78j1fs4amp5lia39kpq7vzv02x4nnwhgbsd9r";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+  nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
   buildInputs = [
-    cmake
     gtk glib pcre libappindicator libpthreadstubs
     libXdmcp libxkbcommon epoxy at-spi2-core
     dbus libdbusmenu

--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, python36
+{ stdenv, fetchFromGitHub, cmake, boost165, pkg-config, python36
 , tbb, openimageio, libjpeg, libpng, zlib, libtiff, ilmbase
 , freetype, openexr, libXdmcp, libxkbcommon, epoxy, at-spi2-core
 , dbus, doxygen, qt5, c-blosc, libGLU, gnome3, dconf, gtk3, pcre
@@ -30,17 +30,17 @@ in stdenv.mkDerivation {
     inherit sha256;
   };
 
+  nativeBuildInputs = [ cmake flex bison doxygen makeWrapper pkg-config ];
   buildInputs =
-   [ embree2 pkgconfig cmake zlib boost_static libjpeg
+   [ embree2 zlib boost_static libjpeg
      libtiff libpng ilmbase freetype openexr openimageio
-     tbb qt5.full c-blosc libGLU pcre bison
-     flex libX11 libpthreadstubs python libXdmcp libxkbcommon
-     epoxy at-spi2-core dbus doxygen
+     tbb qt5.full c-blosc libGLU pcre
+     libX11 libpthreadstubs python libXdmcp libxkbcommon
+     epoxy at-spi2-core dbus
      # needed for GSETTINGS_SCHEMAS_PATH
      gsettings-desktop-schemas glib gtk3
      # needed for XDG_ICON_DIRS
      gnome3.adwaita-icon-theme
-     makeWrapper
      (stdenv.lib.getLib dconf)
    ] ++ stdenv.lib.optionals withOpenCL [opencl-headers ocl-icd opencl-clhpp];
 

--- a/pkgs/tools/graphics/yafaray-core/default.nix
+++ b/pkgs/tools/graphics/yafaray-core/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, opencv, zlib
+{ stdenv, fetchFromGitHub, cmake, pkg-config, opencv, zlib
 , libxml2, freetype, libjpeg, libtiff, swig, openexr
 , ilmbase, boost165
 , withPython ? true, python3
@@ -20,8 +20,9 @@ stdenv.mkDerivation rec {
       NIX_CFLAGS_COMPILE+=" -isystem ${ilmbase.dev}/include/OpenEXR"
     '';
 
+    nativeBuildInputs = [ cmake pkg-config ];
     buildInputs = [
-      cmake pkgconfig boost165 opencv zlib libxml2 freetype libjpeg libtiff
+      boost165 opencv zlib libxml2 freetype libjpeg libtiff
       swig openexr ilmbase
     ] ++ stdenv.lib.optional withPython python3;
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-anthy/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-anthy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, anthy, gettext, pkgconfig }:
+{ stdenv, fetchurl, cmake, fcitx, anthy, gettext, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-anthy";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "01jx7wwq0mifqrzkswfglqhwkszbfcl4jinxgdgqx9kc6mb4k6zd";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx anthy gettext ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx anthy gettext ];
 
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-chewing/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-chewing/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext, libchewing, pkgconfig }:
+{ stdenv, fetchurl, cmake, fcitx, gettext, libchewing, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-chewing";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1w5smp5zvjx681cp1znjypyr9sw5x6v0wnsk8a7ncwxi9q9wf4xk";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx gettext libchewing ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx gettext libchewing ];
 
   preInstall = ''
    substituteInPlace src/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-cloudpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-cloudpinyin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, curl }:
+{ stdenv, fetchurl, cmake, pkg-config, fcitx, gettext, curl }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-cloudpinyin";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ai347wv3qdjzcbh0j9hdjpzwvh2kk57324xbxq37nzagrdgg5x0";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx gettext curl ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx gettext curl ];
 
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-hangul/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-hangul/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, libhangul, gettext, pkgconfig }:
+{ stdenv, fetchurl, cmake, fcitx, libhangul, gettext, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-hangul";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ds4071ljq620w7vnprm2jl8zqqkw7qsxvzbjapqak4jarczvmbd";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx libhangul gettext ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx libhangul gettext ];
 
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
+{ stdenv, fetchurl, cmake, pkg-config, fcitx, gettext, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-libpinyin";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "196c229ckib3xvafkk4n3n3jk9rpksfcjsbbwka6a9k2f34qrjj6";
   };
 
-  nativeBuildInputs = [ pkgconfig  ];
-  buildInputs = [ fcitx-qt5 qtbase qtwebengine.dev cmake fcitx gettext libpinyin glib pcre dbus ];
+  nativeBuildInputs = [ cmake pkg-config  ];
+  buildInputs = [ fcitx-qt5 qtbase qtwebengine.dev fcitx gettext libpinyin glib pcre dbus ];
 
   # With a typical installation via NixOS option i18n.inputMethod.fcitx.engines,
   # the FCITXDIR environment variable is set to $out of fcitx-with-plugins,

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-m17n/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-m17n/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext, m17n_lib, m17n_db, pkgconfig }:
+{ stdenv, fetchurl, cmake, fcitx, gettext, m17n_lib, m17n_db, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-m17n";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "15s52h979xz967f8lm0r0qkplig2w3wjck1ymndbg9kvj25ib0ng";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx gettext m17n_lib m17n_db ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx gettext m17n_lib m17n_db ];
 
   preInstall = ''
     substituteInPlace im/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, librime, brise, hicolor-icon-theme }:
+{ stdenv, fetchurl, cmake, pkg-config, fcitx, librime, brise, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-rime";
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0bd8snfa6jr8dhnm0s0z021iryh5pbaf7p15rhkgbigw2pssczpr";
   };
 
-  buildInputs = [ cmake pkgconfig fcitx librime brise hicolor-icon-theme ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx librime brise hicolor-icon-theme ];
 
   # cmake cannont automatically find our nonstandard brise install location
   cmakeFlags = [ "-DRIME_DATA_DIR=${brise}/share/rime-data" ];

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-extra/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-extra/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "c91bb19c1a7b53c5339bf2f75ae83839020d337990f237a8b9bc0f4416c120ef";
   };
 
-  buildInputs = [ cmake fcitx gettext ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ fcitx gettext ];
 
   preInstall = ''
    substituteInPlace tables/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1di60lr6l5k2sdwi3yrc0hl89j2k0yipayrsn803vd040w1fgfhq";
   };
 
-  buildInputs = [ cmake fcitx gettext ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ fcitx gettext ];
 
   preInstall = ''
    substituteInPlace tables/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext, pkgconfig }:
+{ stdenv, fetchurl, cmake, fcitx, gettext, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-unikey";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "063vc29v7ycaai98v3z4q319sv9sm91my17pmhblw1vifxnw02wf";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake fcitx gettext ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fcitx gettext ];
 
   NIX_CFLAGS_COMPILE = "-Wno-narrowing";
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     substituteInPlace data/cmake_install.cmake \
       --replace ${fcitx} $out
   '';
-  
+
   meta = with stdenv.lib; {
     isFcitxEngine = true;
     homepage      = "https://github.com/fcitx/fcitx-unikey";

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, cmake, fcitx, gtk3, isocodes, gnome3 }:
+{ stdenv, fetchurl, makeWrapper, pkg-config, cmake, fcitx, gtk3, isocodes, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-configtool-0.4.10";
@@ -15,9 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1yyi9jhkwn49lx9a47k1zbvwgazv4y4z72gnqgzdpgdzfrlrgi5w";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ makeWrapper fcitx cmake isocodes gtk3
-    gnome3.adwaita-icon-theme ];
+  nativeBuildInputs = [ cmake pkg-config makeWrapper ];
+  buildInputs = [ fcitx isocodes gtk3 gnome3.adwaita-icon-theme ];
 
   # Patch paths to `fcitx-remote`
   prePatch = ''
@@ -32,4 +31,3 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS";
   '';
 }
-

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, fetchFromGitHub, pkgconfig,  ibus, ibus-table, python3, cmake }:
+{ stdenv, fetchgit, fetchFromGitHub, pkg-config, ibus, ibus-table, python3, cmake }:
 
 let
   src = fetchFromGitHub {
@@ -51,7 +51,8 @@ in stdenv.mkDerivation {
     rm -rf $HOME
   '';
 
-  buildInputs = [ pkgconfig ibus ibus-table python3 cmake ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ ibus ibus-table python3 ];
 
   meta = with stdenv.lib; {
     isIbusEngine = true;

--- a/pkgs/tools/inputmethods/ibus/ibus-qt.nix
+++ b/pkgs/tools/inputmethods/ibus/ibus-qt.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ibus, cmake, pkgconfig, qt4, icu, doxygen }:
+{ stdenv, fetchurl, ibus, cmake, pkg-config, qt4, icu, doxygen }:
 
 stdenv.mkDerivation rec {
   pname = "ibus-qt";
@@ -9,10 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1q9g7qghpcf07valc2ni7yf994xqx2pmdffknj7scxfidav6p19g";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    ibus cmake qt4 icu doxygen
-  ];
+  nativeBuildInputs = [ cmake pkg-config doxygen ];
+  buildInputs = [ ibus qt4 icu ];
 
   cmakeFlags = [ "-DQT_PLUGINS_DIR=lib/qt4/plugins" ];
 

--- a/pkgs/tools/misc/aspcud/default.nix
+++ b/pkgs/tools/misc/aspcud/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0vrf7h7g99vw1mybqfrpxamsnf89p18czlzgjmxl1zkiwc7vjpzw";
   };
 
-  buildInputs = [ boost clasp cmake gringo re2c ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost clasp gringo re2c ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/tools/misc/bcunit/default.nix
+++ b/pkgs/tools/misc/bcunit/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   # https://gitlab.linphone.org/BC/public/bcunit/issues/1
   version = "unstable-2019-11-19";
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";

--- a/pkgs/tools/misc/ddate/default.nix
+++ b/pkgs/tools/misc/ddate/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, cmake} :
+{ stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "ddate";
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "1qchxnxvghbma6gp1g78wnjxsri0b72ha9axyk31cplssl7yn73f";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://github.com/bo0ts/ddate";
     description = "Discordian version of the date program";
-    license = stdenv.lib.licenses.publicDomain;
-    maintainers = with stdenv.lib.maintainers; [ kovirobi ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ kovirobi ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/sdl-jstest/default.nix
+++ b/pkgs/tools/misc/sdl-jstest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, pkgconfig, SDL, SDL2, ncurses, docbook_xsl, git }:
+{ stdenv, fetchgit, cmake, pkg-config, SDL, SDL2, ncurses, docbook_xsl, git }:
 
 stdenv.mkDerivation {
   pname = "sdl-jstest";
@@ -12,8 +12,8 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ SDL SDL2 ncurses ];
-  nativeBuildInputs = [ cmake pkgconfig docbook_xsl git ];
-  
+  nativeBuildInputs = [ cmake pkg-config docbook_xsl git ];
+
   meta = with stdenv.lib; {
     homepage = "https://github.com/Grumbel/sdl-jstest";
     description = "Simple SDL joystick test application for the console";

--- a/pkgs/tools/misc/wv2/default.nix
+++ b/pkgs/tools/misc/wv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, cmake, libgsf, glib, libxml2 }:
+{ stdenv, fetchurl, pkg-config, cmake, libgsf, glib, libxml2 }:
 
 stdenv.mkDerivation rec {
   name = "wv2-0.4.2";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-include.patch ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libgsf glib libxml2 ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libgsf glib libxml2 ];
 
   NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2";
 

--- a/pkgs/tools/networking/badvpn/default.nix
+++ b/pkgs/tools/networking/badvpn/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cmake, openssl, nss, pkgconfig, nspr, bash, debug ? false}:
+{stdenv, fetchurl, cmake, openssl, nss, pkg-config, nspr, bash, debug ? false}:
 let
   s = # Generated upstream information
   rec {
@@ -10,15 +10,15 @@ let
     sha256="02b1fra43l75mljkhrq45vcrrqv0znicjn15g7nbqx3jppzbpm5z";
   };
 
-  buildInputs = [
-    cmake openssl nss nspr
-  ];
+
   compileFlags = "-O3 ${stdenv.lib.optionalString (!debug) "-DNDEBUG"}";
 in
 stdenv.mkDerivation {
   inherit (s) name version;
-  nativeBuildInputs = [ pkgconfig ];
-  inherit buildInputs;
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    openssl nss nspr
+  ];
   src = fetchurl {
     inherit (s) url sha256;
   };

--- a/pkgs/tools/security/haka/default.nix
+++ b/pkgs/tools/security/haka/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation {
     sed -i 's,/etc,'$out'/etc,' doc/user/tool_suite_haka.rst
   '';
 
-  buildInputs = [ cmake swig wireshark check rsync libpcap gawk libedit pcre ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ swig wireshark check rsync libpcap gawk libedit pcre ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/text/ebook-tools/default.nix
+++ b/pkgs/tools/text/ebook-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libxml2, libzip }:
+{ stdenv, fetchurl, cmake, pkg-config, libxml2, libzip }:
 
 stdenv.mkDerivation rec {
   name = "ebook-tools-0.2.2";
@@ -8,18 +8,19 @@ stdenv.mkDerivation rec {
     sha256 = "1bi7wsz3p5slb43kj7lgb3r6lb91lvb6ldi556k4y50ix6b5khyb";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libxml2 libzip ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ libxml2 libzip ];
 
-  preConfigure = 
+  preConfigure =
     ''
       NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags libzip)"
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "http://ebook-tools.sourceforge.net";
     description = "Tools and library for dealing with various ebook file formats";
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
+    license = licenses.mit;
   };
 }

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, cmake, protobuf }:
+
 stdenv.mkDerivation rec {
   pname = "jumanpp";
   version = "2.0.0-rc2";
@@ -7,7 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/ku-nlp/${pname}/releases/download/v${version}/${pname}-${version}.tar.xz";
     sha256 = "17fzmd0f5m9ayfhsr0mg7hjp3pg1mhbgknhgyd8v87x46g8bg6qp";
   };
-  buildInputs = [ cmake protobuf ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ protobuf ];
 
   meta = with stdenv.lib; {
     description = "A Japanese morphological analyser using a recurrent neural network language model (RNNLM)";


### PR DESCRIPTION
###### Motivation for this change
It is very likely that `cmake` should be in `nativeBuildInputs` rather than `buildInputs`, which would matter when cross-compiling, `cmake` should be built on the build platform but not the host.

Additionally I am performing minor changes to the expressions that should not change the outcome, for instance

- `pkgconfig` -> `pkg-config`
- `fetchFromGit` -> `fetchFromGitHub`
- adding missing license
- `gpl(2|3)` -> `gpl(2|3)(Only|Plus)`
- remove `enableParallelBuilding = true` (already defaults to true when using cmake)

Edit: after seeing the affected packages approach 1000+ I have made much more conservative changes, future PRs should be done to check if packages like `flex`, `bison`, `doxygen` etc. are placed in the correct inputs list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
