### PR TITLE
python3Packages.aiopulse: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/aiopulse/default.nix
+++ b/pkgs/development/python-modules/aiopulse/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, async-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "aiopulse";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fnscm27l77c8cd7jhbn35axyalq61kksy3fcqzv21fz55lklsm0";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+  ];
+
+  # tests are not present
+  doCheck = false;
+
+  pythonImportsCheck = [ "aiopulse" ];
+
+  meta = with lib; {
+    description = "Python Rollease Acmeda Automate Pulse hub protocol implementation";
+    longDescription = ''
+      The Rollease Acmeda Pulse Hub is a WiFi hub that communicates with
+      Rollease Acmeda Automate roller blinds via a proprietary RF protocol.
+      This module communicates over a local area network using a propriatery
+      binary protocol to issues commands to the Pulse Hub.
+    '';
+    homepage = "https://github.com/atmurray/aiopulse";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -7,7 +7,7 @@
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
     "acer_projector" = ps: with ps; [ pyserial ];
-    "acmeda" = ps: with ps; [ ]; # missing inputs: aiopulse
+    "acmeda" = ps: with ps; [ aiopulse ];
     "actiontec" = ps: with ps; [ ];
     "adguard" = ps: with ps; [ adguardhome ];
     "ads" = ps: with ps; [ pyads ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -243,6 +243,8 @@ in {
 
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
+  aiopulse = callPackage ../development/python-modules/aiopulse { };
+
   aioredis = callPackage ../development/python-modules/aioredis { };
 
   aioresponses = callPackage ../development/python-modules/aioresponses { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The Rollease Acmeda Pulse Hub is a WiFi hub that communicates with
Rollease Acmeda Automate roller blinds via a proprietary RF protocol.
This module communicates over a local area network using a propriatery
binary protocol to issues commands to the Pulse Hub.

https://github.com/atmurray/aiopulse

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
