### PR TITLE
python3Packages.pytile: init at 5.1.0

### DIFF
--- a/pkgs/development/python-modules/pytile/default.nix
+++ b/pkgs/development/python-modules/pytile/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, aiohttp
+, async-timeout
+, aresponses
+, buildPythonPackage
+, fetchFromGitHub
+, poetry
+, pylint
+, pytest-aiohttp
+, pytest-asyncio
+, pytestCheckHook
+, pythonAtLeast
+}:
+buildPythonPackage rec {
+  pname = "pytile";
+  version = "5.1.0";
+  disabled = pythonAtLeast "3.9";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "0hdyb8ca4ihqf7yfkr3hbpkwz7g182ycra151y5dxn0319fillc3";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    pylint
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-aiohttp
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  # Ignore the examples as they are prefixed with test_
+  pytestFlagsArray = [ "--ignore examples/" ];
+  pythonImportsCheck = [ "pytile" ];
+
+  meta = with lib; {
+    description = " Python API for Tile Bluetooth trackers";
+    longDescription = ''
+      pytile is a simple Python library for retrieving information on Tile
+      Bluetooth trackers (including last location and more).
+    '';
+    homepage = "https://github.com/bachya/pytile";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -838,7 +838,7 @@
     "threshold" = ps: with ps; [ ];
     "tibber" = ps: with ps; [ ]; # missing inputs: pyTibber
     "tikteck" = ps: with ps; [ ]; # missing inputs: tikteck
-    "tile" = ps: with ps; [ ]; # missing inputs: pytile
+    "tile" = ps: with ps; [ pytile ];
     "time_date" = ps: with ps; [ ];
     "timer" = ps: with ps; [ ];
     "tmb" = ps: with ps; [ ]; # missing inputs: tmb

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6222,6 +6222,8 @@ in {
 
   pyeverlights = callPackage ../development/python-modules/pyeverlights { };
 
+  pytile = callPackage ../development/python-modules/pytile { };
+
   pytimeparse = callPackage ../development/python-modules/pytimeparse { };
 
   pytmx = callPackage ../development/python-modules/pytmx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
pytile is a simple Python library for retrieving information on Tile® Bluetooth trackers (including last location and more).

https://github.com/bachya/pytile

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
