### PR TITLE
signumone-ks: init at 3.1.2

### DIFF
--- a/pkgs/applications/misc/signumone-ks/default.nix
+++ b/pkgs/applications/misc/signumone-ks/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, dpkg, autoPatchelfHook, makeWrapper,
+  atk, ffmpeg, gdk-pixbuf, glibc, gtk3, libav_0_8, libXtst }:
+
+stdenv.mkDerivation rec {
+  pname = "signumone-ks";
+  version = "3.1.2";
+
+  src = fetchurl {
+    url = "https://cdn-dist.signum.one/${version}/${pname}-${version}.deb";
+    sha256 = "4efd80e61619ccf26df1292194fcec68eb14d77dfcf0a1a673da4cf5bf41f4b7";
+  };
+
+  # Necessary to avoid using multiple ffmpeg and gtk libs
+  autoPatchelfIgnoreMissingDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    atk glibc gdk-pixbuf stdenv.cc.cc ffmpeg
+    libav_0_8 gtk3 libXtst
+  ];
+
+  libPath = stdenv.lib.makeLibraryPath buildInputs;
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase = ''
+    DESKTOP_PATH=$out/share/applications/signumone-ks.desktop
+
+    mkdir -p $out/bin $out/share/applications
+    mv opt/SignumOne-KS/SignumOne-KS.desktop $DESKTOP_PATH
+    mv opt $out
+
+    substituteInPlace $DESKTOP_PATH --replace 'Exec=/opt/SignumOne-KS' Exec=$out/bin
+    substituteInPlace $DESKTOP_PATH --replace 'Icon=' Icon=$out
+
+    makeWrapper $out/opt/SignumOne-KS/SignumOne-KS \
+      $out/bin/SignumOne-KS \
+      --prefix LD_LIBRARY_PATH : ${libPath}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Digital signature tool for Costa Rican electronic invoicing";
+    homepage = "https://signum.one/download.html";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wolfangaukang ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7371,6 +7371,8 @@ in
   # aka., pgp-tools
   signing-party = callPackage ../tools/security/signing-party { };
 
+  signumone-ks = callPackage ../applications/misc/signumone-ks { };
+
   silc_client = callPackage ../applications/networking/instant-messengers/silc-client { };
 
   silc_server = callPackage ../servers/silc-server { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
