### PR TITLE
monado: Add serviceSupport option

### DIFF
--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -1,23 +1,29 @@
 { stdenv
 , fetchFromGitLab
 , fetchpatch
+, writeText
 , cmake
+, doxygen
+, glslang
 , pkg-config
 , python3
 , SDL2
 , dbus
 , eigen
 , ffmpeg
-, glslang
+, gst-plugins-base
+, gstreamer
 , hidapi
 , libGL
 , libXau
 , libXdmcp
 , libXrandr
 , libffi
+, libjpeg
 # , librealsense
 , libsurvive
 , libusb1
+, libuv
 , libuvc
 , libv4l
 , libxcb
@@ -29,6 +35,11 @@
 , wayland
 , wayland-protocols
 , zlib
+# Set as 'false' to build monado without service support, i.e. allow VR
+# applications linking against libopenxr_monado.so to use OpenXR standalone
+# instead of via the monado-service program. For more information see:
+# https://gitlab.freedesktop.org/monado/monado/-/blob/master/doc/targets.md#xrt_feature_service-disabled
+, serviceSupport ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -51,23 +62,36 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake pkg-config python3 ];
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    glslang
+    pkg-config
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DXRT_FEATURE_SERVICE=${if serviceSupport then "ON" else "OFF"}"
+  ];
 
   buildInputs = [
     SDL2
     dbus
     eigen
     ffmpeg
-    glslang
+    gst-plugins-base
+    gstreamer
     hidapi
     libGL
     libXau
     libXdmcp
     libXrandr
+    libjpeg
     libffi
     # librealsense.dev - see below
     libsurvive
     libusb1
+    libuv
     libuvc
     libv4l
     libxcb
@@ -91,11 +115,16 @@ stdenv.mkDerivation rec {
   # for some reason cmake is trying to use ${librealsense}/include
   # instead of ${librealsense.dev}/include as an include directory
 
+  # Help openxr-loader find this runtime
+  setupHook = writeText "setup-hook" ''
+    export XDG_CONFIG_DIRS=@out@/etc/xdg''${XDG_CONFIG_DIRS:+:''${XDG_CONFIG_DIRS}}
+  '';
+
   meta = with stdenv.lib; {
     description = "Open source XR runtime";
     homepage = "https://monado.freedesktop.org/";
     license = licenses.boost;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ expipiplus1 prusnak ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/graphics/xrgears/default.nix
+++ b/pkgs/applications/graphics/xrgears/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitLab
+, glm
+, glslang
+, meson
+, ninja
+, openxr-loader
+, pkg-config
+, vulkan-headers
+, vulkan-loader
+, xxd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xrgears";
+  version = "unstable-2020-04-15";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "monado";
+    repo = "demos/xrgears";
+    rev = "d0bee35fbf8f181e8313f1ead13d88c4fb85c154";
+    sha256 = "1k0k8dkclyiav99kf0933kyd2ymz3hs1p0ap2wbciq9s62jgz29i";
+  };
+
+  nativeBuildInputs = [
+    glslang
+    meson
+    ninja
+    pkg-config
+    xxd
+  ];
+
+  buildInputs = [
+    glm
+    openxr-loader
+    vulkan-headers
+    vulkan-loader
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.freedesktop.org/monado/demos/xrgears";
+    description = "An OpenXR example using Vulkan for rendering";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ expipiplus1 ];
+  };
+}

--- a/pkgs/development/libraries/libsurvive/default.nix
+++ b/pkgs/development/libraries/libsurvive/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Open Source Lighthouse Tracking System";
     homepage = "https://github.com/cntools/libsurvive";
     license = licenses.mit;
-    maintainers = with maintainers; [ prusnak ];
+    maintainers = with maintainers; [ expipiplus1 prusnak ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25553,6 +25553,8 @@ in
 
   xrestop = callPackage ../tools/X11/xrestop { };
 
+  xrgears = callPackage ../applications/graphics/xrgears { };
+
   xsd = callPackage ../development/libraries/xsd { };
 
   xscope = callPackage ../applications/misc/xscope { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2492,7 +2492,9 @@ in
 
   monetdb = callPackage ../servers/sql/monetdb { };
 
-  monado = callPackage ../applications/graphics/monado {};
+  monado = callPackage ../applications/graphics/monado {
+    inherit (gst_all_1) gstreamer gst-plugins-base;
+  };
 
   mons = callPackage ../tools/misc/mons {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- rebases PR https://github.com/NixOS/nixpkgs/pull/107001 by @expipiplus1 on top of current master
  - monado: Add serviceSupport option
  - xrgears: init at unstable-2020-04-15
  - libsurvive: add expipiplus1 to maintainers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
