### PR TITLE
utsushi: unstable-2020-11-10 -> unstable-2021-01-01

### DIFF
--- a/pkgs/misc/drivers/utsushi/default.nix
+++ b/pkgs/misc/drivers/utsushi/default.nix
@@ -12,13 +12,13 @@ let
   '';
 in stdenv.mkDerivation rec {
   pname = "utsushi";
-  version = "unstable-2020-11-10";
+  version = "unstable-2021-01-01";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
-    rev = "04700043e2d16062eb8bd27f4efff3024f387d32";
-    sha256 = "0rxv5n0985d414i6hwichsn7hybwgwsimpy5s4hmcsvxqcpks4li";
+    rev = "1646d7d301f3d2aeb24930696688853fed5f0d43";
+    sha256 = "1g9m00qljhlw56h3hgfq67ywf4r92nl37m7x5mxa7ygaxc0dyb14";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
