### PR TITLE
nixos: fix "nixos-rebuild build-vm-with-bootloader" for EFI systems (v2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,11 @@
                     modules = modules ++ [
                       ./nixos/modules/virtualisation/qemu-vm.nix
                       { virtualisation.useBootLoader = true; }
+                      ({ config, ... }: {
+                        virtualisation.useEFIBoot =
+                          config.boot.loader.systemd-boot.enable ||
+                          config.boot.loader.efi.canTouchEfiVariables;
+                      })
                     ];
                   })).config;
               in

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -22,6 +22,11 @@ let
       [ configuration
         ./modules/virtualisation/qemu-vm.nix
         { virtualisation.useBootLoader = true; }
+        ({ config, ... }: {
+          virtualisation.useEFIBoot =
+            config.boot.loader.systemd-boot.enable ||
+            config.boot.loader.efi.canTouchEfiVariables;
+        })
       ];
   }).config;
 


### PR DESCRIPTION
###### Motivation for this change

(The first version of this change, in commit 39fad297fd, broke
`nix-build -A nixosTests.installer.simpleUefiSystemdBoot`. This is the
2nd version, which hopefully does not break anything.)

`nixos-rebuild build-vm-with-bootloader` currently fails with the
default NixOS EFI configuration:

  $ cat >configuration.nix <<EOF
  {
    fileSystems."/".device = "/dev/sda1";
    boot.loader.systemd-boot.enable = true;
    boot.loader.efi.canTouchEfiVariables = true;
  }
  EOF

  $ nixos-rebuild build-vm-with-bootloader -I nixos-config=$PWD/configuration.nix -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-20.09.tar.gz
  [...]
  insmod: ERROR: could not insert module /nix/store/1ibmgfr13r8b6xyn4f0wj115819f359c-linux-5.4.83/lib/modules/5.4.83/kernel/fs/efivarfs/efivarfs.ko.xz: No such device
  mount: /sys/firmware/efi/efivars: mount point does not exist.
  [    1.908328] reboot: Power down
  builder for '/nix/store/dx2ycclyknvibrskwmii42sgyalagjxa-nixos-boot-disk.drv' failed with exit code 32
  [...]

Fix it by setting virtualisation.useEFIBoot = true when needed.

Before:
* release-20.03: successful build, unsuccessful run
* release-20.09 (and master): unsuccessful build

After:
* Successful build and run.

Fixes #107255

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
