### PR TITLE
stegseek: init at 0.5

### DIFF
--- a/pkgs/tools/security/stegseek/default.nix
+++ b/pkgs/tools/security/stegseek/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, cmake
+, fetchFromGitHub
+, libjpeg
+, libmcrypt
+, libmhash
+, libtool
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stegseek";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "RickdeJager";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19hzr5533b607ihmjj71x682qjr45s75cqxh9zap21z16346ahqn";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    libjpeg
+    libmcrypt
+    libmhash
+    libtool
+    zlib
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Tool to crack steganography";
+    longDescription = ''
+      Stegseek is a lightning fast steghide cracker that can be
+      used to extract hidden data from files.
+    '';
+    homepage = "https://github.com/RickdeJager/stegseek";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16278,6 +16278,8 @@ in
 
   steghide = callPackage ../tools/security/steghide {};
 
+  stegseek = callPackage ../tools/security/stegseek {};
+
   stlport = callPackage ../development/libraries/stlport { };
 
   streamlink = callPackage ../applications/video/streamlink { pythonPackages = python3Packages; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Stegseek is a lightning fast steghide cracker that can be
used to extract hidden data from files.

https://github.com/RickdeJager/stegseek

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
