### PR TITLE
dbeaver: 7.3.2 -> 7.3.5, build from source and add darwin build

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -1,14 +1,20 @@
-{ lib, stdenv, fetchurl, makeDesktopItem, makeWrapper
-, fontconfig, freetype, glib, gtk3
-, jdk, libX11, libXrender, libXtst, zlib }:
-
-# The build process is almost like eclipse's.
-# See `pkgs/applications/editors/eclipse/*.nix`
-
-stdenv.mkDerivation rec {
-  pname = "dbeaver-ce";
-  version = "7.3.2";
-
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeDesktopItem
+, makeWrapper
+, fontconfig
+, freetype
+, glib
+, gtk3
+, jdk
+, libX11
+, libXrender
+, libXtst
+, zlib
+, maven
+}:
+let
   desktopItem = makeDesktopItem {
     name = "dbeaver";
     exec = "dbeaver";
@@ -18,44 +24,89 @@ stdenv.mkDerivation rec {
     genericName = "SQL Integrated Development Environment";
     categories = "Development;";
   };
+in
+stdenv.mkDerivation rec {
+  pname = "dbeaver-ce";
+  version = "7.3.2"; # When updating also update fetchedMavenDeps.sha256
+
+  src = fetchFromGitHub {
+    owner = "dbeaver";
+    repo = "dbeaver";
+    rev = version;
+    sha256 = "sha256-gh3++IEQzWOKGsazqeMp0aHuZ835etAou62cgz0GoNQ=";
+  };
+
+  fetchedMavenDeps = stdenv.mkDerivation {
+    name = "dbeaver-${version}-maven-deps";
+    inherit src;
+
+    buildInputs = [
+      maven
+    ];
+
+    buildPhase = "mvn package -Dmaven.repo.local=$out/.m2";
+
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+    '';
+
+    # don't do any fixup
+    dontFixup = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-uTKevwZvKiYOBz0hshh1rLEj7htYF7FQiTq6vZiVs7Q=";
+  };
 
   buildInputs = [
-    fontconfig freetype glib gtk3
-    jdk libX11 libXrender libXtst zlib
+    fontconfig
+    freetype
+    glib
+    gtk3
+    jdk
+    libX11
+    libXrender
+    libXtst
+    makeWrapper
+    zlib
   ];
 
   nativeBuildInputs = [
-    makeWrapper
+    maven
   ];
 
-  src = fetchurl {
-    url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "sha256-4BVXcR8/E4uIrPQJe9KU9577j4XLTxJWTO8g0vCHWts=";
-  };
-
-  installPhase = ''
-    # remove bundled jre
-    rm -rf jre
-
-    mkdir -p $out/
-    cp -r . $out/dbeaver
-
-    # Patch binaries.
-    interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
-    patchelf --set-interpreter $interpreter $out/dbeaver/dbeaver
-
-    makeWrapper $out/dbeaver/dbeaver $out/bin/dbeaver \
-      --prefix PATH : ${jdk}/bin \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([ glib gtk3 libXtst ])} \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
-    # Create desktop item.
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
-
-    mkdir -p $out/share/pixmaps
-    ln -s $out/dbeaver/icon.xpm $out/share/pixmaps/dbeaver.xpm
+  buildPhase = ''
+    mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
   '';
+
+  installPhase =
+    let
+      productTargetPath = "product/standalone/target/products/org.jkiss.dbeaver.core.product";
+    in
+    ''
+      mkdir -p $out/
+      cp -r ${productTargetPath}/linux/gtk/x86_64/dbeaver $out/dbeaver
+
+      # Patch binaries.
+      interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
+      patchelf --set-interpreter $interpreter $out/dbeaver/dbeaver
+
+      makeWrapper $out/dbeaver/dbeaver $out/bin/dbeaver \
+        --prefix PATH : ${jdk}/bin \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([ glib gtk3 libXtst ])} \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+
+      # Create desktop item.
+      mkdir -p $out/share/applications
+      cp ${desktopItem}/share/applications/* $out/share/applications
+
+      mkdir -p $out/share/pixmaps
+      ln -s $out/dbeaver/icon.xpm $out/share/pixmaps/dbeaver.xpm
+    '';
 
   meta = with lib; {
     homepage = "https://dbeaver.io/";
@@ -68,6 +119,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.asl20;
     platforms = [ "x86_64-linux" ];
-    maintainers = [ maintainers.jojosch ];
+    maintainers = with maintainers; [ jojosch ];
   };
 }

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -87,7 +87,18 @@ stdenv.mkDerivation rec {
     let
       productTargetPath = "product/standalone/target/products/org.jkiss.dbeaver.core.product";
     in
-    ''
+    if stdenv.isDarwin then ''
+      mkdir -p $out/Applications $out/bin
+      cp -r ${productTargetPath}/macosx/cocoa/x86_64/DBeaver.app $out/Applications
+
+      sed -i "/^-vm/d; /bin\/java/d" $out/Applications/DBeaver.app/Contents/Eclipse/dbeaver.ini
+
+      ln -s $out/Applications/DBeaver.app/Contents/MacOS/dbeaver $out/bin/dbeaver
+
+      wrapProgram $out/Applications/DBeaver.app/Contents/MacOS/dbeaver \
+        --prefix JAVA_HOME : ${jdk.home} \
+        --prefix PATH : ${jdk}/bin
+    '' else ''
       mkdir -p $out/
       cp -r ${productTargetPath}/linux/gtk/x86_64/dbeaver $out/dbeaver
 
@@ -118,7 +129,7 @@ stdenv.mkDerivation rec {
       Teradata, Firebird, Derby, etc.
     '';
     license = licenses.asl20;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ jojosch ];
   };
 }

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -27,13 +27,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "7.3.3"; # When updating also update fetchedMavenDeps.sha256
+  version = "7.3.4"; # When updating also update fetchedMavenDeps.sha256
 
   src = fetchFromGitHub {
     owner = "dbeaver";
     repo = "dbeaver";
     rev = version;
-    sha256 = "sha256-FlnPPf7Fa4FH4/ORMgZbeUT3ScCRNtLDuZCRnqUAjU0=";
+    sha256 = "sha256-fgQeKnDm3m453Rqg1tb9R+H5uZgFnSwpPR6DDrInK4U=";
   };
 
   fetchedMavenDeps = stdenv.mkDerivation {

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -27,13 +27,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "7.3.4"; # When updating also update fetchedMavenDeps.sha256
+  version = "7.3.5"; # When updating also update fetchedMavenDeps.sha256
 
   src = fetchFromGitHub {
     owner = "dbeaver";
     repo = "dbeaver";
     rev = version;
-    sha256 = "sha256-fgQeKnDm3m453Rqg1tb9R+H5uZgFnSwpPR6DDrInK4U=";
+    sha256 = "sha256-gEE7rndOaXzruWL7TG+QgVkq1+06tIZwyGzU9cFc+oU=";
   };
 
   fetchedMavenDeps = stdenv.mkDerivation {
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     dontFixup = true;
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-M/10RGfhlBJzmFzTkEIo3AgA4B5yGDBL+elV0M65nn0=";
+    outputHash = "sha256-jT0Z154rVmafUbb6dqYSl3cUxMuK5MR4HUsprkrgSDw=";
   };
 
   buildInputs = [

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -27,13 +27,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "7.3.2"; # When updating also update fetchedMavenDeps.sha256
+  version = "7.3.3"; # When updating also update fetchedMavenDeps.sha256
 
   src = fetchFromGitHub {
     owner = "dbeaver";
     repo = "dbeaver";
     rev = version;
-    sha256 = "sha256-gh3++IEQzWOKGsazqeMp0aHuZ835etAou62cgz0GoNQ=";
+    sha256 = "sha256-FlnPPf7Fa4FH4/ORMgZbeUT3ScCRNtLDuZCRnqUAjU0=";
   };
 
   fetchedMavenDeps = stdenv.mkDerivation {
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     dontFixup = true;
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-uTKevwZvKiYOBz0hshh1rLEj7htYF7FQiTq6vZiVs7Q=";
+    outputHash = "sha256-M/10RGfhlBJzmFzTkEIo3AgA4B5yGDBL+elV0M65nn0=";
   };
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3479,7 +3479,13 @@ in
 
   davfs2 = callPackage ../tools/filesystems/davfs2 { };
 
-  dbeaver = callPackage ../applications/misc/dbeaver { };
+  dbeaver = callPackage ../applications/misc/dbeaver {
+    # TODO: remove once maven uses JDK 11
+    # error: org/eclipse/tycho/core/p2/P2ArtifactRepositoryLayout has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+    maven = maven.override {
+      jdk = jdk11;
+    };
+  };
 
   dbench = callPackage ../development/tools/misc/dbench { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3480,6 +3480,8 @@ in
   davfs2 = callPackage ../tools/filesystems/davfs2 { };
 
   dbeaver = callPackage ../applications/misc/dbeaver {
+    jdk = jdk11; # AlgorithmId.md5WithRSAEncryption_oid was removed in jdk15
+
     # TODO: remove once maven uses JDK 11
     # error: org/eclipse/tycho/core/p2/P2ArtifactRepositoryLayout has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
     maven = maven.override {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I finally got around to building dbeaver from source (resolving #34182). Here one problem occurred: maven needs JDK 11 as the jdk dependency to fix:

```
error: org/eclipse/tycho/core/p2/P2ArtifactRepositoryLayout has been compiled 
by a more recent version of the Java Runtime (class file version 55.0), this version 
of the Java Runtime only recognizes class file versions up to 52.0
```

Using JDK < 15 also fixes the build because `AlgorithmId.md5WithRSAEncryption_oid` was removed with JDK 15 and #107547 did update the default JDK to version 15:

```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:2.0.0:compile (default-compile) on project org.jkiss.dbeaver.model: Compilation failure: Compilation failure:
[ERROR] /build/source/plugins/org.jkiss.dbeaver.model/src/org/jkiss/dbeaver/model/impl/app/CertificateGenHelper.java:[69]
[ERROR] 	AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
[ERROR] 	                                               ^^^^^^^^^^^^^^^^^^^^^^^^
[ERROR] md5WithRSAEncryption_oid cannot be resolved or is not a field
```

-------------------

In addition, I've included some modifications for a macOS build (resolving #98631), since I have access to a Mac for a short time.

Could someone more familiar with the macOS side of things check my changes?

-------------------

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS (nix-build and run the .../MacOS/dbeaver Mach-O exe) - idk how to add the resulting Application to "Applications"
   - [x] other Linux distributions (Ubuntu 20.10)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/7r66lj6a84c94m9rp1wmcnd562gg0f0f-dbeaver-ce-7.3.2	 1461069608 (from source)
/nix/store/y1gihgszwbn7g4mgs6lcz8rjgnkhsq0i-dbeaver-ce-7.3.2	 1463280536 (from tarball)
/nix/store/vcdjp7ihjl5928s6q9c82lf17aky5m56-dbeaver-ce-7.3.3	 1318132560 (from source)
/nix/store/yxgbd9nzibm5cc2ra8158az8dv0iq36l-dbeaver-ce-7.3.2	 403813864 (macOS)
```
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
