### PR TITLE
python3Packages.slither-analyzer: 0.6.14 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -6,6 +6,10 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.6";
 
+  patchPhase = ''
+    substituteInPlace setup.py --replace 'version="0.1.11",' 'version="${version}",'
+  '';
+
   src = fetchFromGitHub {
     owner = "crytic";
     repo = "crytic-compile";
@@ -21,7 +25,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Abstraction layer for smart contract build systems";
     homepage = "https://github.com/crytic/crytic-compile";
-    license = licenses.agpl3;
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ SuperSandro2000 arturcygan ];
   };
 }

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -1,5 +1,7 @@
-{ lib, buildPythonPackage, fetchPypi, makeWrapper, pythonOlder
-, crytic-compile, prettytable, setuptools, solc
+{ lib, stdenv, buildPythonPackage, fetchPypi, makeWrapper, pythonOlder
+, crytic-compile, prettytable, setuptools
+# solc is currently broken on Darwin, default to false
+, solc, withSolc ? !stdenv.isDarwin
 }:
 
 buildPythonPackage rec {
@@ -19,7 +21,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ makeWrapper ];
   propagatedBuildInputs = [ crytic-compile prettytable setuptools ];
 
-  postFixup = ''
+  postFixup = lib.optionalString withSolc ''
     wrapProgram $out/bin/slither \
       --prefix PATH : "${lib.makeBinPath [ solc ]}"
   '';
@@ -32,7 +34,7 @@ buildPythonPackage rec {
       contract details, and provides an API to easily write custom analyses.
     '';
     homepage = "https://github.com/trailofbits/slither";
-    license = licenses.agpl3;
-    maintainers = [ maintainers.asymmetric ];
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ asymmetric arturcygan ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump of `slither-analyzer` version. This required bumping `crytic-compile` and patching it due to old version in `setup.py`. Added a way to opt-out from wrapping `solc` since often another/specific version of `solc` is needed. Also, the current `solc` fails to build on macOS which makes `slither-analyzer` fail as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
