### PR TITLE
treewide: fix double quoted strings in meta.description

### DIFF
--- a/pkgs/applications/audio/AMB-plugins/default.nix
+++ b/pkgs/applications/audio/AMB-plugins/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   preInstall="mkdir -p $out/lib/ladspa";
 
   meta = {
-    description = ''A set of ambisonics ladspa plugins'';
+    description = "A set of ambisonics ladspa plugins";
     longDescription = ''
       Mono and stereo to B-format panning, horizontal rotator, square, hexagon and cube decoders.
     '';

--- a/pkgs/applications/audio/FIL-plugins/default.nix
+++ b/pkgs/applications/audio/FIL-plugins/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   preInstall="mkdir -p $out/lib/ladspa";
 
   meta = {
-    description = ''a four-band parametric equaliser, which has the nice property of being stable even while parameters are being changed'';
+    description = "a four-band parametric equaliser, which has the nice property of being stable even while parameters are being changed";
     longDescription = ''
       Each section has an active/bypass switch, frequency, bandwidth and gain controls.
       There is also a global bypass switch and gain control.

--- a/pkgs/applications/audio/mi2ly/default.nix
+++ b/pkgs/applications/audio/mi2ly/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   meta = {
     inherit (s) version;
-    description = ''MIDI to Lilypond converter'';
+    description = "MIDI to Lilypond converter";
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/graphics/rapcad/default.nix
+++ b/pkgs/applications/graphics/rapcad/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
-    description = ''Constructive solid geometry package'';
+    description = "Constructive solid geometry package";
     broken = true; # 2018-04-11
   };
 }

--- a/pkgs/applications/misc/slmenu/default.nix
+++ b/pkgs/applications/misc/slmenu/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   makeFlags = [ "PREFIX=$(out)" ];
   meta = {
     inherit (s) version;
-    description = ''A console dmenu-like tool'';
+    description = "A console dmenu-like tool";
     license = lib.licenses.mit;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = ''A vi-like file manager${if isFullPackage then "; Includes support for optional features" else ""}'';
+    description = "A vi-like file manager${if isFullPackage then "; Includes support for optional features" else ""}";
     maintainers = with maintainers; [ raskin ];
     platforms = if mediaSupport then platforms.linux else platforms.unix;
     license = licenses.gpl2;

--- a/pkgs/data/fonts/tempora-lgc/default.nix
+++ b/pkgs/data/fonts/tempora-lgc/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   outputHash = "1kwj31cjgdirqvh6bxs4fnvvr1ppaz6z8w40kvhkivgs69jglmzw";
 
   meta = {
-    description = ''Tempora font'';
+    description = "Tempora font";
     license = lib.licenses.gpl2 ;
     maintainers = [lib.maintainers.raskin];
   };

--- a/pkgs/data/fonts/unscii/default.nix
+++ b/pkgs/data/fonts/unscii/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     inherit version;
-    description = ''Bitmapped character-art-friendly Unicode fonts'';
+    description = "Bitmapped character-art-friendly Unicode fonts";
     # Basically GPL2+ with font exception — because of the Unifont-augmented
     # version. The reduced version is public domain.
     license = "http://unifoundry.com/LICENSE.txt";

--- a/pkgs/development/beam-modules/pc/default.nix
+++ b/pkgs/development/beam-modules/pc/default.nix
@@ -6,7 +6,7 @@ buildHex {
   sha256 = "0xq411ig5ny3iilkkkqa4vm3w3dgjc9cfzkqwk8pm13dw9mcm8h0";
 
   meta = {
-    description = ''a rebar3 port compiler for native code'';
+    description = "a rebar3 port compiler for native code";
     license = stdenv.lib.licenses.mit;
     homepage = "https://github.com/blt/port_compiler";
   };

--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [jre ant jdk jre];
   meta = {
     inherit version;
-    description = ''A JVM-based Common Lisp implementation'';
+    description = "A JVM-based Common Lisp implementation";
     license = stdenv.lib.licenses.gpl3 ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     inherit version;
-    description = ''A Common Lisp implementation based on LLVM with C++ integration'';
+    description = "A Common Lisp implementation based on LLVM with C++ integration";
     license = stdenv.lib.licenses.lgpl21Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/compilers/obliv-c/default.nix
+++ b/pkgs/development/compilers/obliv-c/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     inherit version;
-    description = ''A GCC wrapper that makes it easy to embed secure computation protocols inside regular C programs'';
+    description = "A GCC wrapper that makes it easy to embed secure computation protocols inside regular C programs";
     license = stdenv.lib.licenses.bsd3;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/interpreters/icon-lang/default.nix
+++ b/pkgs/development/interpreters/icon-lang/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = ''A very high level general-purpose programming language'';
+    description = "A very high level general-purpose programming language";
     maintainers = with maintainers; [ vrthra yurrriq ];
     platforms = with platforms; linux ++ darwin ++ freebsd ++ netbsd ++ openbsd ++ cygwin ++ illumos;
     license = licenses.publicDomain;

--- a/pkgs/development/interpreters/rebol/default.nix
+++ b/pkgs/development/interpreters/rebol/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = ''Relative expression based object language, a language where code is data'';
+    description = "Relative expression based object language, a language where code is data";
     maintainers = with maintainers; [ vrthra ];
     platforms = [ "x86_64-linux" ];
     license = licenses.asl20;

--- a/pkgs/development/interpreters/unicon-lang/default.nix
+++ b/pkgs/development/interpreters/unicon-lang/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    description = ''A very high level, goal-directed, object-oriented, general purpose applications language'';
+    description = "A very high level, goal-directed, object-oriented, general purpose applications language";
     maintainers = with maintainers; [ vrthra ];
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/development/libraries/arb/default.nix
+++ b/pkgs/development/libraries/arb/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
   meta = with stdenv.lib; {
     inherit version;
-    description = ''A library for arbitrary-precision interval arithmetic'';
+    description = "A library for arbitrary-precision interval arithmetic";
     homepage = "http://arblib.org/";
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = teams.sage.members;

--- a/pkgs/development/libraries/cddlib/default.nix
+++ b/pkgs/development/libraries/cddlib/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
   meta = with stdenv.lib; {
     inherit version;
-    description = ''An implementation of the Double Description Method for generating all vertices of a convex polyhedron'';
+    description = "An implementation of the Double Description Method for generating all vertices of a convex polyhedron";
     license = licenses.gpl2Plus;
     maintainers = teams.sage.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/dxflib/default.nix
+++ b/pkgs/development/libraries/dxflib/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation rec {
   meta = {
     maintainers = with stdenv.lib.maintainers; [raskin];
     platforms = stdenv.lib.platforms.linux;
-    description = ''DXF file format library'';
+    description = "DXF file format library";
   };
 }

--- a/pkgs/development/libraries/eclib/default.nix
+++ b/pkgs/development/libraries/eclib/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
   meta = with stdenv.lib; {
     inherit version;
-    description = ''Elliptic curve tools'';
+    description = "Elliptic curve tools";
     homepage = "https://github.com/JohnCremona/eclib";
     license = licenses.gpl2Plus;
     maintainers = teams.sage.members;

--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     inherit version;
-    description = ''Finite Field Linear Algebra Subroutines'';
+    description = "Finite Field Linear Algebra Subroutines";
     license = licenses.lgpl21Plus;
     maintainers = teams.sage.members;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
   meta = {
     inherit version;
-    description = ''Fast Library for Number Theory'';
+    description = "Fast Library for Number Theory";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/fplll/20160331.nix
+++ b/pkgs/development/libraries/fplll/20160331.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [gmp mpfr];
   meta = {
     inherit version;
-    description = ''Lattice algorithms using floating-point arithmetic'';
+    description = "Lattice algorithms using floating-point arithmetic";
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/fplll/default.nix
+++ b/pkgs/development/libraries/fplll/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    description = ''Lattice algorithms using floating-point arithmetic'';
+    description = "Lattice algorithms using floating-point arithmetic";
     changelog = [
       # Some release notes are added to the github tags, though they are not
       # always complete.

--- a/pkgs/development/libraries/gf2x/default.nix
+++ b/pkgs/development/libraries/gf2x/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = ''Routines for fast arithmetic in GF(2)[x]'';
+    description = "Routines for fast arithmetic in GF(2)[x]";
     homepage = "http://gf2x.gforge.inria.fr";
     license = licenses.gpl2Plus;
     maintainers = teams.sage.members;

--- a/pkgs/development/libraries/givaro/3.7.nix
+++ b/pkgs/development/libraries/givaro/3.7.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   buildInputs = [autoconf automake libtool gmpxx];
   meta = {
     inherit version;
-    description = ''A C++ library for arithmetic and algebraic computations'';
+    description = "A C++ library for arithmetic and algebraic computations";
     license = stdenv.lib.licenses.cecill-b;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/givaro/3.nix
+++ b/pkgs/development/libraries/givaro/3.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   buildInputs = [autoconf automake libtool gmpxx];
   meta = {
     inherit version;
-    description = ''A C++ library for arithmetic and algebraic computations'';
+    description = "A C++ library for arithmetic and algebraic computations";
     license = stdenv.lib.licenses.cecill-b;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     inherit version;
-    description = ''A C++ library for arithmetic and algebraic computations'';
+    description = "A C++ library for arithmetic and algebraic computations";
     license = stdenv.lib.licenses.cecill-b;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/gle/default.nix
+++ b/pkgs/development/libraries/gle/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "09zs1di4dsssl9k322nzildvf41jwipbzhik9p43yb1bcfsp92nw";
   };
   meta = {
-    description = ''Tubing and extrusion library'';
+    description = "Tubing and extrusion library";
     license = stdenv.lib.licenses.gpl2 ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/qtinstaller/default.nix
+++ b/pkgs/development/libraries/qtinstaller/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = ''Qt installer framework'';
+    description = "Qt installer framework";
     inherit (qtbase.meta) platforms license homepage;
   };
 }

--- a/pkgs/development/libraries/tachyon/default.nix
+++ b/pkgs/development/libraries/tachyon/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
   '';
   meta = {
     inherit version;
-    description = ''A Parallel / Multiprocessor Ray Tracing System'';
+    description = "A Parallel / Multiprocessor Ray Tracing System";
     license = stdenv.lib.licenses.bsd3;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = with stdenv.lib.platforms; linux ++ cygwin ++ darwin;

--- a/pkgs/development/lisp-modules/asdf/2.26.nix
+++ b/pkgs/development/lisp-modules/asdf/2.26.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   '';
   meta = {
     inherit (s) version;
-    description = ''Standard software-system definition library for Common Lisp'';
+    description = "Standard software-system definition library for Common Lisp";
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/lisp-modules/asdf/3.1.nix
+++ b/pkgs/development/lisp-modules/asdf/3.1.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   '';
   meta = {
     inherit (s) version;
-    description = ''Standard software-system definition library for Common Lisp'';
+    description = "Standard software-system definition library for Common Lisp";
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/lisp-modules/asdf/default.nix
+++ b/pkgs/development/lisp-modules/asdf/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   '';
   meta = {
     inherit (s) version;
-    description = ''Standard software-system definition library for Common Lisp'';
+    description = "Standard software-system definition library for Common Lisp";
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/lisp-modules/clwrapper/default.nix
+++ b/pkgs/development/lisp-modules/clwrapper/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    description = ''Script used to wrap Common Lisp implementations'';
+    description = "Script used to wrap Common Lisp implementations";
     maintainers = [stdenv.lib.maintainers.raskin];
   };
 }

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -85,7 +85,7 @@ let lispPackages = rec {
           buildSystems = [ "clx-truetype" ];
           parasites = [ "clx-truetype-test" ];
 
-          description = ''clx-truetype is pure common lisp solution for antialiased TrueType font rendering using CLX and XRender extension.'';
+          description = "clx-truetype is pure common lisp solution for antialiased TrueType font rendering using CLX and XRender extension.";
           deps = with pkgs.lispPackages; [
                   alexandria bordeaux-threads cl-aa cl-fad cl-paths cl-paths-ttf cl-store
                           cl-vectors clx trivial-features zpb-ttf

--- a/pkgs/development/perl-modules/Percona-Toolkit/default.nix
+++ b/pkgs/development/perl-modules/Percona-Toolkit/default.nix
@@ -24,7 +24,7 @@ buildPerlPackage rec {
   '';
 
   meta = with lib; {
-    description = ''Collection of advanced command-line tools to perform a variety of MySQL and system tasks.'';
+    description = "Collection of advanced command-line tools to perform a variety of MySQL and system tasks.";
     homepage = "https://www.percona.com/software/database-tools/percona-toolkit";
     license = with licenses; [ gpl2 ];
     maintainers = with maintainers; [ izorkin ];

--- a/pkgs/development/python-modules/spark_parser/default.nix
+++ b/pkgs/development/python-modules/spark_parser/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ click ];
 
   meta = with lib; {
-    description = ''An Early-Algorithm Context-free grammar Parser'';
+    description = "An Early-Algorithm Context-free grammar Parser";
     homepage = "https://github.com/rocky/python-spark";
     license = licenses.mit;
     maintainers = with maintainers; [raskin];

--- a/pkgs/os-specific/linux/sinit/default.nix
+++ b/pkgs/os-specific/linux/sinit/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     ;
   meta = {
     inherit (s) version;
-    description = ''A very minimal Linux init implementation from suckless.org'';
+    description = "A very minimal Linux init implementation from suckless.org";
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/servers/http/nix-binary-cache/default.nix
+++ b/pkgs/servers/http/nix-binary-cache/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = ''A set of scripts to serve the Nix store as a binary cache'';
+    description = "A set of scripts to serve the Nix store as a binary cache";
     longDescription = ''
       This package installs a CGI script that serves Nix store path in the
       binary cache format. It also installs a launcher called

--- a/pkgs/servers/nosql/apache-jena/binary.nix
+++ b/pkgs/servers/nosql/apache-jena/binary.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   '';
   meta = {
     inherit (s) version;
-    description = ''RDF database'';
+    description = "RDF database";
     license = lib.licenses.asl20;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;

--- a/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
+++ b/pkgs/servers/nosql/apache-jena/fuseki-binary.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   '';
   meta = {
     inherit (s) version;
-    description = ''SPARQL server'';
+    description = "SPARQL server";
     license = lib.licenses.asl20;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;

--- a/pkgs/tools/X11/ratmen/default.nix
+++ b/pkgs/tools/X11/ratmen/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   ];
   meta = {
     inherit (s) version;
-    description = ''A minimalistic X11 menu creator'';
+    description = "A minimalistic X11 menu creator";
     license = lib.licenses.free ; # 9menu derivative with 9menu license
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;

--- a/pkgs/tools/X11/skippy-xd/default.nix
+++ b/pkgs/tools/X11/skippy-xd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
   meta = {
     inherit version;
-    description = ''Expose-style compositing-based standalone window switcher'';
+    description = "Expose-style compositing-based standalone window switcher";
     license = lib.licenses.gpl2Plus ;
     maintainers = [lib.maintainers.raskin];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Replace double single quotes `''` with single double quotes `"` in various fields:
- description

###### Things done
```ShellSession
$  git ls-files | grep pkgs | xargs sed -i -e -E "s#description.*''(.*)''#description = \"\1\"#g"
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
