### PR TITLE
ocamlPackages.zed: refactor; ocamlPackages.charInfo_width: use Dune 2

### DIFF
--- a/pkgs/development/ocaml-modules/charInfo_width/default.nix
+++ b/pkgs/development/ocaml-modules/charInfo_width/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "charInfo_width";
   version = "1.1.0";
+  useDune2 = true;
   src = fetchzip {
     url = "https://bitbucket.org/zandoye/charinfo_width/get/${version}.tar.bz2";
     sha256 = "19mnq9a1yr16srqs8n6hddahr4f9d2gbpmld62pvlw1ps7nfrp9w";

--- a/pkgs/development/ocaml-modules/zed/default.nix
+++ b/pkgs/development/ocaml-modules/zed/default.nix
@@ -1,36 +1,19 @@
-{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, camomile, react, dune, charInfo_width }:
+{ lib, buildDunePackage, fetchFromGitHub, camomile, react, charInfo_width }:
 
-let param =
-  if lib.versionAtLeast ocaml.version "4.02" then
-  {
-    version = "3.1.0";
+buildDunePackage rec {
+  pname = "zed";
+  version = "3.1.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "ocaml-community";
+    repo = pname;
+    rev = version;
     sha256 = "04vr1a94imsghm98iigc35rhifsz0rh3qz2qm0wam2wvp6vmrx0p";
-    buildInputs = [ dune ];
-    propagatedBuildInputs = [ charInfo_width ];
-    extra = {
-     buildPhase = "dune build -p zed";
-     inherit (dune) installPhase; };
-  } else {
-    version = "1.4";
-    sha256 = "0d8qfy0qiydrrqi8qc9rcwgjigql6vx9gl4zp62jfz1lmjgb2a3w";
-    buildInputs = [ ocamlbuild ];
-    propagatedBuildInputs = [ camomile ];
-    extra = { createFindlibDestdir = true; };
-  }
-; in
-
-stdenv.mkDerivation (rec {
-  inherit (param) version;
-  name = "ocaml-zed-${version}";
-
-  src = fetchzip {
-    url = "https://github.com/diml/zed/archive/${version}.tar.gz";
-    inherit (param) sha256;
   };
 
-  buildInputs = [ ocaml findlib ] ++ param.buildInputs;
-
-  propagatedBuildInputs = [ react ] ++ param.propagatedBuildInputs;
+  propagatedBuildInputs = [ charInfo_width react ];
 
   meta = {
     description = "Abstract engine for text edition in OCaml";
@@ -41,11 +24,10 @@ stdenv.mkDerivation (rec {
 
     To support efficient text edition capabilities, Zed provides macro recording and cursor management facilities.
     '';
-    homepage = "https://github.com/diml/zed";
+    inherit (src.meta) homepage;
     license = lib.licenses.bsd3;
-    platforms = ocaml.meta.platforms or [];
     maintainers = [
       lib.maintainers.gal_bolle
     ];
   };
-} // param.extra)
+}


### PR DESCRIPTION
###### Motivation for this change

Use Dune 2.

cc maintainer @FlorentBecker (`zed`).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
