### PR TITLE
python3Packages.idna: 2.10 -> 3.1

### DIFF
--- a/pkgs/development/python-modules/idna/2.10.nix
+++ b/pkgs/development/python-modules/idna/2.10.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "idna";
+  version = "2.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xmk3s92d2vq42684p61wixfmh3qpr2mw762w0n6662vhlpqf1xk";
+  };
+
+  checkInput = [ pytestCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/kjd/idna/";
+    description = "Internationalized Domain Names in Applications (IDNA)";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/idna/default.nix
+++ b/pkgs/development/python-modules/idna/default.nix
@@ -1,16 +1,19 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "idna";
-  version = "2.10";
+  version = "3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6";
+    sha256 = "1qal827pcllmqjk3gj4jfm82sq9kp1xiygqadc795a8yw13j3c65";
   };
+
+  checkInput = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://github.com/kjd/idna/";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2962,7 +2962,10 @@ in {
 
   identify = callPackage ../development/python-modules/identify { };
 
-  idna = callPackage ../development/python-modules/idna { };
+  idna = if isPy27 then
+    callPackage ../development/python-modules/idna/2.10.nix { }
+  else
+    callPackage ../development/python-modules/idna { };
 
   idna-ssl = callPackage ../development/python-modules/idna-ssl { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Freeze python2Packages.idna at 2.10.

###### Motivation for this change

https://github.com/kjd/idna/releases/tag/v3.0
https://github.com/kjd/idna/releases/tag/v3.1

Enable tests using pytestCheckHook.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
