### PR TITLE
cargo-flamegraph: 0.3.0 -> 0.4.0 and clean up

### DIFF
--- a/pkgs/development/tools/cargo-flamegraph/default.nix
+++ b/pkgs/development/tools/cargo-flamegraph/default.nix
@@ -1,19 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, makeWrapper, perf
+{ lib, stdenv, fetchFromGitHub, rustPlatform, makeWrapper, perf, nix-update-script
 , Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-flamegraph";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "flamegraph-rs";
     repo = "flamegraph";
     rev = "v${version}";
-    sha256 = "0d6k2qr76p93na39j4zbcpc9kaswd806wrqhcwisqxdrcxrjbwhk";
+    sha256 = "sha256-IpmvFUWNaFQ1ls7u625vvj1TnRYXR+X1mAGdBcwRFLk=";
   };
 
-  cargoSha256 = "1qz4a1b58j3bv3akqvc3bcgvqq4bi8cbm3gzws6a52dz7ycrgq46";
+  cargoSha256 = "sha256-2YHkEQZqjKEvg4h9kIVhqmgq+SMF1c3r8UbSQivZh7w=";
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ makeWrapper ];
   buildInputs = lib.optionals stdenv.isDarwin [
@@ -22,10 +22,14 @@ rustPlatform.buildRustPackage rec {
 
   postFixup = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/cargo-flamegraph \
-      --suffix PATH ':' ${perf}/bin
+      --set-default PERF ${perf}/bin/perf
     wrapProgram $out/bin/flamegraph \
-      --suffix PATH ':' ${perf}/bin
+      --set-default PERF ${perf}/bin/perf
   '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
 
   meta = with lib; {
     description = "Easy flamegraphs for Rust projects and everything else, without Perl or pipes <3";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Bump version.
- Add update script.
- Set `perf` through environment `PERF` which is available in 0.4.0 , instead of `PATH`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  ```
  1 package built:
  cargo-flamegraph
  ```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
