### PR TITLE
ocamlPackages.mirage-crypto*: 0.8.7 -> 0.8.8

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -4,11 +4,11 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.8.7";
+  version = "0.8.8";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "1gx86h6kk39zq3kvl854jc2ap2755paalp1f7iv8r9js2xnbxfxy";
+    sha256 = "19czylfyakckfzzcbqgv9ygl243wix7ak8zkbdcb9hcl2k2shswb";
   };
 
   useDune2 = true;

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage
+, mirage-crypto, mirage-crypto-rng
+, dune-configurator, async, logs
+}:
+
+buildDunePackage {
+  pname = "mirage-crypto-rng-async";
+
+  inherit (mirage-crypto) useDune2 version minimumOCamlVersion src;
+
+  nativeBuildInputs = [
+    dune-configurator
+  ];
+
+  propagatedBuildInputs = [
+    async
+    logs
+    mirage-crypto
+    mirage-crypto-rng
+  ];
+
+  meta = mirage-crypto.meta // {
+    description = "Feed the entropy source in an Async-friendly way";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -1,5 +1,7 @@
 { buildDunePackage, mirage-crypto-rng, duration, cstruct, mirage-runtime
-, mirage-time, mirage-clock, mirage-unix, mirage-time-unix, mirage-clock-unix }:
+, mirage-time, mirage-clock, mirage-unix, mirage-time-unix, mirage-clock-unix
+, logs, lwt
+}:
 
 buildDunePackage {
   pname = "mirage-crypto-rng-mirage";
@@ -10,7 +12,7 @@ buildDunePackage {
   checkInputs = [ mirage-unix mirage-clock-unix mirage-time-unix ];
 
   propagatedBuildInputs = [ duration cstruct mirage-crypto-rng mirage-runtime
-                            mirage-time mirage-clock ];
+                            mirage-time mirage-clock logs lwt ];
 
   meta = mirage-crypto-rng.meta // {
     description = "Entropy collection for a cryptographically secure PRNG";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -601,6 +601,8 @@ let
 
     mirage-crypto-rng = callPackage ../development/ocaml-modules/mirage-crypto/rng.nix { };
 
+    mirage-crypto-rng-async = callPackage ../development/ocaml-modules/mirage-crypto/rng-async.nix { };
+
     mirage-crypto-rng-mirage = callPackage ../development/ocaml-modules/mirage-crypto/rng-mirage.nix { };
 
     mirage-device = callPackage ../development/ocaml-modules/mirage-device { };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/mirage-crypto/releases/tag/v0.8.8>

New package: ocamlPackages.mirage-crypto-rng-async


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
