### PR TITLE
python3Packages.nitime: 0.8.1 -> 0.9

### DIFF
--- a/pkgs/development/python-modules/nitime/default.nix
+++ b/pkgs/development/python-modules/nitime/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , python
 , fetchPypi
+, isPy27
 , pytestCheckHook
 , cython
 , numpy
@@ -13,19 +14,17 @@
 
 buildPythonPackage rec {
   pname = "nitime";
-  version = "0.8.1";
-  disabled = python.pythonVersion != "3.7";  # gcc error when running Cython with Python 3.8
+  version = "0.9";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0hb3x5196z2zaawb8s7lhja0vd3n983ncaynqfl9qg315x9ax7i6";
+    sha256 = "sha256-bn2QrbsfqUJim84vH5tt5T6h3YsGAlgu9GCMiNQ0OHQ=";
   };
 
-  buildInputs = [ cython ];
-
-  propagatedBuildInputs = [ numpy scipy matplotlib networkx nibabel ];
-
   checkInputs = [ pytestCheckHook ];
+  buildInputs = [ cython ];
+  propagatedBuildInputs = [ numpy scipy matplotlib networkx nibabel ];
 
   meta = with lib; {
     homepage = "https://nipy.org/nitime";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update nitime to 0.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
