### PR TITLE
losslesscut-bin: init at 3.33.1

### DIFF
--- a/pkgs/applications/video/losslesscut-bin/appimage.nix
+++ b/pkgs/applications/video/losslesscut-bin/appimage.nix
@@ -1,0 +1,45 @@
+{ appimageTools, lib, fetchurl, gtk3, gsettings-desktop-schemas, version }:
+
+let
+  pname = "losslesscut";
+  nameRepo = "lossless-cut";
+  nameCamel = "LosslessCut";
+  name = "${pname}-${version}";
+  nameSource = "${nameCamel}-linux.AppImage";
+  nameExecutable = "losslesscut";
+  owner = "mifi";
+  src = fetchurl {
+    url = "https://github.com/${owner}/${nameRepo}/releases/download/v${version}/${nameSource}";
+    name = nameSource;
+    sha256 = "0aqz5ijl5japfzzbcdcd2mmihkb8b2fc2hs9kkm3211yb37c5ygv";
+  };
+  extracted = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  extraPkgs = ps: appimageTools.defaultFhsEnvArgs.multiPkgs ps;
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${nameExecutable}}
+    (
+      mkdir -p $out/share
+      cd ${extracted}/usr
+      find share -mindepth 1 -type d -exec mkdir -p $out/{} \;
+      find share -mindepth 1 -type f,l -exec ln -s $PWD/{} $out/{} \;
+    )
+    ln -s ${extracted}/${nameExecutable}.png $out/share/icons/${nameExecutable}.png
+    mkdir $out/share/applications
+    cp ${extracted}/${nameExecutable}.desktop $out/share/applications
+    substituteInPlace $out/share/applications/${nameExecutable}.desktop \
+        --replace AppRun ${nameExecutable}
+  '';
+
+  meta.platforms = with lib.platforms; [ "x86_64-linux" ];
+}

--- a/pkgs/applications/video/losslesscut-bin/default.nix
+++ b/pkgs/applications/video/losslesscut-bin/default.nix
@@ -1,0 +1,24 @@
+{ callPackage, stdenvNoCC, lib }:
+let
+  version = "3.33.1";
+  appimage = callPackage ./appimage.nix { inherit version; };
+  dmg = callPackage ./dmg.nix { inherit version; };
+  windows = callPackage ./windows.nix { inherit version; };
+in (
+  if stdenvNoCC.isDarwin then dmg
+  else if stdenvNoCC.isCygwin then windows
+  else appimage
+).overrideAttrs
+(oldAttrs: {
+  meta = with lib; {
+    description = "The swiss army knife of lossless video/audio editing";
+    homepage = "https://mifi.no/losslesscut/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ShamrockLee ];
+  } // oldAttrs.meta // {
+    platforms =
+      appimage.meta.platforms
+      ++ dmg.meta.platforms
+      ++ windows.meta.platforms;
+  };
+})

--- a/pkgs/applications/video/losslesscut-bin/dmg.nix
+++ b/pkgs/applications/video/losslesscut-bin/dmg.nix
@@ -1,0 +1,31 @@
+{ stdenvNoCC, lib, fetchurl, undmg, version }:
+
+let
+  pname = "losslesscut";
+  nameRepo = "lossless-cut";
+  nameCamel = "LosslessCut";
+  nameSource = "${nameCamel}-mac.dmg";
+  nameApp = nameCamel + ".app";
+  owner = "mifi";
+  src = fetchurl {
+    url = "https://github.com/${owner}/${nameRepo}/releases/download/v${version}/${nameSource}";
+    name = nameSource;
+    sha256 = "0xa1avbwar7x7kv5yn2ldca4vj3nwaz0dhjm3bcdy59q914xn3dj";
+  };
+in stdenvNoCC.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [ undmg ];
+
+  unpackPhase = ''
+    undmg ${src}
+  '';
+  sourceRoot = nameApp;
+
+  installPhase = ''
+    mkdir -p $out/Applications/${nameApp}
+    cp -R . $out/Applications/${nameApp}
+  '';
+
+  meta.platforms = lib.platforms.darwin;
+}

--- a/pkgs/applications/video/losslesscut-bin/windows.nix
+++ b/pkgs/applications/video/losslesscut-bin/windows.nix
@@ -1,0 +1,45 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+, unzip
+, version
+, useMklink ? false
+, customSymlinkCommand ? null
+}:
+let
+  pname = "losslesscut";
+  nameRepo = "lossless-cut";
+  nameCamel = "LosslessCut";
+  nameSourceBase = "${nameCamel}-win";
+  nameSource = "${nameSourceBase}.zip";
+  nameExecutable = "${nameCamel}.exe";
+  owner = "mifi";
+  getSymlinkCommand = if (customSymlinkCommand != null) then customSymlinkCommand
+    else if useMklink then (targetPath: linkPath: "mklink ${targetPath} ${linkPath}")
+    else (targetPath: linkPath: "ln -s ${targetPath} ${linkPath}");
+in stdenvNoCC.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    name = nameSource;
+    url = "https://github.com/${owner}/${nameRepo}/releases/download/v${version}/${nameSource}";
+    sha256 = "1rq9frab0jl9y1mgmjhzsm734jvz0a646zq2wi5xzzspn4wikhvb";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src -d ${nameSourceBase}
+  '';
+
+  sourceRoot = nameSourceBase;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/libexec
+    cd ..
+    mv ${nameSourceBase} $out/libexec
+
+  '' + (getSymlinkCommand "${nameSourceBase}/${nameExecutable}" "$out/bin/${nameExecutable}");
+
+  meta.platforms = lib.platforms.windows;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23831,6 +23831,8 @@ in
     portaudio = null;
   };
 
+  losslesscut-bin = callPackage ../applications/video/losslesscut-bin { };
+
   loxodo = callPackage ../applications/misc/loxodo { };
 
   lsd2dsl = libsForQt5.callPackage ../applications/misc/lsd2dsl { };


### PR DESCRIPTION
Add binary package for
* Linux (AppImage)
* Mac (dmg, x86_64 version)
* Windows (zip)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
If applied, [LosslessCut](https://github.com/mifi/lossless-cut) -- a convenient video editor -- will be available in nixpkgs for Linux, Mac and Windows users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
