### PR TITLE
nixos/doc/manual: In the preface, add link to #chap-contributing

### DIFF
--- a/nixos/doc/manual/contributing-to-this-manual.xml
+++ b/nixos/doc/manual/contributing-to-this-manual.xml
@@ -1,7 +1,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xml:id="chap-contributing">
- <title>Contributing to this documentation</title>
+ <title>Contributing to this manual</title>
  <para>
   The DocBook sources of NixOS' manual are in the <filename
 xlink:href="https://github.com/NixOS/nixpkgs/tree/master/nixos/doc/manual">

--- a/nixos/doc/manual/preface.xml
+++ b/nixos/doc/manual/preface.xml
@@ -21,7 +21,11 @@
    xlink:href="https://discourse.nixos.org">Discourse</literal> or
   on the <link
    xlink:href="irc://irc.freenode.net/#nixos">
-  <literal>#nixos</literal> channel on Freenode</link>. Bugs should be
+  <literal>#nixos</literal> channel on Freenode</link>, or
+  consider
+  <link
+   xlink:href="#chap-contributing">
+   contributing to this manual</link>. Bugs should be
   reported in
   <link
    xlink:href="https://github.com/NixOS/nixpkgs/issues">NixOS’


### PR DESCRIPTION
###### Motivation for this change

it took me long minutes to find out where the sources are for this document.

###### Things done

- in the preface i added a link to #chap-contributing
- turned the freetext suggestion about opening the build output into a copy-pastable xdg-open line
- renamed chapter title to 'Contributing to this manual'
- tested the build on x86_64 nixos

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
