### PR TITLE
nixos/redshift: use config file instead of passing parameters

### DIFF
--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -78,19 +78,25 @@ in {
 
     gamma = {
       day = mkOption {
-        type = types.float;
+        type = with types; either float str;
         default = 1.0;
         description = ''
           Screen gamma to apply during the day,
           between <literal>0.1</literal> and <literal>1.0</literal>.
+
+          It is also possible to set screen gamma for each color channel
+          individually, using <literal>"0.8:0.7:0.8"</literal>.
         '';
       };
       night = mkOption {
-        type = types.float;
+        type = with types; either float str;
         default = 1.0;
         description = ''
           Screen gamma to apply during the night,
           between <literal>0.1</literal> and <literal>1.0</literal>.
+
+          It is also possible to set screen gamma for each color channel
+          individually, using <literal>"0.8:0.7:0.8"</literal>.
         '';
       };
     };
@@ -122,7 +128,7 @@ in {
     };
 
     extraConfig = mkOption {
-      type = types.attrs;
+      type = with types; attrsOf (attrsOf (oneOf [float int str]));
       default = {};
       example = {
         redshift = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Not every option is exposed by `redshift`/`gammastep` parameters, for example gamma options are only exposed in configuration file. So this PR refactors this module to generate a configuration file and pass it to the `redshift`/`gammastep` using -c parameter.

Also, it implements fade/gamma options not available in the previous version of this module (since it was not exposed by parameters).

This is a slightly breaking change, since `extraOptions` was renamed to `extraConfig` and now accept a attribute set instead of a list of string

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
