### PR TITLE
WIP m4: propagate native dependency

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, udev, libusb1
-, darwin
-, gnum4
-}:
+, darwin }:
 
 stdenv.mkDerivation rec {
   pname = "hidapi";
@@ -14,13 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1nr4z4b10vpbh3ss525r7spz4i43zim2ba5qzfl15dgdxshxxivb";
   };
 
-  nativeBuildInputs = [
-    autoreconfHook
-    pkgconfig
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    # Could be added always, but added conditionally here to avoid large rebuild
-    gnum4
-  ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   buildInputs = [ ]
     ++ stdenv.lib.optionals stdenv.isLinux [ libusb1 udev ];

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" ];
 
-  nativeBuildInputs = [ perl help2man m4 ];
-  propagatedBuildInputs = [ m4 ];
+  nativeBuildInputs = [ perl help2man ];
+  propagatedNativeBuildInputs = [ m4 ];
 
   # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the
   # "fixed" path in generated files!

--- a/pkgs/development/tools/parsing/bison/default.nix
+++ b/pkgs/development/tools/parsing/bison/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qkp2rfi5njyp5c5avajab00aj74pkmkgzkvshv4p2ydkhswgazv";
   };
 
-  nativeBuildInputs = [ m4 perl ] ++ stdenv.lib.optional stdenv.isSunOS help2man;
-  propagatedBuildInputs = [ m4 ];
+  nativeBuildInputs = [ perl ] ++ stdenv.lib.optional stdenv.isSunOS help2man;
+  propagatedNativeBuildInputs = [ m4 ];
 
   doCheck = false; # fails
   doInstallCheck = false; # fails

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ flex bison texinfo help2man autoreconfHook ];
 
-  propagatedBuildInputs = [ m4 ];
+  propagatedNativeBuildInputs = [ m4 ];
 
   preConfigure = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"

--- a/pkgs/development/tools/parsing/flex/2.6.1.nix
+++ b/pkgs/development/tools/parsing/flex/2.6.1.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation {
     substituteInPlace Makefile.in --replace "tests" " ";
   '';
 
-  buildInputs = [ bison ];
+  nativeBuildInputs = [ bison ];
 
-  propagatedBuildInputs = [ m4 ];
+  propagatedNativeBuildInputs = [ m4 ];
 
   preConfigure = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ autoreconfHook help2man ];
   buildInputs = [ bison ];
-  propagatedBuildInputs = [ m4 ];
+  propagatedNativeBuildInputs = [ m4 ];
 
   preConfigure = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

m4 was propagated as non-native dependency. This caused native builds to build fine, but cross to fail because of a missing m4.

Should we propagate m4 to begin with? If so, which one, or both?

Replaces https://github.com/NixOS/nixpkgs/pull/108044.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
