### PR TITLE
nixos/etc: pass data via json to the build to avoid whitespace issues

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1039,7 +1039,7 @@ in
           done
         '' + concatMapStrings (name: optionalString (hasPrefix "tmpfiles.d/" name) ''
           rm -f $out/${removePrefix "tmpfiles.d/" name}
-        '') config.system.build.etc.targets;
+        '') config.system.build.etc.passthru.targets;
       }) + "/*";
 
       "systemd/system-generators" = { source = hooks "generators" cfg.generators; };

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -12,16 +12,13 @@ let
     name = "etc";
 
     builder = ./make-etc.sh;
+    nativeBuildInputs = [ pkgs.jq ];
 
     preferLocalBuild = true;
     allowSubstitutes = false;
 
-    /* !!! Use toXML. */
-    sources = map (x: x.source) etc';
-    targets = map (x: x.target) etc';
-    modes = map (x: x.mode) etc';
-    users  = map (x: x.user) etc';
-    groups  = map (x: x.group) etc';
+    data = pkgs.writeText "etc-data" (lib.generators.toJSON {} etc');
+    passthru.targets = map (x: x.target) etc';
   };
 
 in

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -2,43 +2,40 @@ source $stdenv/setup
 
 mkdir -p $out/etc
 
-set -f
-sources_=($sources)
-targets_=($targets)
-modes_=($modes)
-users_=($users)
-groups_=($groups)
-set +f
+readarray -t items < <(jq -c '.[]' < "$data")
 
-for ((i = 0; i < ${#targets_[@]}; i++)); do
-    source="${sources_[$i]}"
-    target="${targets_[$i]}"
+for item in "${items[@]}"; do
+    source="$(jq -nr '$item.source' --argjson item "$item")"
+    target="$(jq -nr '$item.target' --argjson item "$item")"
+    mode="$(jq -nr '$item.mode' --argjson item "$item")"
+    user="$(jq -nr '$item.user' --argjson item "$item")"
+    group="$(jq -nr '$item.group' --argjson item "$item")"
 
     if [[ "$source" =~ '*' ]]; then
 
         # If the source name contains '*', perform globbing.
-        mkdir -p $out/etc/$target
+        mkdir -p "$out/etc/$target"
         for fn in $source; do
-            ln -s "$fn" $out/etc/$target/
+            ln -s "$fn" "$out/etc/$target/"
         done
 
     else
 
-        mkdir -p $out/etc/$(dirname $target)
-        if ! [ -e $out/etc/$target ]; then
-            ln -s $source $out/etc/$target
+        mkdir -p $out/etc/$(dirname "$target")
+        if ! [ -e $out/etc/"$target" ]; then
+            ln -s "$source" "$out/etc/$target"
         else
             echo "duplicate entry $target -> $source"
-            if test "$(readlink $out/etc/$target)" != "$source"; then
-                echo "mismatched duplicate entry $(readlink $out/etc/$target) <-> $source"
+            if test "$(readlink "$out/etc/$target")" != "$source"; then
+                echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $source"
                 exit 1
             fi
         fi
 
-        if test "${modes_[$i]}" != symlink; then
-            echo "${modes_[$i]}"  > $out/etc/$target.mode
-            echo "${users_[$i]}"  > $out/etc/$target.uid
-            echo "${groups_[$i]}" > $out/etc/$target.gid
+        if test "$mode" != symlink; then
+            echo "$mode"  > "$out/etc/$target.mode"
+            echo "$user"  > "$out/etc/$target.uid"
+            echo "$group" > "$out/etc/$target.gid"
         fi
 
     fi


### PR DESCRIPTION
###### Motivation for this change
alternative approach to https://github.com/NixOS/nixpkgs/pull/41276

###### Things done

I built my system from this branch, and only a few symlink targets in the generated etc changed (as should be expected as the hashes changed).

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
