### PR TITLE
zathura: fix fish completions

### DIFF
--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -7,10 +7,19 @@ symlinkJoin {
 
   buildInputs = [ makeWrapper ];
 
-  postBuild = ''
+  postBuild = let
+    fishCompletion = "share/fish/vendor_completions.d/zathura.fish";
+  in ''
     makeWrapper ${zathura_core.bin}/bin/zathura $out/bin/zathura \
       --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
       --add-flags --plugins-dir="$out/lib/zathura"
+
+    # zathura fish completion references the zathura_core derivation to
+    # check for supported plugins which live in the wrapper derivation,
+    # so we need to fix the path to reference $out instead.
+    rm "$out/${fishCompletion}"
+    substitute "${zathura_core.out}/${fishCompletion}" "$out/${fishCompletion}" \
+      --replace "${zathura_core.out}" "$out"
   '';
 
   meta = with lib; {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The fish completion for zathura on master only completes options, not files.

The fish completion checks the plugin directory for supported file types
to complete. However the plugin dir checked was the one of the
zathura_core derivation which of course has no plugin dir. We now patch
up the referenced path in the wrapper derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
