### PR TITLE
python3Packages.crytic-compile: 0.1.9 -> 0.1.12

### DIFF
--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "crytic-compile";
-  version = "0.1.9";
+  version = "0.1.12";
 
   disabled = pythonOlder "3.6";
 
@@ -10,12 +10,13 @@ buildPythonPackage rec {
     owner = "crytic";
     repo = "crytic-compile";
     rev = version;
-    sha256 = "01mis7bqsh0l5vjl6jwibzy99djza35fxmywy56q8k4jbxwmdcna";
+    sha256 = "1q75n84yxv2cb6x7gqyk3vcwkxpq7pni30wgz3d1bk6pmi2pqgw6";
   };
 
   propagatedBuildInputs = [ pysha3 setuptools ];
 
   doCheck = false;
+  pythonImportsCheck = [ "crytic_compile" ];
 
   meta = with lib; {
     description = "Abstraction layer for smart contract build systems";

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -4,7 +4,7 @@
 
 buildPythonPackage rec {
   pname = "slither-analyzer";
-  version = "0.6.14";
+  version = "0.7.0";
 
   disabled = pythonOlder "3.6";
 
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "79f5098d27c149ca9cce2b8008ed29e2e0c8cee8fa3414c7e5455cb73c90a9a8";
+    sha256 = "10r479xidgxvas4wb0z6injp59jrn7rfq8d7bxlcalc2dy4mawr0";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.1.12.

Change log: https://github.com/crytic/crytic-compile/releases/tag/0.1.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
