### PR TITLE
appimage-run: fix #108426

### DIFF
--- a/pkgs/build-support/appimage/appimage-exec.sh
+++ b/pkgs/build-support/appimage/appimage-exec.sh
@@ -75,15 +75,15 @@ apprun() {
 
 wrap() {
 
-  cd "$APPDIR" || exit
   # quite same in appimageTools
   export APPIMAGE_SILENT_INSTALL=1
 
   if [ -n "$APPIMAGE_DEBUG_EXEC" ]; then
+    cd "$APPDIR" || true
     exec "$APPIMAGE_DEBUG_EXEC"
   fi
 
-  exec ./AppRun "$@"
+  exec "$APPDIR/AppRun" "$@"
 }
 
 usage() {

--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -1,4 +1,4 @@
-{ appimageTools, buildFHSUserEnv, extraPkgs ? pkgs: [] }:
+{ appimageTools, buildFHSUserEnv, extraPkgs ? pkgs: [], appimage-run-tests ? null }:
 
 let
   fhsArgs = appimageTools.defaultFhsEnvArgs;
@@ -8,4 +8,6 @@ in buildFHSUserEnv (fhsArgs // {
   targetPkgs = pkgs: [ appimageTools.appimage-exec ]
     ++ fhsArgs.targetPkgs pkgs ++ extraPkgs pkgs;
   runScript = "appimage-exec.sh";
+
+  passthru.tests.appimage-run = appimage-run-tests;
 })

--- a/pkgs/tools/package-management/appimage-run/test.nix
+++ b/pkgs/tools/package-management/appimage-run/test.nix
@@ -1,0 +1,24 @@
+{ runCommand, fetchurl, appimage-run, glibcLocales, file }:
+let
+  # any AppImage usable on cli, really
+  sample-appImage = fetchurl {
+    url = "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage";
+    sha256 =  "04ws94q71bwskmhizhwmaf41ma4wabvfgjgkagr8wf3vakgv866r";
+  };
+in
+  runCommand "appimage-run-tests" {
+    buildInputs = [ appimage-run glibcLocales file ];
+    meta.platforms = [ "x86_64-linux" ];
+  }
+  ''
+    export HOME=$(mktemp -d)
+    set -x
+    # regression test for #101137, must come first
+    LANG=fr_FR appimage-run ${sample-appImage} --list ${sample-appImage}
+    # regression test for #108426
+    cp ${sample-appImage} foo.appImage
+    LANG=fr_FR appimage-run ${sample-appImage} --list foo.appImage
+    set +x
+    touch $out
+  ''
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -852,7 +852,12 @@ in
     inherit (androidenv.androidPkgs_9_0) build-tools;
   };
 
-  appimage-run = callPackage ../tools/package-management/appimage-run {};
+  appimage-run = callPackage ../tools/package-management/appimage-run { };
+  appimage-run-tests = callPackage ../tools/package-management/appimage-run/test.nix {
+    appimage-run = appimage-run.override {
+      appimage-run-tests = null; /* break boostrap cycle for passthru.tests */
+    };
+  };
 
   appimagekit = callPackage ../tools/package-management/appimagekit {};
 


### PR DESCRIPTION
Fixes #108426
Adds regression tests for this issue and https://github.com/NixOS/nixpkgs/issues/101137
You can test that it tests the latter by locally reverting 4d51f95
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
