### PR TITLE
treewide: stop maintaining most packages

### DIFF
--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     homepage = "https://repo.or.cz/w/llpp.git";
     description = "A MuPDF based PDF pager written in OCaml";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ pSub enzime ];
+    maintainers = with maintainers; [ pSub ];
     license = licenses.gpl3;
   };
 }

--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
     description = "Share one mouse and keyboard between multiple computers";
     homepage = "http://synergy-project.org/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ enzime ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -48,6 +48,6 @@ pythonPackages.buildPythonApplication rec {
     '';
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ dezgeg zraexy enzime ];
+    maintainers = with maintainers; [ dezgeg zraexy ];
   };
 }

--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     homepage = "https://github.com/yshui/picom";
-    maintainers = with maintainers; [ ertes enzime twey ];
+    maintainers = with maintainers; [ ertes twey ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ enzime ];
+    maintainers = with maintainers; [ ];
     license = stdenv.lib.licenses.lgpl3;
     description = "An opensource database of photographic lenses and their characteristics";
     homepage = "http://lensfun.sourceforge.net/";

--- a/pkgs/development/tools/flootty/default.nix
+++ b/pkgs/development/tools/flootty/default.nix
@@ -13,6 +13,6 @@ python3Packages.buildPythonApplication rec {
     description = "A collaborative terminal. In practice, it's similar to a shared screen or tmux session";
     homepage = "https://floobits.com/help/flootty";
     license = licenses.asl20;
-    maintainers = with maintainers; [ sellout enzime ];
+    maintainers = with maintainers; [ sellout ];
   };
 }

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -196,6 +196,6 @@ buildPythonApplication rec {
     license = licenses.agpl3Plus;
     broken = stdenv.hostPlatform.isAarch64;
     platforms = platforms.mesaPlatforms;
-    maintainers = with maintainers; [ oxij Profpatsch enzime ];
+    maintainers = with maintainers; [ oxij Profpatsch ];
   };
 }

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     '';
     license = licenses.publicDomain;
     platforms = with platforms; linux ++ darwin;
-    maintainers = with maintainers; [ bluescreen303 phreedom AndersonTorres fpletz enzime ma27 zowoq ];
+    maintainers = with maintainers; [ bluescreen303 phreedom AndersonTorres fpletz ma27 zowoq ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Removed myself from packages I no longer use, I hope someone who is interested can pick up some of these orphaned packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
