### PR TITLE
ocamlPackages.bitstring: 3.1.1 → 4.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -2,6 +2,7 @@
 , ocaml, findlib, ocamlbuild, ocaml_oasis,
  bitstring, camlzip, cmdliner, core_kernel, ezjsonm, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm, frontc, ounit, ppx_jane, parsexp,
  utop, libxml2,
+ ppx_bitstring,
  ppx_tools_versioned,
  which, makeWrapper, writeText
 , z3
@@ -40,7 +41,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which makeWrapper ];
 
   buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis
-                  llvm ppx_tools_versioned
+                  llvm ppx_bitstring ppx_tools_versioned
                   z3
                   utop libxml2 ];
 
@@ -62,6 +63,10 @@ stdenv.mkDerivation rec {
   disableIda = "--disable-ida";
 
   patches = [ ./dont-add-curses.patch ];
+
+  preConfigure = ''
+    substituteInPlace oasis/elf --replace bitstring.ppx ppx_bitstring
+  '';
 
   configureFlags = [ "--enable-everything ${disableIda}" "--with-llvm-config=${llvm}/bin/llvm-config" ];
 

--- a/pkgs/development/ocaml-modules/bitstring/default.nix
+++ b/pkgs/development/ocaml-modules/bitstring/default.nix
@@ -1,20 +1,21 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, ppx_tools_versioned, ounit }:
+{ lib, fetchFromGitHub, buildDunePackage, stdlib-shims }:
 
 buildDunePackage rec {
   pname = "bitstring";
-  version = "3.1.1";
+  version = "4.0.1";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "xguerin";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ys8xx174jf8v5sm0lbxvzhdlcs5p0fhy1gvf58gad2g4gvgpvxc";
+    sha256 = "1z7jmgljvp52lvn3ml2cp6gssxqp4sikwyjf6ym97cycbcw0fjjm";
   };
 
-  buildInputs = [ ppx_tools_versioned ounit ];
-  doCheck = true;
+  propagatedBuildInputs = [ stdlib-shims ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "This library adds Erlang-style bitstrings and matching over bitstrings as a syntax extension and library for OCaml";
     homepage = "https://github.com/xguerin/bitstring";
     license = licenses.lgpl21Plus;

--- a/pkgs/development/ocaml-modules/bitstring/ppx.nix
+++ b/pkgs/development/ocaml-modules/bitstring/ppx.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage, ocaml
+, bitstring, ppxlib
+, ounit
+}:
+
+buildDunePackage rec {
+  pname = "ppx_bitstring";
+  inherit (bitstring) version useDune2 src;
+
+  buildInputs = [ bitstring ppxlib ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  checkInputs = [ ounit ];
+
+  meta = bitstring.meta // {
+    description = "Bitstrings and bitstring matching for OCaml - PPX extension";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -846,6 +846,8 @@ let
 
     posix-types = callPackage ../development/ocaml-modules/posix/types.nix { };
 
+    ppx_bitstring = callPackage ../development/ocaml-modules/bitstring/ppx.nix { };
+
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };
 
     ppxlib = callPackage ../development/ocaml-modules/ppxlib { };


### PR DESCRIPTION
###### Motivation for this change

Port to `ppxlib`.
Use Dune 2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
