### PR TITLE
nixos/prometheus: fix remote_{read,write} options

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -112,17 +112,21 @@ let
           http://tools.ietf.org/html/rfc4366#section-3.1
         '';
       };
-      remote_timeout = mkDefOpt types.str "30s" ''
-        Timeout for requests to the remote write endpoint.
-      '';
-      relabel_configs = mkOpt (types.listOf promTypes.relabel_config) ''
-         List of remote write relabel configurations.
-         List of relabel configurations.
-       '';
       name = mkOpt types.string ''
-        Name of the remote write config, which if specified must be unique among remote write configs.
+        Name of the remote read config, which if specified must be unique among remote read configs.
         The name will be used in metrics and logging in place of a generated value to help users distinguish between
-        remote write configs.
+        remote read configs.
+      '';
+      required_matchers = mkOpt (types.attrsOf types.str) ''
+        An optional list of equality matchers which have to be
+        present in a selector to query the remote read endpoint.
+      '';
+      remote_timeout = mkOpt types.str ''
+        Timeout for requests to the remote read endpoint.
+      '';
+      read_recent = mkOpt types.bool ''
+        Whether reads should be made for queries for time ranges that
+        the local storage should have complete data for.
       '';
       basic_auth = mkOpt (types.submodule {
         options = {
@@ -136,30 +140,22 @@ let
           password_file = mkOpt types.str "HTTP password file";
         };
       }) ''
-        Sets the `Authorization` header on every remote write request with the
+        Sets the `Authorization` header on every remote read request with the
         configured username and password.
         password and password_file are mutually exclusive.
       '';
       bearer_token = mkOpt types.str ''
-        Sets the `Authorization` header on every remote write request with
+        Sets the `Authorization` header on every remote read request with
         the configured bearer token. It is mutually exclusive with `bearer_token_file`.
       '';
       bearer_token_file = mkOpt types.str ''
-        Sets the `Authorization` header on every remote write request with the bearer token
+        Sets the `Authorization` header on every remote read request with the bearer token
         read from the configured file. It is mutually exclusive with `bearer_token`.
       '';
       tls_config = mkOpt promTypes.tls_config ''
-        Configures the remote write request's TLS settings.
+        Configures the remote read request's TLS settings.
       '';
       proxy_url = mkOpt types.str "Optional Proxy URL.";
-      metadata_config = {
-        send = mkDefOpt types.bool "true" ''
-          Whether metric metadata is sent to remote storage or not.
-        '';
-        send_interval = mkDefOpt types.str "1m" ''
-          How frequently metric metadata is sent to remote storage.
-        '';
-      };
     };
   };
 
@@ -172,13 +168,12 @@ let
           http://tools.ietf.org/html/rfc4366#section-3.1
         '';
       };
-      remote_timeout = mkDefOpt types.str "30s" ''
+      remote_timeout = mkOpt types.str ''
         Timeout for requests to the remote write endpoint.
       '';
-      relabel_configs = mkOpt (types.listOf promTypes.relabel_config) ''
-         List of remote write relabel configurations.
-         List of relabel configurations.
-       '';
+      write_relabel_configs = mkOpt (types.listOf promTypes.relabel_config) ''
+        List of remote write relabel configurations.
+      '';
       name = mkOpt types.string ''
         Name of the remote write config, which if specified must be unique among remote write configs.
         The name will be used in metrics and logging in place of a generated value to help users distinguish between
@@ -212,14 +207,50 @@ let
         Configures the remote write request's TLS settings.
       '';
       proxy_url = mkOpt types.str "Optional Proxy URL.";
-      metadata_config = {
-        send = mkDefOpt types.bool "true" ''
-          Whether metric metadata is sent to remote storage or not.
-        '';
-        send_interval = mkDefOpt types.str "1m" ''
-          How frequently metric metadata is sent to remote storage.
-        '';
-      };
+      queue_config = mkOpt (types.submodule {
+        options = {
+          capacity = mkOpt types.int ''
+            Number of samples to buffer per shard before we block reading of more
+            samples from the WAL. It is recommended to have enough capacity in each
+            shard to buffer several requests to keep throughput up while processing
+            occasional slow remote requests.
+          '';
+          max_shards = mkOpt types.int ''
+            Maximum number of shards, i.e. amount of concurrency.
+          '';
+          min_shards = mkOpt types.int ''
+            Minimum number of shards, i.e. amount of concurrency.
+          '';
+          max_samples_per_send = mkOpt types.int ''
+            Maximum number of samples per send.
+          '';
+          batch_send_deadline = mkOpt types.str ''
+            Maximum time a sample will wait in buffer.
+          '';
+          min_backoff = mkOpt types.str ''
+            Initial retry delay. Gets doubled for every retry.
+          '';
+          max_backoff = mkOpt types.str ''
+            Maximum retry delay.
+          '';
+        };
+      }) ''
+        Configures the queue used to write to remote storage.
+      '';
+      metadata_config = mkOpt (types.submodule {
+        options = {
+          send = mkOpt types.bool ''
+            Whether metric metadata is sent to remote storage or not.
+          '';
+          send_interval = mkOpt types.str ''
+            How frequently metric metadata is sent to remote storage.
+          '';
+        };
+      }) ''
+        Configures the sending of series metadata to remote storage.
+        Metadata configuration is subject to change at any point
+        or be removed in future releases.
+      '';
     };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Apparently some options are different between remote_read and remote_write.
Fixing this oversight.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
