### PR TITLE
lttng-ust: python2 => python3

### DIFF
--- a/pkgs/development/tools/misc/lttng-ust/default.nix
+++ b/pkgs/development/tools/misc/lttng-ust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, liburcu, python }:
+{ stdenv, fetchurl, liburcu, python3 }:
 
 # NOTE:
 #   ./configure ...
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "0ddwk0nl28bkv2xb78gz16a2bvlpfbjmzwfbgwf5p1cq46dyvy86";
   };
 
-  buildInputs = [ python ];
+  buildInputs = [ python3 ];
 
   preConfigure = ''
     patchShebangs .
   '';
-  
+
   propagatedBuildInputs = [ liburcu ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

I realized that there was still a python 2 rolling through when building my home config.

Python 2 is EOL since February 2020 and shouldn't be used anymore.

Therefore I have hunted down this transitive dependency and updated its inputs accordingly.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

----

```plain
$ ./result/bin/lttng-gen-tp --help

 lttng-gen-tp - Generate the LTTng-UST header and source based on a simple template

 usage: lttng-gen-tp TEMPLATE_FILE [-o OUTPUT_FILE][-o OUTPUT_FILE]

 If no OUTPUT_FILE is given, the .h and .c file will be generated.
 (The basename of the template file with be used for the generated file.
  for example sample.tp will generate sample.h, sample.c and sample.o)

 When using the -o option, the OUTPUT_FILE must end with either .h, .c or .o
 The -o option can be repeated multiple times.

 The template file must contains TRACEPOINT_EVENT and TRACEPOINT_LOGLEVEL
 as per defined in the lttng/tracepoint.h file.
 See the lttng-ust(3) man page for more details on the format.
```

----

```plain
$ nix path-info -Ss  # before
/nix/store/d4k4zis25zmhb02ggcnv0dxqi115g4gp-lttng-ust-2.10.5        1433200       107057992
$ nix path-info -Ss  # after
/nix/store/wj71mpz1v2i0v6hkag60967q700x172z-lttng-ust-2.10.5        1433200       112641288
```

Despite the fact that the actual closure size increases, it is probably a netshrink, as we reduce the number of occasions that pull in python 2.

-----

`nix-review` is still building `ceph`. Another 3 to go after that. So far only a single fail, which does currently fail on `master` even without this change:

```plain
$ hydra-check --channel master coreclr
Build Status for coreclr.x86_64-linux on master
✖ (Failed) coreclr-2.0.7 from 2021-01-03 - https://hydra.nixos.org/build/134237825
```

```plain
§ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   a9fe5fa39fd..e44a4abdbeb  master     -> refs/nixpkgs-review/0
$ git worktree add /home/nmelzer/.cache/nixpkgs-review/rev-e44a4abdbeb479a6cff041a80be9ec9e2cfa78ce-dirty/nixpkgs e44a4abdbeb479a6cff041a80be9ec9e2cfa78ce
Preparing worktree (detached HEAD e44a4abdbeb)
Updating files: 100% (23805/23805), done.
HEAD is now at e44a4abdbeb zfs: 2.0.0 -> 2.0.1
$ nix-env -f /home/nmelzer/.cache/nixpkgs-review/rev-e44a4abdbeb479a6cff041a80be9ec9e2cfa78ce-dirty/nixpkgs -qaP --xml --out-path --show-trace
Applying `nixpkgs` diff...
$ nix-env -f /home/nmelzer/.cache/nixpkgs-review/rev-e44a4abdbeb479a6cff041a80be9ec9e2cfa78ce-dirty/nixpkgs -qaP --xml --out-path --show-trace --meta
16 packages updated:
bareos ceph ceph ceph-client codeql coreclr lttng-tools lttng-tools lttng-ust lttng-ust osu-lazer powershell samba vscode-extension-ms-python-python vscode-extension-ms-vsliveshare-vsliveshare zoxide

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/nmelzer/.cache/nixpkgs-review/rev-e44a4abdbeb479a6cff041a80be9ec9e2cfa78ce-dirty/build.nix
error: --- Error --- nix-daemon
builder for '/nix/store/r09hyccbw7hlzk04pzx75kpz0l4vzcms-coreclr-2.0.7.drv' failed with exit code 1; last 10 log lines:
  [  3%] Building ASM object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/context2.S.o
  [  3%] Building ASM object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/debugbreak.S.o
  [  3%] Building ASM object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/exceptionhelper.S.o
  [  3%] Building CXX object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/processor.cpp.o
  [  3%] Building ASM object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/callsignalhandlerwrapper.S.o
  [  3%] Building CXX object src/pal/src/CMakeFiles/coreclrpal.dir/arch/amd64/signalhandlerhelper.cpp.o
  [  3%] Linking CXX static library libcoreclrpal.a
  [  3%] Built target coreclrpal
  make: *** [Makefile:149: all] Error 2
  Failed to build CoreCLR component.
# build progress display
```

(`§` represents my prompt, `$` is as emitted by `nix-review`)

----

Also I have already rebuild `powershell` with the updated `lttng-ust`. No malfunction observable in a shallow test.