### PR TITLE
nixos/redis: add test for unix socket access

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -11,6 +11,7 @@ let
     port ${toString cfg.port}
     ${condOption "bind" cfg.bind}
     ${condOption "unixsocket" cfg.unixSocket}
+    unixsocketperm 770
     daemonize no
     supervised systemd
     loglevel ${cfg.logLevel}

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -11,7 +11,7 @@ let
     port ${toString cfg.port}
     ${condOption "bind" cfg.bind}
     ${condOption "unixsocket" cfg.unixSocket}
-    unixsocketperm 770
+    ${condOption "unixsocketperm" cfg.unixSocketPerm}
     daemonize no
     supervised systemd
     loglevel ${cfg.logLevel}
@@ -101,6 +101,17 @@ in
         default = null;
         description = "The path to the socket to bind to.";
         example = "/run/redis/redis.sock";
+      };
+
+      unixSocketPerm = mkOption {
+        type = with types; nullOr int;
+        default = null;
+        description = ''
+          The permissions of the socket to bind to.
+
+          See <link xlink:href="https://raw.githubusercontent.com/redis/redis/${cfg.package.version}/redis.conf" />.
+        '';
+        example = 700;
       };
 
       logLevel = mkOption {

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -15,6 +15,17 @@ in
       {
         services.redis.enable = true;
         services.redis.unixSocket = redisSocket;
+        services.redis.unixSocketPerm = 770;
+
+        users.users."member" = {
+          createHome = false;
+          description = "Test user that is a member of the redis group";
+          extraGroups = [
+            "redis"
+          ];
+          group = "users";
+          shell = "/bin/sh";
+        };
       };
   };
 
@@ -30,6 +41,7 @@ in
     machine.succeed(
         'owner="$(stat -c \'%U:%G\' ${redisSocket})" && test "$owner" = "redis:redis"'
     )
+    machine.succeed('su member -c "redis-cli ping | grep PONG"')
 
     machine.succeed("redis-cli ping | grep PONG")
     machine.succeed("redis-cli -s ${redisSocket} ping | grep PONG")


### PR DESCRIPTION
Makes the redis unix socket accessible to the `redis` group. This group
was added in #90027. 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
