### PR TITLE
radicle-upstream: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/radicle-upstream/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "radicle-upstream";
-  version = "0.1.5";
+  version = "0.1.6";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://releases.radicle.xyz/radicle-upstream-${version}.AppImage";
-    sha256 =  "1q5p6bvzi5awxd9a3xvvdhy26bz0dx8drb1z0zzqdvqqcxxyydq7";
+    sha256 =  "1s299rxala6gqj69j5q4d4n5wfdk2zsb4r9qrhml0m79b4f79yar";
   };
 
   contents = appimageTools.extractType2 { inherit name src; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[new release](https://radicle.community/t/radicle-upstream-v0-1-6-is-out/461)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
