### PR TITLE
python3Packages.aiomultiprocess: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/aiomultiprocess/default.nix
+++ b/pkgs/development/python-modules/aiomultiprocess/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aiomultiprocess";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "omnilib";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vkj1vgvlv828pi3sn0hjzdy9f0j63gljs2ylibbsaixa7mbkpvy";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [ "aiomultiprocess/tests/*.py" ];
+  pythonImportsCheck = [ "aiomultiprocess" ];
+
+  meta = with lib; {
+    description = "Python module to improve performance";
+    longDescription = ''
+      aiomultiprocess presents a simple interface, while running a full
+      AsyncIO event loop on each child process, enabling levels of
+      concurrency never before seen in a Python application. Each child
+      process can execute multiple coroutines at once, limited only by
+      the workload and number of cores available.
+    '';
+    homepage = "https://github.com/omnilib/aiomultiprocess";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -237,6 +237,8 @@ in {
 
   aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };
 
+  aiomultiprocess = callPackage ../development/python-modules/aiomultiprocess { };
+
   aiomysql = callPackage ../development/python-modules/aiomysql { };
 
   aionotify = callPackage ../development/python-modules/aionotify { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
aiomultiprocess presents a simple interface, while running a full
AsyncIO event loop on each child process, enabling levels of
concurrency never before seen in a Python application. Each child
process can execute multiple coroutines at once, limited only by
the workload and number of cores available.

https://github.com/omnilib/aiomultiprocess

This will be needed for an update of the `theHarvester` package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
