### PR TITLE
flutter: reduce derivation size and refactor

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -1,5 +1,4 @@
 { callPackage, dart }:
-
 let
   dart_stable = dart.override { version = "2.10.0"; };
   dart_beta = dart.override { version = "2.10.0"; };
@@ -8,7 +7,8 @@ let
   getPatches = dir:
     let files = builtins.attrNames (builtins.readDir dir);
     in map (f: dir + ("/" + f)) files;
-in {
+in
+{
   mkFlutter = mkFlutter;
   stable = mkFlutter rec {
     pname = "flutter";

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -12,7 +12,6 @@
 , cacert
 , coreutils
 , git
-, makeWrapper
 , runCommand
 , stdenv
 , fetchurl
@@ -43,7 +42,7 @@ let
       sha256 = sha256Hash;
     };
 
-    buildInputs = [ makeWrapper git ];
+    buildInputs = [ git ];
 
     inherit patches;
 
@@ -58,28 +57,27 @@ let
       SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.snapshot"
       STAMP_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.stamp"
       SCRIPT_PATH="$FLUTTER_TOOLS_DIR/bin/flutter_tools.dart"
-      DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
-
-      DART="$DART_SDK_PATH/bin/dart"
-      PUB="$DART_SDK_PATH/bin/pub"
+      DART_SDK_PATH="${dart}"
 
       HOME=../.. # required for pub upgrade --offline, ~/.pub-cache
                  # path is relative otherwise it's replaced by /build/flutter
 
-      (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade --offline)
+      (cd "$FLUTTER_TOOLS_DIR" && ${dart}/bin/pub upgrade --offline)
 
       local revision="$(cd "$FLUTTER_ROOT"; git rev-parse HEAD)"
-      "$DART" --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
+      ${dart}/bin/dart --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.packages" "$SCRIPT_PATH"
       echo "$revision" > "$STAMP_PATH"
       echo -n "${version}" > version
 
-      rm -rf bin/cache/{artifacts,downloads}
+      rm -rf bin/cache/{artifacts,dart-sdk,downloads}
       rm -f  bin/cache/*.stamp
     '';
 
     installPhase = ''
       mkdir -p $out
       cp -r . $out
+      mkdir -p $out/bin/cache/
+      ln -sf ${dart} $out/bin/cache/dart-sdk
     '';
   };
 
@@ -155,8 +153,4 @@ runCommand drvName
 
   echo -n "$startScript" > $out/bin/${pname}
   chmod +x $out/bin/${pname}
-
-  mkdir -p $out/bin/cache/dart-sdk/
-  cp -r ${dart}/* $out/bin/cache/dart-sdk/
-  ln $out/bin/cache/dart-sdk/bin/dart $out/bin/dart
 ''

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -1,10 +1,37 @@
-{ channel, pname, version, sha256Hash, patches, dart
-, filename ? "flutter_linux_${version}-${channel}.tar.xz"}:
+{ channel
+, pname
+, version
+, sha256Hash
+, patches
+, dart
+, filename ? "flutter_linux_${version}-${channel}.tar.xz"
+}:
 
-{ bash, buildFHSUserEnv, cacert, coreutils, git, makeWrapper, runCommand, stdenv
-, fetchurl, alsaLib, dbus, expat, libpulseaudio, libuuid, libX11, libxcb
-, libXcomposite, libXcursor, libXdamage, libXfixes, libGL, nspr, nss, systemd }:
-
+{ bash
+, buildFHSUserEnv
+, cacert
+, coreutils
+, git
+, makeWrapper
+, runCommand
+, stdenv
+, fetchurl
+, alsaLib
+, dbus
+, expat
+, libpulseaudio
+, libuuid
+, libX11
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXfixes
+, libGL
+, nspr
+, nss
+, systemd
+}:
 let
   drvName = "flutter-${channel}-${version}";
   flutter = stdenv.mkDerivation {
@@ -100,7 +127,9 @@ let
       ];
   };
 
-in runCommand drvName {
+in
+runCommand drvName
+{
   startScript = ''
     #!${bash}/bin/bash
     export PUB_CACHE=''${PUB_CACHE:-"$HOME/.pub-cache"}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR refactors the flutter derivation, with the main objective to reduce derivation size:

```
Before:
/nix/store/p3avfmvd0yrjpwwml7vvqbjin5vacx2k-flutter-stable-1.22.0       2084894968

After:
/nix/store/750k4z1yj5xsw7ymmwvn7cfjjzkaygzg-flutter-stable-1.22.0       1647047080
```

~~Also, bump the packages to the latest versions.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
