### PR TITLE
python3Packages.python-mystrom: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/python-mystrom/default.nix
+++ b/pkgs/development/python-modules/python-mystrom/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, click
+, requests
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "python-mystrom";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "050dkx29wrmdd8z7pmyk36k2ihpapqi4qmyb70bm6xl5l4jh4k7j";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    click
+    requests
+    setuptools
+  ];
+
+  # no tests are present
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pymystrom.bulb"
+    "pymystrom.pir"
+    "pymystrom.switch"
+  ];
+
+  meta = with lib; {
+    description = "Python API client for interacting with myStrom devices";
+    longDescription = ''
+      Asynchronous Python API client for interacting with myStrom devices.
+      There is support for bulbs, motion sensors, plugs and buttons.
+    '';
+    homepage = "https://github.com/home-assistant-ecosystem/python-mystrom";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -522,7 +522,7 @@
     "mycroft" = ps: with ps; [ ]; # missing inputs: mycroftapi
     "myq" = ps: with ps; [ ]; # missing inputs: pymyq
     "mysensors" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: pymysensors
-    "mystrom" = ps: with ps; [ aiohttp-cors ]; # missing inputs: python-mystrom
+    "mystrom" = ps: with ps; [ aiohttp-cors python-mystrom ];
     "mythicbeastsdns" = ps: with ps; [ ]; # missing inputs: mbddns
     "n26" = ps: with ps; [ ]; # missing inputs: n26
     "nad" = ps: with ps; [ ]; # missing inputs: nad_receiver

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6025,6 +6025,8 @@ in {
 
   python-multipart = callPackage ../development/python-modules/python-multipart { };
 
+  python-mystrom = callPackage ../development/python-modules/python-mystrom { };
+
   python-nest = callPackage ../development/python-modules/python-nest { };
 
   pythonnet = callPackage


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Asynchronous Python API client for interacting with myStrom devices.
There is support for bulbs, motion sensors, plugs and buttons.

https://github.com/home-assistant-ecosystem/python-mystrom

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
