### PR TITLE
gitAndTools.lab: 0.17.2 -> 0.18.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/lab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/default.nix
@@ -1,32 +1,32 @@
-{ lib, buildGoModule, fetchFromGitHub, makeWrapper, xdg_utils }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, xdg_utils, installShellFiles, git }:
 
 buildGoModule rec {
   pname = "lab";
-  version = "0.17.2";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "zaquestion";
     repo = "lab";
     rev = "v${version}";
-    sha256 = "0zkwvmzgj7h8lc8jkg2a81392b28c8hkwqzj6dds6q4asbmymx5c";
+    sha256 = "1vl5ylix4h6z1vrdslv9qphgb6yqpqd4r54jzk5kd6zgrnf9c2zc";
   };
 
   subPackages = [ "." ];
 
-  vendorSha256 = "1lrmafvv5zfn9kc0p8g5vdz351n1zbaqwhwk861fxys0rdpqskyc";
+  vendorSha256 = "07zl5xhzgrgr5skba6cds5nal58pllf10gak0ap62j1k9gk2ych2";
 
   doCheck = false;
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
 
   postInstall = ''
-    mkdir -p "$out/share/bash-completion/completions" "$out/share/zsh/site-functions"
-    export LAB_CORE_HOST=a LAB_CORE_USER=b LAB_CORE_TOKEN=c
-    $out/bin/lab completion bash > $out/share/bash-completion/completions/lab
-    $out/bin/lab completion zsh > $out/share/zsh/site-functions/_lab
-    wrapProgram $out/bin/lab --prefix PATH ":" "${lib.makeBinPath [ xdg_utils ]}";
+    wrapProgram $out/bin/lab --prefix PATH ":" "${lib.makeBinPath [ git xdg_utils ]}";
+    for shell in bash fish zsh; do
+      $out/bin/lab completion $shell > lab.$shell
+      installShellCompletion lab.$shell
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/zaquestion/lab/releases/tag/v0.18.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
