### PR TITLE
python3Packages.asgiref: 3.2.10 -> 3.3.1

### DIFF
--- a/pkgs/development/python-modules/asgiref/default.nix
+++ b/pkgs/development/python-modules/asgiref/default.nix
@@ -1,25 +1,31 @@
-{ stdenv, buildPythonPackage, pythonOlder, fetchFromGitHub, async-timeout, pytest, pytest-asyncio }:
+{ stdenv
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
 buildPythonPackage rec {
-  version = "3.2.10";
+  version = "3.3.1";
   pname = "asgiref";
 
   disabled = pythonOlder "3.5";
 
-  # PyPI tarball doesn't include tests directory
   src = fetchFromGitHub {
     owner = "django";
     repo = pname;
     rev = version;
-    sha256 = "1sj4yy2injaskwfi5pkb542jl8s6ljijnyra81gpw0pgd3d0bgxv";
+    sha256 = "00r4l9x425wkbac6b6c2ksm2yjinrvvdf0ajizrzq32h0jg82016";
   };
 
   propagatedBuildInputs = [ async-timeout ];
 
-  checkInputs = [ pytest pytest-asyncio ];
-
-  checkPhase = ''
-    py.test
-  '';
+  checkInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
 
   meta = with stdenv.lib; {
     description = "Reference ASGI adapters and channel layers";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.3.1 and use `pytestCheckHook`.

Change log: https://github.com/django/asgiref/blob/master/CHANGELOG.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
