### PR TITLE
openldap: fix build if openssl or cyrus_sasl are overridden to null, add flag for cyrus_sasl, require openssl

### DIFF
--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -62,10 +62,10 @@ stdenv.mkDerivation rec {
   #    is in Nixpkgs patchelf.
   # 2. Fixup broken libtool for openssl and cyrus_sasl (if it is not disabled)
   preFixup = ''
-    rm -r "$out/var"
+    rm -r $out/var
     rm -r libraries/*/.libs
     rm -r contrib/slapd-modules/passwd/*/.libs
-    for f in "$out/lib/libldap.la" "$out/lib/libldap_r.la"; do
+    for f in $out/lib/libldap.la $out/lib/libldap_r.la; do
       substituteInPlace "$f" --replace '-lssl' '-L${openssl.out}/lib -lssl'
   '' + lib.optionalString withCyrusSasl ''
       substituteInPlace "$f" --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, openssl, cyrus_sasl, db, groff, libtool }:
+{ lib, stdenv, fetchurl, openssl, db, groff, libtool
+, withCyrusSasl ? true
+, cyrus_sasl
+}:
 
 stdenv.mkDerivation rec {
   pname = "openldap";
@@ -37,8 +40,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--with-yielding_select=yes"
     "ac_cv_func_memcmp_working=yes"
-  ] ++ lib.optional (openssl == null) "--without-tls"
-    ++ lib.optional (cyrus_sasl == null) "--without-cyrus-sasl"
+  ] ++ lib.optional (!withCyrusSasl) "--without-cyrus-sasl"
     ++ lib.optional stdenv.isFreeBSD "--with-pic";
 
   postBuild = ''
@@ -58,18 +60,15 @@ stdenv.mkDerivation rec {
   #    Delete these to let patchelf discover the right path instead.
   #    FIXME: that one can be removed when https://github.com/NixOS/patchelf/pull/98
   #    is in Nixpkgs patchelf.
-  # 2. Fixup broken libtool for openssl and cyrus_sasl respectly if they are not
-  #    overridden to be null.
+  # 2. Fixup broken libtool for openssl and cyrus_sasl (if it is not disabled)
   preFixup = ''
     rm -rf $out/var
     rm -r libraries/*/.libs
     rm -r contrib/slapd-modules/passwd/*/.libs
-
     for f in $out/lib/libldap.la $out/lib/libldap_r.la; do
-  '' + stdenv.lib.optionalString (cyrus_sasl != null) ''
-      substituteInPlace $f --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'
-  '' + stdenv.lib.optionalString (openssl != null) ''
       substituteInPlace $f --replace '-lssl' '-L${openssl.out}/lib -lssl'
+  '' + lib.optionalString withCyrusSasl ''
+      substituteInPlace $f --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'
   '' + ''
     done
   '';

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -62,13 +62,13 @@ stdenv.mkDerivation rec {
   #    is in Nixpkgs patchelf.
   # 2. Fixup broken libtool for openssl and cyrus_sasl (if it is not disabled)
   preFixup = ''
-    rm -rf $out/var
+    rm -r "$out/var"
     rm -r libraries/*/.libs
     rm -r contrib/slapd-modules/passwd/*/.libs
-    for f in $out/lib/libldap.la $out/lib/libldap_r.la; do
-      substituteInPlace $f --replace '-lssl' '-L${openssl.out}/lib -lssl'
+    for f in "$out/lib/libldap.la" "$out/lib/libldap_r.la"; do
+      substituteInPlace "$f" --replace '-lssl' '-L${openssl.out}/lib -lssl'
   '' + lib.optionalString withCyrusSasl ''
-      substituteInPlace $f --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'
+      substituteInPlace "$f" --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'
   '' + ''
     done
   '';


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Compiling `openldap.override { cyrus_sasl = null; }` results in an evaluation error.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @lovek323