### PR TITLE
hplip: fix hp-setup crash by adding proper NixOS PPD search path

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -93,6 +93,12 @@ python3Packages.buildPythonApplication {
     # https://bugs.launchpad.net/hplip/+bug/1788706
     # https://bugs.launchpad.net/hplip/+bug/1787289
     ./image-processor.patch
+
+    # HPLIP's getSystemPPDs() function relies on searching for PPDs below common FHS
+    # paths, and hp-setup crashes if none of these paths actually exist (which they
+    # don't on NixOS).  Add the equivalent NixOS path, /var/lib/cups/path/share.
+    # See: https://github.com/NixOS/nixpkgs/issues/21796
+    ./hplip-3.20.11-nixos-cups-ppd-search-path.patch
   ];
 
   prePatch = ''

--- a/pkgs/misc/drivers/hplip/hplip-3.20.11-nixos-cups-ppd-search-path.patch
+++ b/pkgs/misc/drivers/hplip/hplip-3.20.11-nixos-cups-ppd-search-path.patch
@@ -1,0 +1,24 @@
+From: Bryan Gardiner <bog@khumba.net>
+Date: Sat, 9 Jan 2021 16:51:20 -0800
+Subject: [PATCH] Add NixOS CUPS PPD search path.
+
+---
+ base/g.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/base/g.py b/base/g.py
+index f73e23f..758f339 100644
+--- a/base/g.py
++++ b/base/g.py
+@@ -283,7 +283,7 @@ prop.max_message_len = 8192
+ prop.max_message_read = 65536
+ prop.read_timeout = 90
+ 
+-prop.ppd_search_path = '/usr/share;/usr/local/share;/usr/lib;/usr/local/lib;/usr/libexec;/opt;/usr/lib64'
++prop.ppd_search_path = '/var/lib/cups/path/share;/usr/share;/usr/local/share;/usr/lib;/usr/local/lib;/usr/libexec;/opt;/usr/lib64'
+ prop.ppd_search_pattern = 'HP-*.ppd.*'
+ prop.ppd_download_url = 'http://www.linuxprinting.org/ppd-o-matic.cgi'
+ prop.ppd_file_suffix = '-hpijs.ppd'
+-- 
+2.29.2
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is to address the crash I hit recently trying to use `hp-setup`, details here: https://github.com/NixOS/nixpkgs/issues/21796.

From the commit description:

> HPLIP's getSystemPPDs() function relies on searching for PPDs below common FHS
> paths.  None of these exist on NixOS, but the code assumes that at least one of
> the directories will be found, and crashes when it doesn't (cups_ppd_path is
> None and the code passes that to os.path.join).
> 
> A usable PPD search path for the running system on NixOS is
> /var/lib/cups/path/share, so this patches the source to check this path as well.
> This should fix the NixOS case and keep non-NixOS cases working too.

**Disclaimer here,** this fixes my problem with 20.09 and I've built my system config against master, but I haven't run a machine with master to actually test this out there.  I plan to do so on a spare machine when I get time to set one up, but I'm opening this now to get some eyes on it.

I'm interested in having this backported to 20.09, if it's considered safe enough.

Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - `nixos/tests/printing.nix` passes with these changes applied to master.
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
  - Well it said no packages were found.  I have done a full build of my own system config though, which includes `hplipWithPlugin`.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - Not all, but I tested `hp-setup`.
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - +24 bytes.
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
