### PR TITLE
python3Packages.pymodbus: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/pymodbus/default.nix
+++ b/pkgs/development/python-modules/pymodbus/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pyserial
+, pyserial-asyncio
+, pytestCheckHook
+, pythonOlder
+, redis
+, sqlalchemy
+, tornado
+, twisted
+}:
+
+buildPythonPackage rec {
+  pname = "pymodbus";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "riptideio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0x0dv02shcc2yxxm9kvcbhip111sna74dvcfssxdzzy967vnq76v";
+  };
+
+  # Twisted asynchronous version is not supported due to a missing dependency
+  propagatedBuildInputs = [
+    pyserial
+    pyserial-asyncio
+    tornado
+  ];
+
+  checkInputs = [
+    asynctest
+    mock
+    pyserial-asyncio
+    pytestCheckHook
+    redis
+    sqlalchemy
+    tornado
+    twisted
+  ];
+
+  pythonImportsCheck = [ "pymodbus" ];
+
+  meta = with lib; {
+    description = "Python implementation of the Modbus protocol";
+    longDescription = ''
+      Pymodbus is a full Modbus protocol implementation using twisted,
+      torndo or asyncio for its asynchronous communications core. It can
+      also be used without any third party dependencies if a more
+      lightweight project is needed.
+    '';
+    homepage = "https://github.com/riptideio/pymodbus";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -258,7 +258,7 @@
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
     "fixer" = ps: with ps; [ ]; # missing inputs: fixerio
     "fleetgo" = ps: with ps; [ ]; # missing inputs: ritassist
-    "flexit" = ps: with ps; [ ]; # missing inputs: pyflexit pymodbus
+    "flexit" = ps: with ps; [ pymodbus ]; # missing inputs: pyflexit
     "flic" = ps: with ps; [ ]; # missing inputs: pyflic-homeassistant
     "flick_electric" = ps: with ps; [ ]; # missing inputs: PyFlick
     "flo" = ps: with ps; [ ]; # missing inputs: aioflo
@@ -503,7 +503,7 @@
     "mjpeg" = ps: with ps; [ ];
     "mobile_app" = ps: with ps; [ pynacl aiohttp-cors emoji hass-nabucasa pillow ];
     "mochad" = ps: with ps; [ ]; # missing inputs: pymochad
-    "modbus" = ps: with ps; [ ]; # missing inputs: pymodbus
+    "modbus" = ps: with ps; [ pymodbus ];
     "modem_callerid" = ps: with ps; [ ]; # missing inputs: basicmodem
     "mold_indicator" = ps: with ps; [ ];
     "monoprice" = ps: with ps; [ ]; # missing inputs: pymonoprice
@@ -785,7 +785,7 @@
     "statistics" = ps: with ps; [ sqlalchemy ];
     "statsd" = ps: with ps; [ statsd ];
     "steam_online" = ps: with ps; [ ]; # missing inputs: steamodd
-    "stiebel_eltron" = ps: with ps; [ ]; # missing inputs: pymodbus pystiebeleltron
+    "stiebel_eltron" = ps: with ps; [ pymodbus ]; # missing inputs: pystiebeleltron
     "stookalert" = ps: with ps; [ ]; # missing inputs: stookalert
     "stream" = ps: with ps; [ aiohttp-cors av ];
     "streamlabswater" = ps: with ps; [ ]; # missing inputs: streamlabswater

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5419,6 +5419,8 @@ in {
 
   pymetno = callPackage ../development/python-modules/pymetno { };
 
+  pymodbus = callPackage ../development/python-modules/pymodbus { };
+
   pymongo = callPackage ../development/python-modules/pymongo { };
 
   pympler = callPackage ../development/python-modules/pympler { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Pymodbus is a full Modbus protocol implementation using twisted/torndo/asyncio for its asynchronous communications core. It can also be used without any third party dependencies (aside from pyserial) if a more lightweight project is needed. 

https://github.com/riptideio/pymodbus

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
