### PR TITLE
python3Packages.connect-box: init at 0.2.8

### DIFF
--- a/pkgs/development/python-modules/connect_box/default.nix
+++ b/pkgs/development/python-modules/connect_box/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, attrs
+, defusedxml
+}:
+
+buildPythonPackage rec {
+  pname = "connect-box";
+  version = "0.2.8";
+
+  src = fetchPypi {
+    pname = "connect_box";
+    inherit version;
+    sha256 = "1lvz7g2f0a9ifnjczmbavn105miirdgyayr4sixhzgdgadcdhz3l";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    attrs
+    defusedxml
+  ];
+
+  # no tests are present
+  doCheck = false;
+
+  pythonImportsCheck = [ "connect_box" ];
+
+  meta = with lib; {
+    description = "Interact with a Compal CH7465LG cable modem/router";
+    longDescription = ''
+      Python Client for interacting with the cable modem/router Compal
+      CH7465LG which is provided under different names by various ISP
+      in Europe, e.g., UPC Connect Box (CH), Irish Virgin Media Super
+      Hub 3.0 (IE), Ziggo Connectbox (NL) or Unitymedia Connect Box (DE).
+    '';
+    homepage = "https://github.com/home-assistant-ecosystem/python-connect-box";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -879,7 +879,7 @@
     "unifiled" = ps: with ps; [ ]; # missing inputs: unifiled
     "universal" = ps: with ps; [ ];
     "upb" = ps: with ps; [ ]; # missing inputs: upb_lib
-    "upc_connect" = ps: with ps; [ ]; # missing inputs: connect-box
+    "upc_connect" = ps: with ps; [ connect-box ];
     "upcloud" = ps: with ps; [ ]; # missing inputs: upcloud-api
     "updater" = ps: with ps; [ distro ];
     "upnp" = ps: with ps; [ async-upnp-client ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1116,6 +1116,8 @@ in {
 
   cement = callPackage ../development/python-modules/cement { };
 
+  connect-box = callPackage ../development/python-modules/connect_box { };
+
   cerberus = callPackage ../development/python-modules/cerberus { };
 
   certbot = callPackage ../development/python-modules/certbot { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Client for interacting with the cable modem/router Compal CH7465LG which
is provided under different names by various ISP in Europe.

- UPC Connect Box (CH)
- Irish Virgin Media Super Hub 3.0 (IE)
- Ziggo Connectbox (NL)
- Unitymedia Connect Box (DE)

https://github.com/home-assistant-ecosystem/python-connect-box

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
