### PR TITLE
self: 4.5.0 -> 2017.1

### DIFF
--- a/pkgs/development/interpreters/self/default.nix
+++ b/pkgs/development/interpreters/self/default.nix
@@ -1,6 +1,6 @@
-{ fetchgit, stdenv, xorg, makeWrapper, ncurses, cmake }:
+{ stdenv, fetchFromGitHub, libX11, libXext, makeWrapper, ncurses, cmake }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   # The Self wrapper stores source in $XDG_DATA_HOME/self or ~/.local/share/self
   # so that it can be written to when using the Self transposer. Running 'Self'
   # after installation runs without an image. You can then build a Self image with:
@@ -11,16 +11,18 @@ stdenv.mkDerivation {
   # This image can later be started with:
   #   $ Self -s myimage.snap
   #
-  version = "4.5.0";
   pname = "self";
+  version = "2017.1";
 
-  src = fetchgit {
-    url    = "https://github.com/russellallen/self";
-    rev    = "d16bcaad3c5092dae81ad0b16d503f2a53b8ef86";
-    sha256 = "1dhs6209407j0ll9w9id31vbawdrm9nz1cjak8g8hixrw1nid4i5";
+  src = fetchFromGitHub {
+    owner = "russellallen";
+    repo = pname;
+    rev = version;
+    sha256 = "C/1Q6yFmoXx2F97xuvkm8DxFmmvuBS7uYZOxq/CRNog=";
   };
 
-  buildInputs = [ ncurses xorg.libX11 xorg.libXext makeWrapper cmake ];
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = [ ncurses libX11 libXext ];
 
   selfWrapper = ./self;
 
@@ -33,12 +35,11 @@ stdenv.mkDerivation {
       --set SELF_ROOT "$out"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A prototype-based dynamic object-oriented programming language, environment, and virtual machine";
     homepage = "https://selflanguage.org/";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = [ stdenv.lib.maintainers.doublec ];
-    platforms = with stdenv.lib.platforms; linux;
-    broken = true; # segfaults on gcc > 4.4
+    license = licenses.bsd3;
+    maintainers = [ maintainers.doublec ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
