### PR TITLE
[hdf4] Fix build on Darwin, which blocked gdal, postgis and more

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -8,7 +8,8 @@
 , zlib
 , szip ? null
 }:
-
+let uselibtirpc = stdenv.isLinux;
+in
 stdenv.mkDerivation rec {
   pname = "hdf";
   version = "4.2.15";
@@ -49,12 +50,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libjpeg
-    libtirpc
     szip
     zlib
+  ] ++ stdenv.lib.optionals uselibtirpc [
+    libtirpc
   ];
 
-  preConfigure = ''
+  preConfigure = stdenv.lib.optionalString uselibtirpc ''
     # Make tirpc discovery work with CMAKE_PREFIX_PATH
     substituteInPlace config/cmake/FindXDR.cmake \
       --replace 'find_path(XDR_INCLUDE_DIR NAMES rpc/types.h PATHS "/usr/include" "/usr/include/tirpc")' \


### PR DESCRIPTION
The libtirpc library is not available on Darwin, which led to hdf4 failing to build and subsequently blocking dependent packages.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
