### PR TITLE
python3Packages.asyncwhois: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/asyncwhois/default.nix
+++ b/pkgs/development/python-modules/asyncwhois/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, aiodns
+, tldextract
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "asyncwhois";
+  version = "0.2.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rdmg59jzzfz59b3ckg5187lc0wk9r0pzp9x09nq3xs21mcwqjxz";
+  };
+
+  propagatedBuildInputs = [
+    aiodns
+    tldextract
+  ];
+
+  # tests are only present at GitHub but not the released source tarballs
+  # https://github.com/pogzyb/asyncwhois/issues/10
+  doCheck = false;
+  pythonImportsCheck = [ "asyncwhois" ];
+
+  meta = with lib; {
+    description = "Python module for retrieving WHOIS information";
+    homepage = "https://github.com/pogzyb/asyncwhois";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -453,6 +453,8 @@ in {
 
   async-upnp-client = callPackage ../development/python-modules/async-upnp-client { };
 
+  asyncwhois = callPackage ../development/python-modules/asyncwhois { };
+
   atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };
 
   atom = callPackage ../development/python-modules/atom { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for performing WHOIS queries for any domain.

https://github.com/pogzyb/asyncwhois

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
