### PR TITLE
stdenv/setup.sh: fix consumeEntire in bash5

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -710,8 +710,9 @@ substituteStream() {
 }
 
 consumeEntire() {
-    # read returns non-0 on EOF, so we want read to fail
-    if IFS='' read -r -N 2147483647 $1; then
+    # read returns 0 when delimiter \x04 (EOF) is found
+    # if we don’t find it, we haven’t gotten all of the data yet
+    if ! IFS='' read -r -d $'\x04' $1; then
         echo "consumeEntire(): ERROR: Input null bytes, won't process" >&2
         return 1
     fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -711,7 +711,7 @@ substituteStream() {
 
 consumeEntire() {
     # read returns non-0 on EOF, so we want read to fail
-    if IFS='' read -r -N 0 $1; then
+    if IFS='' read -r -N 2147483647 $1; then
         echo "consumeEntire(): ERROR: Input null bytes, won't process" >&2
         return 1
     fi


### PR DESCRIPTION
Unfortunately, bash5 has changed how read -N 0 works, meaning that
consumeEntire no longer works as expected. Compare:

```
$ nix shell github:nixos/nixpkgs\?ref=nixos-20.03#bash -c bash -c 'read -N 0 contents < /bin/sh; echo $?'
1
$ nix shell github:nixos/nixpkgs\?ref=nixos-20.03#bash_5 -c bash -c 'read -N 0 contents < /bin/sh; echo $?'
0
```

Bash 5 no longer reaches EOF when nchars=0. I could not find this
documented anywhere.

The best substitute I can find is to provide the max read nchars
value (2147483647). This appears to have the same effect as nchars=0
in practice.
