### PR TITLE
crystal/make-package: enable parallel builds

### DIFF
--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -24,6 +24,7 @@
   # Specify binaries to build in the form { foo.src = "src/foo.cr"; }
   # The default `crystal build` options can be overridden with { foo.options = [ "--optionname" ]; }
 , crystalBinaries ? { }
+, enableParallelBuilding ? true
 , ...
 }@args:
 
@@ -51,6 +52,20 @@ let
 
   buildDirectly = shardsFile == null || crystalBinaries != { };
 
+  mkCrystalBuildArgs = bin: attrs:
+    lib.concatStringsSep " " ([
+      "crystal"
+      "build"
+    ] ++ lib.optionals enableParallelBuilding [
+      "--threads"
+      "$NIX_BUILD_CORES"
+    ] ++ [
+      "-o"
+      bin
+      (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
+      (lib.concatStringsSep " " (attrs.options or defaultOptions))
+    ]);
+
 in
 stdenv.mkDerivation (mkDerivationArgs // {
 
@@ -72,6 +87,7 @@ stdenv.mkDerivation (mkDerivationArgs // {
 
   PREFIX = placeholder "out";
 
+  inherit enableParallelBuilding;
   strictDeps = true;
   buildInputs = args.buildInputs or [ ] ++ [ crystal ];
 
@@ -88,16 +104,7 @@ stdenv.mkDerivation (mkDerivationArgs // {
     "runHook preBuild"
   ] ++ lib.optional (format == "make")
     "make \${buildTargets:-build} $makeFlags"
-  ++ lib.optionals (format == "crystal") (lib.mapAttrsToList
-    (bin: attrs: ''
-      crystal ${lib.escapeShellArgs ([
-        "build"
-        "-o"
-        bin
-        (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
-      ] ++ (attrs.options or defaultOptions))}
-    '')
-    crystalBinaries)
+  ++ lib.optionals (format == "crystal") (lib.mapAttrsToList mkCrystalBuildArgs crystalBinaries)
   ++ lib.optional (format == "shards")
     "shards build --local --production ${lib.concatStringsSep " " (args.options or defaultOptions)}"
   ++ [ "runHook postBuild" ]));


### PR DESCRIPTION
###### Motivation for this change
Allow for crystal builds to use more than 1 core.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
https://github.com/NixOS/nixpkgs/pull/108539

4 packages failed to build:
icr mint oq scry

6 packages built:
ameba crystal2nix gitAndTools.thicket lucky-cli shards shards_0_11
```