### PR TITLE
python3Packages.pylacrosse: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/pylacrosse/default.nix
+++ b/pkgs/development/python-modules/pylacrosse/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, nose
+, pyserial
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pylacrosse";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "hthiery";
+    repo = "python-lacrosse";
+    rev = version;
+    sha256 = "0g5hqm8lq0gsnvhcydjk54rjf7lpxzph8k7w1nnvnqfbhf31xfcf";
+  };
+
+  propagatedBuildInputs = [ pyserial ];
+
+  checkInputs = [
+    mock
+    nose
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pylacrosse" ];
+
+  meta = with lib; {
+    description = "Python library for Jeelink LaCrosse";
+    homepage = "https://github.com/hthiery/python-lacrosse";
+    license = with licenses; [ lgpl2Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -424,7 +424,7 @@
     "konnected" = ps: with ps; [ aiohttp-cors ]; # missing inputs: konnected
     "kulersky" = ps: with ps; [ ]; # missing inputs: pykulersky
     "kwb" = ps: with ps; [ ]; # missing inputs: pykwb
-    "lacrosse" = ps: with ps; [ ]; # missing inputs: pylacrosse
+    "lacrosse" = ps: with ps; [ pylacrosse ];
     "lametric" = ps: with ps; [ ]; # missing inputs: lmnotify
     "lannouncer" = ps: with ps; [ ];
     "lastfm" = ps: with ps; [ pylast ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5341,6 +5341,8 @@ in {
 
   pykwalify = callPackage ../development/python-modules/pykwalify { };
 
+  pylacrosse = callPackage ../development/python-modules/pylacrosse { };
+
   pylama = callPackage ../development/python-modules/pylama { };
 
   pylast = callPackage ../development/python-modules/pylast { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for Jeelink LaCrosse.

https://github.com/hthiery/python-lacrosse

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
