### PR TITLE
Add sh/bash dependency to fix 'missing sh in PATH' error

### DIFF
--- a/pkgs/applications/version-management/sparkleshare/default.nix
+++ b/pkgs/applications/version-management/sparkleshare/default.nix
@@ -1,5 +1,6 @@
 {
   appindicator-sharp,
+  bash,
   coreutils,
   fetchFromGitHub,
   git,
@@ -57,6 +58,7 @@ stdenv.mkDerivation rec {
         --set PATH ${symlinkJoin {
           name = "mono-path";
           paths = [
+            bash
             coreutils
             git
             git-lfs


### PR DESCRIPTION
Sparkleshare requires 'sh' to be in its PATH, or push-operations fail. Its PATH consists of a single entry, which is configured in the postInstall phase. The bash-derivative includes 'sh', and adding it to the dependencies resolves the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


@kevincox