### PR TITLE
pgmodeler: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -1,21 +1,26 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, qmake, mkDerivation,
-  qtsvg,
-  libxml2, postgresql }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, qmake
+, mkDerivation
+, qtsvg
+, libxml2
+, postgresql
+}:
 
 mkDerivation rec {
   pname = "pgmodeler";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "pgmodeler";
     repo = "pgmodeler";
     rev = "v${version}";
-    sha256 = "1wkvg20krfwkziz7skgmwlinx07jm5nl3455payg5brv69zf60kl";
+    sha256 = "1bci5x418dbnkny7hn0b5q5lxyajrgl3frv41ji0hcw9vivrds2g";
   };
 
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [ pkgconfig qmake ];
+  nativeBuildInputs = [ pkg-config qmake ];
   qmakeFlags = [ "pgmodeler.pro" "CONFIG+=release" ];
 
   # todo: libpq would suffice here. Unfortunately this won't work, if one uses only postgresql.lib here.
@@ -23,7 +28,6 @@ mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A database modeling tool for PostgreSQL";
-    longDescription = ''pgModeler (PostgreSQL Database Modeler) is an open source database modeling tool designed for PostgreSQL.'';
     homepage = "https://pgmodeler.io/";
     license = licenses.gpl3;
     maintainers = [ maintainers.esclear ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade pgModeler to the latest version. This version also fixes crashes after startup present in the current version.

Note: Database model file structure has changed - this can affect anyone upgrading from earlier versions. More info [here](https://pgmodeler.io/blog/2020/12/30/pgmodeler-093-is-finally-here-after-a-long-year-of-hard-work).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
