### PR TITLE
darwin: generate apple packages preparing for update macos sdk

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -1,6 +1,9 @@
 { lib, stdenv, fetchurl, fetchzip, pkgs }:
 
 let
+  macosPackages_11_0_1 = import ./macos-11.0.1.nix { inherit applePackage'; };
+  developerToolsPackages_11_3_1 = import ./developer-tools-11.3.1.nix { inherit applePackage'; };
+
   # This attrset can in theory be computed automatically, but for that to work nicely we need
   # import-from-derivation to work properly. Currently it's rather ugly when we try to bootstrap
   # a stdenv out of something like this. With some care we can probably get rid of this, but for
@@ -56,6 +59,9 @@ let
       # neither of those versions are publicly available.
       libplatform   = "125";
       mDNSResponder = "625.41.2";
+
+      # IOKit contains a set of packages with different versions, so we don't have a general version
+      IOKit         = "";
 
       libutil       = "43";
       libunwind     = "35.3";
@@ -135,35 +141,47 @@ let
     };
   };
 
-  fetchApple = version: sha256: name: let
+  fetchApple' = pname: version: sha256: let
     # When cross-compiling, fetchurl depends on libiconv, resulting
     # in an infinite recursion without this. It's not clear why this
     # worked fine when not cross-compiling
-    fetch = if name == "libiconv"
+    fetch = if pname == "libiconv"
       then stdenv.fetchurlBoot
       else fetchurl;
   in fetch {
-    url = "http://www.opensource.apple.com/tarballs/${name}/${name}-${versions.${version}.${name}}.tar.gz";
+    url = "http://www.opensource.apple.com/tarballs/${pname}/${pname}-${version}.tar.gz";
     inherit sha256;
   };
 
-  appleDerivation_ = name: version: sha256: attrs: stdenv.mkDerivation ({
-    inherit version;
-    name = "${name}-${version}";
-    enableParallelBuilding = true;
-    meta = {
-      platforms = lib.platforms.darwin;
-    };
-  } // (if attrs ? srcs then {} else {
-    src  = fetchApple version sha256 name;
-  }) // attrs);
+  fetchApple = sdkName: sha256: pname: let
+    version = versions.${sdkName}.${pname};
+  in fetchApple' pname version sha256;
 
