### PR TITLE
urlhunter: init at 0.1.1

### DIFF
--- a/pkgs/tools/security/urlhunter/default.nix
+++ b/pkgs/tools/security/urlhunter/default.nix
@@ -1,0 +1,29 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "urlhunter";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "utkusen";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ph0pwfd8bb5499bsx3bd8sqhn69y00zk32ayc3n61gpcc6rmvn7";
+  };
+
+  vendorSha256 = "165kplaqigis0anafvzfqzwc3jjhsn2mwgf4phb4ck75n3yf85ys";
+
+  meta = with stdenv.lib; {
+    description = "Recon tool that allows searching shortened URLs";
+    longDescription = ''
+      urlhunter is a recon tool that allows searching on URLs that are
+      exposed via shortener services such as bit.ly and goo.gl.
+    '';
+    homepage = "https://github.com/utkusen/urlhunter";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8488,6 +8488,8 @@ in
 
   urjtag = callPackage ../tools/misc/urjtag { };
 
+  urlhunter = callPackage ../tools/security/urlhunter { };
+
   urlwatch = callPackage ../tools/networking/urlwatch { };
 
   valum = callPackage ../development/web/valum { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
urlhunter is a recon tool that allows searching on URLs that are
exposed via shortener services such as bit.ly and goo.gl.

https://github.com/utkusen/urlhunter

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
