### PR TITLE
pythonPackages.pillow: Add libxcb support, convert to generic; pythonPackages.pillow-simd: Init at 7.0.0.post3

### DIFF
--- a/pkgs/development/python-modules/pillow-simd/default.nix
+++ b/pkgs/development/python-modules/pillow-simd/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, isPyPy, isPy3k
+, olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2
+, tk, libX11, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
+}@args:
+
+import ../pillow/generic.nix (rec {
+  pname = "Pillow-SIMD";
+  version = "7.0.0.post3";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "uploadcare";
+    repo = "pillow-simd";
+    rev = "v${version}";
+    sha256 = "1h832xp1bzf951hr4dmjmxqfsv28sx9lr2cq96qdz1c72k40zj1h";
+  };
+
+  meta = with lib; {
+    homepage = "https://python-pillow.github.io/pillow-perf/";
+    description = "The friendly PIL fork - SIMD version";
+    longDescription = ''
+      Pillow-SIMD is "following" Pillow. Pillow-SIMD versions are 100% compatible drop-in replacements for Pillow of the same version.
+
+      SIMD stands for "single instruction, multiple data" and its essence is in performing the same operation on multiple data points simultaneously by using multiple processing elements. Common CPU SIMD instruction sets are MMX, SSE-SSE4, AVX, AVX2, AVX512, NEON.
+
+      Currently, Pillow-SIMD can be compiled with SSE4 (default) or AVX2 support.
+    '';
+    license = "http://www.pythonware.com/products/pil/license.htm";
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+} // args )

--- a/pkgs/development/python-modules/pillow/6.nix
+++ b/pkgs/development/python-modules/pillow/6.nix
@@ -1,75 +1,22 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPyPy
-, olefile
-, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
-, openjpeg, libimagequant
-, pytest, pytestrunner, pyroma, numpy
-}:
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPyPy, isPy3k
+, olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
+, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
+}@args:
 
-buildPythonPackage rec {
+import ./generic.nix (rec {
   pname = "Pillow";
   version = "6.2.2";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0l5rv8jkdrb5q846v60v03mcq64yrhklidjkgwv6s1pda71g17yv";
   };
 
-  # Disable imagefont tests, because they don't work well with infinality:
-  # https://github.com/python-pillow/Pillow/issues/1259
-  postPatch = ''
-    rm Tests/test_imagefont.py
-  '';
-
-  checkPhase = ''
-    runHook preCheck
-    python -m pytest -v -x -W always${lib.optionalString stdenv.isDarwin " --deselect=Tests/test_file_icns.py::TestFileIcns::test_save --deselect=Tests/test_imagegrab.py::TestImageGrab::test_grab"}
-    runHook postCheck
-  '';
-
-  propagatedBuildInputs = [ olefile ];
-
-  checkInputs = [ pytest pytestrunner pyroma numpy ];
-
-  buildInputs = [
-    freetype libjpeg openjpeg libimagequant zlib libtiff libwebp tcl lcms2 ]
-    ++ lib.optionals (isPyPy) [ tk libX11 ];
-
-  # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
-  # NOTE: The Pillow install script will, by default, add paths like /usr/lib
-  # and /usr/include to the search paths. This can break things when building
-  # on a non-NixOS system that has some libraries installed that are not
-  # installed in Nix (for example, Arch Linux has jpeg2000 but Nix doesn't
-  # build Pillow with this support). We patch the `disable_platform_guessing`
-  # setting here, instead of passing the `--disable-platform-guessing`
-  # command-line option, since the command-line option doesn't work when we run
-  # tests.
-  preConfigure = let
-    libinclude' = pkg: ''"${pkg.out}/lib", "${pkg.out}/include"'';
-    libinclude = pkg: ''"${pkg.out}/lib", "${pkg.dev}/include"'';
-  in ''
-    sed -i "setup.py" \
-        -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude freetype}|g ;
-            s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude libjpeg}|g ;
-            s|^JPEG2K_ROOT =.*$|JPEG2K_ROOT = ${libinclude openjpeg}|g ;
-            s|^IMAGEQUANT_ROOT =.*$|IMAGEQUANT_ROOT = ${libinclude' libimagequant}|g ;
-            s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude zlib}|g ;
-            s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude lcms2}|g ;
-            s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude libtiff}|g ;
-            s|^TCL_ROOT=.*$|TCL_ROOT = ${libinclude' tcl}|g ;
-            s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
-    export LDFLAGS="-L${libwebp}/lib"
-    export CFLAGS="-I${libwebp}/include"
-  ''
-  # Remove impurities
-  + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace setup.py \
-      --replace '"/Library/Frameworks",' "" \
-      --replace '"/System/Library/Frameworks"' ""
-  '';
-
   meta = with lib; {
-    homepage = "https://python-pillow.github.io/";
-    description = "Fork of The Python Imaging Library (PIL)";
+    homepage = "https://python-pillow.org/";
+    description = "The friendly PIL fork (Python Imaging Library)";
     longDescription = ''
       The Python Imaging Library (PIL) adds image processing
       capabilities to your Python interpreter.  This library
@@ -77,6 +24,6 @@ buildPythonPackage rec {
       processing and graphics capabilities.
     '';
     license = "http://www.pythonware.com/products/pil/license.htm";
-    maintainers = with maintainers; [ goibhniu prikhi ];
+    maintainers = with maintainers; [ goibhniu prikhi SuperSandro2000 ];
   };
-}
+} // args )

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, buildPythonPackage, fetchPypi, isPyPy, isPy3k
 , olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
-, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
+, libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
 }@args:
 
 import ./generic.nix (rec {

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,12 +1,9 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPyPy
-, olefile
-, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
-, openjpeg, libimagequant
-, pyroma, numpy, pytestCheckHook
-, isPy3k
-}:
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPyPy, isPy3k
+, olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
+, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
+}@args:
 
-buildPythonPackage rec {
+import ./generic.nix (rec {
   pname = "Pillow";
   version = "8.0.1";
 
@@ -16,56 +13,6 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e";
   };
-
-  # Disable imagefont tests, because they don't work well with infinality:
-  # https://github.com/python-pillow/Pillow/issues/1259
-  postPatch = ''
-    rm Tests/test_imagefont.py
-  '';
-
-  # Disable darwin tests which require executables: `iconutil` and `screencapture`
-  disabledTests = lib.optionals stdenv.isDarwin [ "test_save" "test_grab" "test_grabclipboard" ];
-
-  propagatedBuildInputs = [ olefile ];
-
-  checkInputs = [ pytestCheckHook pyroma numpy ];
-
-  buildInputs = [
-    freetype libjpeg openjpeg libimagequant zlib libtiff libwebp tcl lcms2 ]
-    ++ lib.optionals (isPyPy) [ tk libX11 ];
-
-  # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
-  # NOTE: The Pillow install script will, by default, add paths like /usr/lib
-  # and /usr/include to the search paths. This can break things when building
-  # on a non-NixOS system that has some libraries installed that are not
-  # installed in Nix (for example, Arch Linux has jpeg2000 but Nix doesn't
-  # build Pillow with this support). We patch the `disable_platform_guessing`
-  # setting here, instead of passing the `--disable-platform-guessing`
-  # command-line option, since the command-line option doesn't work when we run
-  # tests.
-  preConfigure = let
-    libinclude' = pkg: ''"${pkg.out}/lib", "${pkg.out}/include"'';
-    libinclude = pkg: ''"${pkg.out}/lib", "${pkg.dev}/include"'';
-  in ''
-    sed -i "setup.py" \
-        -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude freetype}|g ;
-            s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude libjpeg}|g ;
-            s|^JPEG2K_ROOT =.*$|JPEG2K_ROOT = ${libinclude openjpeg}|g ;
-            s|^IMAGEQUANT_ROOT =.*$|IMAGEQUANT_ROOT = ${libinclude' libimagequant}|g ;
-            s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude zlib}|g ;
-            s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude lcms2}|g ;
-            s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude libtiff}|g ;
-            s|^TCL_ROOT=.*$|TCL_ROOT = ${libinclude' tcl}|g ;
-            s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
-    export LDFLAGS="-L${libwebp}/lib"
-    export CFLAGS="-I${libwebp}/include"
-  ''
-  # Remove impurities
-  + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace setup.py \
-      --replace '"/Library/Frameworks",' "" \
-      --replace '"/System/Library/Frameworks"' ""
-  '';
 
   meta = with lib; {
     homepage = "https://python-pillow.org/";
@@ -77,6 +24,6 @@ buildPythonPackage rec {
       processing and graphics capabilities.
     '';
     license = "http://www.pythonware.com/products/pil/license.htm";
-    maintainers = with maintainers; [ goibhniu prikhi ];
+    maintainers = with maintainers; [ goibhniu prikhi SuperSandro2000 ];
   };
-}
+} // args )

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -22,6 +22,10 @@ buildPythonPackage rec {
     "test_grab"
     "test_grabclipboard"
     "test_save"
+
+    # pillow-simd
+    "test_roundtrip"
+    "test_basic"
   ];
 
   propagatedBuildInputs = [ olefile ];

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -29,6 +29,7 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook pyroma numpy ];
 
   buildInputs = [ freetype libjpeg openjpeg libimagequant zlib libtiff libwebp tcl lcms2 ]
