### PR TITLE
hidapi: drop cross conditional on gnum4

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, udev, libusb1
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, udev
+, libusb1
 , darwin
 , gnum4
 }:
@@ -16,14 +21,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
-    pkgconfig
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    # Could be added always, but added conditionally here to avoid large rebuild
     gnum4
+    pkg-config
   ];
 
-  buildInputs = [ ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ libusb1 udev ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ libusb1 udev ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
f6514239ee9b0739a6e884ba28e9302c0102f8c0 only added this in the cross
case to avoid another mass rebuild, but there's no reason to not clean
this up during the next staging cycle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
