### PR TITLE
Use cargoHash in buildRustPackage crates with SRI hashes

### DIFF
--- a/pkgs/applications/virtualization/cntr/default.nix
+++ b/pkgs/applications/virtualization/cntr/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-4ogyOKuz6702/sOQNvE+UP+cvQrPPU3VjL4b0FUfRNw=";
   };
 
-  cargoSha256 = "sha256-lblvun2T1qpFiowld77Ti2MFPzhs5pOWWRbErORXYCM=";
+  cargoHash = "sha256-lblvun2T1qpFiowld77Ti2MFPzhs5pOWWRbErORXYCM=";
 
   meta = with stdenv.lib; {
     description = "A container debugging tool based on FUSE";

--- a/pkgs/development/interpreters/evcxr/default.nix
+++ b/pkgs/development/interpreters/evcxr/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-33XeepqwYmTMcObroPTuxykYuM9qYI1+LV5lZIFSomg=";
   };
 
-  cargoSha256 = "sha256-tjCID3YeGkxcq/LqJDMHGNpv1MCXKtcLlDnNkFwx1zU=";
+  cargoHash = "sha256-tjCID3YeGkxcq/LqJDMHGNpv1MCXKtcLlDnNkFwx1zU=";
 
   RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
 

--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -59,7 +59,7 @@ in rustPlatform.buildRustPackage rec {
     hash = "sha256-JXoH9yfhMIFg5qDY5zrF6iWb7XKugjMfk1NxSizfaWg=";
   };
 
-  cargoSha256 = "sha256-u9qitrOxJSABs0VjwHUZgmw7VTQXNbp6l8fKKE/RQ7M=";
+  cargoHash = "sha256-u9qitrOxJSABs0VjwHUZgmw7VTQXNbp6l8fKKE/RQ7M=";
 
   sourceRoot = "source/bindings/python";
 

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -18,7 +18,7 @@ let
   # 3) run the ./result script that is output by that (it updates ./grammars)
   version = "0.17.3";
   sha256 = "sha256-uQs80r9cPX8Q46irJYv2FfvuppwonSS5HVClFujaP+U=";
-  cargoSha256 = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
+  cargoHash = "sha256-fonlxLNh9KyEwCj7G5vxa7cM/DlcHNFbQpp0SwVQ3j4=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";

--- a/pkgs/development/tools/rebazel/default.nix
+++ b/pkgs/development/tools/rebazel/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-v84ZXhtJpejQmP61NmP06+qrtMu/0yb7UyD7U12xlME=";
   };
 
-  cargoSha256 = "sha256-2FmtbvtNfNoocj3Ly553KBLfOgBAa/eAxOrfZ3NGzzw=";
+  cargoHash = "sha256-2FmtbvtNfNoocj3Ly553KBLfOgBAa/eAxOrfZ3NGzzw=";
 
   meta = with lib; {
     description = "tool for expediting bazel build workflows";

--- a/pkgs/development/tools/rust/crate2nix/default.nix
+++ b/pkgs/development/tools/rust/crate2nix/default.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
       sha256 = "sha256-pqg1BsEq3kGmUzt1zpQvXgdnRcIsiuIyvtUBi3VxtZ4=";
     } + "/crate2nix";
 
-  cargoSha256 = "sha256-dAMWrGNMleQ3lDbG46Hr4qvCyxR+QcPOUZw9r2/CxV4=";
+  cargoHash = "sha256-dAMWrGNMleQ3lDbG46Hr4qvCyxR+QcPOUZw9r2/CxV4=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/filesystems/sandboxfs/default.nix
+++ b/pkgs/tools/filesystems/sandboxfs/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "Ia6rq6FN4abnvLXjlQh4Q+8ra5JThKnC86UXC7s9//U=";
   };
 
-  cargoSha256 = "sha256-k303TjWG+n+/ZMmko84KJtYb7swuQ1ZJOc4Vq6aOhX0=";
+  cargoHash = "sha256-k303TjWG+n+/ZMmko84KJtYb7swuQ1ZJOc4Vq6aOhX0=";
 
   # Issue to add Cargo.lock upstream: https://github.com/bazelbuild/sandboxfs/pull/115
   cargoPatches = [ ./Cargo.lock.patch ];

--- a/pkgs/tools/security/rage/default.nix
+++ b/pkgs/tools/security/rage/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-XSDfAsXfwSoe5JMdJtZlC324Sra+4fVJhE3/k2TthEc=";
   };
 
-  cargoSha256 = "sha256-GPr5zxeODAjD+ynp/nned9gZUiReYcdzosuEbLIKZSs=";
+  cargoHash = "sha256-GPr5zxeODAjD+ynp/nned9gZUiReYcdzosuEbLIKZSs=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/tools/system/bottom/default.nix
+++ b/pkgs/tools/system/bottom/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.IOKit;
 
-  cargoSha256 = "sha256-qnh4Tl6JRgxBJbu+t9IJX/XChIR15rTRLvsl+/ZvPxY=";
+  cargoHash = "sha256-qnh4Tl6JRgxBJbu+t9IJX/XChIR15rTRLvsl+/ZvPxY=";
 
   doCheck = false;
 

--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkgconfig asciidoctor installShellFiles ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "sha256-mnDUIJhEGNoh3eq2Vhww1T/tpZh9RP+RxbRsBNrpOzw=";
+  cargoHash = "sha256-mnDUIJhEGNoh3eq2Vhww1T/tpZh9RP+RxbRsBNrpOzw=";
 
   checkInputs = [ ansi2html ];
   # Skip tests that use the network and that include files.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

We now have `cargoHash` (as a replacement for `cargoSha256`) for SRI
hashes. So, use it in derivations that use a SRI hash for vendored
Cargo dependencies.

This change does not update rust-analyzer. It also requires changing
the update script, which relies on nix-prefetch, which returns non-SRI
hashes (didn't have time to look deeper). (@oxalica)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
