### PR TITLE
linuxPackages.hid-nintendo: init at 3.1

### DIFF
--- a/pkgs/os-specific/linux/hid-nintendo/default.nix
+++ b/pkgs/os-specific/linux/hid-nintendo/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "hid-nintendo";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "nicman23";
+    repo = "dkms-hid-nintendo";
+    rev = version;
+    sha256 = "sha256-IanH3yHfkQhqtKvKD8lh+muc9yX8XJ5bfdy1Or8Vd5g=";
+  };
+
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/source/src
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(sourceRoot)"
+  ];
+
+  buildFlags = [ "modules" ];
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+  meta = with lib; {
+    description = "A Nintendo HID kernel module";
+    homepage = "https://github.com/nicman23/dkms-hid-nintendo";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.rencire ];
+    platforms = platforms.linux;
+    broken = versionOlder kernel.version "4.14";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20374,6 +20374,8 @@ in
 
     gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
 
+    hid-nintendo = callPackage ../os-specific/linux/hid-nintendo { };
+
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
     e1000e = if lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add  [dkms-hid-nintendo](https://github.com/nicman23/dkms-hid-nintendo) "out-of-tree" kernel module.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - No binary files available; tested with a Nintendo Switch Pro Controller.
  - Added the module to `configuration.nix`.
    - i.e. `boot.extraModulePackages = with config.boot.kernelPackages; [ hid-nintendo ];`
  - Output from `modinfo`:
    ```
    > modinfo hid_nintendo
    filename:       /run/current-system/kernel-modules/lib/modules/5.9.16/extra/hid-nintendo.ko.xz
    description:    Driver for Nintendo Switch Controllers
    author:         Daniel J. Ogorchock <djogorchock@gmail.com>
    license:        GPL
    alias:          hid:b0005g*v0000057Ep00002007
    alias:          hid:b0005g*v0000057Ep00002006
    alias:          hid:b0003g*v0000057Ep0000200E
    alias:          hid:b0005g*v0000057Ep00002009
    alias:          hid:b0003g*v0000057Ep00002009
    depends:        hid,ff-memless,led-class
    retpoline:      Y
    name:           hid_nintendo
    vermagic:       5.9.16 SMP mod_unload
    ```
  - Tested with Nintendo Switch Pro Controller 
  - Controller is detected via either USB or Bluetooth.  
  - Tested with games that support SDL by remapping the  controller buttons, works fine.
  - Also tested buttons w/ Steam Input; mostly works fine when it is connected.  However, bluetooth sometimes disconnects, but outside scope of this PR. (might be related to https://github.com/ValveSoftware/steam-for-linux/issues/6651)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
