### PR TITLE
Fetch pffft from upstream project website instead of bitbucket

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, fetchFromBitbucket, fetchFromGitHub, pkgconfig
+{ stdenv, makeWrapper, fetchzip, fetchFromGitHub, pkgconfig
 , alsaLib, curl, glew, glfw, gtk2-x11, jansson, libjack2, libXext, libXi
 , libzip, rtaudio, rtmidi, speex, libsamplerate }:
 
@@ -7,10 +7,8 @@ let
   # Others are downloaded with `make deps`. Due to previous issues with the
   # `glfw` submodule (see above) and because we can not access the network when
   # building in a sandbox, we fetch the dependency source manually.
-  pfft-source = fetchFromBitbucket {
-    owner = "jpommier";
-    repo = "pffft";
-    rev = "74d7261be17cf659d5930d4830609406bd7553e3";
+  pfft-source = fetchzip {
+    url = "https://vcvrack.com/downloads/dep/pffft.zip";
     sha256 = "084csgqa6f1a270bhybjayrh3mpyi2jimc87qkdgsqcp8ycsx1l1";
   };
   nanovg-source = fetchFromGitHub {


### PR DESCRIPTION
Starting from this commit
https://github.com/VCVRack/Rack/commit/2db08f15a00f6792bb3a45db31dd13f94966beed
the upstream project does not expect to use bitbucket anymore. The title
mentions that “BitBucket deleted all Mercurial repos”. Instead, an archive of
the pffft source is hosted on vcvrack.com directly. The unziped sha256 is the
same as before this change.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/107580

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
