### PR TITLE
germinal: init at 26

### DIFF
--- a/pkgs/applications/terminal-emulators/germinal/default.nix
+++ b/pkgs/applications/terminal-emulators/germinal/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, appstream-glib
+, dbus
+, pango
+, pcre2
+, tmux
+, vte
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "germinal";
+  version = "26";
+
+  src = fetchFromGitHub {
+    owner = "Keruspe";
+    repo = "Germinal";
+    rev = "v${version}";
+    sha256 = "sha256-HUi+skF4bJj5CY2cNTOC4tl7jhvpXYKqBx2rqKzjlo0=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config wrapGAppsHook ];
+  buildInputs = [
+    appstream-glib
+    dbus
+    pango
+    pcre2
+    vte
+  ];
+
+  configureFlags = [
+    "--with-dbusservicesdir=${placeholder "out"}/etc/dbus-1/system-services/"
+  ];
+
+  dontWrapGApps = true;
+
+  fixupPhase = ''
+    runHook preFixup
+    wrapProgram $out/bin/germinal \
+     --prefix PATH ":" "${stdenv.lib.makeBinPath [ tmux ]}" \
+      "''${gappsWrapperArgs[@]}"
+    runHook postFixup
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A minimal terminal emulator";
+    homepage = "https://github.com/Keruspe/Germinal";
+    license = with licenses; gpl3Plus;
+    platforms = with platforms; unix;
+    maintainers = with maintainers; [ AndersonTorres ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -730,6 +730,8 @@ in
 
   foot = callPackage ../applications/terminal-emulators/foot { };
 
+  germinal = callPackage ../applications/terminal-emulators/germinal { };
+
   guake = callPackage ../applications/terminal-emulators/guake { };
 
   havoc = callPackage ../applications/terminal-emulators/havoc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
