### PR TITLE
tartube: 2.1.0 -> 2.3.042

### DIFF
--- a/pkgs/applications/video/tartube/default.nix
+++ b/pkgs/applications/video/tartube/default.nix
@@ -10,17 +10,18 @@
 , wrapGAppsHook
 , youtube-dl
 , glib
+, ffmpeg
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "tartube";
-  version = "2.1.0";
+  version = "2.3.042";
 
   src = fetchFromGitHub {
     owner = "axcore";
     repo = "tartube";
     rev = "v${version}";
-    sha256 = "1klqjwqm29y2f6nc8gn222ykfvb5d64z1w2kifw9bq5bv0np9bda";
+    sha256 = "117q4s2b2js3204506qv3kjcsy3amcf0mpwj6q0ixs1256ilkxwj";
   };
 
   nativeBuildInputs = [
@@ -37,6 +38,7 @@ python3Packages.buildPythonApplication rec {
     requests
     feedparser
     playsound
+    ffmpeg
   ];
 
   buildInputs = [
@@ -48,7 +50,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postPatch = ''
-    sed -i "/^\s*install_requires/s/, 'gi'\|'gi', \|'gi'//" setup.py
+    sed -i "/^\s*install_requires/s/, 'pgi'\|'pgi', \|'pgi'//" setup.py
   '';
 
   postInstall = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Add new ffmpeg dependency.
- Update patch since gi was renamed pgi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
