### PR TITLE
ocamlPackages.bisect_ppx: 1.4.0 → 2.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/bisect_ppx-ocamlbuild/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx-ocamlbuild/default.nix
@@ -1,8 +1,0 @@
-{ buildDunePackage, bisect_ppx, ocamlbuild }:
-
-buildDunePackage {
-  minimumOCamlVersion = "4.02";
-  inherit (bisect_ppx) version src meta;
-  pname = "bisect_ppx-ocamlbuild";
-  propagatedBuildInputs = [ ocamlbuild ];
-}

--- a/pkgs/development/ocaml-modules/bisect_ppx/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx/default.nix
@@ -1,24 +1,27 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, ocaml-migrate-parsetree, ppx_tools_versioned }:
+{ lib, fetchFromGitHub, buildDunePackage, cmdliner, ocaml-migrate-parsetree, ppx_tools_versioned }:
 
 buildDunePackage rec {
   pname = "bisect_ppx";
-  version = "1.4.0";
+  version = "2.5.0";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "aantron";
     repo = "bisect_ppx";
     rev = version;
-    sha256 = "1plhm4pvrhpapz5zaks194ji1fgzmp13y942g10pbn9m7kgkqg4h";
+    sha256 = "0w2qd1myvh333jvkf8hgrqzl8ns4xgfggk4frf1ij3jyc7qc0868";
   };
 
   buildInputs = [
+    cmdliner
     ocaml-migrate-parsetree
     ppx_tools_versioned
   ];
 
   meta = {
     description = "Code coverage for OCaml";
-    license = stdenv.lib.licenses.mpl20;
+    license = lib.licenses.mit;
     homepage = "https://github.com/aantron/bisect_ppx";
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -117,7 +117,6 @@ let
     bin_prot_p4 = callPackage ../development/ocaml-modules/bin_prot { };
 
     bisect_ppx = callPackage ../development/ocaml-modules/bisect_ppx { };
-    bisect_ppx-ocamlbuild = callPackage ../development/ocaml-modules/bisect_ppx-ocamlbuild { };
 
     ocaml_cairo = callPackage ../development/ocaml-modules/ocaml-cairo { };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/aantron/bisect_ppx/releases

The plugin for ocamlbuild is no longer part of the source distribution and no longer maintained.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
