### PR TITLE
direnv: 2.25.1 -> 2.27.0

### DIFF
--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -2,26 +2,21 @@
 
 buildGoModule rec {
   pname = "direnv";
-  version = "2.25.1";
-
-  vendorSha256 = null;
+  version = "2.27.0";
 
   src = fetchFromGitHub {
     owner = "direnv";
     repo = "direnv";
     rev = "v${version}";
-    sha256 = "0bwr7zdzjm5p6bjyzafc2n57y83f0pv2bmj99rhi8f94hhfydlsf";
+    sha256 = "05vvn59xd2q4yjizh5fprjib5xqq58by80d5avsm8nb1qxf383b1";
   };
+
+  vendorSha256 = "084x7d7sshcsyim76d6pl6127nlqacgwwnm965srl9y5w5nqzba6";
 
   # we have no bash at the moment for windows
   BASH_PATH =
     stdenv.lib.optionalString (!stdenv.hostPlatform.isWindows)
     "${bash}/bin/bash";
-
-  # fix hardcoded GOFLAGS in makefile. remove once https://github.com/direnv/direnv/issues/718 is closed.
-  postPatch = ''
-    substituteInPlace GNUmakefile --replace "export GOFLAGS=-mod=vendor" ""
-  '';
 
   # replace the build phase to use the GNUMakefile instead
   buildPhase = ''
@@ -29,9 +24,7 @@ buildGoModule rec {
   '';
 
   installPhase = ''
-    make install DESTDIR=$out
-    mkdir -p $out/share/fish/vendor_conf.d
-    echo "eval ($out/bin/direnv hook fish)" > $out/share/fish/vendor_conf.d/direnv.fish
+    make install PREFIX=$out
   '';
 
   checkInputs = [ fish zsh ];


### PR DESCRIPTION
###### Motivation for this change

update!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).