### PR TITLE
libcst: fix python 3.6 support

### DIFF
--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, pythonOlder, black, isort
-, pytestCheckHook, pyyaml, typing-extensions, typing-inspect }:
+, pytestCheckHook, pyyaml, typing-extensions, typing-inspect, dataclasses }:
 
 buildPythonPackage rec {
   pname = "libcst";
@@ -16,7 +16,8 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6";
 
-  propagatedBuildInputs = [ pyyaml typing-inspect ];
+  propagatedBuildInputs = [ pyyaml typing-inspect ]
+    ++ lib.optional (pythonOlder "3.7") dataclasses;
 
   checkInputs = [ black isort pytestCheckHook ];
 


### PR DESCRIPTION
The 'dataclasses' module is a required dependency of libcst.
Python >= 3.7 include this module natively.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
