### PR TITLE
nvidia-docker: fix VERSION reporting bug

### DIFF
--- a/pkgs/applications/virtualization/nvidia-docker/default.nix
+++ b/pkgs/applications/virtualization/nvidia-docker/default.nix
@@ -62,7 +62,10 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     mkdir bin
+
     cp nvidia-docker bin
+    substituteInPlace bin/nvidia-docker --subst-var-by VERSION ${version}
+
     cp ${libnvidia-container}/bin/nvidia-container-cli bin
     cp ${nvidia-container-toolkit}/bin/nvidia-container-{toolkit,runtime-hook} bin
     cp ${nvidia-container-runtime}/bin/nvidia-container-runtime bin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change fixes the reported version of `nvidia-docker version` to be 2.5.0 rather than `@VERSION@`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
