### PR TITLE
python3Packages.python-opendata-transport: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/python-opendata-transport/default.nix
+++ b/pkgs/development/python-modules/python-opendata-transport/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, async-timeout
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "python-opendata-transport";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    pname = "python_opendata_transport";
+    inherit version;
+    sha256 = "0pxs9zqk00vn1s74cx1416mqmixrr74wb0jb0j6b1c3xpvzlfbks";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    urllib3
+  ];
+
+  # no tests are present
+  doCheck = false;
+
+  pythonImportsCheck = [ "opendata_transport" ];
+
+  meta = with lib; {
+    description = "Python client for interacting with transport.opendata.ch";
+    homepage = "https://github.com/home-assistant-ecosystem/python-opendata-transport";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -796,7 +796,7 @@
     "supla" = ps: with ps; [ ]; # missing inputs: asyncpysupla
     "surepetcare" = ps: with ps; [ ]; # missing inputs: surepy
     "swiss_hydrological_data" = ps: with ps; [ ]; # missing inputs: swisshydrodata
-    "swiss_public_transport" = ps: with ps; [ ]; # missing inputs: python_opendata_transport
+    "swiss_public_transport" = ps: with ps; [ python-opendata-transport ];
     "swisscom" = ps: with ps; [ ];
     "switch" = ps: with ps; [ ];
     "switchbot" = ps: with ps; [ ]; # missing inputs: PySwitchbot

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6044,6 +6044,8 @@ in {
 
   python-olm = callPackage ../development/python-modules/python-olm { };
 
+  python-opendata-transport = callPackage ../development/python-modules/python-opendata-transport { };
+
   python_openzwave = callPackage ../development/python-modules/python_openzwave { inherit (pkgs) pkgconfig; };
 
   python-otr = callPackage ../development/python-modules/python-otr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for interacting with transport.opendata.ch

https://github.com/home-assistant-ecosystem/python-opendata-transport

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
