### PR TITLE
vimPlugins.telescope-fzy-native-nvim: init at 2021-01-02

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -3912,6 +3912,19 @@ let
     meta.homepage = "https://github.com/nvim-telescope/telescope-fzf-writer.nvim/";
   };
 
+  telescope-fzy-native-nvim = buildVimPluginFrom2Nix {
+     pname = "telescope-fzy-native-nvim";
+     version = "2021-01-02";
+     src = fetchFromGitHub {
+       owner = "nvim-telescope";
+       repo = "telescope-fzy-native.nvim";
+       rev = "654dffd924b29fb9a9252dcbd63528b1498ac9fb";
+       sha256 = "01x9z3n03qharjw778cxb16gw1dsxzmsxph4xsbfy1avf21c6x9g";
+       fetchSubmodules = true;
+     };
+     meta.homepage = "https://github.com/nvim-telescope/telescope-fzy-native.nvim/";
+   };
+
   telescope-nvim = buildVimPluginFrom2Nix {
     pname = "telescope-nvim";
     version = "2021-01-18";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -671,6 +671,31 @@ self: super: {
       ln -s ${tabnine}/bin/TabNine $target/binaries/TabNine_$(uname -s)
     '';
   });
+
+  telescope-fzy-native-nvim = super.telescope-fzy-native-nvim.overrideAttrs (old: {
+    preFixup =
+      let
+        fzy-lua-native-path = "deps/fzy-lua-native";
+        fzy-lua-native =
+          stdenv.mkDerivation {
+            name = "fzy-lua-native";
+            src = "${old.src}/${fzy-lua-native-path}";
+            # remove pre-compiled binaries
+            preBuild = "rm -rf static/*";
+            installPhase = ''
+              install -Dm 444 -t $out/static static/*
+              install -Dm 444 -t $out/lua lua/*
+            '';
+          };
+      in
+      ''
+        rm -rf $target/${fzy-lua-native-path}/*
+        ln -s ${fzy-lua-native}/static $target/${fzy-lua-native-path}/static
+        ln -s ${fzy-lua-native}/lua $target/${fzy-lua-native-path}/lua
+      '';
+    meta.platforms = stdenv.lib.platforms.all;
+  });
+
 } // (
   let
     nodePackageNames = [

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -407,6 +407,7 @@ nvim-lua/lsp_extensions.nvim
 nvim-lua/plenary.nvim
 nvim-lua/popup.nvim
 nvim-telescope/telescope-fzf-writer.nvim
+nvim-telescope/telescope-fzy-native.nvim
 nvim-telescope/telescope.nvim
 nvim-treesitter/completion-treesitter
 nvim-treesitter/nvim-treesitter


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add https://github.com/nvim-telescope/telescope-fzy-native.nvim

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
