### PR TITLE
[20.09] chromium: Backport various patches from nixos-unstable

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -82,6 +82,5 @@ mkChromiumDerivation (base: rec {
     platforms = platforms.linux;
     hydraPlatforms = if channel == "stable" then ["aarch64-linux" "x86_64-linux"] else [];
     timeout = 172800; # 48 hours (increased from the Hydra default of 10h)
-    broken = channel == "dev"; # Blocked on https://bugs.chromium.org/p/chromium/issues/detail?id=1141896
   };
 })

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -15,7 +15,7 @@
 , glibc
 , libXScrnSaver, libXcursor, libXtst, libGLU, libGL
 , protobuf, speechd, libXdamage, cups
-, ffmpeg_3, libxslt, libxml2, at-spi2-core
+, ffmpeg, libxslt, libxml2, at-spi2-core
 , jre8
 , pipewire_0_2
 
@@ -76,11 +76,16 @@ let
     in attrs: concatStringsSep " " (attrValues (mapAttrs toFlag attrs));
 
   gnSystemLibraries = [
-    "flac" "libwebp" "libxslt" "opus" "snappy" "libpng"
-    # "zlib" # version 77 reports unresolved dependency on //third_party/zlib:zlib_config
-    # "libjpeg" # fails with multiple undefined references to chromium_jpeg_*
+    "ffmpeg"
+    "flac"
+    "libjpeg"
+    "libpng"
+    "libwebp"
+    "libxslt"
+    "opus"
+    "snappy"
+    "zlib"
     # "re2" # fails with linker errors
-    # "ffmpeg" # https://crbug.com/731766
     # "harfbuzz-ng" # in versions over 63 harfbuzz and freetype are being built together
                     # so we can't build with one from system and other from source
   ];
@@ -95,7 +100,7 @@ let
     libpng libcap
     xdg_utils minizip libwebp
     libusb1 re2 zlib
-    ffmpeg_3 libxslt libxml2
+    ffmpeg libxslt libxml2
     nasm
     # harfbuzz # in versions over 63 harfbuzz and freetype are being built together
                # so we can't build with one from system and other from source

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -18,20 +18,14 @@
 , ffmpeg, libxslt, libxml2, at-spi2-core
 , jre8
 , pipewire_0_2
+, libva
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
-, libva ? null # useVaapi
 , libdrm ? null, wayland ? null, mesa ? null, libxkbcommon ? null # useOzone
 
 # package customization
-, useOzone ? false
-, useVaapi ? !(useOzone || stdenv.isAarch64) # Built if supported, but disabled in the wrapper
-# VA-API TODOs:
-# - Ozone: M81 fails to build due to "ozone_platform_gbm = false"
-#   - Possible solutions: Write a patch to fix the build (wrong gn dependencies)
-#     or build with minigbm
-# - AArch64: Causes serious regressions (https://github.com/NixOS/nixpkgs/pull/85253#issuecomment-614405879)
+, useOzone ? true
 , gnomeSupport ? false, gnome ? null
 , gnomeKeyringSupport ? false, libgnome-keyring3 ? null
 , proprietaryCodecs ? true
@@ -141,8 +135,8 @@ let
       pciutils protobuf speechd libXdamage at-spi2-core
       jre
       pipewire_0_2
-    ] ++ optional useVaapi libva
-      ++ optional gnomeKeyringSupport libgnome-keyring3
+      libva
+    ] ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
       ++ optional pulseSupport libpulseaudio
@@ -256,8 +250,6 @@ let
       proprietary_codecs = true;
       enable_hangout_services_extension = true;
       ffmpeg_branding = "Chrome";
-    } // optionalAttrs useVaapi {
-      use_vaapi = true;
     } // optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -214,10 +214,8 @@ let
       custom_toolchain = "//build/toolchain/linux/unbundle:default";
       host_toolchain = "//build/toolchain/linux/unbundle:default";
       is_official_build = true;
-      is_debug = false;
 
       use_vaapi = !stdenv.isAarch64; # TODO: Remove once M88 is released
