### PR TITLE
fix string escaping

### DIFF
--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -8,9 +8,9 @@ let
   # Convert systemd-style address specification to kresd config line(s).
   # On Nix level we don't attempt to precisely validate the address specifications.
   mkListen = kind: addr: let
-    al_v4 = builtins.match "([0-9.]\+):([0-9]\+)" addr;
-    al_v6 = builtins.match "\\[(.\+)]:([0-9]\+)" addr;
-    al_portOnly = builtins.match "()([0-9]\+)" addr;
+    al_v4 = builtins.match "([0-9.]+):([0-9]+)" addr;
+    al_v6 = builtins.match "\\[(.+)]:([0-9]+)" addr;
+    al_portOnly = builtins.match "()([0-9]+)" addr;
     al = findFirst (a: a != null)
       (throw "services.kresd.*: incorrect address specification '${addr}'")
       [ al_v4 al_v6 al_portOnly ];

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -329,7 +329,7 @@ in
           extraConfig = "internal;";
         };
 
-        locations."~ ^/lib.*\.(js|css|gif|png|ico|jpg|jpeg)$" = {
+        locations."~ ^/lib.*\\.(js|css|gif|png|ico|jpg|jpeg)$" = {
           extraConfig = "expires 365d;";
         };
 
@@ -349,7 +349,7 @@ in
           '';
         };
 
-        locations."~ \.php$" = {
+        locations."~ \\.php$" = {
           extraConfig = ''
               try_files $uri $uri/ /doku.php;
               include ${pkgs.nginx}/conf/fastcgi_params;

--- a/nixos/tests/php/fpm.nix
+++ b/nixos/tests/php/fpm.nix
@@ -10,7 +10,7 @@ import ../make-test-python.nix ({pkgs, lib, ...}: {
         testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
       in {
         root = "${testdir}/web";
-        locations."~ \.php$".extraConfig = ''
+        locations."~ \\.php$".extraConfig = ''
           fastcgi_pass unix:${config.services.phpfpm.pools.foobar.socket};
           fastcgi_index index.php;
           include ${pkgs.nginx}/conf/fastcgi_params;

--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -108,8 +108,8 @@ in stdenv.mkDerivation (fBuildAttrs // {
       rm -rf $bazelOut/external/{bazel_tools,\@bazel_tools.marker}
       ${if removeRulesCC then "rm -rf $bazelOut/external/{rules_cc,\\@rules_cc.marker}" else ""}
       rm -rf $bazelOut/external/{embedded_jdk,\@embedded_jdk.marker}
-      ${if removeLocalConfigCc then "rm -rf $bazelOut/external/{local_config_cc,\@local_config_cc.marker}" else ""}
-      ${if removeLocal then "rm -rf $bazelOut/external/{local_*,\@local_*.marker}" else ""}
+      ${if removeLocalConfigCc then "rm -rf $bazelOut/external/{local_config_cc,\\@local_config_cc.marker}" else ""}
+      ${if removeLocal then "rm -rf $bazelOut/external/{local_*,\\@local_*.marker}" else ""}
 
       # Clear markers
       find $bazelOut/external -name '@*\.marker' -exec sh -c 'echo > {}' \;

--- a/pkgs/development/libraries/libcutl/default.nix
+++ b/pkgs/development/libraries/libcutl/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     description = "C++ utility library from Code Synthesis";
     longDescription = ''
         libcutl is a C++ utility library.
-        It contains a collection of generic and independent components such as 
+        It contains a collection of generic and independent components such as
         meta-programming tests, smart pointers, containers, compiler building blocks, etc.
     '';
     homepage = "https://codesynthesis.com/projects/libcutl/";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
   };
 
-  majmin = builtins.head ( builtins.match "([[:digit:]]\.[[:digit:]]+)\.*" "${version}" );
+  majmin = builtins.head ( builtins.match "([[:digit:]]\\.[[:digit:]]+)\\.*" "${version}" );
   src = fetchurl {
     url = "https://codesynthesis.com/download/${pname}/${majmin}/${pname}-${version}.tar.bz2";
     sha256 = "070j2x02m4gm1fn7gnymrkbdxflgzxwl7m96aryv8wp3f3366l8j";

--- a/pkgs/development/libraries/libcutl/default.nix
+++ b/pkgs/development/libraries/libcutl/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
   };
 
-  majmin = builtins.head ( builtins.match "([[:digit:]]\\.[[:digit:]]+)\\.*" "${version}" );
+  majmin = builtins.head ( builtins.match "([[:digit:]]\\.[[:digit:]]+).*" "${version}" );
   src = fetchurl {
     url = "https://codesynthesis.com/download/${pname}/${majmin}/${pname}-${version}.tar.bz2";
     sha256 = "070j2x02m4gm1fn7gnymrkbdxflgzxwl7m96aryv8wp3f3366l8j";

--- a/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix
@@ -157,7 +157,7 @@ let
       missingBuildBackendError = "No build-system.build-backend section in pyproject.toml. "
         + "Add such a section as described in https://python-poetry.org/docs/pyproject/#poetry-and-pep-517";
       requires = lib.attrByPath [ "build-system" "requires" ] (throw missingBuildBackendError) pyProject;
-      requiredPkgs = builtins.map (n: lib.elemAt (builtins.match "([^!=<>~\[]+).*" n) 0) requires;
+      requiredPkgs = builtins.map (n: lib.elemAt (builtins.match "([^!=<>~[]+).*" n) 0) requires;
     in
     builtins.map (drvAttr: pythonPackages.${drvAttr} or (throw "unsupported build system requirement ${drvAttr}")) requiredPkgs;
 

--- a/pkgs/development/tools/poetry2nix/poetry2nix/semver.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/semver.nix
@@ -3,7 +3,7 @@ let
   inherit (builtins) elemAt match;
   operators =
     let
-      matchWildCard = s: match "([^\*])(\.[\*])" s;
+      matchWildCard = s: match "([^*])(\\.[*])" s;
       mkComparison = ret: version: v: builtins.compareVersions version v == ret;
       mkIdxComparison = idx: version: v:
         let
@@ -52,8 +52,8 @@ let
       #
     };
   re = {
-    operators = "([=><!~\^]+)";
-    version = "([0-9\.\*x]+)";
+    operators = "([=><!~^]+)";
+    version = "([0-9.*x]+)";
   };
   parseConstraint = constraint:
     let


### PR DESCRIPTION
Sequences like `"\."` and `"\@"` are wacky within single quoted strings, there must be either `"."` or `"\\."`