### PR TITLE
python3Packages.sortedcollections: 1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/development/python-modules/sortedcollections/default.nix
+++ b/pkgs/development/python-modules/sortedcollections/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, pytestCheckHook
 , sortedcontainers
 }:
 
@@ -8,15 +9,18 @@ buildPythonPackage rec {
   pname = "sortedcollections";
   version = "1.2.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0i9cvwz4gikkp5jmk0bzsbyisnwy4sfazm9bg7b8q9j266plr4rl";
+  src = fetchFromGitHub {
+    owner = "grantjenks";
+    repo = "python-sortedcollections";
+    rev = "v${version}";
+    sha256 = "06ifkbhkj5fpsafibw0fs7b778g7q0gd03crvbjk04k0f3wjxc5z";
   };
 
   propagatedBuildInputs = [ sortedcontainers ];
 
-  # No tests in PyPi tarball
-  doCheck = false;
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "sortedcollections" ];
 
   meta = with stdenv.lib; {
     description = "Python Sorted Collections";

--- a/pkgs/development/python-modules/sortedcollections/default.nix
+++ b/pkgs/development/python-modules/sortedcollections/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python Sorted Collections";
     homepage = "http://www.grantjenks.com/docs/sortedcollections/";
-    license = licenses.asl20;
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
   };
-
 }

--- a/pkgs/development/python-modules/sortedcollections/default.nix
+++ b/pkgs/development/python-modules/sortedcollections/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "sortedcollections";
-  version = "1.2.1";
+  version = "1.2.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0sihzm5aqz7r3irh4jn6rzicb7lf81d27z7vl6kaslnhwcsizhsq";
+    sha256 = "0i9cvwz4gikkp5jmk0bzsbyisnwy4sfazm9bg7b8q9j266plr4rl";
   };
 
   propagatedBuildInputs = [ sortedcontainers ];

--- a/pkgs/tools/audio/google-music-scripts/default.nix
+++ b/pkgs/tools/audio/google-music-scripts/default.nix
@@ -26,11 +26,11 @@ buildPythonApplication rec {
     sha256 = "0apwgj86whrc077dfymvyb4qwj19bawyrx49g4kg364895v0rbbq";
   };
 
-  # pendulum pinning was to prevent PEP517 from trying to build from source
+  # there are already later releases present
   postPatch = ''
     substituteInPlace setup.py \
       --replace "tomlkit>=0.5,<0.6" "tomlkit" \
-      --replace "pendulum>=2.0,<=3.0,!=2.0.5,!=2.1.0" "pendulum"
+      --replace "attrs>=18.2,<19.4" "attrs"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.2.3

Commit log: https://github.com/grantjenks/python-sortedcollections/commits/master

`attrs` is at 20.3.0 and this leads to build failures. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
