### PR TITLE
python3Packages.aiohomekit: init at 0.2.60

### DIFF
--- a/pkgs/development/python-modules/aiohomekit/default.nix
+++ b/pkgs/development/python-modules/aiohomekit/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, poetry
+, pytest-aiohttp
+, pytestCheckHook
+, pythonAtLeast
+, zeroconf
+}:
+
+buildPythonPackage rec {
+  pname = "aiohomekit";
+  version = "0.2.60";
+  format = "pyproject";
+  disabled = pythonAtLeast "3.9";
+
+  src = fetchFromGitHub {
+    owner = "Jc2k";
+    repo = pname;
+    rev = version;
+    sha256 = "03llk5i22hq163x568kz0qar5h0sda8f8cxbmgya6z2dcxv0a83p";
+  };
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [
+    cryptography
+    zeroconf
+  ];
+
+  checkInputs = [
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  # Some test requires network access
+  disabledTests = [
+    "test_remove_pairing"
+    "test_pair"
+    "test_add_and_remove_pairings"
+  ];
+
+  pythonImportsCheck = [ "aiohomekit" ];
+
+  meta = with lib; {
+    description = "Python module that implements the HomeKit protocol";
+    longDescription = ''
+      This Python library implements the HomeKit protocol for controlling
+      Homekit accessories.
+    '';
+    homepage = "https://github.com/Jc2k/aiohomekit";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -351,7 +351,7 @@
     "home_connect" = ps: with ps; [ aiohttp-cors ]; # missing inputs: homeconnect
     "homeassistant" = ps: with ps; [ ];
     "homekit" = ps: with ps; [ HAP-python pyqrcode aiohttp-cors base36 ha-ffmpeg zeroconf ]; # missing inputs: PyTurboJPEG fnvhash
-    "homekit_controller" = ps: with ps; [ aiohttp-cors zeroconf ]; # missing inputs: aiohomekit
+    "homekit_controller" = ps: with ps; [ aiohomekit aiohttp-cors zeroconf ];
     "homematic" = ps: with ps; [ pyhomematic ];
     "homematicip_cloud" = ps: with ps; [ ]; # missing inputs: homematicip
     "homeworks" = ps: with ps; [ ]; # missing inputs: pyhomeworks

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -218,6 +218,8 @@ in {
 
   aioharmony = callPackage ../development/python-modules/aioharmony { };
 
+  aiohomekit = callPackage ../development/python-modules/aiohomekit { };
+
   aiohttp = callPackage ../development/python-modules/aiohttp { };
 
   aiohttp-cors = callPackage ../development/python-modules/aiohttp-cors { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This Python library implements the HomeKit protocol for controlling
Homekit accessories.

https://github.com/Jc2k/aiohomekit

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
