### PR TITLE
rdrview: init at unstable-2020-12-22

### DIFF
--- a/pkgs/tools/networking/rdrview/default.nix
+++ b/pkgs/tools/networking/rdrview/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, libxml2, curl, libseccomp }:
+
+stdenv.mkDerivation {
+  name = "rdrview";
+  version = "unstable-2020-12-22";
+
+  src = fetchFromGitHub {
+    owner = "eafer";
+    repo = "rdrview";
+    rev = "7be01fb36a6ab3311a9ad1c8c2c75bf5c1345d93";
+    sha256 = "00hnvrrrkyp5429rzcvabq2z00lp1l8wsqxw4h7qsdms707mjnxs";
+  };
+
+  buildInputs = [ libxml2 curl libseccomp ];
+
+  installPhase = ''
+    install -Dm755 rdrview -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command line tool to extract main content from a webpage";
+    homepage = "https://github.com/eafer/rdrview";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7002,6 +7002,7 @@ in
 
   rdma-core = callPackage ../os-specific/linux/rdma-core { };
 
+  rdrview = callPackage ../tools/networking/rdrview {};
 
   real_time_config_quick_scan = callPackage ../applications/audio/real_time_config_quick_scan { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`rdrview` extracts the main content from a webpage on the command line. I've been combining this with pandoc to pull down arbitrary webpages as text:

```
$ rdrview -H 'https://nixos.org' | pandoc -f html -t plain | head -n 3
Nix is a tool that takes a unique approach to package management and
system configuration. Learn how to make reproducible, declarative and
reliable systems.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
