### PR TITLE
ccloud-cli: Declare the actual supported platforms

### DIFF
--- a/pkgs/development/tools/ccloud-cli/default.nix
+++ b/pkgs/development/tools/ccloud-cli/default.nix
@@ -28,6 +28,13 @@ stdenv.mkDerivation rec {
     homepage = "https://docs.confluent.io/current/cloud/cli/index.html";
     license = licenses.unfree;
     maintainers = with maintainers; [ kalbasit ];
-    platforms = platforms.linux ++ platforms.darwin;
+
+    # TODO: There's support for i686 systems but I do not have any such system
+    # to build it locally on, it's also unfree so I cannot rely on ofborg to
+    # build it. Get the list of supported system by looking at the list of
+    # files in the S3 bucket:
+    #
+    #   https://s3-us-west-2.amazonaws.com/confluent.cloud?prefix=ccloud-cli/archives/1.25.0/&delimiter=/%27
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/tools/ccloud-cli/default.nix
+++ b/pkgs/development/tools/ccloud-cli/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.25.0";
 
   # To get the latest version:
-  # curl -L 'https://s3-us-west-2.amazonaws.com/confluent.cloud?prefix=ccloud-cli/archives/&delimiter=/' | nix run nixpkgs.libxml2 -c xmllint --format -
+  # curl -L https://cnfl.io/ccloud-cli | sh -s -- -l | grep -v latest | sort -V | tail -n1
   src = fetchurl (if stdenv.hostPlatform.isDarwin then {
       url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/ccloud-cli/archives/${version}/ccloud_v${version}_darwin_amd64.tar.gz";
       sha256 = "0306jg36dpccwyy239r2xvw3bvsrnrdc88390g26fhcb0048qmgb";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

TODO:
- [ ] Test it locally on Linux
- [ ] Test it locally on Darwin