### PR TITLE
catboost: init at 0.24.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7125,6 +7125,12 @@
     githubId = 13000278;
     name = "Maksim Bronsky";
   };
+  PlushBeaver = {
+    name = "Dmitry Kozlyuk";
+    email = "dmitry.kozliuk+nixpkgs@gmail.com";
+    github = "PlushBeaver";
+    githubId = 8988269;
+  };
   pmahoney = {
     email = "pat@polycrystal.org";
     github = "pmahoney";

--- a/pkgs/development/python-modules/catboost/default.nix
+++ b/pkgs/development/python-modules/catboost/default.nix
@@ -1,0 +1,56 @@
+{ buildPythonPackage, fetchFromGitHub, fetchpatch, lib, pythonOlder
+, clang_7, python2
+, graphviz, matplotlib, numpy, pandas, plotly, scipy, six
+, withCuda ? false, cudatoolkit }:
+
+buildPythonPackage rec {
+  pname = "catboost";
+  version = "0.24.4";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "catboost";
+    repo = "catboost";
+    rev = "v${version}";
+    sha256 = "sha256-pzmwEiKziB4ldnKgeCsP2HdnisX8sOkLssAzNfcSEx8=";
+  };
+
+  nativeBuildInputs = [ clang_7 python2 ];
+
+  propagatedBuildInputs = [ graphviz matplotlib numpy pandas scipy plotly six ]
+    ++ lib.optional withCuda [ cudatoolkit ];
+
+  patches = [
+    ./nix-support.patch
+    (fetchpatch {
+      name = "format.patch";
+      url = "https://github.com/catboost/catboost/pull/1528/commits/a692ba42e5c0f62e5da82b2f6fccfa77deb3419c.patch";
+      sha256 = "sha256-fNGucHxsSDFRLk3hFH7rm+zzTdDpY9/QjRs8K+AzVvo=";
+    })
+  ];
+
+  preBuild = ''
+    cd catboost/python-package
+    '';
+  setupPyBuildFlags = [ "--with-ymake=no" ];
+  CUDA_ROOT = lib.optional withCuda cudatoolkit;
+  enableParallelBuilding = true;
+
+  # Tests use custom "ya" tool, not yet supported.
+  dontUseSetuptoolsCheck = true;
+  pythonImportsCheck = [ "catboost" ];
+
+  meta = with lib; {
+    description = "High-performance library for gradient boosting on decision trees.";
+    longDescription = ''
+      A fast, scalable, high performance Gradient Boosting on Decision Trees
+      library, used for ranking, classification, regression and other machine
+      learning tasks for Python, R, Java, C++. Supports computation on CPU and GPU.
+    '';
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    homepage = "https://catboost.ai";
+    maintainers = with maintainers; [ PlushBeaver ];
+  };
+}

