### PR TITLE
bibtex2html: add perl dependency

### DIFF
--- a/pkgs/tools/misc/bibtex2html/default.nix
+++ b/pkgs/tools/misc/bibtex2html/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml }:
+{ stdenv, fetchurl, ocaml, perl }:
 
 stdenv.mkDerivation {
   pname = "bibtex2html";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "07gzrs4lfrkvbn48cgn2gn6c7cx3jsanakkrb2irj0gmjzfxl96j";
   };
 
-  buildInputs = [ ocaml ];
+  buildInputs = [ ocaml perl ];
 
   meta = with stdenv.lib; {
     description = "A collection of tools for translating from BibTeX to HTML";


### PR DESCRIPTION
The `aux2bib` tool that is part of the bibtex2html package requires
perl. Without this dependency, the `aux2bib` script is installed with
a shebang pointing to `/usr/bin/perl`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
