### PR TITLE
platformio: 5.0.3 -> 5.0.4

### DIFF
--- a/pkgs/development/arduino/platformio/default.nix
+++ b/pkgs/development/arduino/platformio/default.nix
@@ -4,14 +4,14 @@
 let
   callPackage = newScope self;
 
-  version = "5.0.3";
+  version = "5.0.4";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "0sf5dy0cmhy66rmk0hq1by7nrmf7qz0a99hrk55dpbp6r6vnk3hw";
+    sha256 = "15jnhlhkk9z6cyzxw065r3080dqan951klwf65p152vfzg79wf84";
   };
 
   self = {


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (before: 908703400) (after: 905282992) (% change: -0.3%)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
