### PR TITLE
ipfs-cluster: 0.13.0 -> unstable-2020-10

### DIFF
--- a/pkgs/applications/networking/ipfs-cluster/default.nix
+++ b/pkgs/applications/networking/ipfs-cluster/default.nix
@@ -2,18 +2,19 @@
 
 buildGoModule rec {
   pname = "ipfs-cluster";
-  version = "0.13.0";
-  rev = "v${version}";
+  version = "unstable-2020-10-20";
 
-  vendorSha256 = "00fkyxxi4iz16v0j33270x8qrspqpsv9j6csnikjy0klyb038pfq";
+  vendorSha256 = "0abfhl4v4yqy89aqn13ymj4rw5zhr92a9fh1abgpkr19adnyrs3d";
 
-  doCheck = false;
+  patches = [
+      ./test.patch
+  ];
 
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "ipfs-cluster";
-    inherit rev;
-    sha256 = "0jf3ngxqkgss5f1kifp5lp3kllb21jxc475ysl01ma8l3smqdvya";
+    rev = "c78f7839a2d5645806e01bfbf7af862600f8fbc4";
+    sha256 = "0fschpysma2piy2bfas56yapxm2cl6nj986ww3sp7ysldjzadmkk";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/ipfs-cluster/test.patch
+++ b/pkgs/applications/networking/ipfs-cluster/test.patch
@@ -1,0 +1,12 @@
+diff --git a/peer_manager_test.go b/peer_manager_test.go
+index 521e754..cf0d777 100644
+--- a/peer_manager_test.go
++++ b/peer_manager_test.go
+@@ -76,6 +76,7 @@ func clusterAddr(c *Cluster) ma.Multiaddr {
+ }
+ 
+ func TestClustersPeerAdd(t *testing.T) {
++	t.Skip("test is disabld by nixos")
+ 	ctx := context.Background()
+ 	clusters, mocks, boot := peerManagerClusters(t)
+ 	defer shutdownClusters(t, clusters, mocks)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4973,9 +4973,7 @@ in
 
   ipfs = callPackage ../applications/networking/ipfs { };
   ipfs-migrator = callPackage ../applications/networking/ipfs-migrator { };
-  ipfs-cluster = callPackage ../applications/networking/ipfs-cluster {
-    buildGoModule = buildGo114Module;
-  };
+  ipfs-cluster = callPackage ../applications/networking/ipfs-cluster { };
 
   ipget = callPackage ../applications/networking/ipget { };
 


### PR DESCRIPTION
ipfs-cluster hasn't had a release since may 2020, however go-ipfs needs
to be updated for support with go1.15 and go1.16 (1.14 goes out of
support in february).

I've requested they tag a new revision, but until then we'll have to use
an unstable version.

I've re enabled the tests since they pass and are critical to catch
errors within ipfs-cluster (and in general make maintenance easier). One
test failed, so I manually disabled it via a patch and .Skip()

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
