### PR TITLE
python3Packages.ldappool: fix build

### DIFF
--- a/pkgs/development/python-modules/ldappool/default.nix
+++ b/pkgs/development/python-modules/ldappool/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage rec {
   postPatch = ''
     # Tests run without most of the dependencies
     echo "" > test-requirements.txt
+    # PrettyTable is now maintained again
+    substituteInPlace requirements.txt --replace "PrettyTable<0.8,>=0.7.2" "PrettyTable"
   '';
 
   nativeBuildInputs = [ pbr ];
@@ -24,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A simple connector pool for python-ldap";
-    homepage = "https://git.openstack.org/cgit/openstack/ldappool";
-    license = licenses.mpl20;
+    homepage = "https://opendev.org/openstack/ldappool/";
+    license = with licenses; [ mpl11 lgpl21Plus gpl2Plus ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The build was failing due to the update of PrettyTable.

Also, missing licenses were added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
