### PR TITLE
sumneko-lua-language-server: init at 1.11.2

### DIFF
--- a/pkgs/development/tools/sumneko-lua-language-server/default.nix
+++ b/pkgs/development/tools/sumneko-lua-language-server/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, ninja, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "sumneko-lua-language-server";
+  version = "1.11.2";
+
+  src = fetchFromGitHub {
+    owner = "sumneko";
+    repo = "lua-language-server";
+    rev = version;
+    sha256 = "1cnzwfqmzlzi6797l37arhhx2l6wsvs3jjgxdxwdbgq3rfz1ncr8";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    ninja
+    makeWrapper
+  ];
+
+  preBuild = ''
+    cd 3rd/luamake
+  '';
+
+  ninjaFlags = [
+    "-f ninja/linux.ninja"
+    ];
+
+  postBuild = ''
+    cd ../..
+    ./3rd/luamake/luamake rebuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/extras
+    cp -r ./{locale,meta,script,*.lua} $out/extras/
+    cp ./bin/Linux/{bee.so,lpeglabel.so} $out/extras
+    cp ./bin/Linux/lua-language-server $out/extras/.lua-language-server-unwrapped
+    makeWrapper $out/extras/.lua-language-server-unwrapped \
+      $out/bin/lua-language-server \
+      --add-flags "-E $out/extras/main.lua \
+      --logpath='~/.cache/sumneko_lua/log' \
+      --metapath='~/.cache/sumneko_lua/meta'"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Lua Language Server coded by Lua ";
+    homepage = "https://github.com/sumneko/lua-language-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mjlbach ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28456,6 +28456,8 @@ in
 
   sqsh = callPackage ../development/tools/sqsh { };
 
+  sumneko-lua-language-server = callPackage ../development/tools/sumneko-lua-language-server { };
+
   go-swag = callPackage ../development/tools/go-swag { };
 
   go-swagger = callPackage ../development/tools/go-swagger { };


### PR DESCRIPTION
###### Motivation for this change
sumneko-lua-language-server: init at 1.11.2

Things I'm not happy with.

- [x] ~Currently sumneko requires that lua-language-server, bee.so, lpeglabel.so are all in the same directory, so with this derivation they are all in bin which pollutes path~
- [x] ~Currently sumneko does not expand "\~" to home directory, so logs write in "\~" (prior to some upstreamed patches, it was always writing to "root" which would default into nix store. I'm not sure if this can be addressed with wrap program or has to be fixed within sumneko~ I wrote a pretty large in-tree patch to work around this, so not happy about that either.

Both fixed, not sure if the former could have been done more cleanly/if extras is the appropriate directory to redirect to, and the latter required a fairly lengthy patch which is mostly copying functions from penlight.

It won't work on mac, since it requires MacOS 10.13 SDK to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
