### PR TITLE
paperwork: 2.0.1 -> 2.0.2, libinsane: 1.0.8 -> 1.0.9

### DIFF
--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -2,8 +2,6 @@
 , python3Packages
 , gtk3
 , cairo
-, aspellDicts
-, buildEnv
 , gnome3
 , librsvg
 , xvfb_run
@@ -40,16 +38,19 @@ python3Packages.buildPythonApplication rec {
     make l10n_compile
   '';
 
-  ASPELL_CONF = "dict-dir ${buildEnv {
-    name = "aspell-all-dicts";
-    paths = lib.collect lib.isDerivation aspellDicts;
-  }}/lib/aspell";
-
   postInstall = ''
     # paperwork-shell needs to be re-wrapped with access to paperwork
     cp ${python3Packages.paperwork-shell}/bin/.paperwork-cli-wrapped $out/bin/paperwork-cli
     # install desktop files and icons
     XDG_DATA_HOME=$out/share $out/bin/paperwork-gtk install --user
+
+    # fixes [WARNING] [openpaperwork_core.resources.setuptools] Failed to find
+    # resource file paperwork_gtk.icon.out/paperwork_128.png, tried at path
+    # /nix/store/3n5lz6y8k9yks76f0nar3smc8djan3xr-paperwork-2.0.2/lib/python3.8/site-packages/paperwork_gtk/icon/out/paperwork_128.png.
+    site=$out/lib/${python3Packages.python.libPrefix}/site-packages/paperwork_gtk
+    for i in $site/data/paperwork_*.png; do
+      ln -s $i $site/icon/out;
+    done
   '';
 
   checkInputs = [ xvfb_run dbus.daemon ];

--- a/pkgs/applications/office/paperwork/paperwork-shell.nix
+++ b/pkgs/applications/office/paperwork/paperwork-shell.nix
@@ -10,6 +10,7 @@
 , paperwork-backend
 , fabulous
 , getkey
+, psutil
 
 , pkgs
 }:
@@ -34,6 +35,7 @@ buildPythonPackage rec {
     paperwork-backend
     fabulous
     getkey
+    psutil
   ];
 
   checkInputs = [

--- a/pkgs/applications/office/paperwork/src.nix
+++ b/pkgs/applications/office/paperwork/src.nix
@@ -1,12 +1,12 @@
 {fetchFromGitLab}:
 rec {
-  version = "2.0.1";
+  version = "2.0.2";
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     repo = "paperwork";
     group = "World";
     owner = "OpenPaperwork";
     rev = version;
-    sha256 = "16pc4drwpjl4937wdavs6wk0j1qs474b072wplhs8ywxfgqip1h4";
+    sha256 = "1di7nnl8ywyiwfpl5m1kvip1m0hvijbmqmkdpviwqw7ajizrr1ly";
   };
 }

--- a/pkgs/development/libraries/libinsane/default.nix
+++ b/pkgs/development/libraries/libinsane/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libinsane";
-  version = "1.0.8";
+  version = "1.0.9";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     group = "World";
     owner = "OpenPaperwork";
     rev = version;
-    sha256 = "0mcvqpixilzs4d4afkbxa1nqm6ddmhpaz5j56pfvc5wpv6s99h44";
+    sha256 = "1a1lszhq3j11i1jybc5kmn7hhhji44xhjqsxsldsy9l3344rkzv4";
   };
 
   nativeBuildInputs = [ meson pkg-config ninja doxygen gtk-doc docbook_xsl gobject-introspection vala ];


### PR DESCRIPTION
###### Motivation for this change


Update and some clean up. I asked to the main developer on freenode and paperwork does not use aspell anymore.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
