### PR TITLE
[staging-next] qtlocation: fix build with Qt < 5.15

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -77,6 +77,7 @@ let
         ./qtbase.patch.d/0014-qtbase-pkg-config.patch
       ];
     qtdeclarative = [ ./qtdeclarative.patch ];
+    qtlocation = [ ./qtlocation-gcc-9.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qtwebengine = [

--- a/pkgs/development/libraries/qt-5/5.12/qtlocation-gcc-9.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtlocation-gcc-9.patch
@@ -1,0 +1,21 @@
+diff --git a/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp b/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
+index d475c38..c1710a6 100644
+--- a/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
++++ b/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
+@@ -5,6 +5,7 @@
+ #include <unicode/ushape.h>
+ 
+ #include <memory>
++#include <stdexcept>
+ 
+ namespace mbgl {
+ 
+diff --git a/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp b/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp
+index 97bfe91..56d3e17 100644
+--- a/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp
++++ b/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp
+@@ -1,3 +1,4 @@
++#include <cstdint>
+ #include <mbgl/util/convert.hpp>
+ 
+ namespace mbgl {

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -75,6 +75,7 @@ let
         ./qtbase.patch.d/0011-fix-header_module.patch
       ];
     qtdeclarative = [ ./qtdeclarative.patch ];
+    qtlocation = [ ./qtlocation-gcc-9.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qtwebengine = [

--- a/pkgs/development/libraries/qt-5/5.14/qtlocation-gcc-9.patch
+++ b/pkgs/development/libraries/qt-5/5.14/qtlocation-gcc-9.patch
@@ -1,0 +1,21 @@
+diff --git a/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp b/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
+index d475c38..c1710a6 100644
+--- a/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
++++ b/src/3rdparty/mapbox-gl-native/platform/default/bidi.cpp
+@@ -5,6 +5,7 @@
+ #include <unicode/ushape.h>
+ 
+ #include <memory>
++#include <stdexcept>
+ 
+ namespace mbgl {
+ 
+diff --git a/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp b/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp
+index 97bfe91..56d3e17 100644
+--- a/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp
++++ b/src/3rdparty/mapbox-gl-native/src/mbgl/util/convert.cpp
+@@ -1,3 +1,4 @@
++#include <cstdint>
+ #include <mbgl/util/convert.hpp>
+ 
+ namespace mbgl {

--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -10,5 +10,4 @@ qtModule {
      # https://libcxx.llvm.org/docs/UsingLibcxx.html#c-17-specific-configuration-macros
      "QMAKE_CXXFLAGS+=-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR"
   ];
-
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes Qt Location 5.12 and 5.14. See #107783.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
