### PR TITLE
ocamlPackages.cstruct: 5.0.0 -> 6.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,8 +1,8 @@
-{ lib, fetchurl, buildDunePackage, bigarray-compat }:
+{ lib, fetchurl, buildDunePackage, bigarray-compat, alcotest, ocaml }:
 
 buildDunePackage rec {
   pname = "cstruct";
-  version = "5.0.0";
+  version = "6.0.0";
 
   useDune2 = true;
 
@@ -10,10 +10,14 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-v${version}.tbz";
-    sha256 = "1z403q2nkgz5x07j0ypy6q0mk2yxgqbp1jlqkngbajna7124x2pb";
+    sha256 = "0xi6cj85z033fqrqdkwac6gg07629vzdhx03c3lhiwwc4lpnv8bq";
   };
 
   propagatedBuildInputs = [ bigarray-compat ];
+
+  # alcotest isn't available for OCaml < 4.05 due to fmt
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ alcotest ];
 
   meta = {
     description = "Access C-like structures directly from OCaml";

--- a/pkgs/development/ocaml-modules/cstruct/lwt.nix
+++ b/pkgs/development/ocaml-modules/cstruct/lwt.nix
@@ -8,7 +8,7 @@ buildDunePackage {
   pname = "cstruct-lwt";
   inherit (cstruct) version src useDune2 meta;
 
-  minimumOCamlVersion = "4.02";
+  minimumOCamlVersion = "4.03";
 
   propagatedBuildInputs = [ cstruct lwt ];
 }

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -1,4 +1,7 @@
-{ lib, buildDunePackage, cstruct, sexplib, ppx_tools_versioned, ppxlib }:
+{ lib, buildDunePackage, cstruct, sexplib, ppxlib, stdlib-shims
+, ounit, cppo, ppx_sexp_conv, cstruct-unix, cstruct-sexp
+, fetchpatch
+}:
 
 if !lib.versionAtLeast (cstruct.version or "1") "3"
 then cstruct
@@ -8,7 +11,22 @@ buildDunePackage {
   pname = "ppx_cstruct";
   inherit (cstruct) version src useDune2 meta;
 
-  minimumOCamlVersion = "4.03";
+  minimumOCamlVersion = "4.07";
 
-  propagatedBuildInputs = [ cstruct ppx_tools_versioned ppxlib sexplib ];
+  # prevent ANSI escape sequences from messing up the test cases
+  # https://github.com/mirage/ocaml-cstruct/issues/283
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/mirage/ocaml-cstruct/pull/285/commits/60dfed98b4c34455bf339ac60e2ed5ef05feb48f.patch";
+      sha256 = "1x9i62nrlfy9l44vb0a7qjfrg2wyki4c8nmmqnzwpcbkgxi3q6n5";
+    })
+  ];
+
+  propagatedBuildInputs = [ cstruct ppxlib sexplib stdlib-shims ];
+
+  # disable until ppx_sexp_conv uses ppxlib 0.20.0 (or >= 0.16.0)
+  # since the propagation of the older ppxlib breaks the ppx_cstruct
+  # build.
+  doCheck = false;
+  checkInputs = [ ounit cppo ppx_sexp_conv cstruct-sexp cstruct-unix ];
 }

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -8,8 +8,11 @@ buildDunePackage rec {
   pname = "cstruct-sexp";
   inherit (cstruct) version src useDune2 meta;
 
-  doCheck = lib.versionAtLeast ocaml.version "4.03";
-  checkInputs = lib.optional doCheck alcotest;
+  minimumOCamlVersion = "4.03";
+
+  # alcotest is only available on OCaml >= 4.05 due to fmt
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ alcotest ];
 
   propagatedBuildInputs = [ cstruct sexplib ];
 }

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, result, js_of_ocaml }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, result, js_of_ocaml
+, jsooSupport ? true
+}:
 
 stdenv.mkDerivation rec {
   version = "0.8.5";
@@ -10,11 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ findlib topkg js_of_ocaml ];
+  buildInputs = [ findlib topkg ]
+    ++ lib.optional jsooSupport js_of_ocaml;
 
   propagatedBuildInputs = [ result ];
 
-  buildPhase = "${topkg.run} build --with-js_of_ocaml true";
+  buildPhase = "${topkg.run} build --with-js_of_ocaml ${lib.boolToString jsooSupport}";
 
   inherit (topkg) installPhase;
 

--- a/pkgs/development/ocaml-modules/xenstore/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore/default.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage, fetchurl
-, cstruct, ppx_cstruct, lwt, ounit
+, cstruct, ppx_cstruct, lwt, ounit, stdlib-shims
 }:
 
 buildDunePackage rec {
@@ -16,7 +16,7 @@ buildDunePackage rec {
   };
 
   nativeBuildInputs = [ ppx_cstruct ];
-  propagatedBuildInputs = [ cstruct lwt ];
+  propagatedBuildInputs = [ stdlib-shims cstruct lwt ];
 
   doCheck = true;
   checkInputs = [ ounit ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -975,7 +975,7 @@ let
 
     ppx_blob = callPackage ../development/ocaml-modules/ppx_blob { };
 
-    ppx_cstruct = callPackage ../development/ocaml-modules/cstruct/ppx.nix {};
+    ppx_cstruct = callPackage ../development/ocaml-modules/cstruct/ppx.nix { };
 
     ppx_derivers = callPackage ../development/ocaml-modules/ppx_derivers {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

<https://github.com/mirage/ocaml-cstruct/releases/tag/v6.0.0>, switch to ppxlib.

This PR also contains commits from #108137 (which made this upgrade possible) and should probably reviewed after the mentioned PR has been merged. For now this is for informational purposes mostly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
