### PR TITLE
home-assistant: 2020.12.2 -> 2021.1.0 (+entourage)

### DIFF
--- a/pkgs/development/python-modules/h11/default.nix
+++ b/pkgs/development/python-modules/h11/default.nix
@@ -1,33 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, fetchpatch }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "h11";
-  version = "0.9.0";
+  version = "0.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1qfad70h59hya21vrzz8dqyyaiqhac0anl2dx3s3k80gpskvrm1k";
+    sha256 = "0hk0nll6qazsambp3kl8cxxsbl4gv5y9252qadyk0jky0sv2q8j7";
   };
 
-  patches = [
-    # pytest5 compatability
-    (fetchpatch {
-      url = "https://github.com/python-hyper/h11/commit/241e220493a511a5f5a5d472cb88d72661a92ab1.patch";
-      sha256 = "1s3ipf9s41m1lksws3xv3j133q7jnjdqvmgk4sfnm8q7li2dww39";
-    })
-  ];
-
-  checkInputs = [ pytest ];
-
-  checkPhase = ''
-    py.test
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   # Some of the tests use localhost networking.
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Pure-Python, bring-your-own-I/O implementation of HTTP/1.1";
+    homepage = "https://github.com/python-hyper/h11";
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/openwebifpy/default.nix
+++ b/pkgs/development/python-modules/openwebifpy/default.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "openwebifpy";
-  version = "3.1.1";
+  version = "3.2.7";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zqa74i54ww9qjciiv8s58mxbs6vxq06cq5k4pxfarc0l75l4gh2";
+    sha256 = "0n9vi6b0y8b41fd7m9p361y3qb5m3b9p9d8g4fasqi7yy4mw2hns";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyarlo/default.nix
+++ b/pkgs/development/python-modules/pyarlo/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, requests
+, requests-mock
+, sseclient-py
+}:
+
+buildPythonPackage rec {
+  pname = "pyarlo";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "tchellomello";
+    repo = "python-arlo";
+    rev = version;
+    sha256 = "0pp7y2llk4xnf6zh57j5xas0gw5zqm42qaqssd8p4qa3g5rds8k3";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    sseclient-py
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    mock
+    requests-mock
+  ];
+
+  pythonImportsCheck = [ "pyarlo" ];
+
+  meta = with lib; {
+    description = "Python library to work with Netgear Arlo cameras";
+    homepage = "https://github.com/tchellomello/python-arlo";
+    license = with licenses; [ lgpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/uvicorn/default.nix
+++ b/pkgs/development/python-modules/uvicorn/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage rec {
 
   doCheck = !stdenv.isDarwin;
 
+  __darwinAllowLocalNetworking = true;
+
   pytestFlagsArray = [
     # watchgod required the watchgod package, which isn't available in nixpkgs
     "--ignore=tests/supervisors/test_reload.py"

--- a/pkgs/development/python-modules/uvicorn/default.nix
+++ b/pkgs/development/python-modules/uvicorn/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , buildPythonPackage
 , fetchFromGitHub
 , click
@@ -7,21 +8,26 @@
 , uvloop
 , websockets
 , wsproto
-, pytest
+, pytestCheckHook
+, pytest-mock
+, pyyaml
 , requests
+, trustme
+, typing-extensions
 , isPy27
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "uvicorn";
-  version = "0.11.5";
+  version = "0.13.2";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "0cf0vw6kzxwlkvk5gw85wv3kg1kdil0wkq3s7rmxpvrk6gjk8jvq";
+    sha256 = "04zgmp9z46k72ay6cz7plga6d3w3a6x41anabm7ramp7jdqf6na9";
   };
 
   propagatedBuildInputs = [
@@ -31,25 +37,31 @@ buildPythonPackage rec {
     uvloop
     websockets
     wsproto
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    typing-extensions
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "h11==0.8.*" "h11" \
-      --replace "httptools==0.0.13" "httptools"
-  '';
-
-  checkInputs = [ pytest requests ];
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+    pyyaml
+    requests
+    trustme
+  ];
 
   doCheck = !stdenv.isDarwin;
 
-  # watchgod required the watchgod package, which isn't available in nixpkgs
-  checkPhase = ''
-    pytest --ignore=tests/supervisors/test_watchgodreload.py \
-      -k 'not test_supported_upgrade_request and not test_invalid_upgrade[WSProtocol]'
-  '';
+  pytestFlagsArray = [
+    # watchgod required the watchgod package, which isn't available in nixpkgs
+    "--ignore=tests/supervisors/test_reload.py"
+  ];
 
-  meta = with stdenv.lib; {
+  disabledTests = [
+    "test_supported_upgrade_request"
+    "test_invalid_upgrade"
+  ];
+
+  meta = with lib; {
     homepage = "https://www.uvicorn.org/";
     description = "The lightning-fast ASGI server";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "voluptuous";
-  version = "0.12.0";
+  version = "0.12.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p5j3fgbpqj31fajkaisdrz10ah9667sijz4kp3m0sbgw6ag4kis";
+    sha256 = "0js4avmhmmys78z376xk1w9305hq5nad8zqrnksgmpc1j90p4db6";
   };
 
   checkInputs = [ nose ];

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -1,18 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi
-, aiohttp, zigpy, conftest, asynctest
-, pytestCheckHook }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, zigpy
+, conftest
+, asynctest
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.47";
+  version = "0.0.51";
+
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zha-device-handlers";
+    rev = version;
+    sha256 = "14v01kclf096ax88cd6ckfs8gcffqissli9vpr0wfzli08afmbi9";
+  };
 
   propagatedBuildInputs = [ aiohttp zigpy ];
   checkInputs = [ pytestCheckHook conftest asynctest ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "bf7dbd5d1c1a3849b059e62afcef248b6955f5ceef78f87201ae2fc8420738de";
-  };
 
   meta = with lib; {
     description = "ZHA Device Handlers are custom quirks implementations for Zigpy";

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -1,20 +1,29 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pyserial, pyserial-asyncio, zigpy
-, pytest, pytest-asyncio, asynctest }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pyserial-asyncio
+, zigpy
+, pytestCheckHook
+, pytest-asyncio
+, asynctest
+}:
 
 buildPythonPackage rec {
   pname = "zigpy-deconz";
-  version = "0.11.0";
+  version = "0.11.1";
 
-  propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];
-  checkInputs = [ pytest pytest-asyncio asynctest ];
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a2263f8bc5807ebac55bb665eca553b514384ce270b66f83df02c39184193020";
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = pname;
+    rev = version;
+    sha256 = "1p9mdsfc200iyszppcflazzfwqg4v8nqqwqsx114nip5km7a5s37";
   };
 
-  meta = with stdenv.lib; {
+  propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];
+  checkInputs = [ pytestCheckHook pytest-asyncio asynctest ];
+
+  meta = with lib; {
     description = "Library which communicates with Deconz radios for zigpy";
     homepage = "https://github.com/zigpy/zigpy-deconz";
     license = licenses.gpl3Plus;

--- a/pkgs/development/python-modules/zigpy-zigate/default.nix
+++ b/pkgs/development/python-modules/zigpy-zigate/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy-zigate";
-  version = "0.7.3";
+  version = "0.7.4";
   # https://github.com/Martiusweb/asynctest/issues/152
   # broken by upstream python bug with asynctest and
   # is used exclusively by home-assistant with python 3.8
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zigpy-zigate";
     rev = version;
-    sha256 = "068v8n8yimmpnwqcdz5m9g35z1x0dir478cbc1s1nyhw1xn50vg1";
+    sha256 = "0xl8qgljvmypi602f52m89iv9pcrzsdal3jw619vrcavp40rc04d";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -45,6 +45,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # zigpy-znp was too slow to sync up with the zigpy 0.29 release and has API breakage, remove >0.3.0
+    "test_force_remove"
+  ];
+
   meta = with stdenv.lib; {
     description = "A library for zigpy which communicates with TI ZNP radios";
     homepage = "https://github.com/zha-ng/zigpy-znp";

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -1,5 +1,6 @@
 { lib
 , aiohttp
+, aiosqlite
 , asynctest
 , buildPythonPackage
 , crccheck
@@ -14,17 +15,18 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.26.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     rev = version;
-    sha256 = "ba8Ru6RCbFOHhctFtklnrxVD3uEpxF4XDvO5RMgXPBs=";
+    sha256 = "1r4i2ya9f241rls9mi24dksx4srrzi8agshnqy12rclxlh7qb1aw";
   };
 
   propagatedBuildInputs = [
     aiohttp
+    aiosqlite
     crccheck
     pycrypto
     pycryptodome

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2020.12.2";
+  version = "2021.1.0";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -45,7 +45,7 @@
     "arcam_fmj" = ps: with ps; [ ]; # missing inputs: arcam-fmj
     "arduino" = ps: with ps; [ ]; # missing inputs: PyMata
     "arest" = ps: with ps; [ ];
-    "arlo" = ps: with ps; [ ha-ffmpeg ]; # missing inputs: pyarlo
+    "arlo" = ps: with ps; [ ha-ffmpeg pyarlo ];
     "arris_tg2492lg" = ps: with ps; [ ]; # missing inputs: arris-tg2492lg
     "aruba" = ps: with ps; [ pexpect ];
     "arwn" = ps: with ps; [ aiohttp-cors paho-mqtt ];
@@ -60,9 +60,8 @@
     "aurora_abb_powerone" = ps: with ps; [ ]; # missing inputs: aurorapy
     "auth" = ps: with ps; [ aiohttp-cors ];
     "automation" = ps: with ps; [ aiohttp-cors ];
-    "avea" = ps: with ps; [ ]; # missing inputs: avea
+    "avea" = ps: with ps; [ avea ];
     "avion" = ps: with ps; [ ]; # missing inputs: avion
-    "avri" = ps: with ps; [ pycountry ]; # missing inputs: avri-api
     "awair" = ps: with ps; [ ]; # missing inputs: python_awair
     "aws" = ps: with ps; [ aiobotocore ];
     "axis" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: axis
@@ -528,7 +527,7 @@
     "nad" = ps: with ps; [ ]; # missing inputs: nad_receiver
     "namecheapdns" = ps: with ps; [ defusedxml ];
     "nanoleaf" = ps: with ps; [ pynanoleaf ];
-    "neato" = ps: with ps; [ pybotvac ];
+    "neato" = ps: with ps; [ aiohttp-cors pybotvac ];
     "nederlandse_spoorwegen" = ps: with ps; [ ]; # missing inputs: nsapi
     "nello" = ps: with ps; [ ]; # missing inputs: pynello
     "ness_alarm" = ps: with ps; [ ]; # missing inputs: nessclient
@@ -624,7 +623,7 @@
     "plex" = ps: with ps; [ aiohttp-cors plexapi plexauth plexwebsocket pysonos ];
     "plugwise" = ps: with ps; [ ]; # missing inputs: plugwise
     "plum_lightpad" = ps: with ps; [ ]; # missing inputs: plumlightpad
-    "pocketcasts" = ps: with ps; [ ]; # missing inputs: pocketcasts
+    "pocketcasts" = ps: with ps; [ ]; # missing inputs: pycketcasts
     "point" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pypoint
     "poolsense" = ps: with ps; [ ]; # missing inputs: poolsense
     "powerwall" = ps: with ps; [ ]; # missing inputs: tesla-powerwall

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -62,7 +62,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2020.12.2";
+  hassVersion = "2021.1.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -78,7 +78,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "1hd3z0bvscrg0ihy26djm1x9cj1pkdbnsgpzhdy42j8vy80q9bxr";
+    sha256 = "14njb2j16h536xq5df4zpna874fxjcd6fqr881y6mq081f00i0r0";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -176,6 +176,11 @@ in with py.pkgs; buildPythonApplication rec {
     "test_cached_event_message"
     # ValueError: count must be a positive integer (got 0)
     "test_media_view"
+    # AssertionError: len(events) == 1
+    "test_error_posted_as_event"
+    # keyring.errors.NoKeyringError: No recommended backend was available.
+    "test_secrets_from_unrelated_fails"
+    "test_secrets_credstash"
   ];
 
   preCheck = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -71,6 +71,9 @@ in with py.pkgs; buildPythonApplication rec {
   # check REQUIRED_PYTHON_VER in homeassistant/const.py
   disabled = pythonOlder "3.7.1";
 
+  # don't try and fail to strip 6600+ python files, it takes minutes!
+  dontStrip = true;
+
   inherit availableComponents;
 
   # PyPI tarball is missing tests/ directory

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20201212.0";
+  version = "20201229.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1nz5f7bpj0xs740af8i6j33idff6yzx7z9vydlah2sxcdgpwmz84";
+    sha256 = "sha256-3JMWugAiVDq/NBgX8ft2Bchim2g493jy7wZvvXrX+Ws=";
   };
 
   # no Python tests implemented

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -11,6 +11,9 @@ buildPythonPackage rec {
     sha256 = "sha256-3JMWugAiVDq/NBgX8ft2Bchim2g493jy7wZvvXrX+Ws=";
   };
 
+  # there is nothing to strip in this package
+  dontStrip = true;
+
   # no Python tests implemented
   doCheck = false;
 

--- a/pkgs/servers/home-assistant/update.sh
+++ b/pkgs/servers/home-assistant/update.sh
@@ -31,4 +31,4 @@ sed -i -e "s/hassVersion =.*/hassVersion = \"${TARGET_VERSION}\";/" \
 )
 
 git add ./component-packages.nix ./default.nix ./frontend.nix
-git commit -m "homeassistant: ${CURRENT_VERSION} -> ${TARGET_VERSION}"
+git commit -m "home-assistant: ${CURRENT_VERSION} -> ${TARGET_VERSION}"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5024,6 +5024,8 @@ in {
 
   pyannotate = callPackage ../development/python-modules/pyannotate { };
 
+  pyarlo = callPackage ../development/python-modules/pyarlo { };
+
   pyarrow = callPackage ../development/python-modules/pyarrow { inherit (pkgs) arrow-cpp cmake pkgconfig; };
 
   pyasn1 = callPackage ../development/python-modules/pyasn1 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.home-assistant.io/blog/2021/01/06/release-20211/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
