### PR TITLE
python3Packages.coronavirus: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/coronavirus/default.nix
+++ b/pkgs/development/python-modules/coronavirus/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "coronavirus";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "nabucasa";
+    repo = pname;
+    rev = version;
+    sha256 = "0mx6ifp8irj3669c67hs9r79k8gar6j4aq7d4ji21pllyhyahdwm";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  # no tests are present
+  doCheck = false;
+  pythonImportsCheck = [ "coronavirus" ];
+
+  meta = with lib; {
+    description = "Python client for getting Corona virus info";
+    homepage = "https://github.com/nabucasa/coronavirus";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -137,7 +137,7 @@
     "control4" = ps: with ps; [ ]; # missing inputs: pyControl4
     "conversation" = ps: with ps; [ aiohttp-cors ];
     "coolmaster" = ps: with ps; [ ]; # missing inputs: pycoolmasternet-async
-    "coronavirus" = ps: with ps; [ ]; # missing inputs: coronavirus
+    "coronavirus" = ps: with ps; [ coronavirus ];
     "counter" = ps: with ps; [ ];
     "cover" = ps: with ps; [ ];
     "cppm_tracker" = ps: with ps; [ ]; # missing inputs: clearpasspy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1384,6 +1384,8 @@ in {
 
   cornice = callPackage ../development/python-modules/cornice { };
 
+  coronavirus = callPackage ../development/python-modules/coronavirus { };
+
   cot = callPackage ../development/python-modules/cot { };
 
   covCore = callPackage ../development/python-modules/cov-core { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for getting Corona virus info.

https://github.com/nabucasa/coronavirus

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
