### PR TITLE
tdlib-purple: init at 0.7.6

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/tdlib-purple/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake, tdlib, pidgin, libwebp, libtgvoip } :
+
+stdenv.mkDerivation rec {
+  pname = "tdlib-purple";
+  version = "0.7.6";
+
+  src = fetchFromGitHub {
+    owner = "ars3niy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1inamfzbrz0sy4y431jgwjfg6lz14a7c71khrg02481raxchhzzf";
+  };
+
+  cmakeFlags = [
+    "-Dtgvoip_INCLUDE_DIRS=${libtgvoip.dev}/include/tgvoip"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ pidgin tdlib libwebp libtgvoip ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/purple-2/
+    cp *.so $out/lib/purple-2/
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ars3niy/tdlib-purple";
+    description = "New libpurple plugin for Telegram";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.lassulus ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23653,6 +23653,8 @@ in
 
   telegram-purple = callPackage ../applications/networking/instant-messengers/pidgin-plugins/telegram-purple { };
 
+  tdlib-purple = callPackage ../applications/networking/instant-messengers/pidgin-plugins/tdlib-purple { };
+
   toxprpl = callPackage ../applications/networking/instant-messengers/pidgin-plugins/tox-prpl {
     libtoxcore = libtoxcore-new;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

currently running this with bitlbee-purple. works better then the old telegram-purple :)