### PR TITLE
far2l: 2019-12-14 -> 2020-12-30 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3807,6 +3807,12 @@
     githubId = 15371828;
     name = "Hugo Lageneste";
   };
+  hypersw = {
+    email = "baltic@hypersw.net";
+    github = "hypersw";
+    githubId = 2332070;
+    name = "Serge Baltic";
+  };
   hyphon81 = {
     email = "zero812n@gmail.com";
     github = "hyphon81";

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, cmake, pkg-config, wxGTK30, glib, pcre, m4, bash,
-  xdg-utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick, darwin,
-  libuchardet, spdlog, xercesc, fmt }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, cmake, pkg-config, wxGTK30, glib, pcre, m4, bash
+, xdg-utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick
+, libuchardet, spdlog, xercesc, fmt, openssl, libssh, samba, neon, libnfs, libarchive }:
 
 stdenv.mkDerivation rec {
   pname = "far2l";
@@ -15,8 +15,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config m4 makeWrapper imagemagick ];
 
-  buildInputs = [ wxGTK30 glib pcre libuchardet spdlog xercesc fmt ]
-    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
+  buildInputs = [ wxGTK30 glib pcre libuchardet spdlog xercesc fmt ] # base requirements of the build
+    ++ [ openssl libssh samba neon libnfs libarchive ]; # optional feature packages, like protocol support for Network panel, or archive formats
+    #++ lib.optional stdenv.isDarwin Cocoa # Mac support -- disabled, see "meta.broken" below
 
   postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace far2l/bootstrap/trash.sh \
@@ -66,10 +67,13 @@ stdenv.mkDerivation rec {
   stripDebugList = [ "bin" "share" ];
 
   meta = with lib; {
-    description = "An orthodox file manager";
+    description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";
     homepage = "https://github.com/elfmz/far2l";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.volth ];
+    license = licenses.gpl2Plus; # NOTE: might change in far2l repo soon, check next time
+    maintainers = with maintainers; [ volth hypersw ];
     platforms = platforms.all;
+    # fails to compile with:
+    # error: no member named 'st_ctim' in 'stat'
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -1,28 +1,21 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, cmake, pkg-config, wxGTK30, glib, pcre, m4, bash,
-  xdg-utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick, darwin }:
+  xdg-utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick, darwin,
+  libuchardet, spdlog, xercesc, fmt }:
 
-let
-  newer-colorer-schemes = fetchFromGitHub {
-    owner = "colorer";
-    repo = "Colorer-schemes";
-    rev = "7c831f5e94a90530ace8b2bb9916210e3a2fcda6"; # 2019-11-28 (far2l has older Colorer-schemes)
-    sha256 = "18vaahdz5i7xdf00c9h9kjjswm4jszywm8zkhva4c4ivr4qqnv2c";
-  };
-in
 stdenv.mkDerivation rec {
   pname = "far2l";
-  version = "2019-12-14.git${builtins.substring 0 7 src.rev}";
+  version = "2020-12-30.git${builtins.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "elfmz";
     repo = "far2l";
-    rev = "dceaa3918ea2c5e43600bad3fc63f861b8d26fc4";
-    sha256 = "1ssd3hwz4b7vl4r858d9whl61cn23pgcamcjmvfa6ysf4x2b7sgi";
+    rev = "52c1372441443aafd1a7dff6f17969a6ec19885d";
+    sha256 = "0s7427fgxzj5zkyy6mhb4y5hqa6adsr30m0bigycp12b0495ryx0";
   };
 
   nativeBuildInputs = [ cmake pkg-config m4 makeWrapper imagemagick ];
 
-  buildInputs = [ wxGTK30 glib pcre ]
+  buildInputs = [ wxGTK30 glib pcre libuchardet spdlog xercesc fmt ]
     ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Cocoa;
 
   postPatch = lib.optionalString stdenv.isLinux ''
@@ -48,10 +41,6 @@ stdenv.mkDerivation rec {
       --replace '"gzip '      '"${gzip}/bin/gzip '         \
       --replace '"bzip2 '     '"${bzip2}/bin/bzip2 '       \
       --replace '"tar '       '"${gnutar}/bin/tar '
-
-    cp ${newer-colorer-schemes}/hrc/hrc/base/nix.hrc     colorer/configs/base/hrc/base/
-    cp ${newer-colorer-schemes}/hrc/hrc/base/cpp.hrc     colorer/configs/base/hrc/base/
-    cp ${newer-colorer-schemes}/hrc/hrc/inet/jscript.hrc colorer/configs/base/hrc/base/
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

`far2l` were not able to run on a GUI-less NixOS installation, just exited silently. Upon a short diagnostic together with folks from far2l, ruled out that we had a version bundled which didn't have the tty-compat code yet.

###### Things done

Updated to a fresh `master` revision, fixed compilation, checked that it runs and appears operational.
The app build has some packages optional, needed to enable operations of plugins like network share browsers, added them to the build.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) -- found no relevant tests
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` -- the command messed up in patches, but I believe no packages depend on far2l, based on repo search
- [x] Tested execution of all binary files (usually in `./result/bin/`) -- tested running some of the plugins, incl which were just added
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date -- I think there're no docs outside package
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
