### PR TITLE
WIP: flatbuffers: fix compilation errors by upgrading to latest master

### DIFF
--- a/pkgs/development/libraries/flatbuffers/default.nix
+++ b/pkgs/development/libraries/flatbuffers/default.nix
@@ -2,13 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "flatbuffers";
-  version = "1.12.0";
+  # Fixes https://github.com/google/flatbuffers/issues/5950
+  # Compilation errors [gcc 10.1, Linux 5.6]
+  version = "795408115ac4a54b6cde291f4703473d5ff0bf8a"; # post 1.12.0
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flatbuffers";
-    rev = "v${version}";
-    sha256 = "0f7xd66vc1lzjbn7jzd5kyqrgxpsfxi4zc7iymhb5xrwyxipjl1g";
+    rev = version;
+    sha256 = "1zaqqcjpmh8vp1bm4vms6csl1jazyflvsrn9wrmw04kayb707ily";
   };
 
   preConfigure = stdenv.lib.optional stdenv.buildPlatform.isDarwin ''


### PR DESCRIPTION
This is a placeholder. I'm not sure what the appropriate strategy is here, but 1.12.0 fails to build now and there is no newer release tag yet.

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions