### PR TITLE
python3Packages.py-air-control-exporter: add passthru.tests

### DIFF
--- a/pkgs/development/python-modules/py-air-control-exporter/default.nix
+++ b/pkgs/development/python-modules/py-air-control-exporter/default.nix
@@ -1,5 +1,6 @@
-{ buildPythonPackage, fetchPypi, flask, isPy27, lib, prometheus_client
-, py-air-control, pytestCheckHook, pytestcov, pytestrunner, setuptools_scm }:
+{ buildPythonPackage, fetchPypi, flask, isPy27, lib, nixosTests
+, prometheus_client, py-air-control, pytestCheckHook, pytestcov, pytestrunner
+, setuptools_scm }:
 
 buildPythonPackage rec {
   pname = "py-air-control-exporter";
@@ -14,6 +15,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools_scm ];
   checkInputs = [ pytestCheckHook pytestcov pytestrunner ];
   propagatedBuildInputs = [ flask prometheus_client py-air-control ];
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) py-air-control; };
 
   meta = with lib; {
     description = "Exports Air Quality Metrics to Prometheus.";


### PR DESCRIPTION
This change adds integration tests to the py-air-control-exporter package. These tests verify that the exporter exports metrics correctly in an actual NixOS virtual machine.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To have better coverage of the exporter in CI.

###### Things done

Output of `nix run nixpkgs.nixpkgs-review -c nixpkgs-review rev HEAD`:
```
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
