### PR TITLE
chromium: 87.0.4280.88 -> 87.0.4280.141

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,8 +1,8 @@
 {
   "stable": {
-    "version": "87.0.4280.88",
-    "sha256": "1h09g9b2zxad85vd146ymvg3w2kpngpi78yig3dn1vrmhwr4aiiy",
-    "sha256bin64": "0n3fm6wf8zfkv135d50xl8xxrnng3q55vyxkck1da8jyvh18bijb",
+    "version": "87.0.4280.141",
+    "sha256": "0x9k809m36pfirnw2vnr9pk93nxdbgrvna0xf1rs3q91zkbr2x8l",
+    "sha256bin64": "0wq3yi0qyxzcid390w5rh4xjq92fjajvlifjl70g6sqnbk6vgvdp",
     "deps": {
       "gn": {
         "version": "2020-09-09",
@@ -13,7 +13,7 @@
     },
     "chromedriver": {
       "version": "87.0.4280.88",
-      "sha256_linux": "11plh2hs2zpa14ymlbnj92pa58krl28yw4c0s55wk8qsxvzvl02m",
+      "sha256_linux": "1insh1imi25sj4hdkbll5rzwnag8wvfxv4ckshpq8akl8r13p6lj",
       "sha256_darwin": "048hsqp6575r980m769lzznvxypmfcwn89f1d3ik751ymzmb5r78"
     }
   },


### PR DESCRIPTION
###### Motivation for this change
https://chromereleases.googleblog.com/2021/01/stable-channel-update-for-desktop.html

This update includes 16 security fixes.

CVEs:
CVE-2021-21106 CVE-2021-21107 CVE-2021-21108 CVE-2021-21109
CVE-2021-21110 CVE-2021-21111 CVE-2021-21112 CVE-2021-21113
CVE-2020-16043 CVE-2021-21114 CVE-2020-15995 CVE-2021-21115
CVE-2021-21116

@primeos @danielfullmer @thefloweringash

###### Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).