### PR TITLE
python3Packages.pythonix: 0.1.6 -> 0.1.7, fix python module

### DIFF
--- a/pkgs/development/python-modules/pythonix/default.nix
+++ b/pkgs/development/python-modules/pythonix/default.nix
@@ -1,22 +1,30 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, ninja, boost, meson, pkgconfig, nix, isPy3k }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, ninja, boost, meson, pkg-config, nix, isPy3k, python }:
 
 buildPythonPackage rec {
   pname = "pythonix";
-  version = "0.1.6";
+  version = "0.1.7";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "pythonix";
     rev = "v${version}";
-    sha256 = "1qzcrpn333hsgn6fj1m1s3cvaf0ny8qpygamcrazqv57xmwyr8h5";
+    sha256 = "1wxqv3i4bva2qq9mx670bcx0g0irjn68fvk28dwvhay9ndwcspqf";
   };
 
   disabled = !isPy3k;
 
-  nativeBuildInputs = [ meson ninja pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
 
   buildInputs = [ nix boost ];
+
+  postInstall = ''
+    # This is typically set by pipInstallHook/eggInstallHook,
+    # so we have to do so manually when using meson
+    export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "nix" ];
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6007,7 +6007,10 @@ in {
 
   pythonIRClib = callPackage ../development/python-modules/pythonirclib { };
 
-  pythonix = callPackage ../development/python-modules/pythonix { inherit (pkgs) meson pkgconfig; };
+  pythonix = callPackage ../development/python-modules/pythonix {
+    inherit (pkgs) pkg-config;
+    meson = pkgs.meson.override { python3 = self.python; };
+  };
 
   python-jenkins = callPackage ../development/python-modules/python-jenkins { };
 


### PR DESCRIPTION
Pythonix uses the same python as meson, so we need to override
meson to use the right python version or the module won't import.

Also added a pythonImportsCheck to prevent regressions.

Corresponding upstream fix: https://github.com/Mic92/pythonix/commit/ee22a8f732344d802798e31ce73d1fcd016e8aed

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/103151#issuecomment-723638622

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
