### PR TITLE
libstrangle: 2017-02-22 -> 0.1.1

### DIFF
--- a/pkgs/tools/X11/libstrangle/default.nix
+++ b/pkgs/tools/X11/libstrangle/default.nix
@@ -1,14 +1,16 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitLab, libGL, libX11 }:
 
 stdenv.mkDerivation rec {
   pname = "libstrangle";
-  version = "2017-02-22";
+  version = "0.1.1";
 
-  src = fetchFromGitHub {
-    owner = "milaq";
+  buildInputs = [ libGL libX11 ];
+
+  src = fetchFromGitLab {
+    owner = "torkel104";
     repo = pname;
-    rev = "6020f9e375ba747c75eb7996b7d5f0214ac3221e";
-    sha256 = "04ikacbjcq9phdc8q5y1qjjpa1sxmzfm0idln9ys95prg289zp4h";
+    rev = version;
+    sha256 = "135icr544w5ynlxfnxqgjn794bsm9i703rh9jfnracjb7jgnha4w";
   };
 
   makeFlags = [ "prefix=" "DESTDIR=$(out)" ];
@@ -17,10 +19,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteAllInPlace src/strangle.sh
+    substituteAllInPlace src/stranglevk.sh
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/milaq/libstrangle";
+    homepage = "https://gitlab.com/torkel104/libstrangle";
     description = "Frame rate limiter for Linux/OpenGL";
     license = licenses.gpl3;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/tools/X11/libstrangle/nixos.patch
+++ b/pkgs/tools/X11/libstrangle/nixos.patch
@@ -1,29 +1,43 @@
 diff --git a/makefile b/makefile
-index eb13054..a3a1125 100644
 --- a/makefile
 +++ b/makefile
-@@ -27,12 +27,10 @@ $(BUILDDIR)libstrangle32.so: $(BUILDDIR)
- 	$(CC) $(CFLAGS) $(LDFLAGS) -m32 -o $(BUILDDIR)libstrangle32.so $(SOURCES)
+@@ -86,10 +86,6 @@ install-common:
+ 	install -m 0755 -D -T $(SOURCEDIR)/stranglevk.sh $(DESTDIR)$(bindir)/stranglevk
+ 	install -m 0644 -D -T $(SOURCEDIR)/vulkan/libstrangle_vk.json $(DESTDIR)$(datarootdir)/vulkan/implicit_layer.d/libstrangle_vk.json
  
- install: all
--	install -m 0644 -D -T $(BUILDDIR)libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf
- 	install -m 0755 -D -T $(BUILDDIR)libstrangle32.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so
- 	install -m 0755 -D -T $(BUILDDIR)libstrangle64.so $(DESTDIR)$(LIB64_PATH)/libstrangle.so
- 	install -m 0755 -D -T $(SOURCEDIR)strangle.sh $(DESTDIR)$(bindir)/strangle
- 	install -m 0644 -D -T COPYING $(DESTDIR)$(DOC_PATH)/LICENSE
+-install-ld: ld
+-	install -m 0644 -D -T $(BUILDDIR)/libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf
 -	ldconfig
+-
+ install-32: 32-bit
+ 	install -m 0755 -D -T $(BUILDDIR)/libstrangle32.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so
+ 	install -m 0755 -D -T $(BUILDDIR)/libstrangle32_nodlsym.so $(DESTDIR)$(LIB32_PATH)/libstrangle_nodlsym.so
+@@ -109,8 +105,7 @@ install: \
+ 	all \
+ 	install-common \
+ 	install-32 \
+-	install-64 \
+-	install-ld
++	install-64
  
  clean:
- 	rm -f $(BUILDDIR)libstrangle64.so
+ 	rm -f $(BUILDDIR)/libstrangle64.so
 diff --git a/src/strangle.sh b/src/strangle.sh
-index e280e86..b2dd42b 100755
 --- a/src/strangle.sh
 +++ b/src/strangle.sh
-@@ -31,6 +31,5 @@ if [ "$#" -eq 0 ]; then
-   exit 1
+@@ -130,6 +130,5 @@ if [ "$STRANGLE_VKONLY" != "1" ]; then
+ 	fi
  fi
  
 -# Execute the strangled program under a clean environment
  # pass through the FPS and overriden LD_PRELOAD environment variables
--exec env FPS="${FPS}" LD_PRELOAD="${LD_PRELOAD}:libstrangle.so" "$@"
-+FPS="${FPS}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}@out@/lib/libstrangle/lib64:@out@/lib/libstrangle/lib32" LD_PRELOAD="${LD_PRELOAD}:libstrangle.so" exec "$@"
+-exec env ENABLE_VK_LAYER_TORKEL104_libstrangle=1 LD_PRELOAD="${LD_PRELOAD}" "$@"
++ENABLE_VK_LAYER_TORKEL104_libstrangle=1 XDG_DATA_DIRS="${XDG_DATA_DIRS}${XDG_DATA_DIRS:+:}@out@/share" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}@out@/lib/libstrangle/lib64:@out@/lib/libstrangle/lib32" LD_PRELOAD="${LD_PRELOAD}" exec "$@"
+diff --git a/src/stranglevk.sh b/src/stranglevk.sh
+--- a/src/stranglevk.sh
++++ b/src/stranglevk.sh
+@@ -1,3 +1,3 @@
+ #!/bin/sh
+
+-ENABLE_VK_LAYER_TORKEL104_libstrangle=1 STRANGLE_VKONLY=1 strangle "$@"
++ENABLE_VK_LAYER_TORKEL104_libstrangle=1 STRANGLE_VKONLY=1 @out@/bin/strangle "$@"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package update. Adds Vulkan support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
