### PR TITLE
Amazon ec2 utils

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4654,6 +4654,12 @@
     githubId = 2029444;
     name = "James Kent";
   };
+  ketzacoatl = {
+    email = "ketzacoatl@protonmail.com";
+    github = "ketzacoatl";
+    githubId = 10122937;
+    name = "ketzacoatl";
+  };
   kevincox = {
     email = "kevincox@kevincox.ca";
     github = "kevincox";

--- a/pkgs/tools/admin/amazon-ec2-utils/default.nix
+++ b/pkgs/tools/admin/amazon-ec2-utils/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, curl
+, python3
+}:
+stdenv.mkDerivation rec {
+  pname = "amazon-ec2-utils";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "amazon-ec2-utils";
+    rev = version;
+    hash = "sha256:04dpxaaca144a74r6d93q4lp0d5l32v07rldj7v2v1c6s9nsf4mv";
+  };
+
+  buildInputs = [
+    python3
+  ];
+
+  propagatedBuildInputs = [
+    curl
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin/
+
+    cp ebsnvme-id $out/bin/
+    cp ec2-metadata $out/bin/
+    cp ec2udev-vbd $out/bin/
+    cp ec2udev-vcpu $out/bin/
+
+    chmod +x $out/bin/*
+  '';
+
+  doInstallCheck = true;
+
+  # We cannot run
+  #     ec2-metadata --help
+  # because it actually checks EC2 metadata even if --help is given
+  # so it won't work in the test sandbox.
+  installCheckPhase = ''
+    $out/bin/ebsnvme-id --help
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/aws/amazon-ec2-utils";
+    description = "Contains a set of utilities and settings for Linux deployments in EC2";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ketzacoatl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -831,6 +831,8 @@ in
 
   alpine-make-vm-image = callPackage ../tools/virtualization/alpine-make-vm-image { };
 
+  amazon-ec2-utils = callPackage ../tools/admin/amazon-ec2-utils { };
+
   amazon-ecs-cli = callPackage ../tools/virtualization/amazon-ecs-cli { };
 
   amber = callPackage ../tools/text/amber {


### PR DESCRIPTION
###### Motivation for this change

Adding `amazon-ec2-utils` as a new package.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
