### PR TITLE
expenses: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5490,6 +5490,12 @@
     githubId = 346094;
     name = "Michael Alyn Miller";
   };
+  manojkarthick = {
+    email = "smanojkarthick@gmail.com";
+    github = "manojkarthick";
+    githubId = 7802795;
+    name = "Manoj Karthick";
+  };
   manveru = {
     email = "m.fellinger@gmail.com";
     github = "manveru";

--- a/pkgs/applications/misc/expenses/default.nix
+++ b/pkgs/applications/misc/expenses/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+, sqlite
+}:
+
+buildGoModule rec {
+  pname = "expenses";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "manojkarthick";
+    repo = "expenses";
+    rev = "v${version}";
+    sha256 = "11wxaqbnrrg0rykx5905chi6rhmai1nqggdbhh6hiappr5rksl0j";
+  };
+
+  vendorSha256 = "1kwj63wl4kb16zl3lmi9bzj1az7vi453asdy52na0mjx4ymmjyk1";
+
+  # package does not contain any tests as of v0.2.1
+  doCheck = false;
+
+  buildInputs = [ sqlite ];
+
+  buildFlagsArray = [
+    "-ldflags=-s -w -X github.com/manojkarthick/expenses/cmd.Version=${version}"
+  ];
+
+  meta = with stdenv.lib; {
+   description = "An interactive command line expense logger";
+   license = licenses.mit;
+   maintainers = [ maintainers.manojkarthick ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21438,6 +21438,8 @@ in
 
   exercism = callPackage ../applications/misc/exercism { };
 
+  expenses = callPackage ../applications/misc/expenses { };
+
   go-libp2p-daemon = callPackage ../servers/go-libp2p-daemon { };
 
   go-motion = callPackage ../development/tools/go-motion { };


### PR DESCRIPTION
###### Motivation for this change

An interactive command line expense logger
GitHub: https://github.com/manojkarthick/expenses

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
