### PR TITLE
qemu-guest: remove security.rngd setting

### DIFF
--- a/nixos/doc/manual/configuration/profiles/qemu-guest.xml
+++ b/nixos/doc/manual/configuration/profiles/qemu-guest.xml
@@ -11,8 +11,7 @@
  </para>
 
  <para>
-  It makes virtio modules available on the initrd, sets the system time from
-  the hardware clock to work around a bug in qemu-kvm, and
-  <link linkend="opt-security.rngd.enable">enables rngd</link>.
+  It makes virtio modules available on the initrd and sets the system time from
+  the hardware clock to work around a bug in qemu-kvm.
  </para>
 </section>

--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -1,7 +1,7 @@
 # Common configuration for virtual machines running under QEMU (using
 # virtio).
 
-{ lib, ... }:
+{ ... }:
 
 {
   boot.initrd.availableKernelModules = [ "virtio_net" "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_scsi" "9p" "9pnet_virtio" ];
@@ -14,6 +14,4 @@
       # to the *boot time* of the host).
       hwclock -s
     '';
-
-  security.rngd.enable = lib.mkDefault false;
 }


### PR DESCRIPTION
#### Copy of commit msg
Since release 20.09 `rngd.enable` defaults to false, so this setting is redundant.

Also fix the `qemu-quest` section of the manual that incorrectly claimed that `rngd` was enabled.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change