### PR TITLE
solanum: use older autoreconfHook & support parallel building

### DIFF
--- a/pkgs/servers/irc/solanum/default.nix
+++ b/pkgs/servers/irc/solanum/default.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
 
   doCheck = !stdenv.isDarwin;
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     description = "An IRCd for unified networks";
     homepage = "https://github.com/solanum-ircd/solanum";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8029,7 +8029,9 @@ in
 
   solaar = callPackage ../applications/misc/solaar {};
 
-  solanum = callPackage ../servers/irc/solanum {};
+  solanum = callPackage ../servers/irc/solanum {
+    autoreconfHook = buildPackages.autoreconfHook269;
+  };
 
   sourceHighlight = callPackage ../tools/text/source-highlight { };
 


### PR DESCRIPTION

###### Motivation for this change

This enables parallel building and fixes the build by using an older version of autoreconfHook that was recently updated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS


@mweinelt @SuperSandro2000 how did you initially test this package? When I try to run it just segfaults:

```console
$ result/bin/solanum -foreground -logfile test -conftest
WARNING: Unable to access logfile test - access to parent directory . failed: Permission denied
[1]    3586 segmentation fault (core dumped)  result/bin/solanum -foreground -logfile test -conftest
$ coredumpctl debug
           PID: 3586 (solanum)
           UID: 1000 (andi)
           GID: 100 (users)
        Signal: 11 (SEGV)
     Timestamp: Sun 2021-01-03 17:03:59 CET (6s ago)
  Command Line: result/bin/solanum -foreground -logfile test -conftest
    Executable: /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/bin/solanum
 Control Group: /user.slice/user-1000.slice/session-1.scope
          Unit: session-1.scope
         Slice: user-1000.slice
       Session: 1
     Owner UID: 1000 (andi)
       Boot ID: 82040828410e48608793725130070687
    Machine ID: 7e0c1f9fca0c4fe3bff4f6cd5ff739a9
      Hostname: wrt
       Storage: /var/lib/systemd/coredump/core.solanum.1000.82040828410e48608793725130070687.3586.1609689839000000.lz4
       Message: Process 3586 (solanum) of user 1000 dumped core.

GNU gdb (GDB) 10.1
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-unknown-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:45: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if sys.version_info.major is 3:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:5792: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 2:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:5794: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:5803: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 2:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:5805: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:5814: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 2:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/peda.py:5816: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/lib/shellcode.py:24: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if sys.version_info.major is 3:
/nix/store/995m2mixdlx60g5hgq7vabryvw9d1796-source/lib/shellcode.py:379: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if pyversion is 3:
Reading symbols from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/bin/solanum...
(No debugging symbols found in /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/bin/solanum)
[New LWP 3586]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/nix/store/1yvpgm763b3hvg8q4fzpzmflr5674x4j-glibc-2.32-10/lib/libthread_db.so.1".
Core was generated by `result/bin/solanum -foreground -logfile test -conftest'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f44acba8da7 in call_hook () from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/lib/libircd.so
gdb-peda$ bt
#0  0x00007f44acba8da7 in call_hook () from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/lib/libircd.so
#1  0x00007f44acbc6d12 in sendto_realops_snomask () from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/lib/libircd.so
#2  0x00007f44acbaf35b in verify_logfile_access () from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/lib/libircd.so
#3  0x00007f44acbaf3e0 in init_main_logfile () from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/lib/libircd.so
#4  0x00007f44acbaab54 in solanum_main () from /nix/store/aznrjkf4kl1qbnzpkvqpclv4jljijy7a-solanum-unstable-2020-12-14/lib/libircd.so
#5  0x00007f44ac5c9dbd in __libc_start_main () from /nix/store/rqrklqsvw4ydpcg5kdcvn506fhcbqxk2-glibc-2.32-10/lib/libc.so.6
#6  0x000000000040107a in _start ()
gdb-peda$ quit
```