### PR TITLE
Osmscout server

### DIFF
--- a/pkgs/applications/misc/osmscout-server/default.nix
+++ b/pkgs/applications/misc/osmscout-server/default.nix
@@ -1,0 +1,65 @@
+{ lib, mkDerivation, fetchFromGitHub, fetchpatch, pkg-config
+, qmake, qttools, kirigami2, qtquickcontrols2, qtlocation
+, libosmscout, mapnik, valhalla, libpostal, osrm-backend, protobuf
+, libmicrohttpd_0_9_70, sqlite, marisa, kyotocabinet, boost
+}:
+
+let
+  date = fetchFromGitHub {
+    owner = "HowardHinnant";
+    repo = "date";
+    rev = "a2fdba1adcb076bf9a8343c07524afdf09aa8dcc";
+    sha256 = "00sf1pbaz0g0gsa0dlm23lxk4h46xm1jv1gzbjj5rr9sf1qccyr5";
+  };
+in
+mkDerivation rec {
+  pname = "osmscout-server";
+  version = "1.17.1";
+
+  src = fetchFromGitHub {
+    owner = "rinigus";
+    repo = "osmscout-server";
+    rev = version;
+    sha256 = "0rpsi6nyhcz6bv0jab4vixkxhjmn84xi0q2xz15a097hn46cklx9";
+    fetchSubmodules = true;
+  };
+
+  # Two patches required to work with valhalla 3.1
+  patches = [
+    # require C++14 to match latest Valhalla
+    (fetchpatch {
+      url = "https://github.com/rinigus/osmscout-server/commit/78b41b9b4c607fe9bfd6fbd61ae31cb7c8a725cd.patch";
+      sha256 = "0gk9mdwa75awl0bj30gm8waj454d8k2yixxwh05m0p550cbv3lg0";
+    })
+    # add Valhalla 3.1 config
+    (fetchpatch {
+      url = "https://github.com/rinigus/osmscout-server/commit/584de8bd47700053960fa139a2d7f8d3d184c876.patch";
+      sha256 = "0liz72n83q93bzzyyiqjkxa6hp9zjx7v9rgsmpwf88gc4caqm2dz";
+    })
+  ];
+
+  nativeBuildInputs = [ qmake pkg-config qttools ];
+  buildInputs = [
+    kirigami2 qtquickcontrols2 qtlocation
+    mapnik valhalla libosmscout osrm-backend libmicrohttpd_0_9_70
+    libpostal sqlite marisa kyotocabinet boost protobuf date
+  ];
+
+  # OSMScout server currently defaults to an earlier version of valhalla,
+  # but valhalla 3.1 support has been added. (See patches above)
+  # Replace the default valhalla.json with the valhalla 3.1 version
+  postPatch = ''
+    mv data/valhalla.json-3.1 data/valhalla.json
+  '';
+
+  # Choose to build the kirigami UI variant
+  qmakeFlags = [ "SCOUT_FLAVOR=kirigami" ];
+
+  meta = with lib; {
+    description = "Maps server providing tiles, geocoder, and router";
+    homepage = "https://github.com/rinigus/osmscout-server";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libosmscout/default.nix
+++ b/pkgs/development/libraries/libosmscout/default.nix
@@ -1,0 +1,24 @@
+{ lib, mkDerivation, fetchgit, cmake, pkg-config
+, marisa, qtlocation }:
+
+mkDerivation rec {
+  pname = "libosmscout";
+  version = "2017.06.30";
+
+  src = fetchgit {
+    url = "git://git.code.sf.net/p/libosmscout/code";
+    rev = "0c0fde4d9803539c99911389bc918377a93f350c";
+    sha256 = "1pa459h52kw88mvsdvkz83f4p35vvgsfy2qfjwcj61gj4y9d2rq4";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ marisa qtlocation ];
+
+  meta = with lib; {
+    description = "Simple, high-level interfaces for offline location and POI lokup, rendering and routing functionalities based on OpenStreetMap (OSM) data";
+    homepage = "http://libosmscout.sourceforge.net/";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libpostal/default.nix
+++ b/pkgs/development/libraries/libpostal/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "libpostal";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "openvenues";
+    repo = "libpostal";
+    rev = "v${version}";
+    sha256 = "0qf5nkfkfjl2ylkrnw7kzax71y85gkr8i24glyp9rflyzmpj6giy";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  configureFlags = [
+    "--disable-data-download"
+  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "--disable-sse2" ];
+
+  meta = with lib; {
+    description = "A C library for parsing/normalizing street addresses around the world. Powered by statistical NLP and open geo data";
+    homepage = "https://github.com/openvenues/libpostal";
+    license = licenses.mit;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/prime-server/default.nix
+++ b/pkgs/development/libraries/prime-server/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, curl, zeromq, czmq, libsodium }:
+
+stdenv.mkDerivation rec {
+  pname = "prime-server";
+  version = "0.6.7";
+
+  src = fetchFromGitHub {
+    owner = "kevinkreiser";
+    repo = "prime_server";
+    rev = version;
+    sha256 = "027w3cqfnciyy2x78hfclpb77askn773fab37mzwf6r3mcc7vyl5";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ curl zeromq czmq libsodium ];
+
+  meta = with lib; {
+    description = "Non-blocking (web)server API for distributed computing and SOA based on zeromq";
+    homepage = "https://github.com/kevinkreiser/prime_server";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/valhalla/default.nix
+++ b/pkgs/development/libraries/valhalla/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, zlib, curl, protobuf, prime-server, boost, sqlite, libspatialite
+, luajit, geos, python3, zeromq }:
+
+stdenv.mkDerivation rec {
+  pname = "valhalla";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "valhalla";
+    repo = "valhalla";
+    rev = version;
+    sha256 = "04vxvzy6hnhdvb9lh1p5vqzzi2drv0g4l2gnbdp44glipbzgd4dr";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    zlib curl protobuf prime-server boost sqlite libspatialite
+    luajit geos python3 zeromq
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_TESTS=OFF"
+    "-DENABLE_BENCHMARKS=OFF"
+  ];
+
+  meta = with lib; {
+    description = "Open Source Routing Engine for OpenStreetMap";
+    homepage = "https://valhalla.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = [ maintainers.Thra11 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17324,6 +17324,10 @@ in
 
   vale = callPackage ../tools/text/vale { };
 
+  valhalla = callPackage ../development/libraries/valhalla {
+    boost = boost.override { enablePython = true; python = python38; };
+  };
+
   vamp-plugin-sdk = callPackage ../development/libraries/audio/vamp-plugin-sdk { };
 
   vc = callPackage ../development/libraries/vc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24485,6 +24485,8 @@ in
 
   osmo = callPackage ../applications/office/osmo { };
 
+  osmscout-server = libsForQt5.callPackage ../applications/misc/osmscout-server { };
+
   palemoon = callPackage ../applications/networking/browsers/palemoon {
     # https://developer.palemoon.org/build/linux/
     stdenv = gcc8Stdenv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15598,6 +15598,8 @@ in
   libpng_apng = libpng.override { apngSupport = true; };
   libpng12 = callPackage ../development/libraries/libpng/12.nix { };
 
+  libpostal = callPackage ../development/libraries/libpostal { };
+
   libpaper = callPackage ../development/libraries/libpaper { };
 
   libpfm = callPackage ../development/libraries/libpfm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16490,6 +16490,8 @@ in
 
   portmidi = callPackage ../development/libraries/portmidi {};
 
+  prime-server = callPackage ../development/libraries/prime-server { };
+
   primesieve = callPackage ../development/libraries/science/math/primesieve { };
 
   prison = callPackage ../development/libraries/prison { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15570,6 +15570,8 @@ in
 
   libosmocore = callPackage ../applications/misc/libosmocore { };
 
+  libosmscout = libsForQt5.callPackage ../development/libraries/libosmscout { };
+
   libotr = callPackage ../development/libraries/libotr { };
 
   libow = callPackage ../development/libraries/libow { };


### PR DESCRIPTION
###### Motivation for this change
Package osmscout-server and its dependencies. It's an application which allows you to manage offline OSM maps and serve them to pure-maps (PR #107836).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
