### PR TITLE
kinfocenter: fix symlink to systemsettings5

### DIFF
--- a/pkgs/desktops/plasma-5/kinfocenter.nix
+++ b/pkgs/desktops/plasma-5/kinfocenter.nix
@@ -5,7 +5,7 @@
   kcmutils, kcompletion, kconfig, kconfigwidgets, kcoreaddons, kdbusaddons,
   kdeclarative, kdelibs4support, ki18n, kiconthemes, kio, kirigami2, kpackage,
   kservice, kwayland, kwidgetsaddons, kxmlgui, libraw1394, libGLU, pciutils,
-  solid
+  solid, systemsettings
 }:
 
 mkDerivation {
@@ -15,6 +15,11 @@ mkDerivation {
   buildInputs = [
     kcmutils kcompletion kconfig kconfigwidgets kcoreaddons kdbusaddons
     kdeclarative kdelibs4support ki18n kiconthemes kio kirigami2 kpackage
-    kservice kwayland kwidgetsaddons kxmlgui libraw1394 libGLU pciutils solid
+    kservice kwayland kwidgetsaddons kxmlgui libraw1394 libGLU pciutils solid systemsettings
   ];
+  preFixup = ''
+    # fix wrong symlink of infocenter pointing to a 'systemsettings5' binary in the same directory,
+    # while it is actually located in a completely different store path
+    ln -sf ${lib.getBin systemsettings}/bin/systemsettings5 $out/bin/kinfocenter
+  '';
 }


### PR DESCRIPTION
As `kinfocenter`'s implementation consists of only KCMs, which are
actually just displayed using `systemsettings5`' KCM shell, the
`kinfocenter` binary is just a symlink to `systemsettings5`.

In traditional FHS environments, having a relative symlink to the
`systemsettings5` binary within the same `bin/` directory works just
fine, whereas this is broken on NixOS where `systemsettings5` resides in
a completely different `bin/` directory of the corresponding store item.

Usually CMake's `find_package` should be able to locate the
`systemsettings5` binary, but fails for reasons unknown to do so on
NixOS - so for now fixing the symlink manually as part of the `preFixup`
phase will do the job of making `kinfocenter` work again.

###### Motivation for this change
Get rid of this message when starting **Info Center**: 
![image](https://user-images.githubusercontent.com/48491/103490397-c91aea80-4e1b-11eb-858c-52a861d694d5.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
