### PR TITLE
laminar: 0.8 -> 1.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/laminar/default.nix
+++ b/pkgs/development/tools/continuous-integration/laminar/default.nix
@@ -8,18 +8,16 @@
 , zlib
 , rapidjson
 , pandoc
-, enableSystemd ? false
-, customConfig ? null
 }:
 let
   js.vue = fetchurl {
-    url = "https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js";
-    sha256 = "01zklp5cyik65dfn64m8h2y2dxzgbyzgmbf99y7fwgnf0155r7pq";
+    url = "https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js";
+    sha256 = "1hm5kci2g6n5ikrvp1kpkkdzimjgylv1xicg2vnkbvd9rb56qa99";
   };
   js.vue-router = fetchurl {
     url =
-      "https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.7.0/vue-router.min.js";
-    sha256 = "07gx7znb30rk1z7w6ca7dlfjp44q12bbq6jghwfm27mf6psa80as";
+      "https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.4.8/vue-router.min.js";
+    sha256 = "0418waib896ywwxkxliip75zp94k3s9wld51afrqrcq70axld0c9";
   };
   js.ansi_up = fetchurl {
     url = "https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js";
@@ -29,17 +27,12 @@ let
     url = "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js";
     sha256 = "1jh4h12qchsba03dx03mrvs4r8g9qfjn56xm56jqzgqf7r209xq9";
   };
