### PR TITLE
cmake/setup-hook.sh: Don't skip build-RPATH

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -128,7 +128,6 @@ in mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DWITH_3D=True"
     "-DWITH_PDAL=TRUE"
     "-DPYQT5_SIP_DIR=${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -128,7 +128,6 @@ in mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DWITH_3D=True"
     "-DWITH_PDAL=TRUE"
     "-DPYQT5_SIP_DIR=${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"

--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -44,13 +44,6 @@ in mkDerivation rec {
     export QT_PLUGIN_PATH=${qtbase.bin}/${qtbase.qtPluginPrefix}
   '';
 
-  # During build, binaries are called that rely on freshly built
-  # libraries.  These reside in build/lib, and are not found by
-  # default.
-  preBuild = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/lib:$PWD/VTK/ThirdParty/vtkm/vtk-m/lib
-  '';
-
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DPARAVIEW_ENABLE_FFMPEG=ON"

--- a/pkgs/applications/kde/dolphin.nix
+++ b/pkgs/applications/kde/dolphin.nix
@@ -27,8 +27,4 @@ mkDerivation {
     wayland qtwayland
   ];
   outputs = [ "out" "dev" ];
-  # We need the RPATH for linking, because the `libkdeinit5_dolphin.so` links
-  # private against its dependencies and without the correct RPATH, these
-  # dependencies are not found.
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
 }

--- a/pkgs/applications/misc/audio/soxr/default.nix
+++ b/pkgs/applications/misc/audio/soxr/default.nix
@@ -16,13 +16,6 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "doc" ]; # headers are just two and very small
 
