### PR TITLE
python3Packages.volkszaehler: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/volkszaehler/default.nix
+++ b/pkgs/development/python-modules/volkszaehler/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, async-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "volkszaehler";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "087gw1k3f81lm859r0j65cjia8c2dcy4cx8c7s3mb5msb1csdh0x";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+  ];
+
+  # no tests are present
+  doCheck = false;
+
+  pythonImportsCheck = [ "volkszaehler" ];
+
+  meta = with lib; {
+    description = "Python Wrapper for interacting with the Volkszahler API";
+    homepage = "https://github.com/home-assistant-ecosystem/python-volkszaehler";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -908,7 +908,7 @@
     "vlc" = ps: with ps; [ python-vlc ];
     "vlc_telnet" = ps: with ps; [ ]; # missing inputs: python-telnet-vlc
     "voicerss" = ps: with ps; [ ];
-    "volkszaehler" = ps: with ps; [ ]; # missing inputs: volkszaehler
+    "volkszaehler" = ps: with ps; [ volkszaehler ];
     "volumio" = ps: with ps; [ ]; # missing inputs: pyvolumio
     "volvooncall" = ps: with ps; [ ]; # missing inputs: volvooncall
     "vultr" = ps: with ps; [ vultr ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7758,6 +7758,8 @@ in {
 
   vobject = callPackage ../development/python-modules/vobject { };
 
+  volkszaehler = callPackage ../development/python-modules/volkszaehler { };
+
   voluptuous = callPackage ../development/python-modules/voluptuous { };
 
   voluptuous-serialize = callPackage ../development/python-modules/voluptuous-serialize { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Wrapper for interacting with the Volkszahler API

https://github.com/home-assistant-ecosystem/python-volkszaehler

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
