### PR TITLE
mtPaint: 3.49.12 → 3.50.01

### DIFF
--- a/pkgs/applications/graphics/mtpaint/default.nix
+++ b/pkgs/applications/graphics/mtpaint/default.nix
@@ -1,25 +1,27 @@
 { stdenv, fetchFromGitHub
-, pkgconfig
-, freetype, giflib, gtk2, lcms2, libjpeg, libpng, libtiff, openjpeg, gifsicle
+, pkg-config
+, freetype, giflib, gtk3, lcms2, libjpeg, libpng, libtiff, openjpeg, gifsicle
 }:
 
 stdenv.mkDerivation rec {
   p_name  = "mtPaint";
-  ver_maj = "3.49";
-  ver_min = "12";
+  ver_maj = "3.50";
+  ver_min = "01";
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   src = fetchFromGitHub {
     owner = "wjaguar";
     repo = p_name;
-    rev = "6aed1b0441f99055fc7d475942f8bd5cb23c41f8";
-    sha256 = "0bvf623g0n2ifijcxv1nw0z3wbs2vhhdky4n04ywsbjlykm44nd1";
+    rev = "a4675ff5cd9fcd57d291444cb9f332b48f11243f";
+    sha256 = "04wqxz8i655gz5rnz90cksy8v6m2jhcn1j8rzhqpp5xhawlmq24y";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    freetype giflib gtk2 lcms2 libjpeg libpng libtiff openjpeg gifsicle
+    freetype giflib gtk3 lcms2 libjpeg libpng libtiff openjpeg gifsicle
   ];
+
+  configureFlags = [ "gtk3" "intl" "man" ];
 
   meta = {
     description = "A simple GTK painting program";
@@ -33,7 +35,7 @@ stdenv.mkDerivation rec {
       GNU/Linux, Windows and older PC hardware.
     '';
     homepage = "http://mtpaint.sourceforge.net/";
-    license = stdenv.lib.licenses.gpl3;
+    license = stdenv.lib.licenses.gpl3Plus;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.vklquevs ];
   };


### PR DESCRIPTION
###### Motivation for this change
* [Version 3.50 released](http://mtpaint.sourceforge.net/news.html)
* Use GTK3 ([GTK2 has reached end of life](https://blog.gtk.org/2020/12/16/gtk-4-0/))
* Enable i18n
* Install .desktop, man files
* Fix license

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @vklquevs 