### PR TITLE
nvidia-docker: 2.0.3 -> 2.5.0

### DIFF
--- a/pkgs/applications/virtualization/nvidia-docker/default.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/default.nix
@@ -1,47 +1,61 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, callPackage, makeWrapper
-, buildGoPackage, runc, glibc }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, callPackage
+, makeWrapper
+, buildGoModule
+, buildGoPackage
+, git
+, glibc
+}:
 
 with lib; let
-
   libnvidia-container = callPackage ./libnvc.nix { };
 
-  nvidia-container-runtime = fetchFromGitHub {
-    owner = "NVIDIA";
-    repo = "nvidia-container-runtime";
-    rev = "runtime-v2.0.0";
-    sha256 = "0jcj5xxbg7x7gyhbb67h3ds6vly62gx7j02zm6lg102h34jajj7a";
-  };
-
-  nvidia-container-runtime-hook = buildGoPackage {
-    pname = "nvidia-container-runtime-hook";
-    version = "1.4.0";
-
-    goPackagePath = "nvidia-container-runtime-hook";
-
-    src = "${nvidia-container-runtime}/hook/nvidia-container-runtime-hook";
-  };
-
-  nvidia-runc = runc.overrideAttrs (oldAttrs: rec {
-    name = "nvidia-runc";
-    version = "1.0.0-rc6";
+  nvidia-container-runtime = buildGoPackage rec {
+    pname = "nvidia-container-toolkit";
+    version = "3.4.0";
     src = fetchFromGitHub {
-      owner = "opencontainers";
-      repo = "runc";
+      owner = "NVIDIA";
+      repo = "nvidia-container-runtime";
       rev = "v${version}";
-      sha256 = "1jwacb8xnmx5fr86gximhbl9dlbdwj3rpf27hav9q1si86w5pb1j";
+      sha256 = "095mks0r4079vawi50pk4zb5jk0g6s9idg2s1w55a0d27jkknldr";
     };
-    patches = [ "${nvidia-container-runtime}/runtime/runc/3f2f8b84a77f73d38244dd690525642a72156c64/0001-Add-prestart-hook-nvidia-container-runtime-hook-to-t.patch" ];
-  });
+    goPackagePath = "github.com/nvidia-container-runtime/src";
+    buildFlagsArray = [ "-ldflags=" "-s -w" ];
+    postInstall = ''
+      mv $out/bin/{src,nvidia-container-runtime}
+    '';
+  };
 
-in stdenv.mkDerivation rec {
+  nvidia-container-toolkit = buildGoModule rec {
+    pname = "nvidia-container-toolkit";
+    version = "1.3.0";
+    src = fetchFromGitHub {
+      owner = "NVIDIA";
+      repo = "nvidia-container-toolkit";
+      rev = "v${version}";
+      sha256 = "04284bhgx4j55vg9ifvbji2bvmfjfy3h1lq7q356ffgw3yr9n0hn";
+    };
+    vendorSha256 = "17zpiyvf22skfcisflsp6pn56y6a793jcx89kw976fq2x5br1bz7";
+    buildFlagsArray = [ "-ldflags=" "-s -w" ];
+    postInstall = ''
+      mv $out/bin/{pkg,${pname}}
+      cp $out/bin/{${pname},nvidia-container-runtime-hook}
+    '';
+  };
+
+in
+stdenv.mkDerivation rec {
   pname = "nvidia-docker";
-  version = "2.0.3";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nvidia-docker";
     rev = "v${version}";
-    sha256 = "1vx5m591mnvcb9vy0196x5lh3r8swjsk0fnlv5h62m7m4m07v6wx";
+    sha256 = "1n1k7fnimky67s12p2ycaq9mgk245fchq62vgd7bl3bzfcbg0z4h";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -50,8 +64,8 @@ in stdenv.mkDerivation rec {
     mkdir bin
     cp nvidia-docker bin
     cp ${libnvidia-container}/bin/nvidia-container-cli bin
-    cp ${nvidia-container-runtime-hook}/bin/nvidia-container-runtime-hook bin
-    cp ${nvidia-runc}/bin/runc bin/nvidia-container-runtime
+    cp ${nvidia-container-toolkit}/bin/nvidia-container-{toolkit,runtime-hook} bin
+    cp ${nvidia-container-runtime}/bin/nvidia-container-runtime bin
   '';
 
   installPhase = ''
@@ -68,5 +82,6 @@ in stdenv.mkDerivation rec {
     description = "NVIDIA container runtime for Docker";
     license = licenses.bsd3;
     platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ cpcloud ];
   };
 }

--- a/pkgs/applications/virtualization/nvidia-docker/libnvc-ldconfig-and-path-fixes.patch
+++ b/pkgs/applications/virtualization/nvidia-docker/libnvc-ldconfig-and-path-fixes.patch
@@ -86,7 +86,7 @@ index 30e3cfd..6d12a50 100644
          if (info->libs == NULL)
                  goto fail;
          if (ldcache_resolve(&ld, LIB_ARCH, root, libs,
--            info->libs, info->nlibs, select_libraries, info) < 0)
+-            info->libs, info->nlibs, select_libraries_fn, info) < 0)
 +            info->libs, info->nlibs, info->nvrm_version) < 0)
                  goto fail;
  
