### PR TITLE
flatbuffers: unbreak with gcc10

### DIFF
--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -10,6 +10,21 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0f7xd66vc1lzjbn7jzd5kyqrgxpsfxi4zc7iymhb5xrwyxipjl1g";
   };
+  patches = [
+    (fetchpatch {
+      # Fixed a compilation error with GCC 10.0 to 11.0. June 1, 2020.
+      # Should be included in the next release after 1.12.0
+      url = "https://github.com/google/flatbuffers/commit/988164f6e1675bbea9c852e2d6001baf4d1fcf59.patch";
+      sha256 = "0d8c2bywqmkhdi0a41cry85wy4j58pl0vd6h5xpfqm3fr8w0mi9s";
+      excludes = [ "src/idl_gen_cpp.cpp" ];
+    })
+    (fetchpatch {
+      # Fixed a compilation error with GCC 10.0 to 11.0. July 6, 2020.
+      # Should be included in the next release after 1.12.0
+      url = "https://github.com/google/flatbuffers/pull/6020/commits/44c7a4cf439b0a298720b5a448bcc243a882b0c9.patch";
+      sha256 = "126xwkvnlc4ignjhxv9jygfd9j6kr1jx39hyk0ddpcmvzfqsccf4";
+    })
+  ];
 
   preConfigure = stdenv.lib.optional stdenv.buildPlatform.isDarwin ''
     rm BUILD


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Hydra failures -- https://hydra.nixos.org/job/nixpkgs/trunk/flatbuffers.x86_64-linux. I think because of an upgrade of gcc but I didn't bisect all the way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
