### PR TITLE
caprine-bin: init at 2.55.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-appimage.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchurl
+, appimageTools
+, gtk3
+, gsettings-desktop-schemas
+, xorg
+, pname
+, version
+, sha256
+, metaCommon ? { }
+}:
+
+let
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://github.com/sindresorhus/caprine/releases/download/v${version}/Caprine-${version}.AppImage";
+    name = "Caprine-${version}.AppImage";
+    inherit sha256;
+  };
+  extracted = appimageTools.extractType2 { inherit name src; };
+in
+(appimageTools.wrapType2 {
+  inherit name src;
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs;
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},caprine}
+
+    mkdir -p $out/share
+    "${xorg.lndir}/bin/lndir" -silent "${extracted}/usr/share" "$out/share"
+    ln -s ${extracted}/caprine.png $out/share/icons/caprine.png
+    mkdir $out/share/applications
+    cp ${extracted}/caprine.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/caprine.desktop \
+        --replace AppRun caprine
+  '';
+
+  meta = metaCommon // {
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "caprine";
+  };
+}) // {
+  inherit pname version;
+}

--- a/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-dmg.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine-bin/build-from-dmg.nix
@@ -1,0 +1,35 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+, undmg
+, pname
+, version
+, sha256
+, metaCommon ? { }
+}:
+
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://github.com/sindresorhus/caprine/releases/download/v${version}/Caprine-${version}.dmg";
+    name = "Caprine-${version}.dmg";
+    inherit sha256;
+  };
+
+  sourceRoot = "Caprine.app";
+
+  nativeBuildInputs = [ undmg ];
+
+  installPhase = ''
+    mkdir -p "$out/Applications/Caprine.app"
+    cp -R . "$out/Applications/Caprine.app"
+    mkdir "$out/bin"
+    ln -s "$out/Applications/Caprine.app/Contents/MacOS/Caprine" "$out/bin/caprine"
+  '';
+
+  meta = metaCommon // {
+    platforms = with lib.platforms; darwin;
+    mainProgram = "caprine";
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/caprine-bin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/caprine-bin/default.nix
@@ -1,0 +1,25 @@
+{ lib, callPackage, stdenvNoCC }:
+let
+  pname = "caprine";
+  version = "2.55.2";
+  metaCommon = with lib; {
+    description = "An elegant Facebook Messenger desktop app";
+    homepage = "https://sindresorhus.com/caprine";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+  x86_64-appimage = callPackage ./build-from-appimage.nix {
+    inherit pname version metaCommon;
+    sha256 = "J7eHVXjWSIcTpLMM8FlGKZzVh6XgpQ0d82kxfMbPyZ4=";
+  };
+  x86_64-dmg = callPackage ./build-from-dmg.nix {
+    inherit pname version metaCommon;
+    sha256 = "du/9N1BFq1s7spPiEDgDbjjcnkA0x1ExhAEpQvmO3aA=";
+  };
+in
+(if stdenvNoCC.isDarwin then x86_64-dmg else x86_64-appimage).overrideAttrs (oldAttrs: {
+  passthru = (oldAttrs.passthru or { }) // { inherit x86_64-appimage x86_64-dmg; };
+  meta = oldAttrs.meta // {
+    platforms = x86_64-appimage.meta.platforms ++ x86_64-dmg.meta.platforms;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24484,6 +24484,8 @@ with pkgs;
 
   canto-daemon = callPackage ../applications/networking/feedreaders/canto-daemon { };
 
+  caprine-bin = callPackage ../applications/networking/instant-messengers/caprine-bin { };
+
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
   carla = libsForQt5.callPackage ../applications/audio/carla { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[Caprine](https://github.com/sindresorhus/caprine) is a third-party Facebook messenger client with a beautiful UI and features to enhance the privacy of users.
As an NodeJS-Electron application, the build-from-source attempt suffer from NPM trying to download Electron at build time, and the binary build can serve as a workaround.

Update:
Closes #90375 

###### Known issue

~~Crash when doing things involving "open files with file manager", complaining:~~
```
WARNING: Kernel has no file descriptor comparison support: Function not implemented

(caprine:22216): GLib-GIO-ERROR **: 05:53:43.885: No GSettings schemas are installed on the system
Trace/breakpoint trap (core dumped)

```
~~Tried adding some Gnome-related packages to extraPagkages, but it doesn't solve the problem. It has been mentioned [on NixOS Discourse](https://discourse.nixos.org/t/failure-appimage-run-with-gsetting/4403).~~

~~This is common on AppImages, and is also happen when executing using appimage-run.~~

~~Nevertheless, drag-and-drop of files still work, which can serve as a workaround to the problem above.~~

__Solved__ after referencing [dtzWill's work on minetime](https://github.com/NixOS/nixpkgs/blob/48feb84a9d91ac2601ac33e660d9f6c76f476a1e/pkgs/applications/office/minetime/default.nix#L31-L34) and add
```Nix
appimageTools.wrapType2 {
# ...
  profile = ''
    export LC_ALL=C.UTF-8
    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
  '';
# ...
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) (The binary build from AppImage works. I don't have Mac with me, so I cannot test the dmg part.)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
