### PR TITLE
qt512: fix darwin patches

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -51,7 +51,7 @@ let
 
   patches = {
     qtbase =
-      optionals stdenv.isDarwin [
+      [
         ./qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
         ./qtbase.patch.d/0002-qtbase-mac.patch
         ./qtbase.patch.d/0013-define-kiosurfacesuccess.patch
@@ -59,8 +59,7 @@ let
         # Patch framework detection to support X.framework/X.tbd,
         # extending the current support for X.framework/X.
         ./qtbase.patch.d/0015-qtbase-tbd-frameworks.patch
-      ]
-      ++ [
+
         ./qtbase.patch.d/0003-qtbase-mkspecs.patch
         ./qtbase.patch.d/0004-qtbase-replace-libdir.patch
         ./qtbase.patch.d/0005-qtbase-cmake.patch
@@ -97,7 +96,7 @@ let
         stripLen = 1;
         extraPrefix = "src/3rdparty/";
       })
-    ] ++ optionals stdenv.isDarwin [
+
       ./qtwebengine-darwin-no-platform-check.patch
       ./qtwebengine-darwin-fix-failed-static-assertion.patch
     ];
@@ -108,7 +107,7 @@ let
         sha256 = "0h8ymfnwgkjkwaankr3iifiscsvngqpwb91yygndx344qdiw9y0n";
       })
       ./qtwebkit.patch
-    ] ++ optionals stdenv.isDarwin [
+
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch
     ];

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
@@ -1,18 +1,5 @@
-From 361a9395704ca1ee170a8bb3823ba860293eecee Mon Sep 17 00:00:00 2001
-From: Thomas Tuegel <ttuegel@mailbox.org>
-Date: Tue, 17 Sep 2019 05:34:00 -0500
-Subject: [PATCH 01/12] qtbase-mkspecs-mac
-
----
- mkspecs/common/mac.conf               |   2 +-
- mkspecs/features/mac/default_post.prf | 202 ----------------------------------
- mkspecs/features/mac/default_pre.prf  |  58 ----------
- mkspecs/features/mac/sdk.mk           |  25 -----
- mkspecs/features/mac/sdk.prf          |  61 ----------
- 5 files changed, 1 insertion(+), 347 deletions(-)
-
 diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
-index b77494ec9b..470c38e772 100644
+index b77494ec..470c38e7 100644
 --- a/mkspecs/common/mac.conf
 +++ b/mkspecs/common/mac.conf
 @@ -24,7 +24,7 @@ QMAKE_INCDIR_OPENGL     = \
@@ -25,7 +12,7 @@ index b77494ec9b..470c38e772 100644
  
  QMAKE_LFLAGS_REL_RPATH  =
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index 993f4d56a9..b80ec1e801 100644
+index d052808c..b80ec1e8 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
 @@ -68,208 +68,6 @@ qt {
@@ -161,7 +148,7 @@ index 993f4d56a9..b80ec1e801 100644
 -                -isysroot$$xcodeSDKInfo(Path, $$sdk)
 -            QMAKE_XARCH_LFLAGS_$${arch} = $$version_min_flags \
 -                -Xarch_$${arch} \
--                -Wl,-syslibroot,$$xcodeSDKInfo(Path, $$sdk)
+-                -isysroot$$xcodeSDKInfo(Path, $$sdk)
 -
 -            QMAKE_XARCH_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS_$${arch})
 -            QMAKE_XARCH_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS_$${arch})
@@ -182,7 +169,7 @@ index 993f4d56a9..b80ec1e801 100644
 -        version_min_flag = -m$${version_identifier}-version-min=$$deployment_target
 -        QMAKE_CFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
 -        QMAKE_CXXFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
--        QMAKE_LFLAGS += -Wl,-syslibroot,$$QMAKE_MAC_SDK_PATH $$version_min_flag
+-        QMAKE_LFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
 -    }
 -
 -    # Enable precompiled headers for multiple architectures
@@ -238,7 +225,7 @@ index 993f4d56a9..b80ec1e801 100644
      generate_xcode_project.commands = @$(QMAKE) -spec macx-xcode \"$(EXPORT__PRO_FILE_)\" $$QMAKE_ARGS
      generate_xcode_project.target = xcodeproj
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index e3534561a5..3b01424e67 100644
+index e3534561..3b01424e 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
 @@ -1,60 +1,2 @@
