### PR TITLE
python3Packages.fixerio: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/fixerio/default.nix
+++ b/pkgs/development/python-modules/fixerio/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, pytestCheckHook
+, httpretty
+}:
+
+buildPythonPackage rec {
+  pname = "fixerio";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "amatellanes";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1k9ss5jc7sbpkjd2774vbmvljny0wm2lrc8155ha8yk2048jsaxk";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "requests==2.10.0" "requests"
+  '';
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  checkInputs = [
+    httpretty
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fixerio" ];
+
+  meta = with lib; {
+    description = "Python client for Fixer.io";
+    longDescription = ''
+      Fixer.io is a free JSON API for current and historical foreign
+      exchange rates published by the European Central Bank.
+    '';
+    homepage = "https://github.com/amatellanes/fixerio";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -256,7 +256,7 @@
     "fireservicerota" = ps: with ps; [ ]; # missing inputs: pyfireservicerota
     "firmata" = ps: with ps; [ ]; # missing inputs: pymata-express
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
-    "fixer" = ps: with ps; [ ]; # missing inputs: fixerio
+    "fixer" = ps: with ps; [ fixerio ];
     "fleetgo" = ps: with ps; [ ]; # missing inputs: ritassist
     "flexit" = ps: with ps; [ ]; # missing inputs: pyflexit pymodbus
     "flic" = ps: with ps; [ ]; # missing inputs: pyflic-homeassistant

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2149,6 +2149,8 @@ in {
 
   fitbit = callPackage ../development/python-modules/fitbit { };
 
+  fixerio = callPackage ../development/python-modules/fixerio { };
+
   fixtures = callPackage ../development/python-modules/fixtures { };
 
   flake8-blind-except = callPackage ../development/python-modules/flake8-blind-except { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for Fixer.io.

https://github.com/amatellanes/fixerio

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
