### PR TITLE
python3Packages.airly: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/airly/default.nix
+++ b/pkgs/development/python-modules/airly/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "airly";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ak-ambi";
+    repo = "python-airly";
+    rev = "v${version}";
+    sha256 = "0an6nbl0i5pahxm6x4z03s9apzgqrw9zf7srjcs0r3y1ppicb4s6";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    "InstallationsLoaderTestCase"
+    "MeasurementsSessionTestCase"
+  ];
+  pythonImportsCheck = [ "airly" ];
+
+  meta = with lib; {
+    description = "Python module for getting air quality data from Airly sensors";
+    homepage = "https://github.com/ak-ambi/python-airly";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -15,7 +15,7 @@
     "aftership" = ps: with ps; [ pyaftership ];
     "agent_dvr" = ps: with ps; [ ]; # missing inputs: agent-py
     "air_quality" = ps: with ps; [ ];
-    "airly" = ps: with ps; [ ]; # missing inputs: airly
+    "airly" = ps: with ps; [ airly ];
     "airvisual" = ps: with ps; [ pyairvisual ];
     "aladdin_connect" = ps: with ps; [ ]; # missing inputs: aladdin_connect
     "alarm_control_panel" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -269,6 +269,8 @@ in {
 
   aiozeroconf = callPackage ../development/python-modules/aiozeroconf { };
 
+  airly = callPackage ../development/python-modules/airly { };
+
   ajpy = callPackage ../development/python-modules/ajpy { };
 
   alabaster = callPackage ../development/python-modules/alabaster { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for getting air quality data from Airly sensors

https://github.com/ak-ambi/python-airly

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
