### PR TITLE
haskell: Inline static overlay

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -33,7 +33,7 @@ in
 , profilingDetail ? "exported-functions"
 # TODO enable shared libs for cross-compiling
 , enableSharedExecutables ? false
-, enableSharedLibraries ? (ghc.enableShared or false)
+, enableSharedLibraries ? !stdenv.hostPlatform.isStatic && (ghc.enableShared or false)
 , enableDeadCodeElimination ? (!stdenv.isDarwin)  # TODO: use -dead_strip for darwin
 , enableStaticLibraries ? !(stdenv.hostPlatform.isWindows or stdenv.hostPlatform.isWasm)
 , enableHsc2hsViaAsm ? stdenv.hostPlatform.isWindows && stdenv.lib.versionAtLeast ghc.version "8.4"

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -50,15 +50,6 @@ self: super: let
     # ++ optional (super.stdenv.hostPlatform.libc == "glibc") ((flip overrideInStdenv) [ self.stdenv.glibc.static ])
   ;
 
-  # Force everything to link statically.
-  haskellStaticAdapter = self: super: {
-    mkDerivation = attrs: super.mkDerivation (attrs // {
-      enableSharedLibraries = false;
-      enableSharedExecutables = false;
-      enableStaticLibraries = true;
-    });
-  };
-
   removeUnknownConfigureFlags = f: with self.lib;
     remove "--disable-shared"
     (remove "--enable-static" f);
@@ -101,12 +92,6 @@ in {
   gcc9Stdenv = foldl (flip id) super.gcc9Stdenv staticAdapters;
   clangStdenv = foldl (flip id) super.clangStdenv staticAdapters;
   libcxxStdenv = foldl (flip id) super.libcxxStdenv staticAdapters;
-
-  haskell = super.haskell // {
-    packageOverrides = composeExtensions
-      (super.haskell.packageOverrides or (_: _: {}))
-      haskellStaticAdapter;
-  };
 
   zlib = super.zlib.override {
     # Don’t use new stdenv zlib because


### PR DESCRIPTION
###### Motivation for this change

We don't force `enableStaticLibraries` for Windows or WASM because it
will just fail an assertion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
