### PR TITLE
ldeep: init at 1.0.9

### DIFF
--- a/pkgs/development/python-modules/commandparse/default.nix
+++ b/pkgs/development/python-modules/commandparse/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "commandparse";
+  version = "1.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06mcxc0vs5qdcywalgyx5zm18z4xcsrg5g0wsqqv5qawkrvmvl53";
+  };
+
+  # tests only distributed upstream source, not PyPi
+  doCheck = false;
+  pythonImportsCheck = [ "commandparse" ];
+
+  meta = with lib; {
+    description = "Python module to parse command based CLI application";
+    homepage = "https://github.com/flgy/commandparse";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.fab ];
+  };
+}

--- a/pkgs/tools/security/ldeep/default.nix
+++ b/pkgs/tools/security/ldeep/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, commandparse
+, dnspython
+, ldap3
+, termcolor
+, tqdm
+}:
+
+buildPythonApplication rec {
+  pname = "ldeep";
+  version = "1.0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n38idkn9hy31m5xkrc36dmw364d137c7phssvj76gr2gqsrqjy3";
+  };
+
+  propagatedBuildInputs = [
+    commandparse
+    dnspython
+    ldap3
+    termcolor
+    tqdm
+  ];
+
+  # no tests are present
+  doCheck = false;
+  pythonImportsCheck = [ "ldeep" ];
+
+  meta = with lib; {
+    description = "In-depth LDAP enumeration utility";
+    homepage = "https://github.com/franc-pentest/ldeep";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5450,6 +5450,8 @@ in
 
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
+  ldeep = python3Packages.callPackage ../tools/security/ldeep { };
+
   ldns = callPackage ../development/libraries/ldns { };
 
   leafpad = callPackage ../applications/editors/leafpad { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1313,6 +1313,8 @@ in {
 
   colour = callPackage ../development/python-modules/colour { };
 
+  commandparse = callPackage ../development/python-modules/commandparse { };
+
   CommonMark = callPackage ../development/python-modules/commonmark { };
 
   compiledb = callPackage ../development/python-modules/compiledb { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
In-depth LDAP enumeration utility

https://github.com/franc-pentest/ldeep

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
