### PR TITLE
modules/boot: Specify the type for tmpfs mounts

### DIFF
--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -34,6 +34,7 @@ with lib;
       {
         what = "tmpfs";
         where = "/tmp";
+        type = "tmpfs";
         mountConfig.Options = [ "mode=1777" "strictatime" "rw" "nosuid" "nodev" "size=50%" ];
       }
     ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/107497 broke booting on many systems that
use tmpOnTmpfs due to the lack of specifying the mount type.

This commit explicitly adds the mount type, which should fix booting
such systems.

The original change may want to be revisited however too, because we don't differ from the upstream unit (for 247 at least) https://github.com/systemd/systemd/blob/v247/units/tmp.mount

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
