### PR TITLE
clojure-lsp: 20201228T020543 -> 2021.01.03-00.42.23

### DIFF
--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "clojure-lsp";
-  version = "20201228T020543";
+  version = "2021.01.03-00.42.23";
 
   src = fetchurl {
-    url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/release-${version}/${pname}.jar";
-    sha256 = "0jkpw7dx7976p63c08bp43fiwk6f2h2nxj9vv1zr103hgywpplri";
+    url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${version}/${pname}.jar";
+    sha256 = "06h69hwm3kl1nr94l43j91pnvkzgnacsg6a6cly4abrg041qhbv3";
   };
 
   dontUnpack = true;
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm644 $src $out/share/java/${pname}.jar
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
-      --add-flags "-jar $out/share/java/${pname}.jar" \
       --add-flags "-Xmx2g" \
-      --add-flags "-server"
+      --add-flags "-server" \
+      --add-flags "-jar $out/share/java/${pname}.jar"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
- Fix clojure-lsp that is broken ATM passing JVM args as the program args
- Bump to the latest version following its new version pattern

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
