### PR TITLE
python3Packages.glances-api: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/glances-api/default.nix
+++ b/pkgs/development/python-modules/glances-api/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, async-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "glances-api";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-ecosystem";
+    repo = "python-glances-api";
+    rev = version;
+    sha256 = "0rgv77n0lvr7d3vk4qc8svipxafmm6s4lfxrl976hsygrhaqidch";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+  ];
+
+  # no tests are present
+  doCheck = false;
+  pythonImportsCheck = [ "glances_api" ];
+
+  meta = with lib; {
+    description = "Python Wrapper for interacting with the Volkszahler API";
+    homepage = "https://github.com/home-assistant-ecosystem/python-glances-api";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -303,7 +303,7 @@
     "github" = ps: with ps; [ PyGithub ];
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [ ]; # missing inputs: gitterpy
-    "glances" = ps: with ps; [ ]; # missing inputs: glances_api
+    "glances" = ps: with ps; [ glances-api ];
     "gntp" = ps: with ps; [ gntp ];
     "goalfeed" = ps: with ps; [ ]; # missing inputs: pysher
     "goalzero" = ps: with ps; [ ]; # missing inputs: goalzero

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2466,6 +2466,8 @@ in {
 
   glances = throw "glances has moved to pkgs.glances"; # added 2020-20-28
 
+  glances-api = callPackage ../development/python-modules/glances-api { };
+
   glasgow = callPackage ../development/python-modules/glasgow { };
 
   glob2 = callPackage ../development/python-modules/glob2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for interacting with Glances.

https://github.com/home-assistant-ecosystem/python-glances-api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
