### PR TITLE
tab-rs: init at 0.5.5

### DIFF
--- a/pkgs/tools/misc/tab-rs/default.nix
+++ b/pkgs/tools/misc/tab-rs/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, rustPlatform, IOKit }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tab-rs";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "austinjones";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06nip7g5y7jslqj8anvn2z7w1c8yr0gl32bpnzv26xschan4gc2h";
+  };
+
+  cargoSha256 = "1clpl9fi07lms0din8f9m4y6br5jg8k5xsklsqmvgdwf83wyn321";
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ IOKit ];
+
+  # many tests are failing
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Intuitive, config-driven terminal multiplexer designed for software & systems engineers";
+    homepage = "https://github.com/austinjones/tab-rs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7753,6 +7753,10 @@ in
 
   tabnine = callPackage ../development/tools/tabnine { };
 
+  tab-rs = callPackage ../tools/misc/tab-rs {
+    inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
+
   t1utils = callPackage ../tools/misc/t1utils { };
 
   talkfilters = callPackage ../misc/talkfilters {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

> Intuitive, config-driven terminal multiplexer designed for software & systems engineers

I disabled the tests for now since too many of them are failing.

Note that the compilation is taking a long time. Maybe because of lto.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
