### PR TITLE
python3Packages.geopy: unstable-2019-11-10 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -6,8 +6,8 @@
 }:
 
 buildPythonPackage rec {
-  pname = "geopy-unstable";
-  version = "2019-11-10";
+  pname = "geopy";
+  version = "2.1.0";
 
   disabled = !isPy3k; # only Python 3
   doCheck = false; # Needs network access
@@ -15,10 +15,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ geographiclib ];
 
   src = fetchFromGitHub {
-    owner = "geopy";
-    repo = "geopy";
-    rev = "531b7de6126838a3e69370227aa7f2086ba52b89";
-    sha256 = "07l1pblzg3hb3dbvd9rq8x78ly5dv0zxbc5hwskqil0bhv5v1p39";
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "0239a4achk49ngagb6aqy6cgzfwgbxir07vwi13ysbpx78y0l4g9";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -1,18 +1,16 @@
-{ lib, stdenv
+{ lib
+, async_generator
 , buildPythonPackage
 , fetchFromGitHub
-, isPy3k
 , geographiclib
+, isPy3k
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "geopy";
   version = "2.1.0";
-
   disabled = !isPy3k; # only Python 3
-  doCheck = false; # Needs network access
-
-  propagatedBuildInputs = [ geographiclib ];
 
   src = fetchFromGitHub {
     owner = pname;
@@ -21,10 +19,24 @@ buildPythonPackage rec {
     sha256 = "0239a4achk49ngagb6aqy6cgzfwgbxir07vwi13ysbpx78y0l4g9";
   };
 
+  propagatedBuildInputs = [ geographiclib ];
+
+  checkInputs = [
+    async_generator
+    pytestCheckHook
+  ];
+
+  # Exclude tests which perform API calls
+  pytestFlagsArray = [ "--ignore test/geocoders/" ];
+  pythonImportsCheck = [ "geopy" ];
+
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     homepage = "https://github.com/geopy/geopy";
     description = "Python Geocoding Toolbox";
-    license = licenses.mit;
-    maintainers = with maintainers; [GuillaumeDesforges];
+    changelog = "https://github.com/geopy/geopy/releases/tag/${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ GuillaumeDesforges ];
   };
 }

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -39,7 +39,7 @@
     "apns" = ps: with ps; [ ]; # missing inputs: apns2
     "apple_tv" = ps: with ps; [ aiohttp-cors netdisco pyatv zeroconf ];
     "apprise" = ps: with ps; [ apprise ];
-    "aprs" = ps: with ps; [ ]; # missing inputs: aprslib geopy
+    "aprs" = ps: with ps; [ geopy ]; # missing inputs: aprslib
     "aqualogic" = ps: with ps; [ ]; # missing inputs: aqualogic
     "aquostv" = ps: with ps; [ ]; # missing inputs: sharp_aquos_rc
     "arcam_fmj" = ps: with ps; [ ]; # missing inputs: arcam-fmj


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.0

Change log: https://geopy.readthedocs.io/en/stable/changelog_2xx.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
