### PR TITLE
masterpdfeditor4: init at 4.3.89

### DIFF
--- a/pkgs/applications/misc/masterpdfeditor4/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor4/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, sane-backends, qtbase, qtsvg, autoPatchelfHook, lib, wrapQtAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "masterpdfeditor4";
+  version = "4.3.89";
+
+  src = fetchurl {
+    url = "https://code-industry.net/public/master-pdf-editor-${version}_qt5.amd64.tar.gz";
+    sha256 = "0k5bzlhqglskiiq86nmy18mnh5bf2w3mr9cq3pibrwn5pisxnxxc";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook wrapQtAppsHook ];
+
+  buildInputs = [ qtbase qtsvg sane-backends stdenv.cc.cc ];
+
+  installPhase = ''
+    runHook preInstall
+
+    app_dir=$out/opt/masterpdfeditor4
+    mkdir -p $out/bin
+
+    substituteInPlace masterpdfeditor4.desktop \
+      --replace 'Exec=/opt/master-pdf-editor-4' "Exec=$out/bin" \
+      --replace 'Path=/opt/master-pdf-editor-4' "Path=$out/bin" \
+      --replace 'Icon=/opt/master-pdf-editor-4' "Icon=$out/share/pixmaps"
+
+    install -Dm644 -t $out/share/pixmaps      masterpdfeditor4.png
+    install -Dm644 -t $out/share/applications masterpdfeditor4.desktop
+    install -Dm755 -t $app_dir                masterpdfeditor4
+    install -Dm644 license.txt $out/share/$name/LICENSE
+    ln -s $app_dir/masterpdfeditor4 $out/bin/masterpdfeditor4
+    cp -v -r stamps templates lang fonts $app_dir
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Master PDF Editor - version 4, without watermark";
+    homepage = "https://code-industry.net/free-pdf-editor/";
+    license = licenses.unfreeRedistributable;
+    platforms = with platforms; [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20583,6 +20583,8 @@ in
 
   masterpdfeditor = libsForQt5.callPackage ../applications/misc/masterpdfeditor { };
 
+  masterpdfeditor4 = libsForQt5.callPackage ../applications/misc/masterpdfeditor4 { };
+
   aeolus = callPackage ../applications/audio/aeolus { };
 
   aewan = callPackage ../applications/editors/aewan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The free version of masterpdfeditor 5 adds a watermark to saved PDFs, whereas version 4 does not.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
