### PR TITLE
treewide: remove trailing whitespace

### DIFF
--- a/pkgs/applications/audio/aj-snapshot/default.nix
+++ b/pkgs/applications/audio/aj-snapshot/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Tool for storing/restoring JACK and/or ALSA connections to/from cml files";
     longDescription = ''
-    Aj-snapshot is a small program that can be used to make snapshots of the connections made between JACK and/or ALSA clients. 
-    Because JACK can provide both audio and MIDI support to programs, aj-snapshot can store both types of connections for JACK. 
-    ALSA, on the other hand, only provides routing facilities for MIDI clients. 
+    Aj-snapshot is a small program that can be used to make snapshots of the connections made between JACK and/or ALSA clients.
+    Because JACK can provide both audio and MIDI support to programs, aj-snapshot can store both types of connections for JACK.
+    ALSA, on the other hand, only provides routing facilities for MIDI clients.
     You can also run aj-snapshot in daemon mode if you want to have your connections continually restored.
     '';
 

--- a/pkgs/applications/audio/jack-oscrolloscope/default.nix
+++ b/pkgs/applications/audio/jack-oscrolloscope/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     mv jack_oscrolloscope $out/bin/
   '';
 
-  meta = with stdenv.lib; { 
+  meta = with stdenv.lib; {
     description = "A simple waveform viewer for JACK";
     homepage = "http://das.nasophon.de/jack_oscrolloscope";
     license = licenses.gpl2;

--- a/pkgs/applications/audio/jackmeter/default.nix
+++ b/pkgs/applications/audio/jackmeter/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libjack2 ];
 
-  meta = { 
+  meta = {
     description = "Console jack loudness meter";
     homepage = "https://www.aelius.com/njh/jackmeter/";
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/applications/blockchains/bitcoin-gold.nix
+++ b/pkgs/applications/blockchains/bitcoin-gold.nix
@@ -19,7 +19,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  
+
   pname = "bitcoin" + toString (optional (!withGui) "d") + "-gold";
   version = "0.15.2";
 

--- a/pkgs/applications/blockchains/pivx.nix
+++ b/pkgs/applications/blockchains/pivx.nix
@@ -4,7 +4,7 @@
 , util-linux, qtbase ? null, qttools ? null
 , enableUpnp ? false
 , disableWallet ? false
-, disableDaemon ? false 
+, disableDaemon ? false
 , withGui ? false }:
 
 with stdenv.lib;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
                     ++ optionals withGui [ "--with-gui=yes"
                                            "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
                                          ];
-  
+
   enableParallelBuilding = true;
   doChecks = true;
   postBuild = ''

--- a/pkgs/applications/display-managers/ly/default.nix
+++ b/pkgs/applications/display-managers/ly/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, linux-pam }:
 
-stdenv.mkDerivation rec { 
+stdenv.mkDerivation rec {
   pname = "ly";
   version = "0.2.1";
 
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "16gjcrd4a6i4x8q8iwlgdildm7cpdsja8z22pf2izdm6rwfki97d";
     fetchSubmodules = true;
-  }; 
+  };
 
   buildInputs = [ linux-pam ];
   makeFlags = [ "FLAGS=-Wno-error" ];
 
   installPhase = ''
     mkdir -p $out/bin
-    cp bin/ly $out/bin 
+    cp bin/ly $out/bin
   '';
 
   meta = with lib; {

--- a/pkgs/applications/editors/dhex/default.nix
+++ b/pkgs/applications/editors/dhex/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ncurses ];
- 
+
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/share/man/man1

--- a/pkgs/applications/editors/emacs-modes/session-management-for-emacs/default.nix
+++ b/pkgs/applications/editors/emacs-modes/session-management-for-emacs/default.nix
@@ -2,20 +2,20 @@
 
 stdenv.mkDerivation {
   name = "session-management-for-emacs-2.2a";
-  
+
   src = fetchurl {
     url = "mirror://sourceforge/emacs-session/session-2.2a.tar.gz";
     sha256 = "37dfba7420b5164eab90dafa9e8bf9a2c8f76505fe2fefa14a64e81fa76d0144";
   };
 
   buildInputs = [emacs];
-  
+
   installPhase = ''
     mkdir -p "$out/share/emacs/site-lisp"
     cp lisp/*.el "$out/share/emacs/site-lisp/"
   '';
 
-  meta = { 
+  meta = {
     /* installation: add to your ~/.emacs
        (require 'session)
        (add-hook 'after-init-hook 'session-initialize)

--- a/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
@@ -7,14 +7,14 @@ let
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  
+
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
     sha256 = "0ay6m6j6zgrbcm48f14bass83bk4w5qnx76xihc05p69i9w32ff1";
   };
 
   nativeBuildInputs = [ cmake pkgconfig extra-cmake-modules ];
-  
+
   buildInputs = [ qtbase ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/editors/monodevelop/default.nix
+++ b/pkgs/applications/editors/monodevelop/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     > export MONO_GAC_PREFIX=${gnome-sharp}:${gtk-sharp-2_0}:\$MONO_GAC_PREFIX
     > export PATH=${mono}/bin:\$PATH
     > export LD_LIBRARY_PATH=${stdenv.lib.makeLibraryPath [ glib gnome2.libgnomeui gnome2.gnome_vfs gnome-sharp gtk-sharp-2_0 gtk-sharp-2_0.gtk ]}:\$LD_LIBRARY_PATH
-    > 
+    >
     EOF
     done
 

--- a/pkgs/applications/graphics/apitrace/default.nix
+++ b/pkgs/applications/graphics/apitrace/default.nix
@@ -27,13 +27,13 @@ stdenv.mkDerivation rec {
     # to the `RUNPATH` of dispatcher libraries `dlopen()` ing OpenGL drivers.
     # `RUNPATH` doesn't propagate throughout the whole application, but only
     # from the module performing the `dlopen()`.
-    # 
+    #
     # Apitrace wraps programs by running them with `LD_PRELOAD` pointing to `.so`
     # files in $out/lib/apitrace/wrappers.
-    # 
+    #
     # Theses wrappers effectively wrap the `dlopen()` calls from `libglvnd`
     # and other dispatcher libraries, and run `dlopen()`  by themselves.
-    # 
+    #
     # As `RUNPATH` doesn't propagate through the whole library, and they're now the
     # library doing the real `dlopen()`, they also need to have
     # `/run-opengl-driver[-32]` added to their `RUNPATH`.

--- a/pkgs/applications/graphics/drawing/default.nix
+++ b/pkgs/applications/graphics/drawing/default.nix
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
   version = "0.4.13";
 
   format = "other";
-  
+
   src = fetchFromGitHub {
     owner = "maoschanz";
     repo = pname;

--- a/pkgs/applications/graphics/fstl/default.nix
+++ b/pkgs/applications/graphics/fstl/default.nix
@@ -13,7 +13,7 @@ mkDerivation rec {
   preBuild = ''
     qmake qt/fstl.pro
   '';
-  
+
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     mv fstl.app $out/Applications

--- a/pkgs/applications/graphics/kcc/default.nix
+++ b/pkgs/applications/graphics/kcc/default.nix
@@ -14,7 +14,7 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     pname = "KindleComicConverter";
     sha256 = "5dbee5dc5ee06a07316ae5ebaf21ffa1970094dbae5985ad735e2807ef112644";
   };
-  
+
   propagatedBuildInputs = with python3Packages ; [
     pillow
     pyqt5

--- a/pkgs/applications/graphics/sane/backends/brscan4/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan4/default.nix
@@ -11,7 +11,7 @@ let
 
 in stdenv.mkDerivation rec {
   name = "brscan4-0.4.8-1";
-  src = 
+  src =
     if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         url = "http://download.brother.com/welcome/dlf006646/${name}.i386.deb";

--- a/pkgs/applications/misc/audio/wavrsocvt/default.nix
+++ b/pkgs/applications/misc/audio/wavrsocvt/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   phases = [ "unpackPhase" "installPhase" ];
 
   unpackPhase = ''
-    tar -zxf $src 
+    tar -zxf $src
     '';
 
   installPhase = ''

--- a/pkgs/applications/misc/candle/default.nix
+++ b/pkgs/applications/misc/candle/default.nix
@@ -12,7 +12,7 @@ mkDerivation rec {
   };
 
   nativeBuildInputs = [ qmake ];
-  
+
   sourceRoot = "source/src";
 
   installPhase = ''

--- a/pkgs/applications/misc/deadd-notification-center/default.nix
+++ b/pkgs/applications/misc/deadd-notification-center/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     cp $src $out/bin/deadd-notification-center
     chmod +x $out/bin/deadd-notification-center
 
-    sed "s|##PREFIX##|$out|g" ${dbusService} > $out/share/dbus-1/services/com.ph-uhl.deadd.notification.service 
+    sed "s|##PREFIX##|$out|g" ${dbusService} > $out/share/dbus-1/services/com.ph-uhl.deadd.notification.service
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/fme/default.nix
+++ b/pkgs/applications/misc/fme/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   pname = "fme";
   version = "1.1.3";
-  
+
   src = fetchurl {
     url = "https://github.com/rdehouss/fme/archive/v${version}.tar.gz";
     sha256 = "d1c81a6a38c0faad02943ad65d6d0314bd205c6de841669a2efe43e4c503e63d";

--- a/pkgs/applications/misc/fusee-interfacee-tk/default.nix
+++ b/pkgs/applications/misc/fusee-interfacee-tk/default.nix
@@ -1,40 +1,40 @@
-{ stdenv , fetchFromGitHub , python3 , makeWrapper }: 
+{ stdenv , fetchFromGitHub , python3 , makeWrapper }:
 
-let pythonEnv = python3.withPackages(ps: [ ps.tkinter ps.pyusb ]); 
-in stdenv.mkDerivation rec { 
+let pythonEnv = python3.withPackages(ps: [ ps.tkinter ps.pyusb ]);
+in stdenv.mkDerivation rec {
   pname = "fusee-interfacee-tk";
   version = "1.0.1";
 
-  src = fetchFromGitHub { 
+  src = fetchFromGitHub {
     owner = "nh-server";
     repo = pname;
-    rev = "V${version}"; 
+    rev = "V${version}";
     sha256 = "0ngwbwsj999flprv14xvhk7lp51nprrvcnlbnbk6y4qx5casm5md";
   };
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ pythonEnv ];
 
-  installPhase = '' 
+  installPhase = ''
     mkdir -p $out/bin
-			      
-    # The program isn't just called app, so I'm renaming it based on the repo name 
+
+    # The program isn't just called app, so I'm renaming it based on the repo name
     # It also isn't a standard program, so we need to append the shebang to the top
-    echo "#!${pythonEnv.interpreter}" > $out/bin/fusee-interfacee-tk 
+    echo "#!${pythonEnv.interpreter}" > $out/bin/fusee-interfacee-tk
     cat app.py >> $out/bin/fusee-interfacee-tk
-    chmod +x $out/bin/fusee-interfacee-tk 
-							      
-    # app.py depends on these to run 
-    cp *.py $out/bin/ 
+    chmod +x $out/bin/fusee-interfacee-tk
+
+    # app.py depends on these to run
+    cp *.py $out/bin/
     cp intermezzo.bin $out/bin/intermezzo.bin
   '';
 
-  meta = with stdenv.lib; { 
+  meta = with stdenv.lib; {
     homepage = "https://github.com/nh-server/fusee-interfacee-tk";
     description = "A tool to send .bin files to a Nintendo Switch in RCM mode";
-    longDescription = "A mod of falquinhos Fusée Launcher for use with Nintendo Homebrew Switch Guide. It also adds the ability to mount SD while in RCM. 
+    longDescription = "A mod of falquinhos Fusée Launcher for use with Nintendo Homebrew Switch Guide. It also adds the ability to mount SD while in RCM.
     Must be run as sudo.";
     maintainers = with maintainers; [ kristian-brucaj ];
     license = licenses.gpl2;
   };
-} 
+}

--- a/pkgs/applications/misc/keepass/extractWinRscIconsToStdFreeDesktopDir.sh
+++ b/pkgs/applications/misc/keepass/extractWinRscIconsToStdFreeDesktopDir.sh
@@ -43,7 +43,7 @@ if [ "ico" = "$rscFileExt" ]; then
 else
     wrestool -x --output=$tmp/ico -t14 $rscFile
 fi
-    
+
 icotool --icon -x --palette-size=0 -o $tmp/png $tmp/ico/*.ico
 
 mkdir -p $out

--- a/pkgs/applications/misc/minergate-cli/default.nix
+++ b/pkgs/applications/misc/minergate-cli/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     interpreter=${stdenv.glibc}/lib/ld-linux-x86-64.so.2
     patchelf --set-interpreter "$interpreter" $pgm
 
-    wrapProgram $pgm --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl stdenv.cc.cc ]} 
+    wrapProgram $pgm --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl stdenv.cc.cc ]}
 
     rm $out/usr/bin/minergate-cli
     mkdir -p $out/bin

--- a/pkgs/applications/misc/nanoblogger/default.nix
+++ b/pkgs/applications/misc/nanoblogger/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     cp -r * $out
-    cat > $out/bin/nb << EOF 
+    cat > $out/bin/nb << EOF
     #!${bash}/bin/bash
     $out/nb "\$@"
     EOF

--- a/pkgs/applications/misc/phwmon/default.nix
+++ b/pkgs/applications/misc/phwmon/default.nix
@@ -16,11 +16,11 @@ stdenv.mkDerivation {
   buildInputs = [ pythonPackages.pygtk pythonPackages.psutil ];
 
   pythonPath = [ pythonPackages.pygtk pythonPackages.psutil ];
-  
+
   patchPhase = ''
     substituteInPlace install.sh --replace "/usr/local" "$out"
   '';
-    
+
   installPhase = ''
     mkdir -p $out/bin $out/share/applications
     ./install.sh

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -27,7 +27,7 @@
 let
   version = "4.4";
 
-  binpath = stdenv.lib.makeBinPath [ 
+  binpath = stdenv.lib.makeBinPath [
     cabextract
     python
     gettext
@@ -70,7 +70,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ 
+  buildInputs = [
     xorg.libX11
     libGL
     python

--- a/pkgs/applications/misc/sleepyhead/default.nix
+++ b/pkgs/applications/misc/sleepyhead/default.nix
@@ -24,7 +24,7 @@ in mkDerivation {
   patchPhase = ''
     patchShebangs configure
   '';
-  
+
   installPhase = if stdenv.isDarwin then ''
     mkdir -p $out/Applications
     cp -r sleepyhead/SleepyHead.app $out/Applications

--- a/pkgs/applications/misc/ssocr/default.nix
+++ b/pkgs/applications/misc/ssocr/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0yzprwflky9a7zxa3zic7gvdwqg0zy49zvrqkdxng2k1ng78k3s7";
   };
 
-  nativeBuildInputs = [ imlib2 libX11 ]; 
+  nativeBuildInputs = [ imlib2 libX11 ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/misc/xrandr-invert-colors/default.nix
+++ b/pkgs/applications/misc/xrandr-invert-colors/default.nix
@@ -22,5 +22,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/zoltanp/xrandr-invert-colors";
     maintainers = [stdenv.lib.maintainers.magnetophon ];
     platforms = platforms.linux;
-  }; 
+  };
 }

--- a/pkgs/applications/networking/firehol/default.nix
+++ b/pkgs/applications/networking/firehol/default.nix
@@ -20,69 +20,19 @@ stdenv.mkDerivation rec {
   patches = [
     # configure tries to determine if `ping6` or the newer, combined
     # `ping` is installed by using `ping -6` which would fail.
-    (pkgs.writeText "firehol-ping6.patch"
-      ''
-      --- a/m4/ax_check_ping_ipv6.m4
-      +++ b/m4/ax_check_ping_ipv6.m4
-      @@ -42,16 +42,16 @@ AC_DEFUN([AX_CHECK_PING_IPV6],
-
-           AC_CACHE_CHECK([whether ]PING[ has working -6 option], [ac_cv_ping_6_opt],
-           [
-      -        ac_cv_ping_6_opt=no
-      -        if test -n "$PING"; then
-      -            echo "Trying '$PING -6 -c 1 ::1'" >&AS_MESSAGE_LOG_FD
-      -            $PING -6 -c 1 ::1 > conftest.out 2>&1
-      -            if test "$?" = 0; then
-      -                ac_cv_ping_6_opt=yes
-      -            fi
-      -            cat conftest.out >&AS_MESSAGE_LOG_FD
-      -            rm -f conftest.out
-      -        fi
-      +        ac_cv_ping_6_opt=yes
-      +        #if test -n "$PING"; then
-      +        #    echo "Trying '$PING -6 -c 1 ::1'" >&AS_MESSAGE_LOG_FD
-      +        #    $PING -6 -c 1 ::1 > conftest.out 2>&1
-      +        #    if test "$?" = 0; then
-      +        #        ac_cv_ping_6_opt=yes
-      +        #    fi
-      +        #    cat conftest.out >&AS_MESSAGE_LOG_FD
-      +        #    rm -f conftest.out
-      +        #fi
-           ])
-
-           AS_IF([test "x$ac_cv_ping_6_opt" = "xyes"],[
-      '')
+    ./firehol-ping6.patch
 
     # put firehol config files in /etc/firehol (not $out/etc/firehol)
     # to avoid error on startup, see #35114
-    (pkgs.writeText "firehol-sysconfdir.patch"
-      ''
-      --- a/sbin/install.config.in.in
-      +++ b/sbin/install.config.in.in
-      @@ -4 +4 @@
-      -SYSCONFDIR="@sysconfdir_POST@"
-      +SYSCONFDIR="/etc"
-      '')
+    ./firehol-sysconfdir.patch
 
-    # we must quote "$UNAME_CMD", or the dash in /nix/store/...-coreutils-.../bin/uname
-    # will be interpreted as IFS -> error. this might be considered an upstream bug
-    # but only appears when there are dashes in the command path
-    (pkgs.writeText "firehol-uname-command.patch"
-      ''
-      --- a/sbin/firehol
-      +++ b/sbin/firehol
-      @@ -10295,7 +10295,7 @@
-       	kmaj=$1
-       	kmin=$2
-       
-      -	set -- $($UNAME_CMD -r)
-      +	set -- $("$UNAME_CMD" -r)
-       	eval $kmaj=\$1 $kmin=\$2
-       }
-       kernel_maj_min KERNELMAJ KERNELMIN
-      '')
+    # we must quote "$UNAME_CMD", or the dash in
+    # /nix/store/...-coreutils-.../bin/uname will be interpreted as
+    # IFS -> error. this might be considered an upstream bug but only
+    # appears when there are dashes in the command path
+    ./firehol-uname-command.patch
   ];
-  
+
   nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
     curl iprange iproute ipset iptables iputils kmod

--- a/pkgs/applications/networking/firehol/firehol-ping6.patch
+++ b/pkgs/applications/networking/firehol/firehol-ping6.patch
@@ -1,0 +1,29 @@
+--- a/m4/ax_check_ping_ipv6.m4
++++ b/m4/ax_check_ping_ipv6.m4
+@@ -42,16 +42,16 @@ AC_DEFUN([AX_CHECK_PING_IPV6],
+
+     AC_CACHE_CHECK([whether ]PING[ has working -6 option], [ac_cv_ping_6_opt],
+     [
+-        ac_cv_ping_6_opt=no
+-        if test -n "$PING"; then
+-            echo "Trying '$PING -6 -c 1 ::1'" >&AS_MESSAGE_LOG_FD
+-            $PING -6 -c 1 ::1 > conftest.out 2>&1
+-            if test "$?" = 0; then
+-                ac_cv_ping_6_opt=yes
+-            fi
+-            cat conftest.out >&AS_MESSAGE_LOG_FD
+-            rm -f conftest.out
+-        fi
++        ac_cv_ping_6_opt=yes
++        #if test -n "$PING"; then
++        #    echo "Trying '$PING -6 -c 1 ::1'" >&AS_MESSAGE_LOG_FD
++        #    $PING -6 -c 1 ::1 > conftest.out 2>&1
++        #    if test "$?" = 0; then
++        #        ac_cv_ping_6_opt=yes
++        #    fi
++        #    cat conftest.out >&AS_MESSAGE_LOG_FD
++        #    rm -f conftest.out
++        #fi
+     ])
+
+     AS_IF([test "x$ac_cv_ping_6_opt" = "xyes"],[

--- a/pkgs/applications/networking/firehol/firehol-sysconfdir.patch
+++ b/pkgs/applications/networking/firehol/firehol-sysconfdir.patch
@@ -1,0 +1,5 @@
+--- a/sbin/install.config.in.in
++++ b/sbin/install.config.in.in
+@@ -4,1 +4,1 @@
+-SYSCONFDIR="@sysconfdir_POST@"
++SYSCONFDIR="/etc"

--- a/pkgs/applications/networking/firehol/firehol-uname-command.patch
+++ b/pkgs/applications/networking/firehol/firehol-uname-command.patch
@@ -1,0 +1,11 @@
+--- a/sbin/firehol
++++ b/sbin/firehol
+@@ -10295,7 +10295,7 @@
+ 	kmaj=$1
+ 	kmin=$2
+
+-	set -- $($UNAME_CMD -r)
++	set -- $("$UNAME_CMD" -r)
+ 	eval $kmaj=\$1 $kmin=\$2
+ }
+ kernel_maj_min KERNELMAJ KERNELMIN


### PR DESCRIPTION
###### Motivation for this change
We already do this check in ofborg, might as well apply it to all Nix files.

```ShellSession
$  find . -name "*.nix" -type f -print0 | xargs -0 sed -i '' -E "s/[[:space:]]*$//"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
