### PR TITLE
json-schema-for-humans: init at 0.27.0

### DIFF
--- a/pkgs/development/python-modules/json-schema-for-humans/default.nix
+++ b/pkgs/development/python-modules/json-schema-for-humans/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchurl
+, pbr, click, dataclasses-json, htmlmin, jinja2, markdown2, pygments, pytz, pyyaml, requests, pytestCheckHook, beautifulsoup4, tox
+}:
+
+buildPythonPackage rec {
+  pname = "json-schema-for-humans";
+  version = "0.27.0";
+
+  src = fetchFromGitHub {
+    owner = "coveooss";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1r40i192z6aasil5vsgcgp5yvx392dhhqnfc2qxbxvpja6l3p6p2";
+  };
+
+  patches = [ (fetchurl {
+    url = "https://github.com/coveooss/json-schema-for-humans/commit/1fe2e2391da5a796204fd1889e4a11a53f83f7c9.patch";
+    sha256 = "0kpydpddlg0rib9snl8albhbrrs6d3ds292gpgpg7bdpqrwamdib";
+  }) (fetchurl {
+    url = "https://github.com/astro/json-schema-for-humans/commit/9bcc9b461102062dff214ca1ec2375b8aea53711.patch";
+    sha256 = "142a07v8bn1j20b7177yb60f4944kbx4cdqqq2nz6xkxmamw704d";
+  }) ];
+
+  nativeBuildInputs = [ pbr ];
+  propagatedBuildInputs = [
+    click dataclasses-json htmlmin jinja2 markdown2
+    pygments pytz pyyaml requests
+  ];
+
+  preBuild = ''
+    export PBR_VERSION=0.0.1
+  '';
+
+  checkInputs = [ pytestCheckHook beautifulsoup4 ];
+  pytestFlagsArray = [ "--ignore tests/generate_test.py" ];
+
+  meta = with stdenv.lib; {
+    description = "Quickly generate HTML documentation from a JSON schema";
+    homepage    = "https://github.com/coveooss/json-schema-for-humans";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ astro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5076,6 +5076,8 @@ in
 
   jsduck = callPackage ../development/tools/jsduck { };
 
+  json-schema-for-humans = with python3Packages; toPythonApplication json-schema-for-humans;
+
   jtc = callPackage ../development/tools/jtc { };
 
   jumpapp = callPackage ../tools/X11/jumpapp {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3208,6 +3208,8 @@ in {
 
   json-merge-patch = callPackage ../development/python-modules/json-merge-patch { };
 
+  json-schema-for-humans = callPackage ../development/python-modules/json-schema-for-humans { };
+
   jsonnet = buildPythonPackage { inherit (pkgs.jsonnet) name src; };
 
   jsonpatch = callPackage ../development/python-modules/jsonpatch { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Quickly generate HTML documentation from a JSON schema

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
