### PR TITLE
ldapdomaindump: init at 0.9.3

### DIFF
--- a/pkgs/tools/security/ldapdomaindump/default.nix
+++ b/pkgs/tools/security/ldapdomaindump/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, dnspython
+, future
+, ldap3
+}:
+
+buildPythonApplication rec {
+  pname = "ldapdomaindump";
+  version = "0.9.3";
+
+  src = fetchPypi {
+    inherit pname;
+    inherit version;
+    sha256 = "10cis8cllpa9qi5qil9k7521ag3921mxwg2wj9nyn0lk41rkjagc";
+  };
+
+  propagatedBuildInputs = [
+    dnspython
+    future
+    ldap3
+  ];
+
+  # no tests are present
+  doCheck = false;
+
+  pythonImportsCheck = [ "ldapdomaindump" ];
+
+  meta = with lib; {
+    description = "Tool for dumping Active Directory information";
+    longDescription = ''
+      ldapdomaindump is a tool which aims to solve this problem, by collecting
+      and parsing information available via LDAP and outputting it in a human
+      readable HTML format, as well as machine readable JSON and csv/tsv/
+      greppable files.
+    '';
+    homepage = "https://github.com/dirkjanm/ldapdomaindump";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5448,6 +5448,8 @@ in
 
   lcdf-typetools = callPackage ../tools/misc/lcdf-typetools { };
 
+  ldapdomaindump = python3Packages.callPackage ../tools/security/ldapdomaindump { };
+
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
   ldns = callPackage ../development/libraries/ldns { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ldapdomaindump is a tool which aims to solve this problem, by collecting
and parsing information available via LDAP and outputting it in a human
readable HTML format, as well as machine readable JSON and csv/tsv/
greppable files.

https://github.com/dirkjanm/ldapdomaindump

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
