### PR TITLE
turbogit: init at v1.2.0

### DIFF
--- a/pkgs/development/tools/turbogit/default.nix
+++ b/pkgs/development/tools/turbogit/default.nix
@@ -1,0 +1,42 @@
+{ fetchFromGitHub, buildGoModule, lib, installShellFiles }:
+buildGoModule rec {
+  pname = "turbogit";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "b4nst";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-alVgXnsoC2nmUe6i/l0ttUjoXpKLHr0n/7p6WbIIGBU=";
+  };
+
+  vendorSha256 = "sha256-6fxbxpROYiNw5SYdQAIdy5NfqzOcFfAlJ+vTQyFtink=";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    # Move turbogit binary to tug
+    ln -s $out/bin/turbogit $out/bin/tug
+
+    # Generate completion files
+    mkdir -p share/completions
+    $out/bin/tug completion bash > share/completions/tug.bash
+    $out/bin/tug completion fish > share/completions/tug.fish
+    $out/bin/tug completion zsh > share/completions/tug.zsh
+
+    installShellCompletion share/completions/tug.{bash,fish,zsh}
+  '';
+
+  meta = with lib; {
+    description = "Keep your git workflow clean without headache.";
+    longDescription = ''
+      turbogit (tug) is a cli tool built to help you deal with your day-to-day git work.
+      turbogit enforces convention (e.g. The Conventional Commits) but tries to keep things simple and invisible for you.
+      turbogit is your friend.
+    '';
+    homepage = "https://b4nst.github.io/turbogit";
+    license = licenses.mit;
+    maintainers = [ maintainers.yusdacra ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12365,6 +12365,8 @@ in
 
   ttyd = callPackage ../servers/ttyd { };
 
+  turbogit = callPackage ../development/tools/turbogit { };
+
   tweak = callPackage ../applications/editors/tweak { };
 
   tychus = callPackage ../development/tools/tychus {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [turbogit](https://github.com/b4nst/turbogit).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
