### PR TITLE
target-isns: init at 0.6.8

### DIFF
--- a/pkgs/os-specific/linux/target-isns/default.nix
+++ b/pkgs/os-specific/linux/target-isns/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, cmake, fetchFromGitHub, fetchpatch } :
+
+stdenv.mkDerivation rec {
+  pname = "target-isns";
+  version = "0.6.8";
+
+  src = fetchFromGitHub {
+    owner = "open-iscsi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1b6jjalvvkkjyjbg1pcgk8vmvc6xzzksyjnh2pfi45bbpya4zxim";
+  };
+
+  patches = [
+    # fix absoulute paths
+    ./install_prefix_path.patch
+
+    # fix gcc 10 compiler warning, remove with next update
+    (fetchpatch {
+      url = "https://github.com/open-iscsi/target-isns/commit/3d0c47dd89bcf83d828bcc22ecaaa5f58d78b58e.patch";
+      sha256 = "1x2bkc1ff15621svhpq1r11m0q4ajv0j4fng6hm7wkkbr2s6d1vx";
+    })
+  ];
+
+  cmakeFlags = [ "-DSUPPORT_SYSTEMD=ON" ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "iSNS client for the Linux LIO iSCSI target";
+    homepage = "https://github.com/open-iscsi/target-isns";
+    maintainers = [ maintainers.markuskowa ];
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/target-isns/install_prefix_path.patch
+++ b/pkgs/os-specific/linux/target-isns/install_prefix_path.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f46144d..aeac3e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,10 +14,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+ option(SUPPORT_SYSTEMD "Support service control via systemd" OFF)
+
+ add_subdirectory(src)
+-install(FILES target-isns.conf DESTINATION /etc/)
++install(FILES target-isns.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/etc/)
+ install(FILES target-isns.8 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man8/)
+ if (SUPPORT_SYSTEMD)
+-  install(FILES target-isns.service DESTINATION /usr/lib/systemd/system/)
++  install(FILES target-isns.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system/)
+ endif (SUPPORT_SYSTEMD)
+
+ add_subdirectory(tests)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7786,6 +7786,8 @@ in
 
   targetcli = callPackage ../os-specific/linux/targetcli { };
 
+  target-isns = callPackage ../os-specific/linux/target-isns { };
+
   tarsnap = callPackage ../tools/backup/tarsnap { };
 
   tarsnapper = callPackage ../tools/backup/tarsnapper { };


### PR DESCRIPTION
###### Motivation for this change
Daemon that registers iSCSI exports from the Linux LIO target with an iSNS server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