-      proprietary_codecs = false;
       use_sysroot = false;
       use_gnome_keyring = gnomeKeyringSupport;
       use_gio = gnomeSupport;
@@ -233,7 +231,6 @@ let
       rtc_use_pipewire = true;
 
       treat_warnings_as_errors = false;
-      is_clang = stdenv.cc.isClang;
       clang_use_chrome_plugins = false;
       blink_symbol_level = 0;
       symbol_level = 0;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -216,6 +216,7 @@ let
       is_official_build = true;
       is_debug = false;
 
+      use_vaapi = !stdenv.isAarch64; # TODO: Remove once M88 is released
       proprietary_codecs = false;
       use_sysroot = false;
       use_gnome_keyring = gnomeKeyringSupport;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -263,7 +263,6 @@ let
       link_pulseaudio = true;
     } // optionalAttrs useOzone {
       use_ozone = true;
-      ozone_platform_gbm = false;
       use_xkbcommon = true;
       use_glib = true;
       use_gtk = true;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -250,6 +250,7 @@ let
       is_clang = stdenv.cc.isClang;
       clang_use_chrome_plugins = false;
       blink_symbol_level = 0;
+      symbol_level = 0;
       fieldtrial_testing_like_official_build = true;
 
       # Google API keys, see:

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -5,7 +5,7 @@
 , libevent, expat, libjpeg, snappy
 , libpng, libcap
 , xdg_utils, yasm, nasm, minizip, libwebp
-, libusb1, pciutils, nss, re2, zlib
+, libusb1, pciutils, nss, re2
 
 , python2Packages, perl, pkgconfig
 , nspr, systemd, kerberos
@@ -46,8 +46,6 @@ buildFun:
 
 with stdenv.lib;
 
-# see http://www.linuxfromscratch.org/blfs/view/cvs/xsoft/chromium.html
-
 let
   jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
 
@@ -63,7 +61,7 @@ let
   mkGnFlags =
     let
       # Serialize Nix types into GN types according to this document:
-      # https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/language.md
+      # https://source.chromium.org/gn/gn/+/master:docs/language.md
       mkGnString = value: "\"${escape ["\"" "$" "\\"] value}\"";
       sanitize = value:
         if value == true then "true"
@@ -75,6 +73,7 @@ let
       toFlag = key: value: "${key}=${sanitize value}";
     in attrs: concatStringsSep " " (attrValues (mapAttrs toFlag attrs));
 
+  # https://source.chromium.org/chromium/chromium/src/+/master:build/linux/unbundle/replace_gn_files.py
   gnSystemLibraries = [
     "ffmpeg"
     "flac"
@@ -85,9 +84,6 @@ let
     "opus"
     "snappy"
     "zlib"
-    # "re2" # fails with linker errors
-    # "harfbuzz-ng" # in versions over 63 harfbuzz and freetype are being built together
-                    # so we can't build with one from system and other from source
   ];
 
   opusWithCustomModes = libopus.override {
@@ -99,11 +95,9 @@ let
     libevent expat libjpeg snappy
     libpng libcap
     xdg_utils minizip libwebp
-    libusb1 re2 zlib
+    libusb1 re2
     ffmpeg libxslt libxml2
     nasm
-    # harfbuzz # in versions over 63 harfbuzz and freetype are being built together
-               # so we can't build with one from system and other from source
   ];
 
   # build paths and release info
@@ -132,6 +126,7 @@ let
     };
 
     nativeBuildInputs = [
+      llvmPackages.lldClang.bintools
       ninja which python2Packages.python perl pkgconfig
       python2Packages.ply python2Packages.jinja2 nodejs
       gnutar python2Packages.setuptools
@@ -160,11 +155,24 @@ let
     ];
 
     postPatch = ''
