### PR TITLE
rmview: init at 2.1

### DIFF
--- a/pkgs/applications/misc/remarkable/rmview/default.nix
+++ b/pkgs/applications/misc/remarkable/rmview/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
+{ stdenv, lib, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
 
 python3Packages.buildPythonApplication rec {
   pname = "rmview";

--- a/pkgs/applications/misc/remarkable/rmview/default.nix
+++ b/pkgs/applications/misc/remarkable/rmview/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rmview";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "bordaigorl";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zyngirpg808k1pkyhrk43qr3i8ilvfci0wzwk4b5f6f9cmjs7kb";
+  };
+
+  nativeBuildInputs = with python3Packages; [ pyqt5 wrapQtAppsHook ];
+  propagatedBuildInputs = with python3Packages; [ pyqt5 paramiko twisted ];
+
+  preBuild = ''
+    pyrcc5 -o src/rmview/resources.py resources.qrc
+  '';
+
+  preFixup = ''
+    wrapQtApp "$out/bin/rmview"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fast live viewer for reMarkable 1 and 2";
+    homepage = "https://github.com/bordaigorl/rmview";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.nickhu ];
+  };
+}

--- a/pkgs/applications/misc/remarkable/rmview/default.nix
+++ b/pkgs/applications/misc/remarkable/rmview/default.nix
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A fast live viewer for reMarkable 1 and 2";
+    description = "Fast live viewer for reMarkable 1 and 2";
     homepage = "https://github.com/bordaigorl/rmview";
     license = licenses.gpl3;
     maintainers = [ maintainers.nickhu ];

--- a/pkgs/applications/misc/remarkable/rmview/default.nix
+++ b/pkgs/applications/misc/remarkable/rmview/default.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
     wrapQtApp "$out/bin/rmview"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Fast live viewer for reMarkable 1 and 2";
     homepage = "https://github.com/bordaigorl/rmview";
     license = licenses.gpl3Only;

--- a/pkgs/applications/misc/remarkable/rmview/default.nix
+++ b/pkgs/applications/misc/remarkable/rmview/default.nix
@@ -25,7 +25,7 @@ python3Packages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Fast live viewer for reMarkable 1 and 2";
     homepage = "https://github.com/bordaigorl/rmview";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = [ maintainers.nickhu ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2618,6 +2618,8 @@ in
 
   rmapi = callPackage ../applications/misc/remarkable/rmapi { };
 
+  rmview = libsForQt5.callPackage ../applications/misc/remarkable/rmview { };
+
   remarkable-mouse = python3Packages.callPackage ../applications/misc/remarkable/remarkable-mouse { };
 
   ryujinx = callPackage ../misc/emulators/ryujinx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds [rMview](https://github.com/bordaigorl/rmview), a VNC viewer for
reMarkable tablets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).