-  css.bootstrap = fetchurl {
-    url =
-      "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css";
-    sha256 = "11vx860prsx7wsy8b0yrrk04ih8kvrxkk8l16snsc4n286bdkyri";
-  };
 in stdenv.mkDerivation rec {
   name = "laminar";
-  version = "0.8";
+  version = "1.0";
   src = fetchurl {
     url = "https://github.com/ohwgiles/laminar/archive/${version}.tar.gz";
-    sha256 = "05g73j3vpib47kr7mackcazf7s6bc3xwz4h6k7sp7yb5ng7gj20g";
+    sha256 = "11m6h3rdmj2rsmsryy7r40gqccj4gg1cnqwy6blscs87gx4s423g";
   };
   patches = [ ./patches/no-network.patch ];
   nativeBuildInputs = [ cmake pandoc ];
@@ -50,31 +43,23 @@ in stdenv.mkDerivation rec {
     cp  ${js.vue-router}  js/vue-router.min.js
     cp  ${js.ansi_up}     js/ansi_up.js
     cp  ${js.Chart}       js/Chart.min.js
-    cp  ${css.bootstrap}  css/bootstrap.min.css
   '';
+
   postInstall = ''
-    mv $out/usr/share $out
-    mkdir $out/bin
-    mv $out/usr/{bin,sbin}/* $out/bin
-    rmdir $out/usr/{bin,sbin}
-    rmdir $out/usr
+    mv $out/usr/share/* $out/share/
+    rmdir $out/usr/share $out/usr
 
     mkdir -p $out/share/doc/laminar
     pandoc -s ../UserManual.md -o $out/share/doc/laminar/UserManual.html
-  '' + lib.optionalString (customConfig != null) ''
-    cp ${customConfig} /etc/etc/laminar.conf
-  '' + (if enableSystemd then ''
-    sed -i "s,/etc/,$out/etc/," $out/lib/systemd/system/laminar.service
-    sed -i "s,/usr/sbin/,$out/bin/," $out/lib/systemd/system/laminar.service
-  '' else ''
-    rm -r $out/lib # it contains only systemd unit file
-  '');
+    rm -rf $out/lib # remove upstream systemd units
+    rm -rf $out/etc # remove upstream config file
+  '';
 
   meta = with lib; {
     description = "Lightweight and modular continuous integration service";
     homepage = "https://laminar.ohwg.net";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ kaction ];
+    maintainers = with maintainers; [ kaction maralorn ];
   };
 }

--- a/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
+++ b/pkgs/development/tools/continuous-integration/laminar/patches/no-network.patch
@@ -6,21 +6,36 @@ put into correct location before build phase starts.
 
 --- laminar-0.8/CMakeLists.txt
 +++ laminar-0.8-new/CMakeLists.txt
-@@ -69,17 +69,6 @@
+@@ -82,15 +82,6 @@
      COMMAND sh -c '( echo -n "\\#define INDEX_HTML_UNCOMPRESSED_SIZE " && wc -c < "${CMAKE_SOURCE_DIR}/src/resources/index.html" ) > index_html_size.h'
      DEPENDS src/resources/index.html)
  
 -# Download 3rd-party frontend JS libs...
--file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js
--        js/vue.min.js EXPECTED_MD5 ae2fca1cfa0e31377819b1b0ffef704c)
--file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.7.0/vue-router.min.js
--        js/vue-router.min.js EXPECTED_MD5 5d3e35710dbe02de78c39e3e439b8d4e)
+-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js
+-	js/vue.min.js EXPECTED_MD5 fb192338844efe86ec759a40152fcb8e)
+-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.4.8/vue-router.min.js
+-	js/vue-router.min.js EXPECTED_MD5 5f51d4dbbf68fd6725956a5a2b865f3b)
 -file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js
 -        js/ansi_up.js EXPECTED_MD5 158566dc1ff8f2804de972f7e841e2f6)
 -file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js
 -        js/Chart.min.js EXPECTED_MD5 f6c8efa65711e0cbbc99ba72997ecd0e)
--file(DOWNLOAD https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css
--        css/bootstrap.min.css EXPECTED_MD5 5d5357cb3704e1f43a1f5bfed2aebf42)
  # ...and compile them
  generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue-router.min.js js/vue.min.js
-     js/ansi_up.js js/Chart.min.js css/bootstrap.min.css)
+     js/ansi_up.js js/Chart.min.js)
+@@ -141,12 +132,12 @@
+     target_link_libraries(laminar-tests ${GTEST_LIBRARY} capnp-rpc capnp kj-http kj-async kj pthread sqlite3 z)
+ endif()
+ 
+-set(SYSTEMD_UNITDIR /lib/systemd/system CACHE PATH "Path to systemd unit files")
+-set(BASH_COMPLETIONS_DIR /usr/share/bash-completion/completions CACHE PATH "Path to bash completions directory")
+-set(ZSH_COMPLETIONS_DIR /usr/share/zsh/site-functions CACHE PATH "Path to zsh completions directory")
++set(SYSTEMD_UNITDIR lib/systemd/system CACHE PATH "Path to systemd unit files")
++set(BASH_COMPLETIONS_DIR usr/share/bash-completion/completions CACHE PATH "Path to bash completions directory")
++set(ZSH_COMPLETIONS_DIR usr/share/zsh/site-functions CACHE PATH "Path to zsh completions directory")
+ install(TARGETS laminard RUNTIME DESTINATION sbin)
+ install(TARGETS laminarc RUNTIME DESTINATION bin)
+-install(FILES etc/laminar.conf DESTINATION /etc)
++install(FILES etc/laminar.conf DESTINATION etc)
+ install(FILES etc/laminarc-completion.bash DESTINATION ${BASH_COMPLETIONS_DIR} RENAME laminarc)
+ install(FILES etc/laminarc-completion.zsh DESTINATION ${ZSH_COMPLETIONS_DIR} RENAME _laminarc)
+ 


### PR DESCRIPTION
Bumped version and updated javascript dependencies.
Had to modify the no-network patch as well because of the changed
javascript libs.

Upstream changed the handling CMAKE_INSTALL_PREFIX in
https://github.com/ohwgiles/laminar/commit/1bb545e3f95178aa024f791f6e01510c9d421440
so I decided to patch around that as well.

@andir told me that an enableSystemd option is not necessary. The
systemd files wouldn‘t be installed without user intervention anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).