### PR TITLE
codeowners: Add myself to autoPatchelfHook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,17 +26,18 @@
 /lib/asserts.nix            @edolstra @nbp @Profpatsch
 
 # Nixpkgs Internals
-/default.nix                          @nbp
-/pkgs/top-level/default.nix           @nbp @Ericson2314
-/pkgs/top-level/impure.nix            @nbp @Ericson2314
-/pkgs/top-level/stage.nix             @nbp @Ericson2314 @matthewbauer
-/pkgs/top-level/splice.nix            @Ericson2314 @matthewbauer
-/pkgs/top-level/release-cross.nix     @Ericson2314 @matthewbauer
-/pkgs/stdenv/generic                  @Ericson2314 @matthewbauer
-/pkgs/stdenv/cross                    @Ericson2314 @matthewbauer
-/pkgs/build-support/cc-wrapper        @Ericson2314 @orivej
-/pkgs/build-support/bintools-wrapper  @Ericson2314 @orivej
-/pkgs/build-support/setup-hooks       @Ericson2314
+/default.nix                                     @nbp
+/pkgs/top-level/default.nix                      @nbp @Ericson2314
+/pkgs/top-level/impure.nix                       @nbp @Ericson2314
+/pkgs/top-level/stage.nix                        @nbp @Ericson2314 @matthewbauer
+/pkgs/top-level/splice.nix                       @Ericson2314 @matthewbauer
+/pkgs/top-level/release-cross.nix                @Ericson2314 @matthewbauer
+/pkgs/stdenv/generic                             @Ericson2314 @matthewbauer
+/pkgs/stdenv/cross                               @Ericson2314 @matthewbauer
+/pkgs/build-support/cc-wrapper                   @Ericson2314 @orivej
+/pkgs/build-support/bintools-wrapper             @Ericson2314 @orivej
+/pkgs/build-support/setup-hooks                  @Ericson2314
+/pkgs/build-support/setup-hooks/auto-patchelf.sh @aszlig
 
 # Nixpkgs build-support
 /pkgs/build-support/writers @lassulus @Profpatsch


### PR DESCRIPTION
I really hate the very concept of this file (the reason being that I think "owner" implies some form of BDFL rather than just being
notified), but since there were [recent](https://github.com/NixOS/nixpkgs/pull/101142) [changes](https://github.com/NixOS/nixpkgs/pull/106830) in `auto-patchelf.sh` which I missed it's probably a good idea to add myself there solely for being notified, because ofborg can't seem to infer maintainer information here.

To make indentation consistent with all the other entries in the codeowners file, I also re-indented the other entries in the "Nixpkgs
Internals" block.