### PR TITLE
libplacebo: fixup glslang headers path

### DIFF
--- a/pkgs/development/libraries/libplacebo/default.nix
+++ b/pkgs/development/libraries/libplacebo/default.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
   pname = "libplacebo";
   version = "2.72.2";
 
+  patches = [
+    ./glsl-import.patch
+  ];
+
   src = fetchFromGitLab {
     domain = "code.videolan.org";
     owner = "videolan";

--- a/pkgs/development/libraries/libplacebo/glsl-import.patch
+++ b/pkgs/development/libraries/libplacebo/glsl-import.patch
@@ -1,0 +1,13 @@
+diff --git a/src/glsl/glslang.cc b/src/glsl/glslang.cc
+index f701acc..c64cbf5 100644
+--- a/src/glsl/glslang.cc
++++ b/src/glsl/glslang.cc
+@@ -26,7 +26,7 @@ extern "C" {
+ 
+ #include <glslang/Include/ResourceLimits.h>
+ #include <glslang/Public/ShaderLang.h>
+-#include <SPIRV/GlslangToSpv.h>
++#include <glslang/SPIRV/GlslangToSpv.h>
+ 
+ #include "glslang.h"
+ 


### PR DESCRIPTION

###### Motivation for this change
See: https://github.com/NixOS/nixpkgs/issues/108723

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
