### PR TITLE
grype: init at 0.6.1

### DIFF
--- a/pkgs/tools/security/grype/default.nix
+++ b/pkgs/tools/security/grype/default.nix
@@ -1,0 +1,35 @@
+{ buildGoModule
+, docker
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "grype";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "anchore";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0schq11vckvdj538mnkdzhxl452nrssqrfapab9qc44yxdi1wf8k";
+  };
+
+  vendorSha256 = "0lna7zhsj3wnw83nv0dp93aj869pplb51gqzrkka7vnqp0rjcw50";
+
+  propagatedBuildInputs = [ docker ];
+
+  # tests require a running Docker instance
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Vulnerability scanner for container images and filesystems";
+    longDescription = ''
+      As a vulnerability scanner is grype abale to scan the contents of a container
+      image or filesystem to find known vulnerabilities.
+    '';
+    homepage = "https://github.com/anchore/grype";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4570,6 +4570,8 @@ in
 
   gssdp = callPackage ../development/libraries/gssdp { };
 
+  grype = callPackage ../tools/security/grype { };
+
   gt5 = callPackage ../tools/system/gt5 { };
 
   gtest = callPackage ../development/libraries/gtest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A vulnerability scanner for container images and filesystems.

https://github.com/anchore/grype

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
