### PR TITLE
fedora-coreos-config-transpiler: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/tools/fedora-coreos-config-transpiler/default.nix
+++ b/pkgs/development/tools/fedora-coreos-config-transpiler/default.nix
@@ -4,13 +4,13 @@ with lib;
 
 buildGoModule rec {
   pname = "fcct";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "coreos";
     repo = "fcct";
     rev = "v${version}";
-    sha256 = "0w3vhfjpmpahb08fp6czixhlqhk6izglmwdpj2l19ksz8fc8aq54";
+    sha256 = "0kdsnsp9nzkkfwakcx64md66yz2k7cpw8bkhdv798yirbrqprgp6";
   };
 
   vendorSha256 = null;


### PR DESCRIPTION
###### Motivation for this change

[A new version was released upstream](https://github.com/coreos/fcct/releases/tag/v0.9.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
