### PR TITLE
monado: init at 0.4.1

### DIFF
--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -1,0 +1,101 @@
+{ stdenv
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, pkg-config
+, python3
+, SDL2
+, dbus
+, eigen
+, ffmpeg
+, glslang
+, hidapi
+, libGL
+, libXau
+, libXdmcp
+, libXrandr
+, libffi
+# , librealsense
+, libsurvive
+, libusb1
+, libuvc
+, libv4l
+, libxcb
+, opencv4
+, openhmd
+, udev
+, vulkan-headers
+, vulkan-loader
+, wayland
+, wayland-protocols
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "monado";
+  version = "0.4.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "114aif79dqyn2qg07mkv6lzmqn15k6fdcii818rdf5g4bp7zzzgm";
+  };
+
+  patches = [
+    # fix libsurvive autodetection, drop with the next version update
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/monado/monado/-/commit/345e9eab56e2de9e8b07cf72c2a67cf2ebd01e62.patch";
+      sha256 = "17c110an6sxc8rn7dfz30rfkbayg64w68licicwc8cqabi6cgrm3";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config python3 ];
+
+  buildInputs = [
+    SDL2
+    dbus
+    eigen
+    ffmpeg
+    glslang
+    hidapi
+    libGL
+    libXau
+    libXdmcp
+    libXrandr
+    libffi
+    # librealsense.dev - see below
+    libsurvive
+    libusb1
+    libuvc
+    libv4l
+    libxcb
+    opencv4
+    openhmd
+    udev
+    vulkan-headers
+    vulkan-loader
+    wayland
+    wayland-protocols
+    zlib
+  ];
+
+  # realsense is disabled, the build ends with the following error:
+  #
+  # CMake Error in src/xrt/drivers/CMakeLists.txt:
+  # Imported target "realsense2::realsense2" includes non-existent path
+  # "/nix/store/2v95aps14hj3jy4ryp86vl7yymv10mh0-librealsense-2.41.0/include"
+  # in its INTERFACE_INCLUDE_DIRECTORIES.
+  #
+  # for some reason cmake is trying to use ${librealsense}/include
+  # instead of ${librealsense.dev}/include as an include directory
+
+  meta = with stdenv.lib; {
+    description = "Open source XR runtime";
+    homepage = "https://monado.freedesktop.org/";
+    license = licenses.boost;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libuvc/default.nix
+++ b/pkgs/development/libraries/libuvc/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libusb1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libuvc";
+  version = "unstable-2020-11-29";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "5cddef71b17d41f7e98875a840c50d9704c3d2b2";
+    sha256 = "0kranb0x1k5qad8rwxnn1w9963sbfj2cfzdgpfmlivb04544m2j7";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libusb1 ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://ken.tossell.net/libuvc/";
+    description = "Cross-platform library for USB video devices";
+    platforms = platforms.linux;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2486,6 +2486,8 @@ in
 
   monetdb = callPackage ../servers/sql/monetdb { };
 
+  monado = callPackage ../applications/graphics/monado {};
+
   mons = callPackage ../tools/misc/mons {};
 
   mousetweaks = callPackage ../applications/accessibility/mousetweaks {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14942,6 +14942,8 @@ in
     inherit (darwin.apple_sdk.frameworks) ApplicationServices CoreServices;
   };
 
+  libuvc = callPackage ../development/libraries/libuvc { };
+
   libv4l = lowPrio (v4l-utils.override {
     withUtils = false;
   });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Monado is an open source XR runtime delivering immersive experiences such as VR and AR on mobile, PC/desktop, and other devices. Monado aims to be a complete and conformant implementation of the OpenXR API made by Khronos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
