### PR TITLE
gensio: 2.1.7 -> 2.2.1, ser2net: 4.2.1 -> 4.3.0

### DIFF
--- a/pkgs/development/libraries/gensio/default.nix
+++ b/pkgs/development/libraries/gensio/default.nix
@@ -1,21 +1,42 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook }:
+{ autoreconfHook
+, fetchFromGitHub
+, fetchpatch
+, lib
+, nix-update-script
+, pkg-config
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "gensio";
-  version = "2.1.7";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "cminyard";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07m8rbdk05biarc9xskwcx9lghj0dff1msxasfc6hi3jywc3xaih";
+    sha256 = "083khzvyvcgi9j99hbaswglivm9s6dly6spjvisvyacavaybgwgb";
+  };
+
+  patches =  [
+    # Fix compilation without openipmi, can be dropped for the next release.
+    (fetchpatch {
+      url = "https://github.com/cminyard/gensio/commit/12f6203e6f7aa42172177d7b0870777b605af8d9.patch";
+      sha256 = "19dr4iacccc4il3asdxkag6cj2yc4bxd8p451syfxdm6289rwxic";
+    })
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
   };
 
   configureFlags = [
     "--with-python=no"
   ];
 
-  buildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   meta = with lib; {
     description = "General Stream I/O";

--- a/pkgs/servers/ser2net/default.nix
+++ b/pkgs/servers/ser2net/default.nix
@@ -1,17 +1,33 @@
-{ stdenv, lib, fetchFromGitHub, gensio, libyaml, autoreconfHook, pkgconfig }:
+{ autoreconfHook
+, fetchFromGitHub
+, gensio
+, lib
+, libyaml
+, nix-update-script
+, pkg-config
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "ser2net";
-  version = "4.2.1";
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "cminyard";
     repo = pname;
     rev = "v${version}";
-    sha256 = "01w82nrgffsfz2c80p4cyppg3bz56d90jm6i6356j0nva3784haw";
+    sha256 = "13zhds3zav03f1snc4bb1j07i2x606bmnqm17yx37frib2hjs4nx";
   };
 
-  buildInputs = [ pkgconfig autoreconfHook gensio libyaml ];
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  buildInputs = [ gensio libyaml ];
 
   meta = with lib; {
     description = "Serial to network connection server";


### PR DESCRIPTION

###### Motivation for this change
Version bumps, organize imports, add `passthru.updateScript`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
