### PR TITLE
droidcam: init at 1.6

### DIFF
--- a/pkgs/applications/video/droidcam/default.nix
+++ b/pkgs/applications/video/droidcam/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub
+, ffmpeg, libjpeg_turbo, gtk3, alsaLib, speex, libusbmuxd, libappindicator-gtk3
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "droidcam";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "aramg";
+    repo = "droidcam";
+    rev = "v${version}";
+    sha256 = "sha256-3RmEmLNUbwIh+yr7vtYZnMwbzfmtW3mz5u4Ohau9OLU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    ffmpeg
+    libjpeg_turbo
+    gtk3
+    alsaLib
+    speex
+    libusbmuxd
+    libappindicator-gtk3
+  ];
+
+  postPatch = ''
+    substituteInPlace linux/src/droidcam.c \
+      --replace "/opt/droidcam-icon.png" "$out/share/icons/hicolor/droidcam.png"
+  '';
+
+  preBuild = ''
+    cd linux
+    makeFlagsArray+=("JPEG=$(pkg-config --libs --cflags libturbojpeg)")
+    makeFlagsArray+=("USBMUXD=$(pkg-config --libs --cflags libusbmuxd-2.0)")
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/bin droidcam droidcam-cli
+    install -D icon2.png $out/share/icons/hicolor/droidcam.png
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux client for DroidCam app";
+    homepage = "https://github.com/aramg/droidcam";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.suhr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1173,6 +1173,8 @@ in
 
   doona = callPackage ../tools/security/doona { };
 
+  droidcam = callPackage ../applications/video/droidcam { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   sedutil = callPackage ../tools/security/sedutil { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
