### PR TITLE
[20.09] grocy: 2.7.1 -> 3.0.1 (CVE-2020-15253)

### DIFF
--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -115,9 +115,9 @@ in {
       user = "grocy";
       group = "nginx";
 
-      # PHP 7.3 is the only version which is supported/tested by upstream:
-      # https://github.com/grocy/grocy/blob/v2.6.0/README.md#how-to-install
-      phpPackage = pkgs.php73;
+      # PHP 7.4 is the only version which is supported/tested by upstream:
+      # https://github.com/grocy/grocy/blob/v3.0.0/README.md#how-to-install
+      phpPackage = pkgs.php74;
 
       inherit (cfg.phpfpm) settings;
 

--- a/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
+++ b/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
@@ -1,20 +1,20 @@
-From 931958d8f11cb55f2e88a178a3b828f3c537eba8 Mon Sep 17 00:00:00 2001
+From 7ed6c641cc501246931721700b73f40dce7e8f4b Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
-Date: Fri, 6 Mar 2020 23:43:58 +0100
+Date: Tue, 22 Dec 2020 15:38:56 +0100
 Subject: [PATCH 1/2] Define configs with env vars
 
 ---
  app.php                      | 4 ++--
  services/DatabaseService.php | 2 +-
  services/FilesService.php    | 2 +-
- services/StockService.php    | 2 +-
- 4 files changed, 5 insertions(+), 5 deletions(-)
+ services/StockService.php    | 3 +--
+ 4 files changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/app.php b/app.php
-index af65ad1..4963c28 100644
+index 8176ebe..04432ba 100644
 --- a/app.php
 +++ b/app.php
-@@ -25,7 +25,7 @@ else
+@@ -10,7 +10,7 @@ use Slim\Factory\AppFactory;
  require_once __DIR__ . '/vendor/autoload.php';
  
  // Load config files
@@ -23,33 +23,32 @@ index af65ad1..4963c28 100644
  require_once __DIR__ . '/config-dist.php'; // For not in own config defined values we use the default ones
  
  // Definitions for dev/demo/prerelease mode
-@@ -50,7 +50,7 @@ $app = AppFactory::create();
+@@ -37,7 +37,7 @@ $app = AppFactory::create();
+ 
  $container = $app->getContainer();
- $container->set('view', function(Container $container)
- {
+ $container->set('view', function (Container $container) {
 -	return new Slim\Views\Blade(__DIR__ . '/views', GROCY_DATAPATH . '/viewcache');
-+	return new \Slim\Views\Blade(__DIR__ . '/views', getenv('GROCY_CACHE_DIR'));
++	return new Slim\Views\Blade(__DIR__ . '/views', getenv('GROCY_CACHE_DIR'));
  });
- $container->set('LoginControllerInstance', function(Container $container)
- {
+ $container->set('UrlManager', function (Container $container) {
+ 	return new UrlManager(GROCY_BASE_URL);
 diff --git a/services/DatabaseService.php b/services/DatabaseService.php
-index 23fc7b9..daa1993 100644
+index d1080b0..8bc4ee1 100644
 --- a/services/DatabaseService.php
 +++ b/services/DatabaseService.php
-@@ -25,7 +25,7 @@ class DatabaseService
- 			return GROCY_DATAPATH . '/grocy_' . GROCY_CULTURE . '.db';
+@@ -105,6 +105,6 @@ class DatabaseService
+ 			return GROCY_DATAPATH . '/grocy_' . $dbSuffix . '.db';
  		}
  
 -		return GROCY_DATAPATH . '/grocy.db';
 +		return getenv('GROCY_DB_FILE');
  	}
- 
-     private static $DbConnectionRaw = null;
+ }
 diff --git a/services/FilesService.php b/services/FilesService.php
-index cecdae3..357298d 100644
+index 8c1483e..8f74b4b 100644
 --- a/services/FilesService.php
 +++ b/services/FilesService.php
-@@ -12,7 +12,7 @@ class FilesService extends BaseService
+@@ -70,7 +70,7 @@ class FilesService extends BaseService
  	{
  		parent::__construct();
  
@@ -59,18 +58,19 @@ index cecdae3..357298d 100644
  		if (!file_exists($this->StoragePath))
  		{
 diff --git a/services/StockService.php b/services/StockService.php
-index bfde3fc..53b2245 100644
+index 4741b4b..6d4e748 100644
 --- a/services/StockService.php
 +++ b/services/StockService.php
-@@ -934,7 +934,7 @@ class StockService extends BaseService
+@@ -1374,8 +1374,7 @@ class StockService extends BaseService
  			throw new \Exception('No barcode lookup plugin defined');
  		}
  
 -		$path = GROCY_DATAPATH . "/plugins/$pluginName.php";
-+		$path = getenv('GROCY_PLUGIN_DIR');
+-
++		$path = getenv('GROCY_PLUGIN_DIR') . "/$pluginName.php";
  		if (file_exists($path))
  		{
  			require_once $path;
 -- 
-2.25.0
+2.29.2
 

--- a/pkgs/servers/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
+++ b/pkgs/servers/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
@@ -1,6 +1,6 @@
-From 1556489f0b475ae56e5ed3afba19cc2abb696a76 Mon Sep 17 00:00:00 2001
+From c46323dfc4a3d5bf17f7508f5b5f223858a598c3 Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
-Date: Thu, 16 Apr 2020 19:37:32 +0200
+Date: Tue, 22 Dec 2020 15:39:15 +0100
 Subject: [PATCH 2/2] Remove check for config-file as it's stored in /etc/grocy
 
 ---
@@ -8,17 +8,17 @@ Subject: [PATCH 2/2] Remove check for config-file as it's stored in /etc/grocy
  1 file changed, 1 deletion(-)
 
 diff --git a/helpers/PrerequisiteChecker.php b/helpers/PrerequisiteChecker.php
-index d4bf74c6..ca7686c9 100644
+index cbe0a3a..a484db2 100644
 --- a/helpers/PrerequisiteChecker.php
 +++ b/helpers/PrerequisiteChecker.php
-@@ -8,7 +8,6 @@ class PrerequisiteChecker
+@@ -11,7 +11,6 @@ class PrerequisiteChecker
  {
-     public function checkRequirements()
-     {
--        self::checkForConfigFile();
-         self::checkForConfigDistFile();
-         self::checkForComposer();
-         self::checkForYarn();
+ 	public function checkRequirements()
+ 	{
+-		self::checkForConfigFile();
+ 		self::checkForConfigDistFile();
+ 		self::checkForComposer();
+ 		self::checkForPhpExtensions();
 -- 
-2.25.0
+2.29.2
 

--- a/pkgs/servers/grocy/default.nix
+++ b/pkgs/servers/grocy/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "grocy";
-  version = "2.7.1";
+  version = "3.0.0";
 
   src = fetchurl {
     url = "https://github.com/grocy/grocy/releases/download/v${version}/grocy_${version}.zip";
-    sha256 = "0ab1yxj499vadakq2c1lils3ir6fm02wrdgrirrlar4s4z6c4p7r";
+    sha256 = "sha256-O7DksfA95IHvLJyRrWG8iECcUUDsOtytd78koNZdQzE=";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     unzip ${src} -d .
   '';
 
+  # NOTE: if patches are created from a git checkout, those should be modified
+  # with `unixdos` to make sure those apply here.
   patches = [
     ./0001-Define-configs-with-env-vars.patch
     ./0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch

--- a/pkgs/servers/grocy/default.nix
+++ b/pkgs/servers/grocy/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "grocy";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchurl {
     url = "https://github.com/grocy/grocy/releases/download/v${version}/grocy_${version}.zip";
-    sha256 = "sha256-O7DksfA95IHvLJyRrWG8iECcUUDsOtytd78koNZdQzE=";
+    sha256 = "sha256-Yjxv0LcLNtpYs4ntBano9NUxwdWgF5etA/M6hUVzOa8=";
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change

cc @NixOS/backports 

ChangeLogs:
* https://github.com/grocy/grocy/releases/tag/v3.0.0
* https://github.com/grocy/grocy/releases/tag/v3.0.1

Update to 3.0.0 is needed to fix [CVE-2020-15253](https://nvd.nist.gov/vuln/detail/CVE-2020-15253). I tested the update on my production instance and it worked fine. The major release mainly happened due to changes in the REST API, though I'm not aware of any third-party client which consumes data from `grocy`.

Closes #102794 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
