### PR TITLE
nixos/redshift: use config file instead of passing parameters, using RFC42

### DIFF
--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -12,6 +12,8 @@ let
 
 in {
 
+  meta.maintainers = with maintainers; [ thiagokokada ];
+
   imports = [
     (mkChangedOptionModule [ "services" "redshift" "latitude" ] [ "location" "latitude" ]
       (config:

--- a/nixos/modules/services/x11/redshift.nix
+++ b/nixos/modules/services/x11/redshift.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, options, ... }:
 
 with lib;
 
@@ -6,6 +6,9 @@ let
 
   cfg = config.services.redshift;
   lcfg = config.location;
+  settingsFormat = pkgs.formats.ini {};
+  isGeoclue2 = lcfg.provider == "geoclue2";
+  isManual = lcfg.provider == "manual";
 
 in {
 
@@ -23,7 +26,14 @@ in {
           throw "services.redshift.longitude is set to null, you can remove this"
           else builtins.fromJSON value))
     (mkRenamedOptionModule [ "services" "redshift" "provider" ] [ "location" "provider" ])
-  ];
+    (mkRemovedOptionModule [ "services" "redshift" "extraOptions" ] "All Redshift configuration is now available through services.redshift.settings instead.")
+  ] ++
+  (map (option: mkRenamedOptionModule ([ "services" "redshift" ] ++ option.old) [ "services" "redshift" "settings" "redshift" option.new ]) [
+      { old = [ "temperature" "day" ];    new = "temp-day"; }
+      { old = [ "temperature" "night" ];  new = "temp-night"; }
+      { old = [ "brightness" "day" ];     new = "brightness-day"; }
+      { old = [ "brightness" "night" ];   new = "brightness-night"; }
+    ]);
 
   options.services.redshift = {
     enable = mkOption {
@@ -32,45 +42,11 @@ in {
       description = ''
         Enable Redshift to change your screen's colour temperature depending on
         the time of day.
+
+        This module also supports Gammastep, look for
+        <literal>services.redshift.package</literal> and
+        <literal>services.redshift.executable</literal> options.
       '';
-    };
-
-    temperature = {
-      day = mkOption {
-        type = types.int;
-        default = 5500;
-        description = ''
-          Colour temperature to use during the day, between
-          <literal>1000</literal> and <literal>25000</literal> K.
-        '';
-      };
-      night = mkOption {
-        type = types.int;
-        default = 3700;
-        description = ''
-          Colour temperature to use at night, between
-          <literal>1000</literal> and <literal>25000</literal> K.
-        '';
-      };
-    };
-
-    brightness = {
-      day = mkOption {
-        type = types.str;
-        default = "1";
-        description = ''
-          Screen brightness to apply during the day,
-          between <literal>0.1</literal> and <literal>1.0</literal>.
-        '';
-      };
-      night = mkOption {
-        type = types.str;
-        default = "1";
-        description = ''
-          Screen brightness to apply during the night,
-          between <literal>0.1</literal> and <literal>1.0</literal>.
-        '';
-      };
     };
 
     package = mkOption {
@@ -78,7 +54,9 @@ in {
       default = pkgs.redshift;
       defaultText = "pkgs.redshift";
       description = ''
-        redshift derivation to use.
+        Redshift derivation to use.
+
+        To use Gammastep, pass <package>gammastep</package>.
       '';
     };
 
@@ -88,51 +66,100 @@ in {
       example = "/bin/redshift-gtk";
       description = ''
         Redshift executable to use within the package.
+
+        To use Gammastep, pass either <literal>/bin/gammastep</literal>
+        or <literal>/bin/gammastep-indicator</literal>.
       '';
     };
 
-    extraOptions = mkOption {
-      type = types.listOf types.str;
-      default = [];
-      example = [ "-v" "-m randr" ];
+    settings = mkOption {
+      type = types.submodule ({ options, ... }: {
+        freeformType = settingsFormat.type;
+
+        options.redshift = mkOption {
+          type = settingsFormat.type.functor.wrapped;
+        };
+
+        # Copy all redshift definitions to general, such that in case of gammastep,
+        # which prefers general over redshift, gets both values from general and redshift
+        # While the original redshift just gets values from redshift, as it should
+        # https://gitlab.com/chinstrap/gammastep/-/commit/1608ed61154cc652b087e85c4ce6125643e76e2f
+        config.general = modules.mkAliasAndWrapDefsWithPriority id options.redshift;
+      });
+
+      default = {};
+
+      example = literalExample ''
+        {
+          redshift = {
+            temp-day = 5500;
+            temp-night = 3700;
+            brightness-day = 1.0;
+            brightness-night = 0.8;
+            fade = 1;
+          };
+          randr = {
+            screen = 0;
+          };
+        };
+      '';
+
       description = ''
-        Additional command-line arguments to pass to
-        <command>redshift</command>.
+        The configuration to pass to Redshift/Gammastep.
+
+        Available options for Redshift described in
+        <citerefentry>
+          <refentrytitle>redshift</refentrytitle>
+          <manvolnum>1</manvolnum>
+        </citerefentry> and for Gammastep in
+        <citerefentry>
+          <refentrytitle>gammastep</refentrytitle>
+          <manvolnum>1</manvolnum>
+        </citerefentry>.
       '';
     };
   };
 
-  config = mkIf cfg.enable {
+  config = let
+    target = if (cfg.settings.redshift.adjustment-method or null) == "drm"
+      then "basic.target"
+      else "graphical-session.target";
+    configFile = settingsFormat.generate "redshift.conf" cfg.settings;
+  in mkIf cfg.enable {
     # needed so that .desktop files are installed, which geoclue cares about
     environment.systemPackages = [ cfg.package ];
 
-    services.geoclue2.appConfig.redshift = {
+    services.geoclue2.appConfig.redshift = mkIf isGeoclue2 {
       isAllowed = true;
       isSystem = true;
     };
 
-    systemd.user.services.redshift =
-    let
-      providerString = if lcfg.provider == "manual"
-        then "${toString lcfg.latitude}:${toString lcfg.longitude}"
-        else lcfg.provider;
-    in
-    {
+    assertions = [
+      {
+        assertion = (cfg.settings ? redshift.dawn-time) == (cfg.settings ? redshift.dusk-time);
+        message = "Time of dawn and time of dusk must be provided together.";
+      }
+    ];
+
+    services.redshift.settings = {
+      redshift.location-provider = lcfg.provider;
+      manual = mkIf isManual {
+        lat = lcfg.latitude;
+        lon = lcfg.longitude;
+      };
+    };
+
+    systemd.user.services.redshift = {
       description = "Redshift colour temperature adjuster";
-      wantedBy = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
+      wantedBy = [ target ];
+      partOf = [ target ];
       serviceConfig = {
         ExecStart = ''
-          ${cfg.package}${cfg.executable} \
-            -l ${providerString} \
-            -t ${toString cfg.temperature.day}:${toString cfg.temperature.night} \
-            -b ${toString cfg.brightness.day}:${toString cfg.brightness.night} \
-            ${lib.strings.concatStringsSep " " cfg.extraOptions}
+          ${cfg.package}${cfg.executable} -c ${configFile}
         '';
         RestartSec = 3;
-        Restart = "always";
+        Restart = "on-failure";
       };
     };
   };
-
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -326,6 +326,7 @@ in
   radicale = handleTest ./radicale.nix {};
   redis = handleTest ./redis.nix {};
   redmine = handleTest ./redmine.nix {};
+  redshift = handleTest ./redshift.nix {};
   restic = handleTest ./restic.nix {};
   ripgrep = handleTest ./ripgrep.nix {};
   robustirc-bridge = handleTest ./robustirc-bridge.nix {};

--- a/nixos/tests/redshift.nix
+++ b/nixos/tests/redshift.nix
@@ -1,0 +1,40 @@
+import ./make-test-python.nix ( { pkgs, ... }: {
+  name = "redshift";
+  meta = {
+    maintainers = with pkgs.stdenv.lib.maintainers; [ thiagokokada ];
+  };
+
+  machine = { pkgs, ... }:
+    {
+      imports = [
+        ./common/user-account.nix
+        ./common/x11.nix
+      ];
+      test-support.displayManager.auto.user = "alice";
+
+      location = {
+        provider = "manual";
+        latitude = 0.0;
+        longitude = 0.0;
+      };
+
+      services.redshift = {
+        enable = true;
+        settings = {
+          redshift = {
+            temp-day = 1500;
+            temp-night = 1500;
+            gamma = 0.8;
+            fade = 0;
+          };
+        };
+      };
+    };
+
+  testScript =
+    ''
+      machine.start()
+      machine.wait_for_x()
+      machine.wait_for_unit("redshift.service", "alice")
+    '';
+})

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -7,6 +7,7 @@
 , withRandr ? stdenv.isLinux, libxcb
 , withDrm ? stdenv.isLinux, libdrm
 
+, nixosTests
 , withGeolocation ? true
 , withCoreLocation ? withGeolocation && stdenv.isDarwin, CoreLocation, Foundation, Cocoa
 , withGeoclue ? withGeolocation && stdenv.isLinux, geoclue
@@ -65,6 +66,9 @@ let
       preConfigure = "./bootstrap";
 
       postFixup = "wrapPythonPrograms";
+
+      # TODO: Enable for redshift-wlr/gammstep
+      passthru.tests.redshift = lib.mkIf (pname == "redshift") nixosTests.redshift;
 
       # the geoclue agent may inspect these paths and expect them to be
       # valid without having the correct $PATH set


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Not every option is exposed by redshift/gammastep parameters, for example gamma options are only exposed in configuration file. So this PR refactors this module to generate a configuration file and pass it to the redshift/gammastep using -c parameter.

This is a breaking change since there is no support for some of the older options like `extraOptions`. Also, the way to pass settings completely changed (but there is some aliases).

Second try of PR #108625, now following [RFC 42](https://github.com/NixOS/rfcs/pull/42). Also some parts of it taken from PR #50979.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
