### PR TITLE
nixos/gitea: add cache option

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -422,7 +422,7 @@ in
           (if (network == "unix") then {
             HOST = "network=unix,addr=${redis.unixSocket},db=${database},pool_size=${toString poolSize},idle_timeout=${idleTimeout}";
           } else if (network == "tcp") then {
-            HOST = "redis://:${if (user != null) then "${user}@" else ""}${host}:${toString port}/${database}?pool_size=${poolSize}&idle_timeout=${idleTimeout}";
+            HOST = "redis://:${if (user != null) then "${user}@" else ""}${host}:${toString port}/${toString database}?pool_size=${toString poolSize}&idle_timeout=${idleTimeout}";
           } else {
             # See allowed values in cfg.cache.redis.network
           })

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -422,7 +422,7 @@ in
           (if (network == "unix") then {
             HOST = "network=unix,addr=${redis.unixSocket},db=${database},pool_size=${toString poolSize},idle_timeout=${idleTimeout}";
           } else if (network == "tcp") then {
-            HOST = "redis://:${if (user != null) then "${user}@" else ""}${host}:${toString port}/${toString database}?pool_size=${toString poolSize}&idle_timeout=${idleTimeout}";
+            HOST = "redis://${if (user != null) then "${user}@" else ""}${host}:${toString port}/${toString database}?pool_size=${toString poolSize}&idle_timeout=${idleTimeout}";
           } else {
             # See allowed values in cfg.cache.redis.network
           })

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -432,7 +432,7 @@ in
         else if cfg.cache.memcached.enable then {
           ENABLE = true;
           ADAPTER = "memcache";
-          HOST = concatStringSep ";" (foreach cfg.memcached.caches (c: "${c.host}:${c.port}"));
+          HOST = builtins.concatStringsSep ";" (lists.forEach cfg.cache.memcached.caches (c: "${c.host}:${toString c.port}"));
         } else {
           ENABLE = true;
           ADAPTER = "memory";

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -433,9 +433,14 @@ in
           ENABLE = true;
           ADAPTER = "memcache";
           HOST = builtins.concatStringsSep ";" (lists.forEach cfg.cache.memcached.caches (c: "${c.host}:${toString c.port}"));
-        } else {
+
+        # Memory cache
+        } else if cfg.cache.memory.enable then {
           ENABLE = true;
           ADAPTER = "memory";
+
+        # Use gitea's default or users's settings for backwards compatibility
+        } else {
         };
 
       database = mkMerge [

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -49,7 +49,7 @@ in
 
       cache = {
         redis = {
-          enable = mkEnableOption "Enable the redis cache";
+          enable = mkEnableOption "Redis cache";
           network = mkOption {
             description = "Socket type";
             type = types.enum [ "tcp" "unix" ];
@@ -94,7 +94,7 @@ in
           };
         };
         memcached = {
-          enable = mkEnableOption "Enable memcached cache";
+          enable = mkEnableOption "memcached cache";
           caches = mkOption {
             description = "Memcached caches";
             type = types.listOf (types.submodule (
@@ -118,7 +118,7 @@ in
           };
         };
         memory = {
-          enable = mkEnableOption "Enable the built-in memory cache";
+          enable = mkEnableOption "memory cache";
         };
       };
 

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -115,9 +115,6 @@ in
     ++ [
       # Test with local redis over TCP
       (makeGiteaTest "redis-tcp" "sqlite3" {
-        redis = {
-          network = "tcp";
-          host = "127.0.0.1";
-        };
+        redis.network = "tcp";
       })
     ])

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -115,6 +115,9 @@ in
     ++ [
       # Test with local redis over TCP
       (makeGiteaTest "redis-tcp" "sqlite3" {
-        redis.network = "tcp";
+        redis = {
+          enable = true;
+          network = "tcp";
+        };
       })
     ])

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -20,14 +20,7 @@ let
           enable = true;
           database = { inherit type; };
           disableRegistration = true;
-          cache = if (cache == "redis") then {
-            redis.enable = true;
-          } else if (cache == "memcache") then {
-            memcached.enable = true;
-          } else if (cache == "memory") then {
-            memory.enable = true;
-          } else {
-          };
+          cache = { ${cache}.enable = true; };
         };
         environment.systemPackages = [ pkgs.gitea pkgs.jq ];
         services.openssh.enable = true;

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -109,9 +109,14 @@ let
   });
 in
   listToAttrs (
+    # Test all supported database types
     (map (db: makeGiteaTest "${db}" db { }) supportedDbTypes)
     ++
+    # Test all supported cache types
     (map (cache: makeGiteaTest "${cache}" "sqlite3" { "${cache}".enable = true; }) supportedCacheTypes)
+    ++
+    # Test with gitea's default cache settings
+    [(makeGiteaTest "default-cache" "sqlite3" {})]
     ++ [
       # Test with local redis over TCP
       (makeGiteaTest "redis-tcp" "sqlite3" {


### PR DESCRIPTION
This adds an option that sets up an in-memory cache.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
