### PR TITLE
pihole-ftl: init at 5.8.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -769,6 +769,7 @@
   ./services/networking/ostinato.nix
   ./services/networking/owamp.nix
   ./services/networking/pdnsd.nix
+  ./services/networking/pihole-ftl.nix
   ./services/networking/pixiecore.nix
   ./services/networking/pleroma.nix
   ./services/networking/polipo.nix

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -1,0 +1,107 @@
+{ pkgs
+, lib
+, config
+, ...
+}:
+
+with lib;
+
+let
+
+  cfg = config.services.pihole-ftl;
+  stateDir = "/etc/pihole";
+  confFile = "${stateDir}/pihole-FTL.conf";
+  logFile = "/var/log/pihole-FTL.log";
+  confText = pkgs.writeText "pihole-FTL.conf" cfg.config;
+
+in
+{
+
+  options.services.pihole-ftl = {
+    enable = mkEnableOption "Pi-hole FTL";
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Open ports in the firewall for Pi-hole FTL.";
+    };
+
+    config = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Configuration file content for Pi-hole FTL.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.pihole-ftl;
+      defaultText = "pkgs.pihole-ftl";
+      description = "Pi-hole FTL package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = !config.services.dnsmasq.enable;
+        message = "pihole-ftl conflicts with dnsmasq";
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d ${stateDir} 0700 pihole pihole - -"
+      "L+ ${confFile} - - - - ${confText}"
+      "f ${logFile} 0700 pihole pihole - -"
+    ];
+
+    systemd.services.pihole-ftl = {
+      description = "Pi-hole FTL";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = "pihole";
+        Group = "pihole";
+        AmbientCapabilities = [
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_RAW"
+          "CAP_NET_ADMIN"
+          "CAP_SYS_NICE"
+        ];
+        ExecStart = "${cfg.package}/bin/pihole-FTL no-daemon";
+        Restart = "on-failure";
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        DevicePolicy = "closed";
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ReadWritePaths = [ stateDir logFile ];
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedUDPPorts = [ 53 ];
+      allowedTCPPorts = [ 53 ];
+    };
+
+    users.users.pihole = {
+      group = "pihole";
+      isSystemUser = true;
+    };
+
+    users.groups.pihole = { };
+  };
+}

--- a/nixos/tests/pihole-ftl.nix
+++ b/nixos/tests/pihole-ftl.nix
@@ -1,0 +1,17 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+  with lib;
+
+  {
+    name = "pihole-ftl";
+    meta.maintainers = with maintainers; [ jamiemagee ];
+
+    nodes.machine = { pkgs, ... }: { services.pihole-ftl.enable = true; };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("pihole-ftl.service")
+      machine.wait_for_open_port(53)
+      machine.wait_for_file("/etc/pihole/pihole-FTL.conf")
+    '';
+  })

--- a/pkgs/tools/networking/pihole-ftl/default.nix
+++ b/pkgs/tools/networking/pihole-ftl/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, cmake
+, fetchFromGitHub
+, gmp
+, libidn
+, nettle
+, readline
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pihole-ftl";
+  version = "5.8.1";
+
+  src = fetchFromGitHub {
+    owner = "pi-hole";
+    repo = "FTL";
+    rev = "v${version}";
+    sha512 = "1ybf71jwr781c7q3xvjla2vhnarba6dpp94ghzd31vhdc038g36f0ad2xp3hh8bk1hmlwzzqpcd5pl23w0f4b19kgms4cbk8rh6nvpr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gmp libidn nettle readline ];
+
+  CFLAGS = [
+    # Upstream converts from enum to const enum
+    "-Wno-error=enum-conversion"
+  ];
+
+  postPatch = ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace "CMAKE_STATIC_LIBRARY_SUFFIX" "CMAKE_SHARED_LIBRARY_SUFFIX" \
+
+    substituteInPlace src/version.h.in \
+      --replace "@GIT_VERSION@" "v${version}" \
+      --replace "@GIT_DATE@" "1970-01-01" \
+      --replace "@GIT_BRANCH@" "master" \
+      --replace "@GIT_TAG@" "v${version}" \
+      --replace "@GIT_HASH@" "builtfromreleasetarball"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp pihole-FTL $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Pi-hole FTL engine";
+    homepage = "https://github.com/pi-hole/FTL";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ jamiemagee ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2990,6 +2990,8 @@ in
 
   piglit = callPackage ../tools/graphics/piglit { };
 
+  pihole-ftl = callPackage ../tools/networking/pihole-ftl { };
+
   playerctl = callPackage ../tools/audio/playerctl { };
 
   poweralertd = callPackage ../tools/misc/poweralertd { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The first part of a trio of PRs (to be followed by pihole and pihole-admin). Based on [the work](https://github.com/nuxeh/nixpkgs/tree/add-pi-hole) of @nuxeh and the [`pi-hole-ftl` Arch Linux package](https://aur.archlinux.org/packages/pi-hole-ftl/)

#61617

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
