### PR TITLE
co-log, chronos: unmarkBroken by disabling tests for chronos

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -928,6 +928,10 @@ self: super: {
   # Work around overspecified constraint on github ==0.18.
   github-backup = doJailbreak super.github-backup;
 
+  # https://github.com/andrewthad/chronos/issues/62
+  # doctests are failing on newer GHC versions
+  chronos = dontCheck super.chronos;
+
   # Test suite depends on cabal-install
   doctest = dontCheck super.doctest;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3950,7 +3950,6 @@ broken-packages:
   - ChristmasTree
   - chromatin
   - chronograph
-  - chronos
   - chronos-bench
   - chu2
   - chunks
@@ -4061,7 +4060,6 @@ broken-packages:
   - cmt
   - cmv
   - cnc-spec-compiler
-  - co-log
   - co-log-polysemy
   - co-log-polysemy-formatting
   - co-log-sys


### PR DESCRIPTION
###### Motivation for this change

The only reason `co-log` is broken because one of its dependencies `chronos` fails the doctests on GHC 8.10. I created an issue in the `chronos` repo but I think we can unbreak both packages until that is resolved

~Will run nix review once PR is up~

Strangely `nix review` says nothing to be built

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
