### PR TITLE
pythonPackages.djangorestframework: 3.11.2 -> 3.12.2

### DIFF
--- a/pkgs/development/python-modules/djangorestframework/default.nix
+++ b/pkgs/development/python-modules/djangorestframework/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, buildPythonPackage, fetchPypi, django, isPy27 }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, django, isPy27 }:
 
 buildPythonPackage rec {
-  version = "3.11.2";
+  version = "3.12.2";
   pname = "djangorestframework";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a5967b68a04e0d97d10f4df228e30f5a2d82ba63b9d03e1759f84993b7bf1b53";
+  src = fetchFromGitHub {
+    owner = "encode";
+    repo = "django-rest-framework";
+    rev = version;
+    sha256 = "y/dw6qIOc6NaNpBWJXDwHX9aFodgKv9rGKWQKS6STlk=";
   };
 
   # Test settings are missing


### PR DESCRIPTION
###### Motivation for this change

There is a newer version of `djangorestframework` available upstream.

###### Things done

Instead of using the PyPI version of this package we now point to github.  Unfortunately the maintainer of `djangorestframework` did not upload a source distribution of this package to PyPI. This is why the change to github was done. An issue with upstream was already opened [here](https://github.com/encode/django-rest-framework/issues/7680).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
