### PR TITLE
envoy: init at 1.16.2

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -172,7 +172,9 @@ in stdenv.mkDerivation (fBuildAttrs // {
 
     chmod -R +w $bazelOut
     find $bazelOut -type l | while read symlink; do
-      ln -sf $(readlink "$symlink" | sed "s,NIX_BUILD_TOP,$NIX_BUILD_TOP,") "$symlink"
+      if [[ $(readlink "$symlink") == *NIX_BUILD_TOP* ]]; then
+        ln -sf $(readlink "$symlink" | sed "s,NIX_BUILD_TOP,$NIX_BUILD_TOP,") "$symlink"
+      fi
     done
   '' + fBuildAttrs.preConfigure or "";
 

--- a/pkgs/servers/http/envoy/0001-quiche-update-QUICHE-tar-13949.patch
+++ b/pkgs/servers/http/envoy/0001-quiche-update-QUICHE-tar-13949.patch
@@ -1,0 +1,2980 @@
+From 97d7c456e03d4a11157fac17c7b8cbcee1d8a657 Mon Sep 17 00:00:00 2001
+From: danzh <danzh2010@users.noreply.github.com>
+Date: Mon, 16 Nov 2020 14:27:13 -0500
+Subject: [PATCH] quiche: update QUICHE tar (#13949)
+
+Signed-off-by: Dan Zhang <danzh@google.com>
+---
+ bazel/envoy_internal.bzl                      |   2 +
+ bazel/external/quiche.BUILD                   |  85 +--
+ bazel/repository_locations.bzl                |   6 +-
+ source/extensions/quic_listeners/quiche/BUILD |   1 +
+ .../quiche/active_quic_listener.cc            |   2 +-
+ .../quiche/envoy_quic_client_connection.cc    |   2 +-
+ .../quiche/envoy_quic_client_stream.cc        |   1 +
+ .../quiche/envoy_quic_connection.cc           |   6 +-
+ .../quiche/envoy_quic_connection.h            |   1 +
+ .../quiche/envoy_quic_dispatcher.cc           |   6 +-
+ .../quiche/envoy_quic_dispatcher.h            |   2 +-
+ .../quiche/envoy_quic_proof_source.cc         |   2 +-
+ .../quiche/envoy_quic_proof_source.h          |   2 +-
+ .../quiche/envoy_quic_proof_source_base.cc    |   7 +-
+ .../quiche/envoy_quic_proof_source_base.h     |   6 +-
+ .../quiche/envoy_quic_proof_verifier_base.cc  |   4 +-
+ .../quiche/envoy_quic_server_connection.cc    |  10 +-
+ .../quiche/envoy_quic_server_connection.h     |   1 +
+ .../quic_listeners/quiche/platform/BUILD      |  42 +-
+ .../quiche/platform/flags_impl.cc             | 108 +++-
+ .../quiche/platform/flags_impl.h              |  46 +-
+ .../quiche/platform/flags_list.h              | 502 ------------------
+ .../quiche/platform/http2_flags_impl.h        |   4 +-
+ .../quiche/platform/quic_aligned_impl.h       |  18 -
+ .../quiche/platform/quic_cert_utils_impl.cc   |  38 +-
+ .../quiche/platform/quic_cert_utils_impl.h    |   9 +-
+ .../quiche/platform/quic_fallthrough_impl.h   |  11 -
+ .../quiche/platform/quic_file_utils_impl.cc   |   4 +-
+ .../quiche/platform/quic_file_utils_impl.h    |   6 +-
+ .../quiche/platform/quic_flags_impl.h         |   6 +-
+ .../platform/quic_hostname_utils_impl.cc      |   6 +-
+ .../platform/quic_hostname_utils_impl.h       |   8 +-
+ .../quiche/platform/quic_macros_impl.h        |  13 -
+ .../platform/quic_mem_slice_span_impl.cc      |   3 +-
+ .../platform/quic_mem_slice_span_impl.h       |   9 +-
+ ..._ptr_util_impl.h => quic_testvalue_impl.h} |  11 +-
+ .../platform/quic_udp_socket_platform_impl.h  |   3 +
+ .../quiche/platform/quiche_arraysize_impl.h   |  11 -
+ .../quiche/platform/quiche_optional_impl.h    |  17 -
+ .../quiche/platform/quiche_text_utils_impl.h  |  63 +--
+ .../quiche/platform/quiche_time_utils_impl.cc |   4 +-
+ .../quiche/platform/quiche_time_utils_impl.h  |   4 +-
+ .../platform/spdy_endianness_util_impl.h      |  29 -
+ .../quiche/platform/spdy_flags_impl.h         |   4 +-
+ .../quiche/platform/spdy_string_utils_impl.h  |   2 +-
+ .../spdy_server_push_utils_for_envoy.cc       |  10 +-
+ .../quiche/envoy_quic_client_session_test.cc  |   2 +-
+ .../quiche/envoy_quic_client_stream_test.cc   |  44 +-
+ .../quiche/envoy_quic_proof_source_test.cc    |   6 +-
+ .../quiche/envoy_quic_proof_verifier_test.cc  |   8 +-
+ .../quiche/envoy_quic_server_session_test.cc  |   3 +-
+ .../quiche/envoy_quic_server_stream_test.cc   |  53 +-
+ .../quic_listeners/quiche/platform/BUILD      |  22 -
+ .../quiche/platform/http2_platform_test.cc    |  22 +-
+ .../quiche/platform/quic_platform_test.cc     |  61 +--
+ .../quiche/platform/quic_test_output_impl.cc  |  15 +-
+ .../quiche/platform/quic_test_output_impl.h   |  12 +-
+ .../quiche/platform/quiche_platform_test.cc   |  39 --
+ .../quiche/platform/spdy_platform_test.cc     |  20 +-
+ .../quic_listeners/quiche/test_proof_source.h |   2 +-
+ .../quic_listeners/quiche/test_utils.h        |   4 +-
+ 61 files changed, 396 insertions(+), 1054 deletions(-)
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/flags_list.h
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/quic_aligned_impl.h
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/quic_fallthrough_impl.h
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/quic_macros_impl.h
+ rename source/extensions/quic_listeners/quiche/platform/{quiche_ptr_util_impl.h => quic_testvalue_impl.h} (52%)
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/quiche_arraysize_impl.h
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/quiche_optional_impl.h
+ delete mode 100644 source/extensions/quic_listeners/quiche/platform/spdy_endianness_util_impl.h
+ delete mode 100644 test/extensions/quic_listeners/quiche/platform/quiche_platform_test.cc
+
+diff --git a/bazel/envoy_internal.bzl b/bazel/envoy_internal.bzl
+index 5ad86609a..3f9ddfd23 100644
+--- a/bazel/envoy_internal.bzl
++++ b/bazel/envoy_internal.bzl
+@@ -54,6 +54,8 @@ def envoy_copts(repository, test = False):
+            }) + select({
+                repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand", "-Wc++2a-extensions", "-Wrange-loop-analysis"],
+                repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
++               # TODO: Replace with /Zc:preprocessor for cl.exe versions >= 16.5
++               repository + "//bazel:windows_x86_64": ["-experimental:preprocessor", "-Wv:19.4"],
+                "//conditions:default": [],
+            }) + select({
+                repository + "//bazel:no_debug_info": ["-g0"],
+diff --git a/bazel/external/quiche.BUILD b/bazel/external/quiche.BUILD
+index 7541909aa..b6b208fc5 100644
+--- a/bazel/external/quiche.BUILD
++++ b/bazel/external/quiche.BUILD
+@@ -57,16 +57,12 @@ quiche_common_copts = [
+     "-Wno-unused-function",
+     # quic_inlined_frame.h uses offsetof() to optimize memory usage in frames.
+     "-Wno-invalid-offsetof",
+-    "-Wno-range-loop-analysis",
+ ]
+ 
+ quiche_copts = select({
+     # Ignore unguarded #pragma GCC statements in QUICHE sources
+     "@envoy//bazel:windows_x86_64": ["-wd4068"],
+     # Remove these after upstream fix.
+-    "@envoy//bazel:gcc_build": [
+-        "-Wno-sign-compare",
+-    ] + quiche_common_copts,
+     "//conditions:default": quiche_common_copts,
+ })
+ 
+@@ -737,7 +733,6 @@ envoy_cc_library(
+     hdrs = [
+         "quiche/spdy/platform/api/spdy_bug_tracker.h",
+         "quiche/spdy/platform/api/spdy_containers.h",
+-        "quiche/spdy/platform/api/spdy_endianness_util.h",
+         "quiche/spdy/platform/api/spdy_estimate_memory_usage.h",
+         "quiche/spdy/platform/api/spdy_flags.h",
+         "quiche/spdy/platform/api/spdy_logging.h",
+@@ -935,6 +930,7 @@ envoy_cc_library(
+     copts = quiche_copts,
+     repository = "@envoy",
+     deps = [
++        ":http2_hpack_huffman_hpack_huffman_encoder_lib",
+         ":spdy_core_protocol_lib",
+         ":spdy_platform",
+     ],
+@@ -1049,19 +1045,16 @@ envoy_cc_library(
+ envoy_cc_library(
+     name = "quic_platform_base",
+     hdrs = [
+-        "quiche/quic/platform/api/quic_aligned.h",
+         "quiche/quic/platform/api/quic_bug_tracker.h",
+         "quiche/quic/platform/api/quic_client_stats.h",
+         "quiche/quic/platform/api/quic_containers.h",
+         "quiche/quic/platform/api/quic_error_code_wrappers.h",
+         "quiche/quic/platform/api/quic_estimate_memory_usage.h",
+         "quiche/quic/platform/api/quic_exported_stats.h",
+-        "quiche/quic/platform/api/quic_fallthrough.h",
+         "quiche/quic/platform/api/quic_flag_utils.h",
+         "quiche/quic/platform/api/quic_flags.h",
+         "quiche/quic/platform/api/quic_iovec.h",
+         "quiche/quic/platform/api/quic_logging.h",
+-        "quiche/quic/platform/api/quic_macros.h",
+         "quiche/quic/platform/api/quic_map_util.h",
+         "quiche/quic/platform/api/quic_mem_slice.h",
+         "quiche/quic/platform/api/quic_prefetch.h",
+@@ -1072,6 +1065,7 @@ envoy_cc_library(
+         "quiche/quic/platform/api/quic_stream_buffer_allocator.h",
+         "quiche/quic/platform/api/quic_string_utils.h",
+         "quiche/quic/platform/api/quic_uint128.h",
++        "quiche/quic/platform/api/quic_testvalue.h",
+         # TODO: uncomment the following files as implementations are added.
+         # "quiche/quic/platform/api/quic_fuzzed_data_provider.h",
+         # "quiche/quic/platform/api/quic_test_loopback.h",
+@@ -1147,7 +1141,6 @@ envoy_cc_test_library(
+     hdrs = ["quiche/quic/platform/api/quic_port_utils.h"],
+     repository = "@envoy",
+     tags = ["nofips"],
+-    deps = ["@envoy//test/extensions/quic_listeners/quiche/platform:quic_platform_port_utils_impl_lib"],
+ )
+ 
+ envoy_cc_library(
+@@ -1216,15 +1209,14 @@ envoy_cc_test_library(
+ )
+ 
+ envoy_cc_library(
+-    name = "quiche_common_platform_endian",
+-    hdrs = ["quiche/common/platform/api/quiche_endian.h"],
++    name = "quiche_common_endian_lib",
++    hdrs = ["quiche/common/quiche_endian.h"],
+     repository = "@envoy",
+     tags = ["nofips"],
+     visibility = ["//visibility:public"],
+     deps =
+         [
+             ":quiche_common_platform_export",
+-            "@envoy//source/extensions/quic_listeners/quiche/platform:quiche_common_platform_endian_impl_lib",
+         ],
+ )
+ 
+@@ -1932,6 +1924,7 @@ envoy_cc_library(
+     visibility = ["//visibility:public"],
+     deps = [
+         ":quic_core_clock_lib",
++        ":quic_core_crypto_certificate_view_lib",
+         ":quic_core_crypto_encryption_lib",
+         ":quic_core_crypto_hkdf_lib",
+         ":quic_core_crypto_proof_source_interface_lib",
+@@ -2167,6 +2160,15 @@ envoy_cc_library(
+     ],
+ )
+ 
++envoy_cc_library(
++    name = "quic_core_flags_list_lib",
++    hdrs = ["quiche/quic/core/quic_flags_list.h"],
++    copts = quiche_copts,
++    repository = "@envoy",
++    tags = ["nofips"],
++    visibility = ["//visibility:public"],
++)
++
+ envoy_cc_library(
+     name = "quic_core_framer_lib",
+     srcs = ["quiche/quic/core/quic_framer.cc"],
+@@ -2339,6 +2341,7 @@ envoy_cc_library(
+     repository = "@envoy",
+     tags = ["nofips"],
+     deps = [
++        ":http2_constants_lib",
+         ":quic_core_data_lib",
+         ":quic_core_error_codes_lib",
+         ":quic_core_http_http_frames_lib",
+@@ -2723,6 +2726,27 @@ envoy_cc_library(
+     ],
+ )
+ 
++envoy_cc_library(
++    name = "quic_core_path_validator_lib",
++    srcs = ["quiche/quic/core/quic_path_validator.cc"],
++    hdrs = ["quiche/quic/core/quic_path_validator.h"],
++    copts = quiche_copts,
++    repository = "@envoy",
++    tags = ["nofips"],
++    deps = [
++        ":quic_core_alarm_factory_interface_lib",
++        ":quic_core_alarm_interface_lib",
++        ":quic_core_arena_scoped_ptr_lib",
++        ":quic_core_clock_lib",
++        ":quic_core_constants_lib",
++        ":quic_core_crypto_random_lib",
++        ":quic_core_one_block_arena_lib",
++        ":quic_core_packet_writer_interface_lib",
++        ":quic_core_types_lib",
++        ":quic_platform",
++    ],
++)
++
+ envoy_cc_library(
+     name = "quic_core_process_packet_interface_lib",
+     hdrs = ["quiche/quic/core/quic_process_packet_interface.h"],
+@@ -2735,6 +2759,15 @@ envoy_cc_library(
+     ],
+ )
+ 
++envoy_cc_library(
++    name = "quic_core_protocol_flags_list_lib",
++    hdrs = ["quiche/quic/core/quic_protocol_flags_list.h"],
++    copts = quiche_copts,
++    repository = "@envoy",
++    tags = ["nofips"],
++    visibility = ["//visibility:public"],
++)
++
+ envoy_cc_library(
+     name = "quic_core_qpack_blocking_manager_lib",
+     srcs = ["quiche/quic/core/qpack/qpack_blocking_manager.cc"],
+@@ -2896,6 +2929,7 @@ envoy_cc_library(
+     deps = [
+         ":http2_decoder_decode_buffer_lib",
+         ":http2_decoder_decode_status_lib",
++        ":quic_core_error_codes_lib",
+         ":quic_core_qpack_qpack_instruction_decoder_lib",
+         ":quic_core_qpack_qpack_instructions_lib",
+         ":quic_core_qpack_qpack_stream_receiver_lib",
+@@ -3368,7 +3402,7 @@ envoy_cc_library(
+         ":quic_core_error_codes_lib",
+         ":quic_core_time_lib",
+         ":quic_platform_base",
+-        ":quiche_common_platform_endian",
++        ":quiche_common_endian_lib",
+     ],
+ )
+ 
+@@ -3420,6 +3454,7 @@ envoy_cc_library(
+     repository = "@envoy",
+     tags = ["nofips"],
+     deps = [
++        ":quic_core_circular_deque_lib",
+         ":quic_core_connection_stats_lib",
+         ":quic_core_packets_lib",
+         ":quic_core_session_notifier_interface_lib",
+@@ -3459,6 +3494,7 @@ envoy_cc_library(
+     deps = [
+         ":quic_core_versions_lib",
+         ":quic_platform_base",
++        ":quiche_common_endian_lib",
+     ],
+ )
+ 
+@@ -3475,7 +3511,6 @@ envoy_cc_library(
+         ":quic_core_tag_lib",
+         ":quic_core_types_lib",
+         ":quic_platform_base",
+-        ":quiche_common_platform_endian",
+     ],
+ )
+ 
+@@ -3746,6 +3781,7 @@ envoy_cc_test_library(
+         ":quic_core_packet_creator_lib",
+         ":quic_core_packet_writer_interface_lib",
+         ":quic_core_packets_lib",
++        ":quic_core_path_validator_lib",
+         ":quic_core_received_packet_manager_lib",
+         ":quic_core_sent_packet_manager_lib",
+         ":quic_core_server_id_lib",
+@@ -3836,25 +3872,10 @@ envoy_cc_test_library(
+     deps = [":epoll_server_platform"],
+ )
+ 
+-envoy_cc_library(
+-    name = "quiche_common_platform_optional",
+-    hdrs = ["quiche/common/platform/api/quiche_optional.h"],
+-    repository = "@envoy",
+-    tags = ["nofips"],
+-    visibility = ["//visibility:public"],
+-    deps = [
+-        ":quiche_common_platform_export",
+-        "@envoy//source/extensions/quic_listeners/quiche/platform:quiche_common_platform_optional_impl_lib",
+-    ],
+-)
+-
+ envoy_cc_library(
+     name = "quiche_common_platform",
+     hdrs = [
+-        "quiche/common/platform/api/quiche_arraysize.h",
+         "quiche/common/platform/api/quiche_logging.h",
+-        "quiche/common/platform/api/quiche_optional.h",
+-        "quiche/common/platform/api/quiche_ptr_util.h",
+         "quiche/common/platform/api/quiche_str_cat.h",
+         "quiche/common/platform/api/quiche_string_piece.h",
+         "quiche/common/platform/api/quiche_text_utils.h",
+@@ -3866,7 +3887,6 @@ envoy_cc_library(
+     visibility = ["//visibility:public"],
+     deps = [
+         ":quiche_common_platform_export",
+-        ":quiche_common_platform_optional",
+         "@envoy//source/extensions/quic_listeners/quiche/platform:quiche_common_platform_impl_lib",
+     ],
+ )
+@@ -3874,7 +3894,6 @@ envoy_cc_library(
+ envoy_cc_test_library(
+     name = "quiche_common_platform_test",
+     srcs = [
+-        "quiche/common/platform/api/quiche_endian_test.cc",
+         "quiche/common/platform/api/quiche_str_cat_test.cc",
+         "quiche/common/platform/api/quiche_text_utils_test.cc",
+         "quiche/common/platform/api/quiche_time_utils_test.cc",
+@@ -3884,7 +3903,6 @@ envoy_cc_test_library(
+     tags = ["nofips"],
+     deps = [
+         ":quiche_common_platform",
+-        ":quiche_common_platform_endian",
+         "@envoy//test/extensions/quic_listeners/quiche/platform:quiche_common_platform_test_impl_lib",
+     ],
+ )
+@@ -3904,8 +3922,8 @@ envoy_cc_library(
+     tags = ["nofips"],
+     visibility = ["//visibility:public"],
+     deps = [
++        ":quiche_common_endian_lib",
+         ":quiche_common_platform",
+-        ":quiche_common_platform_endian",
+     ],
+ )
+ 
+@@ -3944,6 +3962,7 @@ envoy_cc_test(
+     deps = [
+         ":http2_platform",
+         ":http2_test_tools_random",
++        ":quiche_common_test_tools_test_utils_lib",
+     ],
+ )
+ 
+diff --git a/bazel/repository_locations.bzl b/bazel/repository_locations.bzl
+index 6eba5a821..19ddc76e8 100644
+--- a/bazel/repository_locations.bzl
++++ b/bazel/repository_locations.bzl
+@@ -671,9 +671,9 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
+         project_name = "QUICHE",
+         project_desc = "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols",
+         project_url = "https://quiche.googlesource.com/quiche",
+-        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/f555d99a084cdd086a349548c70fb558ac5847cf.tar.gz
+-        version = "f555d99a084cdd086a349548c70fb558ac5847cf",
+-        sha256 = "1833f08e7b0f18b49d7498b029b7f3e6559a82113ec82a98a9e945553756e351",
++        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/ecc28c0d7428f3323ea26eb1ddb98a5e06b23dea.tar.gz
++        version = "ecc28c0d7428f3323ea26eb1ddb98a5e06b23dea",
++        sha256 = "52680dea984dbe899c27176155578b97276e1f1516b7c3a63fb16ba593061859",
+         urls = ["https://storage.googleapis.com/quiche-envoy-integration/{version}.tar.gz"],
+         use_category = ["dataplane_ext"],
+         extensions = ["envoy.transport_sockets.quic"],
+diff --git a/source/extensions/quic_listeners/quiche/BUILD b/source/extensions/quic_listeners/quiche/BUILD
+index 29eb78d15..a90cfde6d 100644
+--- a/source/extensions/quic_listeners/quiche/BUILD
++++ b/source/extensions/quic_listeners/quiche/BUILD
+@@ -212,6 +212,7 @@ envoy_cc_library(
+         "//source/common/buffer:buffer_lib",
+         "//source/common/common:assert_lib",
+         "//source/common/http:header_map_lib",
++        "//source/common/http:header_utility_lib",
+         "//source/extensions/quic_listeners/quiche/platform:quic_platform_mem_slice_storage_impl_lib",
+         "@com_googlesource_quiche//:quic_core_http_client_lib",
+     ],
+diff --git a/source/extensions/quic_listeners/quiche/active_quic_listener.cc b/source/extensions/quic_listeners/quiche/active_quic_listener.cc
+index f4808adc5..86912292a 100644
+--- a/source/extensions/quic_listeners/quiche/active_quic_listener.cc
++++ b/source/extensions/quic_listeners/quiche/active_quic_listener.cc
+@@ -55,7 +55,7 @@ ActiveQuicListener::ActiveQuicListener(
+   quic::QuicRandom* const random = quic::QuicRandom::GetInstance();
+   random->RandBytes(random_seed_, sizeof(random_seed_));
+   crypto_config_ = std::make_unique<quic::QuicCryptoServerConfig>(
+-      quiche::QuicheStringPiece(reinterpret_cast<char*>(random_seed_), sizeof(random_seed_)),
++      absl::string_view(reinterpret_cast<char*>(random_seed_), sizeof(random_seed_)),
+       quic::QuicRandom::GetInstance(),
+       std::make_unique<EnvoyQuicProofSource>(listen_socket_, listener_config.filterChainManager(),
+                                              stats_),
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+index e79b08ad9..95d63729d 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+@@ -43,7 +43,7 @@ EnvoyQuicClientConnection::EnvoyQuicClientConnection(
+     const quic::ParsedQuicVersionVector& supported_versions, Event::Dispatcher& dispatcher,
+     Network::ConnectionSocketPtr&& connection_socket)
+     : EnvoyQuicConnection(
+-          server_connection_id,
++          server_connection_id, quic::QuicSocketAddress(),
+           envoyIpAddressToQuicSocketAddress(connection_socket->remoteAddress()->ip()), helper,
+           alarm_factory, writer, owns_writer, quic::Perspective::IS_CLIENT, supported_versions,
+           std::move(connection_socket)),
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.cc b/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.cc
+index 866e35416..a759b26b1 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.cc
+@@ -20,6 +20,7 @@
+ 
+ #include "common/buffer/buffer_impl.h"
+ #include "common/http/header_map_impl.h"
++#include "common/http/header_utility.h"
+ #include "common/common/assert.h"
+ 
+ namespace Envoy {
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_connection.cc b/source/extensions/quic_listeners/quiche/envoy_quic_connection.cc
+index dcc311a6e..d813dfe4b 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_connection.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_connection.cc
+@@ -6,6 +6,7 @@ namespace Envoy {
+ namespace Quic {
+ 
+ EnvoyQuicConnection::EnvoyQuicConnection(const quic::QuicConnectionId& server_connection_id,
++                                         quic::QuicSocketAddress initial_self_address,
+                                          quic::QuicSocketAddress initial_peer_address,
+                                          quic::QuicConnectionHelperInterface& helper,
+                                          quic::QuicAlarmFactory& alarm_factory,
+@@ -13,8 +14,9 @@ EnvoyQuicConnection::EnvoyQuicConnection(const quic::QuicConnectionId& server_co
+                                          quic::Perspective perspective,
+                                          const quic::ParsedQuicVersionVector& supported_versions,
+                                          Network::ConnectionSocketPtr&& connection_socket)
+-    : quic::QuicConnection(server_connection_id, initial_peer_address, &helper, &alarm_factory,
+-                           writer, owns_writer, perspective, supported_versions),
++    : quic::QuicConnection(server_connection_id, initial_self_address, initial_peer_address,
++                           &helper, &alarm_factory, writer, owns_writer, perspective,
++                           supported_versions),
+       connection_socket_(std::move(connection_socket)) {}
+ 
+ EnvoyQuicConnection::~EnvoyQuicConnection() { connection_socket_->close(); }
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_connection.h b/source/extensions/quic_listeners/quiche/envoy_quic_connection.h
+index f4c8589d7..f8543bc93 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_connection.h
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_connection.h
+@@ -26,6 +26,7 @@ class EnvoyQuicConnection : public quic::QuicConnection,
+                             protected Logger::Loggable<Logger::Id::connection> {
+ public:
+   EnvoyQuicConnection(const quic::QuicConnectionId& server_connection_id,
++                      quic::QuicSocketAddress initial_self_address,
+                       quic::QuicSocketAddress initial_peer_address,
+                       quic::QuicConnectionHelperInterface& helper,
+                       quic::QuicAlarmFactory& alarm_factory, quic::QuicPacketWriter* writer,
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.cc b/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.cc
+index ba8f7f3a8..e6351f643 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.cc
+@@ -48,11 +48,11 @@ void EnvoyQuicDispatcher::OnConnectionClosed(quic::QuicConnectionId connection_i
+ }
+ 
+ std::unique_ptr<quic::QuicSession> EnvoyQuicDispatcher::CreateQuicSession(
+-    quic::QuicConnectionId server_connection_id, const quic::QuicSocketAddress& /*self_address*/,
+-    const quic::QuicSocketAddress& peer_address, quiche::QuicheStringPiece /*alpn*/,
++    quic::QuicConnectionId server_connection_id, const quic::QuicSocketAddress& self_address,
++    const quic::QuicSocketAddress& peer_address, absl::string_view /*alpn*/,
+     const quic::ParsedQuicVersion& version) {
+   auto quic_connection = std::make_unique<EnvoyQuicServerConnection>(
+-      server_connection_id, peer_address, *helper(), *alarm_factory(), writer(),
++      server_connection_id, self_address, peer_address, *helper(), *alarm_factory(), writer(),
+       /*owns_writer=*/false, quic::ParsedQuicVersionVector{version}, listen_socket_);
+   auto quic_session = std::make_unique<EnvoyQuicServerSession>(
+       config(), quic::ParsedQuicVersionVector{version}, std::move(quic_connection), this,
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.h b/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.h
+index 589ff5327..d59307f41 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.h
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_dispatcher.h
+@@ -62,7 +62,7 @@ protected:
+   std::unique_ptr<quic::QuicSession>
+   CreateQuicSession(quic::QuicConnectionId server_connection_id,
+                     const quic::QuicSocketAddress& self_address,
+-                    const quic::QuicSocketAddress& peer_address, quiche::QuicheStringPiece alpn,
++                    const quic::QuicSocketAddress& peer_address, absl::string_view alpn,
+                     const quic::ParsedQuicVersion& version) override;
+ 
+ private:
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.cc b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.cc
+index 1f65e4e7e..967765829 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.cc
+@@ -36,7 +36,7 @@ EnvoyQuicProofSource::GetCertChain(const quic::QuicSocketAddress& server_address
+ 
+ void EnvoyQuicProofSource::signPayload(
+     const quic::QuicSocketAddress& server_address, const quic::QuicSocketAddress& client_address,
+-    const std::string& hostname, uint16_t signature_algorithm, quiche::QuicheStringPiece in,
++    const std::string& hostname, uint16_t signature_algorithm, absl::string_view in,
+     std::unique_ptr<quic::ProofSource::SignatureCallback> callback) {
+   CertConfigWithFilterChain res =
+       getTlsCertConfigAndFilterChain(server_address, client_address, hostname);
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.h b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.h
+index 6e1c74c92..e22bf3465 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.h
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source.h
+@@ -28,7 +28,7 @@ protected:
+   // quic::ProofSource
+   void signPayload(const quic::QuicSocketAddress& server_address,
+                    const quic::QuicSocketAddress& client_address, const std::string& hostname,
+-                   uint16_t signature_algorithm, quiche::QuicheStringPiece in,
++                   uint16_t signature_algorithm, absl::string_view in,
+                    std::unique_ptr<quic::ProofSource::SignatureCallback> callback) override;
+ 
+ private:
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.cc b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.cc
+index 2c82c04d9..9ad3cb07f 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.cc
+@@ -21,7 +21,7 @@ void EnvoyQuicProofSourceBase::GetProof(const quic::QuicSocketAddress& server_ad
+                                         const std::string& hostname,
+                                         const std::string& server_config,
+                                         quic::QuicTransportVersion /*transport_version*/,
+-                                        quiche::QuicheStringPiece chlo_hash,
++                                        absl::string_view chlo_hash,
+                                         std::unique_ptr<quic::ProofSource::Callback> callback) {
+   quic::QuicReferenceCountedPointer<quic::ProofSource::Chain> chain =
+       GetCertChain(server_address, client_address, hostname);
+@@ -68,13 +68,12 @@ void EnvoyQuicProofSourceBase::GetProof(const quic::QuicSocketAddress& server_ad
+   auto signature_callback = std::make_unique<SignatureCallback>(std::move(callback), chain);
+ 
+   signPayload(server_address, client_address, hostname, sign_alg,
+-              quiche::QuicheStringPiece(payload.get(), payload_size),
+-              std::move(signature_callback));
++              absl::string_view(payload.get(), payload_size), std::move(signature_callback));
+ }
+ 
+ void EnvoyQuicProofSourceBase::ComputeTlsSignature(
+     const quic::QuicSocketAddress& server_address, const quic::QuicSocketAddress& client_address,
+-    const std::string& hostname, uint16_t signature_algorithm, quiche::QuicheStringPiece in,
++    const std::string& hostname, uint16_t signature_algorithm, absl::string_view in,
+     std::unique_ptr<quic::ProofSource::SignatureCallback> callback) {
+   signPayload(server_address, client_address, hostname, signature_algorithm, in,
+               std::move(callback));
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.h b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.h
+index b7d76981e..a9e7e8c3f 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.h
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_source_base.h
+@@ -57,7 +57,7 @@ public:
+   void GetProof(const quic::QuicSocketAddress& server_address,
+                 const quic::QuicSocketAddress& client_address, const std::string& hostname,
+                 const std::string& server_config, quic::QuicTransportVersion /*transport_version*/,
+-                quiche::QuicheStringPiece chlo_hash,
++                absl::string_view chlo_hash,
+                 std::unique_ptr<quic::ProofSource::Callback> callback) override;
+ 
+   TicketCrypter* GetTicketCrypter() override { return nullptr; }
+@@ -65,14 +65,14 @@ public:
+   void ComputeTlsSignature(const quic::QuicSocketAddress& server_address,
+                            const quic::QuicSocketAddress& client_address,
+                            const std::string& hostname, uint16_t signature_algorithm,
+-                           quiche::QuicheStringPiece in,
++                           absl::string_view in,
+                            std::unique_ptr<quic::ProofSource::SignatureCallback> callback) override;
+ 
+ protected:
+   virtual void signPayload(const quic::QuicSocketAddress& server_address,
+                            const quic::QuicSocketAddress& client_address,
+                            const std::string& hostname, uint16_t signature_algorithm,
+-                           quiche::QuicheStringPiece in,
++                           absl::string_view in,
+                            std::unique_ptr<quic::ProofSource::SignatureCallback> callback) PURE;
+ 
+ private:
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_base.cc b/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_base.cc
+index 229b3ab36..e37590529 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_base.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_base.cc
+@@ -58,8 +58,8 @@ bool EnvoyQuicProofVerifierBase::verifySignature(const std::string& server_confi
+     *error_details = "QuicPacketWriter error.";
+     return false;
+   }
+-  bool valid = cert_view->VerifySignature(quiche::QuicheStringPiece(payload.get(), payload_size),
+-                                          signature, sign_alg);
++  bool valid = cert_view->VerifySignature(absl::string_view(payload.get(), payload_size), signature,
++                                          sign_alg);
+   if (!valid) {
+     *error_details = "Signature is not valid.";
+   }
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.cc b/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.cc
+index b8fa94221..974c6c8eb 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.cc
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.cc
+@@ -11,11 +11,13 @@ namespace Quic {
+ 
+ EnvoyQuicServerConnection::EnvoyQuicServerConnection(
+     const quic::QuicConnectionId& server_connection_id,
+-    quic::QuicSocketAddress initial_peer_address, quic::QuicConnectionHelperInterface& helper,
+-    quic::QuicAlarmFactory& alarm_factory, quic::QuicPacketWriter* writer, bool owns_writer,
++    quic::QuicSocketAddress initial_self_address, quic::QuicSocketAddress initial_peer_address,
++    quic::QuicConnectionHelperInterface& helper, quic::QuicAlarmFactory& alarm_factory,
++    quic::QuicPacketWriter* writer, bool owns_writer,
+     const quic::ParsedQuicVersionVector& supported_versions, Network::Socket& listen_socket)
+-    : EnvoyQuicConnection(server_connection_id, initial_peer_address, helper, alarm_factory, writer,
+-                          owns_writer, quic::Perspective::IS_SERVER, supported_versions,
++    : EnvoyQuicConnection(server_connection_id, initial_self_address, initial_peer_address, helper,
++                          alarm_factory, writer, owns_writer, quic::Perspective::IS_SERVER,
++                          supported_versions,
+                           std::make_unique<Network::ConnectionSocketImpl>(
+                               // Wraps the real IoHandle instance so that if the connection socket
+                               // gets closed, the real IoHandle won't be affected.
+diff --git a/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.h b/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.h
+index 7b7fac05e..7625fad02 100644
+--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.h
++++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_connection.h
+@@ -10,6 +10,7 @@ namespace Quic {
+ class EnvoyQuicServerConnection : public EnvoyQuicConnection {
+ public:
+   EnvoyQuicServerConnection(const quic::QuicConnectionId& server_connection_id,
++                            quic::QuicSocketAddress initial_self_address,
+                             quic::QuicSocketAddress initial_peer_address,
+                             quic::QuicConnectionHelperInterface& helper,
+                             quic::QuicAlarmFactory& alarm_factory, quic::QuicPacketWriter* writer,
+diff --git a/source/extensions/quic_listeners/quiche/platform/BUILD b/source/extensions/quic_listeners/quiche/platform/BUILD
+index f53e07b58..839664d52 100644
+--- a/source/extensions/quic_listeners/quiche/platform/BUILD
++++ b/source/extensions/quic_listeners/quiche/platform/BUILD
+@@ -36,15 +36,16 @@ envoy_extension_package()
+ envoy_cc_library(
+     name = "flags_impl_lib",
+     srcs = ["flags_impl.cc"],
+-    hdrs = [
+-        "flags_impl.h",
+-        "flags_list.h",
+-    ],
++    hdrs = ["flags_impl.h"],
+     external_deps = [
+         "abseil_base",
+         "abseil_synchronization",
+     ],
+     visibility = ["//visibility:public"],
++    deps = [
++        "@com_googlesource_quiche//:quic_core_flags_list_lib",
++        "@com_googlesource_quiche//:quic_core_protocol_flags_list_lib",
++    ],
+ )
+ 
+ envoy_cc_library(
+@@ -62,7 +63,6 @@ envoy_cc_library(
+ envoy_cc_library(
+     name = "http2_platform_impl_lib",
+     hdrs = [
+-        "http2_arraysize_impl.h",
+         "http2_bug_tracker_impl.h",
+         "http2_containers_impl.h",
+         "http2_estimate_memory_usage_impl.h",
+@@ -74,7 +74,6 @@ envoy_cc_library(
+     ],
+     external_deps = [
+         "abseil_base",
+-        "abseil_optional",
+         "abseil_str_format",
+     ],
+     visibility = ["//visibility:public"],
+@@ -114,16 +113,13 @@ envoy_cc_library(
+         "quic_mem_slice_impl.cc",
+     ],
+     hdrs = [
+-        "quic_aligned_impl.h",
+         "quic_client_stats_impl.h",
+         "quic_containers_impl.h",
+         "quic_error_code_wrappers_impl.h",
+         "quic_estimate_memory_usage_impl.h",
+-        "quic_fallthrough_impl.h",
+         "quic_flag_utils_impl.h",
+         "quic_flags_impl.h",
+         "quic_iovec_impl.h",
+-        "quic_macros_impl.h",
+         "quic_map_util_impl.h",
+         "quic_mem_slice_impl.h",
+         "quic_prefetch_impl.h",
+@@ -132,6 +128,7 @@ envoy_cc_library(
+         "quic_server_stats_impl.h",
+         "quic_stack_trace_impl.h",
+         "quic_stream_buffer_allocator_impl.h",
++        "quic_testvalue_impl.h",
+         "quic_uint128_impl.h",
+     ],
+     external_deps = [
+@@ -141,7 +138,6 @@ envoy_cc_library(
+         "abseil_memory",
+         "abseil_node_hash_map",
+         "abseil_node_hash_set",
+-        "abseil_optional",
+     ],
+     tags = ["nofips"],
+     visibility = ["//visibility:public"],
+@@ -236,6 +232,7 @@ envoy_cc_library(
+     }),
+     repository = "@envoy",
+     tags = ["nofips"],
++    visibility = ["//visibility:public"],
+ )
+ 
+ envoy_cc_library(
+@@ -250,23 +247,12 @@ envoy_cc_library(
+     ],
+ )
+ 
+-envoy_cc_library(
+-    name = "quiche_common_platform_optional_impl_lib",
+-    hdrs = ["quiche_optional_impl.h"],
+-    external_deps = [
+-        "abseil_node_hash_map",
+-    ],
+-    visibility = ["//visibility:public"],
+-)
+-
+ envoy_cc_library(
+     name = "quiche_common_platform_impl_lib",
+     srcs = ["quiche_time_utils_impl.cc"],
+     hdrs = [
+-        "quiche_arraysize_impl.h",
+         "quiche_logging_impl.h",
+         "quiche_map_util_impl.h",
+-        "quiche_ptr_util_impl.h",
+         "quiche_str_cat_impl.h",
+         "quiche_string_piece_impl.h",
+         "quiche_text_utils_impl.h",
+@@ -281,17 +267,14 @@ envoy_cc_library(
+     deps = [
+         ":quic_platform_logging_impl_lib",
+         ":string_utils_lib",
+-        "@com_googlesource_quiche//:quiche_common_platform_optional",
+     ],
+ )
+ 
+ envoy_cc_library(
+     name = "spdy_platform_impl_lib",
+     hdrs = [
+-        "spdy_arraysize_impl.h",
+         "spdy_bug_tracker_impl.h",
+         "spdy_containers_impl.h",
+-        "spdy_endianness_util_impl.h",
+         "spdy_estimate_memory_usage_impl.h",
+         "spdy_flags_impl.h",
+         "spdy_logging_impl.h",
+@@ -331,14 +314,3 @@ envoy_cc_library(
+     tags = ["nofips"],
+     visibility = ["//visibility:public"],
+ )
+-
+-envoy_cc_library(
+-    name = "quiche_common_platform_endian_impl_lib",
+-    hdrs = ["quiche_endian_impl.h"],
+-    tags = ["nofips"],
+-    visibility = ["//visibility:public"],
+-    deps = [
+-        "quiche_common_platform_export_impl_lib",
+-        "//source/common/common:byte_order_lib",
+-    ],
+-)
+diff --git a/source/extensions/quic_listeners/quiche/platform/flags_impl.cc b/source/extensions/quic_listeners/quiche/platform/flags_impl.cc
+index 70fb182d6..9d4ea89ce 100644
+--- a/source/extensions/quic_listeners/quiche/platform/flags_impl.cc
++++ b/source/extensions/quic_listeners/quiche/platform/flags_impl.cc
+@@ -15,12 +15,24 @@ namespace quiche {
+ 
+ namespace {
+ 
+-absl::flat_hash_map<std::string, Flag*> MakeFlagMap() {
++absl::flat_hash_map<std::string, Flag*> makeFlagMap() {
+   absl::flat_hash_map<std::string, Flag*> flags;
+ 
+-#define QUICHE_FLAG(type, flag, value, help) flags.emplace(FLAGS_##flag->name(), FLAGS_##flag);
+-#include "extensions/quic_listeners/quiche/platform/flags_list.h"
+-#undef QUICHE_FLAG
++#define QUIC_FLAG(flag, ...) flags.emplace(flag->name(), flag);
++#include "quiche/quic/core/quic_flags_list.h"
++  QUIC_FLAG(FLAGS_quic_reloadable_flag_spdy_testonly_default_false, false)
++  QUIC_FLAG(FLAGS_quic_reloadable_flag_spdy_testonly_default_true, true)
++  QUIC_FLAG(FLAGS_quic_restart_flag_spdy_testonly_default_false, false)
++  QUIC_FLAG(FLAGS_quic_restart_flag_spdy_testonly_default_true, true)
++  QUIC_FLAG(FLAGS_quic_reloadable_flag_http2_testonly_default_false, false)
++  QUIC_FLAG(FLAGS_quic_reloadable_flag_http2_testonly_default_true, true)
++  QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_false, false)
++  QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_true, true)
++#undef QUIC_FLAG
++
++#define QUIC_PROTOCOL_FLAG(type, flag, ...) flags.emplace(FLAGS_##flag->name(), FLAGS_##flag);
++#include "quiche/quic/core/quic_protocol_flags_list.h"
++#undef QUIC_PROTOCOL_FLAG
+ 
+   return flags;
+ }
+@@ -28,75 +40,123 @@ absl::flat_hash_map<std::string, Flag*> MakeFlagMap() {
+ } // namespace
+ 
+ // static
+-FlagRegistry& FlagRegistry::GetInstance() {
++FlagRegistry& FlagRegistry::getInstance() {
+   static auto* instance = new FlagRegistry();
+   return *instance;
+ }
+ 
+-FlagRegistry::FlagRegistry() : flags_(MakeFlagMap()) {}
++FlagRegistry::FlagRegistry() : flags_(makeFlagMap()) {}
+ 
+-void FlagRegistry::ResetFlags() const {
++void FlagRegistry::resetFlags() const {
+   for (auto& kv : flags_) {
+-    kv.second->ResetValue();
++    kv.second->resetValue();
+   }
+ }
+ 
+-Flag* FlagRegistry::FindFlag(const std::string& name) const {
++Flag* FlagRegistry::findFlag(const std::string& name) const {
+   auto it = flags_.find(name);
+   return (it != flags_.end()) ? it->second : nullptr;
+ }
+ 
+-template <> bool TypedFlag<bool>::SetValueFromString(const std::string& value_str) {
++template <> bool TypedFlag<bool>::setValueFromString(const std::string& value_str) {
+   static const auto* kTrueValues = new std::set<std::string>({"1", "t", "true", "y", "yes"});
+   static const auto* kFalseValues = new std::set<std::string>({"0", "f", "false", "n", "no"});
+   auto lower = absl::AsciiStrToLower(value_str);
+   if (kTrueValues->find(lower) != kTrueValues->end()) {
+-    SetValue(true);
++    setValue(true);
+     return true;
+   }
+   if (kFalseValues->find(lower) != kFalseValues->end()) {
+-    SetValue(false);
++    setValue(false);
+     return true;
+   }
+   return false;
+ }
+ 
+-template <> bool TypedFlag<int32_t>::SetValueFromString(const std::string& value_str) {
++template <> bool TypedFlag<int32_t>::setValueFromString(const std::string& value_str) {
+   int32_t value;
+   if (absl::SimpleAtoi(value_str, &value)) {
+-    SetValue(value);
++    setValue(value);
+     return true;
+   }
+   return false;
+ }
+ 
+-template <> bool TypedFlag<int64_t>::SetValueFromString(const std::string& value_str) {
++template <> bool TypedFlag<int64_t>::setValueFromString(const std::string& value_str) {
+   int64_t value;
+   if (absl::SimpleAtoi(value_str, &value)) {
+-    SetValue(value);
++    setValue(value);
+     return true;
+   }
+   return false;
+ }
+ 
+-template <> bool TypedFlag<double>::SetValueFromString(const std::string& value_str) {
++template <> bool TypedFlag<double>::setValueFromString(const std::string& value_str) {
+   double value;
+   if (absl::SimpleAtod(value_str, &value)) {
+-    SetValue(value);
++    setValue(value);
+     return true;
+   }
+   return false;
+ }
+ 
+-template <> bool TypedFlag<std::string>::SetValueFromString(const std::string& value_str) {
+-  SetValue(value_str);
++template <> bool TypedFlag<std::string>::setValueFromString(const std::string& value_str) {
++  setValue(value_str);
+   return true;
+ }
+ 
++template <> bool TypedFlag<unsigned long>::setValueFromString(const std::string& value_str) {
++  unsigned long value;
++  if (absl::SimpleAtoi(value_str, &value)) {
++    setValue(value);
++    return true;
++  }
++  return false;
++}
++
++template <> bool TypedFlag<unsigned long long>::setValueFromString(const std::string& value_str) {
++  unsigned long long value;
++  if (absl::SimpleAtoi(value_str, &value)) {
++    setValue(value);
++    return true;
++  }
++  return false;
++}
++
+ // Flag definitions
+-#define QUICHE_FLAG(type, flag, value, help)                                                       \
+-  TypedFlag<type>* FLAGS_##flag = new TypedFlag<type>(#flag, value, help);
+-#include "extensions/quic_listeners/quiche/platform/flags_list.h"
+-#undef QUICHE_FLAG
++#define QUIC_FLAG(flag, value) TypedFlag<bool>* flag = new TypedFlag<bool>(#flag, value, "");
++#include "quiche/quic/core/quic_flags_list.h"
++QUIC_FLAG(FLAGS_quic_reloadable_flag_spdy_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_reloadable_flag_spdy_testonly_default_true, true)
++QUIC_FLAG(FLAGS_quic_restart_flag_spdy_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_restart_flag_spdy_testonly_default_true, true)
++QUIC_FLAG(FLAGS_quic_reloadable_flag_http2_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_reloadable_flag_http2_testonly_default_true, true)
++QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_true, true)
++
++#undef QUIC_FLAG
++
++#define STRINGIFY(X) #X
++
++#define DEFINE_QUIC_PROTOCOL_FLAG_IMPL(type, flag, value, help)                                    \
++  TypedFlag<type>* FLAGS_##flag = new TypedFlag<type>(STRINGIFY(FLAGS_##flag), value, help);
++
++#define DEFINE_QUIC_PROTOCOL_FLAG_SINGLE_VALUE(type, flag, value, doc)                             \
++  DEFINE_QUIC_PROTOCOL_FLAG_IMPL(type, flag, value, doc)
++
++#define DEFINE_QUIC_PROTOCOL_FLAG_TWO_VALUES(type, flag, internal_value, external_value, doc)      \
++  DEFINE_QUIC_PROTOCOL_FLAG_IMPL(type, flag, external_value, doc)
++
++// Select the right macro based on the number of arguments.
++#define GET_6TH_ARG(arg1, arg2, arg3, arg4, arg5, arg6, ...) arg6
++
++#define QUIC_PROTOCOL_FLAG_MACRO_CHOOSER(...)                                                      \
++  GET_6TH_ARG(__VA_ARGS__, DEFINE_QUIC_PROTOCOL_FLAG_TWO_VALUES,                                   \
++              DEFINE_QUIC_PROTOCOL_FLAG_SINGLE_VALUE)
++
++#define QUIC_PROTOCOL_FLAG(...) QUIC_PROTOCOL_FLAG_MACRO_CHOOSER(__VA_ARGS__)(__VA_ARGS__)
++#include "quiche/quic/core/quic_protocol_flags_list.h"
++#undef QUIC_PROTOCOL_FLAG
+ 
+ } // namespace quiche
+diff --git a/source/extensions/quic_listeners/quiche/platform/flags_impl.h b/source/extensions/quic_listeners/quiche/platform/flags_impl.h
+index 5db939925..83ed8430c 100644
+--- a/source/extensions/quic_listeners/quiche/platform/flags_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/flags_impl.h
+@@ -26,13 +26,13 @@ public:
+   ~FlagRegistry() = default;
+ 
+   // Return singleton instance.
+-  static FlagRegistry& GetInstance();
++  static FlagRegistry& getInstance();
+ 
+   // Reset all registered flags to their default values.
+-  void ResetFlags() const;
++  void resetFlags() const;
+ 
+   // Look up a flag by name.
+-  Flag* FindFlag(const std::string& name) const;
++  Flag* findFlag(const std::string& name) const;
+ 
+ private:
+   FlagRegistry();
+@@ -48,10 +48,10 @@ public:
+   virtual ~Flag() = default;
+ 
+   // Set flag value from given string, returning true iff successful.
+-  virtual bool SetValueFromString(const std::string& value_str) = 0;
++  virtual bool setValueFromString(const std::string& value_str) = 0;
+ 
+   // Reset flag to default value.
+-  virtual void ResetValue() = 0;
++  virtual void resetValue() = 0;
+ 
+   // Return flag name.
+   std::string name() const { return name_; }
+@@ -70,15 +70,15 @@ public:
+   TypedFlag(const char* name, T default_value, const char* help)
+       : Flag(name, help), value_(default_value), default_value_(default_value) {}
+ 
+-  bool SetValueFromString(const std::string& value_str) override;
++  bool setValueFromString(const std::string& value_str) override;
+ 
+-  void ResetValue() override {
++  void resetValue() override {
+     absl::MutexLock lock(&mutex_);
+     value_ = default_value_;
+   }
+ 
+   // Set flag value.
+-  void SetValue(T value) {
++  void setValue(T value) {
+     absl::MutexLock lock(&mutex_);
+     value_ = value;
+   }
+@@ -96,15 +96,29 @@ private:
+ };
+ 
+ // SetValueFromString specializations
+-template <> bool TypedFlag<bool>::SetValueFromString(const std::string& value_str);
+-template <> bool TypedFlag<int32_t>::SetValueFromString(const std::string& value_str);
+-template <> bool TypedFlag<int64_t>::SetValueFromString(const std::string& value_str);
+-template <> bool TypedFlag<double>::SetValueFromString(const std::string& value_str);
+-template <> bool TypedFlag<std::string>::SetValueFromString(const std::string& value_str);
++template <> bool TypedFlag<bool>::setValueFromString(const std::string& value_str);
++template <> bool TypedFlag<int32_t>::setValueFromString(const std::string& value_str);
++template <> bool TypedFlag<int64_t>::setValueFromString(const std::string& value_str);
++template <> bool TypedFlag<double>::setValueFromString(const std::string& value_str);
++template <> bool TypedFlag<std::string>::setValueFromString(const std::string& value_str);
++template <> bool TypedFlag<unsigned long>::setValueFromString(const std::string& value_str);
++template <> bool TypedFlag<unsigned long long>::setValueFromString(const std::string& value_str);
+ 
+ // Flag declarations
+-#define QUICHE_FLAG(type, flag, value, help) extern TypedFlag<type>* FLAGS_##flag;
+-#include "extensions/quic_listeners/quiche/platform/flags_list.h"
+-#undef QUICHE_FLAG
++#define QUIC_FLAG(flag, ...) extern TypedFlag<bool>* flag;
++#include "quiche/quic/core/quic_flags_list.h"
++QUIC_FLAG(FLAGS_quic_reloadable_flag_spdy_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_reloadable_flag_spdy_testonly_default_true, true)
++QUIC_FLAG(FLAGS_quic_restart_flag_spdy_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_restart_flag_spdy_testonly_default_true, true)
++QUIC_FLAG(FLAGS_quic_reloadable_flag_http2_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_reloadable_flag_http2_testonly_default_true, true)
++QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_false, false)
++QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_true, true)
++#undef QUIC_FLAG
++
++#define QUIC_PROTOCOL_FLAG(type, flag, ...) extern TypedFlag<type>* FLAGS_##flag;
++#include "quiche/quic/core/quic_protocol_flags_list.h"
++#undef QUIC_PROTOCOL_FLAG
+ 
+ } // namespace quiche
+diff --git a/source/extensions/quic_listeners/quiche/platform/flags_list.h b/source/extensions/quic_listeners/quiche/platform/flags_list.h
+deleted file mode 100644
+index 7e9e20a7c..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/flags_list.h
++++ /dev/null
+@@ -1,502 +0,0 @@
+-// This file intentionally does not have header guards. It is intended to be
+-// included multiple times, each time with a different definition of
+-// QUICHE_FLAG.
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-// This file is generated by //third_party/quic/tools:quic_flags_list in
+-// Google3.
+-
+-#if defined(QUICHE_FLAG)
+-
+-QUICHE_FLAG(
+-    bool, http2_reloadable_flag_http2_backend_alpn_failure_error_code, false,
+-    "If true, the GFE will return a new ResponseCodeDetails error when ALPN to the backend fails.")
+-
+-QUICHE_FLAG(bool, http2_reloadable_flag_http2_ip_based_cwnd_exp, true,
+-            "If true, enable IP address based CWND bootstrapping experiment with different "
+-            "bandwidth models and priorities in HTTP2.")
+-
+-QUICHE_FLAG(
+-    bool, http2_reloadable_flag_http2_load_based_goaway_warning, false,
+-    "If true, load-based connection closures will send a warning GOAWAY before the actual GOAWAY.")
+-
+-QUICHE_FLAG(bool, http2_reloadable_flag_http2_security_requirement_for_client3, false,
+-            "If true, check whether client meets security requirements during SSL handshake. If "
+-            "flag is true and client does not meet security requirements, do not negotiate HTTP/2 "
+-            "with client or terminate the session with SPDY_INADEQUATE_SECURITY if HTTP/2 is "
+-            "already negotiated. The spec contains both cipher and TLS version requirements.")
+-
+-QUICHE_FLAG(bool, http2_reloadable_flag_http2_websocket_detection, false,
+-            "If true, uses a HTTP/2-specific method of detecting websocket upgrade requests.")
+-
+-QUICHE_FLAG(bool, http2_reloadable_flag_permissive_http2_switch, false,
+-            "If true, the GFE allows both HTTP/1.0 and HTTP/1.1 versions in HTTP/2 upgrade "
+-            "requests/responses.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_advertise_quic_for_https_for_debugips, false, "")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_advertise_quic_for_https_for_external_users, false, "")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_gclb_quic_allow_alia, true,
+-            "If gfe2_reloadable_flag_gclb_use_alia is also true, use Alia for GCLB QUIC "
+-            "handshakes. To be used as a big red button if there's a problem with Alia/QUIC.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_abort_qpack_on_stream_close, false,
+-            "If true, abort async QPACK header decompression in QuicSpdyStream::OnClose().")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_ack_delay_alarm_granularity, false,
+-            "When true, ensure the ACK delay is never less than the alarm granularity when ACK "
+-            "decimation is enabled.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_add_missing_connected_checks, false,
+-            "If true, add missing connected checks.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_add_silent_idle_timeout, true,
+-            "If true, when server is silently closing connections due to idle timeout, serialize "
+-            "the connection close packets which will be added to time wait list.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_add_stream_info_to_idle_close_detail, false,
+-            "If true, include stream information in idle timeout connection close detail.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_allow_backend_set_stream_ttl, false,
+-            "If true, check backend response header for X-Response-Ttl. If it is provided, the "
+-            "stream TTL is set. A QUIC stream will be immediately canceled when tries to write "
+-            "data if this TTL expired.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_allow_client_enabled_bbr_v2, true,
+-            "If true, allow client to enable BBRv2 on server via connection option 'B2ON'.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_alpn_dispatch, false,
+-            "Support different QUIC sessions, as indicated by ALPN. Used for QBONE.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_bbr2_avoid_too_low_probe_bw_cwnd, false,
+-            "If true, QUIC BBRv2's PROBE_BW mode will not reduce cwnd below BDP+ack_height.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_bbr2_fewer_startup_round_trips, false,
+-            "When true, the 1RTT and 2RTT connection options decrease the number of round trips in "
+-            "BBRv2 STARTUP without a 25% bandwidth increase to 1 or 2 round trips respectively.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_bbr2_limit_inflight_hi, false,
+-    "When true, the B2HI connection option limits reduction of inflight_hi to (1-Beta)*CWND.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_bbr2_use_post_inflight_to_detect_queuing, false,
+-            "If true, QUIC BBRv2 will use inflight byte after congestion event to detect queuing "
+-            "during PROBE_UP.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_bbr_no_bytes_acked_in_startup_recovery, false,
+-            "When in STARTUP and recovery, do not add bytes_acked to QUIC BBR's CWND in "
+-            "CalculateCongestionWindow()")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_bootstrap_cwnd_by_spdy_priority, true,
+-            "If true, bootstrap initial QUIC cwnd by SPDY priorities.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_cap_large_client_initial_rtt, true,
+-            "If true, cap client suggested initial RTT to 1s if it is longer than 1s.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_clean_up_spdy_session_destructor, false,
+-            "If true, QuicSpdySession's destructor won't need to do cleanup.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_close_connection_in_on_can_write_with_blocked_writer,
+-            false,
+-            "If true, close connection if writer is still blocked while OnCanWrite is called.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_close_connection_on_serialization_failure, false,
+-            "If true, close connection on packet serialization failures.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_conservative_bursts, false,
+-            "If true, set burst token to 2 in cwnd bootstrapping experiment.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_conservative_cwnd_and_pacing_gains, false,
+-            "If true, uses conservative cwnd gain and pacing gain when cwnd gets bootstrapped.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_copy_bbr_cwnd_to_bbr2, false,
+-    "If true, when switching from BBR to BBRv2, BBRv2 will use BBR's cwnd as its initial cwnd.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_default_enable_5rto_blackhole_detection2, true,
+-            "If true, default-enable 5RTO blachole detection.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_default_on_pto, false,
+-            "If true, default on PTO which unifies TLP + RTO loss recovery.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_default_to_bbr, true,
+-            "When true, defaults to BBR congestion control instead of Cubic.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_default_to_bbr_v2, false,
+-            "If true, use BBRv2 as the default congestion controller. Takes precedence over "
+-            "--quic_default_to_bbr.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_server_blackhole_detection, false,
+-            "If true, disable blackhole detection on server side.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_draft_27, false,
+-            "If true, disable QUIC version h3-27.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_draft_29, false,
+-            "If true, disable QUIC version h3-29.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_q043, false,
+-            "If true, disable QUIC version Q043.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_q046, false,
+-            "If true, disable QUIC version Q046.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_q050, false,
+-            "If true, disable QUIC version Q050.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_t050, false,
+-            "If true, disable QUIC version h3-T050.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_disable_version_t051, false,
+-            "If true, disable QUIC version h3-T051.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_discard_initial_packet_with_key_dropped, false,
+-            "If true, discard INITIAL packet if the key has been dropped.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_do_not_accept_stop_waiting, false,
+-    "In v44 and above, where STOP_WAITING is never sent, close the connection if it's received.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_donot_reset_ideal_next_packet_send_time, false,
+-            "If true, stop resetting ideal_next_packet_send_time_ in pacing sender.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_enable_loss_detection_experiment_at_gfe, false,
+-            "If ture, enable GFE-picked loss detection experiment.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_enable_loss_detection_tuner, false,
+-            "If true, allow QUIC loss detection tuning to be enabled by connection option ELDT.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_enable_mtu_discovery_at_server, false,
+-    "If true, QUIC will default enable MTU discovery at server, with a target of 1450 bytes.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_enabled, false, "")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_fix_arm_pto_for_application_data, false,
+-            "If true, do not arm PTO for application data until handshake confirmed.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_fix_bytes_left_for_batch_write, false,
+-            "If true, convert bytes_left_for_batch_write_ to unsigned int.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_fix_http3_goaway_stream_id, false,
+-    "If true, send the lowest stream ID that can be retried by the client in a GOAWAY frame. If "
+-    "false, send the highest received stream ID, which actually should not be retried.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_fix_out_of_order_sending, false,
+-            "If true, fix a potential out of order sending caused by handshake gets confirmed "
+-            "while the coalescer is not empty.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_fix_pto_pending_timer_count, false,
+-    "If true, make sure there is pending timer credit when trying to PTO retransmit any packets.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_fix_undecryptable_packets2, false,
+-            "If true, remove processed undecryptable packets.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_get_stream_information_from_stream_map, true,
+-            "If true, gQUIC will only consult stream_map in QuicSession::GetNumActiveStreams().")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_give_sent_packet_to_debug_visitor_after_sent, false,
+-            "If true, QUIC connection will pass sent packet information to the debug visitor after "
+-            "a packet is recorded as sent in sent packet manager.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_http3_new_default_urgency_value, false,
+-            "If true, QuicStream::kDefaultUrgency is 3, otherwise 1.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_ip_based_cwnd_exp, true,
+-            "If true, enable IP address based CWND bootstrapping experiment with different "
+-            "bandwidth models and priorities. ")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_listener_never_fake_epollout, false,
+-            "If true, QuicListener::OnSocketIsWritable will always return false, which means there "
+-            "will never be a fake EPOLLOUT event in the next epoll iteration.")
+-
+-QUICHE_FLAG(bool,
+-            quic_reloadable_flag_quic_neuter_initial_packet_in_coalescer_with_initial_key_discarded,
+-            false, "If true, neuter initial packet in the coalescer when discarding initial keys.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_no_dup_experiment_id_2, false,
+-            "If true, transport connection stats doesn't report duplicated experiments for same "
+-            "connection.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_no_silent_close_for_idle_timeout, true,
+-            "If true, always send connection close for idle timeout if NSLC is received.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_only_set_uaid_in_tcs_visitor, false,
+-            "If true, QuicTransportConnectionStatsVisitor::PopulateTransportConnectionStats will "
+-            "be the only place where TCS's uaid field is set.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_only_truncate_long_cids, true,
+-            "In IETF QUIC, only truncate long CIDs from the client's Initial, don't modify them.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_preferred_altsvc_version, false,
+-            "When true, we will send a preferred QUIC version at the start of our Alt-Svc list.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_proxy_write_packed_strings, false,
+-            "If true, QuicProxyDispatcher will write packed_client_address and packed_server_vip "
+-            "in TcpProxyHeaderProto.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_record_frontend_service_vip_mapping, true,
+-            "If true, for L1 GFE, as requests come in, record frontend service to VIP mapping "
+-            "which is used to announce VIP in SHLO for proxied sessions. ")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_record_received_min_ack_delay, false,
+-            "If true, record the received min_ack_delay in transport parameters to QUIC config.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_reject_all_traffic, false, "")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_remove_zombie_streams, true,
+-            "If true, QuicSession doesn't keep a separate zombie_streams. Instead, all streams are "
+-            "stored in stream_map_.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_require_handshake_confirmation, false,
+-            "If true, require handshake confirmation for QUIC connections, functionally disabling "
+-            "0-rtt handshakes.")
+-
+-QUICHE_FLAG(
+-    bool, quic_reloadable_flag_quic_send_key_update_not_yet_supported, false,
+-    "When true, QUIC+TLS versions will send the key_update_not_yet_supported transport parameter.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_send_path_response, false,
+-            "If true, send PATH_RESPONSE upon receiving PATH_CHALLENGE regardless of perspective. "
+-            "--gfe2_reloadable_flag_quic_start_peer_migration_earlier has to be true before turn "
+-            "on this flag.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_send_timestamps, false,
+-            "When the STMP connection option is sent by the client, timestamps in the QUIC ACK "
+-            "frame are sent and processed.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_server_push, false,
+-            "If true, enable server push feature on QUIC.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_set_resumed_ssl_session_early, false,
+-            "If true, set resumed_ssl_session if this is a 0-RTT connection.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_start_peer_migration_earlier, false,
+-            "If true, while reading an IETF quic packet, start peer migration immediately when "
+-            "detecting the existence of any non-probing frame instead of at the end of the packet.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_stop_sending_uses_ietf_error_code, false,
+-            "If true, use IETF QUIC application error codes in STOP_SENDING frames. If false, use "
+-            "QuicRstStreamErrorCodes.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_testonly_default_false, false,
+-            "A testonly reloadable flag that will always default to false.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_testonly_default_true, true,
+-            "A testonly reloadable flag that will always default to true.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_unified_iw_options, false,
+-            "When true, set the initial congestion control window from connection options in "
+-            "QuicSentPacketManager rather than TcpCubicSenderBytes.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_use_header_stage_idle_list2, false,
+-            "If true, use header stage idle list for QUIC connections in GFE.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_quic_use_leto_key_exchange, false,
+-            "If true, QUIC will attempt to use the Leto key exchange service and only fall back to "
+-            "local key exchange if that fails.")
+-
+-QUICHE_FLAG(bool, quic_reloadable_flag_send_quic_fallback_server_config_on_leto_error, false,
+-            "If true and using Leto for QUIC shared-key calculations, GFE will react to a failure "
+-            "to contact Leto by sending a REJ containing a fallback ServerConfig, allowing the "
+-            "client to continue the handshake.")
+-
+-QUICHE_FLAG(
+-    bool, quic_restart_flag_dont_fetch_quic_private_keys_from_leto, false,
+-    "If true, GFE will not request private keys when fetching QUIC ServerConfigs from Leto.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_adjust_initial_cwnd_by_gws, true,
+-            "If true, GFE informs backend that a client request is the first one on the connection "
+-            "via frontline header \"first_request=1\". Also, adjust initial cwnd based on "
+-            "X-Google-Gws-Initial-Cwnd-Mode sent by GWS.")
+-
+-QUICHE_FLAG(
+-    bool, quic_restart_flag_quic_allow_loas_multipacket_chlo, false,
+-    "If true, inspects QUIC CHLOs for kLOAS and early creates sessions to allow multi-packet CHLOs")
+-
+-QUICHE_FLAG(
+-    bool, quic_restart_flag_quic_disable_gws_cwnd_experiment, false,
+-    "If true, X-Google-Gws-Initial-Cwnd-Mode related header sent by GWS becomes no-op for QUIC.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_enable_tls_resumption_v4, true,
+-            "If true, enables support for TLS resumption in QUIC.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_enable_zero_rtt_for_tls_v2, true,
+-            "If true, support for IETF QUIC 0-rtt is enabled.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_offload_pacing_to_usps2, false,
+-            "If true, QUIC offload pacing when using USPS as egress method.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_rx_ring_use_tpacket_v3, false,
+-            "If true, use TPACKET_V3 for QuicRxRing instead of TPACKET_V2.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_should_accept_new_connection, false,
+-            "If true, reject QUIC CHLO packets when dispatcher is asked to do so.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_support_release_time_for_gso, false,
+-            "If true, QuicGsoBatchWriter will support release time if it is available and the "
+-            "process has the permission to do so.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_testonly_default_false, false,
+-            "A testonly restart flag that will always default to false.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_testonly_default_true, true,
+-            "A testonly restart flag that will always default to true.")
+-
+-QUICHE_FLAG(
+-    bool, quic_restart_flag_quic_use_leto_for_quic_configs, false,
+-    "If true, use Leto to fetch QUIC server configs instead of using the seeds from Memento.")
+-
+-QUICHE_FLAG(bool, quic_restart_flag_quic_use_pigeon_socket_to_backend, false,
+-            "If true, create a shared pigeon socket for all quic to backend connections and switch "
+-            "to use it after successful handshake.")
+-
+-QUICHE_FLAG(bool, spdy_reloadable_flag_quic_bootstrap_cwnd_by_spdy_priority, true,
+-            "If true, bootstrap initial QUIC cwnd by SPDY priorities.")
+-
+-QUICHE_FLAG(bool, spdy_reloadable_flag_quic_clean_up_spdy_session_destructor, false,
+-            "If true, QuicSpdySession's destructor won't need to do cleanup.")
+-
+-QUICHE_FLAG(
+-    bool, spdy_reloadable_flag_spdy_discard_response_body_if_disallowed, false,
+-    "If true, SPDY will discard all response body bytes when response code indicates no response "
+-    "body should exist. Previously, we only discard partial bytes on the first response processing "
+-    "and the rest of the response bytes would still be delivered even though the response code "
+-    "said there should not be any body associated with the response code.")
+-
+-QUICHE_FLAG(bool, quic_allow_chlo_buffering, true,
+-            "If true, allows packets to be buffered in anticipation of a "
+-            "future CHLO, and allow CHLO packets to be buffered until next "
+-            "iteration of the event loop.")
+-
+-QUICHE_FLAG(bool, quic_disable_pacing_for_perf_tests, false, "If true, disable pacing in QUIC")
+-
+-QUICHE_FLAG(bool, quic_enforce_single_packet_chlo, true,
+-            "If true, enforce that QUIC CHLOs fit in one packet")
+-
+-QUICHE_FLAG(int64_t, quic_time_wait_list_max_connections, 600000,
+-            "Maximum number of connections on the time-wait list. "
+-            "A negative value implies no configured limit.")
+-
+-QUICHE_FLAG(int64_t, quic_time_wait_list_seconds, 200,
+-            "Time period for which a given connection_id should live in "
+-            "the time-wait state.")
+-
+-QUICHE_FLAG(double, quic_bbr_cwnd_gain, 2.0f,
+-            "Congestion window gain for QUIC BBR during PROBE_BW phase.")
+-
+-QUICHE_FLAG(int32_t, quic_buffered_data_threshold, 8 * 1024,
+-            "If buffered data in QUIC stream is less than this "
+-            "threshold, buffers all provided data or asks upper layer for more data")
+-
+-QUICHE_FLAG(int32_t, quic_send_buffer_max_data_slice_size, 4 * 1024,
+-            "Max size of data slice in bytes for QUIC stream send buffer.")
+-
+-QUICHE_FLAG(int32_t, quic_lumpy_pacing_size, 2,
+-            "Number of packets that the pacing sender allows in bursts during "
+-            "pacing. This flag is ignored if a flow's estimated bandwidth is "
+-            "lower than 1200 kbps.")
+-
+-QUICHE_FLAG(double, quic_lumpy_pacing_cwnd_fraction, 0.25f,
+-            "Congestion window fraction that the pacing sender allows in bursts "
+-            "during pacing.")
+-
+-QUICHE_FLAG(int32_t, quic_max_pace_time_into_future_ms, 10,
+-            "Max time that QUIC can pace packets into the future in ms.")
+-
+-QUICHE_FLAG(double, quic_pace_time_into_future_srtt_fraction, 0.125f,
+-            "Smoothed RTT fraction that a connection can pace packets into the future.")
+-
+-QUICHE_FLAG(bool, quic_export_server_num_packets_per_write_histogram, false,
+-            "If true, export number of packets written per write operation histogram.")
+-
+-QUICHE_FLAG(bool, quic_disable_version_negotiation_grease_randomness, false,
+-            "If true, use predictable version negotiation versions.")
+-
+-QUICHE_FLAG(bool, quic_enable_http3_grease_randomness, true,
+-            "If true, use random greased settings and frames.")
+-
+-QUICHE_FLAG(int64_t, quic_max_tracked_packet_count, 10000, "Maximum number of tracked packets.")
+-
+-QUICHE_FLAG(bool, quic_prober_uses_length_prefixed_connection_ids, false,
+-            "If true, QuicFramer::WriteClientVersionNegotiationProbePacket uses "
+-            "length-prefixed connection IDs.")
+-
+-QUICHE_FLAG(bool, quic_client_convert_http_header_name_to_lowercase, true,
+-            "If true, HTTP request header names sent from QuicSpdyClientBase(and "
+-            "descendents) will be automatically converted to lower case.")
+-
+-QUICHE_FLAG(bool, quic_enable_http3_server_push, false,
+-            "If true, server push will be allowed in QUIC versions that use HTTP/3.")
+-
+-QUICHE_FLAG(int32_t, quic_bbr2_default_probe_bw_base_duration_ms, 2000,
+-            "The default minimum duration for BBRv2-native probes, in milliseconds.")
+-
+-QUICHE_FLAG(int32_t, quic_bbr2_default_probe_bw_max_rand_duration_ms, 1000,
+-            "The default upper bound of the random amount of BBRv2-native "
+-            "probes, in milliseconds.")
+-
+-QUICHE_FLAG(int32_t, quic_bbr2_default_probe_rtt_period_ms, 10000,
+-            "The default period for entering PROBE_RTT, in milliseconds.")
+-
+-QUICHE_FLAG(double, quic_bbr2_default_loss_threshold, 0.02,
+-            "The default loss threshold for QUIC BBRv2, should be a value "
+-            "between 0 and 1.")
+-
+-QUICHE_FLAG(int32_t, quic_bbr2_default_startup_full_loss_count, 8,
+-            "The default minimum number of loss marking events to exit STARTUP.")
+-
+-QUICHE_FLAG(int32_t, quic_bbr2_default_probe_bw_full_loss_count, 2,
+-            "The default minimum number of loss marking events to exit PROBE_UP phase.")
+-
+-QUICHE_FLAG(double, quic_bbr2_default_inflight_hi_headroom, 0.01,
+-            "The default fraction of unutilized headroom to try to leave in path "
+-            "upon high loss.")
+-
+-QUICHE_FLAG(int32_t, quic_bbr2_default_initial_ack_height_filter_window, 10,
+-            "The default initial value of the max ack height filter's window length.")
+-
+-QUICHE_FLAG(double, quic_ack_aggregation_bandwidth_threshold, 1.0,
+-            "If the bandwidth during ack aggregation is smaller than (estimated "
+-            "bandwidth * this flag), consider the current aggregation completed "
+-            "and starts a new one.")
+-
+-QUICHE_FLAG(int32_t, quic_anti_amplification_factor, 5,
+-            "Anti-amplification factor. Before address validation, server will "
+-            "send no more than factor times bytes received.")
+-
+-QUICHE_FLAG(int32_t, quic_max_buffered_crypto_bytes, 16 * 1024,
+-            "The maximum amount of CRYPTO frame data that can be buffered.")
+-
+-QUICHE_FLAG(int32_t, quic_max_aggressive_retransmittable_on_wire_ping_count, 0,
+-            "If set to non-zero, the maximum number of consecutive pings that "
+-            "can be sent with aggressive initial retransmittable on wire timeout "
+-            "if there is no new data received. After which, the timeout will be "
+-            "exponentially back off until exceeds the default ping timeout.")
+-
+-QUICHE_FLAG(int32_t, quic_max_congestion_window, 2000, "The maximum congestion window in packets.")
+-
+-QUICHE_FLAG(int32_t, quic_max_streams_window_divisor, 2,
+-            "The divisor that controls how often MAX_STREAMS frame is sent.")
+-
+-QUICHE_FLAG(bool, http2_reloadable_flag_http2_testonly_default_false, false,
+-            "A testonly reloadable flag that will always default to false.")
+-
+-QUICHE_FLAG(bool, http2_restart_flag_http2_testonly_default_false, false,
+-            "A testonly restart flag that will always default to false.")
+-
+-QUICHE_FLAG(bool, spdy_reloadable_flag_spdy_testonly_default_false, false,
+-            "A testonly reloadable flag that will always default to false.")
+-
+-QUICHE_FLAG(bool, spdy_restart_flag_spdy_testonly_default_false, false,
+-            "A testonly restart flag that will always default to false.")
+-
+-#endif
+diff --git a/source/extensions/quic_listeners/quiche/platform/http2_flags_impl.h b/source/extensions/quic_listeners/quiche/platform/http2_flags_impl.h
+index 7d2561469..dc6fe5429 100644
+--- a/source/extensions/quic_listeners/quiche/platform/http2_flags_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/http2_flags_impl.h
+@@ -8,10 +8,10 @@
+ 
+ #include "extensions/quic_listeners/quiche/platform/flags_impl.h"
+ 
+-#define GetHttp2ReloadableFlagImpl(flag) quiche::FLAGS_http2_reloadable_flag_##flag->value()
++#define GetHttp2ReloadableFlagImpl(flag) quiche::FLAGS_quic_reloadable_flag_##flag->value()
+ 
+ #define SetHttp2ReloadableFlagImpl(flag, value)                                                    \
+-  quiche::FLAGS_http2_reloadable_flag_##flag->SetValue(value)
++  quiche::FLAGS_quic_reloadable_flag_##flag->setValue(value)
+ 
+ #define HTTP2_CODE_COUNT_N_IMPL(flag, instance, total)                                             \
+   do {                                                                                             \
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_aligned_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_aligned_impl.h
+deleted file mode 100644
+index 3f595380b..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/quic_aligned_impl.h
++++ /dev/null
+@@ -1,18 +0,0 @@
+-#pragma once
+-
+-#include "absl/base/optimization.h"
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-#define QUIC_ALIGN_OF_IMPL alignof
+-#ifdef _MSC_VER
+-#define QUIC_ALIGNED_IMPL(X) __declspec(align(X))
+-#else
+-#define QUIC_ALIGNED_IMPL(X) __attribute__((aligned(X)))
+-#endif
+-#define QUIC_CACHELINE_ALIGNED_IMPL ABSL_CACHELINE_ALIGNED
+-#define QUIC_CACHELINE_SIZE_IMPL ABSL_CACHELINE_SIZE
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.cc b/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.cc
+index 2a886a12c..27b977908 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.cc
++++ b/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.cc
+@@ -10,25 +10,7 @@
+ 
+ namespace quic {
+ 
+-// static
+-bool QuicCertUtilsImpl::ExtractSubjectNameFromDERCert(quiche::QuicheStringPiece cert,
+-                                                      quiche::QuicheStringPiece* subject_out) {
+-  CBS tbs_certificate;
+-  if (!SeekToSubject(cert, &tbs_certificate)) {
+-    return false;
+-  }
+-
+-  CBS subject;
+-  if (!CBS_get_asn1_element(&tbs_certificate, &subject, CBS_ASN1_SEQUENCE)) {
+-    return false;
+-  }
+-  *subject_out =
+-      absl::string_view(reinterpret_cast<const char*>(CBS_data(&subject)), CBS_len(&subject));
+-  return true;
+-}
+-
+-// static
+-bool QuicCertUtilsImpl::SeekToSubject(quiche::QuicheStringPiece cert, CBS* tbs_certificate) {
++bool seekToSubject(absl::string_view cert, CBS* tbs_certificate) {
+   CBS der;
+   CBS_init(&der, reinterpret_cast<const uint8_t*>(cert.data()), cert.size());
+   CBS certificate;
+@@ -65,4 +47,22 @@ bool QuicCertUtilsImpl::SeekToSubject(quiche::QuicheStringPiece cert, CBS* tbs_c
+   return true;
+ }
+ 
++// static
++// NOLINTNEXTLINE(readability-identifier-naming)
++bool QuicCertUtilsImpl::ExtractSubjectNameFromDERCert(absl::string_view cert,
++                                                      absl::string_view* subject_out) {
++  CBS tbs_certificate;
++  if (!seekToSubject(cert, &tbs_certificate)) {
++    return false;
++  }
++
++  CBS subject;
++  if (!CBS_get_asn1_element(&tbs_certificate, &subject, CBS_ASN1_SEQUENCE)) {
++    return false;
++  }
++  *subject_out =
++      absl::string_view(reinterpret_cast<const char*>(CBS_data(&subject)), CBS_len(&subject));
++  return true;
++}
++
+ } // namespace quic
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h
+index 0c41b9dbc..29b882b7d 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h
+@@ -6,18 +6,15 @@
+ // consumed or referenced directly by other Envoy code. It serves purely as a
+ // porting layer for QUICHE.
+ 
++#include "absl/strings/string_view.h"
+ #include "openssl/base.h"
+-#include "quiche/common/platform/api/quiche_string_piece.h"
+ 
+ namespace quic {
+ 
+ class QuicCertUtilsImpl {
+ public:
+-  static bool ExtractSubjectNameFromDERCert(quiche::QuicheStringPiece cert,
+-                                            quiche::QuicheStringPiece* subject_out);
+-
+-private:
+-  static bool SeekToSubject(quiche::QuicheStringPiece cert, CBS* tbs_certificate);
++  // NOLINTNEXTLINE(readability-identifier-naming)
++  static bool ExtractSubjectNameFromDERCert(absl::string_view cert, absl::string_view* subject_out);
+ };
+ 
+ } // namespace quic
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_fallthrough_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_fallthrough_impl.h
+deleted file mode 100644
+index aa9d6bc36..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/quic_fallthrough_impl.h
++++ /dev/null
+@@ -1,11 +0,0 @@
+-#pragma once
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-#include "absl/base/macros.h"
+-
+-#define QUIC_FALLTHROUGH_INTENDED_IMPL ABSL_FALLTHROUGH_INTENDED
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.cc b/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.cc
+index 91d52c44a..b2e396fab 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.cc
++++ b/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.cc
+@@ -36,6 +36,7 @@ void depthFirstTraverseDirectory(const std::string& dirname, std::vector<std::st
+ } // namespace
+ 
+ // Traverses the directory |dirname| and returns all of the files it contains.
++// NOLINTNEXTLINE(readability-identifier-naming)
+ std::vector<std::string> ReadFileContentsImpl(const std::string& dirname) {
+   std::vector<std::string> files;
+   depthFirstTraverseDirectory(dirname, files);
+@@ -43,7 +44,8 @@ std::vector<std::string> ReadFileContentsImpl(const std::string& dirname) {
+ }
+ 
+ // Reads the contents of |filename| as a string into |contents|.
+-void ReadFileContentsImpl(quiche::QuicheStringPiece filename, std::string* contents) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++void ReadFileContentsImpl(absl::string_view filename, std::string* contents) {
+ #ifdef WIN32
+   Envoy::Filesystem::InstanceImplWin32 fs;
+ #else
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.h
+index 654c1ad18..25c31e9de 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_file_utils_impl.h
+@@ -8,7 +8,7 @@
+ 
+ #include <vector>
+ 
+-#include "quiche/common/platform/api/quiche_string_piece.h"
++#include "absl/strings/string_view.h"
+ 
+ namespace quic {
+ 
+@@ -16,6 +16,7 @@ namespace quic {
+  * Traverses the directory |dirname| and returns all of the files it contains.
+  * @param dirname full path without trailing '/'.
+  */
++// NOLINTNEXTLINE(readability-identifier-naming)`
+ std::vector<std::string> ReadFileContentsImpl(const std::string& dirname);
+ 
+ /**
+@@ -23,6 +24,7 @@ std::vector<std::string> ReadFileContentsImpl(const std::string& dirname);
+  *  @param filename the full path to the file.
+  *  @param contents output location of the file content.
+  */
+-void ReadFileContentsImpl(quiche::QuicheStringPiece filename, std::string* contents);
++// NOLINTNEXTLINE(readability-identifier-naming)
++void ReadFileContentsImpl(absl::string_view filename, std::string* contents);
+ 
+ } // namespace quic
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_flags_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_flags_impl.h
+index 872495f2d..d562bb1a4 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_flags_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_flags_impl.h
+@@ -15,16 +15,16 @@
+ #define GetQuicFlagImpl(flag) (quiche::flag)->value()
+ 
+ // |flag| is the global flag variable, which is a pointer to TypedFlag<type>.
+-#define SetQuicFlagImpl(flag, value) (quiche::flag)->SetValue(value)
++#define SetQuicFlagImpl(flag, value) (quiche::flag)->setValue(value)
+ 
+ #define GetQuicReloadableFlagImpl(flag) quiche::FLAGS_quic_reloadable_flag_##flag->value()
+ 
+ #define SetQuicReloadableFlagImpl(flag, value)                                                     \
+-  quiche::FLAGS_quic_reloadable_flag_##flag->SetValue(value)
++  quiche::FLAGS_quic_reloadable_flag_##flag->setValue(value)
+ 
+ #define GetQuicRestartFlagImpl(flag) quiche::FLAGS_quic_restart_flag_##flag->value()
+ 
+-#define SetQuicRestartFlagImpl(flag, value) quiche::FLAGS_quic_restart_flag_##flag->SetValue(value)
++#define SetQuicRestartFlagImpl(flag, value) quiche::FLAGS_quic_restart_flag_##flag->setValue(value)
+ 
+ // Not wired into command-line parsing.
+ #define DEFINE_QUIC_COMMAND_LINE_FLAG_IMPL(type, flag, value, help)                                \
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.cc b/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.cc
+index bcbafb566..75849611d 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.cc
++++ b/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.cc
+@@ -19,7 +19,8 @@
+ namespace quic {
+ 
+ // static
+-bool QuicHostnameUtilsImpl::IsValidSNI(quiche::QuicheStringPiece sni) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++bool QuicHostnameUtilsImpl::IsValidSNI(absl::string_view sni) {
+   // TODO(wub): Implement it on top of GoogleUrl, once it is available.
+ 
+   return sni.find_last_of('.') != std::string::npos &&
+@@ -27,7 +28,8 @@ bool QuicHostnameUtilsImpl::IsValidSNI(quiche::QuicheStringPiece sni) {
+ }
+ 
+ // static
+-std::string QuicHostnameUtilsImpl::NormalizeHostname(quiche::QuicheStringPiece hostname) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++std::string QuicHostnameUtilsImpl::NormalizeHostname(absl::string_view hostname) {
+   // TODO(wub): Implement it on top of GoogleUrl, once it is available.
+   std::string host = absl::AsciiStrToLower(hostname);
+ 
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.h
+index 2b7ed4357..67cd787d0 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_hostname_utils_impl.h
+@@ -6,7 +6,7 @@
+ // consumed or referenced directly by other Envoy code. It serves purely as a
+ // porting layer for QUICHE.
+ 
+-#include "quiche/common/platform/api/quiche_string_piece.h"
++#include "absl/strings/string_view.h"
+ #include "quiche/quic/platform/api/quic_export.h"
+ 
+ namespace quic {
+@@ -18,7 +18,8 @@ public:
+   //  (2) check that the hostname contains valid characters only; and
+   //  (3) contains at least one dot.
+   // NOTE(wub): Only (3) is implemented for now.
+-  static bool IsValidSNI(quiche::QuicheStringPiece sni);
++  // NOLINTNEXTLINE(readability-identifier-naming)
++  static bool IsValidSNI(absl::string_view sni);
+ 
+   // Normalize a hostname:
+   //  (1) Canonicalize it, similar to what Chromium does in
+@@ -27,7 +28,8 @@ public:
+   //  (3) Remove the trailing '.'.
+   // WARNING: May mutate |hostname| in place.
+   // NOTE(wub): Only (2) and (3) are implemented for now.
+-  static std::string NormalizeHostname(quiche::QuicheStringPiece hostname);
++  // NOLINTNEXTLINE(readability-identifier-naming)
++  static std::string NormalizeHostname(absl::string_view hostname);
+ 
+ private:
+   QuicHostnameUtilsImpl() = delete;
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_macros_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_macros_impl.h
+deleted file mode 100644
+index b8b70a042..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/quic_macros_impl.h
++++ /dev/null
+@@ -1,13 +0,0 @@
+-#pragma once
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-#include "absl/base/attributes.h"
+-
+-#define QUIC_MUST_USE_RESULT_IMPL ABSL_MUST_USE_RESULT
+-#define QUIC_UNUSED_IMPL ABSL_ATTRIBUTE_UNUSED
+-#define QUIC_CONST_INIT_IMPL ABSL_CONST_INIT
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
+index c2eb527d6..9e46c37df 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
++++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.cc
+@@ -10,7 +10,8 @@
+ 
+ namespace quic {
+ 
+-quiche::QuicheStringPiece QuicMemSliceSpanImpl::GetData(size_t index) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++absl::string_view QuicMemSliceSpanImpl::GetData(size_t index) {
+   Envoy::Buffer::RawSliceVector slices = buffer_->getRawSlices(/*max_slices=*/index + 1);
+   ASSERT(slices.size() > index);
+   return {reinterpret_cast<char*>(slices[index].mem_), slices[index].len_};
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
+index 1824fb8d1..ef40e6387 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_span_impl.h
+@@ -9,7 +9,7 @@
+ #include "envoy/buffer/buffer.h"
+ 
+ #include "absl/container/fixed_array.h"
+-#include "quiche/common/platform/api/quiche_string_piece.h"
++#include "absl/strings/string_view.h"
+ #include "quiche/quic/core/quic_types.h"
+ #include "quiche/quic/platform/api/quic_mem_slice.h"
+ 
+@@ -43,9 +43,13 @@ public:
+   }
+ 
+   // QuicMemSliceSpan
+-  quiche::QuicheStringPiece GetData(size_t index);
++  // NOLINTNEXTLINE(readability-identifier-naming)
++  absl::string_view GetData(size_t index);
++  // NOLINTNEXTLINE(readability-identifier-naming)
+   QuicByteCount total_length() { return buffer_->length(); };
++  // NOLINTNEXTLINE(readability-identifier-naming)
+   size_t NumSlices() { return buffer_->getRawSlices().size(); }
++  // NOLINTNEXTLINE(readability-identifier-naming)
+   template <typename ConsumeFunction> QuicByteCount ConsumeAll(ConsumeFunction consume);
+   bool empty() const { return buffer_->length() == 0; }
+ 
+@@ -54,6 +58,7 @@ private:
+ };
+ 
+ template <typename ConsumeFunction>
++// NOLINTNEXTLINE(readability-identifier-naming)
+ QuicByteCount QuicMemSliceSpanImpl::ConsumeAll(ConsumeFunction consume) {
+   size_t saved_length = 0;
+   for (auto& slice : buffer_->getRawSlices()) {
+diff --git a/source/extensions/quic_listeners/quiche/platform/quiche_ptr_util_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_testvalue_impl.h
+similarity index 52%
+rename from source/extensions/quic_listeners/quiche/platform/quiche_ptr_util_impl.h
+rename to source/extensions/quic_listeners/quiche/platform/quic_testvalue_impl.h
+index aaebe5d5c..4b0201c35 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quiche_ptr_util_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_testvalue_impl.h
+@@ -6,12 +6,11 @@
+ // consumed or referenced directly by other Envoy code. It serves purely as a
+ // porting layer for QUICHE.
+ 
+-#include "absl/memory/memory.h"
++#include "absl/strings/string_view.h"
+ 
+-namespace quiche {
++namespace quic {
+ 
+-template <typename T> std::unique_ptr<T> QuicheWrapUniqueImpl(T* ptr) {
+-  return absl::WrapUnique<T>(ptr);
+-}
++// NOLINTNEXTLINE(readability-identifier-naming)
++template <class T> void AdjustTestValueImpl(absl::string_view /*label*/, T* /*var*/) {}
+ 
+-} // namespace quiche
++} // namespace quic
+diff --git a/source/extensions/quic_listeners/quiche/platform/quic_udp_socket_platform_impl.h b/source/extensions/quic_listeners/quiche/platform/quic_udp_socket_platform_impl.h
+index 248cfc193..1e88abe46 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quic_udp_socket_platform_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quic_udp_socket_platform_impl.h
+@@ -19,4 +19,7 @@ inline bool GetGooglePacketHeadersFromControlMessageImpl(struct ::cmsghdr* /*cms
+   return false;
+ }
+ 
++// NOLINTNEXTLINE(readability-identifier-naming)
++inline void SetGoogleSocketOptionsImpl(int /*fd*/) {}
++
+ } // namespace quic
+diff --git a/source/extensions/quic_listeners/quiche/platform/quiche_arraysize_impl.h b/source/extensions/quic_listeners/quiche/platform/quiche_arraysize_impl.h
+deleted file mode 100644
+index 7a23b53da..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/quiche_arraysize_impl.h
++++ /dev/null
+@@ -1,11 +0,0 @@
+-#pragma once
+-
+-#include "absl/base/macros.h"
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-#define QUICHE_ARRAYSIZE_IMPL(array) ABSL_ARRAYSIZE(array)
+diff --git a/source/extensions/quic_listeners/quiche/platform/quiche_optional_impl.h b/source/extensions/quic_listeners/quiche/platform/quiche_optional_impl.h
+deleted file mode 100644
+index f8b2b6c08..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/quiche_optional_impl.h
++++ /dev/null
+@@ -1,17 +0,0 @@
+-#pragma once
+-
+-#include "absl/types/optional.h"
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-namespace quiche {
+-
+-template <typename T> using QuicheOptionalImpl = absl::optional<T>;
+-
+-#define QUICHE_NULLOPT_IMPL absl::nullopt
+-
+-} // namespace quiche
+diff --git a/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h b/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
+index 3a6d1a393..7b87c1cd6 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
+@@ -2,7 +2,6 @@
+ 
+ #include "common/common/base64.h"
+ 
+-#include "extensions/quic_listeners/quiche/platform/quiche_optional_impl.h"
+ #include "extensions/quic_listeners/quiche/platform/quiche_string_piece_impl.h"
+ #include "extensions/quic_listeners/quiche/platform/string_utils.h"
+ 
+@@ -13,6 +12,7 @@
+ #include "absl/strings/str_cat.h"
+ #include "absl/strings/str_format.h"
+ #include "absl/strings/str_split.h"
++#include "absl/types/optional.h"
+ 
+ // NOLINT(namespace-envoy)
+ 
+@@ -25,58 +25,16 @@ namespace quiche {
+ class QuicheTextUtilsImpl {
+ public:
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool StartsWith(QuicheStringPieceImpl data, QuicheStringPieceImpl prefix) {
+-    return absl::StartsWith(data, prefix);
+-  }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool EndsWith(QuicheStringPieceImpl data, QuicheStringPieceImpl suffix) {
+-    return absl::EndsWith(data, suffix);
+-  }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool EndsWithIgnoreCase(QuicheStringPieceImpl data, QuicheStringPieceImpl suffix) {
+-    return absl::EndsWithIgnoreCase(data, suffix);
+-  }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static std::string ToLower(QuicheStringPieceImpl data) { return absl::AsciiStrToLower(data); }
++  static std::string ToLower(absl::string_view data) { return absl::AsciiStrToLower(data); }
+ 
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static void RemoveLeadingAndTrailingWhitespace(QuicheStringPieceImpl* data) {
++  static void RemoveLeadingAndTrailingWhitespace(absl::string_view* data) {
+     *data = absl::StripAsciiWhitespace(*data);
+   }
+ 
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool StringToUint64(QuicheStringPieceImpl in, uint64_t* out) {
+-    return absl::SimpleAtoi(in, out);
+-  }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool StringToInt(QuicheStringPieceImpl in, int* out) { return absl::SimpleAtoi(in, out); }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool StringToUint32(QuicheStringPieceImpl in, uint32_t* out) {
+-    return absl::SimpleAtoi(in, out);
+-  }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool StringToSizeT(QuicheStringPieceImpl in, size_t* out) {
+-    return absl::SimpleAtoi(in, out);
+-  }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static std::string Uint64ToString(uint64_t in) { return absl::StrCat(in); }
+-
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static std::string HexEncode(QuicheStringPieceImpl data) { return absl::BytesToHexString(data); }
+-
+   // NOLINTNEXTLINE(readability-identifier-naming)
+   static std::string Hex(uint32_t v) { return absl::StrCat(absl::Hex(v)); }
+ 
+-  // NOLINTNEXTLINE(readability-identifier-naming)
+-  static std::string HexDecode(QuicheStringPieceImpl data) { return absl::HexStringToBytes(data); }
+-
+   // NOLINTNEXTLINE(readability-identifier-naming)
+   static void Base64Encode(const uint8_t* data, size_t data_len, std::string* output) {
+     *output =
+@@ -84,27 +42,28 @@ public:
+   }
+ 
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static QuicheOptionalImpl<std::string> Base64Decode(QuicheStringPieceImpl input) {
++  static absl::optional<std::string> Base64Decode(absl::string_view input) {
+     return Envoy::Base64::decodeWithoutPadding(input);
+   }
+ 
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static std::string HexDump(QuicheStringPieceImpl binary_data) {
+-    return quiche::HexDump(binary_data);
+-  }
++  static std::string Uint64ToString(uint64_t in) { return absl::StrCat(in); }
++
++  // NOLINTNEXTLINE(readability-identifier-naming)
++  static std::string HexDump(absl::string_view binary_data) { return quiche::HexDump(binary_data); }
+ 
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool ContainsUpperCase(QuicheStringPieceImpl data) {
++  static bool ContainsUpperCase(absl::string_view data) {
+     return std::any_of(data.begin(), data.end(), absl::ascii_isupper);
+   }
+ 
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static bool IsAllDigits(QuicheStringPieceImpl data) {
++  static bool IsAllDigits(absl::string_view data) {
+     return std::all_of(data.begin(), data.end(), absl::ascii_isdigit);
+   }
+ 
+   // NOLINTNEXTLINE(readability-identifier-naming)
+-  static std::vector<QuicheStringPieceImpl> Split(QuicheStringPieceImpl data, char delim) {
++  static std::vector<absl::string_view> Split(absl::string_view data, char delim) {
+     return absl::StrSplit(data, delim);
+   }
+ };
+diff --git a/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.cc b/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.cc
+index 3260eafee..5387e0598 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.cc
++++ b/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.cc
+@@ -9,7 +9,7 @@
+ namespace quiche {
+ 
+ namespace {
+-QuicheOptional<int64_t> quicheUtcDateTimeToUnixSecondsInner(int year, int month, int day, int hour,
++absl::optional<int64_t> quicheUtcDateTimeToUnixSecondsInner(int year, int month, int day, int hour,
+                                                             int minute, int second) {
+   const absl::CivilSecond civil_time(year, month, day, hour, minute, second);
+   if (second != 60 && (civil_time.year() != year || civil_time.month() != month ||
+@@ -24,7 +24,7 @@ QuicheOptional<int64_t> quicheUtcDateTimeToUnixSecondsInner(int year, int month,
+ } // namespace
+ 
+ // NOLINTNEXTLINE(readability-identifier-naming)
+-QuicheOptional<int64_t> QuicheUtcDateTimeToUnixSecondsImpl(int year, int month, int day, int hour,
++absl::optional<int64_t> QuicheUtcDateTimeToUnixSecondsImpl(int year, int month, int day, int hour,
+                                                            int minute, int second) {
+   // Handle leap seconds without letting any other irregularities happen.
+   if (second == 60) {
+diff --git a/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.h b/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.h
+index a1b70b70a..5e2ef7956 100644
+--- a/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/quiche_time_utils_impl.h
+@@ -10,12 +10,12 @@
+ 
+ #include "absl/time/civil_time.h"
+ #include "absl/time/time.h"
+-#include "quiche/common/platform/api/quiche_optional.h"
++#include "absl/types/optional.h"
+ 
+ namespace quiche {
+ 
+ // NOLINTNEXTLINE(readability-identifier-naming)
+-QuicheOptional<int64_t> QuicheUtcDateTimeToUnixSecondsImpl(int year, int month, int day, int hour,
++absl::optional<int64_t> QuicheUtcDateTimeToUnixSecondsImpl(int year, int month, int day, int hour,
+                                                            int minute, int second);
+ 
+ } // namespace quiche
+diff --git a/source/extensions/quic_listeners/quiche/platform/spdy_endianness_util_impl.h b/source/extensions/quic_listeners/quiche/platform/spdy_endianness_util_impl.h
+deleted file mode 100644
+index 737b81ee2..000000000
+--- a/source/extensions/quic_listeners/quiche/platform/spdy_endianness_util_impl.h
++++ /dev/null
+@@ -1,29 +0,0 @@
+-#pragma once
+-
+-#include <cstdint>
+-
+-#include "envoy/common/platform.h"
+-
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-namespace spdy {
+-
+-inline uint16_t SpdyNetToHost16Impl(uint16_t x) { return ntohs(x); }
+-
+-inline uint32_t SpdyNetToHost32Impl(uint32_t x) { return ntohl(x); }
+-
+-// TODO: implement
+-inline uint64_t SpdyNetToHost64Impl(uint64_t /*x*/) { return 0; }
+-
+-inline uint16_t SpdyHostToNet16Impl(uint16_t x) { return htons(x); }
+-
+-inline uint32_t SpdyHostToNet32Impl(uint32_t x) { return htonl(x); }
+-
+-// TODO: implement
+-inline uint64_t SpdyHostToNet64Impl(uint64_t /*x*/) { return 0; }
+-
+-} // namespace spdy
+diff --git a/source/extensions/quic_listeners/quiche/platform/spdy_flags_impl.h b/source/extensions/quic_listeners/quiche/platform/spdy_flags_impl.h
+index a3cbd680f..833562fab 100644
+--- a/source/extensions/quic_listeners/quiche/platform/spdy_flags_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/spdy_flags_impl.h
+@@ -8,9 +8,9 @@
+ 
+ #include "extensions/quic_listeners/quiche/platform/flags_impl.h"
+ 
+-#define GetSpdyReloadableFlagImpl(flag) quiche::FLAGS_spdy_reloadable_flag_##flag->value()
++#define GetSpdyReloadableFlagImpl(flag) quiche::FLAGS_quic_reloadable_flag_##flag->value()
+ 
+-#define GetSpdyRestartFlagImpl(flag) quiche::FLAGS_spdy_restart_flag_##flag->value()
++#define GetSpdyRestartFlagImpl(flag) quiche::FLAGS_quic_restart_flag_##flag->value()
+ 
+ #define SPDY_CODE_COUNT_N_IMPL(flag, instance, total)                                              \
+   do {                                                                                             \
+diff --git a/source/extensions/quic_listeners/quiche/platform/spdy_string_utils_impl.h b/source/extensions/quic_listeners/quiche/platform/spdy_string_utils_impl.h
+index 41fa3cad8..4b01b2dbd 100644
+--- a/source/extensions/quic_listeners/quiche/platform/spdy_string_utils_impl.h
++++ b/source/extensions/quic_listeners/quiche/platform/spdy_string_utils_impl.h
+@@ -50,7 +50,7 @@ inline std::string SpdyHexEncodeUInt32AndTrimImpl(uint32_t data) {
+ inline std::string SpdyHexDumpImpl(absl::string_view data) { return quiche::HexDump(data); }
+ 
+ struct SpdyStringPieceCaseHashImpl {
+-  size_t operator()(quiche::QuicheStringPiece data) const {
++  size_t operator()(absl::string_view data) const {
+     std::string lower = absl::AsciiStrToLower(data);
+     return absl::Hash<std::string>()(lower);
+   }
+diff --git a/source/extensions/quic_listeners/quiche/spdy_server_push_utils_for_envoy.cc b/source/extensions/quic_listeners/quiche/spdy_server_push_utils_for_envoy.cc
+index 3bd0bc295..5ac5738c4 100644
+--- a/source/extensions/quic_listeners/quiche/spdy_server_push_utils_for_envoy.cc
++++ b/source/extensions/quic_listeners/quiche/spdy_server_push_utils_for_envoy.cc
+@@ -12,25 +12,29 @@ using spdy::SpdyHeaderBlock;
+ namespace quic {
+ 
+ // static
++// NOLINTNEXTLINE(readability-identifier-naming)
+ std::string SpdyServerPushUtils::GetPromisedUrlFromHeaders(const SpdyHeaderBlock& /*headers*/) {
+   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+ }
+ 
+ // static
+ std::string
++// NOLINTNEXTLINE(readability-identifier-naming)
+ SpdyServerPushUtils::GetPromisedHostNameFromHeaders(const SpdyHeaderBlock& /*headers*/) {
+   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+ }
+ 
+ // static
++// NOLINTNEXTLINE(readability-identifier-naming)
+ bool SpdyServerPushUtils::PromisedUrlIsValid(const SpdyHeaderBlock& /*headers*/) {
+   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+ }
+ 
+ // static
+-std::string SpdyServerPushUtils::GetPushPromiseUrl(quiche::QuicheStringPiece /*scheme*/,
+-                                                   quiche::QuicheStringPiece /*authority*/,
+-                                                   quiche::QuicheStringPiece /*path*/) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++std::string SpdyServerPushUtils::GetPushPromiseUrl(absl::string_view /*scheme*/,
++                                                   absl::string_view /*authority*/,
++                                                   absl::string_view /*path*/) {
+   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+ }
+ 
+diff --git a/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc b/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
+index e2d90d916..8fa7d9fe9 100644
+--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
++++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
+@@ -49,9 +49,9 @@ public:
+                                 Network::ConnectionSocketPtr&& connection_socket)
+       : EnvoyQuicClientConnection(server_connection_id, helper, alarm_factory, &writer, false,
+                                   supported_versions, dispatcher, std::move(connection_socket)) {
+-    SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
+     SetEncrypter(quic::ENCRYPTION_FORWARD_SECURE,
+                  std::make_unique<quic::NullEncrypter>(quic::Perspective::IS_CLIENT));
++    SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
+   }
+ 
+   MOCK_METHOD(void, SendConnectionClosePacket, (quic::QuicErrorCode, const std::string&));
+diff --git a/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc b/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
+index 98359c618..f3b02f4cc 100644
+--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
++++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
+@@ -48,11 +48,11 @@ public:
+     quic_session_.ActivateStream(std::unique_ptr<EnvoyQuicClientStream>(quic_stream_));
+     EXPECT_CALL(quic_session_, ShouldYield(_)).WillRepeatedly(testing::Return(false));
+     EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-        .WillRepeatedly(Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
+-                                  quic::StreamSendingState state, bool,
+-                                  quiche::QuicheOptional<quic::EncryptionLevel>) {
+-          return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
+-        }));
++        .WillRepeatedly(
++            Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
++                      quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++              return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
++            }));
+     EXPECT_CALL(writer_, WritePacket(_, _, _, _, _))
+         .WillRepeatedly(Invoke([](const char*, size_t buf_len, const quic::QuicIpAddress&,
+                                   const quic::QuicSocketAddress&, quic::PerPacketOptions*) {
+@@ -146,7 +146,7 @@ TEST_P(EnvoyQuicClientStreamTest, PostRequestAndResponse) {
+     std::unique_ptr<char[]> data_buffer;
+     quic::QuicByteCount data_frame_header_length =
+         quic::HttpEncoder::SerializeDataFrameHeader(response_body_.length(), &data_buffer);
+-    quiche::QuicheStringPiece data_frame_header(data_buffer.get(), data_frame_header_length);
++    absl::string_view data_frame_header(data_buffer.get(), data_frame_header_length);
+     data = absl::StrCat(data_frame_header, response_body_);
+   }
+   quic::QuicStreamFrame frame(stream_id_, false, 0, data);
+@@ -184,7 +184,7 @@ TEST_P(EnvoyQuicClientStreamTest, OutOfOrderTrailers) {
+     std::unique_ptr<char[]> data_buffer;
+     quic::QuicByteCount data_frame_header_length =
+         quic::HttpEncoder::SerializeDataFrameHeader(response_body_.length(), &data_buffer);
+-    quiche::QuicheStringPiece data_frame_header(data_buffer.get(), data_frame_header_length);
++    absl::string_view data_frame_header(data_buffer.get(), data_frame_header_length);
+     data = absl::StrCat(data_frame_header, response_body_);
+   }
+   quic::QuicStreamFrame frame(stream_id_, false, 0, data);
+@@ -301,11 +301,11 @@ TEST_P(EnvoyQuicClientStreamTest, HeadersContributeToWatermarkIquic) {
+   // Unblock writing now, and this will write out 16kB data and cause stream to
+   // be blocked by the flow control limit.
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillOnce(Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
+-                          quic::StreamSendingState state, bool,
+-                          quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
+-      }));
++      .WillOnce(
++          Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
++          }));
+   EXPECT_CALL(stream_callbacks_, onBelowWriteBufferLowWatermark());
+   quic_session_.OnCanWrite();
+   EXPECT_TRUE(quic_stream_->IsFlowControlBlocked());
+@@ -315,20 +315,20 @@ TEST_P(EnvoyQuicClientStreamTest, HeadersContributeToWatermarkIquic) {
+                                              32 * 1024);
+   quic_stream_->OnWindowUpdateFrame(window_update1);
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillOnce(Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
+-                          quic::StreamSendingState state, bool,
+-                          quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
+-      }));
++      .WillOnce(
++          Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
++          }));
+   quic_session_.OnCanWrite();
+   // No data should be buffered at this point.
+ 
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillOnce(Invoke([](quic::QuicStreamId, size_t, quic::QuicStreamOffset,
+-                          quic::StreamSendingState state, bool,
+-                          quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{0u, state != quic::NO_FIN};
+-      }));
++      .WillOnce(
++          Invoke([](quic::QuicStreamId, size_t, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{0u, state != quic::NO_FIN};
++          }));
+   // Send more data. If watermark bytes counting were not cleared in previous
+   // OnCanWrite, this write would have caused the stream to exceed its high watermark.
+   std::string request1(16 * 1024 - 3, 'a');
+diff --git a/test/extensions/quic_listeners/quiche/envoy_quic_proof_source_test.cc b/test/extensions/quic_listeners/quiche/envoy_quic_proof_source_test.cc
+index cbf66f511..8a493a8e8 100644
+--- a/test/extensions/quic_listeners/quiche/envoy_quic_proof_source_test.cc
++++ b/test/extensions/quic_listeners/quiche/envoy_quic_proof_source_test.cc
+@@ -25,7 +25,7 @@ namespace Quic {
+ class TestGetProofCallback : public quic::ProofSource::Callback {
+ public:
+   TestGetProofCallback(bool& called, bool should_succeed, const std::string& server_config,
+-                       quic::QuicTransportVersion& version, quiche::QuicheStringPiece chlo_hash,
++                       quic::QuicTransportVersion& version, absl::string_view chlo_hash,
+                        Network::FilterChain& filter_chain)
+       : called_(called), should_succeed_(should_succeed), server_config_(server_config),
+         version_(version), chlo_hash_(chlo_hash), expected_filter_chain_(filter_chain) {
+@@ -100,7 +100,7 @@ private:
+   bool should_succeed_;
+   const std::string& server_config_;
+   const quic::QuicTransportVersion& version_;
+-  quiche::QuicheStringPiece chlo_hash_;
++  absl::string_view chlo_hash_;
+   Network::FilterChain& expected_filter_chain_;
+   NiceMock<Stats::MockStore> store_;
+   Event::GlobalTimeSystem time_system_;
+@@ -178,7 +178,7 @@ protected:
+   quic::QuicSocketAddress server_address_;
+   quic::QuicSocketAddress client_address_;
+   quic::QuicTransportVersion version_{quic::QUIC_VERSION_UNSUPPORTED};
+-  quiche::QuicheStringPiece chlo_hash_{"aaaaa"};
++  absl::string_view chlo_hash_{"aaaaa"};
+   std::string server_config_{"Server Config"};
+   std::string expected_certs_{quic::test::kTestCertificateChainPem};
+   std::string pkey_{quic::test::kTestCertificatePrivateKeyPem};
+diff --git a/test/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_test.cc b/test/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_test.cc
+index 4a1dfe144..9cdc169cd 100644
+--- a/test/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_test.cc
++++ b/test/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_test.cc
+@@ -163,7 +163,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyProofFailureEmptyCertChain) {
+   std::unique_ptr<quic::CertificateView> cert_view =
+       quic::CertificateView::ParseSingleCertificate(leaf_cert_);
+   quic::QuicTransportVersion version{quic::QUIC_VERSION_UNSUPPORTED};
+-  quiche::QuicheStringPiece chlo_hash{"aaaaa"};
++  absl::string_view chlo_hash{"aaaaa"};
+   std::string server_config{"Server Config"};
+   const std::string ocsp_response;
+   const std::string cert_sct;
+@@ -181,7 +181,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyProofFailureInvalidLeafCert) {
+   std::unique_ptr<quic::CertificateView> cert_view =
+       quic::CertificateView::ParseSingleCertificate(leaf_cert_);
+   quic::QuicTransportVersion version{quic::QUIC_VERSION_UNSUPPORTED};
+-  quiche::QuicheStringPiece chlo_hash{"aaaaa"};
++  absl::string_view chlo_hash{"aaaaa"};
+   std::string server_config{"Server Config"};
+   const std::string ocsp_response;
+   const std::string cert_sct;
+@@ -197,7 +197,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyProofFailureInvalidLeafCert) {
+ TEST_F(EnvoyQuicProofVerifierTest, VerifyProofFailureUnsupportedECKey) {
+   configCertVerificationDetails(true);
+   quic::QuicTransportVersion version{quic::QUIC_VERSION_UNSUPPORTED};
+-  quiche::QuicheStringPiece chlo_hash{"aaaaa"};
++  absl::string_view chlo_hash{"aaaaa"};
+   std::string server_config{"Server Config"};
+   const std::string ocsp_response;
+   const std::string cert_sct;
+@@ -236,7 +236,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyProofFailureInvalidSignature) {
+   std::unique_ptr<quic::CertificateView> cert_view =
+       quic::CertificateView::ParseSingleCertificate(leaf_cert_);
+   quic::QuicTransportVersion version{quic::QUIC_VERSION_UNSUPPORTED};
+-  quiche::QuicheStringPiece chlo_hash{"aaaaa"};
++  absl::string_view chlo_hash{"aaaaa"};
+   std::string server_config{"Server Config"};
+   const std::string ocsp_response;
+   const std::string cert_sct;
+diff --git a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+index 05307c6b9..4fc376857 100644
+--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
++++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+@@ -61,6 +61,7 @@ public:
+                                 const quic::ParsedQuicVersionVector& supported_versions,
+                                 Network::Socket& listen_socket)
+       : EnvoyQuicServerConnection(quic::test::TestConnectionId(),
++                                  quic::QuicSocketAddress(quic::QuicIpAddress::Any4(), 12345),
+                                   quic::QuicSocketAddress(quic::QuicIpAddress::Loopback4(), 12345),
+                                   helper, alarm_factory, &writer, /*owns_writer=*/false,
+                                   supported_versions, listen_socket) {}
+@@ -201,10 +202,10 @@ public:
+       crypto_stream_ = test_crypto_stream;
+     }
+     quic::test::QuicServerSessionBasePeer::SetCryptoStream(&envoy_quic_session_, crypto_stream);
+-    quic_connection_->SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
+     quic_connection_->SetEncrypter(
+         quic::ENCRYPTION_FORWARD_SECURE,
+         std::make_unique<quic::NullEncrypter>(quic::Perspective::IS_SERVER));
++    quic_connection_->SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
+   }
+ 
+   bool installReadFilter() {
+diff --git a/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc b/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
+index c2fd31c6f..f602e2c9a 100644
+--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
++++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_stream_test.cc
+@@ -51,6 +51,7 @@ public:
+                                             POOL_GAUGE(listener_config_.listenerScope()),
+                                             POOL_HISTOGRAM(listener_config_.listenerScope()))}),
+         quic_connection_(quic::test::TestConnectionId(),
++                         quic::QuicSocketAddress(quic::QuicIpAddress::Any6(), 123),
+                          quic::QuicSocketAddress(quic::QuicIpAddress::Any6(), 12345),
+                          connection_helper_, alarm_factory_, &writer_,
+                          /*owns_writer=*/false, {quic_version_}, *listener_config_.socket_),
+@@ -66,11 +67,11 @@ public:
+     quic_session_.ActivateStream(std::unique_ptr<EnvoyQuicServerStream>(quic_stream_));
+     EXPECT_CALL(quic_session_, ShouldYield(_)).WillRepeatedly(testing::Return(false));
+     EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-        .WillRepeatedly(Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
+-                                  quic::StreamSendingState state, bool,
+-                                  quiche::QuicheOptional<quic::EncryptionLevel>) {
+-          return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
+-        }));
++        .WillRepeatedly(
++            Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
++                      quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++              return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
++            }));
+     EXPECT_CALL(writer_, WritePacket(_, _, _, _, _))
+         .WillRepeatedly(Invoke([](const char*, size_t buf_len, const quic::QuicIpAddress&,
+                                   const quic::QuicSocketAddress&, quic::PerPacketOptions*) {
+@@ -110,7 +111,7 @@ public:
+       std::unique_ptr<char[]> data_buffer;
+       quic::QuicByteCount data_frame_header_length =
+           quic::HttpEncoder::SerializeDataFrameHeader(body.length(), &data_buffer);
+-      quiche::QuicheStringPiece data_frame_header(data_buffer.get(), data_frame_header_length);
++      absl::string_view data_frame_header(data_buffer.get(), data_frame_header_length);
+       data = absl::StrCat(data_frame_header, body);
+     }
+     return data;
+@@ -397,11 +398,11 @@ TEST_P(EnvoyQuicServerStreamTest, HeadersContributeToWatermarkIquic) {
+ 
+   // Make the stream blocked by congestion control.
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillOnce(Invoke([](quic::QuicStreamId, size_t /*write_length*/, quic::QuicStreamOffset,
+-                          quic::StreamSendingState state, bool,
+-                          quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{0u, state != quic::NO_FIN};
+-      }));
++      .WillOnce(
++          Invoke([](quic::QuicStreamId, size_t /*write_length*/, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{0u, state != quic::NO_FIN};
++          }));
+   quic_stream_->encodeHeaders(response_headers_, /*end_stream=*/false);
+ 
+   // Encode 16kB -10 bytes request body. Because the high watermark is 16KB, with previously
+@@ -415,11 +416,11 @@ TEST_P(EnvoyQuicServerStreamTest, HeadersContributeToWatermarkIquic) {
+   // Unblock writing now, and this will write out 16kB data and cause stream to
+   // be blocked by the flow control limit.
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillOnce(Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
+-                          quic::StreamSendingState state, bool,
+-                          quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
+-      }));
++      .WillOnce(
++          Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
++          }));
+   EXPECT_CALL(stream_callbacks_, onBelowWriteBufferLowWatermark());
+   quic_session_.OnCanWrite();
+   EXPECT_TRUE(quic_stream_->IsFlowControlBlocked());
+@@ -429,20 +430,20 @@ TEST_P(EnvoyQuicServerStreamTest, HeadersContributeToWatermarkIquic) {
+                                              32 * 1024);
+   quic_stream_->OnWindowUpdateFrame(window_update1);
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillOnce(Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
+-                          quic::StreamSendingState state, bool,
+-                          quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
+-      }));
++      .WillOnce(
++          Invoke([](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{write_length, state != quic::NO_FIN};
++          }));
+   quic_session_.OnCanWrite();
+   // No data should be buffered at this point.
+ 
+   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+-      .WillRepeatedly(Invoke([](quic::QuicStreamId, size_t, quic::QuicStreamOffset,
+-                                quic::StreamSendingState state, bool,
+-                                quiche::QuicheOptional<quic::EncryptionLevel>) {
+-        return quic::QuicConsumedData{0u, state != quic::NO_FIN};
+-      }));
++      .WillRepeatedly(
++          Invoke([](quic::QuicStreamId, size_t, quic::QuicStreamOffset,
++                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
++            return quic::QuicConsumedData{0u, state != quic::NO_FIN};
++          }));
+   // Send more data. If watermark bytes counting were not cleared in previous
+   // OnCanWrite, this write would have caused the stream to exceed its high watermark.
+   std::string response1(16 * 1024 - 3, 'a');
+diff --git a/test/extensions/quic_listeners/quiche/platform/BUILD b/test/extensions/quic_listeners/quiche/platform/BUILD
+index 420e812b8..7dbb08d82 100644
+--- a/test/extensions/quic_listeners/quiche/platform/BUILD
++++ b/test/extensions/quic_listeners/quiche/platform/BUILD
+@@ -9,16 +9,6 @@ licenses(["notice"])  # Apache 2
+ 
+ envoy_package()
+ 
+-envoy_cc_test(
+-    name = "quiche_platform_test",
+-    srcs = ["quiche_platform_test.cc"],
+-    external_deps = ["quiche_common_platform"],
+-    deps = [
+-        "@com_googlesource_quiche//:quiche_common_platform",
+-        "@com_googlesource_quiche//:quiche_common_platform_endian",
+-    ],
+-)
+-
+ envoy_cc_test(
+     name = "http2_platform_test",
+     srcs = ["http2_platform_test.cc"],
+@@ -63,7 +53,6 @@ envoy_cc_test(
+         "@com_googlesource_quiche//:quic_platform_mem_slice_span",
+         "@com_googlesource_quiche//:quic_platform_mem_slice_storage",
+         "@com_googlesource_quiche//:quic_platform_mock_log",
+-        "@com_googlesource_quiche//:quic_platform_port_utils",
+         "@com_googlesource_quiche//:quic_platform_sleep",
+         "@com_googlesource_quiche//:quic_platform_system_event_loop",
+         "@com_googlesource_quiche//:quic_platform_test",
+@@ -150,17 +139,6 @@ envoy_cc_test_library(
+     deps = ["@com_googlesource_quiche//:quic_platform_base"],
+ )
+ 
+-envoy_cc_test_library(
+-    name = "quic_platform_port_utils_impl_lib",
+-    srcs = ["quic_port_utils_impl.cc"],
+-    hdrs = ["quic_port_utils_impl.h"],
+-    tags = ["nofips"],
+-    deps = [
+-        "//source/common/network:utility_lib",
+-        "//test/test_common:environment_lib",
+-    ],
+-)
+-
+ envoy_cc_test_library(
+     name = "quic_platform_test_mem_slice_vector_impl_lib",
+     hdrs = ["quic_test_mem_slice_vector_impl.h"],
+diff --git a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+index 069a79eab..35aee5d27 100644
+--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
++++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+@@ -72,20 +72,14 @@ TEST(Http2PlatformTest, Http2Log) {
+   HTTP2_DLOG_EVERY_N(ERROR, 2) << "DLOG_EVERY_N(ERROR, 2)";
+ }
+ 
+-TEST(Http2PlatformTest, Http2StringPiece) {
+-  std::string s = "bar";
+-  quiche::QuicheStringPiece sp(s);
+-  EXPECT_EQ('b', sp[0]);
+-}
+-
+ TEST(Http2PlatformTest, Http2Macro) {
+   EXPECT_DEBUG_DEATH(HTTP2_UNREACHABLE(), "");
+   EXPECT_DEATH(HTTP2_DIE_IF_NULL(nullptr), "");
+ }
+ 
+ TEST(Http2PlatformTest, Http2Flags) {
+-  auto& flag_registry = quiche::FlagRegistry::GetInstance();
+-  flag_registry.ResetFlags();
++  auto& flag_registry = quiche::FlagRegistry::getInstance();
++  flag_registry.resetFlags();
+   EXPECT_FALSE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+   SetHttp2ReloadableFlag(http2_testonly_default_false, true);
+   EXPECT_TRUE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+@@ -93,22 +87,22 @@ TEST(Http2PlatformTest, Http2Flags) {
+   for (std::string s : {"1", "t", "true", "TRUE", "y", "yes", "Yes"}) {
+     SetHttp2ReloadableFlag(http2_testonly_default_false, false);
+     EXPECT_FALSE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+-    EXPECT_TRUE(flag_registry.FindFlag("http2_reloadable_flag_http2_testonly_default_false")
+-                    ->SetValueFromString(s));
++    EXPECT_TRUE(flag_registry.findFlag("FLAGS_quic_reloadable_flag_http2_testonly_default_false")
++                    ->setValueFromString(s));
+     EXPECT_TRUE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+   }
+   for (std::string s : {"0", "f", "false", "FALSE", "n", "no", "No"}) {
+     SetHttp2ReloadableFlag(http2_testonly_default_false, true);
+     EXPECT_TRUE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+-    EXPECT_TRUE(flag_registry.FindFlag("http2_reloadable_flag_http2_testonly_default_false")
+-                    ->SetValueFromString(s));
++    EXPECT_TRUE(flag_registry.findFlag("FLAGS_quic_reloadable_flag_http2_testonly_default_false")
++                    ->setValueFromString(s));
+     EXPECT_FALSE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+   }
+   for (std::string s : {"some", "invalid", "values", ""}) {
+     SetHttp2ReloadableFlag(http2_testonly_default_false, false);
+     EXPECT_FALSE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+-    EXPECT_FALSE(flag_registry.FindFlag("http2_reloadable_flag_http2_testonly_default_false")
+-                     ->SetValueFromString(s));
++    EXPECT_FALSE(flag_registry.findFlag("FLAGS_quic_reloadable_flag_http2_testonly_default_false")
++                     ->setValueFromString(s));
+     EXPECT_FALSE(GetHttp2ReloadableFlag(http2_testonly_default_false));
+   }
+ }
+diff --git a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+index 68141aa94..902ad1a9e 100644
+--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
++++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+@@ -30,7 +30,6 @@
+ #include "gtest/gtest.h"
+ #include "quiche/common/platform/api/quiche_string_piece.h"
+ #include "quiche/epoll_server/fake_simple_epoll_server.h"
+-#include "quiche/quic/platform/api/quic_aligned.h"
+ #include "quiche/quic/platform/api/quic_bug_tracker.h"
+ #include "quiche/quic/platform/api/quic_cert_utils.h"
+ #include "quiche/quic/platform/api/quic_client_stats.h"
+@@ -42,7 +41,6 @@
+ #include "quiche/quic/platform/api/quic_flags.h"
+ #include "quiche/quic/platform/api/quic_hostname_utils.h"
+ #include "quiche/quic/platform/api/quic_logging.h"
+-#include "quiche/quic/platform/api/quic_macros.h"
+ #include "quiche/quic/platform/api/quic_map_util.h"
+ #include "quiche/quic/platform/api/quic_mem_slice.h"
+ #include "quiche/quic/platform/api/quic_mem_slice_span.h"
+@@ -50,7 +48,6 @@
+ #include "quiche/quic/platform/api/quic_mock_log.h"
+ #include "quiche/quic/platform/api/quic_mutex.h"
+ #include "quiche/quic/platform/api/quic_pcc_sender.h"
+-#include "quiche/quic/platform/api/quic_port_utils.h"
+ #include "quiche/quic/platform/api/quic_ptr_util.h"
+ #include "quiche/quic/platform/api/quic_server_stats.h"
+ #include "quiche/quic/platform/api/quic_sleep.h"
+@@ -92,8 +89,6 @@ protected:
+   const int verbosity_log_threshold_;
+ };
+ 
+-TEST_F(QuicPlatformTest, QuicAlignOf) { EXPECT_LT(0, QUIC_ALIGN_OF(int)); }
+-
+ enum class TestEnum { ZERO = 0, ONE, TWO, COUNT };
+ 
+ TEST_F(QuicPlatformTest, QuicBugTracker) {
+@@ -468,9 +463,9 @@ TEST_F(QuicPlatformTest, QuicCertUtils) {
+   unsigned char* der = nullptr;
+   int len = i2d_X509(x509_cert.get(), &der);
+   ASSERT_GT(len, 0);
+-  quiche::QuicheStringPiece out;
++  absl::string_view out;
+   QuicCertUtils::ExtractSubjectNameFromDERCert(
+-      quiche::QuicheStringPiece(reinterpret_cast<const char*>(der), len), &out);
++      absl::string_view(reinterpret_cast<const char*>(der), len), &out);
+   EXPECT_EQ("0z1\v0\t\x6\x3U\x4\x6\x13\x2US1\x13"
+             "0\x11\x6\x3U\x4\b\f\nCalifornia1\x16"
+             "0\x14\x6\x3U\x4\a\f\rSan Francisco1\r"
+@@ -566,8 +561,8 @@ TEST_F(QuicPlatformTest, MonotonicityWithFakeEpollClock) {
+ }
+ 
+ TEST_F(QuicPlatformTest, QuicFlags) {
+-  auto& flag_registry = quiche::FlagRegistry::GetInstance();
+-  flag_registry.ResetFlags();
++  auto& flag_registry = quiche::FlagRegistry::getInstance();
++  flag_registry.resetFlags();
+ 
+   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
+@@ -583,14 +578,15 @@ TEST_F(QuicPlatformTest, QuicFlags) {
+   SetQuicFlag(FLAGS_quic_time_wait_list_seconds, 100);
+   EXPECT_EQ(100, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
+ 
+-  flag_registry.ResetFlags();
++  flag_registry.resetFlags();
+   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+   EXPECT_TRUE(GetQuicRestartFlag(quic_testonly_default_true));
+   EXPECT_EQ(200, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
+-  flag_registry.FindFlag("quic_reloadable_flag_quic_testonly_default_false")
+-      ->SetValueFromString("true");
+-  flag_registry.FindFlag("quic_restart_flag_quic_testonly_default_true")->SetValueFromString("0");
+-  flag_registry.FindFlag("quic_time_wait_list_seconds")->SetValueFromString("100");
++  flag_registry.findFlag("FLAGS_quic_reloadable_flag_quic_testonly_default_false")
++      ->setValueFromString("true");
++  flag_registry.findFlag("FLAGS_quic_restart_flag_quic_testonly_default_true")
++      ->setValueFromString("0");
++  flag_registry.findFlag("FLAGS_quic_time_wait_list_seconds")->setValueFromString("100");
+   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
+   EXPECT_FALSE(GetQuicRestartFlag(quic_testonly_default_true));
+   EXPECT_EQ(100, GetQuicFlag(FLAGS_quic_time_wait_list_seconds));
+@@ -661,35 +657,6 @@ TEST_F(FileUtilsTest, ReadFileContents) {
+   EXPECT_EQ(data, output);
+ }
+ 
+-TEST_F(QuicPlatformTest, PickUnsedPort) {
+-  int port = QuicPickServerPortForTestsOrDie();
+-  std::vector<Envoy::Network::Address::IpVersion> supported_versions =
+-      Envoy::TestEnvironment::getIpVersionsForTest();
+-  for (auto ip_version : supported_versions) {
+-    Envoy::Network::Address::InstanceConstSharedPtr addr =
+-        Envoy::Network::Test::getCanonicalLoopbackAddress(ip_version);
+-    Envoy::Network::Address::InstanceConstSharedPtr addr_with_port =
+-        Envoy::Network::Utility::getAddressWithPort(*addr, port);
+-    Envoy::Network::SocketImpl sock(Envoy::Network::Socket::Type::Datagram, addr_with_port);
+-    // binding of given port should success.
+-    EXPECT_EQ(0, sock.bind(addr_with_port).rc_);
+-  }
+-}
+-
+-TEST_F(QuicPlatformTest, FailToPickUnsedPort) {
+-  Envoy::Api::MockOsSysCalls os_sys_calls;
+-  Envoy::TestThreadsafeSingletonInjector<Envoy::Api::OsSysCallsImpl> os_calls(&os_sys_calls);
+-  // Actually create sockets.
+-  EXPECT_CALL(os_sys_calls, socket(_, _, _)).WillRepeatedly([](int domain, int type, int protocol) {
+-    os_fd_t fd = ::socket(domain, type, protocol);
+-    return Envoy::Api::SysCallSocketResult{fd, errno};
+-  });
+-  // Fail bind call's to mimic port exhaustion.
+-  EXPECT_CALL(os_sys_calls, bind(_, _, _))
+-      .WillRepeatedly(Return(Envoy::Api::SysCallIntResult{-1, SOCKET_ERROR_ADDR_IN_USE}));
+-  EXPECT_DEATH(QuicPickServerPortForTestsOrDie(), "Failed to pick a port for test.");
+-}
+-
+ TEST_F(QuicPlatformTest, TestEnvoyQuicBufferAllocator) {
+   QuicStreamBufferAllocator allocator;
+   Envoy::Stats::TestUtil::MemoryTest memory_test;
+@@ -711,14 +678,6 @@ TEST_F(QuicPlatformTest, TestSystemEventLoop) {
+   QuicSystemEventLoop("dummy");
+ }
+ 
+-QUIC_MUST_USE_RESULT bool dummyTestFunction() { return false; }
+-
+-TEST_F(QuicPlatformTest, TestQuicMacros) {
+-  // Just make sure it compiles.
+-  EXPECT_FALSE(dummyTestFunction());
+-  int a QUIC_UNUSED;
+-}
+-
+ TEST(EnvoyQuicMemSliceTest, ConstructMemSliceFromBuffer) {
+   std::string str(512, 'b');
+   // Fragment needs to out-live buffer.
+diff --git a/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.cc b/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.cc
+index 556f6cd3e..9eaf8532a 100644
+--- a/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.cc
++++ b/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.cc
+@@ -19,7 +19,7 @@
+ namespace quic {
+ namespace {
+ 
+-void QuicRecordTestOutputToFile(const std::string& filename, quiche::QuicheStringPiece data) {
++void quicRecordTestOutputToFile(const std::string& filename, absl::string_view data) {
+   const char* output_dir_env = std::getenv("QUIC_TEST_OUTPUT_DIR");
+   if (output_dir_env == nullptr) {
+     QUIC_LOG(WARNING) << "Could not save test output since QUIC_TEST_OUTPUT_DIR is not set";
+@@ -64,11 +64,13 @@ void QuicRecordTestOutputToFile(const std::string& filename, quiche::QuicheStrin
+ }
+ } // namespace
+ 
+-void QuicSaveTestOutputImpl(quiche::QuicheStringPiece filename, quiche::QuicheStringPiece data) {
+-  QuicRecordTestOutputToFile(filename.data(), data);
++// NOLINTNEXTLINE(readability-identifier-naming)
++void QuicSaveTestOutputImpl(absl::string_view filename, absl::string_view data) {
++  quicRecordTestOutputToFile(filename.data(), data);
+ }
+ 
+-bool QuicLoadTestOutputImpl(quiche::QuicheStringPiece filename, std::string* data) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++bool QuicLoadTestOutputImpl(absl::string_view filename, std::string* data) {
+   const char* read_dir_env = std::getenv("QUIC_TEST_OUTPUT_DIR");
+   if (read_dir_env == nullptr) {
+     QUIC_LOG(WARNING) << "Could not load test output since QUIC_TEST_OUTPUT_DIR is not set";
+@@ -96,7 +98,8 @@ bool QuicLoadTestOutputImpl(quiche::QuicheStringPiece filename, std::string* dat
+   return true;
+ }
+ 
+-void QuicRecordTraceImpl(quiche::QuicheStringPiece identifier, quiche::QuicheStringPiece data) {
++// NOLINTNEXTLINE(readability-identifier-naming)
++void QuicRecordTraceImpl(absl::string_view identifier, absl::string_view data) {
+   const testing::TestInfo* test_info = testing::UnitTest::GetInstance()->current_test_info();
+ 
+   std::string timestamp = absl::FormatTime("%Y%m%d%H%M%S", absl::Now(), absl::LocalTimeZone());
+@@ -104,7 +107,7 @@ void QuicRecordTraceImpl(quiche::QuicheStringPiece identifier, quiche::QuicheStr
+   std::string filename = fmt::sprintf("%s.%s.%s.%s.qtr", test_info->name(),
+                                       test_info->test_case_name(), identifier.data(), timestamp);
+ 
+-  QuicRecordTestOutputToFile(filename, data);
++  quicRecordTestOutputToFile(filename, data);
+ }
+ 
+ } // namespace quic
+diff --git a/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.h b/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.h
+index a1c6c7305..fcf0c47b3 100644
+--- a/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.h
++++ b/test/extensions/quic_listeners/quiche/platform/quic_test_output_impl.h
+@@ -6,14 +6,16 @@
+ // consumed or referenced directly by other Envoy code. It serves purely as a
+ // porting layer for QUICHE.
+ 
+-#include "quiche/common/platform/api/quiche_string_piece.h"
++#include "absl/strings/string_view.h"
+ 
+ namespace quic {
++// NOLINTNEXTLINE(readability-identifier-naming)
++void QuicSaveTestOutputImpl(absl::string_view filename, absl::string_view data);
+ 
+-void QuicSaveTestOutputImpl(quiche::QuicheStringPiece filename, quiche::QuicheStringPiece data);
++// NOLINTNEXTLINE(readability-identifier-naming)
++bool QuicLoadTestOutputImpl(absl::string_view filename, std::string* data);
+ 
+-bool QuicLoadTestOutputImpl(quiche::QuicheStringPiece filename, std::string* data);
+-
+-void QuicRecordTraceImpl(quiche::QuicheStringPiece identifier, quiche::QuicheStringPiece data);
++// NOLINTNEXTLINE(readability-identifier-naming)
++void QuicRecordTraceImpl(absl::string_view identifier, absl::string_view data);
+ 
+ } // namespace quic
+diff --git a/test/extensions/quic_listeners/quiche/platform/quiche_platform_test.cc b/test/extensions/quic_listeners/quiche/platform/quiche_platform_test.cc
+deleted file mode 100644
+index a733894b5..000000000
+--- a/test/extensions/quic_listeners/quiche/platform/quiche_platform_test.cc
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// NOLINT(namespace-envoy)
+-
+-// This file is part of the QUICHE platform implementation, and is not to be
+-// consumed or referenced directly by other Envoy code. It serves purely as a
+-// porting layer for QUICHE.
+-
+-#include "gtest/gtest.h"
+-#include "quiche/common/platform/api/quiche_arraysize.h"
+-#include "quiche/common/platform/api/quiche_endian.h"
+-#include "quiche/common/platform/api/quiche_optional.h"
+-#include "quiche/common/platform/api/quiche_ptr_util.h"
+-#include "quiche/common/platform/api/quiche_string_piece.h"
+-
+-namespace quiche {
+-
+-TEST(QuichePlatformTest, Arraysize) {
+-  int array[] = {0, 1, 2, 3, 4};
+-  EXPECT_EQ(5, QUICHE_ARRAYSIZE(array));
+-}
+-
+-TEST(QuichePlatformTest, StringPiece) {
+-  std::string s = "bar";
+-  QuicheStringPiece sp(s);
+-  EXPECT_EQ('b', sp[0]);
+-}
+-
+-TEST(QuichePlatformTest, WrapUnique) {
+-  auto p = QuicheWrapUnique(new int(6));
+-  EXPECT_EQ(6, *p);
+-}
+-
+-TEST(QuichePlatformTest, TestQuicheOptional) {
+-  QuicheOptional<int32_t> maybe_a;
+-  EXPECT_FALSE(maybe_a.has_value());
+-  maybe_a = 1;
+-  EXPECT_EQ(1, *maybe_a);
+-}
+-
+-} // namespace quiche
+diff --git a/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc b/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
+index 56453e232..eeae58c0a 100644
+--- a/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
++++ b/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
+@@ -8,7 +8,6 @@
+ #include "gtest/gtest.h"
+ #include "quiche/spdy/platform/api/spdy_bug_tracker.h"
+ #include "quiche/spdy/platform/api/spdy_containers.h"
+-#include "quiche/spdy/platform/api/spdy_endianness_util.h"
+ #include "quiche/spdy/platform/api/spdy_estimate_memory_usage.h"
+ #include "quiche/spdy/platform/api/spdy_flags.h"
+ #include "quiche/spdy/platform/api/spdy_logging.h"
+@@ -47,11 +46,6 @@ TEST(SpdyPlatformTest, SpdyHashSet) {
+   EXPECT_EQ(0, hset.count("qux"));
+ }
+ 
+-TEST(SpdyPlatformTest, SpdyEndianness) {
+-  EXPECT_EQ(0x1234, spdy::SpdyNetToHost16(spdy::SpdyHostToNet16(0x1234)));
+-  EXPECT_EQ(0x12345678, spdy::SpdyNetToHost32(spdy::SpdyHostToNet32(0x12345678)));
+-}
+-
+ TEST(SpdyPlatformTest, SpdyEstimateMemoryUsage) {
+   std::string s = "foo";
+   // Stubbed out to always return 0.
+@@ -92,19 +86,19 @@ TEST(SpdyPlatformTest, SpdyTestHelpers) {
+ }
+ 
+ TEST(SpdyPlatformTest, SpdyFlags) {
+-  auto& flag_registry = quiche::FlagRegistry::GetInstance();
+-  flag_registry.ResetFlags();
++  auto& flag_registry = quiche::FlagRegistry::getInstance();
++  flag_registry.resetFlags();
+   EXPECT_FALSE(GetSpdyReloadableFlag(spdy_testonly_default_false));
+   EXPECT_FALSE(GetSpdyRestartFlag(spdy_testonly_default_false));
+ 
+-  flag_registry.FindFlag("spdy_reloadable_flag_spdy_testonly_default_false")
+-      ->SetValueFromString("true");
++  flag_registry.findFlag("FLAGS_quic_reloadable_flag_spdy_testonly_default_false")
++      ->setValueFromString("true");
+   EXPECT_TRUE(GetSpdyReloadableFlag(spdy_testonly_default_false));
+   EXPECT_FALSE(GetSpdyRestartFlag(spdy_testonly_default_false));
+ 
+-  flag_registry.ResetFlags();
+-  flag_registry.FindFlag("spdy_restart_flag_spdy_testonly_default_false")
+-      ->SetValueFromString("yes");
++  flag_registry.resetFlags();
++  flag_registry.findFlag("FLAGS_quic_restart_flag_spdy_testonly_default_false")
++      ->setValueFromString("yes");
+   EXPECT_FALSE(GetSpdyReloadableFlag(spdy_testonly_default_false));
+   EXPECT_TRUE(GetSpdyRestartFlag(spdy_testonly_default_false));
+ }
+diff --git a/test/extensions/quic_listeners/quiche/test_proof_source.h b/test/extensions/quic_listeners/quiche/test_proof_source.h
+index a249b4314..bbedfd6c7 100644
+--- a/test/extensions/quic_listeners/quiche/test_proof_source.h
++++ b/test/extensions/quic_listeners/quiche/test_proof_source.h
+@@ -36,7 +36,7 @@ protected:
+   void signPayload(const quic::QuicSocketAddress& /*server_address*/,
+                    const quic::QuicSocketAddress& /*client_address*/,
+                    const std::string& /*hostname*/, uint16_t /*signature_algorithm*/,
+-                   quiche::QuicheStringPiece in,
++                   absl::string_view in,
+                    std::unique_ptr<quic::ProofSource::SignatureCallback> callback) override {
+     callback->Run(true, absl::StrCat("Fake signature for { ", in, " }"),
+                   std::make_unique<EnvoyQuicProofSourceDetails>(filter_chain_));
+diff --git a/test/extensions/quic_listeners/quiche/test_utils.h b/test/extensions/quic_listeners/quiche/test_utils.h
+index 102f7608e..7f0ea78e8 100644
+--- a/test/extensions/quic_listeners/quiche/test_utils.h
++++ b/test/extensions/quic_listeners/quiche/test_utils.h
+@@ -46,7 +46,7 @@ public:
+   MOCK_METHOD(quic::QuicConsumedData, WritevData,
+               (quic::QuicStreamId id, size_t write_length, quic::QuicStreamOffset offset,
+                quic::StreamSendingState state, quic::TransmissionType type,
+-               quiche::QuicheOptional<quic::EncryptionLevel> level));
++               absl::optional<quic::EncryptionLevel> level));
+   MOCK_METHOD(bool, ShouldYield, (quic::QuicStreamId id));
+ 
+   absl::string_view requestedServerName() const override {
+@@ -90,7 +90,7 @@ public:
+   MOCK_METHOD(quic::QuicConsumedData, WritevData,
+               (quic::QuicStreamId id, size_t write_length, quic::QuicStreamOffset offset,
+                quic::StreamSendingState state, quic::TransmissionType type,
+-               quiche::QuicheOptional<quic::EncryptionLevel> level));
++               absl::optional<quic::EncryptionLevel> level));
+   MOCK_METHOD(bool, ShouldYield, (quic::QuicStreamId id));
+ 
+   absl::string_view requestedServerName() const override {
+-- 
+2.29.2
+

--- a/pkgs/servers/http/envoy/0002-Add-upb-patch-to-make-it-compile-under-GCC10.patch
+++ b/pkgs/servers/http/envoy/0002-Add-upb-patch-to-make-it-compile-under-GCC10.patch
@@ -1,0 +1,91 @@
+From 8b531c41f956b27e4be32b430db2e7a44e0cdd3e Mon Sep 17 00:00:00 2001
+From: Luke Granger-Brown <git@lukegb.com>
+Date: Thu, 7 Jan 2021 11:09:18 +0000
+Subject: [PATCH] Add upb patch to make it compile under GCC10
+
+---
+ bazel/repositories.bzl |  5 +++-
+ bazel/upb2.patch       | 55 ++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 59 insertions(+), 1 deletion(-)
+ create mode 100644 bazel/upb2.patch
+
+diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
+index 64d61ea49..c6cadc9df 100644
+--- a/bazel/repositories.bzl
++++ b/bazel/repositories.bzl
+@@ -811,7 +811,10 @@ def _com_github_grpc_grpc():
+ def _upb():
+     _repository_impl(
+         name = "upb",
+-        patches = ["@envoy//bazel:upb.patch"],
++        patches = [
++            "@envoy//bazel:upb.patch",
++            "@envoy//bazel:upb2.patch",
++        ],
+         patch_args = ["-p1"],
+     )
+ 
+diff --git a/bazel/upb2.patch b/bazel/upb2.patch
+new file mode 100644
+index 000000000..6e436c61b
+--- /dev/null
++++ b/bazel/upb2.patch
+@@ -0,0 +1,55 @@
++From 9bd23dab4240b015321a53c45b3c9e4847fbf020 Mon Sep 17 00:00:00 2001
++From: Joshua Haberman <jhaberman@gmail.com>
++Date: Tue, 7 Apr 2020 15:22:11 -0700
++Subject: [PATCH] Changed upb status to suit GCC10's warning about strncpy().
++ (#268)
++
++Added tests for all cases. Also removed ellipses from truncated
++messages, they were more trouble than they are worth.
++---
++ tests/test_generated_code.c | 33 +++++++++++++++++++++++++++++++++
++ upb/upb.c                   | 17 +++--------------
++ 2 files changed, 36 insertions(+), 14 deletions(-)
++
++diff --git a/upb/upb.c b/upb/upb.c
++index cb2cdfd9d..258192d79 100644
++--- a/upb/upb.c
+++++ b/upb/upb.c
++@@ -11,17 +11,6 @@
++ 
++ #include "upb/port_def.inc"
++ 
++-/* Guarantee null-termination and provide ellipsis truncation.
++- * It may be tempting to "optimize" this by initializing these final
++- * four bytes up-front and then being careful never to overwrite them,
++- * this is safer and simpler. */
++-static void nullz(upb_status *status) {
++-  const char *ellipsis = "...";
++-  size_t len = strlen(ellipsis);
++-  UPB_ASSERT(sizeof(status->msg) > len);
++-  memcpy(status->msg + sizeof(status->msg) - len, ellipsis, len);
++-}
++-
++ /* upb_status *****************************************************************/
++ 
++ void upb_status_clear(upb_status *status) {
++@@ -37,8 +26,8 @@ const char *upb_status_errmsg(const upb_status *status) { return status->msg; }
++ void upb_status_seterrmsg(upb_status *status, const char *msg) {
++   if (!status) return;
++   status->ok = false;
++-  strncpy(status->msg, msg, sizeof(status->msg));
++-  nullz(status);
+++  strncpy(status->msg, msg, UPB_STATUS_MAX_MESSAGE - 1);
+++  status->msg[UPB_STATUS_MAX_MESSAGE - 1] = '\0';
++ }
++ 
++ void upb_status_seterrf(upb_status *status, const char *fmt, ...) {
++@@ -52,7 +41,7 @@ void upb_status_vseterrf(upb_status *status, const char *fmt, va_list args) {
++   if (!status) return;
++   status->ok = false;
++   _upb_vsnprintf(status->msg, sizeof(status->msg), fmt, args);
++-  nullz(status);
+++  status->msg[UPB_STATUS_MAX_MESSAGE - 1] = '\0';
++ }
++ 
++ /* upb_alloc ******************************************************************/
+-- 
+2.29.2
+

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -1,0 +1,119 @@
+{ buildBazelPackage
+, fetchFromGitHub
+, stdenv
+, cmake
+, go
+, ninja
+, python3
+}:
+
+let
+  srcVer = {
+    # We need the commit hash, since Bazel stamps the build with it.
+    # However, the version string is more useful for end-users.
+    # These are contained in a attrset of their own to make it obvious that
+    # people should update both.
+    version = "1.16.2";
+    commit = "e98e41a8e168af7acae8079fc0cd68155f699aa3";
+  };
+in
+buildBazelPackage rec {
+  pname = "envoy";
+  version = srcVer.version;
+  src = fetchFromGitHub {
+    owner = "envoyproxy";
+    repo = "envoy";
+    rev = srcVer.commit;
+    hash = "sha256-aWVMRKFCZzf9/96NRPCP4jiW38DJhXyi0gEqW7uIpnQ=";
+
+    extraPostFetch = ''
+      chmod -R +w $out
+      rm $out/.bazelversion
+      echo ${srcVer.commit} > $out/SOURCE_VERSION
+      sed -i 's/GO_VERSION = ".*"/GO_VERSION = "host"/g' $out/bazel/dependency_imports.bzl
+    '';
+  };
+
+  patches = [
+    # Quiche needs to be updated to compile under newer GCC.
+    # This is a manual backport of http://github.com/envoyproxy/envoy/pull/13949.
+    ./0001-quiche-update-QUICHE-tar-13949.patch
+
+    # upb needs to be updated to compile under newer GCC.
+    # This is a manual backport of https://github.com/protocolbuffers/upb/commit/9bd23dab4240b015321a53c45b3c9e4847fbf020.
+    ./0002-Add-upb-patch-to-make-it-compile-under-GCC10.patch
+  ];
+  postPatch = ''
+    sed -i 's,#!/usr/bin/env python3,#!${python3}/bin/python,' bazel/foreign_cc/luajit.patch
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    go
+    ninja
+  ];
+
+  fetchAttrs = {
+    sha256 = "sha256-mct7anzErY9eSujZyGORfRJqzAO9XuFAv04DS8VRZKM=";
+    dontUseCmakeConfigure = true;
+    preInstall = ''
+      # Strip out the path to the build location (by deleting the comment line).
+      find $bazelOut/external -name requirements.bzl | while read requirements; do
+        sed -i '/# Generated from /d' "$requirements"
+      done
+
+      # Remove references to paths in the Nix store.
+      sed -i \
+        -e 's,${python3},__NIXPYTHON__,' \
+        -e 's,${stdenv.shellPackage},__NIXSHELL__,' \
+        $bazelOut/external/com_github_luajit_luajit/build.py \
+        $bazelOut/external/local_config_sh/BUILD
+      rm -r $bazelOut/external/go_sdk
+
+      # Replace some wheels which are only used for tests with empty files;
+      # they're nondeterministically built and packed.
+      >$bazelOut/external/config_validation_pip3/PyYAML-5.3.1-cp38-cp38-linux_x86_64.whl
+      >$bazelOut/external/protodoc_pip3/PyYAML-5.3.1-cp38-cp38-linux_x86_64.whl
+      >$bazelOut/external/thrift_pip3/thrift-0.13.0-cp38-cp38-linux_x86_64.whl
+    '';
+  };
+  buildAttrs = {
+    dontUseCmakeConfigure = true;
+    dontUseNinjaInstall = true;
+    preConfigure = ''
+      sed -i 's,#!/usr/bin/env bash,#!${stdenv.shell},' $bazelOut/external/rules_foreign_cc/tools/build_defs/framework.bzl
+
+      # Add paths to Nix store back.
+      sed -i \
+        -e 's,__NIXPYTHON__,${python3},' \
+        -e 's,__NIXSHELL__,${stdenv.shellPackage},' \
+        $bazelOut/external/com_github_luajit_luajit/build.py \
+        $bazelOut/external/local_config_sh/BUILD
+    '';
+    installPhase = ''
+      install -Dm0755 bazel-bin/source/exe/envoy-static $out/bin/envoy
+    '';
+  };
+
+  fetchConfigured = true;
+  removeRulesCC = false;
+  removeLocalConfigCc = true;
+  removeLocal = false;
+  bazelTarget = "//source/exe:envoy-static";
+  bazelBuildFlags = [
+    "-c opt"
+    "--spawn_strategy=standalone"
+    "--noexperimental_strict_action_env"
+    "--cxxopt=-Wno-maybe-uninitialized"
+    "--cxxopt=-Wno-uninitialized"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://envoyproxy.io";
+    description = "Cloud-native edge and service proxy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = [ "x86_64-linux" ];  # Other platforms will generate different fetch hashes.
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17401,6 +17401,8 @@ in
 
   engelsystem = callPackage ../servers/web-apps/engelsystem { };
 
+  envoy = callPackage ../servers/http/envoy { };
+
   etcd = callPackage ../servers/etcd { };
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Add [Envoy](https://github.com/envoyproxy/envoy), a cloud-native proxy.

I'm adding this because I want to add [Pomerium](https://www.pomerium.io/), and Envoy is a dependency (it's the data-plane proxy that Pomerium uses).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
