### PR TITLE
pythonPackages.pytestCheckHook: Add disabledTestFiles option

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -610,6 +610,10 @@ Using the example above, the analagous pytestCheckHook usage would be:
     "download"
     "update"
   ];
+
+  disabledTestFiles = [
+    "tests/test_failing.py"
+  ];
 ```
 
 This is expecially useful when tests need to be conditionallydisabled,

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -2,6 +2,7 @@
 echo "Sourcing pytest-check-hook"
 
 declare -ar disabledTests
+declare -ar disabledTestFiles
 
 function _concatSep {
     local result
@@ -36,6 +37,13 @@ function pytestCheckPhase() {
         disabledTestsString=$(_pytestComputeDisabledTestsString "${disabledTests[@]}")
       args+=" -k \""$disabledTestsString"\""
     fi
+    for file in "${disabledTestFiles[@]}"; do
+      if [ ! -f "$file" ]; then
+        echo "Disabled test file \"$file\" does not exist. Aborting"
+        exit 1
+      fi
+      args+=" --ignore=$file"
+    done
     args+=" ${pytestFlagsArray[@]}"
     eval "@pythonCheckInterpreter@ $args"
 

--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchPypi, buildPythonPackage, isPy3k
+{ lib
+, stdenv
+, fetchPypi
+, buildPythonPackage
+, isPy3k
 , jaraco_functools
 , jaraco_text
 , more-itertools
@@ -33,7 +37,8 @@ buildPythonPackage rec {
     # install_requires
     jaraco_functools
 
-    more-itertools six
+    more-itertools
+    six
   ];
 
   checkInputs = [
@@ -49,10 +54,6 @@ buildPythonPackage rec {
     trustme
   ];
 
-  # avoid attempting to use 3 packages not available on nixpkgs
-  # (jaraco.apt, jaraco.context, yg.lockfile)
-  pytestFlagsArray = [ "--ignore=cheroot/test/test_wsgi.py" ];
-
   # Disable doctest plugin because times out
   # Disable xdist (-n arg) because it's incompatible with testmon
   # Deselect test_bind_addr_unix on darwin because times out
@@ -64,12 +65,18 @@ buildPythonPackage rec {
     rm pytest.ini
   '';
 
-  disabledTests= [
+  disabledTests = [
     "tls" # touches network
     "peercreds_unix_sock" # test urls no longer allowed
   ] ++ lib.optionals stdenv.isDarwin [
     "http_over_https_error"
     "bind_addr_unix"
+  ];
+
+  disabledTestFiles = [
+    # avoid attempting to use 3 packages not available on nixpkgs
+    # (jaraco.apt, jaraco.context, yg.lockfile)
+    "cheroot/test/test_wsgi.py"
   ];
 
   # Some of the tests use localhost networking.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
