### PR TITLE
podman: add nvidia runtime support

### DIFF
--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -2,6 +2,7 @@
 let
   cfg = config.virtualisation.podman;
   toml = pkgs.formats.toml { };
+  nvidia-docker = pkgs.nvidia-docker.override { containerRuntimePath = "${pkgs.runc}/bin/runc"; };
 
   inherit (lib) mkOption types;
 
@@ -99,8 +100,8 @@ in
         containersConf.extraConfig = lib.optionalString cfg.enableNvidia
           (builtins.readFile (toml.generate "podman.nvidia.containers.conf" {
             engine = {
-              conmon_env_vars = [ "PATH=${lib.makeBinPath [ pkgs.nvidia-docker ]}" ];
-              runtimes.nvidia = [ "${pkgs.nvidia-docker}/bin/nvidia-container-runtime" ];
+              conmon_env_vars = [ "PATH=${lib.makeBinPath [ nvidia-docker ]}" ];
+              runtimes.nvidia = [ "${nvidia-docker}/bin/nvidia-container-runtime" ];
             };
           }));
       };
@@ -117,7 +118,7 @@ in
       ];
     }
     (lib.mkIf cfg.enableNvidia {
-      environment.etc."nvidia-container-runtime/config.toml".source = "${pkgs.nvidia-docker}/etc/podman-config.toml";
+      environment.etc."nvidia-container-runtime/config.toml".source = "${nvidia-docker}/etc/podman-config.toml";
     })
   ]);
 }

--- a/nixos/modules/virtualisation/podman.nix
+++ b/nixos/modules/virtualisation/podman.nix
@@ -1,6 +1,7 @@
 { config, lib, pkgs, utils, ... }:
 let
   cfg = config.virtualisation.podman;
+  toml = pkgs.formats.toml { };
 
   inherit (lib) mkOption types;
 
@@ -53,6 +54,14 @@ in
       '';
     };
 
+    enableNvidia = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable use of NVidia GPUs from within podman containers.
+      '';
+    };
+
     extraPackages = mkOption {
       type = with types; listOf package;
       default = [ ];
@@ -78,21 +87,37 @@ in
 
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      environment.systemPackages = [ cfg.package ]
+        ++ lib.optional cfg.dockerCompat dockerCompat;
 
-    environment.systemPackages = [ cfg.package ]
-      ++ lib.optional cfg.dockerCompat dockerCompat;
+      environment.etc."cni/net.d/87-podman-bridge.conflist".source = utils.copyFile "${pkgs.podman-unwrapped.src}/cni/87-podman-bridge.conflist";
 
-    environment.etc."cni/net.d/87-podman-bridge.conflist".source = utils.copyFile "${pkgs.podman-unwrapped.src}/cni/87-podman-bridge.conflist";
+      virtualisation.containers = {
+        enable = true; # Enable common /etc/containers configuration
+        containersConf.extraConfig = lib.optionalString cfg.enableNvidia
+          (builtins.readFile (toml.generate "podman.nvidia.containers.conf" {
+            engine = {
+              conmon_env_vars = [ "PATH=${lib.makeBinPath [ pkgs.nvidia-docker ]}" ];
+              runtimes.nvidia = [ "${pkgs.nvidia-docker}/bin/nvidia-container-runtime" ];
+            };
+          }));
+      };
 
-    # Enable common /etc/containers configuration
-    virtualisation.containers.enable = true;
-
-    assertions = [{
-      assertion = cfg.dockerCompat -> !config.virtualisation.docker.enable;
-      message = "Option dockerCompat conflicts with docker";
-    }];
-
-  };
-
+      assertions = [
+        {
+          assertion = cfg.dockerCompat -> !config.virtualisation.docker.enable;
+          message = "Option dockerCompat conflicts with docker";
+        }
+        {
+          assertion = cfg.enableNvidia -> !config.virtualisation.docker.enableNvidia;
+          message = "Option enableNvidia conflicts with docker.enableNvidia";
+        }
+      ];
+    }
+    (lib.mkIf cfg.enableNvidia {
+      environment.etc."nvidia-container-runtime/config.toml".source = "${pkgs.nvidia-docker}/etc/podman-config.toml";
+    })
+  ]);
 }

--- a/pkgs/applications/virtualization/nvidia-docker/default.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/default.nix
@@ -78,6 +78,9 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:/run/opengl-driver-32/lib
     cp ${./config.toml} $out/etc/config.toml
     substituteInPlace $out/etc/config.toml --subst-var-by glibcbin ${lib.getBin glibc}
+
+    cp ${./podman-config.toml} $out/etc/podman-config.toml
+    substituteInPlace $out/etc/podman-config.toml --subst-var-by glibcbin ${lib.getBin glibc}
   '';
 
   meta = {

--- a/pkgs/applications/virtualization/nvidia-docker/default.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/default.nix
@@ -22,7 +22,7 @@ with lib; let
   ];
 
   nvidia-container-runtime = buildGoPackage rec {
-    pname = "nvidia-container-toolkit";
+    pname = "nvidia-container-runtime";
     version = "3.4.0";
     src = fetchFromGitHub {
       owner = "NVIDIA";

--- a/pkgs/applications/virtualization/nvidia-docker/podman-config.toml
+++ b/pkgs/applications/virtualization/nvidia-docker/podman-config.toml
@@ -1,0 +1,13 @@
+disable-require = true
+#swarm-resource = "DOCKER_RESOURCE_GPU"
+
+[nvidia-container-cli]
+#root = "/run/nvidia/driver"
+#path = "/usr/bin/nvidia-container-cli"
+environment = []
+#debug = "/var/log/nvidia-container-runtime-hook.log"
+ldcache = "/tmp/ld.so.cache"
+load-kmods = true
+no-cgroups = true
+#user = "root:video"
+ldconfig = "@@glibcbin@/bin/ldconfig"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change adds an `enableNvidia` option to the `podman` module that enables the nvidia runtime.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
