### PR TITLE
ttygif: add missing dependencies on xwd, imagemagick

### DIFF
--- a/pkgs/tools/misc/ttygif/default.nix
+++ b/pkgs/tools/misc/ttygif/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, makeWrapper, imagemagick, xorg }:
 
 stdenv.mkDerivation rec {
   pname = "ttygif";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   makeFlags = [ "CC:=$(CC)" "PREFIX=${placeholder "out"}" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/ttygif \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ imagemagick xorg.xwd ]}
+  '';
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/icholy/ttygif";


### PR DESCRIPTION
###### Motivation for this change

As currently packaged, ttygif can fail at execution time due to being unable to find the `convert` command (from ImageMagick), or the `xwd` command (from `xorg`, used to take screenshots).

This PR wraps the executable, adding the dependencies to the PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
