### PR TITLE
nixos/jellyfin: fix hardware acceleration

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -41,6 +41,8 @@ in
       serviceConfig = rec {
         User = cfg.user;
         Group = cfg.group;
+        # Allows access to drm devices for transcoding with hardware acceleration
+        SupplementaryGroups = [ "video" ];
         StateDirectory = "jellyfin";
         CacheDirectory = "jellyfin";
         ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
@@ -54,12 +56,12 @@ in
         CapabilityBoundingSet = "";
 
         # ProtectClock= adds DeviceAllow=char-rtc r
-        DeviceAllow = "";
+        # char-drm Allows ffmpeg to transcode with hardware acceleration
+        DeviceAllow = [ "char-drm rw" ];
 
         LockPersonality = true;
 
         PrivateTmp = true;
-        PrivateDevices = true;
         PrivateUsers = true;
 
         ProtectClock = true;


### PR DESCRIPTION
Issue mentioned in #98176

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Hardware acceleration on jellyfin broke due to added systemd security options in #98176 (sorry about that...). This hopefully fixes it. I did some rudimentary tests on my server, but my video card doesn't seem to support h264 encoding via VAAPI. Playing h264 videos with hardware decoding enabled seems to work fine, though.

@xwvvvvwx Can confirm that this adds hardware encoding / decoding back for you?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
