### PR TITLE
libplacebo: 2.72.2 -> 3.104.0

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchFromGitHub
+{ config, stdenv, fetchFromGitHub, fetchpatch
 , addOpenGLRunpath, docutils, perl, pkgconfig, python3, wafHook, which
 , ffmpeg, freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , nv-codec-headers, lua, libuchardet, libiconv ? null
@@ -103,6 +103,14 @@ in stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-3l32qQBpvWVjbLp5CZtO039oDQeH7C/cNAKtJxrzlRk=";
   };
+
+  patches = [
+    # To make mpv build with libplacebo 3.104.0:
+    (fetchpatch { # vo_gpu: placebo: update for upstream API changes
+      url = "https://github.com/mpv-player/mpv/commit/7c4465cefb27d4e0d07535d368febdf77b579566.patch";
+      sha256 = "1yfc6220ak5kc5kf7zklmsa944nr9q0qaa27l507pgrmvcyiyzrx";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./TOOLS/

--- a/pkgs/development/libraries/libplacebo/default.nix
+++ b/pkgs/development/libraries/libplacebo/default.nix
@@ -11,11 +11,13 @@
 , glslang
 , lcms2
 , epoxy
+, libGL
+, xorg
 }:
 
 stdenv.mkDerivation rec {
   pname = "libplacebo";
-  version = "2.72.2";
+  version = "3.104.0";
 
   patches = [
     ./glsl-import.patch
@@ -26,7 +28,7 @@ stdenv.mkDerivation rec {
     owner = "videolan";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ijqpx1pagc6qg63ynqrinvckwc8aaw1i0lx48gg5szwk8afib4i";
+    sha256 = "0p5mx8ch7cp7b54yrkl4fs8bcvqma1h461gx6ps4kagn4dsx8asb";
   };
 
   nativeBuildInputs = [
@@ -43,6 +45,8 @@ stdenv.mkDerivation rec {
     glslang
     lcms2
     epoxy
+    libGL
+    xorg.libX11
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~~This isn't ready yet. Seems like some breaking changes require a new mpv release:~~
```
[ 98/516] Compiling video/out/placebo/ra_pl.c
../video/out/placebo/ra_pl.c: In function ‘mppl_wrap_tex’:
../video/out/placebo/ra_pl.c:147:13: warning: ‘sample_mode’ is deprecated [-Wdeprecated-declarations]
  147 |             .src_linear = pltex->params.sample_mode == PL_TEX_SAMPLE_LINEAR,
      |             ^
In file included from ../video/out/placebo/ra_pl.h:4,
                 from ../video/out/placebo/ra_pl.c:4:
/nix/store/i8pw7slaskkkkifgww6xxpragxfykmhi-libplacebo-3.104.0/include/libplacebo/gpu.h:352:29: note: declared here
  352 |     enum pl_tex_sample_mode sample_mode PL_DEPRECATED;
      |                             ^~~~~~~~~~~
../video/out/placebo/ra_pl.c:148:13: warning: ‘address_mode’ is deprecated [-Wdeprecated-declarations]
  148 |             .src_repeat = pltex->params.address_mode == PL_TEX_ADDRESS_REPEAT,
      |             ^
In file included from ../video/out/placebo/ra_pl.h:4,
                 from ../video/out/placebo/ra_pl.c:4:
/nix/store/i8pw7slaskkkkifgww6xxpragxfykmhi-libplacebo-3.104.0/include/libplacebo/gpu.h:353:30: note: declared here
  353 |     enum pl_tex_address_mode address_mode PL_DEPRECATED;
      |                              ^~~~~~~~~~~~
../video/out/placebo/ra_pl.c: In function ‘blit_pl’:
../video/out/placebo/ra_pl.c:402:5: error: too many arguments to function ‘pl_tex_blit’
  402 |     pl_tex_blit(get_gpu(ra), dst->priv, src->priv, pldst, plsrc);
      |     ^~~~~~~~~~~
In file included from ../video/out/placebo/ra_pl.h:4,
                 from ../video/out/placebo/ra_pl.c:4:
/nix/store/i8pw7slaskkkkifgww6xxpragxfykmhi-libplacebo-3.104.0/include/libplacebo/gpu.h:458:6: note: declared here
  458 | void pl_tex_blit(const struct pl_gpu *gpu,
      |      ^~~~~~~~~~~

Waf: Leaving directory `/build/source/build'
Build failed
 -> task in 'objects' failed with exit status 1 (run with -v to display more information)
builder for '/nix/store/022m5a6k5nggr1bqrs0z4d4m3qzpw552-mpv-0.33.0.drv' failed with exit code 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
