### PR TITLE
teleport,teleport.client: 4.2.11 -> 5.1.2

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -41,21 +41,29 @@ buildGoPackage rec {
     popd
   '';
 
-  dontStrip = true;
+  # Reduce closure size for client machines
+  outputs = [ "out" "client" ];
+
+  buildTargets = [ "full" ];
+
+  postInstall = ''
+    install -Dm755 -t $client/bin $out/bin/tsh
+  '';
 
   doInstallCheck = true;
 
   installCheckPhase = ''
     $out/bin/tsh version | grep ${version} > /dev/null
+    $client/bin/tsh version | grep ${version} > /dev/null
     $out/bin/tctl version | grep ${version} > /dev/null
     $out/bin/teleport version | grep ${version} > /dev/null
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A SSH CA management suite";
     homepage = "https://gravitational.com/teleport/";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ sigma tomberek ];
-    platforms = lib.platforms.unix;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sigma tomberek freezeboy ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream update

And split the client `tsh` binary from the rest to reduce the size for "users" maybe servers could also be shrinked.

I would prefer someone to double check on their setup as it is quite a sensitive software.

Maybe could be also interesting to add a module and a test for it

I am also unsure if it is better for the default derivation to contain only the client or both the client and the server

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
