### PR TITLE
gnome3.gnome-boxes: remove xen as dependency

### DIFF
--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -44,7 +44,6 @@
 , libsecret
 , libcap_ng
 , numactl
-, xen
 , libapparmor
 , json-glib
 , webkitgtk
@@ -117,7 +116,6 @@ stdenv.mkDerivation rec {
     tracker-miners
     vte
     webkitgtk
-    xen
     yajl
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Xen is not necessary to build gnome-boxes.  there is no Xen as dependency in Gnome-boxes [Flatpak](https://gitlab.gnome.org/GNOME/gnome-boxes/-/blob/master/build-aux/flatpak/org.gnome.Boxes.json), [Debian Package](https://salsa.debian.org/gnome-team/gnome-boxes/-/blob/debian/master/debian/control), neither in [Arch package](https://archlinux.org/packages/community/x86_64/gnome-boxes/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
