### PR TITLE
taskwarrior-tui: init at 0.9.5

### DIFF
--- a/pkgs/applications/misc/taskwarrior-tui/default.nix
+++ b/pkgs/applications/misc/taskwarrior-tui/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "taskwarrior-tui";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "kdheepak";
+    repo = "taskwarrior-tui";
+    rev = "v${version}";
+    sha256 = "1348ypjphm5f46civbrcxbbahwwl2j47z1hg8ndq1cg2bh5wb8kg";
+  };
+
+  # Because there's a test that requires terminal access
+  doCheck = false;
+
+  cargoSha256 = "11zpy3whzir9mlbvf0jyscqwj9z44a6s5i1bc2cnxyciqy9b57md";
+
+  meta = with stdenv.lib; {
+    description = "A terminal user interface for taskwarrior ";
+    homepage = "https://github.com/kdheepak/taskwarrior-tui";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ matthiasbeyer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24574,6 +24574,8 @@ in
 
   taskwarrior = callPackage ../applications/misc/taskwarrior { };
 
+  taskwarrior-tui = callPackage ../applications/misc/taskwarrior-tui { };
+
   dstask = callPackage ../applications/misc/dstask { };
 
   tasksh = callPackage ../applications/misc/tasksh { };


### PR DESCRIPTION

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---

`This PR was brought to you by someone who has no push rights to nixos/nixpkgs, and thus you can trust that this PR did not delete anything in nixos/nixpkgs when it was created.`