### PR TITLE
python3Packages.pyarlo: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/pyarlo/default.nix
+++ b/pkgs/development/python-modules/pyarlo/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, requests
+, requests-mock
+, sseclient-py
+}:
+
+buildPythonPackage rec {
+  pname = "pyarlo";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "tchellomello";
+    repo = "python-arlo";
+    rev = version;
+    sha256 = "0pp7y2llk4xnf6zh57j5xas0gw5zqm42qaqssd8p4qa3g5rds8k3";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    sseclient-py
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    mock
+    requests-mock
+  ];
+
+  pythonImportsCheck = [ "pyarlo" ];
+
+  meta = with lib; {
+    description = "Python library to work with Netgear Arlo cameras";
+    homepage = "https://github.com/tchellomello/python-arlo";
+    license = with licenses; [ lgpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4972,6 +4972,8 @@ in {
 
   pyannotate = callPackage ../development/python-modules/pyannotate { };
 
+  pyarlo = callPackage ../development/python-modules/pyarlo { };
+
   pyarrow = callPackage ../development/python-modules/pyarrow { inherit (pkgs) arrow-cpp cmake pkgconfig; };
 
   pyasn1 = callPackage ../development/python-modules/pyasn1 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Arlo is a library written in Python 2.7/3x that exposes the Netgear Arlo cameras as Python objects.

https://github.com/tchellomello/python-arlo

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