@@ -303,7 +290,7 @@ index e3534561a5..3b01424e67 100644
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
 diff --git a/mkspecs/features/mac/sdk.mk b/mkspecs/features/mac/sdk.mk
-index c40f58c987..e69de29bb2 100644
+index c40f58c9..e69de29b 100644
 --- a/mkspecs/features/mac/sdk.mk
 +++ b/mkspecs/features/mac/sdk.mk
 @@ -1,25 +0,0 @@
@@ -333,7 +320,7 @@ index c40f58c987..e69de29bb2 100644
 -    endif
 -endif
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
-index 3a9c2778bb..e69de29bb2 100644
+index 3a9c2778..e69de29b 100644
 --- a/mkspecs/features/mac/sdk.prf
 +++ b/mkspecs/features/mac/sdk.prf
 @@ -1,61 +0,0 @@
@@ -398,6 +385,3 @@ index 3a9c2778bb..e69de29bb2 100644
 -    $$tool = $$sysrooted $$member(value, 1, -1)
 -    cache($$tool_variable, set stash, $$tool)
 -}
--- 
-2.23.GIT
-

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
@@ -1,5 +1,5 @@
 diff --git a/configure.pri b/configure.pri
-index 897bea54..6f834c20 100644
+index 897bea540..6f834c202 100644
 --- a/configure.pri
 +++ b/configure.pri
 @@ -269,7 +269,7 @@ defineReplace(webEngineGetMacOSVersion) {
@@ -12,7 +12,7 @@ index 897bea54..6f834c20 100644
  }
  
 diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
-index 35eb6b89..7eed640a 100644
+index 35eb6b89c..7eed640a5 100644
 --- a/mkspecs/features/platform.prf
 +++ b/mkspecs/features/platform.prf
 @@ -40,8 +40,6 @@ defineTest(isPlatformSupported) {
@@ -43,10 +43,10 @@ index 35eb6b89..7eed640a 100644
      isEmpty(WEBENGINE_OSX_SDK_PRODUCT_VERSION) {
          skipBuild("Could not resolve SDK product version for \'$$QMAKE_MAC_SDK\'.")
 diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
-index 4426901c..3aa6057e 100644
+index 7b77a8bf7..0e1284ee4 100644
 --- a/src/core/config/mac_osx.pri
 +++ b/src/core/config/mac_osx.pri
-@@ -5,16 +5,16 @@ load(functions)
+@@ -5,7 +5,7 @@ load(functions)
  # otherwise query for it.
  QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
  isEmpty(QMAKE_MAC_SDK_VERSION) {
@@ -55,17 +55,15 @@ index 4426901c..3aa6057e 100644
       isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
  }
  
+@@ -14,11 +14,6 @@ isEmpty(QMAKE_MAC_SDK_VERSION) {
+ QMAKE_MAC_SDK_VERSION_MAJOR_MINOR = $$section(QMAKE_MAC_SDK_VERSION, ".", 0, 1)
+ 
  QMAKE_CLANG_DIR = "/usr"
 -QMAKE_CLANG_PATH = $$eval(QMAKE_MAC_SDK.macx-clang.$${QMAKE_MAC_SDK}.QMAKE_CXX)
 -!isEmpty(QMAKE_CLANG_PATH) {
 -    clang_dir = $$clean_path("$$dirname(QMAKE_CLANG_PATH)/../")
 -    exists($$clang_dir): QMAKE_CLANG_DIR = $$clang_dir
 -}
-+# QMAKE_CLANG_PATH = $$eval(QMAKE_MAC_SDK.macx-clang.$${QMAKE_MAC_SDK}.QMAKE_CXX)
-+# !isEmpty(QMAKE_CLANG_PATH) {
-+#     clang_dir = $$clean_path("$$dirname(QMAKE_CLANG_PATH)/../")
-+#     exists($$clang_dir): QMAKE_CLANG_DIR = $$clang_dir
-+# }
  
  QMAKE_CLANG_PATH = "$${QMAKE_CLANG_DIR}/bin/clang++"
  message("Using clang++ from $${QMAKE_CLANG_PATH}")


### PR DESCRIPTION
###### Motivation for this change

The patches for Qt 5.12 on Darwin no longer apply. Although I cannot test the build on macOS, I can make the Darwin patches apply on all platforms because the patches target only platform-specific files.

See also: https://github.com/NixOS/nixpkgs/pull/107483#issuecomment-752998482

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
