### PR TITLE
ocamlPackages.lwt_ppx: 2.0.1 → 2.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchzip, which, ocsigen_server, ocaml,
   lwt_react,
   opaline, ppx_deriving, findlib
+, ppx_tools_versioned
 , js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
 , js_of_ocaml-lwt
 , js_of_ocaml-tyxml
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec
   };
 
   buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opaline
+    ppx_tools_versioned
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -1,8 +1,12 @@
-{ fetchzip, buildDunePackage, lwt, ppx_tools_versioned }:
+{ fetchzip, buildDunePackage, lwt, ppxlib }:
 
 buildDunePackage {
   pname = "lwt_ppx";
-  version = "2.0.1";
+  version = "2.0.2";
+
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.04";
 
   src = fetchzip {
     # `lwt_ppx` has a different release cycle than Lwt, but it's included in
@@ -12,12 +16,11 @@ buildDunePackage {
     #
     # This is particularly useful for overriding Lwt without breaking `lwt_ppx`,
     # as new Lwt releases may contain broken `lwt_ppx` code.
-    url = "https://github.com/ocsigen/lwt/archive/5.2.0.tar.gz";
-    sha256 = "1znw8ckwdmqsnrcgar4g33zgr659l4l904bllrz69bbwdnfmz2x3";
+    url = "https://github.com/ocsigen/lwt/archive/5.4.0.tar.gz";
+    sha256 = "1ay1zgadnw19r9hl2awfjr22n37l7rzxd9v73pjbahavwm2ay65d";
   };
 
-
-  propagatedBuildInputs = [ lwt ppx_tools_versioned ];
+  propagatedBuildInputs = [ lwt ppxlib ];
 
   meta = {
     description = "Ppx syntax extension for Lwt";


### PR DESCRIPTION
###### Motivation for this change

Migration to ppxlib
Use dune 2

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
