### PR TITLE
chiaki: use mkDerivation for QT5 application

### DIFF
--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -6,6 +6,7 @@
 , python3Packages
 , ffmpeg
 , libopus
+, mkDerivation
 , qtbase
 , qtmultimedia
 , qtsvg
@@ -15,7 +16,7 @@
 , qtmacextras
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "chiaki";
   version = "2.0.1";
 


### PR DESCRIPTION
###### Motivation for this change
Commit fe1151218cbb ("chiaki: cleanup package") replaced mkDerivation
with stdenv mkDerivation, which is wrong for QT5 applications and
results in the following error on start:
```
  qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
  qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
  This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
also see [1] in the manual. Fix the package by using mkDerivation again.

[1]: https://nixos.org/manual/nixpkgs/unstable/#sec-language-qt

Fixes: fe1151218cbb ("chiaki: cleanup package")

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
