### PR TITLE
hello-wayland: init at 2020-07-27

### DIFF
--- a/pkgs/applications/graphics/hello-wayland/default.nix
+++ b/pkgs/applications/graphics/hello-wayland/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchFromGitHub
+, imagemagick, pkg-config, wayland, wayland-protocols
+}:
+
+stdenv.mkDerivation {
+  pname = "hello-wayland-unstable";
+  version = "2020-07-27";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "hello-wayland";
+    rev = "501d0851cfa7f21c780c0eb52f0a6b23f02918c5";
+    sha256 = "0dz6przqp57kw8ycja3gw6jp9x12217nwbwdpgmvw7jf0lzhk4xr";
+  };
+
+  nativeBuildInputs = [ imagemagick pkg-config ];
+  buildInputs = [ wayland wayland-protocols ];
+
+  installPhase = ''
+    runHook preBuild
+    mkdir -p $out/bin
+    install hello-wayland $out/bin
+    runHook postBuild
+  '';
+
+  meta = with lib; {
+    description = "Hello world Wayland client";
+    homepage = "https://github.com/emersion/hello-wayland";
+    maintainers = with maintainers; [ qyliss ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22151,6 +22151,9 @@ in
   heimer = libsForQt5.callPackage ../applications/misc/heimer { };
 
   hello = callPackage ../applications/misc/hello { };
+
+  hello-wayland = callPackage ../applications/graphics/hello-wayland { };
+
   hello-unfree = callPackage ../applications/misc/hello-unfree { };
 
   helmholtz = callPackage ../applications/audio/pd-plugins/helmholtz { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a program that just displays a static cat picture in a Wayland
window.  I packaged it a while ago thinking it wouldn't be useful for
anybody else, but a conversation on IRC today made me realise it would
be!

hello-wayland is very useful as a minimal example when hacking on
Wayland ecosystem stuff -- even if Firefox doesn't work yet,
hello-wayland probably will and that can be useful to guide you in the
right direction!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
