### PR TITLE
kaldi: init at 2020-12-26

### DIFF
--- a/pkgs/tools/audio/kaldi/default.nix
+++ b/pkgs/tools/audio/kaldi/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, openblas
+, blas
+, lapack
+, openfst
+, icu
+, cmake
+, pkg-config
+, fetchFromGitHub
+, git
+, python3
+}:
+
+assert blas.implementation == "openblas" && lapack.implementation == "openblas";
+let
+  # rev from https://github.com/kaldi-asr/kaldi/blob/master/cmake/third_party/openfst.cmake
+  openfst = fetchFromGitHub {
+    owner = "kkm000";
+    repo = "openfst";
+    rev = "0bca6e76d24647427356dc242b0adbf3b5f1a8d9";
+    sha256 = "1802rr14a03zl1wa5a0x1fa412kcvbgprgkadfj5s6s3agnn11rx";
+  };
+in
+stdenv.mkDerivation {
+  pname = "kaldi";
+  version = "2020-12-26";
+
+  src = fetchFromGitHub {
+    owner = "kaldi-asr";
+    repo = "kaldi";
+    rev = "813b73185a18725e4f6021981d17221d6ee23a19";
+    sha256 = "sha256-lTqXTG5ZTPmhCgt+BVzOwjKEIj+bLGUa+IxJq+XtHUg=";
+  };
+
+  cmakeFlags = [
+    "-DKALDI_BUILD_TEST=off"
+    "-DBUILD_SHARED_LIBS=on"
+  ];
+
+  preConfigure = ''
+    mkdir bin
+    cat > bin/git <<'EOF'
+    #!${stdenv.shell}
+    if [[ "$1" == "--version" ]]; then
+      # cmake checks this
+      ${git}/bin/git --version
+    elif [[ "$1" == "clone" ]]; then
+      # mock this call:
+
+      # https://github.com/kaldi-asr/kaldi/blob/c9d8b9ad3fef89237ba5517617d977b7d70a7ed5/cmake/third_party/openfst.cmake#L5
+      cp -r ${openfst} ''${@: -1}
+      chmod -R +w ''${@: -1}
+    elif [[ "$1" == "rev-list" ]]; then
+      # fix up this call:
+      # https://github.com/kaldi-asr/kaldi/blob/c9d8b9ad3fef89237ba5517617d977b7d70a7ed5/cmake/VersionHelper.cmake#L8
+      echo 0
+    fi
+    true
+    EOF
+    chmod +x bin/git
+    export PATH=$(pwd)/bin:$PATH
+  '';
+
+  buildInputs = [
+    openblas
+    openfst
+    icu
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/kaldi
+    cp -r ../egs $out/share/kaldi
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Speech Recognition Toolkit";
+    homepage = "https://kaldi-asr.org";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2362,6 +2362,8 @@ in
 
   kapacitor = callPackage ../servers/monitoring/kapacitor { };
 
+  kaldi = callPackage ../tools/audio/kaldi { };
+
   kisslicer = callPackage ../tools/misc/kisslicer { };
 
   klaus = with python3Packages; toPythonApplication klaus;


### PR DESCRIPTION
State-of-the-art speech-to-text engine - used in rhasspy

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
