### PR TITLE
libpromhttp: 0.1.1 -> 0.1.3

### DIFF
--- a/pkgs/development/libraries/prometheus-client-c/default.nix
+++ b/pkgs/development/libraries/prometheus-client-c/default.nix
@@ -13,35 +13,17 @@ let
     }:
     stdenv.mkDerivation rec {
       inherit pname;
-      version = "0.1.1";
+      version = "0.1.3";
 
       src = fetchFromGitHub {
         owner = "digitalocean";
         repo = "prometheus-client-c";
         rev = "v${version}";
-        sha256 = "0g69s24xwrv5974acshrhnp6i8rpby8c6bhz15m3d8kpgjw3cm8f";
+        sha256 = "0vsvng0nvvflcgick0bpyf8pynf0rzl2yk4mrydzbdkc6646s5sf";
       };
 
       nativeBuildInputs = [ cmake ];
       inherit buildInputs;
-
-      # These patches will be in 0.1.2
-      patches = [
-        # Required so CMAKE_INSTALL_PREFIX is honored, otherwise it
-        # installs headers in /usr/include (absolute)
-        (
-          fetchpatch {
-            url = "https://github.com/digitalocean/prometheus-client-c/commit/5fcedeb506b7d47dd7bab35797f2c3f23db6fe10.patch";
-            sha256 = "10hzg8v5jcgxz224kdq0nha9vs78wz098b0ys7gig2iwgrg018fy";
-          }
-        )
-        (
-          fetchpatch {
-            url = "https://github.com/digitalocean/prometheus-client-c/commit/0c15e7e45ad0c3726593591fdd7d8f2fde845fe3.patch";
-            sha256 = "06899v1xz3lpsdxww4p3q7pv8nrymnibncdc472056znr5fidlp0";
-          }
-        )
-      ];
 
       preConfigure = ''
         cd ${subdir}


### PR DESCRIPTION
###### Motivation for this change
Minor update, but they merged the patches we were including manually.
They also fixed a floating point bug on histograms.


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
