### PR TITLE
kmail: fix calling ext. applications

### DIFF
--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -101,6 +101,7 @@ mkDerivation {
     kleopatra
     pim-data-exporter
   ];
+  outputs = [ "out" "doc" ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
   postFixup = ''
     wrapProgram "$out/bin/kmail" \

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -1,8 +1,10 @@
 { mkDerivation
 , lib
 , akonadi
+, akonadi-import-wizard
 , akonadi-search
 , extra-cmake-modules
+, kaddressbook
 , kbookmarks
 , kcalutils
 , kcmutils
@@ -20,6 +22,7 @@
 , kinit
 , kio
 , kldap
+, kleopatra
 , kmail-account-wizard
 , kmailtransport
 , knotifications
@@ -40,6 +43,7 @@
 , libsecret
 , mailcommon
 , messagelib
+, pim-data-exporter
 , pim-sieve-editor
 , qtkeychain
 , qtscript
@@ -92,6 +96,14 @@ mkDerivation {
     qtkeychain
     qtscript
     qtwebengine
+    akonadi-import-wizard
+    kaddressbook
+    kleopatra
+    pim-data-exporter
   ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
+  postFixup = ''
+    wrapProgram "$out/bin/kmail" \
+      --prefix PATH : "${lib.makeBinPath [ akonadi akonadi-import-wizard kaddressbook kleopatra kmail-account-wizard pim-data-exporter ]}"
+  '';
 }

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -1,14 +1,49 @@
-{
-  mkDerivation, lib, kdepimTeam,
-  extra-cmake-modules, kdoctools,
-  akonadi-search, kbookmarks, kcalutils, kcmutils, kcompletion, kconfig,
-  kconfigwidgets, kcoreaddons, libkdepim,
-  kdepim-runtime, kguiaddons, ki18n, kiconthemes, kinit, kio, kldap,
-  kmail-account-wizard, kmailtransport, knotifications, knotifyconfig,
-  kontactinterface, kparts, kpty, kservice, ktextwidgets, ktnef, kwallet,
-  kwidgetsaddons, kwindowsystem, kxmlgui, libgravatar, libksieve, mailcommon,
-  messagelib, pim-sieve-editor, qtscript, qtwebengine, akonadi, kdepim-addons,
-  qtkeychain, libsecret
+{ mkDerivation
+, lib
+, akonadi
+, akonadi-search
+, extra-cmake-modules
+, kbookmarks
+, kcalutils
+, kcmutils
+, kcompletion
+, kconfig
+, kconfigwidgets
+, kcoreaddons
+, kdepim-addons
+, kdepim-runtime
+, kdepimTeam
+, kdoctools
+, kguiaddons
+, ki18n
+, kiconthemes
+, kinit
+, kio
+, kldap
+, kmail-account-wizard
+, kmailtransport
+, knotifications
+, knotifyconfig
+, kontactinterface
+, kparts
+, kpty
+, kservice
+, ktextwidgets
+, ktnef
+, kwallet
+, kwidgetsaddons
+, kwindowsystem
+, kxmlgui
+, libgravatar
+, libkdepim
+, libksieve
+, libsecret
+, mailcommon
+, messagelib
+, pim-sieve-editor
+, qtkeychain
+, qtscript
+, qtwebengine
 }:
 
 mkDerivation {
@@ -19,13 +54,44 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    akonadi-search kbookmarks kcalutils kcmutils kcompletion kconfig
-    kconfigwidgets kcoreaddons kguiaddons ki18n
-    kiconthemes kinit kio kldap kmail-account-wizard kmailtransport libkdepim
-    knotifications knotifyconfig kontactinterface kparts kpty kservice
-    ktextwidgets ktnef kwidgetsaddons kwindowsystem kxmlgui libgravatar
-    libksieve mailcommon messagelib pim-sieve-editor qtscript qtwebengine
-    kdepim-addons qtkeychain libsecret
+    akonadi-search
+    kbookmarks
+    kcalutils
+    kcmutils
+    kcompletion
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kdepim-addons
+    kguiaddons
+    ki18n
+    kiconthemes
+    kinit
+    kio
+    kldap
+    kmail-account-wizard
+    kmailtransport
+    knotifications
+    knotifyconfig
+    kontactinterface
+    kparts
+    kpty
+    kservice
+    ktextwidgets
+    ktnef
+    kwidgetsaddons
+    kwindowsystem
+    kxmlgui
+    libgravatar
+    libkdepim
+    libksieve
+    libsecret
+    mailcommon
+    messagelib
+    pim-sieve-editor
+    qtkeychain
+    qtscript
+    qtwebengine
   ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet akonadi ];
 }


### PR DESCRIPTION
KMail relies on quite a few external applications, such as:
- kaddressbook
- akonadiimportwizard
- accountwizard

Without those, quite a few core functionalities of KMail aren't available, such as:
- adding a new account to KMail
- using the addressbook for sending a mail
- importing existing PIM data

By providing `QStandardPaths::findExecutable()` the store path of said
components, this problem can be circumvented.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Make KMail work again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
