### PR TITLE
.github/workflows/manual-{nixos,nixpkgs}.yml: fix restrict eval

### DIFF
--- a/.github/workflows/manual-nixos.yml
+++ b/.github/workflows/manual-nixos.yml
@@ -25,4 +25,4 @@ jobs:
           name: nixpkgs-ci
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: Building NixOS manual
-        run: nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux
+        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux

--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -25,4 +25,4 @@ jobs:
           name: nixpkgs-ci
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: Building Nixpkgs manual
-        run: nix-build --option restrict-eval true pkgs/top-level/release.nix -A manual
+        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true pkgs/top-level/release.nix -A manual


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/runs/1638075046?check_suite_focus=true#step:5:6

```
error: access to path '/home/runner/work/nixpkgs/nixpkgs/nixos/release.nix' is forbidden in restricted mode
```

@Mic92 Does this still work how you intended? https://github.com/NixOS/nixpkgs/pull/106036#issuecomment-739464756
