### PR TITLE
darwin: explicitly mark broken for failed building apple packages

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/hfs/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/hfs/default.nix
@@ -5,4 +5,10 @@ appleDerivation {
     mkdir -p $out/include/hfs
     cp core/*.h $out/include/hfs
   '';
+
+  meta = {
+    # Seems nobody wants its binary, so we didn't implement building.
+    broken = !headersOnly;
+    platforms = lib.platforms.darwin;
+  };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/libauto/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libauto/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, appleDerivation, libdispatch, Libsystem }:
+{ lib, stdenv, appleDerivation, libdispatch, Libsystem }:
 
 appleDerivation {
   # these are included in the pure libc
-  buildInputs = stdenv.lib.optionals stdenv.cc.nativeLibc [ libdispatch Libsystem ];
+  buildInputs = lib.optionals stdenv.cc.nativeLibc [ libdispatch Libsystem ];
 
   buildPhase = ''
     cp ${./auto_dtrace.h} ./auto_dtrace.h
@@ -79,6 +79,8 @@ appleDerivation {
   '';
 
   meta = {
-    platforms = stdenv.lib.platforms.darwin;
+    # libauto is only used by objc4/pure.nix , but objc4 is now using the impure approach, so we don't bother to fix this.
+    broken = true;
+    platforms = lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We are trying to update and clean apple packages, so we explicitly mark broken for those mean to fail building.

###### Things done
Mark `hfs` and `libauto` broken.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
