### PR TITLE
tabnine: 3.1.1 -> 3.2.63

### DIFF
--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, lib, fetchurl }:
+{ stdenv, lib, fetchurl, unzip }:
 
 let
-  version = "3.1.1";
+  version = "3.2.63";
   src =
     if stdenv.hostPlatform.system == "x86_64-darwin" then
       fetchurl {
-        url = "https://update.tabnine.com/${version}/x86_64-apple-darwin/TabNine";
-        sha256 = "w+Ufy4pICfQmseKCeohEQIP0VD6YrkYTEn41HX40Zlw=";
+        url = "https://update.tabnine.com/bundles/${version}/x86_64-apple-darwin/TabNine.zip";
+        sha256 = "0y0wb3jdr2qk4k21c11w8c9a5fl0h2rm1wm7m8hqdywy4lz9ppgy";
       }
     else if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
-        url = "https://update.tabnine.com/${version}/x86_64-unknown-linux-musl/TabNine";
-        sha256 = "hSltZWQz2BRFut0NDI4fS/N8XxFJaYGHRtV3llBVOY4=";
+        url = "https://update.tabnine.com/bundles/${version}/x86_64-unknown-linux-musl/TabNine.zip";
+        sha256 = "0zzk2w5azk5f0svjxlj2774x01xdflb767xxvbglj4223dgyx2x5";
       }
     else throw "Not supported on ${stdenv.hostPlatform.system}";
 in stdenv.mkDerivation rec {
@@ -20,10 +20,15 @@ in stdenv.mkDerivation rec {
   inherit version src;
 
   dontBuild = true;
-  dontUnpack = true;
+
+  # Work around the "unpacker appears to have produced no directories"
+  # case that happens when the archive doesn't have a subdirectory.
+  setSourceRoot = "sourceRoot=`pwd`";
+
+  nativeBuildInputs = [ unzip ];
 
   installPhase = ''
-    install -Dm755 $src $out/bin/TabNine
+    install -Dm755 TabNine $out/bin/TabNine
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
