### PR TITLE
s3fs: fix dependencies

### DIFF
--- a/pkgs/development/python-modules/aiobotocore/default.nix
+++ b/pkgs/development/python-modules/aiobotocore/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pytestrunner
+, typing-extensions
+, wrapt
+, aioitertools
+, aiohttp
+, botocore
+}:
+
+buildPythonPackage rec {
+  pname = "aiobotocore";
+  version = "1.1.2";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fn9hgcg3qr9f7srjxc21bzkiix4al9308531slwlm99r0x3xcjl";
+  };
+
+  # relax version constraints: aiobotocore works with newer botocore versions
+  # the pinning used to match some `extras_require` we're not using.
+  preConfigure = ''
+    substituteInPlace setup.py --replace 'botocore>=1.17.44,<1.17.45' 'botocore'
+  '';
+
+  propagatedBuildInputs = [ wrapt aiohttp aioitertools botocore ];
+
+  # tests not distributed on pypi
+  doCheck = false;
+  pythonImportsCheck = [ "aiobotocore" ];
+
+  meta = with lib; {
+    description = "Async client for amazon services using botocore and aiohttp/asyncio.";
+    license = licenses.asl20;
+    homepage = "https://github.com/aio-libs/aiobotocore";
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/aioitertools/default.nix
+++ b/pkgs/development/python-modules/aioitertools/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, typing-extensions
+, coverage
+, python
+, toml
+}:
+
+buildPythonPackage rec {
+  pname = "aioitertools";
+  version = "0.7.1";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18ql6k2j1839jf2rmmmm29v6fb7mr59l75z8nlf0sadmydy6r9al";
+  };
+
+  propagatedBuildInputs = [ typing-extensions ];
+  checkInputs = [ coverage toml ];
+
+  checkPhase = ''
+    ${python.interpreter} -m coverage run -m aioitertools.tests
+  '';
+
+  meta = with lib; {
+    description = "Implementation of itertools, builtins, and more for AsyncIO and mixed-type iterables.";
+    license = licenses.mit;
+    homepage = "https://pypi.org/project/aioitertools/";
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/development/python-modules/s3fs/default.nix
+++ b/pkgs/development/python-modules/s3fs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, docutils, boto3, fsspec }:
+{ stdenv, buildPythonPackage, fetchPypi, docutils, aiobotocore, fsspec }:
 
 buildPythonPackage rec {
   pname = "s3fs";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ docutils ];
-  propagatedBuildInputs = [ boto3 fsspec ];
+  propagatedBuildInputs = [ aiobotocore fsspec ];
 
   # Depends on `moto` which has a long dependency chain with exact
   # version requirements that can't be made to work with current

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -223,6 +223,8 @@ in {
 
   aioitertools = callPackage ../development/python-modules/aioitertools { };
 
+  aiobotocore = callPackage ../development/python-modules/aiobotocore { };
+
   aiohue = callPackage ../development/python-modules/aiohue { };
 
   aioimaplib = callPackage ../development/python-modules/aioimaplib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -221,6 +221,8 @@ in {
 
   aiohttp-swagger = callPackage ../development/python-modules/aiohttp-swagger { };
 
+  aioitertools = callPackage ../development/python-modules/aioitertools { };
+
   aiohue = callPackage ../development/python-modules/aiohue { };
 
   aioimaplib = callPackage ../development/python-modules/aioimaplib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

python3Modules.s3fs is currently broken due to an upstream dependency change (e.g. https://hydra.nixos.org/job/nixpkgs/trunk/python37Packages.s3fs.x86_64-darwin).

This PR inits the missing dependencies at their most recent releases and fixes the s3fs build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
