### PR TITLE
nixos/redis: add test for unix socket access

### DIFF
--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -1,4 +1,8 @@
-import ./make-test-python.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ... }:
+let
+  redisSocket = "/run/redis/redis.sock";
+in
+{
   name = "redis";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ flokli ];
@@ -10,7 +14,20 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
       {
         services.redis.enable = true;
-        services.redis.unixSocket = "/run/redis/redis.sock";
+        services.redis.unixSocket = redisSocket;
+
+        # Allow access to the unix socket for the "redis" group.
+        services.redis.settings.unixsocketperm = "770";
+
+        users.users."member" = {
+          createHome = false;
+          description = "A member of the redis group";
+          extraGroups = [
+            "redis"
+          ];
+          group = "users";
+          shell = "/bin/sh";
+        };
       };
   };
 
@@ -18,7 +35,11 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     start_all()
     machine.wait_for_unit("redis")
     machine.wait_for_open_port("6379")
+
+    # The unix socket is accessible to the redis group
+    machine.succeed('su member -c "redis-cli ping | grep PONG"')
+
     machine.succeed("redis-cli ping | grep PONG")
-    machine.succeed("redis-cli -s /run/redis/redis.sock ping | grep PONG")
+    machine.succeed("redis-cli -s ${redisSocket} ping | grep PONG")
   '';
 })


### PR DESCRIPTION
This adds a test to check if the unix socket is available to the `redis` group
added in #90027. Follow-up to #108440

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
