### PR TITLE
pinnwand: use poetry-core instead of poetry

### DIFF
--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3, fetchFromGitHub, nixosTests }:
+{ lib, python3, fetchFromGitHub, nixosTests, fetchpatch }:
 
 let
   python = python3.override {
@@ -25,7 +25,7 @@ in with python.pkgs; buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    poetry
+    poetry-core
   ];
 
   propagatedBuildInputs = [
@@ -42,6 +42,14 @@ in with python.pkgs; buildPythonApplication rec {
   checkPhase = ''
     pytest
   '';
+
+  patches = [
+    # Use poetry-core instead of poetry. Fixed in 1.2.3
+    (fetchpatch {
+      url = "https://github.com/supakeen/pinnwand/commit/38ff5729c59abb97e4b416d3ca66466528b0eac7.patch";
+      sha256 = "F3cZe29z/7glmS3KWzcfmZnhYmC0LrLLS0zHk7WS2rQ=";
+    })
+  ];
 
   passthru.tests = nixosTests.pinnwand;
 


### PR DESCRIPTION
to reduce build-time closure

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
