### PR TITLE
python3Packages.minikerberos: init at 0.2.7

### DIFF
--- a/pkgs/development/python-modules/asysocks/default.nix
+++ b/pkgs/development/python-modules/asysocks/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "asysocks";
+  version = "0.0.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1h9awwnn4dr3ppdlnjb4abhyw873n1iddipw6wkwjpw7nnaqqr6i";
+  };
+
+  # Upstream hasn't release the tests yet
+  doCheck = false;
+  pythonImportsCheck = [ "asysocks" ];
+
+  meta = with lib; {
+    description = "Python Socks4/5 client and server library";
+    homepage = "https://github.com/skelsec/asysocks";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/minikerberos/default.nix
+++ b/pkgs/development/python-modules/minikerberos/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, asn1crypto
+, asysocks
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "minikerberos";
+  version = "0.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08ngf55pbnzyqkgffzxix6ldal9l38d2jjn9rvxkg88ygxsalfvm";
+  };
+
+  propagatedBuildInputs = [
+    asn1crypto
+    asysocks
+  ];
+
+  # no tests are published: https://github.com/skelsec/minikerberos/pull/5
+  doCheck = false;
+  pythonImportsCheck = [ "minikerberos" ];
+
+  meta = with lib; {
+    description = "Kerberos manipulation library in Python";
+    homepage = "https://github.com/skelsec/minikerberos";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/winsspi/default.nix
+++ b/pkgs/development/python-modules/winsspi/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, minikerberos
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "winsspi";
+  version = "0.0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q8hr8l8d9jxyp55qsrlkyhdhqjc0n18ajzms7hf1xkhdl7rrbd2";
+  };
+  propagatedBuildInputs = [ minikerberos ];
+
+  # Project doesn't have tests
+  doCheck = false;
+  pythonImportsCheck = [ "winsspi" ];
+
+  meta = with lib; {
+    description = "Python module for ACL/ACE/Security descriptor manipulation";
+    homepage = "https://github.com/skelsec/winsspi";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -469,6 +469,8 @@ in {
 
   asyncwhois = callPackage ../development/python-modules/asyncwhois { };
 
+  asysocks = callPackage ../development/python-modules/asysocks { };
+
   atlassian-python-api = callPackage ../development/python-modules/atlassian-python-api { };
 
   atom = callPackage ../development/python-modules/atom { };
@@ -3910,6 +3912,8 @@ in {
   minidb = callPackage ../development/python-modules/minidb { };
 
   minidump = callPackage ../development/python-modules/minidump { };
+
+  minikerberos = callPackage ../development/python-modules/minikerberos { };
 
   minimock = callPackage ../development/python-modules/minimock { };
 
@@ -7972,6 +7976,8 @@ in {
   willow = callPackage ../development/python-modules/willow { };
 
   winacl = callPackage ../development/python-modules/winacl { };
+
+  winsspi = callPackage ../development/python-modules/winsspi { };
 
   wled = callPackage ../development/python-modules/wled { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Kerberos manipulation library in pure Python.

https://github.com/skelsec/minikerberos

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
