### PR TITLE
python3Packages.avea: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/avea/default.nix
+++ b/pkgs/development/python-modules/avea/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, bluepy
+}:
+
+buildPythonPackage rec {
+  pname = "avea";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "k0rventen";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13s21dnhbh10dd60xq2cklp5jyv46rpl3nivn1imcswp02930ihz";
+  };
+
+  propagatedBuildInputs = [
+    bluepy
+  ];
+
+  # no tests are present
+  doCheck = false;
+  pythonImportsCheck = [ "avea" ];
+
+  meta = with lib; {
+    description = "Python module for interacting with Elgato's Avea bulb";
+    homepage = "https://github.com/k0rventen/avea";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -516,6 +516,8 @@ in {
 
   av = callPackage ../development/python-modules/av { inherit (pkgs) pkgconfig; };
 
+  avea = callPackage ../development/python-modules/avea { };
+
   avro3k = callPackage ../development/python-modules/avro3k { };
 
   avro = callPackage ../development/python-modules/avro { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for interacting with Elgato's Avea bulb.

https://github.com/k0rventen/avea

This is a home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
