### PR TITLE
zchunk: 1.1.8 -> 1.1.9

### DIFF
--- a/pkgs/development/libraries/zchunk/default.nix
+++ b/pkgs/development/libraries/zchunk/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "zchunk";
-  version = "1.1.8";
+  version = "1.1.9";
 
   outputs = [ "out" "lib" "dev" ];
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "zchunk";
     repo = pname;
     rev = version;
-    sha256 = "0q1jafxh5nqgn2w5ciljkh8h46xma0qia8a5rj9m0pxixcacqj6q";
+    sha256 = "147h2v6fg3alcqgn4ksls4xyh8nn2xjpyy36wj8mwbm3lfvcga9j";
   };
 
   nativeBuildInputs = [
@@ -32,16 +32,6 @@ stdenv.mkDerivation rec {
     zstd
     curl
   ] ++ stdenv.lib.optional stdenv.isDarwin argp-standalone;
-
-  # Darwin needs a patch for argp-standalone usage and differing endian.h location on macOS
-  # https://github.com/zchunk/zchunk/pull/35
-  patches = [
-  (fetchpatch {
-    name = "darwin-support.patch";
-    url = "https://github.com/zchunk/zchunk/commit/f7db2ac0a95028a7f82ecb89862426bf53a69232.patch";
-    sha256 = "0cm84gyii4ly6nsmagk15g9kbfa13rw395nqk3fdcwm0dpixlkh4";
-  })
-];
 
   meta = with stdenv.lib; {
     description = "File format designed for highly efficient deltas while maintaining good compression";


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to the newest release 1.1.9 and remove the patch that was previously needed to get it to compile on darwin.

###### Things done
- Switch tag to 1.1.9 from 1.1.8
- Remove applied patch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS https://gist.github.com/nima2007/856e32b2c6bb2c2d9f715f6243567cc8
   - [X] other Linux distributions https://gist.github.com/nima2007/2e8c8e565c16c42f78f72641c9f29fe8
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
