### PR TITLE
nixos/firejail: wrappedPackages

### DIFF
--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -133,7 +133,7 @@ in {
         source = "${lib.getBin pkgs.firejail}/bin/firejail";
       };
 
-    environment.systemPackages = [ pkgs.firejail ] ++ [ wrappedBins ] ++ wrappedPkgs;
+    environment.systemPackages = [ pkgs.firejail wrappedBins ] ++ wrappedPkgs;
   };
 
   meta.maintainers = with maintainers; [ peterhoeg ];

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -46,7 +46,7 @@ let
         [[ -d "$out/share/applications" ]] && grep -q -R Exec=/ "$out/share/applications" && \
           >&2 echo -e "\033[1mERROR: ${pkg.name} desktop file cannot be firejailed because it specifies an absolute path to the unwrapped binary. Please use wrappedBinaries or better yet fix the ${pkg.name} desktop file in nixpkgs and/or upstream.\033[0m" && exit 1
         for bin in $(find "$out/bin" -type l); do
-          oldbin="$(readlink "$bin")"
+          oldbin="$(realpath "$bin")"
           rm "$bin"
           cat <<_EOF >"$bin"
         #! ${pkgs.runtimeShell} -e

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -119,16 +119,14 @@ in {
     wrappedPackages = mkOption {
       type = with types; listOf package;
       default = [ ];
-      example = literalExample ''
+      example = literalExpression ''
         [ pkgs.mpv ]
       '';
-      description = ''
-        Put a package into <option>systemPackages</option>,
-        but wrap its binaries with firejail.
-        Compared to <option>wrappedBinaries</option>,
-        this e.g. has the advantage of providing desktop entries and icons.
-        However, you should be careful about using these packages'
-        libraries as they will not be wrapped.
+      description = lib.mdDoc ''
+        Put a package into `systemPackages`, but wrap its binaries with
+        firejail. Compared to `wrappedBinaries`, this e.g. has the advantage of
+        providing desktop entries and icons. However, you should be careful
+        about using these packages' libraries as they will not be wrapped.
       '';
     };
   };

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -27,7 +27,7 @@ let
       ''
         cat <<_EOF >$out/bin/${command}
         #! ${pkgs.runtimeShell} -e
-        exec /run/wrappers/bin/firejail ${args} -- ${toString opts.executable} "\$@"
+        exec ${config.security.wrapperDir}/firejail ${args} -- ${toString opts.executable} "\$@"
         _EOF
         chmod 0755 $out/bin/${command}
 
@@ -50,7 +50,7 @@ let
           rm "$bin"
           cat <<_EOF >"$bin"
         #! ${pkgs.runtimeShell} -e
-        exec /run/wrappers/bin/firejail "$oldbin" "\$@"
+        exec ${config.security.wrapperDir}/firejail "$oldbin" "\$@"
         _EOF
           chmod 0755 "$bin"
         done

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -44,7 +44,7 @@ let
       paths = [ pkg ];
       postBuild = ''
         [[ -d "$out/share/applications" ]] && grep -q -R Exec=/ "$out/share/applications" && \
-          >&2 echo "WARNING: ${pkg.name} desktop file is not firejailed."
+          >&2 echo -e "\033[1mERROR: ${pkg.name} desktop file cannot be firejailed because it specifies an absolute path to the unwrapped binary. Please use wrappedBinaries or better yet fix the ${pkg.name} desktop file in nixpkgs and/or upstream.\033[0m" && exit 1
         for bin in $(find "$out/bin" -type l); do
           oldbin="$(readlink "$bin")"
           rm "$bin"
@@ -120,9 +120,7 @@ in {
         Compared to <option>wrappedBinaries</option>,
         this e.g. has the advantage of providing desktop entries and icons.
         However, you should be careful about using these packages'
-        libraries as they will not be wrapped. Note also that applications may
-        not be firejailed if invoked via a desktop file that specifies an
-        absolute path to the unwrapped binary.
+        libraries as they will not be wrapped.
       '';
     };
   };

--- a/nixos/tests/firejail.nix
+++ b/nixos/tests/firejail.nix
@@ -16,6 +16,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
           extraArgs = [ "--private=~/firejail-home" ];
         };
       };
+      wrappedPackages = [ pkgs.zsh ];
     };
 
     systemd.services.setupFirejailTest = {
@@ -86,6 +87,11 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     machine.fail(
         "sudo -u alice firejail --private-tmp --output=/tmp/foo 'bash -c $(id>/tmp/vuln2;echo id)' && cat /tmp/vuln2"
     )
+
+    # Test path acl with wrapped program
+    machine.succeed("sudo -u alice zsh -c 'cat ~/public' | grep -q publ1c")
+    machine.fail("sudo -u alice zsh -c 'cat ~/.password-store/secret' | grep -q s3cret")
+    machine.fail("sudo -u alice zsh -c 'cat ~/my-secrets/secret' | grep -q s3cret")
   '';
 })
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a rebase and continuation of the work at #45469. See commit messages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
