### PR TITLE
python.buildPythonPackage: Add support for maturin

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -37,6 +37,15 @@ in rec {
       deps = [ ];
     } ./egg-unpack-hook.sh) {};
 
+  maturinWheelHook = callPackage ({ }:
+    makeSetupHook {
+      name = "maturin-unpack-hook";
+      deps = [ ];
+      substitutions = {
+        inherit pythonInterpreter;
+      };
+    } ./maturin-unpack-hook.sh) {};
+
   flitBuildHook = callPackage ({ flit }:
     makeSetupHook {
       name = "flit-build-hook";

--- a/pkgs/development/interpreters/python/hooks/maturin-unpack-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/maturin-unpack-hook.sh
@@ -1,0 +1,18 @@
+# Setup hook to use in case a maturin generated wheel should be unpacked
+echo "Sourcing maturin setup hook"
+
+wheelUnpackPhase(){
+    echo "Executing maturinWheelUnpackPhase"
+    runHook preUnpack
+
+    mkdir -p dist
+    cp "$src"/*.whl dist
+
+#     runHook postUnpack # Calls find...?
+    echo "Finished executing maturinWheelUnpackPhase"
+}
+
+if [ -z "${dontMaturinWheelUnpackPhase-}" ] && [ -z "${unpackPhase-}" ]; then
+    echo "Using maturinWheelUnpackPhase"
+    unpackPhase=maturinWheelUnpackPhase
+fi

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -12,6 +12,7 @@
 , update-python-libraries
 , setuptools
 , flitBuildHook
+, maturinWheelHook
 , pipBuildHook
 , pipInstallHook
 , pythonCatchConflictsHook
@@ -125,6 +126,8 @@ let
       setuptoolsBuildHook
     ] ++ lib.optionals (format == "flit") [
       flitBuildHook
+    ] ++ lib.optionals (format == "maturin") [
+      maturinWheelHook
     ] ++ lib.optionals (format == "pyproject") [
       pipBuildHook
     ] ++ lib.optionals (format == "wheel") [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -109,6 +109,7 @@ in {
     eggBuildHook
     eggInstallHook
     flitBuildHook
+    maturinWheelHook
     pipBuildHook
     pipInstallHook
     pytestCheckHook


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
