### PR TITLE
xorg.xf86videonouveau: 1.0.15 -> 1.0.16

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2029,11 +2029,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xf86videonouveau = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, libdrm, udev, libpciaccess, xorgserver }: stdenv.mkDerivation {
-    name = "xf86-video-nouveau-1.0.15";
+    name = "xf86-video-nouveau-1.0.16";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/driver/xf86-video-nouveau-1.0.15.tar.bz2";
-      sha256 = "0k0xah72ryjwak4dc4crszxrlkmi9x1s7p3sd4la642n77yi1pmf";
+      url = "mirror://xorg/individual/driver/xf86-video-nouveau-1.0.16.tar.bz2";
+      sha256 = "01mz8gnq7j6bvrqb2ljm3d1wpjhi9p2z2w8zbkdrqmqmcj060h1h";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -105,7 +105,7 @@ mirror://xorg/individual/driver/xf86-video-mach64-6.9.6.tar.bz2
 mirror://xorg/individual/driver/xf86-video-mga-2.0.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-neomagic-1.3.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-newport-0.2.4.tar.bz2
-mirror://xorg/individual/driver/xf86-video-nouveau-1.0.15.tar.bz2
+mirror://xorg/individual/driver/xf86-video-nouveau-1.0.16.tar.bz2
 mirror://xorg/individual/driver/xf86-video-nv-2.1.21.tar.bz2
 mirror://xorg/individual/driver/xf86-video-omap-0.4.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-openchrome-0.6.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.freedesktop.org/archives/nouveau/2019-January/032053.html

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).