### PR TITLE
slimserver: add perlPackages.ArchiveZip as a dependency

### DIFF
--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -14,6 +14,7 @@ perlPackages.buildPerlPackage rec {
     makeWrapper
     perlPackages.perl
     perlPackages.AnyEvent
+    perlPackages.ArchiveZip
     perlPackages.AudioScan
     perlPackages.CarpClan
     perlPackages.CGI


### PR DESCRIPTION
###### Motivation for this change

`slimserver` is missing `perlPackages.ArchiveZip` as a dependency. This causes its `PluginDownloader` to fail with the following message:

```
Slim::Utils::PluginDownloader::extract (102) error loading Archive::Zip Can't locate Archive/Zip.pm in @INC (you may need to install the Archive::Zip module) (@INC contains: /var/lib/slimserver/cache/InstalledPlugins [...])
```

I was able to consistently reproduce this by trying to install the Spotify plugin on new Slimserver instances. The WebUI will prompt a server restart, after which the message above can be found with `journalctl -b -u slimserver`.

For a while, I had a custom override in place which fixed this issue on my local machine. If `slimserver` has already been running like this, it will continue to work even when the dependency is removed, since it caches all plugins in its cache folder. To reproduce it, I simply had to wipe the cache and preference folders clean.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
