### PR TITLE
swego: init at 0.7

### DIFF
--- a/pkgs/servers/swego/default.nix
+++ b/pkgs/servers/swego/default.nix
@@ -1,0 +1,36 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "swego";
+  version = "0.7";
+
+  src = fetchFromGitHub {
+    owner = "nodauf";
+    repo = "Swego";
+    rev = "v${version}";
+    sha256 = "14qww4ndvrxmrgkggr8hyvfpz2v7fw0vq6s8715mxa28f8pfi78b";
+  };
+
+  vendorSha256 = "068drahh0aysrm8cr5pgik27jqyk28bsx5130mc2v3xd0xmk8yp1";
+
+  postInstall = ''
+    mv $out/bin/src $out/bin/$pname
+  '';
+
+  meta = with lib; {
+    description = "Simple Webserver in Golang";
+    longDescription = ''
+      Swiss army knife Webserver in Golang. Similar to the Python
+      SimpleHTTPServer but with many features.
+    '';
+    homepage = "https://github.com/nodauf/Swego";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+    # There is an issue with darwin
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/servers/swego/default.nix
+++ b/pkgs/servers/swego/default.nix
@@ -30,7 +30,8 @@ buildGoModule rec {
     homepage = "https://github.com/nodauf/Swego";
     license = with licenses; [ gpl2Only ];
     maintainers = with maintainers; [ fab ];
-    # There is an issue with darwin
+    # darwin crashes with:
+    # src/controllers/parsingArgs.go:130:4: undefined: PrintEmbeddedFiles
     broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2633,6 +2633,8 @@ in
 
   sweep-visualizer = callPackage ../tools/misc/sweep-visualizer { };
 
+  swego = callPackage ../servers/swego { };
+
   syscall_limiter = callPackage ../os-specific/linux/syscall_limiter {};
 
   syslogng = callPackage ../tools/system/syslog-ng { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Swiss army knife Webserver in Golang. Similar to the Python
SimpleHTTPServer but with many features.

https://github.com/nodauf/Swego

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
