### PR TITLE
badchars: init at 0.4.0

### DIFF
--- a/pkgs/tools/security/badchars/default.nix
+++ b/pkgs/tools/security/badchars/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+}:
+
+buildPythonApplication rec {
+  pname = "badchars";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xqki8qnfwl97d60xj69alyzwa1mnfbwki25j0vhvhb05varaxz2";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "argparse" ""
+  '';
+
+  # no tests are available and it can't be imported (it's only a script, not a module)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "HEX badchar generator for different programming languages";
+    longDescription = ''
+      A HEX bad char generator to instruct encoders such as shikata-ga-nai to
+      transform those to other chars.
+    '';
+    homepage = "https://github.com/cytopia/badchars";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1476,6 +1476,8 @@ in
 
   babeld = callPackage ../tools/networking/babeld { };
 
+  badchars = python3Packages.callPackage ../tools/security/badchars { };
+
   badvpn = callPackage ../tools/networking/badvpn {};
 
   barcode = callPackage ../tools/graphics/barcode {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A HEX bad char generator to instruct encoders such as shikata-ga-nai to
transform those to other chars.

https://github.com/cytopia/badchars

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
