### PR TITLE
python3Packages.zha-quirks: remove conftest as a checkInput

### DIFF
--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , aiohttp
 , zigpy
-, conftest
 , asynctest
 , pytestCheckHook
 }:
@@ -20,7 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ aiohttp zigpy ];
-  checkInputs = [ pytestCheckHook conftest asynctest ];
+  checkInputs = [ pytestCheckHook asynctest ];
 
   meta = with lib; {
     description = "ZHA Device Handlers are custom quirks implementations for Zigpy";


### PR DESCRIPTION
###### Motivation for this change

@etu I don't think `zha-quirks` requires `conftest`, below is my reasoning but LMK if I've missed anything

I've built it with and without `conftest` as a `checkInput` and the result is identical.
The only reference to conftest looking at the repo in the browser is a file called `conftest.py` but that's just for [`pytest`](https://stackoverflow.com/questions/34466027/in-pytest-what-is-the-use-of-conftest-py-files), unrelated to [conftest](https://github.com/open-policy-agent/conftest).
Also there's no `.rego` files which you'd need to have any use for `conftest`/`open-policy-agent`

> Conftest helps you write tests against structured configuration data.

It's a golang cli tool not a python library

---
Build output with and without difference:

![image](https://user-images.githubusercontent.com/9866621/104090000-65554f00-526b-11eb-91af-af17ae5eb77a.png)

with:
```log
============================= test session starts ==============================
platform linux -- Python 3.9.1, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /build/source, configfile: setup.cfg, testpaths: tests
collected 402 items

tests/test_ctrl_neutral1.py .                                            [  0%]
tests/test_kof.py .                                                      [  0%]
tests/test_konke.py ssss                                                 [  1%]
tests/test_orvibo.py s                                                   [  1%]
tests/test_quirks.py ................................................... [ 14%]
........................................................................ [ 32%]
........................................................................ [ 50%]
........................................................................ [ 68%]
........................................................................ [ 86%]
................                                                         [ 90%]
tests/test_tuya.py ssssssssssss                                          [ 93%]
tests/test_xiaomi.py ..sss.............ssssssssss                        [100%]

=============================== warnings summary ===============================
../../nix/store/3qhzfcyi089wxjbhl0ndinklm68c7pa0-python3.9-asynctest-0.13.0/lib/python3.9/site-packages/asynctest/mock.py:434
  /nix/store/3qhzfcyi089wxjbhl0ndinklm68c7pa0-python3.9-asynctest-0.13.0/lib/python3.9/site-packages/asynctest/mock.py:434: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def wait(self, skip=0):

# ...

tests/test_tuya.py:153
  /build/source/tests/test_tuya.py:153: PytestCollectionWarning: cannot collect test class 'TestDevice' because it has a __init__ constructor (from: tests/test_tuya.py)
    class TestDevice(CustomDevice):

tests/test_konke.py: 4 warnings
tests/test_orvibo.py: 1 warning
tests/test_tuya.py: 12 warnings
tests/test_xiaomi.py: 13 warnings
  /nix/store/46g9p42rwqx7isq2ps39iwk83sc31pw4-python3.9-pytest-6.1.2/lib/python3.9/site-packages/_pytest/python.py:173: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================= 372 passed, 30 skipped, 44 warnings in 0.62s =================
```

without:
```log
============================= test session starts ==============================
platform linux -- Python 3.9.1, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /build/source, configfile: setup.cfg, testpaths: tests
collected 402 items

tests/test_ctrl_neutral1.py .                                            [  0%]
tests/test_kof.py .                                                      [  0%]
tests/test_konke.py ssss                                                 [  1%]
tests/test_orvibo.py s                                                   [  1%]
tests/test_quirks.py ................................................... [ 14%]
........................................................................ [ 32%]
........................................................................ [ 50%]
........................................................................ [ 68%]
........................................................................ [ 86%]
................                                                         [ 90%]
tests/test_tuya.py ssssssssssss                                          [ 93%]
tests/test_xiaomi.py ..sss.............ssssssssss                        [100%]

=============================== warnings summary ===============================
../../nix/store/3qhzfcyi089wxjbhl0ndinklm68c7pa0-python3.9-asynctest-0.13.0/lib/python3.9/site-packages/asynctest/mock.py:434
  /nix/store/3qhzfcyi089wxjbhl0ndinklm68c7pa0-python3.9-asynctest-0.13.0/lib/python3.9/site-packages/asynctest/mock.py:434: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    def wait(self, skip=0):

# ...

tests/test_tuya.py:153
  /build/source/tests/test_tuya.py:153: PytestCollectionWarning: cannot collect test class 'TestDevice' because it has a __init__ constructor (from: tests/test_tuya.py)
    class TestDevice(CustomDevice):

tests/test_konke.py: 4 warnings
tests/test_orvibo.py: 1 warning
tests/test_tuya.py: 12 warnings
tests/test_xiaomi.py: 13 warnings
  /nix/store/46g9p42rwqx7isq2ps39iwk83sc31pw4-python3.9-pytest-6.1.2/lib/python3.9/site-packages/_pytest/python.py:173: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================= 372 passed, 30 skipped, 44 warnings in 0.56s =================
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
