### PR TITLE
pijul: 1.0.0-alpha.24 -> 1.0.0-alpha.31

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,26 +1,28 @@
 { stdenv
+, darwin
 , fetchCrate
-, rustPlatform
-, pkg-config
 , libsodium
 , openssl
+, pkg-config
+, rustPlatform
 , xxHash
 , zstd
-, darwin
-, gitImportSupport ? true
-, libgit2 ? null
+# Optionals
+, gitImportSupport ? true, libgit2 ? null
 }:
+
+assert gitImportSupport -> libgit2 != null;
 
 rustPlatform.buildRustPackage rec {
   pname = "pijul";
-  version = "1.0.0-alpha.24";
+  version = "1.0.0-alpha.31";
 
   src = fetchCrate {
     inherit version pname;
-    sha256 = "1h1vgx0zlymnhalqsgmp9gv6sxbizmyryldx5vzl6djl23dvzd6s";
+    sha256 = "1zj55qpc4fwjx97yq2lilhvxkx0lip5nmb6flcxlzl6d0aa10b3m";
   };
 
-  cargoSha256 = "1yx7qqfyabhrf6mcca4frdcp9a426khp90nznhshhm71liqr9y44";
+  cargoSha256 = "040m7fid4wq50dmfymvk9250fr3h5j83m90rshzm7qv8gxnkj2az";
 
   cargoBuildFlags = stdenv.lib.optional gitImportSupport "--features=git";
 
@@ -36,6 +38,6 @@ rustPlatform.buildRustPackage rec {
     description = "A distributed version control system";
     homepage = "https://pijul.org";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ gal_bolle dywedir ];
+    maintainers = with maintainers; [ dywedir fabianhjr gal_bolle ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

There have been several fixes to issues and the patch format was changed a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
