### PR TITLE
osmium-tool: 1.12.1 → 1.13.0, libosmium: 2.15.6 → 2.16.0, pyosmium: 3.0.1 → 3.1.0

### DIFF
--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -7,19 +7,20 @@
 , bzip2
 , expat
 , libosmium
+, lz4
 , protozero
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "osmium-tool";
-  version = "1.12.1";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "osmium-tool";
     rev = "v${version}";
-    sha256 = "13142hj8gfgj6w51a62hjzfmzic90xgrnnlnb70hpdqjy86bxv7j";
+    sha256 = "0rn67g4xf01i7pkxrdh87jdj2rzkw5pfkx5wkg9245z5yxjxhqj2";
   };
 
   nativeBuildInputs = [
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     bzip2
     expat
     libosmium
+    lz4
     protozero
     zlib
   ];
@@ -46,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Multipurpose command line tool for working with OpenStreetMap data based on the Osmium library";
     homepage = "https://osmcode.org/osmium-tool/";
-    license = with licenses; [ gpl3 mit bsd3 ];
+    license = with licenses; [ gpl3Plus mit bsd3 ];
     maintainers = with maintainers; [ das-g ];
   };
 }

--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -2,18 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "libosmium";
-  version = "2.15.6";
+  version = "2.16.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "libosmium";
     rev = "v${version}";
-    sha256 = "0rqy18bbakp41f44y5id9ixh0ar2dby46z17p4115z8k1vv9znq2";
+    sha256 = "1na51g6xfm1bx0d0izbg99cwmqn0grp0g41znn93xnhs202qnb2h";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ protozero zlib bzip2 expat boost ];
+
+  cmakeFlags = [ "-DINSTALL_GDALCPP:BOOL=ON" ];
 
   doCheck = true;
 

--- a/pkgs/development/python-modules/pyosmium/default.nix
+++ b/pkgs/development/python-modules/pyosmium/default.nix
@@ -4,7 +4,7 @@
 
 buildPythonPackage rec {
   pname = "pyosmium";
-  version = "3.0.1";
+  version = "3.1.0";
 
   disabled = pythonOlder "3.4" || isPyPy;
 
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     owner = "osmcode";
     repo = pname;
     rev = "v${version}";
-    sha256 = "06jngbmmmswhyi5q5bjph6gwss28d2azn5414zf0arik5bcvz128";
+    sha256 = "0m11hdgiysdhyi5yn6nj8a8ycjzx5hpjy7n1c4j6q5caifj7rf7h";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
* osmium-tool: [1.13.0 changelog](https://github.com/osmcode/osmium-tool/releases/tag/v1.13.0)
  * > Now depends on **libosmium 2.16.0** or greater
  * > Has support for PBF **lz4** compression which is enabled by default if the library is found
* libosmium: [2.16.0 changelog](https://github.com/osmcode/libosmium/releases/tag/v2.16.0)
  * Add `-DINSTALL_GDALCPP:BOOL=ON` cmake flag to install `gdalcpp.hpp`
* pyosmium: [3.1.0 changelog](https://github.com/osmcode/pyosmium/releases/tag/v3.1.0)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - osm2pgsql
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
