### PR TITLE
python3Packages.PyChromecast: 7.7.1 -> 7.7.2

### DIFF
--- a/pkgs/development/python-modules/pychromecast/default.nix
+++ b/pkgs/development/python-modules/pychromecast/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "PyChromecast";
-  version = "7.7.1";
+  version = "7.7.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09mdz1y1bfwkszxsawffwy1mr7lc1j2rma571qkb60sk76107zfn";
+    sha256 = "1w7jayb0z529bh1ybb16pfm0m08qqi4px1q0qwlvcxlcrd2v3m5a";
   };
 
   disabled = !isPy3k;

--- a/pkgs/development/python-modules/pychromecast/default.nix
+++ b/pkgs/development/python-modules/pychromecast/default.nix
@@ -13,6 +13,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ requests zeroconf protobuf casttube ];
 
+  # no tests available
+  doCheck = false;
   pythonImportsCheck = [ "pychromecast" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 7.7.2

Change log: https://github.com/home-assistant-libs/pychromecast/releases/tag/7.7.2

The upstream project doesn't have any test. Disabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
