### PR TITLE
[20.09] Backport zulip: 5.4.3 → 5.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zulip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zulip/default.nix
@@ -5,12 +5,12 @@
 
 let
   pname = "zulip";
-  version = "5.4.3";
+  version = "5.5.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/zulip/zulip-desktop/releases/download/v${version}/Zulip-${version}-x86_64.AppImage";
-    sha256 = "0yd4g87kcwiy1arx3y2nyb7lq1nlh4cn87762k2sd8n4s9i52c7r";
+    sha256 = "059zfcvaq8wnsz2lfd4gdb17b6nngqk3vgisy2kb29ifqf3lpzqi";
     name="${pname}-${version}.AppImage";
   };
 
@@ -32,7 +32,7 @@ in appimageTools.wrapType2 {
 
   meta = with lib; {
     description = "Desktop client for Zulip Chat";
-    homepage = "https://zulipchat.com";
+    homepage = "https://zulip.com";
     license = licenses.asl20;
     maintainers = with maintainers; [ jonafato ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
(cherry picked from commit bfabe2a17a12d4792ba1a30860f67a9bf6288966)

###### Motivation for this change

Update 20.09 package

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
