### PR TITLE
nimlsp: init at 0.2.6

### DIFF
--- a/pkgs/development/tools/misc/nimlsp/default.nix
+++ b/pkgs/development/tools/misc/nimlsp/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, srcOnly, nim }:
+let
+  astpatternmatching = fetchFromGitHub {
+    owner = "krux02";
+    repo = "ast-pattern-matching";
+    rev = "87f7d163421af5a4f5e5cb6da7b93278e6897e96";
+    sha256 = "19mb5bb6riia8380p5dpc3q0vwgrj958dd6p7vw8vkvwiqrzg6zq";
+  };
+
+  jsonschema = fetchFromGitHub {
+    owner = "PMunch";
+    repo = "jsonschema";
+    rev = "7b41c03e3e1a487d5a8f6b940ca8e764dc2cbabf";
+    sha256 = "1js64jqd854yjladxvnylij4rsz7212k31ks541pqrdzm6hpblbz";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "nimlsp";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "PMunch";
+    repo = "nimlsp";
+    rev = "v${version}";
+    sha256 = "13kw3zjh0iqymwqxwhyj8jz6hgswwahf1rjd6iad7c6gcwrrg6yl";
+  };
+
+  nativeBuildInputs = [ nim ];
+
+  buildPhase = ''
+    export HOME=$TMPDIR
+    nim -d:release -p:${astpatternmatching}/src -p:${jsonschema}/src \
+      c --threads:on -d:nimcore -d:nimsuggest -d:debugCommunication \
+      -d:debugLogging -d:explicitSourcePath=${srcOnly nim.unwrapped} -d:tempDir=/tmp src/nimlsp
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin src/nimlsp
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Language Server Protocol implementation for Nim";
+    homepage = "https://github.com/PMunch/nimlsp";
+    license = licenses.mit;
+    platforms = nim.meta.platforms;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10089,6 +10089,8 @@ in
 
   nrpl = callPackage ../development/tools/nrpl { };
 
+  nimlsp = callPackage ../development/tools/misc/nimlsp { };
+
   neko = callPackage ../development/compilers/neko { };
 
   nextpnr = callPackage ../development/compilers/nextpnr { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Supersede and close https://github.com/NixOS/nixpkgs/pull/99474 cc: @nbonfils 
closes https://github.com/NixOS/nixpkgs/issues/99472

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