-  applePackage = namePath: version: sha256:
-    let
-      name = builtins.elemAt (lib.splitString "/" namePath) 0;
-      appleDerivation = appleDerivation_ name version sha256;
-      callPackage = pkgs.newScope (packages // pkgs.darwin // { inherit appleDerivation name version; });
-    in callPackage (./. + "/${namePath}");
+  appleDerivation' = pname: version: sdkName: sha256: attrs: stdenv.mkDerivation ({
+    inherit pname;
+    version = "${version}-${sdkName}";
+
+    src = if attrs ? srcs then null else (fetchApple' pname version sha256);
+
+    enableParallelBuilding = true;
+
+  } // attrs // {
+    meta = (with lib; {
+      platforms = platforms.darwin;
+      license = licenses.apsl20;
+    }) // (attrs.meta or {});
+  });
+
+  applePackage' = namePath: version: sdkName: sha256: let
+    pname = builtins.head (lib.splitString "/" namePath);
+    appleDerivation = appleDerivation' pname version sdkName sha256;
+    callPackage = pkgs.newScope (packages // pkgs.darwin // { inherit appleDerivation; });
+  in callPackage (./. + "/${namePath}");
+
+  applePackage = namePath: sdkName: sha256: let
+    pname = builtins.head (lib.splitString "/" namePath);
+    version = versions.${sdkName}.${pname};
+  in applePackage' namePath version sdkName sha256;
 
   IOKitSpecs = {
     IOAudioFamily                        = fetchApple "osx-10.10.5" "0ggq7za3iq8g02j16rj67prqhrw828jsw3ah3bxq8a1cvr55aqnq";
@@ -192,7 +210,8 @@ let
   # Only used for bootstrapping. It’s convenient because it was the last version to come with a real makefile.
   adv_cmds-boot = applePackage "adv_cmds/boot.nix" "osx-10.5.8" "102ssayxbg9wb35mdmhswbnw0bg7js3pfd8fcbic83c5q3bqa6c6" {};
 
-  packages = {
+  # TODO: shorten this list, we should cut down to a minimum set of bootstrap or necessary packages here.
+  stubPackages = {
     inherit (adv_cmds-boot) ps locale;
     architecture    = applePackage "architecture"      "osx-10.11.6"     "1pbpjcd7is69hn8y29i98ci0byik826if8gnp824ha92h90w0fq3" {};
     bootstrap_cmds  = applePackage "bootstrap_cmds"    "dev-tools-7.0"   "1v5dv2q3af1xwj5kz0a5g54fd5dm6j4c9dd2g66n4kc44ixyrhp3" {};
@@ -254,6 +273,8 @@ let
 
     # TODO(matthewbauer):
     # To be removed, once I figure out how to build a newer Security version.
-    Security      = applePackage "Security/boot.nix" "osx-10.9.5"      "1nv0dczf67dhk17hscx52izgdcyacgyy12ag0jh6nl5hmfzsn8yy" {};
+    Security        = applePackage "Security/boot.nix" "osx-10.9.5"      "1nv0dczf67dhk17hscx52izgdcyacgyy12ag0jh6nl5hmfzsn8yy" {};
   };
+
+  packages = developerToolsPackages_11_3_1 // macosPackages_11_0_1 // stubPackages;
 in packages

--- a/pkgs/os-specific/darwin/apple-source-releases/developer-tools-11.3.1.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/developer-tools-11.3.1.nix
@@ -1,0 +1,8 @@
+# Generated using:  ./generate-sdk-packages.sh developer-tools 11.3.1
+
+{ applePackage' }:
+
+{
+bootstrap_cmds = applePackage' "bootstrap_cmds" "116" "developer-tools-11.3.1" "148xpqkf5xzpslqxch5l8h6vsz7sys8sdzk4ghbg9mkcivp8qa03" {};
+developer_cmds = applePackage' "developer_cmds" "66" "developer-tools-11.3.1" "0q08m4cxxwph7gxqravmx13l418p1i050bd46zwksn9j9zpw9mlr" {};
+}

--- a/pkgs/os-specific/darwin/apple-source-releases/generate-sdk-packages.sh
+++ b/pkgs/os-specific/darwin/apple-source-releases/generate-sdk-packages.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl
+
+# usage:
+#   generate-sdk-packages.sh macos 11.0.1
+
+cd $(dirname "$0")
+
+sdkName="$1-$2"
+outfile="$sdkName.nix"
+
+>$outfile echo "# Generated using:  ./$(basename "$0") $1 $2
+
+{ applePackage' }:
+
+{"
+
+parse_line() {
+    readarray -t -d$'\t' package <<<$2
+    local pname=${package[0]} version=${package[1]}
+
+    if [ -d $pname ]; then
+        sha256=$(nix-prefetch-url "https://opensource.apple.com/tarballs/$pname/$pname-$version.tar.gz")
+        >>$outfile echo "$pname = applePackage' \"$pname\" \"$version\" \"$sdkName\" \"$sha256\" {};"
+    fi
+}
+readarray -s1 -c1 -C parse_line < <(curl -sS "https://opensource.apple.com/text/${sdkName//./}.txt")
+
+>>$outfile echo '}'

--- a/pkgs/os-specific/darwin/apple-source-releases/macos-11.0.1.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/macos-11.0.1.nix
@@ -1,0 +1,46 @@
+# Generated using:  ./generate-sdk-packages.sh macos 11.0.1
+
+{ applePackage' }:
+
+{
+adv_cmds = applePackage' "adv_cmds" "176" "macos-11.0.1" "0x8c25rh6fnzndbc26vcb65vcxilvqyfvm2klfyci1wr4bh3ixgk" {};
+architecture = applePackage' "architecture" "279" "macos-11.0.1" "1cgp33ywa30max6cyp69kvii299hx2vgwvmy3ms8n4gaq2mkpaky" {};
+basic_cmds = applePackage' "basic_cmds" "55" "macos-11.0.1" "0hvab4b1v5q2x134hdkal0rmz5gsdqyki1vb0dbw4py1bqf0yaw9" {};
+bootstrap_cmds = applePackage' "bootstrap_cmds" "121" "macos-11.0.1" "09bwclws6adxb1ky9q35f4ikddk4mbalmgds0cmqaf7j23qxl3fv" {};
+CommonCrypto = applePackage' "CommonCrypto" "60178.40.2" "macos-11.0.1" "0r3b1mlfmbdzpwn6pbsbfaga3k63gpwcwbhkbi4r09aq82skl02v" {};
+configd = applePackage' "configd" "1109.40.9" "macos-11.0.1" "173i55wfzli9pg2x2rw437hs68h6l4ngss5jfgf18g26zjkjzv5v" {};
+copyfile = applePackage' "copyfile" "173.40.2" "macos-11.0.1" "0qyp15qj3fdb7yx033n57l7s61d70mv17f43yiwcbhx09mmlrp07" {};
+Csu = applePackage' "Csu" "88" "macos-11.0.1" "029lgcyj0i16036h2lcx6fd6r1yf1bkj5dnvz905rh6ncl8skgdr" {};
+diskdev_cmds = applePackage' "diskdev_cmds" "667.40.1" "macos-11.0.1" "1bqwkwkwd556rba5000ap77xrhaf4xnmy83mszd7a0yvl2xlma7j" {};
+dtrace = applePackage' "dtrace" "370.40.1" "macos-11.0.1" "1941yczmn94ng5zlnhf0i5mjw2f4g7znisgvhkhn5f86gxmd98wl" {};
+dyld = applePackage' "dyld" "832.7.1" "macos-11.0.1" "1s77ca6jg20z91qlph59da8j61m97y23vrw48xs4rywdzh4915n0" {};
+eap8021x = applePackage' "eap8021x" "304.40.1" "macos-11.0.1" "1ph3kcpf527s0jqsi60j2sgg3m8h128spf292d8kyc08siz9mf9c" {};
+file_cmds = applePackage' "file_cmds" "321.40.3" "macos-11.0.1" "04789vn1wghclfr3ma3ncg716xdsxfj66hrcxi5h3h1ryag2ycfz" {};
+hfs = applePackage' "hfs" "556.41.1" "macos-11.0.1" "1rhkmn2yj5p4wmi4aajy5hj2h0gxk63s8j4qz4ziy4g4bjpdgwmy" {};
+ICU = applePackage' "ICU" "66108" "macos-11.0.1" "1d76cyyqpwkzjlxfajm4nsglxmfrcafbnjwnjxc3j5w3nw67pqhx" {};
+Libc = applePackage' "Libc" "1439.40.11" "macos-11.0.1" "0d5xlnks4lc9391wg31c9126vflb40lc5ffkgxmf2kpyglac1280" {};
+libclosure = applePackage' "libclosure" "78" "macos-11.0.1" "089i2bl4agpnfplrg23xbzma1674g0w05988nxdps6ghxl4kz66f" {};
+libdispatch = applePackage' "libdispatch" "1271.40.12" "macos-11.0.1" "0z7r42zfb8y48f0nrw0qw7fanfvimycimgnrg3jig101kjvjar98" {};
+libiconv = applePackage' "libiconv" "59" "macos-11.0.1" "0hqbsqggjrr0sv6h70lcr3gabgk9inyc8aq1b30wibgjm6crjwpp" {};
+Libinfo = applePackage' "Libinfo" "542.40.3" "macos-11.0.1" "0y5x6wxd3mwn6my1jdp8qrak3y7x7sgjdmwyw9cvvbn3kg9v6z1p" {};
+Libnotify = applePackage' "Libnotify" "279.40.4" "macos-11.0.1" "0aswflxki877izp6sacv35sydn6a3639cflv3zhs3i7vkfbsvbf5" {};
+libplatform = applePackage' "libplatform" "254.40.4" "macos-11.0.1" "1mhi8n66864y98dr3n0pkqad3aqim800kn9bxzp6h5jf2jni3aql" {};
+libpthread = applePackage' "libpthread" "454.40.3" "macos-11.0.1" "18rb4dqjdf3krzi4hdj5i310gy49ipf01klbkp9g51i02a55gphq" {};
+libresolv = applePackage' "libresolv" "68" "macos-11.0.1" "1ysvg6d28xyaky9sn7giglnsflhjsbj17h3h3i6knlzxnzznpkql" {};
+Librpcsvc = applePackage' "Librpcsvc" "26" "macos-11.0.1" "1zwfwcl9irxl1dlnf2b4v30vdybp0p0r6n6g1pd14zbdci1jcg2k" {};
+Libsystem = applePackage' "Libsystem" "1292.50.1" "macos-11.0.1" "0w16zaigq18jfsnw15pfyz2mkfqdkn0cc16q617kmgw2khld8j7j" {};
+libunwind = applePackage' "libunwind" "200.10" "macos-11.0.1" "1pmymcqpfk7lfxh6zqch429vfpvmd2m1dlg898170pkx5zhxisl2" {};
+libutil = applePackage' "libutil" "58.40.2" "macos-11.0.1" "1hhgashfj9g4vjv02070c5pn818a5n0bh5l81l2pflmvb2rrqs3f" {};
+mDNSResponder = applePackage' "mDNSResponder" "1310.40.42" "macos-11.0.1" "0d0b9wwah9rg7rwrr29dxd6iy0y4rlmss3wcz2wcqmnd2qb9x8my" {};
+network_cmds = applePackage' "network_cmds" "606.40.2" "macos-11.0.1" "1dlslk67npvmxx5m50385kmn3ysxih2iv220hhzkin11f8abdjv7" {};
+objc4 = applePackage' "objc4" "818.2" "macos-11.0.1" "177gmh9m9ajy6mvcd2sf7gqydgljy44n3iih0yqsn1b13j784azx" {};
+PowerManagement = applePackage' "PowerManagement" "1132.50.3" "macos-11.0.1" "1n5yn6sc8w67g8iism6ilkyl33j46gcnlqcaq6k16zkngx6lprba" {};
+ppp = applePackage' "ppp" "877.40.2" "macos-11.0.1" "1z506z8ndvb1lfr4pypfy2bnig6qimhmq3yhjvqwfnliv91965iq" {};
+removefile = applePackage' "removefile" "49.40.3" "macos-11.0.1" "1fhp47awi15f02385r25qgw1ag5z0kr1v3kvgqm3r8i8yysfqvwp" {};
+Security = applePackage' "Security" "59754.41.1" "macos-11.0.1" "00kqgg7k80ba70ar2c02f0q9yrdgqcb56nb9z5g0bxwkvi40ryph" {};
+shell_cmds = applePackage' "shell_cmds" "216.40.4" "macos-11.0.1" "1mvp1fp34kkm4mi85fdn3i0l0gig4c0w09zg2mvkpxcf68cq2f69" {};
+system_cmds = applePackage' "system_cmds" "880.40.5" "macos-11.0.1" "1kys4vwfz4559sspdsfhmxc238nd8qgylqypza3zdzaqhfh7lx2x" {};
+text_cmds = applePackage' "text_cmds" "106" "macos-11.0.1" "0cpnfpllwpx20hbxzg5i5488gcjyi9adnbac1sd5hpv3bq6z1hs5" {};
+top = applePackage' "top" "129" "macos-11.0.1" "1nyz5mvq7js3zhsi3dwxl5fslg6m7nhlgc6p2hr889xgyl5prw8f" {};
+xnu = applePackage' "xnu" "7195.50.7.100.1" "macos-11.0.1" "14wqkqp3lcxgpm1sjnsysybrc4ppzkghwv3mb5nr5v8ml37prkib" {};
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
macos sdk is outdated for a long time (#101229), this PR provides scaffolds and candidates for future updating. 
Except for normalizing package name as `${pname}-${version}-${sdkName}`, in essence this PR doesn't update any packages. We may want a smooth update process divided into small tasks instead of a large package commit.

###### Things done
Generate package sources and rewrite some function names. 
Will cause mass rebuild due to some derivation names normalized, but it should not cause any actual change in compiling.

cc @matthewbauer

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
