### PR TITLE
pythonPackages.criticality-score: init at 1.0.7

### DIFF
--- a/pkgs/development/python-modules/criticality-score/default.nix
+++ b/pkgs/development/python-modules/criticality-score/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, PyGithub, python-gitlab }:
+
+buildPythonPackage rec {
+  pname = "criticality_score";
+  version = "1.0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0i811a27i87z3j1rw0dwrnw8v0ckbd918ms6shjawhs4cnb1c6x8";
+  };
+
+  propagatedBuildInputs = [ PyGithub python-gitlab ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "criticality_score" ];
+
+  meta = with lib; {
+    description = "Python tool for computing the Open Source Project Criticality Score.";
+    homepage = "https://github.com/ossf/criticality_score";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ wamserma ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1426,6 +1426,8 @@ in {
 
   credstash = callPackage ../development/python-modules/credstash { };
 
+  criticality-score = callPackage ../development/python-modules/criticality-score { };
+
   croniter = callPackage ../development/python-modules/croniter { };
 
   cryptacular = callPackage ../development/python-modules/cryptacular { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Compute the [criticality score](https://github.com/ossf/criticality_score) of https://github.com/NixOS/nixpkgs.

Result:
```
criticality_score --repo github.com/NixOS/nixpkgs
name: nixpkgs
url: https://github.com/NixOS/nixpkgs
language: Nix
created_since: 217
updated_since: 0
contributor_count: 4790
org_count: 9
commit_frequency: 703.1
recent_releases_count: 6
updated_issues_count: 13120
closed_issues_count: 9727
comment_frequency: 2.0
dependents_count: 33204
criticality_score: 0.96204
```

Seems like nixpkgs is pretty important.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 108794"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
