### PR TITLE
arduino-core: fix 'Save as...'

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -112,7 +112,10 @@ stdenv.mkDerivation rec {
   };
 
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  # the glib setup hook will populate GSETTINGS_SCHEMAS_PATH,
+  # wrapGAppHooks (among other things) adds it to XDG_DATA_DIRS
+  # so 'save as...' works:
+  nativeBuildInputs = [ glib wrapGAppsHook ];
   buildInputs = [
     jdk
     ant


### PR DESCRIPTION
###### Motivation for this change

Before, 'Save as..' would crash because it tries to use GSettings
to find some settings, but the GSettings schema's could not
be found in the XDG_DATA_DIRS.

Adding the glib setup hook populates GSETTINGS_SCHEMAS_PATH
so wrapGAppsHook can add it to XDG_DATA_DIRS, fixing
'Save as..'.

#100137

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).