### PR TITLE
nixos/gitea: make more secrets persistent

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -349,7 +349,7 @@ in
         {
           DOMAIN = cfg.domain;
           STATIC_ROOT_PATH = cfg.staticRootPath;
-          LFS_JWT_SECRET = "#jwtsecret#";
+          LFS_JWT_SECRET = "#lfsjwtsecret#";
           ROOT_URL = cfg.rootUrl;
         }
         (mkIf cfg.enableUnixSocket {
@@ -381,6 +381,7 @@ in
 
       security = {
         SECRET_KEY = "#secretkey#";
+        INTERNAL_TOKEN = "#internaltoken#";
         INSTALL_LOCK = true;
       };
 
@@ -395,6 +396,10 @@ in
 
       mailer = mkIf (cfg.mailerPasswordFile != null) {
         PASSWD = "#mailerpass#";
+      };
+
+      oauth2 = {
+        JWT_SECRET = "#oauth2jwtsecret#";
       };
     };
 
@@ -455,10 +460,20 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ gitea pkgs.gitAndTools.git ];
 
+      # In older versions the secret naming for JWT was kind of confusing.
+      # The file jwt_secret hold the value for LFS_JWT_SECRET and JWT_SECRET
+      # wasn't persistant at all.
+      # To fix that, there is now the file oauth2_jwt_secret containing the
+      # values for JWT_SECRET and the file jwt_secret gets renamed to
+      # lfs_jwt_secret.
+      # We have to consider this to stay compatible with older installations.
       preStart = let
         runConfig = "${cfg.stateDir}/custom/conf/app.ini";
         secretKey = "${cfg.stateDir}/custom/conf/secret_key";
-        jwtSecret = "${cfg.stateDir}/custom/conf/jwt_secret";
+        oauth2JwtSecret = "${cfg.stateDir}/custom/conf/oauth2_jwt_secret";
+        oldLfsJwtSecret = "${cfg.stateDir}/custom/conf/jwt_secret"; # old file for LFS_JWT_SECRET
+        lfsJwtSecret = "${cfg.stateDir}/custom/conf/lfs_jwt_secret"; # new file for LFS_JWT_SECRET
+        internalToken = "${cfg.stateDir}/custom/conf/internal_token";
       in ''
         # copy custom configuration and generate a random secret key if needed
         ${optionalString (cfg.useWizard == false) ''
@@ -468,24 +483,41 @@ in
               ${gitea}/bin/gitea generate secret SECRET_KEY > ${secretKey}
           fi
 
-          if [ ! -e ${jwtSecret} ]; then
-              ${gitea}/bin/gitea generate secret LFS_JWT_SECRET > ${jwtSecret}
+          # Migrate LFS_JWT_SECRET filename
+          if [[ -e ${oldLfsJwtSecret} && ! -e ${lfsJwtSecret} ]]; then
+              mv ${oldLfsJwtSecret} ${lfsJwtSecret}
           fi
 
-          KEY="$(head -n1 ${secretKey})"
+          if [ ! -e ${oauth2JwtSecret} ]; then
+              ${gitea}/bin/gitea generate secret JWT_SECRET > ${oauth2JwtSecret}
+          fi
+
+          if [ ! -e ${lfsJwtSecret} ]; then
+              ${gitea}/bin/gitea generate secret LFS_JWT_SECRET > ${lfsJwtSecret}
+          fi
+
+          if [ ! -e ${internalToken} ]; then
+              ${gitea}/bin/gitea generate secret INTERNAL_TOKEN > ${internalToken}
+          fi
+
+          SECRETKEY="$(head -n1 ${secretKey})"
           DBPASS="$(head -n1 ${cfg.database.passwordFile})"
-          JWTSECRET="$(head -n1 ${jwtSecret})"
+          OAUTH2JWTSECRET="$(head -n1 ${oauth2JwtSecret})"
+          LFSJWTSECRET="$(head -n1 ${lfsJwtSecret})"
+          INTERNALTOKEN="$(head -n1 ${internalToken})"
           ${if (cfg.mailerPasswordFile == null) then ''
             MAILERPASSWORD="#mailerpass#"
           '' else ''
             MAILERPASSWORD="$(head -n1 ${cfg.mailerPasswordFile} || :)"
           ''}
-          sed -e "s,#secretkey#,$KEY,g" \
+          sed -e "s,#secretkey#,$SECRETKEY,g" \
               -e "s,#dbpass#,$DBPASS,g" \
-              -e "s,#jwtsecret#,$JWTSECRET,g" \
+              -e "s,#oauth2jwtsecret#,$OAUTH2JWTSECRET,g" \
+              -e "s,#lfsjwtsecret#,$LFSJWTSECRET,g" \
+              -e "s,#internaltoken#,$INTERNALTOKEN,g" \
               -e "s,#mailerpass#,$MAILERPASSWORD,g" \
               -i ${runConfig}
-          chmod 640 ${runConfig} ${secretKey} ${jwtSecret}
+          chmod 640 ${runConfig} ${secretKey} ${oauth2JwtSecret} ${lfsJwtSecret} ${internalToken}
         ''}
 
         # update all hooks' binary paths


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Added JWT_SECRET and INTERNAL_TOKEN to be persistent, like SECRET_KEY and LFS_JWT_SECRET do. Also renamed some vars belonging to SECRET_KEY and LFS_JWT_SECRET to get a consistent naming scheme over all secrets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
