### PR TITLE
ocamlPackages.camlp5: 7.13 → 7.14

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -1,20 +1,26 @@
-{ stdenv, fetchzip, ocaml }:
+{ stdenv, fetchzip, ocaml, perl }:
+
+if stdenv.lib.versionOlder ocaml.version "4.02"
+then throw "camlp5 is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation {
 
-  name = "camlp5-7.13";
+  name = "camlp5-7.14";
 
   src = fetchzip {
-    url = "https://github.com/camlp5/camlp5/archive/rel713.tar.gz";
-    sha256 = "1d9spy3f5ahixm8nxxk086kpslzva669a5scn49am0s7vx4i71kp";
+    url = "https://github.com/camlp5/camlp5/archive/rel714.tar.gz";
+    sha256 = "1dd68bisbpqn5lq2pslm582hxglcxnbkgfkwhdz67z4w9d5nvr7w";
   };
 
-  buildInputs = [ ocaml ];
+  buildInputs = [ ocaml perl ];
 
   prefixKey = "-prefix ";
 
-  preConfigure = "configureFlagsArray=(--strict" +
-                  " --libdir $out/lib/ocaml/${ocaml.version}/site-lib)";
+  preConfigure = ''
+    configureFlagsArray=(--strict --libdir $out/lib/ocaml/${ocaml.version}/site-lib)
+    patchShebangs ./config/find_stuffversion.pl
+  '';
 
   buildFlags = [ "world.opt" ];
 


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.10.2 & 4.12.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
