### PR TITLE
xxHash: fix static build

### DIFF
--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -11,6 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "0hpbzdd6kfki5f61g103vp7pfczqkdj0js63avl0ss552jfb8h96";
   };
 
+  # Upstream Makefile does not anticipate that user may not want to
+  # build .so library.
+  postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isStatic ''
+    sed -i 's/lib: libxxhash.a libxxhash/lib: libxxhash.a/' Makefile
+    sed -i '/LIBXXH) $(DESTDIR/ d' Makefile
+  '';
+
   outputs = [ "out" "dev" ];
 
   makeFlags = [ "PREFIX=$(dev)" "EXEC_PREFIX=$(out)" ];


### PR DESCRIPTION
Patch upstream Makefile to not attempt to build dynamic library if host
platform is static only (pkgsStatic).


###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@orivej