### PR TITLE
shellhub-agent: add update.sh script

### DIFF
--- a/pkgs/applications/networking/shellhub-agent/default.nix
+++ b/pkgs/applications/networking/shellhub-agent/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, buildGoModule, fetchFromGitHub }:
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+, genericUpdater
+, common-updater-scripts
+}:
 
 buildGoModule rec {
   pname = "shellhub-agent";
@@ -16,6 +21,15 @@ buildGoModule rec {
   vendorSha256 = "19gsfhh6idqysdxhpq45sq35gw19adz9lp83krjlhzj1vqm59qma";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.AgentVersion=v${version}" ];
+
+  passthru = {
+    updateScript = genericUpdater {
+      inherit pname version;
+      versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
+      rev-prefix = "v";
+      ignoredVersions = ".(rc|beta).*";
+    };
+  };
 
   meta = with stdenv.lib; {
     description =


### PR DESCRIPTION
###### Motivation for this change

I am learning more about how to ease the maintainer's life and I am then adding the new script here so we can easily upgrade to the new releases when they are made.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
