### PR TITLE
adminer: Clean up

### DIFF
--- a/pkgs/servers/adminer/default.nix
+++ b/pkgs/servers/adminer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, libbsd, fetchurl, phpPackages, php }:
+{ stdenv, fetchurl, php }:
 
 stdenv.mkDerivation rec {
   version = "4.7.8";
@@ -10,22 +10,36 @@ stdenv.mkDerivation rec {
     sha256 = "0k794agvd8pa3mwl0076i7753fzxd41lhr23aih4l2lbdgnzi68z";
   };
 
-  nativeBuildInputs = with phpPackages; [ php composer ];
+  nativeBuildInputs = [
+    php
+    php.packages.composer
+  ];
 
   buildPhase = ''
+    runHook preBuild
+
     composer --no-cache run compile
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir $out
     cp adminer-${version}.php $out/adminer.php
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
     description = "Database management in a single PHP file";
     homepage = "https://www.adminer.org";
-    license = with licenses; [ asl20 gpl2 ];
-    maintainers = with maintainers; [ sstef ];
+    license = with licenses; [ asl20 gpl2Only ];
+    maintainers = with maintainers; [
+      jtojnar
+      sstef
+    ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
﻿- Drop unused arguments.
- Do not use both php and phpPackages since those can have different PHP versions.
- Do not use with statement just for a single composer package.
- Add phase hooks so that one can easily customize the derivation.
- Clarify license to gpl-2.0-only.
- Add jtojnar to maintainers.

cc @haskelious
Also your github handle is out of date:
https://github.com/NixOS/nixpkgs/blob/d47eae33b0c01add740007f5cf83f3faeb0dc12d/maintainers/maintainer-list.nix#L8504

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
