### PR TITLE
gitlab-runner: make check for docker-image option with machine too

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -66,6 +66,12 @@ let
             ++ optional service.debugTraceDisabled
             "--debug-trace-disabled"
             ++ map (e: "--env ${escapeShellArg e}") (mapAttrsToList (name: value: "${name}=${value}") service.environmentVariables)
+            ++ optionals (service.executor == "docker+machine") (
+              assert (
+                assertMsg (service.dockerImage != null)
+                  "dockerImage option is required for docker+machine executor (${name})");
+              [ "--docker-image ${service.dockerImage}" ]
+            )
             ++ optionals (service.executor == "docker") (
               assert (
                 assertMsg (service.dockerImage != null)


### PR DESCRIPTION
closes: #108759

###### Motivation for this change

The "docker+machine" executor requires setting docker-image too. If not,
it will fail with:

  PANIC: The docker-image needs to be entered

Since the docker-image argument was tied with the docker executor, this
would fail every time when attempting to use docker+machine.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