+      # remove unused third-party
+      for lib in ${toString gnSystemLibraries}; do
+        if [ -d "third_party/$lib" ]; then
+          find "third_party/$lib" -type f \
+            \! -path "third_party/$lib/chromium/*" \
+            \! -path "third_party/$lib/google/*" \
+            \! -path "third_party/harfbuzz-ng/utils/hb_scoped.h" \
+            \! -regex '.*\.\(gn\|gni\|isolate\)' \
+            -delete
+        fi
+      done
+
       # Required for patchShebangs (unsupported interpreter directive, basename: invalid option -- '*', etc.):
-      substituteInPlace native_client/SConstruct \
-        --replace "#! -*- python -*-" ""
-      substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
-        --replace "/usr/bin/env -S make -f" "/usr/bin/make -f"
+      substituteInPlace native_client/SConstruct --replace "#! -*- python -*-" ""
+      if [ -e third_party/harfbuzz-ng/src/src/update-unicode-tables.make ]; then
+        substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
+          --replace "/usr/bin/env -S make -f" "/usr/bin/make -f"
+      fi
 
       # We want to be able to specify where the sandbox is via CHROME_DEVEL_SANDBOX
       substituteInPlace sandbox/linux/suid/client/setuid_sandbox_host.cc \
@@ -192,48 +200,26 @@ let
       sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
         gpu/config/gpu_info_collector_linux.cc
 
-      sed -i -re 's/([^:])\<(isnan *\()/\1std::\2/g' \
-        chrome/browser/ui/webui/engagement/site_engagement_ui.cc
-
-      sed -i -e '/#include/ {
-        i #include <algorithm>
-        :l; n; bl
-      }' gpu/config/gpu_control_list.cc
-
       # Allow to put extensions into the system-path.
       sed -i -e 's,/usr,/run/current-system/sw,' chrome/common/chrome_paths.cc
 
       patchShebangs .
       # use our own nodejs
       mkdir -p third_party/node/linux/node-linux-x64/bin
-      ln -s $(which node) third_party/node/linux/node-linux-x64/bin/node
+      ln -s "$(command -v node)" third_party/node/linux/node-linux-x64/bin/node
 
-      # remove unused third-party
-      # in third_party/crashpad third_party/zlib contains just a header-adapter
-      for lib in ${toString gnSystemLibraries}; do
-        find -type f -path "*third_party/$lib/*"     \
-            \! -path "*third_party/crashpad/crashpad/third_party/zlib/*"  \
-            \! -path "*third_party/$lib/chromium/*"  \
-            \! -path "*third_party/$lib/google/*"    \
-            \! -path "*base/third_party/icu/*"       \
-            \! -path "*base/third_party/libevent/*"  \
-            \! -regex '.*\.\(gn\|gni\|isolate\|py\)' \
-            -delete
-      done
+      # Allow building against system libraries in official builds
+      sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' tools/generate_shim_headers/generate_shim_headers.py
+
     '' + optionalString stdenv.isAarch64 ''
       substituteInPlace build/toolchain/linux/BUILD.gn \
         --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
