### PR TITLE
picom: misc fixes

### DIFF
--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     homepage = "https://github.com/yshui/picom";
-    maintainers = with maintainers; [ ertes twey ];
+    maintainers = with maintainers; [ ertes twey thiagokokada ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, uthash, asciidoc, docbook_xml_dtd_45
+{ stdenv, lib, fetchFromGitHub, pkg-config, uthash, asciidoc, docbook_xml_dtd_45
 , docbook_xsl, libxslt, libxml2, makeWrapper, meson, ninja
 , xorgproto, libxcb ,xcbutilrenderutil, xcbutilimage, pixman, libev
 , dbus, libconfig, libdrm, libGL, pcre, libX11
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja
-    pkgconfig
+    pkg-config
     uthash
     asciidoc
     docbook_xml_dtd_45
@@ -35,10 +35,10 @@ stdenv.mkDerivation rec {
     libxdg_basedir
   ];
 
-  NIX_CFLAGS_COMPILE = "-fno-strict-aliasing";
+  mesonBuildType = "release";
 
   mesonFlags = [
-    "-Dbuild_docs=true"
+    "-Dwith_docs=true"
   ];
 
   installFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Build option `build_docs` was renamed to `with_docs` quite sometime ago: yshui/picom@3f2a671. This means that the manpage were not being build.
- Remove CFLAG `-fno-strict-aliasing` that seems to not be used anywhere in the upstream repository. This was probably added for `compton` a long time ago and never removed, since I can't find the commit that added this.
- Use release build. This is recommended upstream: https://github.com/yshui/picom#to-build.

Also, add myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
~
❯ nix path-info -S /nix/store/zm67sy1dgccz8iz7gy9vw0s01cj5i2r7-picom-8.2/bin/picom # before
/nix/store/zm67sy1dgccz8iz7gy9vw0s01cj5i2r7-picom-8.2	 156816464

~
❯ nix path-info -S /nix/store/s1m8hars4bzjsidlkkphzycaaq24a46z-picom-8.2/bin/picom # after
/nix/store/s1m8hars4bzjsidlkkphzycaaq24a46z-picom-8.2	 156825808
```