### PR TITLE
openjpeg: 2.3.1 -> 2.4.0

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "2.3.1";
-  branch = "2.3";
+  version = "2.4.0";
+  branch = "2.4";
   revision = "v${version}";
-  sha256 = "1dn98d2dfa1lqyxxmab6rrcv52dyhjr4g7i4xf2w54fqsx14ynrb";
+  sha256 = "143dvy5g6v6129lzvl0r8mrgva2fppkn0zl099qmi9yi9l9h7yyf";
 
   extraFlags = [
     "-DOPENJPEG_INSTALL_INCLUDE_DIR=${placeholder "dev"}/include/openjpeg-${branch}"
@@ -14,24 +14,8 @@ callPackage ./generic.nix (args // rec {
   patches = [
     ./fix-cmake-config-includedir.patch
     (fetchpatch {
-      url = "https://github.com/uclouvain/openjpeg/commit/21399f6b7d318fcdf4406d5e88723c4922202aa3.patch";
-      name = "CVE-2019-12973-1.patch";
-      sha256 = "161yvnfbzy2016qqapm0ywfgglgs1v8ljnk6fj8d2bwdh1cxxz8f";
-    })
-    (fetchpatch {
-      url = "https://github.com/uclouvain/openjpeg/commit/3aef207f90e937d4931daf6d411e092f76d82e66.patch";
-      name = "CVE-2019-12973-2.patch";
-      sha256 = "1jkkfw13l7nx4hxdhc7z17f4vfgqcaf09zpl235kypbxx1ygc7vq";
-    })
-    (fetchpatch {
-      url = "https://github.com/uclouvain/openjpeg/commit/024b8407392cb0b82b04b58ed256094ed5799e04.patch";
-      name = "CVE-2020-6851.patch";
-      sha256 = "1lfwlzqxb69cwzjp8v9lijz4c2qhf3b8m6sq1khipqlgrb3l58xw";
-    })
-    (fetchpatch {
-      url = "https://github.com/uclouvain/openjpeg/commit/05f9b91e60debda0e83977e5e63b2e66486f7074.patch";
-      name = "CVE-2020-8112.patch";
-      sha256 = "16kykc8wbq9kx9w9kkf3i7snak82m184qrl9bpxvkjl7h0n9aw49";
+      url = "https://patch-diff.githubusercontent.com/raw/uclouvain/openjpeg/pull/1321.patch";
+      sha256 = "1cjpr76nf9g65nqkfnxnjzi3bv7ifbxpc74kxxibh58pzjlp6al8";
     })
   ];
 })

--- a/pkgs/development/libraries/openjpeg/fix-cmake-config-includedir.patch
+++ b/pkgs/development/libraries/openjpeg/fix-cmake-config-includedir.patch
@@ -1,14 +1,3 @@
---- a/cmake/OpenJPEGConfig.cmake.in
-+++ b/cmake/OpenJPEGConfig.cmake.in
-@@ -32,7 +32,7 @@
-   set(INC_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_INCLUDE_DIR@")
-   file(RELATIVE_PATH PKG_TO_INC_RPATH "${PKG_DIR}" "${INC_DIR}")
- 
--  get_filename_component(OPENJPEG_INCLUDE_DIRS "${SELF_DIR}/${PKG_TO_INC_RPATH}" ABSOLUTE)
-+  get_filename_component(OPENJPEG_INCLUDE_DIRS "@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
- 
- else()
-   if(EXISTS ${SELF_DIR}/OpenJPEGExports.cmake)
 --- a/src/lib/openjp2/libopenjp2.pc.cmake.in
 +++ b/src/lib/openjp2/libopenjp2.pc.cmake.in
 @@ -3,7 +3,7 @@

--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Open-source JPEG 2000 codec written in C language";
-    homepage = "http://www.openjpeg.org/";
+    homepage = "https://www.openjpeg.org/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ codyopel ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/uclouvain/openjpeg/blob/v2.4.0/CHANGELOG.md

Fixes CVE-2020-15389, CVE-2020-27841, CVE-2020-27842, CVE-2020-27843, CVE-2020-27844, and CVE-2020-27845.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).