### PR TITLE
treewide: remove enableParallelBuilding = true if using cmake

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -75,8 +75,6 @@ in mkDerivation {
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = lib.flatten [
     (fstats withTaglib        [ "TAGLIB" "TAGLIB_EXTRAS" ])
     (fstats withReplaygain    [ "FFMPEG" "MPG123" "SPEEXDSP" ])

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -79,8 +79,6 @@ let
       "-DSPOTIFY_BLOB=OFF"
     ];
 
-    enableParallelBuilding = true;
-
     passthru.unfree = unfree;
 
     postInstall = ''
@@ -122,7 +120,7 @@ let
         ln -s "${free}/share/$dir" "$out/share/$dir"
       done
     '';
-    enableParallelBuilding = true;
+
     meta = with stdenv.lib; {
       homepage = "https://www.clementine-player.org";
       description = "Spotify integration for Clementine";

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
   # version and remove fluidsynth 1.x from nixpkgs again.
   version = "6.15.0";
 
-  enableParallelBuilding = true;
-
   hardeningDisable = [ "format" ];
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     export DOCBOOKDIR="${docbook_xsl}/xml/xsl/docbook/"
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A simple and powerful audio tag editor";
     longDescription = ''

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -37,7 +37,6 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [ "-DWANT_QT5=ON" ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "DAW similar to FL Studio (music production software)";

--- a/pkgs/applications/audio/qmmp/default.nix
+++ b/pkgs/applications/audio/qmmp/default.nix
@@ -51,8 +51,6 @@ mkDerivation rec {
       libsamplerate
     ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Qt-based audio player that looks like Winamp";
     homepage = "http://qmmp.ylsoftware.com/";

--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -80,8 +80,6 @@ stdenv.mkDerivation rec {
     "-DBUILD_TESTS=${if doCheck then "ON" else "OFF"}"
   ];
 
-  enableParallelBuilding = true;
-
   checkInputs = [ gtest ];
   doCheck = !stdenv.isAarch64; # single failure that I can't explain
 

--- a/pkgs/applications/audio/rosegarden/default.nix
+++ b/pkgs/applications/audio/rosegarden/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation (rec {
     alsaLib
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://www.rosegardenmusic.com/";
     description = "Music composition and editing environment";

--- a/pkgs/applications/audio/soundkonverter/default.nix
+++ b/pkgs/applications/audio/soundkonverter/default.nix
@@ -62,7 +62,7 @@ mkDerivation rec {
       stripLen = 1;
     })
   ];
-  enableParallelBuilding = true;
+
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig kdelibs4support makeWrapper ];
   propagatedBuildInputs = [ libkcddb kconfig kconfigwidgets ki18n kdelibs4support kio solid kwidgetsaddons kxmlgui qtbase phonon];
   buildInputs = [ taglib ] ++ runtimeDeps;

--- a/pkgs/applications/audio/traverso/default.nix
+++ b/pkgs/applications/audio/traverso/default.nix
@@ -18,7 +18,6 @@ mkDerivation {
 
   cmakeFlags = [ "-DWANT_PORTAUDIO=1" "-DWANT_PULSEAUDIO=1" "-DWANT_MP3_ENCODE=1" "-DWANT_LV2=0" ];
 
-  enableParallelBuilding = true;
   hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/blockchains/bitcoin-abc.nix
+++ b/pkgs/applications/blockchains/bitcoin-abc.nix
@@ -32,8 +32,6 @@ mkDerivation rec {
     find ./. -type f -iname "*.sh" -exec chmod +x {} \;
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Peer-to-peer electronic cash system (Cash client)";
     longDescription= ''

--- a/pkgs/applications/blockchains/dero.nix
+++ b/pkgs/applications/blockchains/dero.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ boost miniupnpc openssl lmdb unbound readline ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Secure, private blockchain with smart contracts based on Monero";
     homepage = "https://dero.io/";

--- a/pkgs/applications/blockchains/masari.nix
+++ b/pkgs/applications/blockchains/masari.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ boost miniupnpc openssl lmdb unbound readline ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "scalability-focused, untraceable, secure, and fungible cryptocurrency using the RingCT protocol";
     homepage = "https://www.getmasari.org/";

--- a/pkgs/applications/blockchains/sumokoin.nix
+++ b/pkgs/applications/blockchains/sumokoin.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
     "-DLMDB_INCLUDE=${lmdb}/include"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "A fork of Monero and a truely fungible cryptocurrency";
     homepage = "https://www.sumokoin.org/";

--- a/pkgs/applications/editors/aseprite/default.nix
+++ b/pkgs/applications/editors/aseprite/default.nix
@@ -96,8 +96,6 @@ stdenv.mkDerivation rec {
     rm -rf "$out"/include "$out"/lib
   '';
 
-  enableParallelBuilding = true;
-
   passthru = { inherit skia; };
 
   meta = with lib; {

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -48,7 +48,6 @@ in
     ];
 
     dontFixCmake = true;
-    enableParallelBuilding = true;
 
     buildInputs = [
       gperf

--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -27,8 +27,6 @@ let
 
     nativeBuildInputs = [ cmake doxygen ];
 
-    enableParallelBuilding = true;
-
     preCheck = ''
       # The GUI tests require a running X server, disable them
       sed -i ../test/CMakeLists.txt \

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -109,8 +109,6 @@ mkDerivation rec {
       popd
     '';
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [ "-DRSTUDIO_TARGET=Desktop" "-DQT_QMAKE_EXECUTABLE=$NIX_QT5_TMP/bin/qmake" ];
 
   desktopItem = makeDesktopItem {

--- a/pkgs/applications/editors/sigil/default.nix
+++ b/pkgs/applications/editors/sigil/default.nix
@@ -36,8 +36,6 @@ mkDerivation rec {
        ''${qtWrapperArgs[@]}
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Free, open source, multi-platform ebook (ePub) editor";
     homepage = "https://github.com/Sigil-Ebook/Sigil/";

--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -31,8 +31,6 @@ mkDerivation {
     sha256 = "04585hdh98fvyhj4wsxf69xal2wvfa6lg76gad8pr6ww9abi5105";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
     guile_1_8

--- a/pkgs/applications/graphics/antimony/default.nix
+++ b/pkgs/applications/graphics/antimony/default.nix
@@ -40,8 +40,6 @@ in
       "-DGITBRANCH=${gitBranch}"
     ];
 
-    enableParallelBuilding = true;
-
     meta = with stdenv.lib; {
       description = "A computer-aided design (CAD) tool from a parallel universe";
       homepage    = "https://github.com/mkeeter/antimony";

--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -109,8 +109,6 @@ mkDerivation rec {
     threadweaver
   ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DENABLE_MYSQLSUPPORT=1"
     "-DENABLE_INTERNALMYSQL=1"

--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
   # disable installation of the python scripting interface
   cmakeFlags = [ "-DBUILD_HSI:BOOl=OFF" ];
 
-  enableParallelBuilding = true;
-
   NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";
 
   postInstall = ''

--- a/pkgs/applications/graphics/kgraphviewer/default.nix
+++ b/pkgs/applications/graphics/kgraphviewer/default.nix
@@ -27,8 +27,6 @@ mkDerivation rec {
     kconfig kinit kio kparts kwidgetsaddons
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A Graphviz dot graph viewer for KDE";
     license     = licenses.gpl2;

--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -84,8 +84,6 @@ mkDerivation rec {
   #     |
   hardeningDisable = [ "format" ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "A system for processing and editing 3D triangular meshes";
     homepage = "https://www.meshlab.net/";

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -27,8 +27,6 @@ mkDerivation rec {
     sha256 = "1bq7bv4p7w67172y893lvpk90d6fgdpnylynbj2kn8m2hs6khya4";
   };
 
-  enableParallelBuilding = true;
-
   setSourceRoot = ''
     sourceRoot=$(echo */ImageLounge)
   '';

--- a/pkgs/applications/graphics/photivo/default.nix
+++ b/pkgs/applications/graphics/photivo/default.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ qt4 fftw graphicsmagick_q16 lcms2 lensfun libjpeg exiv2 liblqr1 ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     license = licenses.gpl3;

--- a/pkgs/applications/graphics/photoqt/default.nix
+++ b/pkgs/applications/graphics/photoqt/default.nix
@@ -37,8 +37,6 @@ mkDerivation rec {
     export MAGICK_LOCATION="${graphicsmagick}/include/GraphicsMagick"
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "https://photoqt.org/";
     description = "Simple, yet powerful and good looking image viewer";

--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation rec {
     echo "set(HG_VERSION $version)" > $sourceRoot/ReleaseInfo.cmake
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "RAW converter and digital photo processing software";
     homepage = "http://www.rawtherapee.com/";

--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -61,8 +61,6 @@ mkDerivation rec {
     addOpenGLRunpath $out/lib/librenderdoc.so
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A single-frame graphics debugger";
     homepage = "https://renderdoc.org/";

--- a/pkgs/applications/graphics/scantailor/default.nix
+++ b/pkgs/applications/graphics/scantailor/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qt4 libjpeg libtiff boost ];
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "http://scantailor.org/";
     description = "Interactive post-processing tool for scanned pages";

--- a/pkgs/applications/graphics/solvespace/default.nix
+++ b/pkgs/applications/graphics/solvespace/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
     json_c fontconfig gtkmm3 pangomm glew libGLU
     xorg.libpthreadstubs xorg.libXdmcp pcre
   ];
-  enableParallelBuilding = true;
 
   preConfigure = ''
     patch CMakeLists.txt <<EOF

--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -18,8 +18,6 @@ mkDerivation rec {
 
   buildInputs = [ qtbase qtdeclarative qtsvg qtx11extras muparser python3 qtcharts ];
 
-  enableParallelBuilding = true;
-
   # We don't have virtualbox sdk so disable plugin
   cmakeFlags = [ "-DBUILD_VIRTUALBOX=OFF" "-DCMAKE_INSTALL_LIBDIR=libs" ];
 

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -119,8 +119,6 @@ stdenv.mkDerivation rec {
   # libstdc++ in our RPATH. Sigh.
   NIX_LDFLAGS = optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
 
-  enableParallelBuilding = true;
-
   blenderExecutable =
     placeholder "out" + (if stdenv.isDarwin then "/Blender.app/Contents/MacOS/Blender" else "/bin/blender");
   # --python-expr is used to workaround https://developer.blender.org/T74304

--- a/pkgs/applications/misc/elf-dissector/default.nix
+++ b/pkgs/applications/misc/elf-dissector/default.nix
@@ -15,8 +15,6 @@ mkDerivation rec {
 
   buildInputs = [ kitemmodels libiberty libelf libdwarf libopcodes ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     homepage = "https://invent.kde.org/sdk/elf-dissector";
     description = "Tools for inspecting, analyzing and optimizing ELF files";

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -76,8 +76,6 @@ stdenv.mkDerivation rec {
 
   stripDebugList = [ "bin" "share" ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "An orthodox file manager";
     homepage = "https://github.com/elfmz/far2l";

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
   ++ optionals dbiSupport [ libdbi libdbiDrivers ]
   ++ optionals postgresSupport [ postgresql ];
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "https://wammu.eu/gammu/";
     description = "Command line utility and library to control mobile phones";

--- a/pkgs/applications/misc/lenmus/default.nix
+++ b/pkgs/applications/misc/lenmus/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "1n639xr1qxx6rhqs0c6sjxp3bv8cwkmw1vfk1cji7514gj2a9v3p";
   };
 
-  enableParallelBuilding = true;
-
   patches = [
     (fetchpatch {
       url = "https://github.com/lenmus/lenmus/commit/421760d84694a0e6e72d0e9b1d4fd30a7e129c6f.patch";

--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -15,8 +15,6 @@ mkDerivation rec {
     sha256 = "1pp3k1802gl1rji98clv17wj0619dliq821mpi4446lk22q692yq";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake gcc-arm-embedded python3Packages.pillow ];
 
   buildInputs = [ qtbase qtmultimedia qttranslations SDL ];

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -7,8 +7,6 @@ stdenv.mkDerivation rec {
   pname = "prusa-slicer";
   version = "2.2.0";
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     cmake
     pkgconfig

--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     "-DNO_GTEST=ON"
     "-DCMAKE_CXX_FLAGS=-I${yubikey-personalization}/include/ykpers-1"
   ];
-  enableParallelBuilding = true;
 
   postPatch = ''
     # Fix perl scripts used during the build.

--- a/pkgs/applications/misc/qlandkartegt/default.nix
+++ b/pkgs/applications/misc/qlandkartegt/default.nix
@@ -63,8 +63,6 @@ mkDerivation rec {
     "-DEXIF_INCLUDE_DIRS=${libexif}/include"
   ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     substituteInPlace ConfigureChecks.cmake \
       --replace \$\{PLUGIN_INSTALL_DIR\} "${garmindev}/lib/qlandkartegt"

--- a/pkgs/applications/misc/qlandkartegt/garmindev.nix
+++ b/pkgs/applications/misc/qlandkartegt/garmindev.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libusb-compat-0_1 ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "http://www.qlandkarte.org/";
     description = "Garmin Device Drivers for QlandkarteGT";

--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -17,8 +17,6 @@ mkDerivation {
     libeb lzo qtbase qtmultimedia qttools qtwebengine
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     homepage = "https://github.com/ludios/qolibri";
     description = "EPWING reader for viewing Japanese dictionaries";

--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -53,8 +53,6 @@ mkDerivation rec {
     runHook postInstall
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     homepage = "https://github.com/sieren/QSyncthingTray/";
     description = "A Traybar Application for Syncthing written in C++";

--- a/pkgs/applications/misc/slade/default.nix
+++ b/pkgs/applications/misc/slade/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig zip ];
   buildInputs = [ wxGTK gtk2 sfml fluidsynth curl freeimage ftgl glew ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";

--- a/pkgs/applications/misc/slade/git.nix
+++ b/pkgs/applications/misc/slade/git.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake pkgconfig zip ];
   buildInputs = [ wxGTK gtk2 sfml fluidsynth curl freeimage ftgl glew ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -91,8 +91,6 @@ in stdenv.mkDerivation {
     "-DNO_PRINTING=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   passthru = { inherit version libdc googlemaps; };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/tasksh/default.nix
+++ b/pkgs/applications/misc/tasksh/default.nix
@@ -4,8 +4,6 @@ stdenv.mkDerivation rec {
   pname = "tasksh";
   version = "1.2.0";
 
-  enableParallelBuilding = true;
-
   src = fetchurl {
     url = "https://taskwarrior.org/download/${pname}-${version}.tar.gz";
     sha256 = "1z8zw8lld62fjafjvy248dncjk0i4fwygw0ahzjdvyyppx4zjhkf";

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -4,8 +4,6 @@ stdenv.mkDerivation rec {
   pname = "timewarrior";
   version = "1.4.2";
 
-  enableParallelBuilding = true;
-
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "timewarrior";

--- a/pkgs/applications/misc/xsuspender/default.nix
+++ b/pkgs/applications/misc/xsuspender/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
   buildInputs = [ glib libwnck3 ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     wrapProgram $out/bin/xsuspender \
       --prefix PATH : "${makeBinPath [ procps ]}"

--- a/pkgs/applications/networking/browsers/falkon/default.nix
+++ b/pkgs/applications/networking/browsers/falkon/default.nix
@@ -47,8 +47,6 @@ mkDerivation rec {
     wrapQtAppsHook
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "QtWebEngine based cross-platform web browser";
     homepage    = "https://community.kde.org/Incubator/Projects/Falkon";

--- a/pkgs/applications/networking/ids/zeek/default.nix
+++ b/pkgs/applications/networking/ids/zeek/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
   #see issue https://github.com/zeek/zeek/issues/804 to modify hardlinking duplicate files.
   inherit preConfigure;
 
-  enableParallelBuilding = true;
-
   patches = stdenv.lib.optionals stdenv.cc.isClang [
     # Fix pybind c++17 build with Clang. See: https://github.com/pybind/pybind11/issues/1604
     (fetchpatch {

--- a/pkgs/applications/networking/instant-messengers/psi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi/default.nix
@@ -21,7 +21,6 @@ mkDerivation rec {
     qtbase qtmultimedia qtx11extras qtwebengine
     libidn qca-qt5 libXScrnSaver hunspell
   ];
-  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://psi-im.org";

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -52,8 +52,6 @@ in mkDerivation rec {
     pcre xorg.libpthreadstubs xorg.libXdmcp util-linux libselinux libsepol epoxy at-spi2-core libXtst
   ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-Ddisable_autoupdate=ON"
     # We're allowed to used the API ID of the Snap package:

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -49,8 +49,6 @@ in (if !buildClient then stdenv.mkDerivation else mkDerivation) rec {
     ./0001-common-Disable-enum-type-stream-operators-for-Qt-5.1.patch
   ];
 
-  enableParallelBuilding = true;
-
   # Prevent ``undefined reference to `qt_version_tag''' in SSL check
   NIX_CFLAGS_COMPILE = "-DQT_NO_VERSION_TAGGING=1";
 

--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -21,8 +21,6 @@ mkDerivation rec {
     "-DNO_SHIBBOLETH=1"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Synchronise your ownCloud with your computer using this desktop client";
     homepage = "https://owncloud.org";

--- a/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
+++ b/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
@@ -54,8 +54,6 @@ stdenv.mkDerivation rec {
     "-DWITH_LUASCRIPTS=ON"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A cross-platform program that uses the Direct Connect and ADC protocols";
     homepage = "https://github.com/eiskaltdcpp/eiskaltdcpp";

--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -22,8 +22,6 @@ mkDerivation rec {
     libktorrent taglib libgcrypt kplotting
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "KDE integrated BtTorrent client";
     homepage    = "https://www.kde.org/applications/internet/ktorrent/";

--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -44,8 +44,6 @@ mkDerivation rec {
     else "qbittorrent-nox"
   } --prefix PATH : ${makeBinPath [ python3 ]}";
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Featureful free software BitTorrent client";
     homepage    = "https://www.qbittorrent.org/";

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -93,8 +93,6 @@ in stdenv.mkDerivation {
     cp ../wiretap/*.h $dev/include/wiretap
   '');
 
-  enableParallelBuilding = true;
-
   dontFixCmake = true;
 
   shellHook = ''

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -82,8 +82,6 @@ stdenv.mkDerivation rec {
   '';
   doCheck = false;
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Personal and small-business financial-accounting application";
 

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
   # Hidden dependency that wasn't included in CMakeLists.txt:
   NIX_CFLAGS_COMPILE = "-I${kitemmodels.dev}/include/KF5";
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     doxygen extra-cmake-modules graphviz kdoctools python2
     python3Packages.wrapPython wrapQtAppsHook

--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake texinfo ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DBUILD_DOCS:BOOL=ON"

--- a/pkgs/applications/office/scribus/default.nix
+++ b/pkgs/applications/office/scribus/default.nix
@@ -18,8 +18,6 @@ in stdenv.mkDerivation rec {
     sha256 = "0bq433myw6h1siqlsakxv6ghb002rp3mfz5k12bg68s0k6skn992";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = with xorg;
     [ freetype lcms libtiff libxml2 libart_lgpl qt4

--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -43,8 +43,6 @@ mkDerivation rec {
     sha256 = "sha256-1CV2lVOc+kDerYq9rwTFHjTU10vK1aLJNNCObp1Dt6s=";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     cmake
     pkgconfig

--- a/pkgs/applications/radio/dsd/default.nix
+++ b/pkgs/applications/radio/dsd/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
     mbelib libsndfile itpp
   ] ++ stdenv.lib.optionals portaudioSupport [ portaudio ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
   preCheck = ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD

--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -8,7 +8,7 @@
 , gflags
 , gnuradio
 , orc
-, pkgconfig
+, pkg-config
 , pythonPackages
 , uhd
 , log4cpp
@@ -29,17 +29,16 @@ stdenv.mkDerivation rec {
     sha256 = "0a3k47fl5dizzhbqbrbmckl636lznyjby2d2nz6fz21637hvrnby";
   };
 
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
     armadillo
     boost.dev
-    cmake
     glog
     gmock
     openssl.dev
     gflags
     gnuradio
     orc
-    pkgconfig
     pythonPackages.Mako
     pythonPackages.six
 
@@ -52,8 +51,6 @@ stdenv.mkDerivation rec {
     pugixml
     protobuf
   ];
-
-  enableParallelBuilding = true;
 
   cmakeFlags = [
     "-DGFlags_ROOT_DIR=${gflags}/lib"

--- a/pkgs/applications/radio/gnuradio/ais.nix
+++ b/pkgs/applications/radio/gnuradio/ais.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Gnuradio block for ais";
     homepage = "https://github.com/bistromath/gr-ais";

--- a/pkgs/applications/radio/gnuradio/gsm.nix
+++ b/pkgs/applications/radio/gnuradio/gsm.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Gnuradio block for gsm";
     homepage = "https://github.com/ptrkrysik/gr-gsm";

--- a/pkgs/applications/radio/gnuradio/limesdr.nix
+++ b/pkgs/applications/radio/gnuradio/limesdr.nix
@@ -28,8 +28,6 @@ in stdenv.mkDerivation {
   ] ++ stdenv.lib.optionals pythonSupport [ python ];
 
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Gnuradio source and sink blocks for LimeSDR";
     homepage = "https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio";

--- a/pkgs/applications/radio/gnuradio/nacl.nix
+++ b/pkgs/applications/radio/gnuradio/nacl.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Gnuradio block for encryption";
     homepage = "https://github.com/stwunsch/gr-nacl";

--- a/pkgs/applications/radio/gnuradio/osmosdr.nix
+++ b/pkgs/applications/radio/gnuradio/osmosdr.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Gnuradio block for OsmoSDR and rtl-sdr";
     homepage = "https://sdr.osmocom.org/trac/wiki/GrOsmoSDR";

--- a/pkgs/applications/radio/gnuradio/rds.nix
+++ b/pkgs/applications/radio/gnuradio/rds.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Gnuradio block for radio data system";
     homepage = "https://github.com/bastibl/gr-rds";

--- a/pkgs/applications/radio/gqrx/default.nix
+++ b/pkgs/applications/radio/gqrx/default.nix
@@ -23,8 +23,6 @@ mkDerivation rec {
     qtbase qtsvg gnuradio boost gr-osmosdr rtl-sdr hackrf
   ] ++ stdenv.lib.optionals pulseaudioSupport [ libpulseaudio ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     install -vD $src/gqrx.desktop -t "$out/share/applications/"
     install -vD $src/resources/icons/gqrx.svg -t "$out/share/pixmaps/"

--- a/pkgs/applications/radio/svxlink/default.nix
+++ b/pkgs/applications/radio/svxlink/default.nix
@@ -29,7 +29,6 @@ in stdenv.mkDerivation rec {
     "-DRTLSDR_INCLUDE_DIRS=${rtl-sdr}/include"
     "../src"
   ];
-  enableParallelBuilding = true;
   dontWrapQtApps = true;
 
   nativeBuildInputs = [ cmake pkgconfig doxygen groff wrapQtAppsHook ];

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -54,8 +54,6 @@ stdenv.mkDerivation rec {
     sha256 = "1fir1a13ac07mqhm4sr34cixiqj2difxq0870qv1wr7a7cbfw6vp";
   };
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DENABLE_LIBUHD=ON"
     "-DENABLE_USB=ON"

--- a/pkgs/applications/radio/welle-io/default.nix
+++ b/pkgs/applications/radio/welle-io/default.nix
@@ -39,8 +39,6 @@ in mkDerivation {
     "-DRTLSDR=true" "-DSOAPYSDR=true"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "A DAB/DAB+ Software Radio";
     homepage = "https://www.welle.io/";

--- a/pkgs/applications/science/biology/EZminc/default.nix
+++ b/pkgs/applications/science/biology/EZminc/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
                  "-DEZMINC_BUILD_MRFSEG=TRUE"
                  "-DEZMINC_BUILD_DD=TRUE" ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/BIC-MNI/${pname}";
     description = "Collection of Perl and shell scripts for processing MINC files";

--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     for file in $out/bin/*; do
       wrapProgram $file --set ANTSPATH "$out/bin"

--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "1cncfwhyhmg18n970lkn6yvp0i74ajznsl8dqz00asqfzmg681n1";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake git ];
   buildInputs = [ libyamlcpp ];
 

--- a/pkgs/applications/science/biology/megahit/default.nix
+++ b/pkgs/applications/science/biology/megahit/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "An ultra-fast single-node solution for large and complex metagenomics assembly via succinct de Bruijn graph";
     license     = licenses.gpl3;

--- a/pkgs/applications/science/biology/messer-slim/default.nix
+++ b/pkgs/applications/science/biology/messer-slim/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, cmake, gcc, gcc-unwrapped }:
 
 stdenv.mkDerivation rec {
-  version = "3.2.1"; 
+  version = "3.2.1";
   pname = "messer-slim";
 
   src = fetchurl {
@@ -9,11 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1j3ssjvxpsc21mmzj59kwimglz8pdazi5w6wplmx11x744k77wa1";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake gcc gcc-unwrapped ];
 
-  cmakeFlags = [ "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar" 
+  cmakeFlags = [ "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
                  "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib" ];
 
   meta = {
@@ -24,4 +22,3 @@ stdenv.mkDerivation rec {
      platforms = stdenv.lib.platforms.all;
   };
 }
-

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/BIC-MNI/minc-tools";
     description = "Command-line utilities for working with MINC files";

--- a/pkgs/applications/science/biology/niftyreg/default.nix
+++ b/pkgs/applications/science/biology/niftyreg/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "http://cmictig.cs.ucl.ac.uk/wiki/index.php/NiftyReg";

--- a/pkgs/applications/science/biology/niftyseg/default.nix
+++ b/pkgs/applications/science/biology/niftyseg/default.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen zlib ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "http://cmictig.cs.ucl.ac.uk/research/software/software-nifty/niftyseg";

--- a/pkgs/applications/science/biology/obitools/obitools3.nix
+++ b/pkgs/applications/science/biology/obitools/obitools3.nix
@@ -26,8 +26,6 @@ pythonPackages.buildPythonApplication rec {
 
   doCheck = true;
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib ; {
     description = "Management of analyses and data in DNA metabarcoding";
     homepage = "https://git.metabarcoding.org/obitools/obitools3";

--- a/pkgs/applications/science/chemistry/d-seams/default.nix
+++ b/pkgs/applications/science/chemistry/d-seams/default.nix
@@ -12,7 +12,6 @@ clangStdenv.mkDerivation rec {
     sha256 = "03zhhl9vhi3rhc3qz1g3zb89jksgpdlrk15fcr8xcz8pkj6r5b1i";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake lua luaPackages.luafilesystem ];
   buildInputs = [ fmt rang libyamlcpp eigen catch2 boost gsl liblapack blas ];
 

--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -38,8 +38,6 @@ in stdenv.mkDerivation {
     openssh
   ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DOPENMP=ON"
     "-DGA=ON"

--- a/pkgs/applications/science/electronics/appcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/appcsxcad/default.nix
@@ -45,8 +45,6 @@ mkDerivation {
     rm $out/bin/AppCSXCAD.sh
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Minimal Application using the QCSXCAD library";
     homepage = "https://github.com/thliebig/AppCSXCAD";

--- a/pkgs/applications/science/electronics/caneda/default.nix
+++ b/pkgs/applications/science/electronics/caneda/default.nix
@@ -14,8 +14,6 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qtbase qttools qtsvg qwt ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Open source EDA software focused on easy of use and portability";
     homepage = "http://caneda.org";

--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -37,8 +37,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A C++ library to describe geometrical objects";
     homepage = "https://github.com/thliebig/CSXCAD";

--- a/pkgs/applications/science/electronics/dsview/default.nix
+++ b/pkgs/applications/science/electronics/dsview/default.nix
@@ -34,8 +34,6 @@ mkDerivation rec {
     python3
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "A GUI program for supporting various instruments from DreamSourceLab, including logic analyzer, oscilloscope, etc";
     homepage = "https://www.dreamsourcelab.com/";

--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -63,8 +63,6 @@ stdenv.mkDerivation {
       -o $out/share/openEMS/matlab/h5readatt_octave.oct
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Open Source Electromagnetic Field Solver";
     homepage = "http://openems.de/index.php/Main_Page.html";

--- a/pkgs/applications/science/logic/abc/default.nix
+++ b/pkgs/applications/science/logic/abc/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];
 
-  enableParallelBuilding = true;
   installPhase = "mkdir -p $out/bin && mv abc $out/bin";
 
   # needed by yosys

--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -35,9 +35,6 @@ stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=Production"
   ];
 
-
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A high-performance theorem prover and SMT solver";
     homepage    = "http://cvc4.cs.stanford.edu/web/";

--- a/pkgs/applications/science/logic/fast-downward/default.nix
+++ b/pkgs/applications/science/logic/fast-downward/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation {
   cmakeFlags =
     lib.optional osi.withCplex [ "-DDOWNWARD_CPLEX_ROOT=${cplex}/cplex" ];
 
-  enableParallelBuilding = true;
-
   configurePhase = ''
     python build.py release
   '';

--- a/pkgs/applications/science/logic/lean/default.nix
+++ b/pkgs/applications/science/logic/lean/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ gmp ];
-  enableParallelBuilding = true;
 
   cmakeDir = "../src";
 

--- a/pkgs/applications/science/logic/stp/default.nix
+++ b/pkgs/applications/science/logic/stp/default.nix
@@ -24,9 +24,6 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  # seems to build fine now, may revert if concurrency does become an issue
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Simple Theorem Prover";
     maintainers = with maintainers; [ ];

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -88,8 +88,6 @@ stdenv.mkDerivation rec {
     (flag "OpenCV" opencvSupport)
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A toolbox which offers a wide range of efficient and unified machine learning methods";
     homepage = "http://shogun-toolbox.org/";

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -46,8 +46,6 @@ stdenv.mkDerivation rec {
     sha256 = "104jp3cm823i3cdph7hgsnj6l77ygbwsy35mdmzhmsi4jxprd9j3";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake doxygen ];
 
   cmakeFlags =

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -90,8 +90,6 @@ in stdenv.mkDerivation rec {
     done
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     # Newer cub is included with cudatoolkit now and it breaks the build.
     # https://github.com/Microsoft/CNTK/issues/3191

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -43,8 +43,6 @@ stdenv.mkDerivation rec {
     rm "$out"/lib/*.a
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler";
     homepage = "https://mxnet.incubator.apache.org/";

--- a/pkgs/applications/science/misc/openmodelica/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  enableParallelBuilding = true;
-
   patchPhase = ''
     cp -fv ${fakegit}/bin/checkout-git.sh libraries/checkout-git.sh
     cp -fv ${fakegit}/bin/checkout-svn.sh libraries/checkout-svn.sh

--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -50,8 +50,6 @@ stdenv.mkDerivation {
 
   dontUseCmakeBuildDir = true;
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A library for computer-vision scientists and especially targeted to the Multi-View Stereo reconstruction community";
     homepage = "http://cdcseacave.github.io/openMVS/";

--- a/pkgs/applications/science/misc/root/5.nix
+++ b/pkgs/applications/science/misc/root/5.nix
@@ -77,8 +77,6 @@ stdenv.mkDerivation rec {
   ]
   ++ stdenv.lib.optional stdenv.isDarwin "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks";
 
-  enableParallelBuilding = true;
-
   setupHook = ./setup-hook.sh;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/misc/root/default.nix
+++ b/pkgs/applications/science/misc/root/default.nix
@@ -80,8 +80,6 @@ stdenv.mkDerivation rec {
     "-Druntime_cxxmodules=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     for prog in rootbrowse rootcp rooteventselector rootls rootmkdir rootmv rootprint rootrm rootslimtree; do
       wrapProgram "$out/bin/$prog" \

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -92,8 +92,6 @@ stdenv.mkDerivation rec {
     EOW
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Framework for the simulation of distributed applications";
     longDescription = ''

--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
     ./fix-cmake.patch
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://elmerfem.org/";
     description = "A finite element software for multiphysical problems";

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -83,7 +83,6 @@ let
         repo  = name;
         inherit rev sha256;
       };
-      enableParallelBuilding = true;
     } // attrs');
 
   ffmpeg = kodiDependency rec {
@@ -241,8 +240,6 @@ in stdenv.mkDerivation {
       "-DCORE_PLATFORM_NAME=gbm"
       "-DGBM_RENDER_SYSTEM=gles"
     ];
-
-    enableParallelBuilding = true;
 
     # 14 tests fail but the biggest issue is that every test takes 30 seconds -
     # I'm guessing there is a thing waiting to time out

--- a/pkgs/data/themes/kde2/default.nix
+++ b/pkgs/data/themes/kde2/default.nix
@@ -15,7 +15,6 @@ mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
-  enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
 

--- a/pkgs/data/themes/qtcurve/default.nix
+++ b/pkgs/data/themes/qtcurve/default.nix
@@ -17,8 +17,6 @@ mkDerivation rec {
     sha256 = "XP9VTeiVIiMm5mkXapCKWxfcvaYCkhY3S5RXZNR3oWo=";
   };
 
-  enableParallelBuilding = true;
-
   patches = [
     # Remove unnecessary constexpr, this is not allowed in C++14
     (fetchpatch {

--- a/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
-  enableParallelBuilding = true;
-
   passthru.updateScript = xfce.updateScript {
     inherit pname version;
     attrPath = "xfce.thunar-dropbox-plugin";

--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake python3 bison jq ];
-  enableParallelBuilding = true;
 
   postPatch = ''
     cp --no-preserve=mode -r "${localSpirv-tools.src}" External/spirv-tools

--- a/pkgs/development/compilers/julia/1.0.nix
+++ b/pkgs/development/compilers/julia/1.0.nix
@@ -171,8 +171,6 @@ stdenv.mkDerivation rec {
     openspecfun pcre2
   ]);
 
-  enableParallelBuilding = true;
-
   doCheck = !stdenv.isDarwin;
   checkTarget = "testall";
   # Julia's tests require read/write access to $HOME

--- a/pkgs/development/compilers/julia/1.3.nix
+++ b/pkgs/development/compilers/julia/1.3.nix
@@ -119,8 +119,6 @@ stdenv.mkDerivation rec {
     openspecfun pcre2 lapack
   ];
 
-  enableParallelBuilding = true;
-
   # Other versions of Julia pass the tests, but we are not sure why these fail.
   doCheck = false;
   checkTarget = "testall";

--- a/pkgs/development/compilers/julia/1.5.nix
+++ b/pkgs/development/compilers/julia/1.5.nix
@@ -119,8 +119,6 @@ stdenv.mkDerivation rec {
     openspecfun pcre2 lapack
   ];
 
-  enableParallelBuilding = true;
-
   # Julia's tests require read/write access to $HOME
   preCheck = ''
     export HOME="$NIX_BUILD_TOP"

--- a/pkgs/development/compilers/ldc/generic.nix
+++ b/pkgs/development/compilers/ldc/generic.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
   pname = "ldc";
   inherit version;
 
-  enableParallelBuilding = true;
-
   src = fetchurl {
     url = "https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc-${version}-src.tar.gz";
     sha256 = ldcSha256;

--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -82,8 +82,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/10/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/10/compiler-rt.nix
@@ -87,5 +87,4 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
   '';
 
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/10/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/10/libc++/default.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ stdenv.lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/10/libunwind.nix
+++ b/pkgs/development/compilers/llvm/10/libunwind.nix
@@ -8,7 +8,5 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
 }

--- a/pkgs/development/compilers/llvm/10/lld.nix
+++ b/pkgs/development/compilers/llvm/10/lld.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/10/lldb.nix
+++ b/pkgs/development/compilers/llvm/10/lldb.nix
@@ -59,8 +59,6 @@ stdenv.mkDerivation (rec {
     "-DSPHINX_OUTPUT_HTML=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     # Editor support
     # vscode:

--- a/pkgs/development/compilers/llvm/10/llvm.nix
+++ b/pkgs/development/compilers/llvm/10/llvm.nix
@@ -154,8 +154,6 @@ in stdenv.mkDerivation (rec {
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -81,8 +81,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/11/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/11/compiler-rt.nix
@@ -86,5 +86,4 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
   '';
 
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/11/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/11/libc++/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ stdenv.lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/11/libunwind.nix
+++ b/pkgs/development/compilers/llvm/11/libunwind.nix
@@ -8,7 +8,5 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
 }

--- a/pkgs/development/compilers/llvm/11/lld.nix
+++ b/pkgs/development/compilers/llvm/11/lld.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/11/lldb.nix
+++ b/pkgs/development/compilers/llvm/11/lldb.nix
@@ -59,8 +59,6 @@ stdenv.mkDerivation (rec {
     "-DSPHINX_OUTPUT_HTML=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     # Editor support
     # vscode:

--- a/pkgs/development/compilers/llvm/11/llvm.nix
+++ b/pkgs/development/compilers/llvm/11/llvm.nix
@@ -156,8 +156,6 @@ in stdenv.mkDerivation (rec {
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/11/openmp.nix
+++ b/pkgs/development/compilers/llvm/11/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -72,8 +72,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -84,5 +84,4 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
   '';
 
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -37,8 +37,6 @@ stdenv.mkDerivation {
     "-DLIBCXX_CXX_ABI=libcxxabi"
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/5/lld.nix
+++ b/pkgs/development/compilers/llvm/5/lld.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/5/lldb.nix
+++ b/pkgs/development/compilers/llvm/5/lldb.nix
@@ -51,8 +51,6 @@ stdenv.mkDerivation {
     "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     mkdir -p $out/share/man/man1
     cp ../docs/lldb.1 $out/share/man/man1/

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -146,8 +146,6 @@ stdenv.mkDerivation ({
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/5/openmp.nix
+++ b/pkgs/development/compilers/llvm/5/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -72,8 +72,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/6/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/6/compiler-rt.nix
@@ -86,5 +86,4 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
   '';
 
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -37,8 +37,6 @@ stdenv.mkDerivation {
     "-DLIBCXX_CXX_ABI=libcxxabi"
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/6/lld.nix
+++ b/pkgs/development/compilers/llvm/6/lld.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/6/lldb.nix
+++ b/pkgs/development/compilers/llvm/6/lldb.nix
@@ -51,8 +51,6 @@ stdenv.mkDerivation {
     "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     mkdir -p $out/share/man/man1
     cp ../docs/lldb.1 $out/share/man/man1/

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -145,8 +145,6 @@ stdenv.mkDerivation ({
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -83,8 +83,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -89,5 +89,4 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
   '';
 
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation {
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1"
   ++ stdenv.lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF" ;
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/7/lld.nix
+++ b/pkgs/development/compilers/llvm/7/lld.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/7/lldb.nix
+++ b/pkgs/development/compilers/llvm/7/lldb.nix
@@ -52,8 +52,6 @@ stdenv.mkDerivation {
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-I${libxml2.dev}/include/libxml2";
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     mkdir -p $out/share/man/man1
     cp ../docs/lldb.1 $out/share/man/man1/

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -167,8 +167,6 @@ in stdenv.mkDerivation ({
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/7/openmp.nix
+++ b/pkgs/development/compilers/llvm/7/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -93,8 +93,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -87,5 +87,4 @@ stdenv.mkDerivation {
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
   '';
 
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/8/libc++/default.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ stdenv.lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/8/libunwind.nix
+++ b/pkgs/development/compilers/llvm/8/libunwind.nix
@@ -19,7 +19,5 @@ stdenv.mkDerivation {
     })
   ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
 }

--- a/pkgs/development/compilers/llvm/8/lld.nix
+++ b/pkgs/development/compilers/llvm/8/lld.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/8/lldb.nix
+++ b/pkgs/development/compilers/llvm/8/lldb.nix
@@ -41,8 +41,6 @@ stdenv.mkDerivation {
     "-DLLDB_CODESIGN_IDENTITY=" # codesigning makes nondeterministic
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     mkdir -p $out/share/man/man1
     cp ../docs/lldb.1 $out/share/man/man1/

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -151,8 +151,6 @@ in stdenv.mkDerivation ({
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/8/openmp.nix
+++ b/pkgs/development/compilers/llvm/8/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -88,8 +88,6 @@ let
       rm $out/bin/c-index-test
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       isClang = true;
       inherit llvm;

--- a/pkgs/development/compilers/llvm/9/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/9/compiler-rt.nix
@@ -85,6 +85,4 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/crtbeginS.o
     ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/crtendS.o
   '';
-
-  enableParallelBuilding = true;
 }

--- a/pkgs/development/compilers/llvm/9/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/9/libc++/default.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ stdenv.lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
-  enableParallelBuilding = true;
-
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/9/libunwind.nix
+++ b/pkgs/development/compilers/llvm/9/libunwind.nix
@@ -8,7 +8,5 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
 }

--- a/pkgs/development/compilers/llvm/9/lld.nix
+++ b/pkgs/development/compilers/llvm/9/lld.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput include "$dev"
     moveToOutput lib "$dev"

--- a/pkgs/development/compilers/llvm/9/lldb.nix
+++ b/pkgs/development/compilers/llvm/9/lldb.nix
@@ -49,8 +49,6 @@ stdenv.mkDerivation rec {
     "-DLLVM_EXTERNAL_LIT=${lit}/bin/lit"
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     # man page
     mkdir -p $out/share/man/man1

--- a/pkgs/development/compilers/llvm/9/llvm.nix
+++ b/pkgs/development/compilers/llvm/9/llvm.nix
@@ -159,8 +159,6 @@ in stdenv.mkDerivation (rec {
 
   checkTarget = "check-all";
 
-  enableParallelBuilding = true;
-
   requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";

--- a/pkgs/development/compilers/llvm/9/openmp.nix
+++ b/pkgs/development/compilers/llvm/9/openmp.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Components required to build an executable OpenMP program";
     homepage    = "https://openmp.llvm.org/";

--- a/pkgs/development/compilers/lobster/default.nix
+++ b/pkgs/development/compilers/lobster/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
     ];
 
   preConfigure = "cd dev";
-  enableParallelBuilding = true;
 
   passthru = {
     tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix {};

--- a/pkgs/development/compilers/mono/llvm.nix
+++ b/pkgs/development/compilers/mono/llvm.nix
@@ -41,8 +41,6 @@ stdenv.mkDerivation {
     "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
   ] ++ stdenv.lib.optional (!isDarwin) "-DBUILD_SHARED_LIBS=ON";
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies - Mono build";
     homepage    = "http://llvm.org/";

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -43,7 +43,6 @@ with stdenv; mkDerivation rec {
     ++ (lib.optional enableGui qtbase)
     ++ (lib.optional stdenv.cc.isClang llvmPackages.openmp);
 
-  enableParallelBuilding = true;
   cmakeFlags =
     [ "-DCURRENT_GIT_VERSION=${lib.substring 0 7 (lib.elemAt srcs 0).rev}"
       "-DARCH=generic;ice40;ecp5"

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -83,8 +83,6 @@ stdenv.mkDerivation (rec {
     ++ stdenv.lib.optionals stdenv.isDarwin [ "bits=64" ]
     ++ stdenv.lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=redundant-move" "-Wno-error=implicit-fallthrough" ];

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
     unix/cmake/configure --prefix=$out --enable-mpg-{mmx,pthreads}
   '';
 
-  enableParallelBuilding = true;
-
   hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchurl, cmake, pkgconfig, alsaLib
+{ stdenv, fetchurl, cmake, pkgconfig, alsaLib
 , libjack2, libsndfile, fftw, curl, gcc
 , libXt, qtbase, qttools, qtwebengine
 , readline, qtwebsockets, useSCEL ? false, emacs
@@ -7,7 +7,7 @@
 let optional = stdenv.lib.optional;
 in
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "supercollider";
   version = "3.11.2";
 
@@ -25,8 +25,6 @@ mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
-
-  enableParallelBuilding = true;
 
   buildInputs = [
     gcc libjack2 libsndfile fftw curl libXt qtbase qtwebengine qtwebsockets readline ]

--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec
   nativeBuildInputs = [ unzip cmake ];
   buildInputs = [ openexr hdf5-threadsafe ];
 
-  enableParallelBuilding = true;
-
   buildPhase = ''
     cmake -DUSE_HDF5=ON -DCMAKE_INSTALL_PREFIX=$out/ -DUSE_TESTS=OFF .
 

--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation rec {
     export CUDA_PATH="${cudatoolkit}"
   '';
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     cmake
     pkgconfig

--- a/pkgs/development/libraries/audio/mbelib/default.nix
+++ b/pkgs/development/libraries/audio/mbelib/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
   preCheck = ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD

--- a/pkgs/development/libraries/avro-c++/default.nix
+++ b/pkgs/development/libraries/avro-c++/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation {
     substituteInPlace test/buffertest.cc --replace "BOOST_MESSAGE" "BOOST_TEST_MESSAGE"
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "A C++ library which implements parts of the Avro Specification";
     homepage = "https://avro.apache.org/";

--- a/pkgs/development/libraries/avro-c/default.nix
+++ b/pkgs/development/libraries/avro-c/default.nix
@@ -19,8 +19,6 @@ in stdenv.mkDerivation {
 
   buildInputs = [ jansson zlib ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A C library which implements parts of the Avro Specification";
     homepage = "https://avro.apache.org/";

--- a/pkgs/development/libraries/beignet/default.nix
+++ b/pkgs/development/libraries/beignet/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation rec {
 
   patches = [ ./clang_llvm.patch ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace /etc/OpenCL/vendors "\''${CMAKE_INSTALL_PREFIX}/etc/OpenCL/vendors"
     patchShebangs src/git_sha1.sh
@@ -65,8 +63,6 @@ stdenv.mkDerivation rec {
     preConfigure = ''
       cd utests
     '';
-
-    enableParallelBuilding = true;
 
     nativeBuildInputs = [
       cmake

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake perl go ];
-  enableParallelBuilding = true;
 
   makeFlags = [ "GOCACHE=$(TMPDIR)/go-cache" ];
 

--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation rec {
     "-DBUILD_UNIT_TESTS=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang
     "-Wno-error=argument-outside-range -Wno-error=c++11-narrowing";
 

--- a/pkgs/development/libraries/bullet/roboschool-fork.nix
+++ b/pkgs/development/libraries/bullet/roboschool-fork.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation {
     "-DBUILD_UNIT_TESTS=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A professional free 3D Game Multiphysics Library";
     longDescription = ''

--- a/pkgs/development/libraries/c-blosc/default.nix
+++ b/pkgs/development/libraries/c-blosc/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A blocking, shuffling and loss-less compression library";
     homepage = "https://www.blosc.org";

--- a/pkgs/development/libraries/cpp-hocon/default.nix
+++ b/pkgs/development/libraries/cpp-hocon/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost curl leatherman ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "A C++ port of the Typesafe Config library";

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [

--- a/pkgs/development/libraries/curlpp/default.nix
+++ b/pkgs/development/libraries/curlpp/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ curl ];
   nativeBuildInputs = [ cmake ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "https://www.curlpp.org/";

--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
     "-DUSE_DLIB_USE_CUDA=${if cudaSupport then "1" else "0"}"
     "-DUSE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}" ];
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libpng libjpeg ] ++ lib.optional guiSupport libX11;
 

--- a/pkgs/development/libraries/doctest/default.nix
+++ b/pkgs/development/libraries/doctest/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/onqtam/doctest";
     description = "The fastest feature-rich C++11/14/17/20 single-header testing framework";

--- a/pkgs/development/libraries/double-conversion/default.nix
+++ b/pkgs/development/libraries/double-conversion/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
     rm BUILD
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Binary-decimal and decimal-binary routines for IEEE doubles";
     homepage = "https://github.com/google/double-conversion";

--- a/pkgs/development/libraries/draco/default.nix
+++ b/pkgs/development/libraries/draco/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
     sha256 = "14ln4la52x38pf8syr7i5v4vd65ya4zij8zj5kgihah03cih0qcd";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/drumstick/default.nix
+++ b/pkgs/development/libraries/drumstick/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "man" ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     cmake docbook_xml_dtd_45 docbook_xml_dtd_45 docbook_xsl doxygen pkg-config wrapQtAppsHook
   ];

--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
                  "-DENABLE_ECCODES_OMP_THREADS=${if enableOpenMPThreads then "ON" else "OFF"}"
                ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
 
   # Only do tests that don't require downloading 120MB of testdata

--- a/pkgs/development/libraries/fcppt/default.nix
+++ b/pkgs/development/libraries/fcppt/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=false" "-DENABLE_BOOST=true" "-DENABLE_EXAMPLES=true" "-DENABLE_CATCH=true" "-DENABLE_TEST=true" ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Freundlich's C++ toolkit";
     longDescription = ''

--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake ];
-  enableParallelBuilding = true;
 
   cmakeFlags = [ "-DFLATBUFFERS_BUILD_TESTS=${if doCheck then "ON" else "OFF"}" ];
 

--- a/pkgs/development/libraries/freeglut/default.nix
+++ b/pkgs/development/libraries/freeglut/default.nix
@@ -23,8 +23,6 @@ in stdenv.mkDerivation {
                  "-DFREEGLUT_BUILD_STATIC:BOOL=OFF"
                ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Create and manage windows containing OpenGL contexts";
     longDescription = ''

--- a/pkgs/development/libraries/freetds/default.nix
+++ b/pkgs/development/libraries/freetds/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Libraries to natively talk to Microsoft SQL Server and Sybase databases";
     homepage    = "https://www.freetds.org";

--- a/pkgs/development/libraries/gbenchmark/default.nix
+++ b/pkgs/development/libraries/gbenchmark/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
     chmod -R u+w googletest
   '';
 
-  enableParallelBuilding = true;
   doCheck = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = stdenv.lib.optional (!stdenv.isLinux) libiconv;
 
-  enableParallelBuilding = true;
-
   doCheck = false; # hangs. or very expensive?
 
   meta = {

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
     sha256 = "0b5lsxz1xkzip7fvbicjkxvg5ig8gbhx1zrlhandqc0rpk56bvyw";
   };
 
-  enableParallelBuilding = true;
-
   propagatedBuildInputs = [ libGL ];
 
   nativeBuildInputs = [ cmake ]

--- a/pkgs/development/libraries/hotpatch/default.nix
+++ b/pkgs/development/libraries/hotpatch/default.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation rec {
     sha256 = "169vdh55wsbn6fl58lpzqx64v6ifzh7krykav33x1d9hsk98qjqh";
   };
 
-  enableParallelBuilding = true;
   doCheck = true;
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/itk/4.x.nix
+++ b/pkgs/development/libraries/itk/4.x.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
     "-DModule_ITKReview=ON"
   ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake xz ];
   buildInputs = [ libX11 libuuid vtk_7 ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 

--- a/pkgs/development/libraries/itk/default.nix
+++ b/pkgs/development/libraries/itk/default.nix
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     "-DModule_ITKReview=ON"
   ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake xz makeWrapper ];
   buildInputs = [ libX11 libuuid vtk_7 ] ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
 

--- a/pkgs/development/libraries/kmsxx/default.nix
+++ b/pkgs/development/libraries/kmsxx/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation {
     sha256 = "0xz4m9bk0naawxwpx5cy1j3cm6c8c9m5y551csk88y88x1g0z0xh";
   };
 
-  enableParallelBuilding = true;
-
   cmakeFlags = stdenv.lib.optional (!withPython) "-DKMSXX_ENABLE_PYTHON=OFF";
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ extra-cmake-modules ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     maintainers = with lib.maintainers; [ peterhoeg ];
     # The build requires at least Qt 5.14:

--- a/pkgs/development/libraries/leatherman/default.nix
+++ b/pkgs/development/libraries/leatherman/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost curl ruby ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/puppetlabs/leatherman/";
     description = "A collection of C++ and CMake utility libraries";

--- a/pkgs/development/libraries/libechonest/default.nix
+++ b/pkgs/development/libraries/libechonest/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake doxygen ];
   buildInputs = [ qt4 qjson ];
 
-  enableParallelBuilding = true;
   doCheck = false; # requires network access
 
   meta = {

--- a/pkgs/development/libraries/libgaminggear/default.nix
+++ b/pkgs/development/libraries/libgaminggear/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
     gtk2 libcanberra libnotify pcre sqlite xorg.libXdmcp xorg.libpthreadstubs
   ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DINSTALL_CMAKE_MODULESDIR=lib/cmake"
     "-DINSTALL_PKGCONFIGDIR=lib/pkgconfig"

--- a/pkgs/development/libraries/libjson-rpc-cpp/default.nix
+++ b/pkgs/development/libraries/libjson-rpc-cpp/default.nix
@@ -56,8 +56,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ jsoncpp argtable curl libmicrohttpd doxygen catch ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "C++ framework for json-rpc (json remote procedure call)";
     homepage = "https://github.com/cinemast/libjson-rpc-cpp";

--- a/pkgs/development/libraries/libktorrent/default.nix
+++ b/pkgs/development/libraries/libktorrent/default.nix
@@ -23,8 +23,6 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ gmp boost ];
 
-  enableParallelBuilding = true;
-
   passthru = {
     inherit mainVersion;
   };

--- a/pkgs/development/libraries/libnabo/default.nix
+++ b/pkgs/development/libraries/libnabo/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen boost ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DEIGEN_INCLUDE_DIR=${eigen}/include/eigen3"
   ];

--- a/pkgs/development/libraries/libnats-c/default.nix
+++ b/pkgs/development/libraries/libnats-c/default.nix
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ libsodium openssl protobuf protobufc ];
 
   separateDebugInfo = true;
-  enableParallelBuilding = true;
   outputs = [ "out" "dev" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen boost libnabo ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DEIGEN_INCLUDE_DIR=${eigen}/include/eigen3"
   ];

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -40,8 +40,6 @@ let
       substituteInPlace ./tls/tls_config.c --replace '"/etc/ssl/cert.pem"' '"${cacert}/etc/ssl/certs/ca-bundle.crt"'
     '';
 
-    enableParallelBuilding = true;
-
     outputs = [ "bin" "dev" "out" "man" "nc" ];
 
     postFixup = ''

--- a/pkgs/development/libraries/librime/default.nix
+++ b/pkgs/development/libraries/librime/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost glog leveldb marisa opencc libyamlcpp gmock ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage    = "https://rime.im/";
     description = "Rime Input Method Engine, the core library";

--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     "--with-boost=${boost.dev}"
   ];
 
-  enableParallelBuilding = true;
   doCheck = true;
   preCheck = ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD${placeholder "out"}/lib

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -28,8 +28,6 @@ let
 
     nativeBuildInputs = [ cmake pkgconfig ];
 
-    enableParallelBuilding = true;
-
     doCheck = false; # hangs, tries to access the net?
     checkInputs = [ check ];
 

--- a/pkgs/development/libraries/libunarr/default.nix
+++ b/pkgs/development/libraries/libunarr/default.nix
@@ -11,8 +11,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/selmf/unarr";
     description = "A lightweight decompression library with support for rar, tar and zip archives";

--- a/pkgs/development/libraries/libwhereami/default.nix
+++ b/pkgs/development/libraries/libwhereami/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost curl leatherman ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "Library to report hypervisor information from inside a VM";

--- a/pkgs/development/libraries/medfile/default.nix
+++ b/pkgs/development/libraries/medfile/default.nix
@@ -9,8 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "1khzclkrd1yn9mz3g14ndgpsbj8j50v8dsjarcj6kkn9zgbbazc4";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake ];
   buildInputs = [ hdf5 ];
 

--- a/pkgs/development/libraries/metal/default.nix
+++ b/pkgs/development/libraries/metal/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Single-header C++11 library designed to make you love template metaprogramming";
     homepage = "https://github.com/brunocodutra/metal";

--- a/pkgs/development/libraries/mimalloc/default.nix
+++ b/pkgs/development/libraries/mimalloc/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ninja ];
-  enableParallelBuilding = true;
   cmakeFlags = stdenv.lib.optional secureBuild [ "-DMI_SECURE=ON" ];
 
   postInstall = let

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -75,8 +75,6 @@ mkDerivation rec {
 
   CXXFLAGS = "-std=c++11";
 
-  enableParallelBuilding = true;
-
   qtWrapperArgs = [
     "--prefix FREI0R_PATH : ${frei0r}/lib/frei0r-1"
     "--prefix LADSPA_PATH : ${ladspaPlugins}/lib/ladspa"

--- a/pkgs/development/libraries/msgpack/generic.nix
+++ b/pkgs/development/libraries/msgpack/generic.nix
@@ -11,12 +11,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
-  cmakeFlags = []
-    ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
-                           "-DMSGPACK_BUILD_EXAMPLES=OFF"
-    ;
+  cmakeFlags = stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DMSGPACK_BUILD_EXAMPLES=OFF";
 
   meta = with stdenv.lib; {
     description = "MessagePack implementation for C and C++";

--- a/pkgs/development/libraries/ngt/default.nix
+++ b/pkgs/development/libraries/ngt/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   NIX_ENFORCE_NO_NATIVE=! enableAVX;
   __AVX2__ = if enableAVX then 1 else 0;
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/yahoojapan/NGT";
     description = "Nearest Neighbor Search with Neighborhood Graph and Tree for High-dimensional Data";

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DBuildTests=${if doCheck then "ON" else "OFF"}"
     "-DJSON_MultipleHeaders=ON"

--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" "man" ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     rm -rf external/Catch2
     ln -sf ${catch2.src} external/Catch2

--- a/pkgs/development/libraries/nvidia-texture-tools/default.nix
+++ b/pkgs/development/libraries/nvidia-texture-tools/default.nix
@@ -37,8 +37,6 @@ stdenv.mkDerivation rec {
     moveToOutput lib "$lib"
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "A set of cuda-enabled texture tools and compressors";
     homepage = "https://github.com/castano/nvidia-texture-tools";

--- a/pkgs/development/libraries/ogrepaged/default.nix
+++ b/pkgs/development/libraries/ogrepaged/default.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DPAGEDGEOMETRY_BUILD_SAMPLES=OFF" ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Paged Geometry for Ogre3D";
     homepage = "https://github.com/RigsOfRods/ogre-paged";

--- a/pkgs/development/libraries/opae/default.nix
+++ b/pkgs/development/libraries/opae/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [ "-DBUILD_ASE=1" ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Open Programmable Acceleration Engine SDK";

--- a/pkgs/development/libraries/openbr/default.nix
+++ b/pkgs/development/libraries/openbr/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Open Source Biometric Recognition";
     homepage = "http://openbiometrics.org/";

--- a/pkgs/development/libraries/opencollada/default.nix
+++ b/pkgs/development/libraries/opencollada/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ libxml2 pcre ];
 
-  enableParallelBuilding = true;
-
   patchPhase = ''
     patch -p1 < ${./pcre.patch}
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -245,8 +245,6 @@ stdenv.mkDerivation {
     "-DEIGEN_INCLUDE_PATH=${eigen}/include/eigen3"
   ];
 
-  enableParallelBuilding = true;
-
   postBuild = lib.optionalString enableDocs ''
     make doxygen
   '';

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -253,8 +253,6 @@ stdenv.mkDerivation {
     "-DOPENCV_SKIP_PYTHON_LOADER=ON"
   ];
 
-  enableParallelBuilding = true;
-
   postBuild = lib.optionalString enableDocs ''
     make doxygen
   '';

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -69,8 +69,6 @@ stdenv.mkDerivation rec {
     (opencvFlag "GSTREAMER" enableGStreamer)
   ];
 
-  enableParallelBuilding = true;
-
   hardeningDisable = [ "bindnow" "relro" ];
 
   # Fix pkgconfig file that gets broken with multiple outputs

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -41,8 +41,6 @@ stdenv.mkDerivation rec {
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
     ];
 
-  enableParallelBuilding = true;
-
   postInstall = "rm $out/lib/*.a";
 
   meta = {

--- a/pkgs/development/libraries/openxr-loader/default.nix
+++ b/pkgs/development/libraries/openxr-loader/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python3 ];
   buildInputs = [ libX11 libXxf86vm libXrandr vulkan-headers libGL ];
-  enableParallelBuilding = true;
 
   cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
 

--- a/pkgs/development/libraries/pangolin/default.nix
+++ b/pkgs/development/libraries/pangolin/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
 
-  enableParallelBuilding = true;
-
   # The tests use cmake's findPackage to find the installed version of
   # pangolin, which isn't what we want (or available).
   doCheck = false;

--- a/pkgs/development/libraries/partio/default.nix
+++ b/pkgs/development/libraries/partio/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ unzip cmake doxygen ];
   buildInputs = [ freeglut libGLU libGL zlib swig python xorg.libXi xorg.libXmu ];
 
-  enableParallelBuilding = true;
-
   buildPhase = ''
     make partio
 

--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
     sha256 = "1cli2rxqsk6nxp36p5mgvvahjz8hm4fb68yi8cf9nw4ygbcvcwb1";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ qhull flann boost eigen libusb1 libpcap
                   libpng vtk qtbase libXt ]

--- a/pkgs/development/libraries/physfs/default.nix
+++ b/pkgs/development/libraries/physfs/default.nix
@@ -17,8 +17,6 @@ let
     buildInputs = [ zlib ]
       ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Foundation ];
 
-    enableParallelBuilding = true;
-
     patchPhase = ''
       sed s,-Werror,, -i CMakeLists.txt
     '';

--- a/pkgs/development/libraries/physics/geant4/default.nix
+++ b/pkgs/development/libraries/physics/geant4/default.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation rec {
     "-DINVENTOR_LIBRARY_RELEASE=${coin3d}/lib/libCoin.so"
   ];
 
-  enableParallelBuilding = true;
   nativeBuildInputs =  [ cmake ];
 
   buildInputs = [ libGLU xlibsWrapper libXmu ]

--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
     "-DPOCO_UNBUNDLED=ON"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://pocoproject.org/";
     description = "Cross-platform C++ libraries with a network/internet focus";

--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake gcc ];
   buildInputs = [ boost eigen libxml2 openmpi python3 python3.pkgs.numpy ];
-  enableParallelBuilding = true;
 
   meta = {
     description = "preCICE stands for Precise Code Interaction Coupling Environment";

--- a/pkgs/development/libraries/qca2/default.nix
+++ b/pkgs/development/libraries/qca2/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl qt ]
     ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
-  enableParallelBuilding = true;
-
   # tells CMake to use this CA bundle file if it is accessible
   preConfigure = ''
     export QC_CERTSTORE_PATH=/etc/ssl/certs/ca-certificates.crt

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -356,8 +356,6 @@ stdenv.mkDerivation {
         ]
     );
 
-  enableParallelBuilding = true;
-
   postInstall =
     # Move selected outputs.
     ''

--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isAarch64;
   checkTarget = "test";
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Experimental range library for C++11/14/17";
     homepage = "https://github.com/ericniebler/range-v3";

--- a/pkgs/development/libraries/science/biology/mirtk/default.nix
+++ b/pkgs/development/libraries/science/biology/mirtk/default.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
     install -Dm644 -t "$out/share/bash-completion/completions/mirtk" share/completion/bash/mirtk
   '';
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake gtest ];
   buildInputs = [ boost eigen python vtk zlib tbb ];
 

--- a/pkgs/development/libraries/science/electronics/qcsxcad/default.nix
+++ b/pkgs/development/libraries/science/electronics/qcsxcad/default.nix
@@ -37,8 +37,6 @@ mkDerivation {
     qtbase
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Qt library for CSXCAD";
     homepage = "https://github.com/thliebig/QCSXCAD";

--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -126,7 +126,6 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = false;
-  enableParallelBuilding = true;
 
   meta = {
     homepage = "https://caffe2.ai/";

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation rec {
     "-DGTEST_DIR:PATH=${gtest.src}/googletest"
   ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
 
   checkPhase = ''

--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation {
 
   doCheck = true;
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     inherit version;
     description = "Linear Algebra PACKage";

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -53,8 +53,6 @@ stdenv.mkDerivation rec {
     python.pkgs.protobuf python.pkgs.six
   ];
 
-  enableParallelBuilding = true;
-
   outputs = [ "out" "python" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake openssh ];
   buildInputs = [ mpi gfortran blas lapack ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
 
   preConfigure = ''

--- a/pkgs/development/libraries/simgear/default.nix
+++ b/pkgs/development/libraries/simgear/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
                   libICE libSM libXt libXmu libGLU libGL boost zlib libjpeg freealut
                   openscenegraph openal expat apr curl ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Simulation construction toolkit";
     homepage = "https://gitorious.org/fg/simgear";

--- a/pkgs/development/libraries/telepathy/qt/default.nix
+++ b/pkgs/development/libraries/telepathy/qt/default.nix
@@ -20,7 +20,6 @@ in stdenv.mkDerivation rec {
   # On 0.9.7, they do not even build with QT4
   cmakeFlags = stdenv.lib.optional (!doCheck) "-DENABLE_TESTS=OFF";
 
-  enableParallelBuilding = true;
   doCheck = false; # giving up for now
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -47,8 +47,6 @@ stdenv.mkDerivation rec {
     gtest
   ];
 
-  enableParallelBuilding = true;
-
   buildInputs = [
     catch2
     zlib

--- a/pkgs/development/libraries/vc/0.7.nix
+++ b/pkgs/development/libraries/vc/0.7.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     sed -i '/OptimizeForArchitecture()/d' cmake/VcMacros.cmake
     sed -i '/AutodetectHostArchitecture()/d' print_target_architecture.cmake

--- a/pkgs/development/libraries/vc/default.nix
+++ b/pkgs/development/libraries/vc/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     sed -i '/OptimizeForArchitecture()/d' cmake/VcMacros.cmake
     sed -i '/AutodetectHostArchitecture()/d' print_target_architecture.cmake

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -31,8 +31,6 @@ in stdenv.mkDerivation rec {
             ++ stdenv.lib.optionals (stdenv.hostPlatform.system == "x86_64-linux")
                   [ "-DCMAKE_CXX_FLAGS=-fPIC" "-DCMAKE_C_FLAGS=-fPIC" ];
 
-  enableParallelBuilding = true;
-
   # fails with "./test_watersheds3d: error while loading shared libraries: libvigraimpex.so.11: cannot open shared object file: No such file or directory"
   doCheck = false;
 

--- a/pkgs/development/libraries/vmmlib/default.nix
+++ b/pkgs/development/libraries/vmmlib/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost lapack ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ Accelerate CoreGraphics CoreVideo ];
 
-  enableParallelBuilding = true;
-
   doCheck = !stdenv.isDarwin;
 
   checkTarget = "test";

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -84,8 +84,6 @@ in stdenv.mkDerivation rec {
     sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/g' ./ThirdParty/libxml2/vtklibxml2/xpath.c
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
     homepage = "https://www.vtk.org/";

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ python3 xlibsWrapper libxcb libXrandr libXext wayland ];
-  enableParallelBuilding = true;
 
   preConfigure = ''
     substituteInPlace loader/vulkan.pc.in \

--- a/pkgs/development/libraries/vxl/default.nix
+++ b/pkgs/development/libraries/vxl/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation {
     "-DCMAKE_C_FLAGS=-fPIC"
   ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "C++ Libraries for Computer Vision Research and Implementation";
     homepage = "http://vxl.sourceforge.net/";

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -17,8 +17,6 @@ let
         inherit sha256;
       };
 
-      enableParallelBuilding = true;
-
       nativeBuildInputs = [ cmake pkg-config ];
       buildInputs = [
         boost doxygen qt48Full libharu

--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -37,7 +37,6 @@ let
   buildLib = has12Bit: stdenv.mkDerivation rec {
     name = "libx265-${if has12Bit then "12" else "10"}-${version}";
     inherit src;
-    enableParallelBuilding = true;
 
     postPatch = ''
       sed -i 's/unknown/${version}/g' source/cmake/version.cmake
@@ -67,8 +66,6 @@ in
 stdenv.mkDerivation rec {
   pname = "x265";
   inherit version src;
-
-  enableParallelBuilding = true;
 
   postPatch = ''
     sed -i 's/unknown/${version}/g' source/cmake/version.cmake

--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
     sha256 = "1zs15k9crkiq7bnr4gqq53mkn3w8z9dq4nwlavmfcr5xr5gw2pw4";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.isDarwin llvmPackages.openmp;
 
   buildInputs = lib.optional cudaSupport cudatoolkit

--- a/pkgs/development/libraries/zeromq/4.x.nix
+++ b/pkgs/development/libraries/zeromq/4.x.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake asciidoc pkg-config ];
   buildInputs = [ libsodium ];
 
-  enableParallelBuilding = true;
-
   doCheck = false; # fails all the tests (ctest)
 
   cmakeFlags = stdenv.lib.optional enableDrafts "-DENABLE_DRAFTS=ON";

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -24,6 +24,5 @@ buildPythonPackage {
 
   checkInputs = [ pytest more-itertools ];
 
-  enableParallelBuilding = true;
   dontUseCmakeConfigure = true;
 }

--- a/pkgs/development/python-modules/hoomd-blue/default.nix
+++ b/pkgs/development/python-modules/hoomd-blue/default.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ python.pkgs.numpy ]
    ++ stdenv.lib.optionals withMPI [ python.pkgs.mpi4py ];
 
-  enableParallelBuilding = true;
-
   dontAddPrefix = true;
   cmakeFlags = [
        "-DENABLE_MPI=${onOffBool withMPI}"

--- a/pkgs/development/python-modules/libgpuarray/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/default.nix
@@ -63,8 +63,6 @@ buildPythonPackage rec {
     Mako
   ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [

--- a/pkgs/development/python-modules/pyside/apiextractor.nix
+++ b/pkgs/development/python-modules/pyside/apiextractor.nix
@@ -11,8 +11,6 @@ in stdenv.mkDerivation {
     sha256 = "1zj8yrxy08iv1pk38djxw3faimm226w6wmi0gm32w4yczblylwz3";
   };
 
-  enableParallelBuilding = true;
-
   outputs = [ "out" "dev" ];
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pyside/default.nix
+++ b/pkgs/development/python-modules/pyside/default.nix
@@ -11,8 +11,6 @@ buildPythonPackage rec {
     sha256 = "90f2d736e2192ac69e5a2ac798fce2b5f7bf179269daa2ec262986d488c3b0f7";
   };
 
-  enableParallelBuilding = true;
-
   outputs = [ "out" "dev" ];
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pyside/generatorrunner.nix
+++ b/pkgs/development/python-modules/pyside/generatorrunner.nix
@@ -13,8 +13,6 @@ in stdenv.mkDerivation {
     sha256 = "0vzk3cp0pfbhd921r8f1xkcz96znla39dhj074k623x9k26lj2sj";
   };
 
-  enableParallelBuilding = true;
-
   outputs = [ "out" "dev" ];
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pyside/shiboken.nix
+++ b/pkgs/development/python-modules/pyside/shiboken.nix
@@ -27,8 +27,6 @@ buildPythonPackage rec {
     sha256 = "0x2lyg52m6a0vn0665pgd1z1qrydglyfxxcggw6xzngpnngb6v5v";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake pkg-config pysideApiextractor pysideGeneratorrunner sphinx qt4 ];
 
   buildInputs = [ python libxml2 libxslt ];

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -37,8 +37,6 @@ in buildPythonPackage rec {
     ln -s ${numpy.cfg} site.cfg
   '';
 
-  enableParallelBuilding = true;
-
   checkPhase = ''
     runHook preCheck
     pushd dist

--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib curl elfutils python libiberty libopcodes ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Code coverage tester for compiled programs, Python scripts and shell scripts";
 

--- a/pkgs/development/tools/analysis/retdec/default.nix
+++ b/pkgs/development/tools/analysis/retdec/default.nix
@@ -216,8 +216,6 @@ in stdenv.mkDerivation rec {
     substituteInPlace scripts/retdec-unpacker.py --replace "'upx'" "'${upx}/bin/upx'"
   '';
 
-  enableParallelBuilding = true;
-
   doInstallCheck = true;
   installCheckPhase = ''
     ${python3.interpreter} "$out/bin/retdec-tests-runner.py"

--- a/pkgs/development/tools/analysis/snowman/default.nix
+++ b/pkgs/development/tools/analysis/snowman/default.nix
@@ -19,8 +19,6 @@ mkDerivation rec {
     export sourceRoot=$sourceRoot/src
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Native code to C/C++ decompiler";
     homepage = "http://derevenets.com/";

--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
 
   installPhase = ''

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -14,8 +14,6 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake bison flex ];
   buildInputs = [ qtbase capstone ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     homepage = "https://github.com/BoomerangDecompiler/boomerang";
     license = licenses.bsd3;

--- a/pkgs/development/tools/misc/cli11/default.nix
+++ b/pkgs/development/tools/misc/cli11/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation rec {
     sed -i '/TrueFalseTest/d' tests/CMakeLists.txt
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Command line parser for C++11";
     homepage = "https://github.com/CLIUtils/CLI11";

--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -32,9 +32,6 @@ stdenv.mkDerivation rec {
       lscpu ${util-linux}/bin/lscpu
   '';
 
-
-  enableParallelBuilding = true;
-
   postInstall = ''
     wrapProgram $out/bin/creduce --prefix PERL5LIB : "$PERL5LIB"
   '';

--- a/pkgs/development/tools/misc/kdbg/default.nix
+++ b/pkgs/development/tools/misc/kdbg/default.nix
@@ -14,9 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules makeWrapper ];
   buildInputs = [ qt5.qtbase ki18n kconfig kiconthemes kxmlgui kwindowsystem ];
 
-  enableParallelBuilding = true;
-
-
   postInstall = ''
     wrapProgram $out/bin/kdbg --prefix QT_PLUGIN_PATH : ${qtbase}/${qtbase.qtPluginPrefix}
   '';

--- a/pkgs/development/tools/misc/uncrustify/default.nix
+++ b/pkgs/development/tools/misc/uncrustify/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA";
     homepage = "http://uncrustify.sourceforge.net/";

--- a/pkgs/development/tools/rtags/default.nix
+++ b/pkgs/development/tools/rtags/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
            LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib"
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "C/C++ client-server indexer based on clang";
     homepage = "https://github.com/andersbakken/rtags";

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "00b7xgyrcb2qq63pp3cnw5q1xqx2d9rfn65lai6n6r89s1vh3vg6";
   };
-  enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake python3 ];
 

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
     # TODO: should this be in stdenv instead?
     "-DCMAKE_INSTALL_DATADIR=${placeholder "out"}/share"
   ];
-  enableParallelBuilding = true;
 
   preConfigure = with builtins; ''
     rmdir database && ln -sfv ${elemAt srcs 1} ./database

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -79,8 +79,6 @@ stdenv.mkDerivation rec {
     wayland
   ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DGLSLANG_INSTALL_DIR=${localGlslang}"
     "-DBUILD_LAYER_SUPPORT_FILES=ON"

--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation {
     "-DImageMagick_mogrify_EXECUTABLE=${imagemagick.out}/bin/mogrify"
   ];
 
-  enableParallelBuilding = true;
   dontWrapQtApps = true;
 
   postInstall = ''

--- a/pkgs/games/dhewm3/default.nix
+++ b/pkgs/games/dhewm3/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ SDL2 libGLU libGL zlib libjpeg libogg libvorbis openal curl ];
 
-  enableParallelBuilding = true;
-
   hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -146,7 +146,6 @@ let
       ln -s ${ruby}/lib/libruby-*.so $out/hack/libruby.so
     '';
 
-    enableParallelBuilding = true;
   };
 in
 

--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -79,8 +79,6 @@ stdenv.mkDerivation {
     install -D -m755 ../build/libgraphics.so $out/lib/libgraphics.so
   '';
 
-  enableParallelBuilding = true;
-
   # Breaks dfhack because of inlining.
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/games/enyo-doom/default.nix
+++ b/pkgs/games/enyo-doom/default.nix
@@ -15,8 +15,6 @@ mkDerivation rec {
 
   buildInputs = [ qtbase ];
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "https://gitlab.com/sdcofer70/enyo-doom";
     description = "Frontend for Doom engines";

--- a/pkgs/games/eternity-engine/default.nix
+++ b/pkgs/games/eternity-engine/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ libGL SDL SDL_mixer SDL_net ];
 
-  enableParallelBuilding = true;
-
   installPhase = ''
     install -Dm755 source/eternity $out/lib/eternity/eternity
     cp -r $src/base $out/lib/eternity/base

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -69,8 +69,6 @@ stdenv.mkDerivation rec {
     "--set FG_ROOT ${data}/share/FlightGear"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Flight simulator";
     maintainers = with maintainers; [ raskin ];

--- a/pkgs/games/freeorion/default.nix
+++ b/pkgs/games/freeorion/default.nix
@@ -15,15 +15,10 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-	(boost168.override { enablePython = true; })
+    (boost168.override { enablePython = true; })
     SDL2 python2 freetype openal libogg libvorbis zlib libpng libtiff libjpeg libGLU libGL glew ];
 
   nativeBuildInputs = [ cmake doxygen graphviz makeWrapper ];
-
-  enableParallelBuilding = true;
-
-  patches = [
-  ];
 
   postInstall = ''
     mkdir -p $out/fixpaths

--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -53,8 +53,6 @@ let
       zmusic
     ];
 
-    enableParallelBuilding = true;
-
     NIX_CFLAGS_LINK = "-lopenal -lfluidsynth";
 
     installPhase = ''

--- a/pkgs/games/katago/default.nix
+++ b/pkgs/games/katago/default.nix
@@ -103,8 +103,6 @@ in env.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "/run/opengl-driver/lib"
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Go engine modeled after AlphaGo Zero";
     homepage    = "https://github.com/lightvector/katago";

--- a/pkgs/games/leela-zero/default.nix
+++ b/pkgs/games/leela-zero/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Go engine modeled after AlphaGo Zero";
     homepage    = "https://github.com/gcp/leela-zero";

--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   WITH_FONTS = "NO";
   WITH_UPDATER = "NO";
 
-  enableParallelBuilding = true;
-
   installPhase =  ''
     mkdir -pv $out/lib
     cp 3rdparty/edbee-lib/edbee-lib/qslog/lib/libQsLog.so $out/lib

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -16,8 +16,6 @@ in mkDerivation rec {
   nativeBuildInputs = [ cmake file makeWrapper ];
   buildInputs = [ qtbase jdk zlib ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [ "-DMultiMC_LAYOUT=lin-system" ];
 
   postInstall = ''

--- a/pkgs/games/odamex/default.nix
+++ b/pkgs/games/odamex/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ SDL SDL_mixer SDL_net wxGTK30 ];
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "http://odamex.net/";
     description = "A client/server port for playing old-school Doom online";

--- a/pkgs/games/openclonk/default.nix
+++ b/pkgs/games/openclonk/default.nix
@@ -24,8 +24,6 @@ in stdenv.mkDerivation rec {
     ln -sv ${soundtrack_src} $out/share/games/openclonk/Music.ocg
   '';
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [

--- a/pkgs/games/openjk/default.nix
+++ b/pkgs/games/openjk/default.nix
@@ -31,7 +31,6 @@ in stdenv.mkDerivation {
   };
 
   dontAddPrefix = true;
-  enableParallelBuilding = true;
 
   nativeBuildInputs = [ makeWrapper cmake ];
   buildInputs = [ libjpeg zlib libpng libGL SDL2 ];

--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
     sha256 = "0rm32zsmxvr6b0jjihfj543skhicbw5kg6shjx312clhlm035w2x";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ boost ffmpeg_3 bullet mygui openscenegraph_ SDL2 unshield openal libXt qtbase ];
 

--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -68,8 +68,6 @@ stdenv.mkDerivation {
     "-DDOWNLOAD_TITLE_SEQUENCES=OFF"
   ];
 
-  enableParallelBuilding = true;
-
   preFixup = "ln -s $out/share/openrct2 $out/bin/data";
 
   meta = with stdenv.lib; {

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -55,8 +55,6 @@ stdenv.mkDerivation rec {
     cp $notoFont $out/share/games/openspades/Resources/
   '';
 
-  enableParallelBuilding = true;
-
   NIX_CFLAGS_LINK = "-lopenal";
 
   meta = with stdenv.lib; {

--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -24,8 +24,6 @@ let
       sha256 = "1dszbvxlh1npq4nv9s4wv4lcyfgb01k92ncxrrczsxy1dddg86pp";
     };
 
-    enableParallelBuilding = true;
-
     nativeBuildInputs = [ cmake ];
 
     buildInputs = [ SDL2 libGL curl ]

--- a/pkgs/games/quake2/yquake2/games.nix
+++ b/pkgs/games/quake2/yquake2/games.nix
@@ -37,8 +37,6 @@ let
       rev = "${lib.toUpper id}_${builtins.replaceStrings ["."] ["_"] version}";
     };
 
-    enableParallelBuilding = true;
-
     nativeBuildInputs = [ cmake ];
 
     installPhase = ''

--- a/pkgs/games/rigsofrods/default.nix
+++ b/pkgs/games/rigsofrods/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
     sha256 = "0cb1il7qm45kfhh6h6jwfpxvjlh2dmg8z1yz9kj4d6098myf2lg4";
   };
 
-  enableParallelBuilding = true;
-
   installPhase = ''
     sed -e "s@/usr/local/lib/OGRE@${ogre}/lib/OGRE@" -i ../tools/linux/binaries/plugins.cfg
     mkdir -p $out/share/rigsofrods

--- a/pkgs/games/riko4/default.nix
+++ b/pkgs/games/riko4/default.nix
@@ -15,7 +15,6 @@ let
     };
     buildInputs = [ SDL2 libGLU ];
     nativeBuildInputs = [ cmake ];
-    enableParallelBuilding = true;
 
     meta = with stdenv.lib; {
       homepage = "https://github.com/grimfang4/sdl-gpu";
@@ -56,8 +55,6 @@ stdenv.mkDerivation rec {
     EOF
     chmod +x $out/bin/riko4
   '';
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/incinirate/Riko4";

--- a/pkgs/games/solarus/default.nix
+++ b/pkgs/games/solarus/default.nix
@@ -22,8 +22,6 @@ mkDerivation rec {
     openal libmodplug libvorbis
     qtbase glm ];
 
-  enableParallelBuilding = true;
-
   preFixup = ''
     mkdir $lib/
     mv $out/lib $lib

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     wrapProgram $out/bin/springlobby \
       --prefix PATH : "${spring}/bin" \

--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation rec {
     ln -s $out/stepmania-5.1/stepmania $out/bin/stepmania
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     homepage = "https://www.stepmania.com/";
     description = "Free dance and rhythm game for Windows, Mac, and Linux";

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -76,8 +76,6 @@ in stdenv.mkDerivation rec {
     wrapProgram $out/bin/supertuxkart --set-default SUPERTUXKART_ASSETS_DIR "${assets}"
   '';
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "A Free 3D kart racing game";
     longDescription = ''

--- a/pkgs/games/the-butterfly-effect/default.nix
+++ b/pkgs/games/the-butterfly-effect/default.nix
@@ -17,7 +17,6 @@ mkDerivation rec {
     qt5.qtbase qt5.qtsvg qt5.qttranslations box2d which cmake
     gettext
   ];
-  enableParallelBuilding = true;
 
   installPhase = ''
     make DESTDIR=.. install

--- a/pkgs/games/warsow/engine.nix
+++ b/pkgs/games/warsow/engine.nix
@@ -32,8 +32,6 @@ in stdenv.mkDerivation (libs // rec {
 
   cmakeFlags = [ "-DQFUSION_GAME=Warsow" ];
 
-  enableParallelBuilding = true;
-
   installPhase = ''
     mkdir -p $out/lib
     cp -r libs $out/lib/warsow

--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DENABLE_TOOLS=${if enableTools then "ON" else "OFF"}" ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "The Battle for Wesnoth, a free, turn-based strategy game with a fantasy theme";
     longDescription = ''

--- a/pkgs/games/widelands/default.nix
+++ b/pkgs/games/widelands/default.nix
@@ -53,6 +53,4 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/applications/"
     cp -v "../debian/org.widelands.widelands.desktop" "$out/share/applications/"
   '';
-
-  enableParallelBuilding = true;
 }

--- a/pkgs/games/zandronum/default.nix
+++ b/pkgs/games/zandronum/default.nix
@@ -51,8 +51,6 @@ in stdenv.mkDerivation rec {
     then [ "-DSERVERONLY=ON" ]
     else [ "-DFMOD_LIBRARY=${fmod}/lib/libfmodex.so" ]);
 
-  enableParallelBuilding = true;
-
   hardeningDisable = [ "format" ];
 
   installPhase = ''

--- a/pkgs/games/zdoom/default.nix
+++ b/pkgs/games/zdoom/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  enableParallelBuilding = true;
-
   NIX_CFLAGS_LINK = [ "-lopenal" "-lfluidsynth" ];
 
   preConfigure = ''

--- a/pkgs/games/zdoom/zdbsp.nix
+++ b/pkgs/games/zdoom/zdbsp.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [cmake unzip];
   buildInputs = [zlib];
-  sourceRoot = ".";
-  enableParallelBuilding = true;
+
   installPhase = ''
     install -Dm755 zdbsp $out/bin/zdbsp
   '';

--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
     sha256 = "1p6fh6ah5v3qz7dxhcsixx38bxg44ypbim4m03bxk3ls5i9xslmn";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [ alsaLib glib ];

--- a/pkgs/misc/dumb/default.nix
+++ b/pkgs/misc/dumb/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "dumb";
   version = "2.0.3";
-  enableParallelBuilding = true;
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ allegro SDL2 ];
 

--- a/pkgs/misc/emulators/citra/default.nix
+++ b/pkgs/misc/emulators/citra/default.nix
@@ -11,7 +11,6 @@ mkDerivation {
     sha256 = "0c1zn1f84h4f6n6p0aqz905yvv5qpdmkj2z58yla6bfgbzabfyrj";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake ];
   buildInputs = [ SDL2 qtbase qtmultimedia boost ];
 

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -69,8 +69,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_LTO=True"
   ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     pkgconfig
     cmake

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -30,7 +30,6 @@ in stdenv.mkDerivation rec {
     sha256 = "0vv3ahk6zdx2hx5diq4jkhl289wjybqcr4lwinrkfiywb83hcabg";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkgconfig ]
   ++ lib.optional stdenv.isLinux wrapQtAppsHook;
 

--- a/pkgs/misc/emulators/emulationstation/default.nix
+++ b/pkgs/misc/emulators/emulationstation/default.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation {
     install -D ../emulationstation $out/bin/emulationstation
   '';
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "A flexible emulator front-end supporting keyboardless navigation and custom system themes";
     homepage = "https://emulationstation.org";

--- a/pkgs/misc/emulators/melonDS/default.nix
+++ b/pkgs/misc/emulators/melonDS/default.nix
@@ -21,7 +21,6 @@ mkDerivation rec {
     sha256 = "0m45m1ch0az8l3d3grjbqvi5vvydbffxwka9w3k3qiia50m7fnph";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook ];
   buildInputs = [
     SDL2

--- a/pkgs/misc/emulators/mgba/default.nix
+++ b/pkgs/misc/emulators/mgba/default.nix
@@ -24,7 +24,6 @@ in stdenv.mkDerivation rec {
     sha256 = "0nqj4bnn5c2z1bq4bnbw1wznc0wpmq4sy3w8pipd6n6620b9m4qq";
   };
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ wrapQtAppsHook pkgconfig cmake ];
 
   buildInputs = [

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -41,8 +41,6 @@ let
         --add-flags "-L $COREDIR/${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary} $@"
     '';
 
-    enableParallelBuilding = true;
-
     passthru = {
       inherit (a) core;
       libretroCore = "/lib/retroarch/cores";

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -44,8 +44,6 @@ mkDerivation {
     ++ lib.optional alsaSupport alsaLib
     ++ lib.optional waylandSupport wayland;
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";

--- a/pkgs/misc/lightspark/default.nix
+++ b/pkgs/misc/lightspark/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
     pango lzma nasm llvm glibmm
   ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Open source Flash Player implementation";
     homepage = "https://lightspark.github.io/";

--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation rec {
     sha256 = "0y4qgm2cpccrsm20rnh92hqplddqsc5q5zhw9nqn2igm3h9i0z7h";
   };
 
-  enableParallelBuilding = true;
-
   buildInputs = with llvmPackages;
     [ llvm clang-unwrapped
       kernel elfutils libelf bcc

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig gettext ];
   buildInputs = [ dbus dbus-glib libgaminggear libgudev lua ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DUDEVDIR=\${out}/lib/udev/rules.d"
     "-DCMAKE_MODULE_PATH=${libgaminggear.dev}/lib/cmake"

--- a/pkgs/servers/domoticz/default.nix
+++ b/pkgs/servers/domoticz/default.nix
@@ -41,8 +41,6 @@ stdenv.mkDerivation rec {
     cp -r ${minizip-src}/* $sourceRoot/extern/minizip
   '';
 
-  enableParallelBuilding = true;
-
   buildInputs = [
     openssl
     python3

--- a/pkgs/servers/foundationdb/cmake.nix
+++ b/pkgs/servers/foundationdb/cmake.nix
@@ -36,7 +36,6 @@ let
           ++ lib.optional useClang [ llvmPackages.lld ];
 
         separateDebugInfo = true;
-        enableParallelBuilding = true;
         dontFixCmake = true;
 
         cmakeFlags =
@@ -66,7 +65,7 @@ let
         # fix up the use of the very weird and custom 'fdb_install' command by just
         # replacing it with cmake's ordinary version.
         postPatch = ''
-          for x in bindings/c/CMakeLists.txt fdbserver/CMakeLists.txt fdbmonitor/CMakeLists.txt fdbbackup/CMakeLists.txt fdbcli/CMakeLists.txt; do 
+          for x in bindings/c/CMakeLists.txt fdbserver/CMakeLists.txt fdbmonitor/CMakeLists.txt fdbbackup/CMakeLists.txt fdbcli/CMakeLists.txt; do
             substituteInPlace $x --replace 'fdb_install' 'install'
           done
         '';

--- a/pkgs/servers/http/h2o/default.nix
+++ b/pkgs/servers/http/h2o/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "dev" "lib" ];
 
-  enableParallelBuilding = true;
   nativeBuildInputs = [ pkgconfig cmake ninja ];
   buildInputs = [ openssl libuv zlib ];
 

--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -36,8 +36,6 @@ let
       "-DASM_OPTIMIZATIONS=${if stdenv.hostPlatform.sse4_2Support then "ON" else "OFF"}"
     ];
 
-    enableParallelBuilding = true;
-
     meta = with lib; {
       homepage = "https://www.arangodb.com";
       description = "A native multi-model database with flexible data models for documents, graphs, and key-values";

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ curl openssl zlib ];
   buildInputs = [ libiconv ];
 
-  enableParallelBuilding = true;
-
   postInstall = ''
     moveToOutput bin/mariadb_config "$dev"
   '';

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -100,8 +100,6 @@ common = rec { # attributes common to both builds
     rm -r $out/share/aclocal
   '';
 
-  enableParallelBuilding = true;
-
   passthru.mysqlVersion = "5.7";
 
   passthru.tests = {

--- a/pkgs/servers/tmate-ssh-server/default.nix
+++ b/pkgs/servers/tmate-ssh-server/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libtool zlib openssl libevent ncurses ruby msgpack libssh ];
   nativeBuildInputs = [ autoreconfHook cmake pkgconfig ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage    = "https://tmate.io/";

--- a/pkgs/servers/ttyd/default.nix
+++ b/pkgs/servers/ttyd/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake xxd ];
   buildInputs = [ openssl libwebsockets json_c libuv zlib ];
-  enableParallelBuilding = true;
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -35,8 +35,6 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
-  enableParallelBuilding = true;
-
   NIX_CFLAGS_COMPILE = [ "-Wno-error=format-truncation" "-Wno-error=stringop-truncation" ];
 
   # disable dvbscan, as having it enabled causes a network download which
@@ -73,9 +71,9 @@ in stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "TV streaming server";
     longDescription = ''
-	Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android
+        Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android
         supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV, SAT>IP and HDHomeRun as input sources.
-	Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming.'';
+        Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming.'';
     homepage = "https://tvheadend.org";
     license = licenses.gpl3;
     platforms = platforms.unix;

--- a/pkgs/servers/xmpp/biboumi/default.nix
+++ b/pkgs/servers/xmpp/biboumi/default.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     cp $louiz_catch/single_include/catch.hpp tests/
   '';
 
-  enableParallelBuilding = true;
   doCheck = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/zoneminder/default.nix
+++ b/pkgs/servers/zoneminder/default.nix
@@ -159,8 +159,6 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DWITH_SYSTEMD=ON"
     "-DZM_LOGDIR=/var/log/${dirName}"

--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -196,8 +196,6 @@ let
       tee -a $out/share/fish/__fish_build_paths.fish < ${fishPreInitHooks}
     '';
 
-    enableParallelBuilding = true;
-
     meta = with lib; {
       description = "Smart and user-friendly command line shell";
       homepage = "http://fishshell.com/";

--- a/pkgs/tools/X11/nx-libs/default.nix
+++ b/pkgs/tools/X11/nx-libs/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-I${libtirpc.dev}/include/tirpc" ];
   NIX_LDFLAGS = [ "-ltirpc" ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     patchShebangs .
     find . -type f -name Makefile -exec sed -i 's|^\(SHELL:=\)/bin/bash$|\1${stdenv.shell}|g' {} \;

--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
       --replace "LD_PRELOAD=libgefaker" "LD_PRELOAD=$out/lib/libgefaker"
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "http://www.virtualgl.org/";
     description = "X11 GL rendering in a remote computer with full 3D hw acceleration";

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -93,8 +93,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = xorg.xorgserver.propagatedBuildInputs;
 
-  enableParallelBuilding = true;
-
   meta = {
     homepage = "https://tigervnc.org/";
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/tools/archivers/innoextract/default.nix
+++ b/pkgs/tools/archivers/innoextract/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper ];
 
-  enableParallelBuilding = true;
-
   # we need unar to for multi-archive extraction
   postFixup = stdenv.lib.optionalString withGog ''
     wrapProgram $out/bin/innoextract \

--- a/pkgs/tools/backup/httrack/qt.nix
+++ b/pkgs/tools/backup/httrack/qt.nix
@@ -14,8 +14,6 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
 
-  enableParallelBuilding = true;
-
   prePatch = ''
     substituteInPlace cmake/HTTRAQTFindHttrack.cmake \
       --replace /usr/include/httrack/ ${httrack}/include/httrack/

--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
     cp $src/src/zopfli/*.h $dev/include/
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "Very good, but slow, deflate or zlib compression";

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -195,8 +195,6 @@ in rec {
       test -f $out/bin/ceph-volume
     '';
 
-    enableParallelBuilding = true;
-
     outputs = [ "out" "lib" "dev" "doc" "man" ];
 
     doCheck = false; # uses pip to install things from the internet

--- a/pkgs/tools/filesystems/cryfs/default.nix
+++ b/pkgs/tools/filesystems/cryfs/default.nix
@@ -48,8 +48,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost cryptopp curl fuse openssl ];
 
-  enableParallelBuilding = true;
-
   cmakeFlags = [
     "-DCRYFS_UPDATE_CHECKS:BOOL=FALSE"
     "-DBoost_USE_STATIC_LIBS:BOOL=FALSE" # this option is case sensitive

--- a/pkgs/tools/filesystems/encfs/default.nix
+++ b/pkgs/tools/filesystems/encfs/default.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
       "-DINSTALL_LIBENCFS=ON"
     ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "An encrypted filesystem in user-space via FUSE";
     homepage = "https://vgough.github.io/encfs";

--- a/pkgs/tools/filesystems/securefs/default.nix
+++ b/pkgs/tools/filesystems/securefs/default.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ fuse ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
     description = "Transparent encryption filesystem";

--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -47,7 +47,6 @@ in stdenv.mkDerivation rec {
       "-DUSE_SSE=ON"
       "-DUSE_SSE42=ON"
   ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Open source, physically-based global illumination rendering engine";

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -61,8 +61,6 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  enableParallelBuilding = true;
-
   # Same as vulkan-validation-layers
   libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
   dontPatchELF = true;

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ python3 vulkan-headers vulkan-loader xlibsWrapper libxcb libXrandr wayland ];
-  enableParallelBuilding = true;
 
   libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation rec {
        --replace ${fcitx} $out
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     isFcitxEngine = true;
     homepage      = "https://github.com/fcitx/fcitx-rime";

--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -14,8 +14,6 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake qttools qtsvg ];
   buildInputs = [ qtbase ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";
     homepage = "https://github.com/flameshot-org/flameshot";

--- a/pkgs/tools/misc/fltrdr/default.nix
+++ b/pkgs/tools/misc/fltrdr/default.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ icu openssl ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://octobanana.com/software/fltrdr";
     description = "A TUI text reader for the terminal";

--- a/pkgs/tools/misc/heimdall/default.nix
+++ b/pkgs/tools/misc/heimdall/default.nix
@@ -39,8 +39,6 @@ mkDerivation {
     install -m644 ../OSX/README.txt $out/share/doc/heimdall/README.osx
   '';
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage    = "http://www.glassechidna.com.au/products/heimdall/";
     description = "A cross-platform tool suite to flash firmware onto Samsung Galaxy S devices";

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -15,8 +15,6 @@ in mkDerivation rec {
     sha256 = "0jhggb4xksb0k0mj752n6pz0xmccnbzlp984xydqbz3hkigra1si";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook wrapQtAppsHook ];
 
   # refer to kpmcore for the use of eject

--- a/pkgs/tools/misc/tmate/default.nix
+++ b/pkgs/tools/misc/tmate/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libtool zlib openssl libevent ncurses ruby msgpack libssh ];
   nativeBuildInputs = [ autoreconfHook cmake pkgconfig ];
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage    = "https://tmate.io/";

--- a/pkgs/tools/networking/pcapc/default.nix
+++ b/pkgs/tools/networking/pcapc/default.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  enableParallelBuilding = true;
-
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/pingtcp/default.nix
+++ b/pkgs/tools/networking/pingtcp/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
   doCheck = false;
 
   postInstall = ''

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation rec {
     "-DUSE_NLS=${if withNLS then "ON" else "OFF"}"
   ];
 
-  enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Command-line package management tools used on Debian-based systems";
     homepage = "https://salsa.debian.org/apt-team/apt";

--- a/pkgs/tools/package-management/packagekit/qt.nix
+++ b/pkgs/tools/package-management/packagekit/qt.nix
@@ -16,8 +16,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 
-  enableParallelBuilding = true;
-
   meta = packagekit.meta // {
     description = "System to facilitate installing and updating packages - Qt";
   };

--- a/pkgs/tools/security/haka/default.nix
+++ b/pkgs/tools/security/haka/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ swig wireshark check rsync libpcap gawk libedit pcre ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "A collection of tools that allows capturing TCP/IP packets and filtering them based on Lua policy files";
     homepage = "http://www.haka-security.org/";

--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
     bash-completion curl openssl libxml2 libxslt
   ];
 
-  enableParallelBuilding = true;
-
   installTargets = [ "install" "install-doc" ];
 
   postInstall = ''

--- a/pkgs/tools/security/nmap/qt.nix
+++ b/pkgs/tools/security/nmap/qt.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase qtscript qtwebengine ];
 
-  enableParallelBuilding = true;
-
   postPatch = ''
     substituteInPlace src/platform/digmanager.cpp \
       --replace '"dig"' '"${dnsutils}/bin/dig"'

--- a/pkgs/tools/system/facter/default.nix
+++ b/pkgs/tools/system/facter/default.nix
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost cpp-hocon curl leatherman libwhereami libyamlcpp openssl ruby util-linux ];
 
-  enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     homepage = "https://github.com/puppetlabs/facter";
     description = "A system inventory tool";


### PR DESCRIPTION
##### Motivation for this change
`cmake` in `nativeBuildInputs` already sets `enableParallelBuilding` to true.

Checked files

```ShellSession
$ ag -l "cmake" | xargs ag -l "enableParallelBuilding = true" > check.txt && wc -l check.txt
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
