### PR TITLE
Fix NixOS cross-compilation SD Image

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -2,7 +2,8 @@
 , intltool, spidermonkey_78, gobject-introspection, libxslt, docbook_xsl, dbus
 , docbook_xml_dtd_412, gtk-doc, coreutils
 , useSystemd ? (stdenv.isLinux && !stdenv.hostPlatform.isMusl), systemd, elogind
-, withIntrospection ? true
+# needed until gobject-introspection does cross-compile (https://github.com/NixOS/nixpkgs/pull/88222)
+, withIntrospection ? (stdenv.buildPlatform == stdenv.hostPlatform)
 # A few tests currently fail on musl (polkitunixusertest, polkitunixgrouptest, polkitidentitytest segfault).
 # Not yet investigated; it may be due to the "Make netgroup support optional"
 # patch not updating the tests correctly yet, or doing something wrong,


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/106759.

###### Motivation for this change
Build NixOS aarch64 sd image by just instantiating the profile, without any required manual hacks in the config.

Apparently, there was very few left to fix https://github.com/NixOS/nixpkgs/issues/106759 (for aarch64 at least).

`polkit` can be built without gobject introspection.

With this, I can just

```sh
nix-build -E 'let pkgs = (import ./.) {}; in (pkgs.pkgsCross.aarch64-multiplatform.nixos ./nixos/modules/installer/cd-dvd/sd-image-aarch64.nix).sdImage'
```

… computer go brrr…

And tada, you get a aarch64 image :-)

No more need to manually disable polkit and udisks.

```
fsck.fat 4.1 (2017-01-24)
Checking we can access the last sector of the filesystem
Boot sector contents:
System ID "mkfs.fat"
Media byte 0xf8 (hard disk)
       512 bytes per logical sector
      2048 bytes per cluster
         4 reserved sectors
First FAT starts at byte 2048 (sector 4)
         2 FATs, 16 bit entries
     30720 bytes per FAT (= 60 sectors)
Root directory starts at byte 63488 (sector 124)
       512 root directory entries
Data area starts at byte 79872 (sector 156)
     15321 data clusters (31377408 bytes)
32 sectors/track, 64 heads
         0 hidden sectors
     61440 sectors total
Checking for unused clusters.
firmware_part.img: 23 files, 11322/15321 clusters
61440+0 records in
61440+0 records out
31457280 bytes (31 MB, 30 MiB) copied, 0.100648 s, 313 MB/s
/nix/store/qg78laagrq3kp5fp0c9107ckapz0fxkw-nixos-sd-image-21.03pre-git-aarch64-linux.img-aarch64-unknown-linux-gnu/sd-image/nixos-sd-image-21.03pre-git-aarch64-linux.img : 25.91%   (4141109248 => 1073112729 bytes, /nix/store/qg78laagrq3kp5fp0c9107ckapz0fxkw-nixos-sd-image-21.03pre-git-aarch64-linux.img-aarch64-unknown-linux-gnu/sd-image/nixos-sd-image-21.03pre-git-aarch64-linux.img.zst)
/nix/store/qg78laagrq3kp5fp0c9107ckapz0fxkw-nixos-sd-image-21.03pre-git-aarch64-linux.img-aarch64-unknown-linux-gnu
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
