### PR TITLE
wio: init at unstable-2020-11-02

### DIFF
--- a/pkgs/applications/window-managers/wio/default.nix
+++ b/pkgs/applications/window-managers/wio/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchgit
+, meson
+, ninja
+, pkg-config
+, alacritty
+, cage
+, cairo
+, libxkbcommon
+, udev
+, wayland
+, wayland-protocols
+, wlroots
+, xwayland
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wio";
+  version = "unstable-2020-11-02";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~sircmpwn/wio";
+    rev = "31b742e473b15a2087be740d1de28bc2afd47a4d";
+    sha256 = "1vpvlahv6dmr7vfb11p5cc5ds2y2vfvcb877nkqx18yin6pg357l";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config makeWrapper ];
+  buildInputs = [
+    cairo
+    libxkbcommon
+    udev
+    wayland
+    wayland-protocols
+    wlroots
+    xwayland
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/wio \
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ alacritty cage ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "That Plan 9 feel, for Wayland";
+    longDescription = ''
+      Wio is a Wayland compositor for Linux and FreeBSD which has a similar look
+      and feel to plan9's rio.
+    '';
+    homepage = "https://wio-project.org/";
+    license = licenses.mit;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+
+  passthru.providedSessions = [ "wio" ];
+}
+# TODO: factor Linux-specific options

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24966,6 +24966,8 @@ in
 
   weston = callPackage ../applications/window-managers/weston { pipewire = pipewire_0_2; };
 
+  wio = callPackage ../applications/window-managers/wio { };
+
   whitebox-tools = callPackage ../applications/gis/whitebox-tools {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
