### PR TITLE
buildLuaPackage: pass propagatedBuildInputs to final derivation

### DIFF
--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -1,11 +1,14 @@
 { lua, writeText, toLuaModule }:
 
-{ disabled ? false, ... } @ attrs:
+{ disabled ? false
+, propagatedBuildInputs ? [ ]
+, ...
+} @ attrs:
 
 if disabled then
   throw "${attrs.name} not supported by interpreter lua-${lua.luaversion}"
 else
-  toLuaModule( lua.stdenv.mkDerivation (
+  toLuaModule (lua.stdenv.mkDerivation (
     {
       makeFlags = [
         "PREFIX=$(out)"
@@ -18,8 +21,8 @@ else
     //
     {
       name = "lua${lua.luaversion}-" + attrs.name;
-      propagatedBuildInputs = [
+      propagatedBuildInputs = propagatedBuildInputs ++ [
         lua # propagate it for its setup-hook
       ];
     }
-  ) )
+  ))


### PR DESCRIPTION
###### Motivation for this change

propagatedBuildInputs got completely overridden in the process

cc @teto 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
