### PR TITLE
rdma-core: 31.2 -> 33.0

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -4,7 +4,7 @@
 } :
 
 let
-  version = "31.2";
+  version = "33.0";
 
 in stdenv.mkDerivation {
   pname = "rdma-core";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     owner = "linux-rdma";
     repo = "rdma-core";
     rev = "v${version}";
-    sha256 = "0njfn8ziip57a2s435d4s0p3yylb85y7hdgbq660vwpsia9fb4sq";
+    sha256 = "04q4z95nxxxjc674qnbwn19bv18nl3x7xwp6aql17h1cw3gdmhw4";
   };
 
   nativeBuildInputs = [ cmake pkgconfig pandoc docutils makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/linux-rdma/rdma-core/releases/tag/v33.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>20 packages marked as broken and skipped:</summary>
  <ul>
    <li>bareos</li>
    <li>python37Packages.arviz</li>
    <li>python37Packages.baselines</li>
    <li>python37Packages.cntk</li>
    <li>python37Packages.dm-sonnet</li>
    <li>python37Packages.edward</li>
    <li>python37Packages.graph_nets</li>
    <li>python37Packages.optuna</li>
    <li>python37Packages.pymc3</li>
    <li>python37Packages.pyslurm</li>
    <li>python37Packages.rl-coach</li>
    <li>python37Packages.tensorflow</li>
    <li>python37Packages.tensorflow-probability</li>
    <li>python37Packages.tensorflowWithCuda</li>
    <li>python37Packages.tensorflowWithoutCuda</li>
    <li>python37Packages.tflearn</li>
    <li>python38Packages.cntk</li>
    <li>python38Packages.pyslurm</li>
    <li>python39Packages.cntk</li>
    <li>python39Packages.pyslurm</li>
  </ul>
</details>
<details>
  <summary>31 packages failed to build:</summary>
  <ul>
    <li>cntk</li>
    <li>python37Packages.dask-gateway</li>
    <li>python37Packages.dask-jobqueue</li>
    <li>python37Packages.dask-ml</li>
    <li>python37Packages.dask-mpi</li>
    <li>python37Packages.dask-xgboost</li>
    <li>python37Packages.datashader</li>
    <li>python37Packages.dftfit</li>
    <li>python37Packages.distributed</li>
    <li>python37Packages.h5py-mpi</li>
    <li>python37Packages.lammps-cython</li>
    <li>python37Packages.mask-rcnn</li>
    <li>python37Packages.streamz</li>
    <li>python37Packages.stumpy</li>
    <li>python37Packages.tensorflow-build_2</li>
    <li>python38Packages.dask-gateway</li>
    <li>python38Packages.dask-jobqueue</li>
    <li>python38Packages.dask-ml</li>
    <li>python38Packages.dask-mpi</li>
    <li>python38Packages.dask-xgboost</li>
    <li>python38Packages.datashader</li>
    <li>python38Packages.dftfit</li>
    <li>python38Packages.distributed</li>
    <li>python38Packages.lammps-cython</li>
    <li>python38Packages.mask-rcnn</li>
    <li>python38Packages.streamz</li>
    <li>python38Packages.stumpy</li>
    <li>python38Packages.tensorflow-build_2</li>
    <li>python39Packages.tensorflow-build_2</li>
    <li>samba4Full</li>
    <li>tts</li>
  </ul>
</details>
<details>
  <summary>49 packages built:</summary>
  <ul>
    <li>ceph</li>
    <li>ceph-client</li>
    <li>dl-poly-classic-mpi</li>
    <li>elmerfem</li>
    <li>freecad</li>
    <li>getdp</li>
    <li>globalarrays</li>
    <li>gromacsDoubleMpi</li>
    <li>gromacsMpi</li>
    <li>hdf5-mpi</li>
    <li>highfive-mpi</li>
    <li>hpcg</li>
    <li>hpl</li>
    <li>rdma-core (infiniband-diags)</li>
    <li>ior</li>
    <li>lammps-mpi</li>
    <li>libceph</li>
    <li>migrate</li>
    <li>netcdf-mpi</li>
    <li>neuron-full</li>
    <li>neuron-mpi</li>
    <li>openmolcas</li>
    <li>openmpi</li>
    <li>opensm</li>
    <li>paraview</li>
    <li>parmetis</li>
    <li>precice</li>
    <li>python37Packages.fenics</li>
    <li>python37Packages.fipy</li>
    <li>python37Packages.mpi4py</li>
    <li>python37Packages.neuron-mpi</li>
    <li>python38Packages.fenics</li>
    <li>python38Packages.fipy</li>
    <li>python38Packages.h5py-mpi</li>
    <li>python38Packages.mpi4py</li>
    <li>python38Packages.neuron-mpi</li>
    <li>python39Packages.fenics</li>
    <li>python39Packages.fipy</li>
    <li>python39Packages.h5py-mpi</li>
    <li>python39Packages.mpi4py</li>
    <li>python39Packages.neuron-mpi</li>
    <li>quantum-espresso-mpi</li>
    <li>raxml-mpi</li>
    <li>scalapack</li>
    <li>scotch</li>
    <li>siesta-mpi</li>
    <li>slurm (slurm-full ,slurm-llnl ,slurm-llnl-full)</li>
    <li>slurm-spank-x11</li>
    <li>ucx</li>
  </ul>
</details>

Broken packages seem to be unrelated to rdma-core update
