### PR TITLE
python3Packages.webthing: init at 0.15.0

### DIFF
--- a/pkgs/development/python-modules/webthing/default.nix
+++ b/pkgs/development/python-modules/webthing/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, ifaddr
+, jsonschema
+, pyee
+, tornado
+, zeroconf
+}:
+
+buildPythonPackage rec {
+  pname = "webthing";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "WebThingsIO";
+    repo = "webthing-python";
+    rev = "v${version}";
+    sha256 = "06264rwchy4qmbn7lv7m00qg864y7aw3rngcqqcr9nvaqz4rb0fg";
+  };
+
+  propagatedBuildInputs = [
+    ifaddr
+    jsonschema
+    pyee
+    tornado
+    zeroconf
+  ];
+
+  # no tests are present
+  doCheck = false;
+  pythonImportsCheck = [ "webthing" ];
+
+  meta = with lib; {
+    description = "Python implementation of a Web Thing server";
+    homepage = "https://github.com/WebThingsIO/webthing-python";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7902,6 +7902,8 @@ in {
 
   webtest = callPackage ../development/python-modules/webtest { };
 
+  webthing = callPackage ../development/python-modules/webthing { };
+
   werkzeug = callPackage ../development/python-modules/werkzeug { };
 
   west = callPackage ../development/python-modules/west { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation of a Web Thing server.

https://github.com/WebThingsIO/webthing-python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
