### PR TITLE
stdenv: use gcc9 for x86_32

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9193,7 +9193,7 @@ in
     else ../development/compilers/gcc/10);
   gcc = if (with stdenv.targetPlatform; isVc4 || libc == "relibc")
     then gcc6 else
-      if stdenv.targetPlatform.isAarch64 then gcc9 else gcc10;
+      if stdenv.targetPlatform.isAarch64 || stdenv.targetPlatform.isx86_32 then gcc9 else gcc10;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {


### PR DESCRIPTION
pkgsi686Linux.efivar is part of the nixos-unstable channel and currently
fails to build with gcc10.

In the spirit of 22f1c746dfbd9f83f63002f5ad79bc48dec21189.

Fixes https://github.com/NixOS/nixpkgs/issues/108375

###### Motivation for this change
Unbreak nixos-unstable. I'm still not sure if we should have switched that early, but I don't want another staging cycle to fix the channels either.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
