### PR TITLE
qmltermwidget: fix build with gcc10

### DIFF
--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp }:
+{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmake, qtmultimedia, utmp, fetchpatch }:
 
 stdenv.mkDerivation {
   version = "2018-11-24";
@@ -15,7 +15,15 @@ stdenv.mkDerivation {
                 ++ stdenv.lib.optional stdenv.isDarwin utmp;
   nativeBuildInputs = [ qmake ];
 
-  patchPhase = ''
+  patches = [
+    (fetchpatch {
+      name = "fix-missing-includes.patch";
+      url = "https://github.com/Swordfish90/qmltermwidget/pull/27/commits/485f8d6d841b607ba49e55a791f7f587e4e193bc.diff";
+      sha256 = "186s8pv3642vr4lxsds919h0y2vrkl61r7wqq9mc4a5zk5vprinj";
+    })
+  ];
+
+  postPatch = ''
     substituteInPlace qmltermwidget.pro \
       --replace '$$[QT_INSTALL_QML]' "/$qtQmlPrefix/"
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the build for `x86_64-linux` which uses `gcc10`.

https://hydra.nixos.org/eval/1640445?filter=qmltermwidget&compare=1640366&full=

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
