### PR TITLE
blobwars: init at 2.00

### DIFF
--- a/pkgs/games/blobwars/default.nix
+++ b/pkgs/games/blobwars/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, pkg-config, gettext, SDL2, SDL2_image, SDL2_mixer, SDL2_net, SDL2_ttf, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "blobwars";
+  version = "2.00";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "c406279f6cdf2aed3c6edb8d8be16efeda0217494acd525f39ee2bd3e77e4a99";
+  };
+
+  nativeBuildInputs = [ pkg-config gettext ];
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_net SDL2_ttf zlib ];
+  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
+  makeFlags = [ "PREFIX=$(out)" "RELEASE=1" ];
+
+  postInstall = ''
+    install -Dm755 $out/games/blobwars -t $out/bin
+    rm -r $out/games
+    cp -r {data,gfx,sound,music} $out/share/games/blobwars/
+    # fix world readable bit
+    find $out/share/games/blobwars/. -type d -exec chmod 755 {} +
+    find $out/share/games/blobwars/. -type f -exec chmod 644 {} +
+  '';
+
+  meta = with lib; {
+    description = "Platform action game featuring a blob with lots of weapons";
+    homepage = "https://www.parallelrealities.co.uk/games/metalBlobSolid/";
+    license = with licenses; [ gpl2Plus free ];
+    maintainers = with maintainers; [ iblech ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26503,6 +26503,8 @@ in
 
   blobby = callPackage ../games/blobby { };
 
+  blobwars = callPackage ../games/blobwars { };
+
   boohu = callPackage ../games/boohu { };
 
   braincurses = callPackage ../games/braincurses { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Blobwars is an old and neat platform game available in Debian and Arch. This pull request adds blobwars to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
