### PR TITLE
pcsc-cyberjack: fix compilation with gcc10

### DIFF
--- a/pkgs/tools/security/pcsc-cyberjack/default.nix
+++ b/pkgs/tools/security/pcsc-cyberjack/default.nix
@@ -23,6 +23,8 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  NIX_CFLAGS_COMPILE = "-Wno-error=narrowing";
+
   configureFlags = [
     "--with-usbdropdir=${placeholder "out"}/pcsc/drivers"
     "--bindir=${placeholder "tools"}/bin"


### PR DESCRIPTION
###### Motivation for this change

The change to GCC 10 did break this package as it does some conversation
from 32bit integer to the type "int" which might be "narrower" depending
on the platform. By default GCC 10 errors in these cases. Since this
code is fine (and has been for a long time) it is okay to disable the
error in this case.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS

