### PR TITLE
bupstash: init at 0.6.4

### DIFF
--- a/pkgs/tools/backup/bupstash/default.nix
+++ b/pkgs/tools/backup/bupstash/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, installShellFiles, rustPlatform, ronn, pkg-config, libsodium }:
+rustPlatform.buildRustPackage rec {
+  pname = "bupstash";
+  version = "0.6.4";
+
+  src = fetchFromGitHub {
+    owner = "andrewchambers";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "013k8pr4865f5rp66fjf3a8069kmd29brxv0l20z571gy2kxs5p9";
+  };
+
+  cargoSha256 = "17cdi93q71wsqqfkpz6mxcaqqhqclsbns0g1r9mni39nikw7amv1";
+
+  nativeBuildInputs = [ ronn pkg-config installShellFiles ];
+  buildInputs = [ libsodium ];
+
+  postBuild = ''
+    RUBYOPT="-KU -E utf-8:utf-8" ronn doc/man/*.md
+  '';
+
+  postInstall = ''
+    installManPage doc/man/*.[1-9]
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Easy and efficient encrypted backups";
+    homepage = "https://bupstash.io";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ andrewchambers ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2874,6 +2874,8 @@ in
 
   bup = callPackage ../tools/backup/bup { };
 
+  bupstash = callPackage ../tools/backup/bupstash { };
+
   burp = callPackage ../tools/backup/burp { };
 
   buku = callPackage ../applications/misc/buku { };


### PR DESCRIPTION
###### Motivation for this change

Adding bupstash encrypted backup software.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
