### PR TITLE
python3Packages.subarulink: init at 0.3.11

### DIFF
--- a/pkgs/development/python-modules/stdiomask/default.nix
+++ b/pkgs/development/python-modules/stdiomask/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "stdiomask";
+  version = "0.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19m3p6i7fj7nmkbsjhiha3f2l7d05j9gf9ha2pd0pqfrx9lp1r61";
+  };
+
+  # tests are not published: https://github.com/asweigart/stdiomask/issues/5
+  doCheck = false;
+  pythonImportsCheck = [ "stdiomask" ];
+
+  meta = with lib; {
+    description = "Python module for masking passwords";
+    homepage = "https://github.com/asweigart/stdiomask";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/subarulink/default.nix
+++ b/pkgs/development/python-modules/subarulink/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, asynctest
+, stdiomask
+, cryptography
+, pytestcov
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "subarulink";
+  version = "0.3.11";
+
+  src = fetchFromGitHub {
+    owner = "G-Two";
+    repo = pname;
+    rev = "subaru-v${version}";
+    sha256 = "1ink9bhph6blidnfsqwq01grhp7ghacmkd4vzgb9hnhl9l52s1jq";
+  };
+
+  propagatedBuildInputs = [ aiohttp stdiomask ];
+
+  checkInputs = [
+    asynctest
+    cryptography
+    pytest-asyncio
+    pytestcov
+    pytestCheckHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "subarulink" ];
+
+  meta = with lib; {
+    description = "Python module for interacting with STARLINK-enabled vehicle";
+    homepage = "https://github.com/G-Two/subarulink";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7179,6 +7179,8 @@ in {
 
   statsmodels = callPackage ../development/python-modules/statsmodels { };
 
+  stdiomask = callPackage ../development/python-modules/stdiomask { };
+
   stem = callPackage ../development/python-modules/stem { };
 
   stevedore = callPackage ../development/python-modules/stevedore { };
@@ -7216,6 +7218,8 @@ in {
   stups-zign = callPackage ../development/python-modules/stups-zign { };
 
   stytra = callPackage ../development/python-modules/stytra { };
+
+  subarulink = callPackage ../development/python-modules/subarulink { };
 
   subdownloader = callPackage ../development/python-modules/subdownloader { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for interacting with STARLINK-enabled vehicle.

https://github.com/G-Two/subarulink

This is a Home Assistant (HACS) dependency.

This add in addition [`stdiomask`](https://github.com/asweigart/stdiomask).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
