### PR TITLE
0ad: fix build by using gcc9Stdenv

### DIFF
--- a/pkgs/games/0ad/default.nix
+++ b/pkgs/games/0ad/default.nix
@@ -1,14 +1,14 @@
-{ wxGTK, newScope }:
-
+{ wxGTK, stdenv, newScope }:
 let
   callPackage = newScope self;
 
   self = {
-    zeroad-unwrapped = callPackage ./game.nix { inherit wxGTK; };
+    zeroad-unwrapped = callPackage ./game.nix { inherit wxGTK stdenv; };
 
-    zeroad-data = callPackage ./data.nix { };
+    zeroad-data = callPackage ./data.nix { inherit stdenv; };
 
     zeroad = callPackage ./wrapper.nix { };
   };
 
-in self
+in
+self

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     # Workaround invalid pkg-config name for mozjs
     mkdir pkg-config
     ln -s ${spidermonkey_38}/lib/pkgconfig/* pkg-config/mozjs-38.pc
-    PKG_CONFIG_PATH="$PWD/pkgconfig:$PKG_CONFIG_PATH"
+    PKG_CONFIG_PATH="$PWD/pkg-config:$PKG_CONFIG_PATH"
 
     # Update Makefiles
     pushd build/workspaces

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27093,6 +27093,7 @@ in
 
   zeroadPackages = dontRecurseIntoAttrs (callPackage ../games/0ad {
     wxGTK = wxGTK30;
+    stdenv = gcc9Stdenv;
   });
 
   zeroad = zeroadPackages.zeroad;


### PR DESCRIPTION
###### Motivation for this change

The 0ad build fails since gcc 10 was made default with this error:
```
CommonConvert.cpp
DLL.cpp
Decompose.cpp
StdSkeletons.cpp
PSAConvert.cpp
XMLFix.cpp
precompiled.cpp
PMDConvert.cpp
Maths.cpp
GeomReindex.cpp
Linking Collada
/nix/store/4l1qrgxfy171bngpphp4p9wj7bhrlfn3-binutils-2.34/bin/ld: ../../../libraries/source/fcollada/lib/libFColladaSR.a(FAXInstanceExport.o): in function `FArchiveXML::WritePhysicsRigidBodyInstance(FCDObject*, _xmlNode*)':
FAXInstanceExport.cpp:(.text+0xc69): undefined reference to `_xmlNode* FArchiveXML::AddPhysicsParameter<FMVector3, 0>(_xmlNode*, char const*, FCDParameterAnimatableT<FMVector3, 0>&)'
/nix/store/4l1qrgxfy171bngpphp4p9wj7bhrlfn3-binutils-2.34/bin/ld: FAXInstanceExport.cpp:(.text+0xc7f): undefined reference to `_xmlNode* FArchiveXML::AddPhysicsParameter<FMVector3, 0>(_xmlNode*, char const*, FCDParameterAnimatableT<FMVector3, 0>&)'
collect2: error: ld returned 1 exit status
make[1]: *** [Collada.make:98: ../../../binaries/system/libCollada.so] Error 1
make: *** [Makefile:173: Collada] Error 2
error: --- Error ------------------------------------------------------------------------------- nix-build
builder for '/nix/store/ybyi0amjy8il1ycmkx6qmq0kshd13dnc-0ad-0.0.23b.drv' failed with exit code 2
error: --- Error ------------------------------------------------------------------------------- nix-build
1 dependencies of derivation '/nix/store/f9aab3b5b74s7lp5k0l541ajwfpg5hms-zeroad-0.0.23b.drv' failed to build
```

This changes the 0ad derivation to use the gcc9Stdenv.

###### Things done

Played a few games using this build method.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