+    ++ lib.optionals (lib.versionAtLeast version "7.1.0") [ libxcb ]
     ++ lib.optionals (isPyPy) [ tk libX11 ];
 
   # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
@@ -56,6 +57,9 @@ buildPythonPackage rec {
             s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
     export LDFLAGS="$LDFLAGS -L${libwebp}/lib"
     export CFLAGS="$CFLAGS -I${libwebp}/include"
+  '' + lib.optionalString (lib.versionAtLeast version "7.1.0") ''
+    export LDFLAGS="$LDFLAGS -L${libxcb}/lib"
+    export CFLAGS="$CFLAGS -I${libxcb.dev}/include"
   '' + lib.optionalString stdenv.isDarwin ''
     # Remove impurities
     substituteInPlace setup.py \

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -1,0 +1,65 @@
+{ pname
+, version
+, disabled
+, src
+, meta
+, ...
+}@args:
+
+with args;
+
+buildPythonPackage rec {
+  inherit pname version src meta;
+
+  # Disable imagefont tests, because they don't work well with infinality:
+  # https://github.com/python-pillow/Pillow/issues/1259
+  postPatch = ''
+    rm Tests/test_imagefont.py
+  '';
+
+  # Disable darwin tests which require executables: `iconutil` and `screencapture`
+  disabledTests = lib.optionals stdenv.isDarwin [
+    "test_grab"
+    "test_grabclipboard"
+    "test_save"
+  ];
+
+  propagatedBuildInputs = [ olefile ];
+
+  checkInputs = [ pytestCheckHook pyroma numpy ];
+
+  buildInputs = [ freetype libjpeg openjpeg libimagequant zlib libtiff libwebp tcl lcms2 ]
+    ++ lib.optionals (isPyPy) [ tk libX11 ];
+
+  # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
+  # NOTE: The Pillow install script will, by default, add paths like /usr/lib
+  # and /usr/include to the search paths. This can break things when building
+  # on a non-NixOS system that has some libraries installed that are not
+  # installed in Nix (for example, Arch Linux has jpeg2000 but Nix doesn't
+  # build Pillow with this support). We patch the `disable_platform_guessing`
+  # setting here, instead of passing the `--disable-platform-guessing`
+  # command-line option, since the command-line option doesn't work when we run
+  # tests.
+  preConfigure = let
+    libinclude' = pkg: ''"${pkg.out}/lib", "${pkg.out}/include"'';
+    libinclude = pkg: ''"${pkg.out}/lib", "${pkg.dev}/include"'';
+  in ''
+    sed -i "setup.py" \
+        -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude freetype}|g ;
+            s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude libjpeg}|g ;
+            s|^JPEG2K_ROOT =.*$|JPEG2K_ROOT = ${libinclude openjpeg}|g ;
+            s|^IMAGEQUANT_ROOT =.*$|IMAGEQUANT_ROOT = ${libinclude' libimagequant}|g ;
+            s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude zlib}|g ;
+            s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude lcms2}|g ;
+            s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude libtiff}|g ;
+            s|^TCL_ROOT=.*$|TCL_ROOT = ${libinclude' tcl}|g ;
+            s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
+    export LDFLAGS="$LDFLAGS -L${libwebp}/lib"
+    export CFLAGS="$CFLAGS -I${libwebp}/include"
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Remove impurities
+    substituteInPlace setup.py \
+      --replace '"/Library/Frameworks",' "" \
+      --replace '"/System/Library/Frameworks"' ""
+  '';
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4849,6 +4849,11 @@ in {
       inherit (pkgs.xorg) libX11;
     };
 
+  pillow-simd = callPackage ../development/python-modules/pillow-simd {
+      inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
+      inherit (pkgs.xorg) libX11;
+  };
+
   pims = callPackage ../development/python-modules/pims { };
 
   pinboard = callPackage ../development/python-modules/pinboard { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4846,7 +4846,7 @@ in {
   else
     callPackage ../development/python-modules/pillow {
       inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
-      inherit (pkgs.xorg) libX11;
+      inherit (pkgs.xorg) libX11 libxcb;
     };
 
   pillow-simd = callPackage ../development/python-modules/pillow-simd {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
