### PR TITLE
unifont: 13.0.04 -> 13.0.05

### DIFF
--- a/pkgs/data/fonts/unifont/default.nix
+++ b/pkgs/data/fonts/unifont/default.nix
@@ -4,16 +4,16 @@
 
 stdenv.mkDerivation rec {
   pname = "unifont";
-  version = "13.0.04";
+  version = "13.0.05";
 
   ttf = fetchurl {
     url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.ttf";
-    sha256 = "sha256-p0wSTyXCXuWIw+hDZ4HZPxgdBJ6oOOqOuX6FzZJmwrE=";
+    sha256 = "0ff7zbyqi45q0171rl9ckj6lpfhcj8a9850d8j89m7wbwky32isf";
   };
 
   pcf = fetchurl {
     url = "mirror://gnu/unifont/${pname}-${version}/${pname}-${version}.pcf.gz";
-    sha256 = "sha256-sKY2qshNV3zXfD2BSbfs0qom1gPt7vD5QmVEkACmx18=";
+    sha256 = "16n666p6rs6l4r8grh67gy4ls33qfnbb5xk7cksywzjwdh42js0r";
   };
 
   nativeBuildInputs = [ libfaketime fonttosfnt mkfontscale ];

--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "13.0.04";
+  version = "13.0.05";
 in fetchzip rec {
   name = "unifont_upper-${version}";
 
@@ -9,7 +9,7 @@ in fetchzip rec {
 
   postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/unifont_upper.ttf";
 
-  sha256 = "0bji0crx84nbjf1m1lzql7icrb02zbs3l66dn21pvr9czsry870f";
+  sha256 = "1cpi44fzsiq3yqg38763awgri1ma46421c3v8167bsxzsx7vzlkp";
 
   meta = with lib; {
     description = "Unicode font for glyphs above the Unicode Basic Multilingual Plane";


### PR DESCRIPTION
Result of `nixpkgs-review pr 108105` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>tests.nixos-functions.nixosTest-test</li>
  </ul>
</details>
<details>
  <summary>9 packages built:</summary>
  <ul>
    <li>grub2 (grub2_full)</li>
    <li>grub2_efi</li>
    <li>grub2_light</li>
    <li>grub2_pvgrub_image</li>
    <li>grub2_xen</li>
    <li>os-prober</li>
    <li>unifont</li>
    <li>unifont_upper</li>
    <li>woeusb</li>
  </ul>
</details>
