### PR TITLE
pcimem: init at unstable-2018-08-29

### DIFF
--- a/pkgs/os-specific/linux/pcimem/default.nix
+++ b/pkgs/os-specific/linux/pcimem/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "pcimem";
+  version = "unstable-2018-08-29";
+
+  src = fetchFromGitHub {
+    owner = "billfarrow";
+    repo = pname;
+    rev = "09724edb1783a98da2b7ae53c5aaa87493aabc9b";
+    sha256 = "0zlbvcl5q4hgna11p3w00px1p8qgn8ga79lh6a2m7d597g86kbq3";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  makeFlags = [ "CFLAGS=-Wno-maybe-uninitialized" ];
+
+  installPhase = ''
+    install -D pcimem "$out/bin/pcimem"
+    install -D README "$doc/doc/README"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple method of reading and writing to memory registers on a PCI card";
+    homepage = "https://github.com/billfarrow/pcimem";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mafo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6527,6 +6527,8 @@ in
 
   pbzip2 = callPackage ../tools/compression/pbzip2 { };
 
+  pcimem = callPackage ../os-specific/linux/pcimem { };
+
   pciutils = callPackage ../tools/system/pciutils { };
 
   pcsclite = callPackage ../tools/security/pcsclite {


### PR DESCRIPTION
###### Motivation for this change

This commit adds the pcimem tool.
pcimem is a simple method of reading and writing to memory registers on a PCI card.
Compared to `pkgs.devmem2`, it does not work on the total memory space
of the machine but restricts access to just one PCI resource.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
