### PR TITLE
nufraw: init at 0.43-3

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -144,6 +144,7 @@ in
         "/share/kservicetypes5"
         "/share/kxmlgui5"
         "/share/systemd"
+        "/share/thumbnailers"
       ];
 
     system.path = pkgs.buildEnv {

--- a/pkgs/applications/graphics/nufraw/default.nix
+++ b/pkgs/applications/graphics/nufraw/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, fetchurl
+, lib
+
+, autoreconfHook
+, bzip2
+, cfitsio
+, exiv2
+, gettext
+, gtk2
+, gtkimageview
+, lcms2
+, lensfun
+, libjpeg
+, libtiff
+, perl
+, pkg-config
+, zlib
+
+, addThumbnailer ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nufraw";
+  version = "0.43-3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/nufraw/nufraw-${version}.tar.gz";
+    sha256 = "0b63qvw9r8kaqw36bk3a9zwxc41h8fr6498indkw4glrj0awqz9c";
+  };
+
+  nativeBuildInputs = [ autoreconfHook gettext perl pkg-config ];
+
+  buildInputs = [
+    bzip2
+    cfitsio
+    exiv2
+    gtk2
+    gtkimageview
+    lcms2
+    lensfun
+    libjpeg
+    libtiff
+    zlib
+  ];
+
+  configureFlags = [
+    "--enable-contrast"
+    "--enable-dst-correction"
+  ];
+
+  postInstall = lib.optionalString addThumbnailer ''
+    mkdir -p $out/share/thumbnailers
+    substituteAll ${./nufraw.thumbnailer} $out/share/thumbnailers/${pname}.thumbnailer
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://nufraw.sourceforge.io/";
+    description = "Utility to read and manipulate raw images from digital cameras";
+    longDescription =
+      ''
+        A new version of the popular raw digital images manipulator ufraw.
+        Forks from the version 0.23 of ufraw (that's why the first nufraw version is the 0.24).
+        Nufraw offers the same features (gimp plugin, batch, ecc) and the same quality of
+        ufraw in a brand new improved user interface.
+      '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ asbachb ];
+    platforms   = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/applications/graphics/nufraw/nufraw.thumbnailer
+++ b/pkgs/applications/graphics/nufraw/nufraw.thumbnailer
@@ -1,0 +1,4 @@
+[Thumbnailer Entry]
+TryExec=@out@/bin/nufraw-batch
+Exec=@out@/bin/nufraw-batch --silent --size %s --out-type=png --noexif --output=%o --embedded-image %i
+MimeType=image/x-canon-cr2;image/x-canon-crw;image/x-minolta-mrw;image/x-nikon-nef;image/x-pentax-pef;image/x-panasonic-rw2;image/x-panasonic-raw2;image/x-samsung-srw;image/x-olympus-orf;image/x-sony-arw

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23504,6 +23504,12 @@ in
 
   muchsync = callPackage ../applications/networking/mailreaders/notmuch/muchsync.nix { };
 
+  nufraw = callPackage ../applications/graphics/nufraw/default.nix { };
+
+  nufraw-thumbnailer = callPackage ../applications/graphics/nufraw/default.nix {
+    addThumbnailer = true;
+  };
+
   notmuch-addrlookup = callPackage ../applications/networking/mailreaders/notmuch-addrlookup { };
 
   nova-filters =  callPackage ../applications/audio/nova-filters { };


### PR DESCRIPTION
In order to enable ability to generate thumbnails for raw images these packages were added:

* `nufraw` is used to manipulate raw images.
* `nufraw-thumbnailer` is used to generate thumbnails for raw images.

relates #108444

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
