### PR TITLE
vim: add vim_darwin package for macOS

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24695,7 +24695,7 @@ in
     gtk3 = if stdenv.isDarwin then gtk3-x11 else gtk3;
   });
 
-  vim_darwin = (vim_configurable.override {
+  vim-darwin = (vim_configurable.override {
     config = {
       vim = {
         gui = "none";
@@ -24703,9 +24703,9 @@ in
       };
     };
   }).overrideAttrs (oldAttrs: rec {
-    pname = "vim_darwin";
+    pname = "vim-darwin";
     meta = {
-      platforms = [ "x86_64-darwin" ];
+      platforms = stdenv.lib.platforms.darwin;
     };
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24695,6 +24695,20 @@ in
     gtk3 = if stdenv.isDarwin then gtk3-x11 else gtk3;
   });
 
+  vim_darwin = (vim_configurable.override {
+    config = {
+      vim = {
+        gui = "none";
+        darwin = true;
+      };
+    };
+  }).overrideAttrs (oldAttrs: rec {
+    pname = "vim_darwin";
+    meta = {
+      platforms = [ "x86_64-darwin" ];
+    };
+  });
+
   vimacs = callPackage ../applications/editors/vim/vimacs.nix { };
 
   vimv = callPackage ../tools/misc/vimv/default.nix { };


### PR DESCRIPTION
The default Vim package does not have some advanced features like
python3, hence we need to use the vim_configurable package and customize
it to provide a fuller build of Vim on macOS.

If one were to use the vim_configurable package as is, the user does not
get the nice OS integration features like copy-pasting from system
clipboard.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Get a fully-featured (python etc.) Vim on macOS, along with the ability to
copy/paste from/to macOS clipboard.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
