### PR TITLE
prometheus-wakatime-exporter: init at 0.1.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/wakatime-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/wakatime-exporter.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  name = "wakatime-exporter";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "MacroPower";
+    repo = "wakatime_exporter";
+    rev = version;
+    sha256 = "14gbpm3kdhrk53xvlivsgzj048gkjv2pl1cmqqji56z1gp5kxfs7";
+  };
+
+  vendorSha256 = null;
+
+  meta = with stdenv.lib; {
+    description = "A Prometheus exporter for Wakatime statistics";
+    homepage = "https//github.com/MacroPower/wakatime_exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17806,6 +17806,7 @@ in
   prometheus-wireguard-exporter = callPackage ../servers/monitoring/prometheus/wireguard-exporter.nix {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  prometheus-wakatime-exporter = callPackage ../servers/monitoring/prometheus/wakatime-exporter.nix { };
   prometheus-xmpp-alerts = callPackage ../servers/monitoring/prometheus/xmpp-alerts.nix {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This package supplements the existing `wakatime` package with a Prometheus exporter for metrics. This can provide a view of your coding history over time on a Grafana dashboard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
