### PR TITLE
cargo-valgrind: init at 1.3.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-valgrind/default.nix
+++ b/pkgs/development/tools/rust/cargo-valgrind/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, nix-update-script
+, makeWrapper
+, valgrind
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-valgrind";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jfrimmel";
+    repo = "cargo-valgrind";
+    # repo lacks the 1.3.0 tag
+    # https://github.com/jfrimmel/cargo-valgrind/issues/33
+    rev = "d47dd810e3971d676cde5757df8b2e05ed563e41";
+    sha256 = "163ch5bpwny1di758rpfib1ddqclxm48j0lmmv741ji3l4nqid32";
+  };
+
+  cargoSha256 = "008s1y3pkn8613kp1gqf494fs93ix0nrwhrkqi5q9bim2mixgccb";
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/cargo-valgrind --prefix PATH : ${stdenv.lib.makeBinPath [ valgrind ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''Cargo subcommand "valgrind": runs valgrind and collects its output in a helpful manner'';
+    homepage = "https://github.com/jfrimmel/cargo-valgrind";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ otavio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10740,6 +10740,7 @@ in
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
+  cargo-valgrind = callPackage ../development/tools/rust/cargo-valgrind { };
   cargo-watch = callPackage ../development/tools/rust/cargo-watch {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Introduce a new useful tool for Rust users

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
