### PR TITLE
cloudbrute: init 1.0.7

### DIFF
--- a/pkgs/tools/security/cloudbrute/default.nix
+++ b/pkgs/tools/security/cloudbrute/default.nix
@@ -1,0 +1,30 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "cloudbrute";
+  version = "1.0.7";
+
+  src = fetchFromGitHub {
+    owner = "0xsha";
+    repo = "CloudBrute";
+    rev = "v${version}";
+    sha256 = "05b9klddk8wvi78j47jyg9pix6qpxyr01l1m7k1j7598siazfv9g";
+  };
+
+  vendorSha256 = "0f3n0wrmg9d2qyn8hlnhf9lsfqd9443myzr04p48v68m8n83j6a9";
+
+  meta = with stdenv.lib; {
+    description = "Cloud enumeration tool";
+    longDescription = ''
+      A tool to find a company (target) infrastructure, files, and apps on
+      the top cloud providers (Amazon, Google, Microsoft, DigitalOcean,
+      Alibaba, Vultr, Linode).
+    '';
+    homepage = "https://github.com/0xsha/CloudBrute";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1828,6 +1828,8 @@ in
 
   cloud-init = python3.pkgs.callPackage ../tools/virtualization/cloud-init { };
 
+  cloudbrute = callPackage ../tools/security/cloudbrute { };
+
   cloudflared = callPackage ../applications/networking/cloudflared { };
 
   cloudmonkey = callPackage ../tools/virtualization/cloudmonkey { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A tool to find a company (target) infrastructure, files, and apps on
the top cloud providers (Amazon, Google, Microsoft, DigitalOcean,
Alibaba, Vultr, Linode).

https://github.com/0xsha/CloudBrute

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
