### PR TITLE
Add scipy and pyyaml to FreeCAD, fix vtk8 build on gcc10

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -26,6 +26,9 @@ in mkDerivation rec {
     wrapQtAppsHook
   ];
 
+  # extra python pkgs for WorkBenches
+  # propagatedBuildInputs = [ yaml ];
+
   buildInputs = [
     cmake coin3d xercesc ode eigen opencascade-occt gts
     zlib swig gfortran soqt libf2c makeWrapper mpi vtk hdf5 medfile
@@ -33,6 +36,7 @@ in mkDerivation rec {
   ] ++ (with pythonPackages; [
     matplotlib pycollada shiboken2 pyside2 pyside2-tools pivy python boost
     GitPython # for addon manager
+    scipy pyyaml # (at least for) PyrateWorkbench
   ]);
 
   cmakeFlags = [

--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -26,9 +26,6 @@ in mkDerivation rec {
     wrapQtAppsHook
   ];
 
-  # extra python pkgs for WorkBenches
-  # propagatedBuildInputs = [ yaml ];
-
   buildInputs = [
     cmake coin3d xercesc ode eigen opencascade-occt gts
     zlib swig gfortran soqt libf2c makeWrapper mpi vtk hdf5 medfile

--- a/pkgs/development/libraries/vtk/7.x.nix
+++ b/pkgs/development/libraries/vtk/7.x.nix
@@ -5,5 +5,10 @@ import ./generic.nix {
   patchesToFetch = [{
    url = "https://gitlab.kitware.com/vtk/vtk/-/commit/706f1b397df09a27ab8981ab9464547028d0c322.diff";
    sha256 = "1q3pi5h40g05pzpbqp75xlgzvbfvyw8raza51svmi7d8dlslqybx";
- }];
+ }
+ {
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/vtk/files/vtk-8.2.0-gcc-10.patch?id=c4256f68d3589570443075eccbbafacf661f785f";
+    sha256 = "sha256:0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
+  }
+  ];
 }

--- a/pkgs/development/libraries/vtk/8.x.nix
+++ b/pkgs/development/libraries/vtk/8.x.nix
@@ -5,5 +5,11 @@ import ./generic.nix {
   patchesToFetch = [{
    url = "https://gitlab.kitware.com/vtk/vtk/-/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab.diff";
    sha256 = "0qdahp4f4gcaznr28j06d5fyxiis774ys0p335aazf7h51zb8rzy";
-  }];
+  }
+  {
+    meta.description = "Fix compiling with gcc-10+";
+    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/vtk/files/vtk-8.2.0-gcc-10.patch?id=c4256f68d3589570443075eccbbafacf661f785f";
+    sha256 = "0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
+  }
+  ];
 }

--- a/pkgs/development/libraries/vtk/8.x.nix
+++ b/pkgs/development/libraries/vtk/8.x.nix
@@ -7,9 +7,12 @@ import ./generic.nix {
    sha256 = "0qdahp4f4gcaznr28j06d5fyxiis774ys0p335aazf7h51zb8rzy";
   }
   {
-    meta.description = "Fix compiling with gcc-10+";
     url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/vtk/files/vtk-8.2.0-gcc-10.patch?id=c4256f68d3589570443075eccbbafacf661f785f";
-    sha256 = "0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
+    sha256 = "sha256:0bpwrdfmi15grsg4jy7bzj2z6511a0c160cmw5lsi65aabyh7cl5";
+  }
+  {
+    url = "https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6943.diff";
+    sha256 = "sha256:1nzdw3f6bsri04y528zj2klqkb9p8s4lnl9g5zvm119m1cmyhn04";
   }
   ];
 }

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -1,5 +1,5 @@
 { majorVersion, minorVersion, sourceSha256, patchesToFetch ? [] }:
-{ gcc9Stdenv, stdenv, lib, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libtiff
+{ stdenv, lib, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libtiff
 , fetchpatch
 , enableQt ? false, wrapQtAppsHook, qtbase, qtx11extras, qttools
 , enablePython ? false, pythonInterpreter ? throw "vtk: Python support requested, but no python interpreter was given."
@@ -13,7 +13,7 @@ let
 
   pythonMajor = lib.substring 0 1 pythonInterpreter.pythonVersion;
 
-in gcc9Stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "vtk${optionalString enableQt "-qvtk"}";
   version = "${majorVersion}.${minorVersion}";
 

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -1,5 +1,5 @@
 { majorVersion, minorVersion, sourceSha256, patchesToFetch ? [] }:
-{ stdenv, lib, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libtiff
+{ gcc9Stdenv, stdenv, lib, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libtiff
 , fetchpatch
 , enableQt ? false, wrapQtAppsHook, qtbase, qtx11extras, qttools
 , enablePython ? false, pythonInterpreter ? throw "vtk: Python support requested, but no python interpreter was given."
@@ -13,7 +13,7 @@ let
 
   pythonMajor = lib.substring 0 1 pythonInterpreter.pythonVersion;
 
-in stdenv.mkDerivation rec {
+in gcc9Stdenv.mkDerivation rec {
   pname = "vtk${optionalString enableQt "-qvtk"}";
   version = "${majorVersion}.${minorVersion}";
 


### PR DESCRIPTION
###### Motivation for this change

Custom build of `freecad` (for additional python modules needed by additional Workbenches) fails due to `vtk` build failing on `gcc10`

###### Things done

FreeCAD `PyrateWorkbench` (possibly others) needs `scipy` and `pyyaml`, these were added to the py-packages in the `freecad` nix. The `freecad` dep `vtk-8.2.0` fails to build with `gcc10`, modified the build file to require the `gcc9` env.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
