### PR TITLE
imv: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -18,20 +18,30 @@
 , pkgconfig
 , stdenv
 , wayland
+, meson
+, ninja
+, inih
 }:
 
 stdenv.mkDerivation rec {
   pname = "imv";
-  version = "4.1.0";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "eXeC64";
     repo = "imv";
     rev = "v${version}";
-    sha256 = "0gk8g178i961nn3bls75a8qpv6wvfvav6hd9lxca1skaikd33zdx";
+    sha256 = "07pcpppmfvvj0czfvp1cyq03ha0jdj4whl13lzvw37q3vpxs5qqh";
   };
 
-  nativeBuildInputs = [ asciidoc cmocka docbook_xsl libxslt ];
+  nativeBuildInputs = [
+    asciidoc
+    cmocka
+    docbook_xsl
+    libxslt
+    meson
+    ninja
+  ];
 
   buildInputs = [
     freeimage
@@ -44,11 +54,11 @@ stdenv.mkDerivation rec {
     pango
     pkgconfig
     wayland
+    inih
+    libtiff
+    libheif
+    libpng
   ];
-
-  installFlags = [ "PREFIX=$(out)" "CONFIGPREFIX=$(out)/etc" ];
-
-  makeFlags = [ "BACKEND_LIBJPEG=yes" "BACKEND_LIBNSGIF=yes" ];
 
   postFixup = ''
     # The `bin/imv` script assumes imv-wayland or imv-x11 in PATH,

--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -64,8 +64,9 @@ stdenv.mkDerivation rec {
     # The `bin/imv` script assumes imv-wayland or imv-x11 in PATH,
     # so we have to fix those to the binaries we installed into the /nix/store
 
-    sed -i "s|\bimv-wayland\b|$out/bin/imv-wayland|" $out/bin/imv
-    sed -i "s|\bimv-x11\b|$out/bin/imv-x11|" $out/bin/imv
+    substituteInPlace "$out/bin/imv" \
+      --replace "imv-wayland" "$out/bin/imv-wayland" \
+      --replace "imv-x11" "$out/bin/imv-x11"
   '';
 
   doCheck = true;


### PR DESCRIPTION
* switch build system to meson
* enable all backends by default

Open questions:

* imv prints a warning from the tiff backend everytime a non tiff file
  is opened: Is this normal? Seems harmless enough though.
* ~~Should we make backends configurable / optional? I readded some
  backends which apparently were removed, but still given as an argument
  to the derivation.~~

Resolves #108185.

cc @markus1189 @rnhmjoj 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (**only wayland**)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
