### PR TITLE
stdenv/setup.sh: Add version check to setup script

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,6 +1,12 @@
 set -eu
 set -o pipefail
 
+if [ -n "${BASH_VERSINFO-}" ] && [ "${BASH_VERSINFO-}" -lt 4 ]; then
+    echo "Detected Bash version that isn't supported by Nixpkgs (${BASH_VERSION})"
+    echo "Please install Bash 4 or greater to continue."
+    exit 1
+fi
+
 if (( "${NIX_DEBUG:-0}" >= 6 )); then
     set -x
 fi


### PR DESCRIPTION
Only bash 4+ works in setup.sh. To make sure this is obvious, we can
check BASH_VERSINFO to get the major version number of Bash.

While Bash 3 is pretty rare, it still comes stock in macOS.

We *could* provide a warning here for non-Bash shells, but it’s not
always clear whether they will work or not. Zsh should have no trouble
while busybox sh, fish, or any others. There’s no great way to detect
what feature set the shell supports.

Fixes #71625
