### PR TITLE
python3Packages.cfn-lint: future-proof tests for date impurity issues

### DIFF
--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -59,6 +59,12 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
+    # These tests depend on the current date, for example because of issues like this.
+    # This makes it possible for them to succeed on hydra and then begin to fail without
+    # any code changes.
+    # https://github.com/aws-cloudformation/cfn-python-lint/issues/1705
+    # See also: https://github.com/NixOS/nixpkgs/issues/108076
+    "TestQuickStartTemplates"
     # requires git directory
     "test_update_docs"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #108076

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
