### PR TITLE
Wine update

### DIFF
--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,32 +44,25 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "5.22";
-    url = "https://dl.winehq.org/wine/source/5.x/wine-${version}.tar.xz";
-    sha256 = "sha256-Cb0GyHyMl05q00UHzsh11yF+tW/Anfg41UU+DrvOTSE=";
+    version = "6.0-rc1";
+    url = "https://dl.winehq.org/wine/source/6.0/wine-${version}.tar.xz";
+    sha256 = "sha256-eN3JSPlGxmJ3m9WUPZGBJ0BIACG8lRy8resQLDi1O8g=";
     inherit (stable) mono gecko32 gecko64;
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
       ./cert-path.patch
-
-      # Hotfix picked from master for https://bugs.winehq.org/show_bug.cgi?id=50163
-      (pkgs.fetchpatch {
-        url = "https://bugs.winehq.org/attachment.cgi?id=68680";
-        sha256 = "sha256-GTPQhRWeu6DPadqgFiuVUjI6MzJPaTN4l//8DSG6hpo=";
-      })
      ];
   };
 
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-HzAKLPlybO1lrkHo4Q1Y9H0vmjiqo9HiT05TcX08Ubk=";
+    sha256 = "sha256-wAvH2BV/j3PbrLYoALVj5YG0VO15ySRodSs2w70YcIs=";
     owner = "wine-staging";
     repo = "wine-staging";
-    #rev = "v${version}"; # revert back to this statement on next release
-    # Include hotfix for https://bugs.winehq.org/show_bug.cgi?id=50162
-    rev = "f257f37b92041fc718de04aa83ec3139b748ffa2";
+    # rev = "v${version}"; # revert back to this statement after stable release
+    rev = "v6.0rc1";
 
     # Just keep list empty, if current release haven't broken patchsets
     disabledPatchsets = [ ];

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.0-rc2";
+    version = "6.0-rc3";
     url = "https://dl.winehq.org/wine/source/6.0/wine-${version}.tar.xz";
-    sha256 = "sha256-8giHy+YsxCU5sh9YI9ZP3DEAGLFTPr8ELagZJ/OSDXY=";
+    sha256 = "sha256-cD1rp4T1wrhIIbTGzbYhCzrE4PUxCM0HoWmvgMnZQz4=";
     inherit (stable) mono gecko32 gecko64;
 
     patches = [
@@ -58,7 +58,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-o5oXY2P/mT323paPifFz5kn/t56MAdlXaxcQlZDGUTI=";
+    sha256 = "sha256-/m4U6kBb89FGXTF6XglUhE+MrIuWQpxsY5SdrEJ5MSY=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.0-rc3";
+    version = "6.0-rc4";
     url = "https://dl.winehq.org/wine/source/6.0/wine-${version}.tar.xz";
-    sha256 = "sha256-cD1rp4T1wrhIIbTGzbYhCzrE4PUxCM0HoWmvgMnZQz4=";
+    sha256 = "sha256-ndeBORgnfYmtPbvZEesaetocknePF8cnyjqfulkcfsU=";
     inherit (stable) mono gecko32 gecko64;
 
     patches = [
@@ -58,7 +58,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-/m4U6kBb89FGXTF6XglUhE+MrIuWQpxsY5SdrEJ5MSY=";
+    sha256 = "sha256-GdFiCGnGSDOxGERlfsPMJdSrQTvnx8gf4z4joqIKT7c=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -44,9 +44,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the SHA256 for staging as well.
-    version = "6.0-rc1";
+    version = "6.0-rc2";
     url = "https://dl.winehq.org/wine/source/6.0/wine-${version}.tar.xz";
-    sha256 = "sha256-eN3JSPlGxmJ3m9WUPZGBJ0BIACG8lRy8resQLDi1O8g=";
+    sha256 = "sha256-8giHy+YsxCU5sh9YI9ZP3DEAGLFTPr8ELagZJ/OSDXY=";
     inherit (stable) mono gecko32 gecko64;
 
     patches = [
@@ -58,11 +58,10 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    sha256 = "sha256-wAvH2BV/j3PbrLYoALVj5YG0VO15ySRodSs2w70YcIs=";
+    sha256 = "sha256-o5oXY2P/mT323paPifFz5kn/t56MAdlXaxcQlZDGUTI=";
     owner = "wine-staging";
     repo = "wine-staging";
-    # rev = "v${version}"; # revert back to this statement after stable release
-    rev = "v6.0rc1";
+    rev = "v${version}";
 
     # Just keep list empty, if current release haven't broken patchsets
     disabledPatchsets = [ ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Regular wineUnstable+staging update to 6.0-rc4 (include intermediate steps)

(wowStaging and 32bit staging tested and works well for me)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
