### PR TITLE
pass-git-helper: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, buildPythonApplication, fetchFromGitHub, pyxdg, pytest }:
+{ lib, stdenv, buildPythonApplication, fetchFromGitHub, pyxdg, pytest, pytest-mock }:
 
 buildPythonApplication rec {
   pname   = "pass-git-helper";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner  = "languitar";
     repo   = "pass-git-helper";
     rev    = "v${version}";
-    sha256 = "18nvwlp0w4aqj268wly60rnjzqw2d8jl0hbs6bkwp3hpzzz5g6yd";
+    sha256 = "sha256-GdsFPpBdoEaOCmdKxw5xTuFOcGFH94w5q/lV891lCUs=";
   };
 
   propagatedBuildInputs = [ pyxdg ];
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest pytest-mock ];
   preCheck = ''
     export HOME=$(mktemp -d)
   '';


### PR DESCRIPTION
###### Motivation for this change

I have released a new version upstream of the package. As I don't use nix and have no tools available, I don't know how to compute and updated sha256sum for this. If someone could help, that would be great.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
