### PR TITLE
fatrace: 0.13 -> 0.16.1

### DIFF
--- a/pkgs/os-specific/linux/fatrace/default.nix
+++ b/pkgs/os-specific/linux/fatrace/default.nix
@@ -1,12 +1,18 @@
-{ stdenv, fetchurl, python3, which }:
+{ stdenv
+, fetchFromGitHub
+, python3
+, which
+}:
 
 stdenv.mkDerivation rec {
   pname = "fatrace";
-  version = "0.13";
+  version = "0.16.1";
 
-  src = fetchurl {
-    url = "https://launchpad.net/fatrace/trunk/${version}/+download/${pname}-${version}.tar.bz2";
-    sha256 = "0hrh45bpzncw0jkxw3x2smh748r65k2yxvfai466043bi5q0d2vx";
+  src = fetchFromGitHub {
+    owner = "martinpitt";
+    repo = pname;
+    rev = version;
+    sha256 = "0lxfqin2bw9235yah8ylb4p8lc3755050sjg30z3gy7bab0lfyg9";
   };
 
   buildInputs = [ python3 which ];
@@ -14,16 +20,13 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace power-usage-report \
       --replace "'which'" "'${which}/bin/which'"
-
-    # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
-    sed 1i'#include <sys/sysmacros.h>' -i fatrace.c
   '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Report system-wide file access events";
-    homepage = "https://launchpad.net/fatrace/";
+    homepage = "https://github.com/martinpitt/fatrace";
     license = licenses.gpl3Plus;
     longDescription = ''
       fatrace reports file access events from all running processes.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.16.1

Change log: https://github.com/martinpitt/fatrace/blob/master/NEWS

Upstream moved to GitHub.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
