### PR TITLE
[20.09] profiles/hardened: Add note about potential instability

### DIFF
--- a/nixos/doc/manual/configuration/profiles/hardened.xml
+++ b/nixos/doc/manual/configuration/profiles/hardened.xml
@@ -7,7 +7,7 @@
 
  <para>
   A profile with most (vanilla) hardening options enabled by default,
-  potentially at the cost of features and performance.
+  potentially at the cost of stability, features and performance.
  </para>
 
  <para>
@@ -21,4 +21,12 @@
    xlink:href="https://github.com/nixos/nixpkgs/tree/master/nixos/modules/profiles/hardened.nix">
   profile source</literal> for further detail on which settings are altered.
  </para>
+ <warning>
+   <para>
+     This profile enables options that are known to affect system
+     stability. If you experience any stability issues when using the
+     profile, try disabling it. If you report an issue and use this
+     profile, always mention that you do.
+   </para>
+ </warning>
 </section>

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -1,5 +1,10 @@
 # A profile with most (vanilla) hardening options enabled by default,
-# potentially at the cost of features and performance.
+# potentially at the cost of stability, features and performance.
+#
+# This profile enables options that are known to affect system
+# stability. If you experience any stability issues when using the
+# profile, try disabling it. If you report an issue and use this
+# profile, always mention that you do.
 
 { config, lib, pkgs, ... }:
 


### PR DESCRIPTION
###### Motivation for this change
Port  #108398 to stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
