### PR TITLE
rls: set RUST_SRC_PATH to rustLibSrc

### DIFF
--- a/pkgs/development/compilers/rust/rls/default.nix
+++ b/pkgs/development/compilers/rust/rls/default.nix
@@ -39,9 +39,9 @@ rustPlatform.buildRustPackage {
     $out/bin/rls --version
   '';
 
-  RUST_SRC_PATH = rustPlatform.rustcSrc;
+  RUST_SRC_PATH = rustPlatform.rustLibSrc;
   postInstall = ''
-    wrapProgram $out/bin/rls --set-default RUST_SRC_PATH ${rustPlatform.rustcSrc}
+    wrapProgram $out/bin/rls --set-default RUST_SRC_PATH ${rustPlatform.rustLibSrc}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION


###### Motivation for this change

rls uses racer for completion, based what I saw in https://github.com/NixOS/nixpkgs/commit/61b8a2c72011b5dd53f212cc9edcc2078ba28bde `RUST_SRC_PATH` should be set to `rustPlatform.rustLibSrc`

cc @Ma27  
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
