### PR TITLE
cargo-wipe: init at 0.3.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-wipe/default.nix
+++ b/pkgs/development/tools/rust/cargo-wipe/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, nix-update-script
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-wipe";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mihai-dinculescu";
+    repo = "cargo-wipe";
+    rev = "v${version}";
+    sha256 = "1kwkifdp98zsinh7xcsz2va252wxbw73xlrv0r7h3m0bn51d52vw";
+  };
+
+  cargoSha256 = "15snr1b1pybwcjzwddxybvry3jyllcmrp8dyfm9yiagks3wrcfb4";
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = ''Cargo subcommand "wipe": recursively finds and optionally wipes all "target" or "node_modules" folders'';
+    homepage = "https://github.com/mihai-dinculescu/cargo-wipe";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ otavio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10250,6 +10250,7 @@ in
   cargo-watch = callPackage ../development/tools/rust/cargo-watch {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
+  cargo-wipe = callPackage ../development/tools/rust/cargo-wipe { };
   cargo-xbuild = callPackage ../development/tools/rust/cargo-xbuild { };
   cargo-generate = callPackage ../development/tools/rust/cargo-generate {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Motivation for this change

`cargo-wipe` is a handy tool to cleanup the home directory. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
