### PR TITLE
raspberrypi-armstubs: fix native compilation on armv7l

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation {
     "LD8=${stdenv.cc.targetPrefix}ld"
     "OBJCOPY8=${stdenv.cc.targetPrefix}objcopy"
     "OBJDUMP8=${stdenv.cc.targetPrefix}objdump"
-    "CC=${stdenv.cc.targetPrefix}cc"
-    "LD=${stdenv.cc.targetPrefix}ld"
-    "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
-    "OBJDUMP=${stdenv.cc.targetPrefix}objdump"
+    "CC7=${stdenv.cc.targetPrefix}cc"
+    "LD7=${stdenv.cc.targetPrefix}ld"
+    "OBJCOPY7=${stdenv.cc.targetPrefix}objcopy"
+    "OBJDUMP7=${stdenv.cc.targetPrefix}objdump"
   ]
   ++ optionals (stdenv.isAarch64) [ "armstub8.bin" "armstub8-gic.bin" ]
   ++ optionals (stdenv.isAarch32) [ "armstub7.bin" "armstub8-32.bin" "armstub8-32-gic.bin" ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The armstubs would not build on armv7l native. See [Makefile](https://github.com/raspberrypi/tools/blob/master/armstubs/Makefile)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@samueldr 