### PR TITLE
ocamlPackages.ppx_gen_rec: use Dune 2

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "ppx_gen_rec";
   version = "1.1.0";
 
-  minimumOCamlVersion = "4.01";
+  useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";


### PR DESCRIPTION
###### Motivation for this change

Prepare for OCaml 4.12.

cc maintainer @frontsideair

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