-    '' + optionalString stdenv.cc.isClang ''
-      mkdir -p third_party/llvm-build/Release+Asserts/bin
-      ln -s ${stdenv.cc}/bin/clang              third_party/llvm-build/Release+Asserts/bin/clang
-      ln -s ${stdenv.cc}/bin/clang++            third_party/llvm-build/Release+Asserts/bin/clang++
-      ln -s ${llvmPackages.llvm}/bin/llvm-ar    third_party/llvm-build/Release+Asserts/bin/llvm-ar
     '';
 
     gnFlags = mkGnFlags ({
-      use_lld = false;
-      use_gold = stdenv.buildPlatform.is64bit;  # ld.gold outs-of-memory on i686
-      gold_path = "${stdenv.cc}/bin";
+      custom_toolchain = "//build/toolchain/linux/unbundle:default";
+      host_toolchain = "//build/toolchain/linux/unbundle:default";
+      is_official_build = true;
       is_debug = false;
 
       proprietary_codecs = false;
@@ -292,8 +278,7 @@ let
 
       # This is to ensure expansion of $out.
       libExecPath="${libExecPath}"
-      python build/linux/unbundle/replace_gn_files.py \
-        --system-libraries ${toString gnSystemLibraries}
+      python build/linux/unbundle/replace_gn_files.py --system-libraries ${toString gnSystemLibraries}
       ${gnChromium}/bin/gn gen --args=${escapeShellArg gnFlags} out/Release | tee gn-gen-outputs.txt
 
       # Fail if `gn gen` contains a WARNING.

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -16,7 +16,6 @@
 , enableWideVine ? false
 , useVaapi ? false # Deprecated, use enableVaapi instead!
 , enableVaapi ? false # Disabled by default due to unofficial support
-, useOzone ? true
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
@@ -35,15 +34,13 @@ let
 
     mkChromiumDerivation = callPackage ./common.nix ({
       inherit channel gnome gnomeSupport gnomeKeyringSupport proprietaryCodecs
-              cupsSupport pulseSupport useOzone;
+              cupsSupport pulseSupport;
       gnChromium = gn.overrideAttrs (oldAttrs: {
         inherit (upstream-info.deps.gn) version;
         src = fetchgit {
           inherit (upstream-info.deps.gn) url rev sha256;
         };
       });
-      # TODO: Cleanup useOzone and useVaapi in common.nix:
-      useVaapi = !stdenv.isAarch64; # TODO: Might be best to not set use_vaapi anymore (default is fine)
     });
 
     browser = callPackage ./browser.nix { inherit channel enableWideVine; };

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -26,15 +26,15 @@
     }
   },
   "dev": {
-    "version": "88.0.4315.5",
-    "sha256": "0k6man2xq8vmnk73dqv3fcc9929agqq8j6s6nvc9z653q4jdphkw",
-    "sha256bin64": "0m139w8lwaawridk8in24ss1g1i6ah5298xky226k3vhk5i4mn3j",
+    "version": "88.0.4324.11",
+    "sha256": "123gqbxrn508wxdj3is0kzccml5zwnf8pfl90xdizvzcm3wy5315",
+    "sha256bin64": "11bswhxpnw7qi6lagfpgxh4yh56w7l0bc3rqwf975cbq2cnzpjby",
     "deps": {
       "gn": {
-        "version": "2020-10-21",
+        "version": "2020-11-05",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "f5f465b52e5df6d4de9fbe67cc79f1914ba4dbfc",
-        "sha256": "1xb31vsvg27ivvcdyiq93h8wj4d90qdrpagfh1dvm6xszkajsca1"
+        "rev": "53d92014bf94c3893886470a1c7c1289f8818db0",
+        "sha256": "1xcm07qjk6m2czi150fiqqxql067i832adck6zxrishm70c9jbr9"
       }
     }
   }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -10,6 +10,11 @@
         "rev": "e002e68a48d1c82648eadde2f6aafa20d08c36f2",
         "sha256": "0x4c7amxwzxs39grqs3dnnz0531mpf1p75niq7zhinyfqm86i4dk"
       }
