### PR TITLE
[20.09] dovecot: 2.3.11.3 -> 2.3.13

### DIFF
--- a/nixos/tests/dovecot.nix
+++ b/nixos/tests/dovecot.nix
@@ -4,8 +4,11 @@ import ./make-test-python.nix {
   machine = { pkgs, ... }: {
     imports = [ common/user-account.nix ];
     services.postfix.enable = true;
-    services.dovecot2.enable = true;
-    services.dovecot2.protocols = [ "imap" "pop3" ];
+    services.dovecot2 = {
+      enable = true;
+      protocols = [ "imap" "pop3" ];
+      modules = [ pkgs.dovecot_pigeonhole ];
+    };
     environment.systemPackages = let
       sendTestMail = pkgs.writeScriptBin "send-testmail" ''
         #!${pkgs.runtimeShell}

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dovecot";
-  version = "2.3.11.3";
+  version = "2.3.13";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/2.3/${pname}-${version}.tar.gz";
-    sha256 = "1p5gp8jbavcsaara5mfn5cbrnlxssajnchczbgmmfzr7228fmnfk";
+    sha256 = "1i7ijss79a23v7b6lycfzaa8r5rh01k0h0b9h0j4a6n11sw7by53";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -89,5 +89,6 @@ stdenv.mkDerivation rec {
   };
   passthru.tests = {
     opensmtpd-interaction = nixosTests.opensmtpd;
+    inherit (nixosTests) dovecot;
   };
 }

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "dovecot-pigeonhole";
-  version = "0.5.11";
+  version = "0.5.13";
 
   src = fetchurl {
     url = "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
-    sha256 = "1w5mryv6izh1gv7davnl94rb0pvh5bxl2bydzbfla1b83x22m5qb";
+    sha256 = "05xz2d82ck6lmv94nbc3qff09j8b60a5640i3fmqwqsvv9kfa7wi";
   };
 
   buildInputs = [ dovecot openssl ];


### PR DESCRIPTION
###### Motivation for this change

Backport of #108404

This fixes CVE_2020-24386, CVE-2020-25725 and a bunch of regular bugs
[1].

* CVE-2020-24386: Specially crafted command can cause IMAP hibernate to
	  allow logged in user to access other people's emails and filesystem
	  information.

* CVE-2020-25275: Mail delivery / parsing crashed when the 10 000th MIME part was
  message/rfc822 (or if parent was multipart/digest). This happened
  due to earlier MIME parsing changes for CVE-2020-12100.

[1] https://raw.githubusercontent.com/dovecot/core/2.3.13/NEWS




###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
