### PR TITLE
nixos/networking: make /etc/netgroup by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -509,6 +509,12 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
        The GNOME desktop manager once again installs <package>gnome3.epiphany</package> by default.
      </para>
    </listitem>
+   <listitem>
+    <para>
+     NixOS now generates empty <literal>/etc/netgroup</literal>.
+     <literal>/etc/netgroup</literal> defines network-wide groups and may affect to setups using NIS.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -193,6 +193,10 @@ in
           cat ${escapeShellArgs cfg.hostFiles} > $out
         '';
 
+        # /etc/netgroup: Network-wide groups.
+        netgroup.text = mkDefault ''
+        '';
+
         # /etc/host.conf: resolver configuration file
         "host.conf".text = ''
           multi on


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change

**I had removed the PR branch for https://github.com/NixOS/nixpkgs/pull/102870 by mistake so the PR was closed and unable to be reopened. Thus I restart a PR here. This is my fault, sorry.**

NixOS now generates an empty file `/etc/netgroup` by default. It will suppress the "`/etc/netgroup`: No such file or directory" messages from nscd.
Inspired by https://github.com/NixOS/nixpkgs/pull/68671 but I changed `config/networking.nix` instead of `services/networking/nscd.nix` since the file is not specific to glibc.

Fixes https://github.com/NixOS/nixpkgs/issues/68603

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