+    },
+    "chromedriver": {
+      "version": "87.0.4280.20",
+      "sha256_linux": "1cpk7mb32z3a7c7cbaaxskpv91il3i8kgsdp2q8zw9w762kql953",
+      "sha256_darwin": "06mx2yk6xy46azvkbyvhqm11prxbh67pfi50fcwxb0zqllbq7scr"
     }
   },
   "beta": {

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -6,12 +6,12 @@ let
   allSpecs = {
     x86_64-linux = {
       system = "linux64";
-      sha256 = "0absr1fp2h87gpyw6jxj2f08sbhkkh3pf13145hfyzdvajj5rfjy";
+      sha256 = "0ndig3gq00nr3zs5f7wl1xw5vsnz1hwmjfrk73vbmb8lqjnfm66l";
     };
 
     x86_64-darwin = {
       system = "mac64";
-      sha256 = "1p9k92fgyx0xis6r50vhcpx3iws2gaspq3dnpigglv3bj9yg8zvi";
+      sha256 = "1ipxla0d8wa2rn3872xpc5akbmk2rnplk9clrdncmdzakw7f66im";
     };
   };
 
@@ -28,7 +28,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "chromedriver";
-  version = "85.0.4183.87";
+  version = "86.0.4240.22";
 
   src = fetchurl {
     url = "https://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchurl, cairo, fontconfig, freetype, gdk-pixbuf, glib
-, glibc, gtk2, libX11, makeWrapper, nspr, nss, pango, unzip, gconf
+{ stdenv, fetchurl, unzip, makeWrapper
+, cairo, fontconfig, freetype, gdk-pixbuf, glib
+, glibc, gtk2, libX11, nspr, nss, pango, gconf
 , libxcb, libXi, libXrender, libXext
 }:
+
 let
+  upstream-info = (stdenv.lib.importJSON ../../../../applications/networking/browsers/chromium/upstream-info.json).stable.chromedriver;
   allSpecs = {
     x86_64-linux = {
       system = "linux64";
-      sha256 = "1cpk7mb32z3a7c7cbaaxskpv91il3i8kgsdp2q8zw9w762kql953";
+      sha256 = upstream-info.sha256_linux;
     };
 
     x86_64-darwin = {
       system = "mac64";
-      sha256 = "06mx2yk6xy46azvkbyvhqm11prxbh67pfi50fcwxb0zqllbq7scr";
+      sha256 = upstream-info.sha256_darwin;
     };
   };
 
@@ -25,10 +28,10 @@ let
     libX11 nspr nss pango libXrender
     gconf libxcb libXext libXi
   ];
-in
-stdenv.mkDerivation rec {
+
+in stdenv.mkDerivation rec {
   pname = "chromedriver";
-  version = "87.0.4280.20";
+  version = upstream-info.version;
 
   src = fetchurl {
     url = "https://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";
@@ -47,10 +50,18 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "https://sites.google.com/a/chromium.org/chromedriver";
+    homepage = "https://chromedriver.chromium.org/";
     description = "A WebDriver server for running Selenium tests on Chrome";
+    longDescription = ''
+      WebDriver is an open source tool for automated testing of webapps across
+      many browsers. It provides capabilities for navigating to web pages, user
+      input, JavaScript execution, and more. ChromeDriver is a standalone
+      server that implements the W3C WebDriver standard.
+    '';
     license = licenses.bsd3;
-    maintainers = [ maintainers.goibhniu maintainers.marsam ];
+    maintainers = with maintainers; [ goibhniu marsam primeos ];
+    # Note from primeos: By updating Chromium I also update Google Chrome and
+    # ChromeDriver.
     platforms = attrNames allSpecs;
   };
 }

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -6,12 +6,12 @@ let
   allSpecs = {
     x86_64-linux = {
       system = "linux64";
-      sha256 = "0ndig3gq00nr3zs5f7wl1xw5vsnz1hwmjfrk73vbmb8lqjnfm66l";
+      sha256 = "1cpk7mb32z3a7c7cbaaxskpv91il3i8kgsdp2q8zw9w762kql953";
     };
 
     x86_64-darwin = {
       system = "mac64";
-      sha256 = "1ipxla0d8wa2rn3872xpc5akbmk2rnplk9clrdncmdzakw7f66im";
+      sha256 = "06mx2yk6xy46azvkbyvhqm11prxbh67pfi50fcwxb0zqllbq7scr";
     };
   };
 
@@ -28,7 +28,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "chromedriver";
-  version = "86.0.4240.22";
+  version = "87.0.4280.20";
 
   src = fetchurl {
     url = "https://chromedriver.storage.googleapis.com/${version}/chromedriver_${spec.system}.zip";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport additional patches from nixos-unstable to keep the differences to a minimum and get various improvements.
This'll better work...

**I can run the VM test but it would be ideal if someone could test `chromium` (warning: takes very long to build) manually on NixOS 20.09 as the switch to the system libraries (etc.) could introduce regressions.**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
