### PR TITLE
python3Packages.winacl: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/winacl/default.nix
+++ b/pkgs/development/python-modules/winacl/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "winacl";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05xhdhbvzs1hcd8lxmdr9mpr6ifx5flhlvk6jr0qi6h25imhqclp";
+  };
+
+  # Project doesn't have tests
+  doCheck = false;
+  pythonImportsCheck = [ "winacl" ];
+
+  meta = with lib; {
+    description = "Python module for ACL/ACE/Security descriptor manipulation";
+    homepage = "https://github.com/skelsec/winacl";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7943,6 +7943,8 @@ in {
 
   willow = callPackage ../development/python-modules/willow { };
 
+  winacl = callPackage ../development/python-modules/winacl { };
+
   wled = callPackage ../development/python-modules/wled { };
 
   word2vec = callPackage ../development/python-modules/word2vec { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Platform independent library for interfacing windows security descriptors.

https://github.com/skelsec/winacl

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
