### PR TITLE
anbox: unstable-2019-11-15 -> unstable-2020-11-29

### DIFF
--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -1,24 +1,28 @@
 { stdenv, fetchFromGitHub, fetchurl
-, cmake, pkgconfig, dbus, makeWrapper
-, gtest
+, cmake, pkg-config, dbus, makeWrapper
 , boost
+, elfutils # for libdw
+, git
+, glib
+, glm
+, gtest
+, libbfd
 , libcap
-, systemd
-, mesa
+, libdwarf
 , libGL
 , libglvnd
-, glib
-, git
-, SDL2
-, SDL2_image
+, lxc
+, mesa
 , properties-cpp
 , protobuf
 , protobufc
-, python
-, lxc
+, python3
+, runtimeShell
+, SDL2
+, SDL2_image
+, systemd
 , writeText
 , writeScript
-, runtimeShell
 }:
 
 let
@@ -45,13 +49,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "anbox";
-  version = "unstable-2019-11-15";
+  version = "unstable-2020-11-29";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "0a49ae08f76de7f886a3dbed4422711c2fa39d10";
-    sha256 = "09l56nv9cnyhykclfmvam6bkcxlamwbql6nrz9n022553w92hkjf";
+    rev = "6c10125a7f13908d2cbe56d2d9ab09872755f265";
+    sha256 = "00bqssh4zcs0jj6w07b91719xkrpdw75vpcplwrvlhwsvl55f901";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
@@ -59,12 +64,26 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    cmake pkgconfig dbus boost libcap gtest systemd mesa glib
-    SDL2 SDL2_image protobuf protobufc properties-cpp lxc python
+    boost
+    cmake
+    dbus
+    elfutils # libdw
+    glib
+    glm
+    gtest
+    libbfd
+    libcap
+    libdwarf
     libGL
+    lxc
+    mesa
+    pkg-config
+    properties-cpp
+    protobuf protobufc
+    python3
+    SDL2 SDL2_image
+    systemd
   ];
-
-  NIX_CFLAGS_COMPILE = "-Wno-error=missing-field-initializers";
 
   patchPhase = ''
     patchShebangs scripts


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to unbreak after gcc10 / binutils 2.34 update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
