### PR TITLE
nixos/binfmt.nix: fix running commands in binfmt

### DIFF
--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -20,8 +20,14 @@ let
                  optionalString fixBinary "F";
   in ":${name}:${type}:${offset'}:${magicOrExtension}:${mask'}:${interpreter}:${flags}";
 
-  activationSnippet = name: { interpreter, ... }:
-    "ln -sf ${interpreter} /run/binfmt/${name}";
+  activationSnippet = name: { interpreter, ... }: ''
+    rm -f /run/binfmt/${name}
+    cat > /run/binfmt/${name} << 'EOF'
+    #!/usr/bin/env sh
+    exec -- ${interpreter} "$@"
+    EOF
+    chmod +x /run/binfmt/${name}
+  '';
 
   getEmulator = system: (lib.systems.elaborate { inherit system; }).emulator pkgs;
 


### PR DESCRIPTION
To allow arguments in binfmt, we need to put the command in a shell
script. This uses exec to run the binfmt interpreter.

Fixes #90683
