### PR TITLE
nixos/lxd: disable cgroup v2 when LXD is active

### DIFF
--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -100,6 +100,10 @@ in
       packages = [ cfg.lxcPackage ];
     };
 
+    # TODO: remove once LXD gets proper support for cgroupsv2
+    # (currently most of the e.g. CPU accounting stuff doesn't work)
+    systemd.enableUnifiedCgroupHierarchy = false;
+
     systemd.services.lxd = {
       description = "LXD Container Management Daemon";
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/c76891314d2f84a75c6591c9e568bca6019b940f changed systemd to use cgroup v2 by default, which kinda-sorta broke lxd, as its support for unified hierarchy is rather poor - e.g. setting CPU limits doesn't work and I've had some issues with nested systemd instances.

Our test for LXD - `nixos/tests/lxd.nix` - would've caught this (as it _currently fails_ on `master`), but TBH I'm not sure why it wasn't ran :/