-  preConfigure =
-    if stdenv.isDarwin then ''
-      export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}"`pwd`/build/src
-    '' else ''
-      export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}"`pwd`/build/src
-    '';
-
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -59,10 +59,6 @@ in stdenv.mkDerivation {
     sed -i -e '1i cmake_policy(SET CMP0025 NEW)' CMakeLists.txt
   '';
 
-  preBuild = ''
-    export LD_LIBRARY_PATH="$PWD/run"
-  '';
-
   postInstall = ''
     # to remove "cycle detected in the references"
     mkdir -p $dev/lib/wireshark

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -154,8 +154,6 @@ stdenv.mkDerivation rec {
       test-xml-pricedb \
       test-xml-transaction \
       test-xml2-is-file
-
-      export LD_LIBRARY_PATH="$PWD/lib:$PWD/lib/gnucash:$PWD/lib/gnucash/test:$PWD/lib/gnucash/test/future"
   '';
 
   preFixup = ''

--- a/pkgs/applications/radio/dsd/default.nix
+++ b/pkgs/applications/radio/dsd/default.nix
@@ -22,10 +22,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals portaudioSupport [ portaudio ];
 
   doCheck = true;
-  preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD
-  '';
 
   meta = with lib; {
     description = "Digital Speech Decoder";

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -134,7 +134,6 @@ stdenv.mkDerivation rec {
     "-DCMAKE_DISABLE_FIND_PACKAGE_Mosek=ON"
     "-DCMAKE_DISABLE_FIND_PACKAGE_TFLogger=ON"
     "-DCMAKE_DISABLE_FIND_PACKAGE_ViennaCL=ON"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;TrainedModelSerialization'"  # Sporadic segfault
     "-DENABLE_TESTING=${enableIf doCheck}"
     "-DDISABLE_META_INTEGRATION_TESTS=ON"

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -73,11 +73,6 @@ stdenv.mkDerivation rec {
     patchShebangs ..
   '';
 
-  # needed by tests (so libsimgrid.so is found)
-  preConfigure = ''
-    export LD_LIBRARY_PATH="$PWD/build/lib"
-  '';
-
   doCheck = true;
   preCheck = ''
     # prevent the execution of tests known to fail

--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation rec {
     cd "$sourceRoot"
     patchPhase
 
-    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${libXext}/lib"
     ${stdenv.shell} bootStrap.bash \
       --with-core \
       ${if withQT then "--with-qt" else "--without-qt"} \

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -119,7 +119,6 @@ stdenv.mkDerivation rec {
     "-DENABLE_UOA=OFF"
     "-DENABLE_VALA_BINDINGS=ON"
     "-DENABLE_INTROSPECTION=ON"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DINCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
     "-DWITH_PHONENUMBER=ON"
     "-DWITH_GWEATHER4=ON"

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -61,7 +61,6 @@ mkDerivation {
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''
   ];
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
   postInstall = ''
     # Some package(s) refer to these service types by the wrong name.
     # I would prefer to patch those packages, but I cannot find them!

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -32,12 +32,6 @@ llvmPackages.stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" "-DWITH_PYTHON_BINDINGS=OFF" ];
 
-  # To handle the lack of 'local' RPATH; required, as they call one of
-  # their built binaries requiring their libs, in the build process.
-  preBuild = ''
-    export LD_LIBRARY_PATH="$(pwd)/src''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-  '';
-
   # Note: only openblas and not atlas part of this Nix expression
   # see pkgs/development/libraries/science/math/liblapack/3.5.0.nix
   # to get a hint howto setup atlas instead of openblas

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -90,12 +90,6 @@ let
     doCheck = false;
 
     checkPhase = ''
-      while IFS= read -r -d ''' dir
-      do
-        LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$(pwd)/$dir
-        export LD_LIBRARY_PATH
-      done <   <(find . -type d -print0)
-
       pushd ..
       # IPC tests need aleth avaliable, so we disable it
       sed -i "s/IPC_ENABLED=true/IPC_ENABLED=false\nIPC_FLAGS=\"--no-ipc\"/" ./scripts/tests.sh

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -204,7 +204,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (!enableShared) [
     "-DARROW_TEST_LINKAGE=static"
   ] ++ lib.optionals stdenv.isDarwin [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # needed for tests
     "-DCMAKE_INSTALL_RPATH=@loader_path/../lib" # needed for tools executables
   ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF"
   ++ lib.optional enableS3 "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp}/include/aws/core/Aws.h";

--- a/pkgs/development/libraries/audio/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/audio/libkeyfinder/default.nix
@@ -11,9 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7w/Wc9ncLinbnM2q3yv5DBtFoJFAM2e9xAUTsqvE9mg=";
   };
 
-  # needed for finding libkeyfinder.so to link it into keyfinder-tests executable
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
-
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ fftw ];

--- a/pkgs/development/libraries/audio/mbelib/default.nix
+++ b/pkgs/development/libraries/audio/mbelib/default.nix
@@ -14,10 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   doCheck = true;
-  preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD
-  '';
 
   meta = with lib; {
     description = "P25 Phase 1 and ProVoice vocoder";

--- a/pkgs/development/libraries/aws-c-auth/default.nix
+++ b/pkgs/development/libraries/aws-c-auth/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
   ] ++ lib.optionals stdenv.hostPlatform.isRiscV [
     "-DCMAKE_C_FLAGS=-fasynchronous-unwind-tables"
   ];

--- a/pkgs/development/libraries/aws-c-compression/default.nix
+++ b/pkgs/development/libraries/aws-c-compression/default.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-c-http/default.nix
+++ b/pkgs/development/libraries/aws-c-http/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-c-mqtt/default.nix
+++ b/pkgs/development/libraries/aws-c-mqtt/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-c-s3/default.nix
+++ b/pkgs/development/libraries/aws-c-s3/default.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-c-sdkutils/default.nix
+++ b/pkgs/development/libraries/aws-c-sdkutils/default.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-crt-cpp/default.nix
+++ b/pkgs/development/libraries/aws-crt-cpp/default.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -85,7 +85,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_DEPS=OFF"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ] ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
   ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "-DENABLE_TESTING=OFF"

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkTarget = "test";
-  preCheck = ''
-    export LD_LIBRARY_PATH=$PWD/libcaf_core:$PWD/libcaf_io
-    export DYLD_LIBRARY_PATH=$PWD/libcaf_core:$PWD/libcaf_io
-  '';
 
   meta = with lib; {
     description = "An open source implementation of the actor model in C++";

--- a/pkgs/development/libraries/cpp-netlib/default.nix
+++ b/pkgs/development/libraries/cpp-netlib/default.nix
@@ -19,11 +19,6 @@ stdenv.mkDerivation rec {
     "-DCPP-NETLIB_BUILD_SHARED_LIBS=ON"
   ];
 
-  # The test driver binary lacks an RPath to the library's libs
-  preCheck = ''
-    export LD_LIBRARY_PATH=$PWD/libs/network/src
-  '';
-
   # Most tests make network GET requests to various websites
   doCheck = false;
 

--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation rec {
     "-DCRC32C_BUILD_BENCHMARKS=0"
     "-DCRC32C_USE_GLOG=0"
     "-DBUILD_SHARED_LIBS=${if staticOnly then "0" else "1"}"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
   ];
 
   doCheck = false;

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -27,9 +27,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DCTESTS=ON" ];
   doCheck = true;
-  preCheck = ''
-    export LD_LIBRARY_PATH=`pwd`''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
-  '';
   checkTarget = "criterion_tests test";
 
   outputs = [ "dev" "out" ];

--- a/pkgs/development/libraries/cutelyst/default.nix
+++ b/pkgs/development/libraries/cutelyst/default.nix
@@ -31,14 +31,6 @@ stdenv.mkDerivation rec {
     "-DPLUGIN_VIEW_GRANTLEE=ON"
   ];
 
-  preBuild = lib.optionalString stdenv.isLinux ''
-    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}`pwd`/Cutelyst:`pwd`/EventLoopEPoll"
-  '';
-
-  postBuild = lib.optionalString stdenv.isLinux ''
-    unset LD_LIBRARY_PATH
-  '';
-
   meta = with lib; {
     description = "C++ Web Framework built on top of Qt";
     homepage = "https://cutelyst.org/";

--- a/pkgs/development/libraries/docopt_cpp/default.nix
+++ b/pkgs/development/libraries/docopt_cpp/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
                 "@CMAKE_INSTALL_LIBDIR@"
   '';
 
-  checkPhase = "LD_LIBRARY_PATH=$(pwd) python ./run_tests";
+  checkPhase = "python ./run_tests";
 
   meta = with lib; {
     description = "C++11 port of docopt";

--- a/pkgs/development/libraries/fcppt/default.nix
+++ b/pkgs/development/libraries/fcppt/default.nix
@@ -13,7 +13,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost catch2 metal ];
 
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=false" "-DENABLE_BOOST=true" "-DENABLE_EXAMPLES=true" "-DENABLE_CATCH=true" "-DENABLE_TEST=true" ];
+  cmakeFlags = [
+    "-DENABLE_BOOST=true"
+    "-DENABLE_EXAMPLES=true"
+    "-DENABLE_CATCH=true"
+    "-DENABLE_TEST=true"
+  ];
 
   meta = with lib; {
     description = "Freundlich's C++ toolkit";

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -23,7 +23,6 @@ let
 
       cmakeFlags = [
         "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}"
-        "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
       ];
 
       doCheck = true;

--- a/pkgs/development/libraries/galario/default.nix
+++ b/pkgs/development/libraries/galario/default.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation rec {
   '';
 
   preCheck = ''
-    ${if stdenv.isDarwin then "export DYLD_LIBRARY_PATH=$(pwd)/src/" else "export LD_LIBRARY_PATH=$(pwd)/src/"}
     ${if enablePython then "sed -i -e 's|^#!.*|#!${stdenv.shell}|' python/py.test.sh" else ""}
   '';
 

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -17,9 +17,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    # Mak CMake place RPATHs such that tests will find the built libraries.
-    # See https://github.com/NixOS/nixpkgs/pull/144561#discussion_r742468811 and https://github.com/NixOS/nixpkgs/pull/108496
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ];
 
   # TODO: Re-enable Darwin tests once we're on a release that has https://github.com/google/glog/issues/709#issuecomment-960381653 fixed

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     "-DgRPC_PROTOBUF_PROVIDER=package"
     "-DgRPC_ABSL_PROVIDER=package"
     "-DBUILD_SHARED_LIBS=ON"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-D_gRPC_PROTOBUF_PROTOC_EXECUTABLE=${buildPackages.protobuf}/bin/protoc"
   ] ++ lib.optionals ((stdenv.hostPlatform.useLLVM or false) && lib.versionOlder stdenv.cc.cc.version "11.0") [

--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -87,13 +87,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  # needed to find libigraph, and liblas on darwin
-  preCheck = if stdenv.isDarwin then ''
-    export DYLD_LIBRARY_PATH="${lib.makeLibraryPath [ blas ]}:$PWD/src"
-  '' else ''
-    export LD_LIBRARY_PATH="$PWD/src"
-  '';
-
   postInstall = ''
     mkdir -p "$out/share"
     cp -r doc "$out/share"

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -43,14 +43,6 @@ stdenv.mkDerivation rec {
     sed -i 's/#define JSONCPP_USING_SECURE_MEMORY 0/#define JSONCPP_USING_SECURE_MEMORY 1/' include/json/version.h
   '';
 
-  # Hack to be able to run the test, broken because we use
-  # CMAKE_SKIP_BUILD_RPATH to avoid cmake resetting rpath on install
-  preBuild = if stdenv.isDarwin then ''
-    export DYLD_LIBRARY_PATH="$PWD/lib''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
-  '' else ''
-    export LD_LIBRARY_PATH="$PWD/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-  '';
-
   nativeBuildInputs = [ cmake python3 validatePkgConfig ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
   # NOTE: disabling tests due to gtest issue
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DLEVELDB_BUILD_TESTS=OFF"
     "-DLEVELDB_BUILD_BENCHMARKS=OFF"
   ];

--- a/pkgs/development/libraries/lib2geom/default.nix
+++ b/pkgs/development/libraries/lib2geom/default.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
     "-D2GEOM_BUILD_SHARED=ON"
   ];
 

--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -129,16 +129,6 @@ stdenv.mkDerivation rec {
 
   doCheck = !stdenv.hostPlatform.isi686;
 
-  # The test driver runs a test `LibraryCLinkageTest` which without
-  # LD_LIBRARY_PATH setting errors with:
-  #     /build/source/build/tools/tests/libjxl_test: error while loading shared libraries: libjxl.so.0
-  # The required file is in the build directory (`$PWD`).
-  preCheck = if stdenv.isDarwin then ''
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD
-  '' else ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD
-  '';
-
   meta = with lib; {
     homepage = "https://github.com/libjxl/libjxl";
     description = "JPEG XL image format reference implementation.";

--- a/pkgs/development/libraries/libminc/default.nix
+++ b/pkgs/development/libraries/libminc/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
 
   doCheck = !stdenv.isDarwin;
   checkPhase = ''
-    export LD_LIBRARY_PATH="$(pwd)"  # see #22060
     ctest -j1 -E 'ezminc_rw_test' --output-on-failure
     # -j1: see https://github.com/BIC-MNI/libminc/issues/110
     # ezminc_rw_test: can't find libminc_io.so.5.2.0

--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkPhase = ''
-    export LD_LIBRARY_PATH=$PWD
     ./utest/utest --path ../examples/data/
   '';
 

--- a/pkgs/development/libraries/libtiff/aarch64-darwin.nix
+++ b/pkgs/development/libraries/libtiff/aarch64-darwin.nix
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
     sha256 = "1jrkjv0xya9radddn8idxvs2gqzp3l2b1s8knlizmn7ad3jq817b";
   };
 
-  cmakeFlags = lib.optional stdenv.isDarwin "-DCMAKE_SKIP_BUILD_RPATH=OFF";
-
   # FreeImage needs this patch
   patches = [ ./headers-cmake.patch ];
 

--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -30,10 +30,6 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-  preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD${placeholder "out"}/lib
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD${placeholder "out"}/lib
-  '';
   checkTarget = "tests test";
 
   meta = with lib; {

--- a/pkgs/development/libraries/libuchardet/default.nix
+++ b/pkgs/development/libraries/libuchardet/default.nix
@@ -13,10 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
-  ];
-
   doCheck = !stdenv.isi686; # tests fail on i686
 
   meta = with lib; {

--- a/pkgs/development/libraries/libversion/default.nix
+++ b/pkgs/development/libraries/libversion/default.nix
@@ -13,10 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = lib.optional stdenv.isDarwin [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # needed for tests
-  ];
-
   preCheck = ''
     export LD_LIBRARY_PATH=/build/source/build/libversion/''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
   '';

--- a/pkgs/development/libraries/libversion/default.nix
+++ b/pkgs/development/libraries/libversion/default.nix
@@ -13,9 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=/build/source/build/libversion/''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
-  '';
   doCheck = true;
   checkTarget = "test";
 

--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DENABLE_FORTRAN=ON"
     "-DBUILD_SHARED_LIBS=ON"
-    # needed for tests to link
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     # Force compilation of higher derivatives
     "-DDISABLE_VXC=0"
     "-DDISABLE_FXC=0"

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     (
       cd unittest
-      LD_LIBRARY_PATH="$(cd ../src; pwd)" TZ=PST8PDT ./unittestcpp ../../unittest/data
+      TZ=PST8PDT ./unittestcpp ../../unittest/data
     )
   '';
 

--- a/pkgs/development/libraries/oneDNN/default.nix
+++ b/pkgs/development/libraries/oneDNN/default.nix
@@ -21,12 +21,6 @@ stdenv.mkDerivation rec {
   # Tests fail on some Hydra builders, because they do not support SSE4.2.
   doCheck = false;
 
-  # The test driver doesn't add an RPath to the build libdir
-  preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/src
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/src
-  '';
-
   # The cmake install gets tripped up and installs a nix tree into $out, in
   # addition to the correct install; clean it up.
   postInstall = ''

--- a/pkgs/development/libraries/orcania/default.nix
+++ b/pkgs/development/libraries/orcania/default.nix
@@ -18,11 +18,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  preCheck = ''
-    export LD_LIBRARY_PATH="$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-    export DYLD_FALLBACK_LIBRARY_PATH="$(pwd):$DYLD_FALLBACK_LIBRARY_PATH"
-  '';
-
   meta = with lib; {
     description = "Potluck with different functions for different purposes that can be shared among C programs";
     homepage = "https://github.com/babelouest/orcania";

--- a/pkgs/development/libraries/plplot/default.nix
+++ b/pkgs/development/libraries/plplot/default.nix
@@ -33,7 +33,9 @@ in stdenv.mkDerivation rec {
     ;
   };
 
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" "-DBUILD_TEST=ON" ];
+  cmakeFlags = [
+    "-DBUILD_TEST=ON"
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -22,14 +22,6 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ check ];
 
-  # Hack to be able to run the test, broken because we use
-  # CMAKE_SKIP_BUILD_RPATH to avoid cmake resetting rpath on install
-  preCheck = if stdenv.isDarwin then ''
-    export DYLD_LIBRARY_PATH="$(pwd)''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
-  '' else ''
-    export LD_LIBRARY_PATH="$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-  '';
-
   preConfigure = ''
     # Enable long long support (required for filezilla)
     sed -ire '/PUGIXML_HAS_LONG_LONG/ s/^\/\///' src/pugiconfig.hpp

--- a/pkgs/development/libraries/s2n-tls/default.nix
+++ b/pkgs/development/libraries/s2n-tls/default.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF" # disable -Werror
   ] ++ lib.optionals stdenv.hostPlatform.isMips64 [
     # See https://github.com/aws/s2n-tls/issues/1592 and https://github.com/aws/s2n-tls/pull/1609

--- a/pkgs/development/libraries/science/biology/bpp-core/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-core/default.nix
@@ -12,10 +12,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$(pwd)/src
-  '';
-
   postFixup = ''
     substituteInPlace $out/lib/cmake/bpp-core/bpp-core-targets.cmake  \
       --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'

--- a/pkgs/development/libraries/science/biology/bpp-phyl/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-phyl/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ bpp-core bpp-seq ];
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$(pwd)/src
-  '';
-
   postFixup = ''
     substituteInPlace $out/lib/cmake/${pname}/${pname}-targets.cmake  \
       --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'

--- a/pkgs/development/libraries/science/biology/bpp-popgen/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-popgen/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ bpp-core bpp-seq ];
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$(pwd)/src
-  '';
-
   postFixup = ''
     substituteInPlace $out/lib/cmake/${pname}/${pname}-targets.cmake  \
       --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'

--- a/pkgs/development/libraries/science/biology/bpp-seq/default.nix
+++ b/pkgs/development/libraries/science/biology/bpp-seq/default.nix
@@ -15,10 +15,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ bpp-core ];
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$(pwd)/src
-  '';
-
   postFixup = ''
     substituteInPlace $out/lib/cmake/${pname}/${pname}-targets.cmake  \
       --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'

--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -24,10 +24,6 @@ stdenv.mkDerivation rec {
 
   doCheck = !stdenv.isDarwin;  # usual dynamic linker issues
 
-  preCheck = "
-    export LD_LIBRARY_PATH=$(pwd)/bin
-  ";
-
   meta = with lib; {
     homepage = "https://elastix.lumc.nl";
     description = "Image registration toolkit based on ITK";

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -36,11 +36,7 @@ stdenv.mkDerivation rec {
     "-DINTERFACE64=${if blas.isILP64 then "1" else "0"}"
   ];
 
-  preCheck = if stdenv.isDarwin then ''
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}`pwd`/lib:${blas}/lib:${lapack}/lib
-  '' else ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}`pwd`/lib
-  '' + ''
+  preCheck = ''
     # Prevent tests from using all cores
     export OMP_NUM_THREADS=2
   '';

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -39,8 +39,6 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   checkPhase = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/itpp
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/itpp
     ./gtests/itpp_gtests
   '';
 

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -67,8 +67,6 @@ stdenv.mkDerivation rec {
 
     # Run single threaded
     export OMP_NUM_THREADS=1
-
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}`pwd`/lib
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -35,11 +35,6 @@ stdenv.mkDerivation rec {
     sed -e '/freetype freetype.c/d' -i ../tests/examples/CMakeLists.txt
   '';
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/src/
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$PWD/src/
-  '';
-
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DSNAPPY_BUILD_TESTS=OFF"
     "-DSNAPPY_BUILD_BENCHMARKS=OFF"
   ];

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -36,11 +36,6 @@ let
       '';
 
       doCheck = true;
-      preCheck =  if stdenv.isDarwin then ''
-        export DYLD_LIBRARY_PATH="$(pwd)''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
-      '' else ''
-        export LD_LIBRARY_PATH="$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-      '';
 
       meta = with lib; {
         description    = "Very fast, header only, C++ logging library";

--- a/pkgs/development/libraries/utf8proc/default.nix
+++ b/pkgs/development/libraries/utf8proc/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DUTF8PROC_ENABLE_TESTING=ON"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -53,10 +53,6 @@ in stdenv.mkDerivation rec {
 
   patches = map fetchpatch patchesToFetch;
 
-  preBuild = ''
-    export LD_LIBRARY_PATH="$(pwd)/lib";
-  '';
-
   dontWrapQtApps = true;
 
   # Shared libraries don't work, because of rpath troubles with the current

--- a/pkgs/development/libraries/yder/default.nix
+++ b/pkgs/development/libraries/yder/default.nix
@@ -39,11 +39,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  preCheck = ''
-    export LD_LIBRARY_PATH="$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-    export DYLD_FALLBACK_LIBRARY_PATH="$(pwd):$DYLD_FALLBACK_LIBRARY_PATH"
-  '';
-
   meta = with lib; {
     description = "Logging library for C applications";
     homepage = "https://github.com/babelouest/yder";

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -102,9 +102,8 @@ cmakeConfigurePhase() {
         cmakeFlags="-DBUILD_TESTING=OFF $cmakeFlags"
     fi
 
-    # Avoid cmake resetting the rpath of binaries, on make install
-    # And build always Release, to ensure optimisation flags
-    cmakeFlags="-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release} -DCMAKE_SKIP_BUILD_RPATH=ON $cmakeFlags"
+    # Always build Release, to ensure optimisation flags
+    cmakeFlags="-DCMAKE_BUILD_TYPE=${cmakeBuildType:-Release} $cmakeFlags"
 
     # Disable user package registry to avoid potential side effects
     # and unecessary attempts to access non-existent home folder

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -157,10 +157,6 @@ let
       touch .git/index .git/modules/library/xml/index
     '';
 
-    preBuild = ''
-      export LD_LIBRARY_PATH="$PWD/depends/protobuf''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-    '';
-
     cmakeFlags = [ "-DDFHACK_BUILD_ARCH=${arch}" "-DDOWNLOAD_RUBY=OFF" ]
       ++ lib.optionals enableStoneSense [ "-DBUILD_STONESENSE=ON" "-DSTONESENSE_INTERNAL_SO=OFF" ];
 

--- a/pkgs/os-specific/linux/tiscamera/default.nix
+++ b/pkgs/os-specific/linux/tiscamera/default.nix
@@ -108,10 +108,6 @@ stdenv.mkDerivation rec {
     "-DTCAM_INTERNAL_ARAVIS=OFF"
     "-DTCAM_ARAVIS_USB_VISION=${if withAravis && withAravisUsbVision then "ON" else "OFF"}"
     "-DTCAM_INSTALL_FORCE_PREFIX=ON"
-    # There are gobject introspection commands launched as part of the build. Those have a runtime
-    # dependency on `libtcam` (which itself is built as part of this build). In order to allow
-    # that, we set the dynamic linker's path to point on the build time location of the library.
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ];
 
   doCheck = true;

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -31,7 +31,6 @@ self = stdenv.mkDerivation rec {
   outputs = [ "out" "static" ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
     "-DWITH_SSL=yes"
     "-DWITH_EMBEDDED_SERVER=yes"
     "-DWITH_UNIT_TESTS=no"

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -34,7 +34,6 @@ self = stdenv.mkDerivation rec {
   outputs = [ "out" "static" ];
 
   cmakeFlags = [
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
     "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
     "-DWITH_ROUTER=OFF" # It may be packaged separately.
     "-DWITH_SYSTEM_LIBS=ON"

--- a/pkgs/tools/backup/percona-xtrabackup/generic.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/generic.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
     "-DWITH_ZLIB=system"
     "-DWITH_VALGRIND=ON"
     "-DWITH_MAN_PAGES=OFF"
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
   ];
 
   postInstall = ''

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -184,8 +184,6 @@ in rec {
       substituteInPlace src/common/module.c --replace "/sbin/modprobe" "modprobe"
       substituteInPlace src/common/module.c --replace "/bin/grep" "grep"
 
-      # for pybind/rgw to find internal dep
-      export LD_LIBRARY_PATH="$PWD/build/lib''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
       # install target needs to be in PYTHONPATH for "*.pth support" check to succeed
       # set PYTHONPATH, so the build system doesn't silently skip installing ceph-volume and others
       export PYTHONPATH=${ceph-python-env}/${sitePackages}:$lib/${sitePackages}:$out/${sitePackages}

--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -93,12 +93,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  preCheck = ''
-    export LD_LIBRARY_PATH=$(pwd)/bin
-  '' + lib.optionalString (stdenv.isDarwin) ''
-    export DYLD_LIBRARY_PATH=$(pwd)/bin
-  '';
-
   excludedTests = lib.optionals stdenv.isDarwin [
     "MFHDF_TEST-hdftest"
     "MFHDF_TEST-hdftest-shared"

--- a/pkgs/tools/security/yubihsm-shell/default.nix
+++ b/pkgs/tools/security/yubihsm-shell/default.nix
@@ -38,11 +38,6 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  cmakeFlags = [
-    # help2man fails without this
-    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
-  ];
-
   postPatch = ''
     # Can't find libyubihsm at runtime because of dlopen() in C code
     substituteInPlace lib/yubihsm.c \

--- a/pkgs/tools/text/opencc/default.nix
+++ b/pkgs/tools/text/opencc/default.nix
@@ -13,13 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake python3 ];
 
-  # let intermediate tools find intermediate library
-  preBuild = lib.optionalString stdenv.isLinux ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$(pwd)/src
-  '' + lib.optionalString stdenv.isDarwin ''
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH''${DYLD_LIBRARY_PATH:+:}$(pwd)/src
-  '';
-
   meta = with lib; {
     homepage = "https://github.com/BYVoid/OpenCC";
     license = licenses.asl20;


### PR DESCRIPTION
###### Motivation for this change

This should simplify using `nix-shell -A` or `nix develop` to develop
CMake based projects. CMake features a mechanism to use a different
RPATH for all executables in the build directory and only rewrite these
RPATHs on installation. This makes it possible to run executables
already from the build directory without having to set LD_LIBRARY_PATH.
This should simplify the checkPhase for cmake based projects and
hopefully not break anything.

Fixes: #22060



###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
