### PR TITLE
python3Packages.aiostream: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/aiostream/default.nix
+++ b/pkgs/development/python-modules/aiostream/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, pytestcov
+, pytest-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "aiostream";
+  version = "0.4.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "vxgmichel";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wwnjrzkd61k3arxzk7yhg7cc1099bcwr5kz5n91ai6ma5ln139s";
+  };
+
+  checkInputs = [ pytestCheckHook pytestcov pytest-asyncio ];
+
+  meta = with lib; {
+    description = "Generator-based operators for asynchronous iteration";
+    homepage = "https://aiostream.readthedocs.io";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.rmcgibbo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -265,6 +265,8 @@ in {
 
   aiosqlite = callPackage ../development/python-modules/aiosqlite { };
 
+  aiostream = callPackage ../development/python-modules/aiostream { };
+
   aiounifi = callPackage ../development/python-modules/aiounifi { };
 
   aiounittest = callPackage ../development/python-modules/aiounittest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
url: https://github.com/vxgmichel/aiostream
stars: 290
test coverage: 100%

seems like a pretty good library, and i was surprised to see we didn't have it already

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
$ nixpkgs-review rev 0383c9c32dd --no-shell

Updating 99264011def..0383c9c32dd
Fast-forward
 pkgs/development/python-modules/aiostream/default.nix | 30 ++++++++++++++++++++++++++++++
 pkgs/top-level/python-packages.nix                    |  2 ++
 2 files changed, 32 insertions(+)
 create mode 100644 pkgs/development/python-modules/aiostream/default.nix

3 packages added:
python37Packages.aiostream (init at 0.4.1) python38Packages.aiostream (init at 0.4.1) python39Packages.aiostream (init at 0.4.1)

3 packages built:
python37Packages.aiostream python38Packages.aiostream python39Packages.aiostream
```