### PR TITLE
rootbar: init at unstable-2020-11-13

### DIFF
--- a/pkgs/applications/misc/rootbar/default.nix
+++ b/pkgs/applications/misc/rootbar/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchhg
+, pkg-config
+, meson
+, ninja
+, gtk3
+, json_c
+, libpulseaudio
+, wayland
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rootbar";
+  version = "unstable-2020-11-13";
+
+  src = fetchhg {
+    url = "https://hg.sr.ht/~scoopta/rootbar";
+    rev = "a018e10cfc5e";
+    sha256 = "sha256-t6oDIYCVaCxaYy4bS1vxESaFDNxsx5JQLQK77eVuafE=";
+  };
+
+  nativeBuildInputs = [
+    meson ninja pkg-config wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    json_c
+    libpulseaudio
+    wayland
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/alexays/waybar";
+    description = "A bar for Wayland WMs";
+    longDescription = ''
+      Root Bar is a bar for wlroots based wayland compositors such as sway and
+      was designed to address the lack of good bars for wayland.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22284,6 +22284,8 @@ in
 
   tiramisu = callPackage ../applications/misc/tiramisu { };
 
+  rootbar = callPackage ../applications/misc/rootbar {};
+
   waybar = callPackage ../applications/misc/waybar {};
 
   hikari = callPackage ../applications/window-managers/hikari { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
