### PR TITLE
clinfo: make it build again

### DIFF
--- a/pkgs/tools/system/clinfo/default.nix
+++ b/pkgs/tools/system/clinfo/default.nix
@@ -4,16 +4,19 @@ stdenv.mkDerivation rec {
   pname = "clinfo";
   version = "3.0.20.11.20";
 
-    src = fetchFromGitHub {
-      owner = "Oblomov";
-      repo = "clinfo";
-      rev = version;
-      sha256 = "052xfkbmgfpalmhfwn0dj5114x2mzwz29y37qqhhsdpaxsz0y422";
-    };
+  src = fetchFromGitHub {
+    owner = "Oblomov";
+    repo = "clinfo";
+    rev = version;
+    sha256 = "052xfkbmgfpalmhfwn0dj5114x2mzwz29y37qqhhsdpaxsz0y422";
+  };
 
   buildInputs = [ ocl-icd opencl-headers ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=stringop-overflow"
+    "-Wno-error=stringop-truncation"
+  ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
@@ -21,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Print all known information about all available OpenCL platforms and devices in the system";
     homepage = "https://github.com/Oblomov/clinfo";
     license = licenses.cc0;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ athas ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

gcc is getting increasingly pedantic - that's a GoodThing(tm) in general but requires a workaround here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).