### PR TITLE
kirigami2: Add qtgraphicaleffects to buildInputs

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kirigami2.nix
+++ b/pkgs/development/libraries/kde-frameworks/kirigami2.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, extra-cmake-modules, qtbase, qtquickcontrols2, qttranslations }:
+{ mkDerivation, extra-cmake-modules, qtbase, qtquickcontrols2, qttranslations, qtgraphicaleffects }:
 
 mkDerivation {
   name = "kirigami2";
@@ -6,6 +6,6 @@ mkDerivation {
     broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ qtbase qtquickcontrols2 qttranslations ];
+  buildInputs = [ qtbase qtquickcontrols2 qttranslations qtgraphicaleffects ];
   outputs = [ "out" "dev" ];
 }


### PR DESCRIPTION
###### Motivation for this change

Many of Kirigami's components require qtgraphicaleffects, so it doesn't
make sense to rely on the packages using kirigami supplying
the dependency.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
