### PR TITLE
pytun: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/pytun/default.nix
+++ b/pkgs/development/python-modules/pytun/default.nix
@@ -5,15 +5,16 @@
 
 buildPythonPackage rec {
   pname = "pytun";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "montag451";
     repo = "pytun";
-    sha256 = "1bxk0z0v8m0b01xg94f039j3bsclkshb7girvjqfzk5whbd2nryh";
+    sha256 = "1cqq8aci38058fjh4a0xf21wac177fw576p2yjl2b8jd9rnsqbl5";
   };
 
+  # Test directory contains examples, not tests.
   doCheck = false;
 
   meta = with stdenv.lib; {
@@ -23,5 +24,4 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ montag451 ];
     platforms = platforms.linux;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update `pytun` to its latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