--- a/pkgs/development/python-modules/catboost/nix-support.patch
+++ b/pkgs/development/python-modules/catboost/nix-support.patch
@@ -1,0 +1,181 @@
+diff --git a/catboost/python-package/setup.py b/catboost/python-package/setup.py
+index 17f1d8ff14..07da618cd1 100644
+--- a/catboost/python-package/setup.py
++++ b/catboost/python-package/setup.py
+@@ -80,7 +80,7 @@ class Helper(object):
+         self.with_cuda = os.environ.get('CUDA_PATH') or os.environ.get('CUDA_ROOT') or None
+         self.os_sdk = 'local'
+         self.with_ymake = True
+-        self.parallel = None
++        self.parallel = os.environ.get('NIX_BUILD_CORES') or None
+ 
+     def finalize_options(self):
+         if os.path.exists(str(self.with_cuda)):
+@@ -222,11 +222,12 @@ class build_ext(_build_ext):
+ 
+     def build_with_make(self, topsrc_dir, build_dir, catboost_ext, put_dir, verbose, dry_run):
+         logging.info('Buildling {} with gnu make'.format(catboost_ext))
+-        makefile = 'python{}.{}CLANG50-LINUX-X86_64.makefile'.format(python_version()[0], 'CUDA.' if self.with_cuda else '')
++        makefile = 'python{}.{}CLANG7-LINUX-X86_64.makefile'.format(python_version()[0], 'CUDA.' if self.with_cuda else '')
+         make_cmd = [
+             'make', '-f', '../../make/' + makefile,
+-            'CC=clang-5.0',
+-            'CXX=clang++-5.0',
++            'CC=clang',
++            'CXX=clang++',
++            'PYTHON=python2',
+             'BUILD_ROOT=' + build_dir,
+             'SOURCE_ROOT=' + topsrc_dir,
+         ]
+diff --git a/make/python2.CLANG7-LINUX-X86_64.makefile b/make/python2.CLANG7-LINUX-X86_64.makefile
+index e54b7078e8..fb7b208af9 100644
+--- a/make/python2.CLANG7-LINUX-X86_64.makefile
++++ b/make/python2.CLANG7-LINUX-X86_64.makefile
+@@ -4,33 +4,6 @@ BUILD_ROOT = $(shell pwd)
+ SOURCE_ROOT = $(shell pwd)
+ PYTHON = $(shell which python)
+ 
+-ifneq ($(MAKECMDGOALS),help)
+-define _CC_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CC_VERSION = $(shell echo '$(_CC_TEST)' | $(CC) -E -P -)
+-$(info _CC_VERSION = '$(_CC_VERSION)')
+-
+-ifneq '$(_CC_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-ifneq ($(MAKECMDGOALS),help)
+-define _CXX_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CXX_VERSION = $(shell echo '$(_CXX_TEST)' | $(CXX) -E -P -)
+-$(info _CXX_VERSION = '$(_CXX_VERSION)')
+-
+-ifneq '$(_CXX_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-
+ all\
+         ::\
+         $(BUILD_ROOT)/catboost/python-package/catboost/_catboost.so\
+diff --git a/make/python2.CUDA.CLANG7-LINUX-X86_64.makefile b/make/python2.CUDA.CLANG7-LINUX-X86_64.makefile
+index 2a22a79b25..522fb54a7c 100644
+--- a/make/python2.CUDA.CLANG7-LINUX-X86_64.makefile
++++ b/make/python2.CUDA.CLANG7-LINUX-X86_64.makefile
+@@ -4,33 +4,6 @@ BUILD_ROOT = $(shell pwd)
+ SOURCE_ROOT = $(shell pwd)
+ PYTHON = $(shell which python)
+ 
+-ifneq ($(MAKECMDGOALS),help)
+-define _CC_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CC_VERSION = $(shell echo '$(_CC_TEST)' | $(CC) -E -P -)
+-$(info _CC_VERSION = '$(_CC_VERSION)')
+-
+-ifneq '$(_CC_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-ifneq ($(MAKECMDGOALS),help)
+-define _CXX_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CXX_VERSION = $(shell echo '$(_CXX_TEST)' | $(CXX) -E -P -)
+-$(info _CXX_VERSION = '$(_CXX_VERSION)')
+-
+-ifneq '$(_CXX_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-
+ all\
+         ::\
+         $(BUILD_ROOT)/catboost/python-package/catboost/_catboost.so\
+diff --git a/make/python3.CLANG7-LINUX-X86_64.makefile b/make/python3.CLANG7-LINUX-X86_64.makefile
+index fee6750bcb..dc55908371 100644
+--- a/make/python3.CLANG7-LINUX-X86_64.makefile
++++ b/make/python3.CLANG7-LINUX-X86_64.makefile
+@@ -4,33 +4,6 @@ BUILD_ROOT = $(shell pwd)
+ SOURCE_ROOT = $(shell pwd)
+ PYTHON = $(shell which python)
+ 
+-ifneq ($(MAKECMDGOALS),help)
+-define _CC_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CC_VERSION = $(shell echo '$(_CC_TEST)' | $(CC) -E -P -)
+-$(info _CC_VERSION = '$(_CC_VERSION)')
+-
+-ifneq '$(_CC_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-ifneq ($(MAKECMDGOALS),help)
+-define _CXX_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CXX_VERSION = $(shell echo '$(_CXX_TEST)' | $(CXX) -E -P -)
+-$(info _CXX_VERSION = '$(_CXX_VERSION)')
+-
+-ifneq '$(_CXX_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-
+ all\
+         ::\
+         $(BUILD_ROOT)/catboost/python-package/catboost/_catboost.so\
+diff --git a/make/python3.CUDA.CLANG7-LINUX-X86_64.makefile b/make/python3.CUDA.CLANG7-LINUX-X86_64.makefile
+index 5146830476..ff8535b03e 100644
+--- a/make/python3.CUDA.CLANG7-LINUX-X86_64.makefile
++++ b/make/python3.CUDA.CLANG7-LINUX-X86_64.makefile
+@@ -4,33 +4,6 @@ BUILD_ROOT = $(shell pwd)
+ SOURCE_ROOT = $(shell pwd)
+ PYTHON = $(shell which python)
+ 
+-ifneq ($(MAKECMDGOALS),help)
+-define _CC_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CC_VERSION = $(shell echo '$(_CC_TEST)' | $(CC) -E -P -)
+-$(info _CC_VERSION = '$(_CC_VERSION)')
+-
+-ifneq '$(_CC_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-ifneq ($(MAKECMDGOALS),help)
+-define _CXX_TEST
+-__clang_major__ __clang_minor__
+-endef
+-
+-_CXX_VERSION = $(shell echo '$(_CXX_TEST)' | $(CXX) -E -P -)
+-$(info _CXX_VERSION = '$(_CXX_VERSION)')
+-
+-ifneq '$(_CXX_VERSION)' '7 0'
+-    $(error clang 7.0 is required)
+-endif
+-endif
+-
+-
+ all\
+         ::\
+         $(BUILD_ROOT)/catboost/python-package/catboost/_catboost.so\

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1135,6 +1135,8 @@ in {
 
   catalogue = callPackage ../development/python-modules/catalogue { };
 
+  catboost = callPackage ../development/python-modules/catboost { };
+
   cbeams = callPackage ../misc/cbeams { };
 
   cbor2 = callPackage ../development/python-modules/cbor2 { };


### PR DESCRIPTION
###### Motivation for this change

* Closes #74395
* Personal interest in decision trees with categorical features.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Tested examples from CatBoost tutorial.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
