### PR TITLE
xorg.xf86videovesa: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2289,11 +2289,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xf86videovesa = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, libpciaccess, xorgserver }: stdenv.mkDerivation {
-    name = "xf86-video-vesa-2.4.0";
+    name = "xf86-video-vesa-2.5.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/driver/xf86-video-vesa-2.4.0.tar.bz2";
-      sha256 = "1373vsxn6qh00na0s9c09kf09gj78rzi98zq93id8v5zsya3qi5z";
+      url = "mirror://xorg/individual/driver/xf86-video-vesa-2.5.0.tar.bz2";
+      sha256 = "0nf6ai74c60xk96kgr8q9mx6lrxm5id3765ws4d801irqzrj85hz";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -125,7 +125,7 @@ mirror://xorg/individual/driver/xf86-video-tga-1.2.2.tar.bz2
 mirror://xorg/individual/driver/xf86-video-trident-1.3.8.tar.bz2
 mirror://xorg/individual/driver/xf86-video-v4l-0.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-vboxvideo-1.0.0.tar.bz2
-mirror://xorg/individual/driver/xf86-video-vesa-2.4.0.tar.bz2
+mirror://xorg/individual/driver/xf86-video-vesa-2.5.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-vmware-13.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2020-September/003060.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).