### PR TITLE
unbound: optionally support DNS-over-HTTPS

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -18,6 +18,9 @@
   #
 , withSystemd ? false
 , systemd ? null
+  # optionally support DNS-over-HTTPS as a server
+, withDoH ? false
+, libnghttp2
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +34,9 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB
 
-  buildInputs = [ openssl nettle expat libevent ] ++ lib.optionals withSystemd [ pkg-config systemd ];
+  buildInputs = [ openssl nettle expat libevent ]
+    ++ lib.optionals withSystemd [ pkg-config systemd ]
+    ++ lib.optionals withDoH [ libnghttp2 ];
 
   configureFlags = [
     "--with-ssl=${openssl.dev}"
@@ -47,6 +52,8 @@ stdenv.mkDerivation rec {
     "--disable-flto"
   ] ++ lib.optionals withSystemd [
     "--enable-systemd"
+  ] ++ lib.optionals withDoH [
+    "--with-libnghttp2=${libnghttp2.dev}"
   ];
 
   installFlags = [ "configfile=\${out}/etc/unbound/unbound.conf" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8915,6 +8915,11 @@ in
     withSystemd = true;
   };
 
+  unbound-full = unbound.override {
+    withSystemd = true;
+    withDoH = true;
+  };
+
   unicorn = callPackage ../development/libraries/unicorn { };
 
   units = callPackage ../tools/misc/units {


### PR DESCRIPTION
###### Motivation for this change
unbound can be used as a DNS-over-HTTPS (DoH) server.

This is a blog post introducing the feature:

https://www.nlnetlabs.nl/news/2020/Oct/08/unbound-1.12.0-released/

###### Notify Maintainers
cc @ehmry @fpletz @globin

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
