### PR TITLE
spacenavd: init at 0.8

### DIFF
--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -1,0 +1,28 @@
+{ fetchFromGitHub, stdenv, libX11, libXi }:
+
+with stdenv.lib;
+
+let
+  pname = "spacenavd";
+  version = "0.8";
+in
+
+stdenv.mkDerivation {
+  name = "${pname}-${version}";
+  src = fetchFromGitHub {
+    owner = "FreeSpacenav";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-jkkmHd5Vk6Pyd6otEgTXh4WwMqJ6fkts0enux0pl4P8=";
+  };
+
+  buildInputs = [ libX11 libXi ];
+
+  meta = {
+    description = "Free user-space driver for 6-dof space-mice. ";
+    maintainers = [ maintainers.leenaars ];
+    platforms = platforms.unix;
+    license = licenses.gpl3;
+    homepage = "http://spacenav.sourceforge.net/";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7568,6 +7568,8 @@ in
 
   sozu = callPackage ../servers/sozu { };
 
+  spacenavd = callPackage ../misc/drivers/spacenavd { };
+
   sparsehash = callPackage ../development/libraries/sparsehash { };
 
   spectre-meltdown-checker = callPackage ../tools/security/spectre-meltdown-checker { };


### PR DESCRIPTION
###### Motivation for this change

Add support for space mice, to be used with 3D applications like Blender.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).