### PR TITLE
idris2: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -5,13 +5,13 @@
 # Uses scheme to bootstrap the build of idris2
 stdenv.mkDerivation rec {
   pname = "idris2";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "idris-lang";
     repo = "Idris2";
     rev = "v${version}";
-    sha256 = "044slgl2pwvj939kz3z92n6l182plc5fzng1n4z4k6bg11msqq14";
+    sha256 = "18m483vccijfh9z6x4zgi37fql3q765x3ypkwixv3rwq9nxnd6hm";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Motivation for this change
There is a new idris2 release.


###### Things done
Just updated the source for the derivation.
There don't seem to be any changes breaking compilation.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (didn't test extensively, but REPL seems to work fine at least)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date (there is none)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @wchresta 