### PR TITLE
nomad: add optional nvml support

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/0.11.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.11.nix
@@ -1,7 +1,11 @@
-{ callPackage, buildGoPackage }:
+{ callPackage
+, buildGoPackage
+, nvidia_x11
+, nvidiaGpuSupport
+}:
 
 callPackage ./generic.nix {
-  inherit buildGoPackage;
+  inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
   version = "0.11.8";
   sha256 = "1dhh07bifr02jh2lls8fv1d9ra67ymgh8qxqvpvm0cd0qdd469z1";
 }

--- a/pkgs/applications/networking/cluster/nomad/0.12.nix
+++ b/pkgs/applications/networking/cluster/nomad/0.12.nix
@@ -1,7 +1,11 @@
-{ callPackage, buildGoPackage }:
+{ callPackage
+, buildGoPackage
+, nvidia_x11
+, nvidiaGpuSupport
+}:
 
 callPackage ./generic.nix {
-  inherit buildGoPackage;
+  inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
   version = "0.12.9";
   sha256 = "1a0ig6pb0z3qp7zk4jgz3h241bifmjlyqsfikyy3sxdnzj7yha27";
 }

--- a/pkgs/applications/networking/cluster/nomad/1.0.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.0.nix
@@ -1,7 +1,11 @@
-{ callPackage, buildGoPackage }:
+{ callPackage
+, buildGoPackage
+, nvidia_x11
+, nvidiaGpuSupport
+}:
 
 callPackage ./generic.nix {
-  inherit buildGoPackage;
+  inherit buildGoPackage nvidia_x11 nvidiaGpuSupport;
   version = "1.0.1";
   sha256 = "07k81csyxhgc7bgn297zlqyvc55qb5fmiavi7dk81rdpg5m2zjvv";
 }

--- a/pkgs/applications/networking/cluster/nomad/generic.nix
+++ b/pkgs/applications/networking/cluster/nomad/generic.nix
@@ -1,4 +1,12 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, version, sha256 }:
+{ lib
+, buildGoPackage
+, fetchFromGitHub
+, version
+, sha256
+, nvidiaGpuSupport
+, patchelf
+, nvidia_x11
+}:
 
 buildGoPackage rec {
   pname = "nomad";
@@ -14,23 +22,33 @@ buildGoPackage rec {
     inherit rev sha256;
   };
 
+  nativeBuildInputs = lib.optionals nvidiaGpuSupport [
+    patchelf
+  ];
+
   # ui:
   #  Nomad release commits include the compiled version of the UI, but the file
   #  is only included if we build with the ui tag.
-  # nonvidia:
-  #  We disable Nvidia GPU scheduling on Linux, as it doesn't work there:
-  #  Ref: https://github.com/hashicorp/nomad/issues/5535
-  preBuild = let
-    tags = ["ui"]
-      ++ stdenv.lib.optional stdenv.isLinux "nonvidia";
-    tagsString = stdenv.lib.concatStringsSep " " tags;
-  in ''
-    export buildFlagsArray=(
-      -tags="${tagsString}"
-    )
- '';
+  preBuild =
+    let
+      tags = [ "ui" ] ++ lib.optional (!nvidiaGpuSupport) "nonvidia";
+      tagsString = lib.concatStringsSep " " tags;
+    in
+    ''
+      export buildFlagsArray=(
+        -tags="${tagsString}"
+      )
+    '';
 
-  meta = with stdenv.lib; {
+  # The dependency on NVML isn't explicit. We have to make it so otherwise the
+  # binary will not know where to look for the relevant symbols.
+  postFixup = lib.optionalString nvidiaGpuSupport ''
+    for bin in $out/bin/*; do
+      patchelf --add-needed "${nvidia_x11}/lib/libnvidia-ml.so" "$bin"
+    done
+  '';
+
+  meta = with lib; {
     homepage = "https://www.nomadproject.io/";
     description = "A Distributed, Highly Available, Datacenter-Aware Scheduler";
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6129,12 +6129,18 @@ in
   # with different versions we pin Go for all versions.
   nomad_0_11 = callPackage ../applications/networking/cluster/nomad/0.11.nix {
     buildGoPackage = buildGo114Package;
+    inherit (linuxPackages) nvidia_x11;
+    nvidiaGpuSupport = config.cudaSupport or (!stdenv.isLinux);
   };
   nomad_0_12 = callPackage ../applications/networking/cluster/nomad/0.12.nix {
     buildGoPackage = buildGo114Package;
+    inherit (linuxPackages) nvidia_x11;
+    nvidiaGpuSupport = config.cudaSupport or (!stdenv.isLinux);
   };
   nomad_1_0 = callPackage ../applications/networking/cluster/nomad/1.0.nix {
     buildGoPackage = buildGo115Package;
+    inherit (linuxPackages) nvidia_x11;
+    nvidiaGpuSupport = config.cudaSupport or (!stdenv.isLinux);
   };
 
   notable = callPackage ../applications/misc/notable { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The original version of this PR (#107030) was reverted after being
merged, because after adding nomad 1.0 the shared use of `generic.nix`
broke because the required arguments added in #107030 weren't being
passed in to the `nomad_1_0` expression.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
