### PR TITLE
wsdd: fix send messages using correct socket

### DIFF
--- a/pkgs/servers/wsdd/default.nix
+++ b/pkgs/servers/wsdd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, nixosTests, python3 }:
+{ stdenv, fetchFromGitHub, makeWrapper, nixosTests, python3, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "wsdd";
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ python3 ];
+
+  patches = [
+    (fetchpatch {	
+      # https://github.com/christgau/wsdd/issues/72
+      name = "fix_send_messages_using_correct_socket.patch";	
+      url = "https://github.com/christgau/wsdd/commit/1ed74fe73a9fe2e2720859e2822116d65e4ffa5b.patch";	
+      sha256 = "1n9bqvh20nhnvnc5pxvzf9kk8nky6rmbmfryg65lfmr1hmg676zg";	
+    })
+  ];
 
   installPhase = ''
     install -Dm0755 src/wsdd.py $out/bin/wsdd


### PR DESCRIPTION
###### Motivation for this change
Fix neighboring subnet.

cc @flokli @aanderse @Mic92
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
