### PR TITLE
bowtie: init at at 1.3.0

### DIFF
--- a/pkgs/applications/science/biology/bowtie/default.nix
+++ b/pkgs/applications/science/biology/bowtie/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "bowtie";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "BenLangmead";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0da2kzyfsn6xv8mlqsv2vv7k8g0c9d2vgqzq8yqk888yljdzcrjp";
+  };
+
+  buildInputs = [ zlib ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "An ultrafast memory-efficient short read aligner";
+    license = licenses.artistic2;
+    homepage = "http://bowtie-bio.sf.net/bowtie";
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1616,6 +1616,8 @@ in
 
   boot = callPackage ../development/tools/build-managers/boot { };
 
+  bowtie = callPackage ../applications/science/biology/bowtie { };
+
   bowtie2 = callPackage ../applications/science/biology/bowtie2 { };
 
   boxfs = callPackage ../tools/filesystems/boxfs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- we have bowtie2 packaged, but since it is not a drop-in replacement for bowtie I packaged bowtie as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
