### PR TITLE
pam-ssh-agent: fix EDCSA crash

### DIFF
--- a/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
+++ b/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     # Allow multiple colon-separated authorized keys files to be
     # specified in the file= option.
     ./multiple-key-files.patch
+    ./edcsa-crash-fix.patch
   ];
 
   configureFlags = [

--- a/pkgs/os-specific/linux/pam_ssh_agent_auth/edcsa-crash-fix.patch
+++ b/pkgs/os-specific/linux/pam_ssh_agent_auth/edcsa-crash-fix.patch
@@ -1,0 +1,53 @@
+commit 1b0d9bcc5f5cd78b0bb1357d6a11da5d616ad26f
+Author: Wout Mertens <Wout.Mertens@gmail.com>
+Date:   Thu Jun 11 18:08:13 2020 +0200
+
+    fix segfault when using ECDSA keys.
+    
+    Author: Marc Deslauriers <marc.deslauriers@canonical.com>
+    Bug-Ubuntu: https://bugs.launchpad.net/bugs/1869512
+
+diff --git a/ssh-ecdsa.c b/ssh-ecdsa.c
+index 5b13b30..5bf29cc 100644
+--- a/ssh-ecdsa.c
++++ b/ssh-ecdsa.c
+@@ -46,7 +46,7 @@ ssh_ecdsa_sign(const Key *key, u_char **sigp, u_int *lenp,
+     u_int len, dlen;
+     Buffer b, bb;
+ #if OPENSSL_VERSION_NUMBER >= 0x10100005L
+-	BIGNUM *r, *s;
++	BIGNUM *r = NULL, *s = NULL;
+ #endif
+ 
+     if (key == NULL || key->type != KEY_ECDSA || key->ecdsa == NULL) {
+@@ -137,20 +137,27 @@ ssh_ecdsa_verify(const Key *key, const u_char *signature, u_int signaturelen,
+ 
+     /* parse signature */
+     if ((sig = ECDSA_SIG_new()) == NULL)
+-        pamsshagentauth_fatal("ssh_ecdsa_verify: DSA_SIG_new failed");
++        pamsshagentauth_fatal("ssh_ecdsa_verify: ECDSA_SIG_new failed");
+ 
+     pamsshagentauth_buffer_init(&b);
+     pamsshagentauth_buffer_append(&b, sigblob, len);
+ #if OPENSSL_VERSION_NUMBER < 0x10100005L
+     if ((pamsshagentauth_buffer_get_bignum2_ret(&b, sig->r) == -1) ||
+         (pamsshagentauth_buffer_get_bignum2_ret(&b, sig->s) == -1))
++        pamsshagentauth_fatal("ssh_ecdsa_verify:"
++            "pamsshagentauth_buffer_get_bignum2_ret failed");
+ #else
+-    DSA_SIG_get0(sig, &r, &s);
++    if ((r = BN_new()) == NULL)
++        pamsshagentauth_fatal("ssh_ecdsa_verify: BN_new failed");
++    if ((s = BN_new()) == NULL)
++        pamsshagentauth_fatal("ssh_ecdsa_verify: BN_new failed");
+     if ((pamsshagentauth_buffer_get_bignum2_ret(&b, r) == -1) ||
+         (pamsshagentauth_buffer_get_bignum2_ret(&b, s) == -1))
+-#endif
+         pamsshagentauth_fatal("ssh_ecdsa_verify:"
+             "pamsshagentauth_buffer_get_bignum2_ret failed");
++    if (ECDSA_SIG_set0(sig, r, s) != 1)
++        pamsshagentauth_fatal("ssh_ecdsa_verify: ECDSA_SIG_set0 failed");
++#endif
+ 
+     /* clean up */
+     memset(sigblob, 0, len);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Actually fixes #83870.

###### Things done

Added patch from Canonical

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
