### PR TITLE
doc: add "prefer lib over stdenv.lib" convention

### DIFF
--- a/doc/contributing/coding-conventions.xml
+++ b/doc/contributing/coding-conventions.xml
@@ -178,6 +178,15 @@ args.stdenv.mkDerivation (args // {
 </programlisting>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Prefer using the top-level <varname>lib</varname> over its alias
+     <literal>stdenv.lib</literal>.  <varname>lib</varname> is unrelated to
+     <varname>stdenv</varname>, and so <literal>stdenv.lib</literal> should only
+     be used as a convenience alias when developing to avoid having to modify
+     the function inputs just to test something out.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
  <section xml:id="sec-package-naming">


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I think we should have something in the manual people can point to
about this, to avoid rehashing it over and over in PRs.  "stdenv.lib"
makes it look like lib is part of stdenv, which it isn't, and makes it
even more confusing as a newcomer to figure out what stdenv is (and
isn't).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
