### PR TITLE
doc: explicit Markdown anchors for top-level headings; remove metadata

### DIFF
--- a/doc/builders/packages/cataclysm-dda.section.md
+++ b/doc/builders/packages/cataclysm-dda.section.md
@@ -1,4 +1,4 @@
-# Cataclysm: Dark Days Ahead
+# Cataclysm: Dark Days Ahead {#cataclysm-dark-days-ahead}
 
 ## How to install Cataclysm DDA
 

--- a/doc/builders/trivial-builders.chapter.md
+++ b/doc/builders/trivial-builders.chapter.md
@@ -37,7 +37,7 @@ This works just like `runCommand`. The only difference is that it also provides 
 
 Variant of `runCommand` that forces the derivation to be built locally, it is not substituted. This is intended for very cheap commands (<1s execution time). It saves on the network roundrip and can speed up a build.
 
-::: {.note}
+::: note
 This sets [`allowSubstitutes` to `false`](https://nixos.org/nix/manual/#adv-attr-allowSubstitutes), so only use `runCommandLocal` if you are certain the user will always have a builder for the `system` of the derivation. This should be true for most trivial use cases (e.g. just copying some files to a different location or adding symlinks), because there the `system` is usually the same as `builtins.currentSystem`.
 :::
 

--- a/doc/languages-frameworks/agda.section.md
+++ b/doc/languages-frameworks/agda.section.md
@@ -1,9 +1,4 @@
----
-title: Agda
-author: Alex Rice (alexarice)
-date: 2020-01-06
----
-# Agda
+# Agda {#agda}
 
 ## How to use Agda
 

--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -1,9 +1,4 @@
----
-title: Android
-author: Sander van der Burg
-date: 2018-11-18
----
-# Android
+# Android {#android}
 
 The Android build environment provides three major features and a number of
 supporting features.

--- a/doc/languages-frameworks/crystal.section.md
+++ b/doc/languages-frameworks/crystal.section.md
@@ -1,4 +1,4 @@
-# Crystal
+# Crystal {#crystal}
 
 ## Building a Crystal package
 

--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -1,4 +1,4 @@
-# Emscripten
+# Emscripten {#emscripten}
 
 [Emscripten](https://github.com/kripken/emscripten): An LLVM-to-JavaScript Compiler
 

--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -1,10 +1,4 @@
----
-title: User's Guide for Haskell in Nixpkgs
-author: Peter Simons
-date: 2015-06-01
----
-
-# Haskell
+# Haskell {#haskell}
 
 The documentation for the Haskell infrastructure is published at
 <https://haskell4nix.readthedocs.io/>. The source code for that

--- a/doc/languages-frameworks/idris.section.md
+++ b/doc/languages-frameworks/idris.section.md
@@ -1,4 +1,4 @@
-# Idris
+# Idris {#idris}
 
 ## Installing Idris
 

--- a/doc/languages-frameworks/ios.section.md
+++ b/doc/languages-frameworks/ios.section.md
@@ -1,9 +1,4 @@
----
-title: iOS
-author: Sander van der Burg
-date: 2019-11-10
----
-# iOS
+# iOS {#ios}
 
 This component is basically a wrapper/workaround that makes it possible to
 expose an Xcode installation as a Nix package by means of symlinking to the

--- a/doc/languages-frameworks/lua.section.md
+++ b/doc/languages-frameworks/lua.section.md
@@ -1,10 +1,4 @@
----
-title: Lua
-author: Matthieu Coudron
-date: 2019-02-05
----
-
-# User's Guide to Lua Infrastructure
+# User's Guide to Lua Infrastructure {#users-guide-to-lua-infrastructure}
 
 ## Using Lua
 

--- a/doc/languages-frameworks/maven.section.md
+++ b/doc/languages-frameworks/maven.section.md
@@ -1,10 +1,4 @@
----
-title: Maven
-author: Farid Zakaria
-date: 2020-10-15
----
-
-# Maven
+# Maven {#maven}
 
 Maven is a well-known build tool for the Java ecosystem however it has some challenges when integrating into the Nix build system.
 

--- a/doc/languages-frameworks/node.section.md
+++ b/doc/languages-frameworks/node.section.md
@@ -1,5 +1,5 @@
-Node.js
-=======
+# Node.js {#node.js}
+
 The `pkgs/development/node-packages` folder contains a generated collection of
 [NPM packages](https://npmjs.com/) that can be installed with the Nix package
 manager.

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1,4 +1,4 @@
-# Python
+# Python {#python}
 
 ## User Guide
 

--- a/doc/languages-frameworks/r.section.md
+++ b/doc/languages-frameworks/r.section.md
@@ -1,5 +1,4 @@
-R
-=
+# R {#r}
 
 ## Installation
 

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -1,10 +1,4 @@
----
-title: Rust
-author: Matthias Beyer
-date: 2017-03-05
----
-
-# Rust
+# Rust {#rust}
 
 To install the rust compiler and cargo put
 

--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -1,4 +1,3 @@
-
 # TeX Live {#sec-language-texlive}
 
 Since release 15.09 there is a new TeX Live packaging that lives entirely under attribute `texlive`.

--- a/doc/languages-frameworks/titanium.section.md
+++ b/doc/languages-frameworks/titanium.section.md
@@ -1,9 +1,4 @@
----
-title: Titanium
-author: Sander van der Burg
-date: 2018-11-18
----
-# Titanium
+# Titanium {#titanium}
 
 The Nixpkgs repository contains facilities to deploy a variety of versions of
 the [Titanium SDK](https://www.appcelerator.com) versions, a cross-platform

--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -1,9 +1,4 @@
----
-title: User's Guide for Vim in Nixpkgs
-author: Marc Weber
-date: 2016-06-25
----
-# Vim
+# Vim {#vim}
 
 Both Neovim and Vim can be configured to include your favorite plugins
 and additional libraries.

--- a/doc/preface.chapter.md
+++ b/doc/preface.chapter.md
@@ -1,10 +1,4 @@
----
-title: Preface
-author: Frederik Rietdijk
-date: 2015-11-25
----
-
-# Preface
+# Preface {#preface}
 
 The Nix Packages collection (Nixpkgs) is a set of thousands of packages for the
 [Nix package manager](https://nixos.org/nix/), released under a


### PR DESCRIPTION
I used the existing anchors generated by Docbook, so the anchor part
should be a no-op. This could be useful depending on the
infrastructure we choose to use, and it is better to be explicit than
rely on Docbook's id generating algorithms.

I got rid of the metadata segments of the Markdown files, because they
are outdated, inaccurate, and could make people less willing to change
them without speaking with the author.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
