### PR TITLE
subjs: init at 1.0.1

### DIFF
--- a/pkgs/tools/security/subjs/default.nix
+++ b/pkgs/tools/security/subjs/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "subjs";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "lc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01cip5rf35dnh3l325p03y6axyqdpf48ry4zcwiyd7hlfsglbk3j";
+  };
+
+  vendorSha256 = "1y01k8pvv7y9zb15wbk068cvkx0g83484jak2dvcvghqcf5j1fr1";
+
+  buildFlagsArray = [ "-ldflags=-s -w -X main.AppVersion=${version}" ];
+
+  meta = with stdenv.lib; {
+    description = "Fetcher for Javascript files";
+    longDescription = ''
+      subjs fetches Javascript files from a list of URLs or subdomains.
+      Analyzing Javascript files can help you find undocumented endpoints,
+      secrets and more.
+    '';
+    homepage = "https://github.com/lc/subjs";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7702,6 +7702,8 @@ in
 
   su = shadow.su;
 
+  subjs = callPackage ../tools/security/subjs { };
+
   subsonic = callPackage ../servers/misc/subsonic { };
 
   subfinder = callPackage ../tools/networking/subfinder { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
subjs fetches Javascript files from a list of URLs or subdomains.
Analyzing Javascript files can help you find undocumented endpoints,
secrets and more.

https://github.com/lc/subjs

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
