### PR TITLE
nitrokey-app: 1.3.2 -> 1.4.2

### DIFF
--- a/nixos/modules/hardware/nitrokey.nix
+++ b/nixos/modules/hardware/nitrokey.nix
@@ -19,23 +19,9 @@ in
         nitrokey-app package, depending on your device and needs.
       '';
     };
-
-    group = mkOption {
-      type = types.str;
-      default = "nitrokey";
-      example = "wheel";
-      description = ''
-        Grant access to Nitrokey devices to users in this group.
-      '';
-    };
   };
 
   config = mkIf cfg.enable {
-    services.udev.packages = [
-      (pkgs.nitrokey-udev-rules.override (attrs:
-        { inherit (cfg) group; }
-      ))
-    ];
-    users.groups.${cfg.group} = {};
+    services.udev.packages = [ pkgs.nitrokey-udev-rules ];
   };
 }

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -3,20 +3,15 @@
 
 stdenv.mkDerivation rec {
   pname = "nitrokey-app";
-  version = "1.3.2";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-app";
     rev = "v${version}";
-    sha256 = "193kzlz3qn9il56h78faiqkgv749hdils1nn1iw6g3wphgx5fjs2";
+    sha256 = "1k0w921hfrya4q2r7bqn7kgmwvwb7c15k9ymlbnksmfc9yyjyfcv";
     fetchSubmodules = true;
   };
-
-  postPatch = ''
-    substituteInPlace libnitrokey/CMakeLists.txt \
-      --replace '/data/41-nitrokey.rules' '/libnitrokey/data/41-nitrokey.rules'
-  '';
 
   buildInputs = [
     bash-completion

--- a/pkgs/tools/security/nitrokey-app/udev-rules.nix
+++ b/pkgs/tools/security/nitrokey-app/udev-rules.nix
@@ -1,6 +1,5 @@
-{ lib, stdenv, nitrokey-app
-, group ? "nitrokey"
-}:
+{ lib, stdenv, nitrokey-app }:
+
 
 stdenv.mkDerivation {
   name = "nitrokey-udev-rules-${lib.getVersion nitrokey-app}";
@@ -8,10 +7,6 @@ stdenv.mkDerivation {
   inherit (nitrokey-app) src;
 
   dontBuild = true;
-
-  patchPhase = ''
-    substituteInPlace libnitrokey/data/41-nitrokey.rules --replace plugdev "${group}"
-  '';
 
   installPhase = ''
     mkdir -p $out/etc/udev/rules.d


### PR DESCRIPTION
The option group was removed because it is no longer used in the
udev-rules that come with the libnitrokey.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
