### PR TITLE
mpris-scrobbler: init at 0.4.0.1

### DIFF
--- a/pkgs/tools/audio/mpris-scrobbler/default.nix
+++ b/pkgs/tools/audio/mpris-scrobbler/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, nix-update-script
+, curl
+, dbus
+, libevent
+, m4
+, meson
+, ninja
+, pkg-config
+, scdoc
+, json_c
+, xdg_utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mpris-scrobbler";
+  version = "0.4.0.1";
+
+  src = fetchFromGitHub {
+    owner  = "mariusor";
+    repo   = "mpris-scrobbler";
+    rev    = "v${version}";
+    sha256 = "0jzmgcb9a19hl8y7iwy8l3cc2vgzi0scw7r5q72kszfyxn0yk2gs";
+  };
+
+  postPatch = ''
+    substituteInPlace src/signon.c \
+      --replace "/usr/bin/xdg-open" "${xdg_utils}/bin/xdg-open"
+  '';
+
+  nativeBuildInputs = [
+    m4
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  buildInputs = [
+    curl
+    dbus
+    json_c
+    libevent
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Minimalistic scrobbler for libre.fm & last.fm";
+    homepage    = "https://github.com/mariusor/mpris-scrobbler";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ emantor ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2510,6 +2510,8 @@ in
 
   mpd-mpris = callPackage ../tools/audio/mpd-mpris { };
 
+  mpris-scrobbler = callPackage ../tools/audio/mpris-scrobbler { };
+
   mq-cli = callPackage ../tools/system/mq-cli { };
 
   nextdns = callPackage ../applications/networking/nextdns { };


### PR DESCRIPTION
###### Motivation for this change

Minimalistic scrobbler using the the MPRIS specification to scrobble to
libre.fm and last.fm.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
