### PR TITLE
rkvm: init at ...

### DIFF
--- a/pkgs/applications/misc/rkvm/default.nix
+++ b/pkgs/applications/misc/rkvm/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, rustPlatform, fetchFromGitHub
+, pkg-config, libevdev, openssl, llvmPackages_latest, linuxHeaders }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rkvm-unstable";
+  version = "ec404c69";
+
+  src = fetchFromGitHub {
+    owner = "htrefil";
+    repo = "rkvm";
+    rev = "ec404c69b38f7feff5103f898612734ee8d7ee95";
+    sha256 = "sha256-YZXHbZ71EsSyAtTenQ4rgp1fJbatkk7BW4Cmr/RpyXc=";
+  };
+
+  cargoSha256 = "sha256-/VNnqKSPqAYXS312GaTtpl5j0uOHLfUX8u7LuEDhUTg=";
+
+  postPatch = ''
+    sed -i 's|.clang_arg("-I/usr/include/libevdev-1.0/")|.clang_arg("-I${libevdev}/include/libevdev-1.0").clang_arg("-I${linuxHeaders}/include")|g' ./input/build.rs
+  '';
+
+  nativeBuildInputs = [ pkg-config openssl llvmPackages_latest.libclang ];
+  LIBCLANG_PATH = "${llvmPackages_latest.libclang}/lib";
+  buildInputs = [ libevdev openssl linuxHeaders ];
+
+  meta = with stdenv.lib; {
+    description = "Virtual KVM switch for Linux machines";
+    homepage = "https://github.com/htrefil/rkvm";
+    license = licenses.mit;
+    maintainers = [ maintainers.colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2596,6 +2596,8 @@ in
 
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
+  rkvm = callPackage ../applications/misc/rkvm { };
+
   ryujinx = callPackage ../misc/emulators/ryujinx { };
 
   scour = with python3Packages; toPythonApplication scour;


### PR DESCRIPTION
###### Motivation for this change
Fixes #108276 by adding `rkvm`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
