### PR TITLE
ajour: init at 0.6.3

### DIFF
--- a/pkgs/tools/games/ajour/default.nix
+++ b/pkgs/tools/games/ajour/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, autoPatchelfHook
+, cmake
+, makeWrapper
+, pkg-config
+, python3
+, expat
+, freetype
+, kdialog
+, zenity
+, openssl
+, libX11
+, libxcb
+, libXcursor
+, libXi
+, libxkbcommon
+, libXrandr
+, vulkan-loader
+, wayland
+}:
+
+let
+  rpathLibs = [
+    libXcursor
+    libXi
+    libxkbcommon
+    libXrandr
+    libX11
+    vulkan-loader
+    wayland
+  ];
+
+in rustPlatform.buildRustPackage rec {
+  pname = "Ajour";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "casperstorm";
+    repo = "ajour";
+    rev = version;
+    sha256 = "080759j18pws5c8bmqn1bwvmlaq8k01kzj7bnwncwinl5j35mi2j";
+  };
+
+  cargoSha256 = "1614lln5zh2j2np68pllwcqmywvzzmkj71b158fw2d98ijbi9lmw";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    makeWrapper
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    expat
+    freetype
+    openssl
+    libxcb
+    libX11
+  ];
+
+  fixupPhase = ''
+    patchelf --set-rpath "${lib.makeLibraryPath rpathLibs}:$(patchelf --print-rpath $out/bin/ajour)" $out/bin/ajour
+    wrapProgram $out/bin/ajour --prefix PATH ":" ${lib.makeBinPath [ zenity kdialog ]}
+  '';
+
+  meta = with lib; {
+    description = "World of Warcraft addon manager written in Rust";
+    longDescription = ''
+      Ajour is a World of Warcraft addon manager written in Rust with a
+      strong focus on performance and simplicity. The project is
+      completely advertisement free, privacy respecting and open source.
+    '';
+    homepage = "https://github.com/casperstorm/ajour";
+    changelog = "https://github.com/casperstorm/ajour/blob/master/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -721,6 +721,11 @@ in
 
   aj-snapshot  = callPackage ../applications/audio/aj-snapshot { };
 
+  ajour = callPackage ../tools/games/ajour {
+    inherit (gnome3) zenity;
+    inherit (plasma5Packages) kdialog;
+  };
+
   albert = libsForQt5.callPackage ../applications/misc/albert {};
 
   metapixel = callPackage ../tools/graphics/metapixel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A cross-plattform addon manager for World of Warcraft.

https://github.com/casperstorm/ajour

cc @MetaDark @cawilliamson

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
