### PR TITLE
ott-mode: Factor our from ott

### DIFF
--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -114,6 +114,19 @@
   org-mac-link =
     callPackage ./org-mac-link { };
 
+  ott-mode = self.trivialBuild {
+    pname = "ott-mod";
+
+    inherit (external.ott) src version;
+
+    postUnpack = "mv $sourceRoot/emacs/ott-mode.el $sourceRoot";
+
+    meta = {
+      description = "Standalone package providing ott-mode without building ott and with compiled bytecode.";
+      inherit (external.Agda.meta) homepage license;
+    };
+  };
+
   perl-completion =
     callPackage ./perl-completion { };
 

--- a/pkgs/applications/science/logic/ott/default.nix
+++ b/pkgs/applications/science/logic/ott/default.nix
@@ -16,7 +16,13 @@ stdenv.mkDerivation rec {
 
   installTargets = "ott.install";
 
-  postInstall = "opaline -prefix $out";
+  postInstall = ''
+    opaline -prefix $out
+  ''
+  # There is `emacsPackages.ott-mode` for this now.
+  + ''
+    rm -r $out/share/emacs
+  '';
 
   meta = {
     description = "A tool for the working semanticist";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21089,7 +21089,7 @@ in
       inherit
         autoconf automake editorconfig-core-c git libffi libpng pkgconfig
         poppler rtags w3m zlib substituteAll rustPlatform cmake llvmPackages
-        libtool zeromq openssl;
+        libtool zeromq openssl ott;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

> ott-mode: Init (version inherited from ott)
>
> This way it is pre-compiled.

>  ott: Don't also install emacs mode
>
> There is now a separate package for that.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
