### PR TITLE
oven-media-engine: 0.10.8 -> 0.10.9-hotfix

### DIFF
--- a/pkgs/servers/misc/oven-media-engine/default.nix
+++ b/pkgs/servers/misc/oven-media-engine/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , srt
 , ffmpeg_3_4
 , bc
@@ -12,6 +13,7 @@
 , libopus
 , srtp
 , jemalloc
+, pcre2
 }:
 
 let
@@ -27,21 +29,30 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "oven-media-engine";
-  version = "0.10.8";
+  version = "0.10.9-hotfix";
 
   src = fetchFromGitHub {
     owner = "AirenSoft";
     repo = "OvenMediaEngine";
     rev = "v${version}";
-    sha256 = "ec4yvS+4/rTBHGEx2OP0yoNGDtzPucFOcZJ0o0cCAHg=";
+    sha256 = "1fhria0vwqsgmsglv5gn858li33vfy2dwy1f1qdd2jwikskb53am";
   };
+
+  patches = [
+    (fetchpatch {
+      # Needed to fix compilation under GCC 10.
+      url = "https://github.com/AirenSoft/OvenMediaEngine/commit/ad83e1d2226445d649e4b7e0c75106e31af4940d.patch";
+      sha256 = "1zk1rgi1wsjl6gdx3hdmgxlgindv6a3lsnkwcgi87ga9abw4vafw";
+      stripLen = 1;
+    })
+  ];
 
   sourceRoot = "source/src";
   makeFlags = "release CONFIG_LIBRARY_PATHS= CONFIG_PKG_PATHS= GLOBAL_CC=$(CC) GLOBAL_CXX=$(CXX) GLOBAL_LD=$(CXX) SHELL=${stdenv.shell}";
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ bc pkgconfig perl ];
-  buildInputs = [ openssl srt zlib ffmpeg libvpx libopus srtp jemalloc ];
+  buildInputs = [ openssl srt zlib ffmpeg libvpx libopus srtp jemalloc pcre2 ];
 
   preBuild = ''
     patchShebangs core/colorg++
@@ -62,7 +73,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Open-source streaming video service with sub-second latency";
     homepage    = "https://ovenmediaengine.com";
-    license     = licenses.gpl2;
+    license     = licenses.gpl2Only;
     maintainers = with maintainers; [ lukegb ];
     platforms   = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release.

0.10.10 is also available, but I'm deliberately not updating to that because upstream recommends you don't use it: AirenSoft/OvenMediaEngine#249

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
