### PR TITLE
 soldat-unstable: init at unstable-2020-11-26;  gamenetworkingsockets: init at 1.2.0 

### DIFF
--- a/pkgs/development/libraries/gamenetworkingsockets/default.nix
+++ b/pkgs/development/libraries/gamenetworkingsockets/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, go, protobuf, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "GameNetworkingSockets";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ValveSoftware";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zghyc4liml8gzxflyh5gp6zi11ny6ng5hv9wyqvp32rfx221gc6";
+  };
+
+  nativeBuildInputs = [ cmake ninja go ];
+
+  cmakeFlags = [ "-G Ninja" ];
+
+  # tmp home for go
+  preBuild = "export HOME=\"$TMPDIR\"";
+
+  buildInputs = [ protobuf openssl ];
+
+  meta = with stdenv.lib; {
+    # build failure is resolved on master, remove at next release
+    broken = stdenv.isDarwin;
+    description = "GameNetworkingSockets is a basic transport layer for games";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    inherit (src.meta) homepage;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/games/soldat-unstable/default.nix
+++ b/pkgs/games/soldat-unstable/default.nix
@@ -1,0 +1,123 @@
+{ stdenv, fetchFromGitHub, fetchpatch, fpc, zip, makeWrapper
+, SDL2, freetype, physfs, openal, gamenetworkingsockets
+, xorg, autoPatchelfHook
+}:
+
+let
+  base = stdenv.mkDerivation rec {
+    pname = "soldat-base";
+    version = "unstable-2020-11-26";
+
+    src = fetchFromGitHub {
+      name = "base";
+      owner = "Soldat";
+      repo = "base";
+      rev = "e5f9c35ec12562595b248a7a921dd3458b36b605";
+      sha256 = "0qg0p2adb5v6di44iqczswldhypdqvn1nl96vxkfkxdg9i8x90w3";
+    };
+
+    nativeBuildInputs = [ zip ];
+
+    buildPhase = ''
+      sh create_smod.sh
+    '';
+
+    installPhase = ''
+      install -Dm644 soldat.smod -t $out/share/soldat
+      install -Dm644 client/play-regular.ttf -t $out/share/soldat
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Soldat's base game content";
+      license = licenses.cc-by-40;
+      platforms = platforms.all;
+      inherit (src.meta) homepage;
+    };
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "soldat-unstable";
+  version = "2020-11-26";
+
+  src = fetchFromGitHub {
+    name = "soldat";
+    owner = "Soldat";
+    repo = "soldat";
+    rev = "2280296ac56883f6a9cad4da48025af8ae7782e7";
+    sha256 = "17i3nlhxm4x4zx00i00aivhxmagbnyizxnpwiqzg57bf23hrvdj3";
+  };
+
+  nativeBuildInputs = [ fpc makeWrapper autoPatchelfHook ];
+
+  buildInputs = [ SDL2 freetype physfs openal gamenetworkingsockets ];
+  runtimeDependencies = [ xorg.libX11 ];
+
+  patches = [
+    # fix an argument parsing issue which prevents
+    # us from passing nix store paths to soldat
+    (fetchpatch {
+      url = "https://github.com/sternenseemann/soldat/commit/9f7687430f5fe142c563b877d2206f5c9bbd5ca0.patch";
+      sha256 = "0wsrazb36i7v4idg06jlzfhqwf56q9szzz7jp5cg4wsvcky3wajf";
+    })
+  ];
+
+  postPatch = ''
+    for f in client/Makefile server/Makefile; do
+      # fix unportable uname invocation
+      substituteInPlace "$f" --replace "uname -p" "uname -m"
+    done
+  '';
+
+  buildPhase = ''
+    mkdir -p client/build server/build
+
+    # build .so from stb headers
+    pushd client/libs/stb
+    make
+    popd
+
+    # build client
+    pushd client
+    make mode=release
+    popd
+
+    # build server
+    pushd server
+    make mode=release
+    popd
+  '';
+
+  installPhase = ''
+    install -Dm644 client/libs/stb/libstb.so -t $out/lib
+    install -Dm755 client/build/soldat_* $out/bin/soldat
+    install -Dm755 server/build/soldatserver_* $out/bin/soldatserver
+
+    # make sure soldat{,server} find their game archive,
+    # let them write their state and configuration files
+    # to $XDG_CONFIG_HOME/soldat/soldat{,server} unless
+    # the user specifies otherwise.
+    for p in $out/bin/soldatserver $out/bin/soldat; do
+      configDir="\''${XDG_CONFIG_HOME:-\$HOME/.config}/soldat/$(basename "$p")"
+
+      wrapProgram "$p" \
+        --run "mkdir -p \"$configDir\"" \
+        --add-flags "-fs_portable 0" \
+        --add-flags "-fs_userpath \"$configDir\"" \
+        --add-flags "-fs_basepath \"${base}/share/soldat\""
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Soldat is a unique 2D (side-view) multiplayer action game";
+    license = [ licenses.mit base.meta.license ];
+    inherit (src.meta) homepage;
+    maintainers = [ maintainers.sternenseemann ];
+    platforms = platforms.x86_64 ++ platforms.i686;
+    # portability currently mainly limited by fpc
+    # in nixpkgs which doesn't work on darwin,
+    # aarch64 and arm support should be possible:
+    # https://github.com/Soldat/soldat/issues/45
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26552,6 +26552,8 @@ in
   solarus = libsForQt5.callPackage ../games/solarus { };
   solarus-quest-editor = libsForQt5.callPackage ../development/tools/solarus-quest-editor { };
 
+  soldat-unstable = callPackage ../games/soldat-unstable { };
+
   # You still can override by passing more arguments.
   space-orbit = callPackage ../games/space-orbit { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13176,6 +13176,8 @@ in
 
   funambol = callPackage ../development/libraries/funambol { };
 
+  gamenetworkingsockets = callPackage ../development/libraries/gamenetworkingsockets { };
+
   gamin = callPackage ../development/libraries/gamin { };
   fam = gamin; # added 2018-04-25
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change



Adds the open sourced development version of soldat, a 2d side
scrolling shooter. The soldat-unstable attribute name was chosen since
this is a development version of the unfinished soldat 1.8 version which
most notably has incompatible netcode to the windows-only soldat 1.7
version which you can download on steam for example, so naming this
soldat-unstable hopefully avoids confusion as to why it is not possible
to connect to soldat 1.7 servers.

We wrap the soldat and soldatserver executables to have fixed paths set
for fs_basepath (the game archive) and fs_userpath (configuration, state
files). The latter is set to `$XDG_CONFIG_HOME/soldat/soldat{,server}` by
default to stop the executables from polluting the working directory.
Both settings can be overriden however by giving the respective options
on the command line of the wrapper.

GameNetworkingSockets is a dependency of soldat.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