@@ -95,7 +95,7 @@ index 30e3cfd..6d12a50 100644
          if (info->libs32 == NULL)
                  goto fail;
          if (ldcache_resolve(&ld, LIB32_ARCH, root, libs,
--            info->libs32, info->nlibs32, select_libraries, info) < 0)
+-            info->libs32, info->nlibs32, select_libraries_fn, info) < 0)
 +            info->libs32, info->nlibs32, info->nvrm_version) < 0)
                  goto fail;
          rv = 0;

--- a/pkgs/applications/virtualization/nvidia-docker/libnvc.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/libnvc.nix
@@ -9,23 +9,23 @@
 , libtirpc
 }:
 let
-  modp-ver = "396.51";
+  modp-ver = "450.57";
   nvidia-modprobe = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nvidia-modprobe";
     rev = modp-ver;
-    sha256 = "1fw2qwc84k64agw6fx2v0mjf88aggph9c6qhs4cv7l3gmflv8qbk";
+    sha256 = "0r4f6lpbbqqs9932xd2mr7bxn6a3xdalcwq332fc1amrrkgzfyv7";
   };
 in
 stdenv.mkDerivation rec {
   pname = "libnvidia-container";
-  version = "1.0.6";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "libnvidia-container";
     rev = "v${version}";
-    sha256 = "1pnpc9knwh8d1zqb28zc3spkjc00w0z10vd3jna8ksvpl35jl7w3";
+    sha256 = "0j6b8z9x9hrrs4xp11zyjjd7kyl7fzcicpiis8k1qb1q2afnqsrq";
   };
 
   patches = [
@@ -58,7 +58,10 @@ stdenv.mkDerivation rec {
     mkdir -p deps/src/nvidia-modprobe-${modp-ver}
     cp -r ${nvidia-modprobe}/* deps/src/nvidia-modprobe-${modp-ver}
     chmod -R u+w deps/src
-    touch deps/src/nvidia-modprobe-${modp-ver}/.download_stamp
+    pushd deps/src
+    patch -p0 < ${./modprobe.patch}
+    touch nvidia-modprobe-${modp-ver}/.download_stamp
+    popd
   '';
 
   NIX_CFLAGS_COMPILE = [ "-I${libtirpc.dev}/include/tirpc" ];

--- a/pkgs/applications/virtualization/nvidia-docker/modprobe.patch
+++ b/pkgs/applications/virtualization/nvidia-docker/modprobe.patch
@@ -1,0 +1,29 @@
+diff -ruN nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c
+--- nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c	2020-07-09 17:06:05.000000000 +0000
++++ nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.c	2020-08-18 12:43:03.223871514 +0000
+@@ -840,10 +840,10 @@
+     return mknod_helper(major, minor_num, vgpu_dev_name, NV_PROC_REGISTRY_PATH);
+ }
+
+-static int nvidia_cap_get_device_file_attrs(const char* cap_file_path,
+-                                            int *major,
+-                                            int *minor,
+-                                            char *name)
++int nvidia_cap_get_device_file_attrs(const char* cap_file_path,
++                                     int *major,
++                                     int *minor,
++                                     char *name)
+ {
+     char field[32];
+     FILE *fp;
+diff -ruN nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h
+--- nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h	2020-07-09 17:06:05.000000000 +0000
++++ nvidia-modprobe-450.57/modprobe-utils/nvidia-modprobe-utils.h	2020-08-18 12:43:44.227745050 +0000
+@@ -81,6 +81,7 @@
+ int nvidia_nvswitch_get_file_state(int minor);
+ int nvidia_cap_mknod(const char* cap_file_path, int *minor);
+ int nvidia_cap_get_file_state(const char* cap_file_path);
++int nvidia_cap_get_device_file_attrs(const char* cap_file_path, int *major, int *minor, char *name);
+ int nvidia_get_chardev_major(const char *name);
+
+ #endif /* NV_LINUX */


### PR DESCRIPTION
- nvidia-docker: format drv
- nvidia-docker: 2.0.3 -> 2.5.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change updates `nvidia-docker` to a more recent version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested by running

```sh
❯ ./result/bin/nvidia-docker run --gpus all --rm -it nvidia/cuda nvidia-smi
Wed Jan  6 19:41:45 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 455.45.01    Driver Version: 455.45.01    CUDA Version: 11.1     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  GeForce RTX 208...  Off  | 00000000:0A:00.0 Off |                  N/A |
| 36%   40C    P0    39W / 250W |      0MiB /  7979MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```
