### PR TITLE
gdu: init at 2.0.0

### DIFF
--- a/pkgs/tools/system/gdu/default.nix
+++ b/pkgs/tools/system/gdu/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "gdu";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dundee";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0239ppiilr8d43z9v27c9h7b5xkj2n9aacpf5a0h3rz4j0dkcwf7";
+  };
+
+  vendorSha256 = "1jqbsda9bch3awdq816w4jybv7wz9mfflmvs5y2wsa2qnhn9nbyp";
+
+  meta = with stdenv.lib; {
+    description = "Disk usage analyzer with console interface";
+    longDescription = ''
+      Gdu is intended primarily for SSD disks where it can fully
+      utilize parallel processing. However HDDs work as well, but
+      the performance gain is not so huge.
+    '';
+    homepage = "https://github.com/dundee/gdu";
+    license = with licenses; [ mit ];
+    maintainers = [ maintainers.fab ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2233,6 +2233,8 @@ in
 
   gdrive = callPackage ../applications/networking/gdrive { };
 
+  gdu = callPackage ../tools/system/gdu { };
+
   go-chromecast = callPackage ../applications/video/go-chromecast { };
 
   go-rice = callPackage ../tools/misc/go.rice {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Gdu is intended primarily for SSD disks where it can fully
utilize parallel processing. However HDDs work as well, but
the performance gain is not so huge.

https://github.com/dundee/gdu

Fixes #108359

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
