### PR TITLE
ocamlPackages.ppx_deriving: 4.5 -> 5.1 and related changes

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,19 +1,31 @@
-{ lib, fetchzip, buildDunePackage
+{ lib, fetchzip, buildDunePackage, ocaml
 , cppo, ppx_derivers, ppxlib, ocaml-migrate-parsetree, result
 , ounit
 }:
 
+let
+  param =
+    if lib.versionAtLeast ocaml.version "4.05"
+    then {
+      version = "5.1";
+      sha256 = "0as0hy606vsbc4bf72vh2v23vdfaqlay22mlw6wbkr5b2l6w5b4w";
+    } else {
+      version = "5.0";
+      sha256 = "0ihw9d75ic82knv1cvc38fr0wki7vrkavaja362ra9cqbwr1y0al";
+    };
+in
+
 buildDunePackage rec {
   pname = "ppx_deriving";
-  version = "5.1";
+  inherit (param) version;
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.05";
+  minimumOCamlVersion = "4.04";
 
   src = fetchzip {
-    url = "https://github.com/ocaml-ppx/ppx_deriving/archive/v${version}.tar.gz";
-    sha256 = "0as0hy606vsbc4bf72vh2v23vdfaqlay22mlw6wbkr5b2l6w5b4w";
+    url = "https://github.com/ocaml-ppx/ppx_deriving/archive/v${param.version}.tar.gz";
+    inherit (param) sha256;
   };
 
   buildInputs = [ cppo ];

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,20 +1,26 @@
 { lib, fetchzip, buildDunePackage
-, cppo, ppxfind, ppx_tools, ppx_derivers, result, ounit, ocaml-migrate-parsetree
+, cppo, ppx_derivers, ppxlib, ocaml-migrate-parsetree, result
+, ounit
 }:
 
 buildDunePackage rec {
   pname = "ppx_deriving";
-  version = "4.5";
+  version = "5.1";
+
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.05";
 
   src = fetchzip {
     url = "https://github.com/ocaml-ppx/ppx_deriving/archive/v${version}.tar.gz";
-    sha256 = "1v2xldag54n0xk69vv3j4nln9bzkkpq3rildq118sydzsc9v239z";
+    sha256 = "0as0hy606vsbc4bf72vh2v23vdfaqlay22mlw6wbkr5b2l6w5b4w";
   };
 
-  buildInputs = [ ppxfind cppo ounit ];
-  propagatedBuildInputs = [ ocaml-migrate-parsetree ppx_derivers ppx_tools result ];
+  buildInputs = [ cppo ];
+  propagatedBuildInputs = [ ppxlib ocaml-migrate-parsetree ppx_derivers result ];
 
   doCheck = true;
+  checkInputs = [ ounit ];
 
   meta = with lib; {
     description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02.";

--- a/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
@@ -19,6 +19,7 @@ buildDunePackage rec {
   buildInputs = [ cppo ppx_tools ppxfind ppx_deriving ];
 
   meta = with lib; {
+    broken = lib.versionAtLeast ppx_deriving.version "5.0";
     homepage = "https://github.com/ocaml-ppx/ppx_deriving_protobuf";
     description = "A Protocol Buffers codec generator for OCaml";
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -1,25 +1,26 @@
-{ lib, buildDunePackage, fetchFromGitHub, ppxfind, ounit
-, ppx_deriving, yojson
+{ lib, buildDunePackage, fetchFromGitHub
+, ounit, ppxlib, ppx_deriving, yojson, result
 }:
 
 buildDunePackage rec {
   pname = "ppx_deriving_yojson";
-  version = "3.5.3";
+  version = "3.6.1";
 
-  minimumOCamlVersion = "4.04";
+  minimumOCamlVersion = "4.05";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = "ppx_deriving_yojson";
     rev = "v${version}";
-    sha256 = "030638gp39mr4hkilrjhd98q4s8gjqxifm6fy6bwqrg74hmrl2y5";
+    sha256 = "1icz5h6p3pfj7my5gi7wxpflrb8c902dqa17f9w424njilnpyrbk";
   };
 
-  buildInputs = [ ppxfind ounit ];
-
-  propagatedBuildInputs = [ ppx_deriving yojson ];
+  propagatedBuildInputs = [ result ppx_deriving yojson ppxlib ];
 
   doCheck = true;
+  checkInputs = [ ounit ];
 
   meta = {
     description = "A Yojson codec generator for OCaml >= 4.04";

--- a/pkgs/development/ocaml-modules/visitors/default.nix
+++ b/pkgs/development/ocaml-modules/visitors/default.nix
@@ -1,24 +1,26 @@
-{ lib, buildDunePackage, fetchFromGitLab, ppx_tools, ppx_deriving, result, cppo }:
+{ lib, buildDunePackage, fetchFromGitLab
+, ppxlib, ppx_deriving, result
+, cppo, core_bench
+}:
 
 buildDunePackage rec {
   pname = "visitors";
-  version = "20200210";
+  version = "unstable-2020-11-12";
+  # 20201112 has a changelog entry, but no release tag
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.02.3";
+  minimumOCamlVersion = "4.07";
 
   src = fetchFromGitLab {
     owner = "fpottier";
     repo = pname;
-    rev = version;
+    rev = "ffa92a0fdfdfe7e8ea12a53cfc7d51d1f3f34d5b";
     domain = "gitlab.inria.fr";
-    sha256 = "12i099h1hc1walabiwqbinnpgcxkc1wn72913v7v6vvyif21rb5a";
+    sha256 = "14b86nh0jlsj71qxzzdkqp2zyah6czhnfb7djakghwl6633445ci";
   };
 
-  buildInputs = [ cppo ];
-
-  propagatedBuildInputs = [ ppx_tools ppx_deriving result ];
+  propagatedBuildInputs = [ ppxlib ppx_deriving result ];
 
   meta = with lib; {
     homepage = "https://gitlab.inria.fr/fpottier/visitors";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -937,12 +937,9 @@ let
 
     ppx_derivers = callPackage ../development/ocaml-modules/ppx_derivers {};
 
-    ppx_deriving =
-      if lib.versionAtLeast ocaml.version "4.02"
-      then callPackage ../development/ocaml-modules/ppx_deriving {}
-      else null;
+    ppx_deriving = callPackage ../development/ocaml-modules/ppx_deriving { };
 
-    ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
+    ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf { };
 
     ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolve #106907.

Update to ppx_deriving 5.1 which supports the dune 2 ppx rewriter stuff properly. Thus we need to use dune 2 for a lot of packages using ppx_deriving. We do *not* update to 5.2, since that requires ppxlib 0.20.0 which is not supported by a large amount of packages that depend on ppx_deriving. This minimizes the problem of multiple interface versions in `$OCAMLPATH` greatly.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
