### PR TITLE
merkaartor: unstable-2019-11-12 -> unstable-2020-07-07, build with latest libsForQt5

### DIFF
--- a/pkgs/applications/misc/merkaartor/default.nix
+++ b/pkgs/applications/misc/merkaartor/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "merkaartor";
-  version = "unstable-2019-11-12";
+  version = "unstable-2020-07-07";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = "merkaartor";
-    rev = "29b3388680a03f1daac0037a2b504ea710da879a";
-    sha256 = "0h3d3srzl06p2ajq911j05zr4vkl88qij18plydx45yqmvyvh0xz";
+    rev = "0db9132ef4d1ee7910d45c3c00302440297c4603";
+    sha256 = "sha256-Y2pZby/iN4uFv9zh5x9frOqkrGydi3X6i9peEop0C8k=";
   };
 
   nativeBuildInputs = [ makeWrapper qmake pkgconfig ];
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     description = "OpenStreetMap editor";
     homepage = "http://merkaartor.be/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ erictapen ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22953,8 +22953,7 @@ in
 
   mercurialFull = appendToName "full" (pkgs.mercurial.override { guiSupport = true; });
 
-  # Needs qtwebkit which is broken on qt5.15
-  merkaartor = libsForQt514.callPackage ../applications/misc/merkaartor { };
+  merkaartor = libsForQt5.callPackage ../applications/misc/merkaartor { };
 
   meshlab = libsForQt5.callPackage ../applications/graphics/meshlab { };
 


### PR DESCRIPTION

###### Motivation for this change

Fix merkaartor build on `nixos-unstable`.

###### Things done

- Bumped to latest commit
- Addressed https://github.com/NixOS/nixpkgs/pull/104474
- Added myself as maintainer
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
