### PR TITLE
python3Packages.dnachisel: init at 3.2.5

### DIFF
--- a/pkgs/development/python-modules/dnachisel/default.nix
+++ b/pkgs/development/python-modules/dnachisel/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, biopython
+, docopt
+, flametree
+, numpy
+, proglog
+, python-codon-tables
+ }:
+
+buildPythonPackage rec {
+  pname = "dnachisel";
+  version = "3.2.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "35301c5eda0baca5902403504e0b5a22eb65da92c2bbd23199d95c4a6bf0ef37";
+  };
+
+  propagatedBuildInputs = [
+    biopython
+    docopt
+    flametree
+    numpy
+    proglog
+    python-codon-tables
+  ];
+
+  # no tests in tarball
+  doCheck = false;
+
+  pythonImportsCheck = [ "dnachisel" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Edinburgh-Genome-Foundry/DnaChisel";
+    description = "Optimize DNA sequences under constraints";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/flametree/default.nix
+++ b/pkgs/development/python-modules/flametree/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "flametree";
+  version = "0.1.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c8eb81dea8c7f8261a2aa03d2bac98b1d21ebceec9c67efaac423f7c1b4fe061";
+  };
+
+  # no tests in tarball
+  doCheck = false;
+
+  pythonImportsCheck = [ "flametree" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Edinburgh-Genome-Foundry/Flametree";
+    description = "Python file and zip operations made easy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/python-codon-tables/default.nix
+++ b/pkgs/development/python-modules/python-codon-tables/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "python-codon-tables";
+  version = "0.1.10";
+
+  src = fetchPypi {
+    pname = "python_codon_tables";
+    inherit version;
+    sha256 = "265beac928cbb77c6745bc728471adc7ffef933b794be303d272ecb9ad37d3d4";
+  };
+
+  # no tests in tarball
+  doCheck = false;
+
+  pythonImportsCheck = [ "python_codon_tables" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Edinburgh-Genome-Foundry/codon-usage-tables";
+    description = "Codon Usage Tables for Python, from kazusa.or.jp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2139,6 +2139,8 @@ in {
 
   flaky = callPackage ../development/python-modules/flaky { };
 
+  flametree = callPackage ../development/python-modules/flametree { };
+
   flammkuchen = callPackage ../development/python-modules/flammkuchen { };
 
   flask-admin = callPackage ../development/python-modules/flask-admin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4687,6 +4687,8 @@ in {
 
   pysbd = callPackage ../development/python-modules/pysbd { };
 
+  python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
+
   python-csxcad = callPackage ../development/python-modules/python-csxcad { };
 
   python-openems = callPackage ../development/python-modules/python-openems { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1793,6 +1793,8 @@ in {
 
   dm-sonnet = callPackage ../development/python-modules/dm-sonnet { };
 
+  dnachisel = callPackage ../development/python-modules/dnachisel { };
+
   dnslib = callPackage ../development/python-modules/dnslib { };
 
   dnspython = if isPy3k then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- package `dnachisel` (+two its dependencies)
- https://berthub.eu/articles/posts/part-2-reverse-engineering-source-code-of-the-biontech-pfizer-vaccine/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
