### PR TITLE
geogebra: 5-0-609-0 → 5-0-620-0, geogebra6: 6-0-609-0 → 6-0-620-0

### DIFF
--- a/pkgs/applications/science/math/geogebra/default.nix
+++ b/pkgs/applications/science/math/geogebra/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, jre, makeDesktopItem, makeWrapper, unzip, language ? "en_US" }:
 let
   pname = "geogebra";
-  version = "5-0-609-0";
+  version = "5-0-620-0";
 
   srcIcon = fetchurl {
     url = "http://static.geogebra.org/images/geogebra-logo.svg";
@@ -27,7 +27,7 @@ let
       calculus in one easy-to-use package.
     '';
     homepage = "https://www.geogebra.org/";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ sikmir ];
     license = with licenses; [ gpl3 cc-by-nc-sa-30 geogebra ];
     platforms = with platforms; linux ++ darwin;
     hydraPlatforms = [];
@@ -41,9 +41,9 @@ let
     src = fetchurl {
       urls = [
         "https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
-        "http://web.archive.org/web/20201022200454/https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
+        "http://web.archive.org/web/20210101213140/https://download.geogebra.org/installers/5.0/GeoGebra-Linux-Portable-${version}.tar.bz2"
       ];
-      sha256 = "0xbhg8hm3dqm3qkraj48pqwslrnjyxpq9mcgylr2m8i1gmqw7xwf";
+      sha256 = "0v4r76b91cj0pns78gh3d432g2jlq2pz37lslg3fnnpvlfh25s9j";
     };
 
     nativeBuildInputs = [ makeWrapper ];
@@ -70,8 +70,11 @@ let
     preferLocalBuild = true;
 
     src = fetchurl {
-      url = "https://download.geogebra.org/installers/5.0/GeoGebra-MacOS-Installer-withJava-${version}.zip";
-      sha256 = "16fgqwxz31cfmia0pyzpk05aqzrqr11sjbw37q9zb3xfh3p1r4gz";
+      urls = [
+        "https://download.geogebra.org/installers/5.0/GeoGebra-MacOS-Installer-withJava-${version}.zip"
+        "https://web.archive.org/web/20210101213641/https://download.geogebra.org/installers/5.0/GeoGebra-MacOS-Installer-withJava-${version}.zip"
+      ];
+      sha256 = "02sbxrns9zvhcfrr68ygv766and6f6b2a3dfarljxszwsviv6ljf";
     };
 
     dontUnpack = true;

--- a/pkgs/applications/science/math/geogebra/geogebra6.nix
+++ b/pkgs/applications/science/math/geogebra/geogebra6.nix
@@ -1,14 +1,14 @@
 { stdenv, unzip, fetchurl, electron_6, makeWrapper, geogebra }:
 let
   pname = "geogebra";
-  version = "6-0-609-0";
+  version = "6-0-620-0";
 
   srcIcon = geogebra.srcIcon;
   desktopItem = geogebra.desktopItem;
 
   meta = with stdenv.lib; geogebra.meta // {
     license = licenses.geogebra;
-    maintainers = with maintainers; [ voidless ];
+    maintainers = with maintainers; [ voidless sikmir ];
     platforms = with platforms; linux ++ darwin;
   };
 
@@ -17,10 +17,10 @@ let
 
     src = fetchurl {
       urls = [
-          "https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
-          "https://web.archive.org/web/20201022200156/https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
-        ];
-      sha256 = "0rzcbq587x8827g9v03awa9hz27vyfjc0cz45ymbchqp31lsx49b";
+        "https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
+        "https://web.archive.org/web/20210101214511/https://download.geogebra.org/installers/6.0/GeoGebra-Linux64-Portable-${version}.zip"
+      ];
+      sha256 = "0xxzmphbfvmhnxnc1pkjgdhccjndyzmlvvaa8xfdrvswwwk7zh43";
     };
 
     dontConfigure = true;
@@ -51,8 +51,11 @@ let
     inherit pname version meta;
 
     src = fetchurl {
-      url = "https://download.geogebra.org/installers/6.0/GeoGebra-Classic-6-MacOS-Portable-${version}.zip";
-      sha256 = "0275869zgwbl1qjj593q6629hnxbwk9c15rkm29a3lh10pinb099";
+      urls = [
+        "https://download.geogebra.org/installers/6.0/GeoGebra-Classic-6-MacOS-Portable-${version}.zip"
+        "https://web.archive.org/web/20210101214236/https://download.geogebra.org/installers/6.0/GeoGebra-Classic-6-MacOS-Portable-${version}.zip"
+      ];
+      sha256 = "13g05d45j6dn9zwxpxnln83j7w1cvcd7l8jnir30pxlmdi7h8r78";
     };
 
     dontUnpack = true;


### PR DESCRIPTION
###### Motivation for this change
* update
* add web.archive.org urls (old version is not available after new version is released)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
