### PR TITLE
python3Packages.aiosqlite: 0.12.0 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/aiosqlite/default.nix
+++ b/pkgs/development/python-modules/aiosqlite/default.nix
@@ -1,31 +1,30 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, setuptools
 , aiounittest
+, buildPythonPackage
+, fetchPypi
 , isPy27
-, pytest
+, pytestCheckHook
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "aiosqlite";
-  version = "0.12.0";
+  version = "0.16.0";
   disabled = isPy27;
 
-  src = fetchFromGitHub {
-    owner = "jreese";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "090vdv210zfry0bms5b3lmm06yhiyjb8ga96996cqs611l7c2a2j";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1a0fjmlvadyzsml10g5p1qif7192k0swy5zwjp8v48y5zc3yy56h";
   };
-
-  buildInputs = [
-    setuptools
-  ];
 
   checkInputs = [
     aiounittest
+    pytestCheckHook
+    typing-extensions
   ];
+
+  # tests are not pick-up automatically by the hook
+  pytestFlagsArray = [ "aiosqlite/tests/*.py" ];
 
   meta = with lib; {
     description = "Asyncio bridge to the standard sqlite3 module";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump to latest upstream release 0.16.0

Upstream switched to poetry thus the switch to the PyPI release.

Change log: https://github.com/omnilib/aiosqlite/blob/main/CHANGELOG.md#v0160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
