### PR TITLE
nodejs: 10.23.0 -> 10.23.1, 12.20.0 -> 12.20.1, 14.15.3 -> 14.15.4, 15.5.0 -> 15.5.1 

### DIFF
--- a/pkgs/development/web/nodejs/v10.nix
+++ b/pkgs/development/web/nodejs/v10.nix
@@ -8,7 +8,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "10.23.0";
-    sha256 = "07vlqr0493a569i0npwgkxk5wa4vc7j68jsivchg08y2slwn0dgx";
+    version = "10.23.1";
+    sha256 = "1ypddif8jc8qrw9n1f8zbpknjcbnjc9xhpm57hc5nqbrmzsidal8";
     patches = stdenv.lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v12.nix
+++ b/pkgs/development/web/nodejs/v12.nix
@@ -8,7 +8,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "12.20.0";
-    sha256 = "12s2vjrlhgap2r12s7rqf0r2wzh9q2r5dkh3ak9fhrgmk9fgvqv1";
+    version = "12.20.1";
+    sha256 = "0lqq6a2byw4qmig98j45gqnl0593xdhx1dr9k7x2nnvhblrfw3p0";
     patches = stdenv.lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v14.nix
+++ b/pkgs/development/web/nodejs/v14.nix
@@ -8,7 +8,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "14.15.3";
-    sha256 = "1zplrfhsrqblvq2wxf5386wc9hf11k42jaw4mzgwy5dxx6dv3krj";
+    version = "14.15.4";
+    sha256 = "177cxp4fhmglyx035j8smiy1bp5fz6q2phlcl0a2mdbldkvfrdxd";
     patches = stdenv.lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v15.nix
+++ b/pkgs/development/web/nodejs/v15.nix
@@ -8,6 +8,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "15.5.0";
-    sha256 = "1wzcypb1kawc6m5q36cd31qjg7ljby8py9qg555m4bqm5gpvvfjg";
+    version = "15.5.1";
+    sha256 = "0qbb4dwgsy1a82ihjxl6r8bj7mwjzb21s720y1rahisd5p69l8ic";
   }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://nodejs.org/en/blog/vulnerability/january-2021-security-releases/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
