### PR TITLE
prometheus-mpd-exporter: init at 0.1.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -36,6 +36,7 @@ let
     "mikrotik"
     "minio"
     "modemmanager"
+    "mpd"
     "nextcloud"
     "nginx"
     "nginxlog"

--- a/nixos/modules/services/monitoring/prometheus/exporters/mpd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mpd.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+let
+  cfg = config.services.prometheus.exporters.mpd;
+in
+{
+  port = 9806;
+  extraOpts = {
+    port = mkOption {
+      type = types.port;
+      default = "9806";
+      description = ''
+        Port to bind to
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address to bind to
+      '';
+    };
+
+    mpdPort = mkOption {
+      type = types.port;
+      default = 6600;
+      description = ''
+        Port of the MPD server
+      '';
+    };
+
+    mpdHost = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address of the MPD server
+      '';
+    };
+
+  };
+
+  serviceOpts.serviceConfig.ExecStart = ''${pkgs.prometheus-mpd-exporter}/bin/prometheus-mpd-exporter \
+    --bind-addr ${cfg.host}                   \
+    --bind-port ${builtins.toString cfg.port} \
+    --mpd-server-addr ${cfg.mpdHost}          \
+    --mpd-server-port ${builtins.toString cfg.mpdPort}
+  '';
+}
+

--- a/pkgs/servers/monitoring/prometheus/mpd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mpd-exporter.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, rustPlatform
+, fetchgit
+, pkg-config
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "prometheus-mpd-exporter";
+  version = "0.1.0";
+
+  src = fetchgit {
+    url = "https://git.beyermatthi.as/prometheus-mpd-exporter";
+    rev = "$v{version}";
+    sha256 = "0nizmz29b64cywamfhfwwjbsfb3n9nb2dndl35li9z4v67lb5khi";
+  };
+
+  cargoSha256 = "0snrfcjawla9ra40x22w5zrr8xnsyhlyj21di8gp5wzf0yj1a9n1";
+
+  nativeBuildInputs = [ pkg-config openssl ];
+
+  meta = with stdenv.lib; {
+    description = "Export mpd metrics to prometheus";
+    homepage = "https://git.beyermatthi.as/prometheus-mpd-exporter";
+    license = with licenses; [ gpl2.0 ];
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18207,6 +18207,7 @@ in
   prometheus-mikrotik-exporter = callPackage ../servers/monitoring/prometheus/mikrotik-exporter.nix { };
   prometheus-minio-exporter = callPackage ../servers/monitoring/prometheus/minio-exporter { };
   prometheus-modemmanager-exporter = callPackage ../servers/monitoring/prometheus/modemmanager-exporter.nix { };
+  prometheus-mpd-exporter = callPackage ../servers/monitoring/prometheus/mpd-exporter.nix { };
   prometheus-mysqld-exporter = callPackage ../servers/monitoring/prometheus/mysqld-exporter.nix { };
   prometheus-nextcloud-exporter = callPackage ../servers/monitoring/prometheus/nextcloud-exporter.nix { };
   prometheus-nginx-exporter = callPackage ../servers/monitoring/prometheus/nginx-exporter.nix { };


### PR DESCRIPTION
###### Motivation for this change

Wrote this today and would find it useful if it were in nixpkgs. Others might be interested as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


I don't know how to properly test the service, but I have a similar service already running on two of my machines.