### PR TITLE
pythonPackages.reflink: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/reflink/default.nix
+++ b/pkgs/development/python-modules/reflink/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage
+, cffi
+, fetchPypi
+, lib
+, pytestCheckHook
+, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "reflink";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-ySU1gtskQTv9cDq/wbKkneePMbSQcjnyhumhkpoebjo=";
+  };
+
+  propagatedBuildInputs = [ cffi pytestrunner ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # FIXME: These do not work, and I have been unable to figure out why.
+  doCheck = false;
+
+  pythonImportsCheck = [ "reflink" ];
+
+  meta = with lib; {
+    description = "Python reflink wraps around platform specific reflink implementations";
+    homepage = "https://gitlab.com/rubdos/pyreflink";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6365,6 +6365,8 @@ in {
 
   reedsolo = callPackage ../development/python-modules/reedsolo { };
 
+  reflink = callPackage ../development/python-modules/reflink { };
+
   regex = callPackage ../development/python-modules/regex { };
 
   regional = callPackage ../development/python-modules/regional { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Beets 1.5.0 will need this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
