### PR TITLE
deepsea: init at 0.9

### DIFF
--- a/pkgs/tools/security/deepsea/default.nix
+++ b/pkgs/tools/security/deepsea/default.nix
@@ -1,0 +1,30 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "deepsea";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "dsnezhkov";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02s03sha8vwp7dsaw3z446pskhb6wmy0hyj0mhpbx58sf147rkig";
+  };
+
+  vendorSha256 = "0vpkzykfg1rq4qi1v5lsa0drpil9i6ccfw96k48ppi9hiwzpq94w";
+
+  meta = with stdenv.lib; {
+    description = "Phishing tool for red teams and pentesters";
+    longDescription = ''
+      DeepSea phishing gear aims to help RTOs and pentesters with the
+      delivery of opsec-tight, flexible email phishing campaigns carried
+      out on the outside as well as on the inside of a perimeter.
+    '';
+    homepage = "https://github.com/dsnezhkov/deepsea";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27032,6 +27032,8 @@ in
 
   dcm2niix = callPackage ../applications/science/biology/dcm2niix { };
 
+  deepsea = callPackage ../tools/security/deepsea { };
+
   deeptools = callPackage ../applications/science/biology/deeptools { python = python3; };
 
   delly = callPackage ../applications/science/biology/delly { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
DeepSea phishing gear aims to help RTOs and pentesters with the
delivery of opsec-tight, flexible email phishing campaigns carried
out on the outside as well as on the inside of a perimeter.

https://github.com/dsnezhkov/deepsea

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
