### PR TITLE
segger-ozone: init at 3.22a

### DIFF
--- a/pkgs/development/tools/misc/segger-ozone/default.nix
+++ b/pkgs/development/tools/misc/segger-ozone/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, fetchurl
+, fontconfig
+, freetype
+, lib
+, libICE
+, libSM
+, udev
+, libX11
+, libXcursor
+, libXext
+, libXfixes
+, libXrandr
+, libXrender
+}:
+
+stdenv.mkDerivation rec {
+  pname = "segger-ozone";
+  version = "3.22a";
+
+  src = fetchurl {
+    url = "https://www.segger.com/downloads/jlink/Ozone_Linux_V${(lib.replaceChars ["."] [""] version)}_x86_64.tgz";
+    sha256 = "0v1r8qvp1w2f3yip9fys004pa0smlmq69p7w77lfvghs1rmg1649";
+  };
+
+  rpath = lib.makeLibraryPath [
+    fontconfig
+    freetype
+    libICE
+    libSM
+    udev
+    libX11
+    libXcursor
+    libXext
+    libXfixes
+    libXrandr
+    libXrender
+  ]
+  + ":${stdenv.cc.cc.lib}/lib64";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv Lib lib
+    mv * $out
+    ln -s $out/Ozone $out/bin
+  '';
+
+  postFixup = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/Ozone" \
+      --set-rpath ${rpath}:$out/lib "$out/Ozone"
+
+    for file in $(find $out/lib -maxdepth 1 -type f -and -name \*.so\*); do
+      patchelf --set-rpath ${rpath}:$out/lib $file
+    done
+  '';
+
+  meta = with lib; {
+    description = "J-Link Debugger and Performance Analyzer";
+    longDescription = ''
+      Ozone is a cross-platform debugger and performance analyzer for J-Link
+      and J-Trace.
+
+        - Stand-alone graphical debugger
+        - Debug output of any tool chain and IDE 1
+        - C/C++ source level debugging and assembly instruction debugging
+        - Debug information windows for any purpose: disassembly, memory,
+          globals and locals, (live) watches, CPU and peripheral registers
+        - Source editor to fix bugs immediately
+        - High-speed programming of the application into the target
+        - Direct use of J-Link built-in features (Unlimited Flash
+          Breakpoints, Flash Download, Real Time Terminal, Instruction Trace)
+        - Scriptable project files to set up everything automatically
+          - New project wizard to ease the basic configuration of new projects
+
+      1 Ozone has been tested with the output of the following compilers:
+      GCC, Clang, ARM, IAR. Output of other compilers may be supported but is
+      not guaranteed to be.
+    '';
+    homepage = "https://www.segger.com/products/development-tools/ozone-j-link-debugger";
+    license = licenses.unfree;
+    maintainers = [ maintainers.bmilanov ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12235,6 +12235,8 @@ in
 
   scss-lint = callPackage ../development/tools/scss-lint { };
 
+  segger-ozone = callPackage ../development/tools/misc/segger-ozone { };
+
   shadowenv = callPackage ../tools/misc/shadowenv {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
From the project's homepage [1]:

Ozone — The J-Link Debugger and Performance Analyzer

Ozone is a cross-platform debugger and performance analyzer for J-Link
and J-Trace.

  - Stand-alone graphical debugger
  - Debug output of any tool chain and IDE 1
  - C/C++ source level debugging and assembly instruction debugging
  - Debug information windows for any purpose: disassembly, memory,
    globals and locals, (live) watches, CPU and peripheral registers
  - Source editor to fix bugs immediately
  - High-speed programming of the application into the target
  - Direct use of J-Link built-in features (Unlimited Flash
    Breakpoints, Flash Download, Real Time Terminal, Instruction Trace)
  - Scriptable project files to set up everything automatically
    - New project wizard to ease the basic configuration of new projects

1 Ozone has been tested with the output of the following compilers:
GCC, Clang, ARM, IAR. Output of other compilers may be supported but is
not guaranteed to be.

[1]: https://www.segger.com/products/development-tools/ozone-j-link-debugger

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

###### TODO

I am not sure how deal with the following:

1. Ozone is published with it's own non-standard filesystem organization: no "/bin", "/lib", etc. Directories and files only related to this package will stand out in the top-level of a nix profile directory. Would this be fine? Should the package be reorganized with the main Ozone binary in "/bin", the libs in "/lib", etc. I am submitting this derivation with only "/Lib" renamed to "/lib", and Ozone symlinked to "/bin/Ozone". The published RPM and DEB packages place the contents of the package in "/opt".
2. The fix-up phase finds ELFs inside "/lib" that are not related to the execution of Ozone, and tries to run patch-elf on them. Is it possible to declare a white/blacklist of directories which fix-up should process/ignore?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
