### PR TITLE
cargo-download: Fix build by bumping url from 1.6.0 to 1.6.1

### DIFF
--- a/pkgs/tools/package-management/cargo-download/Cargo.nix
+++ b/pkgs/tools/package-management/cargo-download/Cargo.nix
@@ -427,7 +427,7 @@ rec {
     serde_urlencoded = "0.5.1";
     tokio = "0.1.7";
     tokio_io = "0.1.10";
-    url = "1.6.0";
+    url = "1.6.1";
     uuid = "0.7.1";
   };
   deps.rustc_version."0.2.3" = {
@@ -464,7 +464,7 @@ rec {
     dtoa = "0.4.2";
     itoa = "0.3.4";
     serde = "1.0.21";
-    url = "1.6.0";
+    url = "1.6.1";
   };
   deps.siphasher."0.2.2" = {};
   deps.slab."0.4.0" = {};
@@ -639,7 +639,7 @@ rec {
   deps.unreachable."1.0.0" = {
     void = "1.0.2";
   };
-  deps.url."1.6.0" = {
+  deps.url."1.6.1" = {
     idna = "0.1.4";
     matches = "0.1.6";
     percent_encoding = "1.0.1";

--- a/pkgs/tools/package-management/cargo-download/crates-io.nix
+++ b/pkgs/tools/package-management/cargo-download/crates-io.nix
@@ -4926,40 +4926,40 @@ rec {
 
 
 # end
-# url-1.6.0
+# url-1.6.1
 
-  crates.url."1.6.0" = deps: { features?(features_.url."1.6.0" deps {}) }: buildRustCrate {
+  crates.url."1.6.1" = deps: { features?(features_.url."1.6.1" deps {}) }: buildRustCrate {
     crateName = "url";
-    version = "1.6.0";
+    version = "1.6.1";
     description = "URL library for Rust, based on the WHATWG URL Standard";
     authors = [ "The rust-url developers" ];
-    sha256 = "1bvzl4dvjj84h46ai3x23wyafa2wwhchj08vr2brf25dxwc7mg18";
+    sha256 = "1qsnhmxznzaxl068a3ksz69kwcz7ghvl4zflg9qj7lyw4bk9ma38";
     dependencies = mapFeatures features ([
-      (crates."idna"."${deps."url"."1.6.0"."idna"}" deps)
-      (crates."matches"."${deps."url"."1.6.0"."matches"}" deps)
-      (crates."percent_encoding"."${deps."url"."1.6.0"."percent_encoding"}" deps)
+      (crates."idna"."${deps."url"."1.6.1"."idna"}" deps)
+      (crates."matches"."${deps."url"."1.6.1"."matches"}" deps)
+      (crates."percent_encoding"."${deps."url"."1.6.1"."percent_encoding"}" deps)
     ]);
-    features = mkFeatures (features."url"."1.6.0" or {});
+    features = mkFeatures (features."url"."1.6.1" or {});
   };
-  features_.url."1.6.0" = deps: f: updateFeatures f (rec {
-    idna."${deps.url."1.6.0".idna}".default = true;
-    matches."${deps.url."1.6.0".matches}".default = true;
-    percent_encoding."${deps.url."1.6.0".percent_encoding}".default = true;
+  features_.url."1.6.1" = deps: f: updateFeatures f (rec {
+    idna."${deps.url."1.6.1".idna}".default = true;
+    matches."${deps.url."1.6.1".matches}".default = true;
+    percent_encoding."${deps.url."1.6.1".percent_encoding}".default = true;
     url = fold recursiveUpdate {} [
-      { "1.6.0"."encoding" =
-        (f.url."1.6.0"."encoding" or false) ||
-        (f.url."1.6.0".query_encoding or false) ||
-        (url."1.6.0"."query_encoding" or false); }
-      { "1.6.0"."heapsize" =
-        (f.url."1.6.0"."heapsize" or false) ||
-        (f.url."1.6.0".heap_size or false) ||
-        (url."1.6.0"."heap_size" or false); }
-      { "1.6.0".default = (f.url."1.6.0".default or true); }
+      { "1.6.1"."encoding" =
+        (f.url."1.6.1"."encoding" or false) ||
+        (f.url."1.6.1".query_encoding or false) ||
+        (url."1.6.1"."query_encoding" or false); }
+      { "1.6.1"."heapsize" =
+        (f.url."1.6.1"."heapsize" or false) ||
+        (f.url."1.6.1".heap_size or false) ||
+        (url."1.6.1"."heap_size" or false); }
+      { "1.6.1".default = (f.url."1.6.1".default or true); }
     ];
   }) [
-    (features_.idna."${deps."url"."1.6.0"."idna"}" deps)
-    (features_.matches."${deps."url"."1.6.0"."matches"}" deps)
-    (features_.percent_encoding."${deps."url"."1.6.0"."percent_encoding"}" deps)
+    (features_.idna."${deps."url"."1.6.1"."idna"}" deps)
+    (features_.matches."${deps."url"."1.6.1"."matches"}" deps)
+    (features_.percent_encoding."${deps."url"."1.6.1"."percent_encoding"}" deps)
   ];
 
 


### PR DESCRIPTION
###### Motivation for this change

url 1.6.0 no longer builds with Rust 1.40 and later due to a lifetime bug uncovered by NLL (Xion/cargo-download#7).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
