### PR TITLE
[20.09] qt512: 5.12.7 -> 5.12.9

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -8,7 +8,7 @@ top-level attribute to `top-level/all-packages.nix`.
 
 1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
-   `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
+   `./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-5/$VERSION`.
 3. Check that the new packages build correctly.
 4. Commit the changes and open a pull request.
 
@@ -71,19 +71,6 @@ let
         # Ensure -I${includedir} is added to Cflags in pkg-config files.
         # See https://github.com/NixOS/nixpkgs/issues/52457
         ./qtbase.patch.d/0014-qtbase-pkg-config.patch
-
-        # https://bugreports.qt.io/browse/QTBUG-81715
-        # remove after updating to qt > 5.12.7
-        (fetchpatch {
-          name = "fix-qt5_make_output_file-cmake-macro.patch";
-          url = "https://code.qt.io/cgit/qt/qtbase.git/patch/?id=8a3fde00bf53d99e9e4853e8ab97b0e1bcf74915";
-          sha256 = "1gpcbdpyazdxnmldvhsf3pfwr2gjvi08x3j6rxf543rq01bp6cpx";
-        })
-        (fetchpatch {
-          name = "QTBUG-78937.patch";
-          url = "https://code.qt.io/cgit/qt/qtbase.git/patch/?id=67a9c600ad14ee44501a6df3509daa8234b97606";
-          sha256 = "1jiky1w9j8rka78r4q0yabb8w2l5j6csdjysynz7gs1ry4xjfdxd";
-        })
       ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -51,7 +51,7 @@ let
 
   patches = {
     qtbase =
-      optionals stdenv.isDarwin [
+      [
         ./qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
         ./qtbase.patch.d/0002-qtbase-mac.patch
         ./qtbase.patch.d/0013-define-kiosurfacesuccess.patch
@@ -93,7 +93,7 @@ let
         stripLen = 1;
         extraPrefix = "src/3rdparty/";
       })
-    ] ++ optionals stdenv.isDarwin [
+
       ./qtwebengine-darwin-no-platform-check.patch
       ./qtwebengine-darwin-fix-failed-static-assertion.patch
     ];
@@ -104,7 +104,7 @@ let
         sha256 = "0h8ymfnwgkjkwaankr3iifiscsvngqpwb91yygndx344qdiw9y0n";
       })
       ./qtwebkit.patch
-    ] ++ optionals stdenv.isDarwin [
+
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch
     ];

--- a/pkgs/development/libraries/qt-5/5.12/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.12/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.7/submodules/ )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.9/submodules/ )

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
@@ -1,18 +1,5 @@
-From 361a9395704ca1ee170a8bb3823ba860293eecee Mon Sep 17 00:00:00 2001
-From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Tue, 17 Sep 2019 05:34:00 -0500
-Subject: [PATCH 01/12] qtbase-mkspecs-mac
-
----
- mkspecs/common/mac.conf               |   2 +-
- mkspecs/features/mac/default_post.prf | 202 ----------------------------------
- mkspecs/features/mac/default_pre.prf  |  58 ----------
- mkspecs/features/mac/sdk.mk           |  25 -----
- mkspecs/features/mac/sdk.prf          |  61 ----------
- 5 files changed, 1 insertion(+), 347 deletions(-)
-
 diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
-index b77494ec9b..470c38e772 100644
+index b77494ec..470c38e7 100644
 --- a/mkspecs/common/mac.conf
 +++ b/mkspecs/common/mac.conf
 @@ -24,7 +24,7 @@ QMAKE_INCDIR_OPENGL     = \
@@ -25,7 +12,7 @@ index b77494ec9b..470c38e772 100644
  
  QMAKE_LFLAGS_REL_RPATH  =
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index 993f4d56a9..b80ec1e801 100644
+index d052808c..b80ec1e8 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
 @@ -68,208 +68,6 @@ qt {
@@ -161,7 +148,7 @@ index 993f4d56a9..b80ec1e801 100644
 -                -isysroot$$xcodeSDKInfo(Path, $$sdk)
 -            QMAKE_XARCH_LFLAGS_$${arch} = $$version_min_flags \
 -                -Xarch_$${arch} \
--                -Wl,-syslibroot,$$xcodeSDKInfo(Path, $$sdk)
+-                -isysroot$$xcodeSDKInfo(Path, $$sdk)
 -
 -            QMAKE_XARCH_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS_$${arch})
 -            QMAKE_XARCH_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS_$${arch})
@@ -182,7 +169,7 @@ index 993f4d56a9..b80ec1e801 100644
 -        version_min_flag = -m$${version_identifier}-version-min=$$deployment_target
 -        QMAKE_CFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
 -        QMAKE_CXXFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
--        QMAKE_LFLAGS += -Wl,-syslibroot,$$QMAKE_MAC_SDK_PATH $$version_min_flag
+-        QMAKE_LFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
 -    }
 -
 -    # Enable precompiled headers for multiple architectures
@@ -238,7 +225,7 @@ index 993f4d56a9..b80ec1e801 100644
      generate_xcode_project.commands = @$(QMAKE) -spec macx-xcode \"$(EXPORT__PRO_FILE_)\" $$QMAKE_ARGS
      generate_xcode_project.target = xcodeproj
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index e3534561a5..3b01424e67 100644
+index e3534561..3b01424e 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
 @@ -1,60 +1,2 @@
@@ -303,7 +290,7 @@ index e3534561a5..3b01424e67 100644
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
 diff --git a/mkspecs/features/mac/sdk.mk b/mkspecs/features/mac/sdk.mk
-index c40f58c987..e69de29bb2 100644
+index c40f58c9..e69de29b 100644
 --- a/mkspecs/features/mac/sdk.mk
 +++ b/mkspecs/features/mac/sdk.mk
 @@ -1,25 +0,0 @@
@@ -333,7 +320,7 @@ index c40f58c987..e69de29bb2 100644
 -    endif
 -endif
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
-index 3a9c2778bb..e69de29bb2 100644
+index 3a9c2778..e69de29b 100644
 --- a/mkspecs/features/mac/sdk.prf
 +++ b/mkspecs/features/mac/sdk.prf
 @@ -1,61 +0,0 @@
@@ -398,6 +385,3 @@ index 3a9c2778bb..e69de29bb2 100644
 -    $$tool = $$sysrooted $$member(value, 1, -1)
 -    cache($$tool_variable, set stash, $$tool)
 -}
--- 
-2.23.GIT
-

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
@@ -1,5 +1,5 @@
 diff --git a/configure.pri b/configure.pri
-index 897bea54..6f834c20 100644
+index 897bea540..6f834c202 100644
 --- a/configure.pri
 +++ b/configure.pri
 @@ -269,7 +269,7 @@ defineReplace(webEngineGetMacOSVersion) {
@@ -12,7 +12,7 @@ index 897bea54..6f834c20 100644
  }
  
 diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
-index 35eb6b89..7eed640a 100644
+index 35eb6b89c..7eed640a5 100644
 --- a/mkspecs/features/platform.prf
 +++ b/mkspecs/features/platform.prf
 @@ -40,8 +40,6 @@ defineTest(isPlatformSupported) {
@@ -43,10 +43,10 @@ index 35eb6b89..7eed640a 100644
      isEmpty(WEBENGINE_OSX_SDK_PRODUCT_VERSION) {
          skipBuild("Could not resolve SDK product version for \'$$QMAKE_MAC_SDK\'.")
 diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
-index 4426901c..3aa6057e 100644
+index 7b77a8bf7..0e1284ee4 100644
 --- a/src/core/config/mac_osx.pri
 +++ b/src/core/config/mac_osx.pri
-@@ -5,16 +5,16 @@ load(functions)
+@@ -5,7 +5,7 @@ load(functions)
  # otherwise query for it.
  QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
  isEmpty(QMAKE_MAC_SDK_VERSION) {
@@ -55,17 +55,15 @@ index 4426901c..3aa6057e 100644
       isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
  }
  
+@@ -14,11 +14,6 @@ isEmpty(QMAKE_MAC_SDK_VERSION) {
+ QMAKE_MAC_SDK_VERSION_MAJOR_MINOR = $$section(QMAKE_MAC_SDK_VERSION, ".", 0, 1)
+ 
  QMAKE_CLANG_DIR = "/usr"
 -QMAKE_CLANG_PATH = $$eval(QMAKE_MAC_SDK.macx-clang.$${QMAKE_MAC_SDK}.QMAKE_CXX)
 -!isEmpty(QMAKE_CLANG_PATH) {
 -    clang_dir = $$clean_path("$$dirname(QMAKE_CLANG_PATH)/../")
 -    exists($$clang_dir): QMAKE_CLANG_DIR = $$clang_dir
 -}
-+# QMAKE_CLANG_PATH = $$eval(QMAKE_MAC_SDK.macx-clang.$${QMAKE_MAC_SDK}.QMAKE_CXX)
-+# !isEmpty(QMAKE_CLANG_PATH) {
-+#     clang_dir = $$clean_path("$$dirname(QMAKE_CLANG_PATH)/../")
-+#     exists($$clang_dir): QMAKE_CLANG_DIR = $$clang_dir
-+# }
  
  QMAKE_CLANG_PATH = "$${QMAKE_CLANG_DIR}/bin/clang++"
  message("Using clang++ from $${QMAKE_CLANG_PATH}")

--- a/pkgs/development/libraries/qt-5/5.12/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.12/srcs.nix
@@ -1,325 +1,326 @@
-# DO NOT EDIT! This file is generated automatically by fetch-kde-qt.sh
+# DO NOT EDIT! This file is generated automatically.
+# Command: ./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-5/5.12
 { fetchurl, mirror }:
 
 {
   qt3d = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qt3d-everywhere-src-5.12.7.tar.xz";
-      sha256 = "2030de3dc93fd4062f677f61938229af9cd7aa4c3d2932cdda2ccb663d681126";
-      name = "qt3d-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qt3d-everywhere-src-5.12.9.tar.xz";
+      sha256 = "6fcde8c99bc5d09a5d2de99cab10c6f662d7db48139e6d5a3904fa0c580070ad";
+      name = "qt3d-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtactiveqt-everywhere-src-5.12.7.tar.xz";
-      sha256 = "302ce1e74dae8ead602ac663e208e6c9b98bdf9a2b7795de4198a28eba2d895d";
-      name = "qtactiveqt-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtactiveqt-everywhere-src-5.12.9.tar.xz";
+      sha256 = "e9df2dacfa4f93b42753066d14d3c504a30b259c177b366e32e6119f714f6527";
+      name = "qtactiveqt-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtandroidextras-everywhere-src-5.12.7.tar.xz";
-      sha256 = "a5acc927bd46ed87627e2ae0f0bfc199189d383a3e17c2f34b8c34ea57b2aea1";
-      name = "qtandroidextras-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtandroidextras-everywhere-src-5.12.9.tar.xz";
+      sha256 = "d6ab58d382feb1d79b7f28033eaa15ecab0c1f97c760fad50f20608189ab1a95";
+      name = "qtandroidextras-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtbase = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtbase-everywhere-src-5.12.7.tar.xz";
-      sha256 = "b18939cb25d90aef8721fb12ec34c3632d3490ced958e41f6c7a52064643665d";
-      name = "qtbase-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtbase-everywhere-src-5.12.9.tar.xz";
+      sha256 = "331dafdd0f3e8623b51bd0da2266e7e7c53aa8e9dc28a8eb6f0b22609c5d337e";
+      name = "qtbase-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtcanvas3d-everywhere-src-5.12.7.tar.xz";
-      sha256 = "b63a513a2ee11548b122e0fd640b1fa22d3eb83cdc51ddfdf3b97c2ecd0d0c50";
-      name = "qtcanvas3d-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtcanvas3d-everywhere-src-5.12.9.tar.xz";
+      sha256 = "351b105507b97e61eef17a5ce8a96fe090a523101e41c20ea373266203dd3ca0";
+      name = "qtcanvas3d-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtcharts-everywhere-src-5.12.7.tar.xz";
-      sha256 = "434065526d0b1d8921e96cc1827b1a3579e073b930fe536455c4c1da2f15cf5f";
-      name = "qtcharts-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtcharts-everywhere-src-5.12.9.tar.xz";
+      sha256 = "9fc2a64a96b73746389c257684af557e70c5360bead53d61d059f968efdc5b04";
+      name = "qtcharts-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtconnectivity-everywhere-src-5.12.7.tar.xz";
-      sha256 = "647148b9b1a0d3e54f788b66797b81bb87434faf6fb12ac481f9165eda0d071a";
-      name = "qtconnectivity-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtconnectivity-everywhere-src-5.12.9.tar.xz";
+      sha256 = "e5457ebc22059954bba6a08b03fd1e6f30e4c8f3146636065bf12c2e6044f41c";
+      name = "qtconnectivity-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtdatavis3d-everywhere-src-5.12.7.tar.xz";
-      sha256 = "07ff5713cfcdf073681d905912e8d871e4451508494c789df805eb241ed98b27";
-      name = "qtdatavis3d-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtdatavis3d-everywhere-src-5.12.9.tar.xz";
+      sha256 = "0cd4f7535bf26e4e59f89fac991fc8a400bd6193680578f31693235f185f4562";
+      name = "qtdatavis3d-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtdeclarative-everywhere-src-5.12.7.tar.xz";
-      sha256 = "5cdc05a035f240ab73b6b37dd3831c1350cd80e5799da47929974085f6eae9bd";
-      name = "qtdeclarative-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtdeclarative-everywhere-src-5.12.9.tar.xz";
+      sha256 = "c11ae68aedcdea7e721ec22a95265ac91b5e128a5c12d3b61b5b732d3a02be80";
+      name = "qtdeclarative-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtdoc-everywhere-src-5.12.7.tar.xz";
-      sha256 = "6c07918cec8494ea05a42234d8f281a2958de7380458f3fb5a189949ce1233e9";
-      name = "qtdoc-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtdoc-everywhere-src-5.12.9.tar.xz";
+      sha256 = "a9d751af85a07bdfc2a30e8f1b08aa249547a8100801f286e77280a9c9ede624";
+      name = "qtdoc-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtgamepad-everywhere-src-5.12.7.tar.xz";
-      sha256 = "07638c42be94be1e5e622b020c6192341b5bb87be34d7b38f2899672d83a1e94";
-      name = "qtgamepad-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtgamepad-everywhere-src-5.12.9.tar.xz";
+      sha256 = "da3333af6b9dccd7dd3a25b01de65e317fe4b70b9d39eeb84e01c232063211fe";
+      name = "qtgamepad-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtgraphicaleffects-everywhere-src-5.12.7.tar.xz";
-      sha256 = "02f0328420c623da8f9ae949fec01e99ba84213dd2ad559cb00c204502bbcace";
-      name = "qtgraphicaleffects-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtgraphicaleffects-everywhere-src-5.12.9.tar.xz";
+      sha256 = "1eb4b913d5cb6d0b46a231288b9717f4785fbd212936e98a8b2a8c9024e3a8bf";
+      name = "qtgraphicaleffects-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtimageformats-everywhere-src-5.12.7.tar.xz";
-      sha256 = "9bd19ee24fb85f249d01c78e637c95377dd738feb61da0deeee6b770fa62f70b";
-      name = "qtimageformats-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtimageformats-everywhere-src-5.12.9.tar.xz";
+      sha256 = "cd8193698f830cce30959564c191e7bb698877aca3a263c652b4a23907c72b6a";
+      name = "qtimageformats-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtlocation-everywhere-src-5.12.7.tar.xz";
-      sha256 = "d1e905b80befda3c9aaad92ea984e6dbf722568b5c91e8d15b027bc5bc22781f";
-      name = "qtlocation-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtlocation-everywhere-src-5.12.9.tar.xz";
+      sha256 = "be31870104af2910690850c4e28bab3ccb76f1aa8deef1e870bcbc6b276aa2c1";
+      name = "qtlocation-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtmacextras-everywhere-src-5.12.7.tar.xz";
-      sha256 = "265b5607664927e1c92af3abc4b034244f37abd83db1f0a8f22f6952f7d6abb8";
-      name = "qtmacextras-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtmacextras-everywhere-src-5.12.9.tar.xz";
+      sha256 = "5458f3e13c37eb8bff8588b29703fb33b61d5ea19989c56c99d36f221e269f35";
+      name = "qtmacextras-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtmultimedia-everywhere-src-5.12.7.tar.xz";
-      sha256 = "28bdaa81371f922223775ae5171c4d589a2c07f255abbe5ccf130ecbbdb4db1d";
-      name = "qtmultimedia-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtmultimedia-everywhere-src-5.12.9.tar.xz";
+      sha256 = "59a2f2418cefe030094687dff0846fb8957abbc0e060501a4fee40cb4a52838c";
+      name = "qtmultimedia-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtnetworkauth-everywhere-src-5.12.7.tar.xz";
-      sha256 = "cbfb7c71a25e74b92b927a5aeae2d099e4142968424a0fcebc1a52fa4fb4576b";
-      name = "qtnetworkauth-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtnetworkauth-everywhere-src-5.12.9.tar.xz";
+      sha256 = "a0979689eda667e299fd9cf5a8859bd9c37eabc0a6d9738103a1143035baf0e4";
+      name = "qtnetworkauth-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtpurchasing-everywhere-src-5.12.7.tar.xz";
-      sha256 = "6f7ecb1e6b6d290b268344ddb031bb7114cd36139c76323732d12661eeb15a76";
-      name = "qtpurchasing-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtpurchasing-everywhere-src-5.12.9.tar.xz";
+      sha256 = "565587811b3cfd201907d3fcbf7120783de32a4d1d3c59a9efff3720cf0af3e5";
+      name = "qtpurchasing-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtquickcontrols-everywhere-src-5.12.7.tar.xz";
-      sha256 = "1038bbc76bba53f9634f40cd9c8ebf0ed8ae82e791f727b228bd81bdcf1859e5";
-      name = "qtquickcontrols-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtquickcontrols-everywhere-src-5.12.9.tar.xz";
+      sha256 = "d89084ebccf155f4c966d4a2a188e6e870c37535a7751740960f5c38088373f6";
+      name = "qtquickcontrols-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtquickcontrols2-everywhere-src-5.12.7.tar.xz";
-      sha256 = "3a9526e5ad01edbfb796a6631983c391ea1b7e22ae6e07840048156a9e92a237";
-      name = "qtquickcontrols2-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtquickcontrols2-everywhere-src-5.12.9.tar.xz";
+      sha256 = "ea1c2864630c6ba2540228f81ec5b582619d5ce9e4cb98e91109b4181a65a31d";
+      name = "qtquickcontrols2-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtremoteobjects-everywhere-src-5.12.7.tar.xz";
-      sha256 = "6d6aaec4e9c140c027b0badaabc6322ea3c16cf649495a27fec1f261e891120f";
-      name = "qtremoteobjects-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtremoteobjects-everywhere-src-5.12.9.tar.xz";
+      sha256 = "f87af7e9931280f2b44a529dc174cae14247e1b50f9dc9bde8966adb0406babd";
+      name = "qtremoteobjects-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtscript = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtscript-everywhere-src-5.12.7.tar.xz";
-      sha256 = "ca1dbc66d4125a678638dd0c9c030b72fdfc4ec2c229b9316a8bc80a86104019";
-      name = "qtscript-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtscript-everywhere-src-5.12.9.tar.xz";
+      sha256 = "8f2e12e37ff1e7629923cf3b9d446f85e005b2248386e33879ba3b790f1416df";
+      name = "qtscript-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtscxml-everywhere-src-5.12.7.tar.xz";
-      sha256 = "afa950bc95f881c90eea564511f3e9918d53fddf0823afb641d20dc6f794fbb6";
-      name = "qtscxml-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtscxml-everywhere-src-5.12.9.tar.xz";
+      sha256 = "d68d04d83366f11b10a101766baf5253e53ad76a683e0bc15e7dd403d475e61c";
+      name = "qtscxml-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtsensors-everywhere-src-5.12.7.tar.xz";
-      sha256 = "2b9aea9f4e2f681b4067f2b9d97c5073c135e41d26601c71f18f199bc980e740";
-      name = "qtsensors-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtsensors-everywhere-src-5.12.9.tar.xz";
+      sha256 = "77054e2449bcac786cc8f07c0d65c503a22bc629af4844259ff0def27b9889e9";
+      name = "qtsensors-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtserialbus-everywhere-src-5.12.7.tar.xz";
-      sha256 = "82201edf971e957d849b041ab2914f7497226939c62884ec2906b37576987eae";
-      name = "qtserialbus-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtserialbus-everywhere-src-5.12.9.tar.xz";
+      sha256 = "08b16363a47f9b41f87e3b7cf63eaed2435bb6b7e27775c9717ff863e56141ed";
+      name = "qtserialbus-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtserialport-everywhere-src-5.12.7.tar.xz";
-      sha256 = "224c282ebed750f46b72dfe18260c3d26fbb74e928dec64bd8c51e7beed8721f";
-      name = "qtserialport-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtserialport-everywhere-src-5.12.9.tar.xz";
+      sha256 = "24a10b65b03fc598acd30f4a52b0b71218e9c03ec4bb31a4ca50aae1b52a986d";
+      name = "qtserialport-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtspeech-everywhere-src-5.12.7.tar.xz";
-      sha256 = "0cc4f14aa21172b84c8ebca442037cd94927dad4921f6f6bfb4d7f2468aa6060";
-      name = "qtspeech-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtspeech-everywhere-src-5.12.9.tar.xz";
+      sha256 = "2efdaf5f49d2fad4a6c4cde12dfee2ff2c66ab4298f22d6c203ecd6019186847";
+      name = "qtspeech-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtsvg-everywhere-src-5.12.7.tar.xz";
-      sha256 = "4bf60916d4e398d9609f1b3a17fc7345a0e13c7c1cc407298df20da4c7c67bb8";
-      name = "qtsvg-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtsvg-everywhere-src-5.12.9.tar.xz";
+      sha256 = "32ec251e411d31734b873dd82fd68b6a3142227fdf06fe6ad879f16997fb98d2";
+      name = "qtsvg-everywhere-src-5.12.9.tar.xz";
     };
   };
   qttools = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qttools-everywhere-src-5.12.7.tar.xz";
-      sha256 = "860a97114d518f83c0a9ab3742071da16bb018e6eb387179d5764a8dcca03948";
-      name = "qttools-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qttools-everywhere-src-5.12.9.tar.xz";
+      sha256 = "002dc23410a9d1af6f1cfc696ee18fd3baeddbbfeb9758ddb04bbdb17b2fffdf";
+      name = "qttools-everywhere-src-5.12.9.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qttranslations-everywhere-src-5.12.7.tar.xz";
-      sha256 = "2c8d1169f1f20ba32639181f1853b4159940cbaaac41adaa018b6f43ca31323f";
-      name = "qttranslations-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qttranslations-everywhere-src-5.12.9.tar.xz";
+      sha256 = "50bd3a329e86f14af05ef0dbef94c7a6cd6c1f89ca4d008088a44ba76e6ecf40";
+      name = "qttranslations-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtvirtualkeyboard-everywhere-src-5.12.7.tar.xz";
-      sha256 = "aaa52aaff923df22de8472d71843dadb80f3f6fe0312122e64ffe5436db40daa";
-      name = "qtvirtualkeyboard-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtvirtualkeyboard-everywhere-src-5.12.9.tar.xz";
+      sha256 = "7598ee3312a2f4e72edf363c16c506740a8b91c5c06544da068a3c0d73f7f807";
+      name = "qtvirtualkeyboard-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwayland-everywhere-src-5.12.7.tar.xz";
-      sha256 = "fc1ab8e25461580e37090e4f82422411dee71a3de48a54be1f4b6569e00f66c5";
-      name = "qtwayland-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwayland-everywhere-src-5.12.9.tar.xz";
+      sha256 = "6f416948a98586b9c13c46b36be5ac6bb96a1dde9f50123b5e6dcdd102e9d77e";
+      name = "qtwayland-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwebchannel-everywhere-src-5.12.7.tar.xz";
-      sha256 = "b0ae72e5957aa4b281a37d2e169fcf91f92382bc36bd0cf09c80b2bb961bce75";
-      name = "qtwebchannel-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwebchannel-everywhere-src-5.12.9.tar.xz";
+      sha256 = "d55a06a0929c86664496e1113e74425d56d175916acd8abbb95c371eb16b43eb";
+      name = "qtwebchannel-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwebengine-everywhere-src-5.12.7.tar.xz";
-      sha256 = "83b754dca3dafeb21be6c7cb5ea99f11f5dbe9055bc1680f5bd7159224bb46fa";
-      name = "qtwebengine-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwebengine-everywhere-src-5.12.9.tar.xz";
+      sha256 = "27a9a19e4deb5e7a0fabc13e38fe5a8818730c92f6a343b9084aa17977468e25";
+      name = "qtwebengine-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwebglplugin = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwebglplugin-everywhere-src-5.12.7.tar.xz";
-      sha256 = "e049ed855bc772a56808844a803aac653d2d64f092a1fd1fe6a73ab460b55c3b";
-      name = "qtwebglplugin-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwebglplugin-everywhere-src-5.12.9.tar.xz";
+      sha256 = "cb7ba4cb66900e5d4315809e2b5ad3e4e381d576a14f6224f8ea58373f997c42";
+      name = "qtwebglplugin-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwebsockets-everywhere-src-5.12.7.tar.xz";
-      sha256 = "6fd13c2558f532a32f20d977b44c0146107a0e93861df84978e4fd72af283b17";
-      name = "qtwebsockets-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwebsockets-everywhere-src-5.12.9.tar.xz";
+      sha256 = "08a92c36d52b4d93a539a950698bb2912ea36055015d421f874bf672637f21ef";
+      name = "qtwebsockets-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwebview-everywhere-src-5.12.7.tar.xz";
-      sha256 = "d3f82d2ceab59dc4dee3b6f54f4b70869c199d63f4534b299d900cdacc9b7be7";
-      name = "qtwebview-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwebview-everywhere-src-5.12.9.tar.xz";
+      sha256 = "3e0506411d101cc08232946bcacef2fb90884c27eb91eeb97a1a68ed3788a7b6";
+      name = "qtwebview-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtwinextras-everywhere-src-5.12.7.tar.xz";
-      sha256 = "cfeec81ee1f75b9786ed28382deecc5e38fd142c0b48476beccadb587f93118c";
-      name = "qtwinextras-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtwinextras-everywhere-src-5.12.9.tar.xz";
+      sha256 = "7bab5053197148a5e1609cab12331e4a3f2e1a86bcbde137948330b288803754";
+      name = "qtwinextras-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtx11extras-everywhere-src-5.12.7.tar.xz";
-      sha256 = "23895f4b1e84f3783526b9e17680df38c587601d4dfa6ff1b81ace432c480b96";
-      name = "qtx11extras-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtx11extras-everywhere-src-5.12.9.tar.xz";
+      sha256 = "09432392641b56205cbcda6be89d0835bfecad64ad61713a414b951b740c9cec";
+      name = "qtx11extras-everywhere-src-5.12.9.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.12.7";
+    version = "5.12.9";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.7/submodules/qtxmlpatterns-everywhere-src-5.12.7.tar.xz";
-      sha256 = "9002014129a1f2a44700df333a7776e23bdfd689e7a619c3540fd9f6819b417b";
-      name = "qtxmlpatterns-everywhere-src-5.12.7.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.9/submodules/qtxmlpatterns-everywhere-src-5.12.9.tar.xz";
+      sha256 = "8d0e92fce6b4cbe7f1ecd1e90f6c7d71681b9b8870a577c0b18cadd93b8713b2";
+      name = "qtxmlpatterns-everywhere-src-5.12.9.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -8,7 +8,7 @@ top-level attribute to `top-level/all-packages.nix`.
 
 1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
-   `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
+   `./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-5/$VERSION`.
 3. Check that the new packages build correctly.
 4. Commit the changes and open a pull request.
 

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -8,7 +8,7 @@ top-level attribute to `top-level/all-packages.nix`.
 
 1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
-   `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
+   `./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-5/$VERSION`.
 3. Check that the new packages build correctly.
 4. Commit the changes and open a pull request.
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1409,6 +1409,7 @@ in
 
   boringtun = callPackage ../tools/networking/boringtun { };
 
+  # Upstream recommends qt5.12 and it doesn't build with qt5.15
   boomerang = libsForQt512.callPackage ../development/tools/boomerang { };
 
   boost-build = callPackage ../development/tools/boost-build { };
@@ -6979,6 +6980,7 @@ in
 
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 
+  # Not updated upstream since 2018, doesn't support qt newer than 5.12
   sleepyhead = libsForQt512.callPackage ../applications/misc/sleepyhead {};
 
   slirp4netns = callPackage ../tools/networking/slirp4netns/default.nix { };
@@ -22607,6 +22609,7 @@ in
 
   plexamp = callPackage ../applications/audio/plexamp { };
 
+  # Upstream says it supports only qt5.9 which is not packaged, and building with qt newer than 5.12 fails
   plex-media-player = libsForQt512.callPackage ../applications/video/plex-media-player { };
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };


### PR DESCRIPTION
###### Motivation for this change

Port Qt 5.12.9 to NixOS 20.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
