### PR TITLE
[staging] python38: fix find_library patch logic

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -216,8 +216,8 @@ in with passthru; stdenv.mkDerivation {
       else
         ./3.7/fix-finding-headers-when-cross-compiling.patch
     )
-  ] ++ optionals (isPy37) [
-    # Backport a fix for ctypes.util.find_library.
+  ] ++ optionals (isPy37 || (isPy38 && pythonOlder "3.8.7")) [
+    # Backport a fix for ctypes.util.find_library. This patch was applied to python3.8 in 3.8.7
     ./3.7/find_library.patch
   ];
 


### PR DESCRIPTION
###### Motivation for this change
closes  #108531

should work if it lands on staging-next as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
