### PR TITLE
python3Packages.aioguardian: init at 1.0.4

### DIFF
--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, aiohttp
+, async-timeout
+, asyncio-dgram
+, asynctest
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, poetry
+, pytest-aiohttp
+, pytest-asyncio
+, pytestCheckHook
+, pythonAtLeast
+, voluptuous
+}:
+
+buildPythonPackage rec {
+  pname = "aioguardian";
+  version = "1.0.4";
+  disabled = pythonAtLeast "3.9";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "1cbxcsxh9c8r2zx3lsjdns26sm2qmlwnqgah2sfzbgp1lay23vvq";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    asyncio-dgram
+    voluptuous
+  ];
+
+  checkInputs = [
+    asyncio-dgram
+    asynctest
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  # Ignore the examples as they are prefixed with test_
+  pytestFlagsArray = [ "--ignore examples/" ];
+  pythonImportsCheck = [ "aioguardian" ];
+
+  meta = with lib; {
+    description = " Python library to interact with Elexa Guardian devices";
+    longDescription = ''
+      aioguardian is a Pytho3, asyncio-focused library for interacting with the
+      Guardian line of water valves and sensors from Elexa.
+    '';
+    homepage = "https://github.com/bachya/aioguardian";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -329,7 +329,7 @@
     "growatt_server" = ps: with ps; [ ]; # missing inputs: growattServer
     "gstreamer" = ps: with ps; [ ]; # missing inputs: gstreamer-player
     "gtfs" = ps: with ps; [ ]; # missing inputs: pygtfs
-    "guardian" = ps: with ps; [ ]; # missing inputs: aioguardian
+    "guardian" = ps: with ps; [ aioguardian ];
     "habitica" = ps: with ps; [ ]; # missing inputs: habitipy
     "hangouts" = ps: with ps; [ ]; # missing inputs: hangups
     "harman_kardon_avr" = ps: with ps; [ ]; # missing inputs: hkavr

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -209,6 +209,8 @@ in {
 
   aioftp = callPackage ../development/python-modules/aioftp { };
 
+  aioguardian = callPackage ../development/python-modules/aioguardian { };
+
   aioh2 = callPackage ../development/python-modules/aioh2 { };
 
   aioharmony = callPackage ../development/python-modules/aioharmony { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
aioguardian is a Python3, asyncio-focused library for interacting with the Guardian line of water valves and sensors from Elexa.

https://github.com/bachya/aioguardian

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
