### PR TITLE
emacs: fix accidental double wrapper (Darwin)

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -203,10 +203,6 @@ runCommand
         --subst-var-by wrapperSiteLisp "$deps/share/emacs/site-lisp" \
         --subst-var-by prog "$emacs/Applications/Emacs.app/Contents/MacOS/Emacs"
       chmod +x $out/Applications/Emacs.app/Contents/MacOS/Emacs
-
-      makeWrapper $emacs/Applications/Emacs.app/Contents/MacOS/Emacs $out/Applications/Emacs.app/Contents/MacOS/Emacs \
-        --suffix EMACSLOADPATH ":" "$deps/share/emacs/site-lisp:" \
-        --suffix EMACSNATIVELOADPATH ":" "$deps/share/emacs/native-lisp:"
     fi
 
     mkdir -p $out/share


### PR DESCRIPTION
This was already fixed on non-Darwin, but the fix missed that it was
also reintroduced for the Darwin code path at the same time.

Fixes: dd5d2482c9d ("emacs: Fix accidental double wrapping")