### PR TITLE
freeplane: init at 1.8.11

### DIFF
--- a/pkgs/applications/misc/freeplane/default.nix
+++ b/pkgs/applications/misc/freeplane/default.nix
@@ -1,0 +1,118 @@
+{ stdenv, lib, fetchpatch, fetchFromGitHub, makeWrapper, writeText, runtimeShell, jdk11, perl, gradle_5, which }:
+
+let
+  pname = "freeplane";
+  version = "1.8.11";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "release-${version}";
+    sha256 = "07xjx9pf62dvy8lx6vnbwwcn1zqy89cmdmwy792k7gb12wz81nnc";
+  };
+
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps";
+    inherit src;
+
+    nativeBuildInputs = [ jdk11 perl gradle_5 ];
+
+    buildPhase = ''
+      GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk11} --no-daemon jar
+    '';
+
+    # Mavenize dependency paths
+    # e.g. org.codehaus.groovy/groovy/2.4.0/{hash}/groovy-2.4.0.jar -> org/codehaus/groovy/groovy/2.4.0/groovy-2.4.0.jar
+    installPhase = ''
+      find ./caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0r7f6713m0whh5hlk1id7z9j5v9494r41sivn9fzl63q70kzz92g";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url '${deps}' }
+        }
+      }
+    }
+  '';
+
+  # downloaded from unicode.org and twemoji.maxcdn.com by code in freeplane/emoji.gradle
+  # the below hash is for versions of freeplane that use twemoji 12.1.4, and emoji 12.1
+  emoji = stdenv.mkDerivation rec {
+    name = "${pname}-emoji";
+    inherit src;
+
+    nativeBuildInputs = [ jdk11 gradle_5 ];
+
+    buildPhase = ''
+      GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk11} --no-daemon --offline --init-script ${gradleInit} emojiGraphicsClasses emojiListClasses
+    '';
+
+    installPhase = ''
+      mkdir -p $out/emoji/txt $out/resources/images
+      cp freeplane/build/emoji/txt/emojilist.txt $out/emoji/txt
+      cp -r freeplane/build/emoji/resources/images/emoji/. $out/resources/images/emoji
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0zikbakbr2fhyv4h4h52ajhznjka0hg6hiqfy1528a39i6psipn3";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ jdk11 gradle_5 ];
+
+  buildPhase = ''
+    mkdir -p -- ./freeplane/build/emoji/{txt,resources/images}
+    cp ${emoji}/emoji/txt/emojilist.txt ./freeplane/build/emoji/txt/emojilist.txt
+    cp -r ${emoji}/resources/images/emoji ./freeplane/build/emoji/resources/images/emoji
+    GRADLE_USER_HOME=$PWD gradle -Dorg.gradle.java.home=${jdk11} --no-daemon --offline --init-script ${gradleInit} -x test -x :freeplane:downloadEmoji build
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share
+
+    cp -a ./BIN/. $out/share/${pname}
+    makeWrapper $out/share/${pname}/${pname}.sh $out/bin/${pname} \
+      --set FREEPLANE_BASE_DIR $out/share/${pname} \
+      --set JAVA_HOME ${jdk11} \
+      --prefix PATH : ${lib.makeBinPath [ jdk11 which ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Mind-mapping software";
+    homepage = "https://freeplane.org/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ chaduffy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22714,6 +22714,8 @@ in
 
   freeoffice = callPackage ../applications/office/softmaker/freeoffice.nix {};
 
+  freeplane = callPackage ../applications/misc/freeplane { };
+
   freepv = callPackage ../applications/graphics/freepv { };
 
   xfontsel = callPackage ../applications/misc/xfontsel { };


### PR DESCRIPTION
###### Motivation for this change

The freemind package has been effectively unmaintained for years -- the most recent release is from 2014.

freeplane is an actively-maintained fork, written by @dpolivaev. In addition to substantial feature improvements, it also has received security fixes.

There was a prior attempt at packaging freeplane made in #34752; this was not completed due to difficulties in getting freeplane to compile in a sandbox without network access. This derivation adopts the pattern used by pdftk and jadx, performing download of dependencies inside fixed-output derivations.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
