### PR TITLE
[20.09] thunderbird: Add gpg/gpgme dependencies to fix smartcard usage

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -39,6 +39,7 @@
 , gnused
 , gnugrep
 , gnupg
+, gpgme
 , runtimeShell
 }:
 
@@ -118,6 +119,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  # See "Note on GPG support" in `../thunderbird/default.nix` for explanations
+  # on adding `gnupg` and `gpgme` into PATH/LD_LIBRARY_PATH.
+
   installPhase =
     ''
       mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
@@ -158,7 +162,9 @@ stdenv.mkDerivation {
         --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
         --set SNAP_NAME "thunderbird" \
         --set MOZ_LEGACY_PROFILES 1 \
-        --set MOZ_ALLOW_DOWNGRADE 1
+        --set MOZ_ALLOW_DOWNGRADE 1 \
+        --prefix PATH : "${stdenv.lib.getBin gnupg}/bin" \
+        --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib gpgme}/lib"
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -14,6 +14,8 @@
 , glib
 , gnugrep
 , gnused
+, gnupg
+, gpgme
 , icu
 , jemalloc
 , lib
@@ -286,6 +288,15 @@ stdenv.mkDerivation rec {
     ${desktopItem.buildCommand}
   '';
 
+  # Note on GPG support:
+  # Thunderbird's native GPG support does not yet support smartcards.
+  # The official upstream recommendation is to configure fall back to gnupg
+  # using the Thunderbird config `mail.openpgp.allow_external_gnupg`
+  # and GPG keys set up; instructions with pictures at:
+  # https://anweshadas.in/how-to-use-yubikey-or-any-gpg-smartcard-in-thunderbird-78/
+  # For that to work out of the box, it requires `gnupg` on PATH and
+  # `gpgme` in `LD_LIBRARY_PATH`; we do this below.
+
   preFixup = ''
     # Needed to find Mozilla runtime
     gappsWrapperArgs+=(
@@ -295,6 +306,8 @@ stdenv.mkDerivation rec {
       --set SNAP_NAME "thunderbird"
       --set MOZ_LEGACY_PROFILES 1
       --set MOZ_ALLOW_DOWNGRADE 1
+      --prefix PATH : "${lib.getBin gnupg}/bin"
+      --prefix LD_LIBRARY_PATH : "${lib.getLib gpgme}/lib"
     )
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Backport of #107122

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
