### PR TITLE
vscode-extensions.donjayamanne.githistory: init at 0.6.14

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -95,6 +95,23 @@ let
         meta = { license = stdenv.lib.licenses.mit; };
       };
 
+      donjayamanne.githistory = buildVscodeMarketplaceExtension {
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items/donjayamanne.githistory/changelog";
+          description = "Git History for Visual Studio Code";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=donjayamanne.githistory";
+          homepage = "https://github.com/DonJayamanne/gitHistoryVSCode/";
+          license = stdenv.lib.licenses.mit;
+          maintainers = [ maintainers.superherointj ];
+        };
+        mktplcRef = {
+          name = "githistory";
+          publisher = "donjayamanne";
+          sha256 = "11x116hzqnhgbryp2kqpki1z5mlnwxb0ly9r1513m5vgbisrsn0i";
+          version = "0.6.14";
+        };
+      };
+
       formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "auto-close-tag";


### PR DESCRIPTION
<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adding "donjayamanne.githistory" VSCode extension to Nixpkgs.

###### Things done
Tested in NixOS, x86-64-bit.

###### Note
I have added myself as a contributor here:
https://github.com/NixOS/nixpkgs/pull/108582
If that PR is not accepted this PR will fail for referencing a non-existing contributor.
I hope I have done things right. Let me know.
Thank you.