### PR TITLE
stdenv: mute errors when failing to write env-vars

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -787,7 +787,7 @@ substituteAllInPlace() {
 # the environment used for building.
 dumpVars() {
     if [ "${noDumpEnvVars:-0}" != 1 ]; then
-        export >| "$NIX_BUILD_TOP/env-vars" || true
+        export 2>/dev/null >| "$NIX_BUILD_TOP/env-vars" || true
     fi
 }
 


### PR DESCRIPTION
The intention of this change is to mute error messages caused when multiple users use `nix-shell`, but only the first one succeeds to dump their environment variables. All others face a permission denied error like this:

```console
$ nix-shell -p coreutils
bash: /tmp/env-vars: Permission denied

[nix-shell:~]$ 
```

_This might not be the most sensible way to resolve this issue, but the fix was inspired by the irrelevance of the dumping's success, i.e. `|| true`... ;)_