### PR TITLE
solanum: init at unstable-2020-12-14

### DIFF
--- a/pkgs/servers/irc/solanum/default.nix
+++ b/pkgs/servers/irc/solanum/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, bison
+, flex
+, openssl
+, sqlite
+, lksctp-tools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "solanum";
+  version = "unstable-2020-12-14";
+
+  src = fetchFromGitHub {
+    owner = "solanum-ircd";
+    repo = pname;
+    rev = "551e5a146eab4948ce4a57d87a7f671f2d7cc02d";
+    sha256 = "14cd2cb04w6nwck7q49jw5zvifkzhkmblwhjfskc2nxcdb5x3l96";
+  };
+
+  patches = [
+    ./dont-create-logdir.patch
+  ];
+
+  configureFlags = [
+    "--enable-epoll"
+    "--enable-ipv6"
+    "--enable-openssl=${openssl.dev}"
+    "--with-program-prefix=solanum-"
+    "--localstatedir=/var/lib/solanum"
+    "--with-rundir=/run/solanum"
+    "--with-logdir=/var/log/solanum"
+  ] ++ stdenv.lib.optionals (stdenv.isLinux) [
+    "--enable-sctp=${lksctp-tools.out}/lib"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    sqlite
+  ];
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = with stdenv.lib; {
+    description = "An IRCd for unified networks";
+    homepage = "https://github.com/solanum-ircd/solanum";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ hexa ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/irc/solanum/dont-create-logdir.patch
+++ b/pkgs/servers/irc/solanum/dont-create-logdir.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile.am b/Makefile.am
+index 19e7b396..21093521 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -35,9 +35,6 @@ include/serno.h:
+ 		echo '#define DATECODE 0UL' >>include/serno.h; \
+ 	fi
+ 
+-install-data-hook:
+-	test -d ${DESTDIR}${logdir} || mkdir -p ${DESTDIR}${logdir}
+-
+ install-exec-hook:
+ 	rm -f ${DESTDIR}${libdir}/*.la
+ 	rm -f ${DESTDIR}${moduledir}/*.la

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7528,6 +7528,8 @@ in
 
   solaar = callPackage ../applications/misc/solaar {};
 
+  solanum = callPackage ../servers/irc/solanum {};
+
   sourceHighlight = callPackage ../tools/text/source-highlight { };
 
   spacebar = callPackage ../os-specific/darwin/spacebar {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Solanum is a fork of charybdis maintained by freenode and OFTC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
