### PR TITLE
Qt: Do not require mkDerivation

### DIFF
--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -15,13 +15,14 @@ which are not shared by other C++ software:
 
 ```{=docbook}
 <programlisting>
-{ stdenv, lib, qtbase }: <co xml:id='qt-default-nix-co-1' />
+{ stdenv, lib, qtbase, wrapQtAppsHook }: <co xml:id='qt-default-nix-co-1' />
 
 stdenv.mkDerivation {
   pname = "myapp";
   version = "1.0";
 
   buildInputs = [ qtbase ];
+  nativeBuildInputs = [ wrapQtAppsHook ]; <co xml:id'qt-default-nix-co-2' />
 }
 </programlisting>
 
@@ -32,6 +33,13 @@ stdenv.mkDerivation {
     <emphasis>Do not</emphasis> import Qt package sets such as <literal>qt5</literal>
     because the Qt versions of dependencies may not be coherent, causing build and runtime failures.
    </para>
+  </callout>
+  <callout arearefs="qt-default-nix-co-2'>
+    <para>
+      All Qt packages must include <literal>wrapQtAppsHook</literal> in
+      <literal>nativeBuildInputs</literal>, or you must explicitly set
+      <literal>dontWrapQtApps</literal>.
+    </para>
   </callout>
  </calloutlist>
 ```
@@ -50,7 +58,8 @@ stdenv.mkDerivation {
 }
 ```
 
-Add entries to `qtWrapperArgs` are to modify the wrappers created by `wrapQtAppsHook`:
+Add entries to `qtWrapperArgs` are to modify the wrappers created by
+`wrapQtAppsHook`:
 
 ```nix
 { stdenv, wrapQtAppsHook }:
@@ -65,7 +74,8 @@ stdenv.mkDerivation {
 The entries are passed as arguments to [wrapProgram](#fun-wrapProgram).
 
 Set `dontWrapQtApps` to stop applications from being wrapped automatically.
-Wrap programs manually with `wrapQtApp`, using the syntax of [wrapProgram](#fun-wrapProgram):
+Wrap programs manually with `wrapQtApp`, using the syntax of
+[wrapProgram](#fun-wrapProgram):
 
 ```nix
 { stdenv, lib, wrapQtAppsHook }:

--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -1,77 +1,78 @@
 # Qt {#sec-language-qt}
 
-This section describes the differences between Nix expressions for Qt libraries and applications and Nix expressions for other C++ software. Some knowledge of the latter is assumed.
+Writing Nix expressions for Qt libraries and applications is largely similar as for other C++ software.
+This section assumes some knowledge of the latter.
+There are two problems that the Nixpkgs Qt infrastructure addresses,
+which are not shared by other C++ software:
 
-There are primarily two problems which the Qt infrastructure is designed to address: ensuring consistent versioning of all dependencies and finding dependencies at runtime.
+1.  There are usually multiple supported versions of Qt in Nixpkgs.
+    All of a package's dependencies must be built with the same version of Qt.
+    This is similar to the version constraints imposed on interpreted languages like Python.
+2.  Qt makes extensive use of runtime dependency detection.
+    Runtime dependencies are made into build dependencies through wrappers.
 
 ## Nix expression for a Qt package (default.nix) {#qt-default-nix}
 
 ```{=docbook}
 <programlisting>
-{ mkDerivation, qtbase }: <co xml:id='qt-default-nix-co-1' />
+{ stdenv, lib, qtbase }: <co xml:id='qt-default-nix-co-1' />
 
-mkDerivation { <co xml:id='qt-default-nix-co-2' />
+stdenv.mkDerivation {
   pname = "myapp";
   version = "1.0";
 
-  buildInputs = [ qtbase ]; <co xml:id='qt-default-nix-co-3' />
+  buildInputs = [ qtbase ];
 }
 </programlisting>
 
  <calloutlist>
   <callout arearefs='qt-default-nix-co-1'>
    <para>
-    Import <literal>mkDerivation</literal> and Qt (such as <literal>qtbase</literal> modules directly. <emphasis>Do not</emphasis> import Qt package sets; the Qt versions of dependencies may not be coherent, causing build and runtime failures.
-   </para>
-  </callout>
-  <callout arearefs='qt-default-nix-co-2'>
-   <para>
-    Use <literal>mkDerivation</literal> instead of <literal>stdenv.mkDerivation</literal>. <literal>mkDerivation</literal> is a wrapper around <literal>stdenv.mkDerivation</literal> which applies some Qt-specific settings. This deriver accepts the same arguments as <literal>stdenv.mkDerivation</literal>; refer to <xref linkend='chap-stdenv' /> for details.
-   </para>
-   <para>
-    To use another deriver instead of <literal>stdenv.mkDerivation</literal>, use <literal>mkDerivationWith</literal>:
-<programlisting>
-mkDerivationWith myDeriver {
-  # ...
-}
-</programlisting>
-    If you cannot use <literal>mkDerivationWith</literal>, please refer to <xref linkend='qt-runtime-dependencies' />.
-   </para>
-  </callout>
-  <callout arearefs='qt-default-nix-co-3'>
-   <para>
-    <literal>mkDerivation</literal> accepts the same arguments as <literal>stdenv.mkDerivation</literal>, such as <literal>buildInputs</literal>.
+    Import Qt modules directly, that is: <literal>qtbase</literal>, <literal>qtdeclarative</literal>, etc.
+    <emphasis>Do not</emphasis> import Qt package sets such as <literal>qt5</literal>
+    because the Qt versions of dependencies may not be coherent, causing build and runtime failures.
    </para>
   </callout>
  </calloutlist>
 ```
 
 ## Locating runtime dependencies {#qt-runtime-dependencies}
-Qt applications need to be wrapped to find runtime dependencies. If you cannot use `mkDerivation` or `mkDerivationWith` above, include `wrapQtAppsHook` in `nativeBuildInputs`:
+
+Qt applications must be wrapped to find runtime dependencies.
+Include `wrapQtAppsHook` in `nativeBuildInputs`:
 
 ```nix
+{ stdenv, wrapQtAppsHook }:
+
 stdenv.mkDerivation {
   # ...
-
   nativeBuildInputs = [ wrapQtAppsHook ];
 }
 ```
-Entries added to `qtWrapperArgs` are used to modify the wrappers created by `wrapQtAppsHook`. The entries are passed as arguments to [wrapProgram executable makeWrapperArgs](#fun-wrapProgram).
+
+Add entries to `qtWrapperArgs` are to modify the wrappers created by `wrapQtAppsHook`:
 
 ```nix
-mkDerivation {
-  # ...
+{ stdenv, wrapQtAppsHook }:
 
+stdenv.mkDerivation {
+  # ...
+  nativeBuildInputs = [ wrapQtAppsHook ];
   qtWrapperArgs = [ ''--prefix PATH : /path/to/bin'' ];
 }
 ```
 
-Set `dontWrapQtApps` to stop applications from being wrapped automatically. It is required to wrap applications manually with `wrapQtApp`, using the syntax of [wrapProgram executable makeWrapperArgs](#fun-wrapProgram):
+The entries are passed as arguments to [wrapProgram](#fun-wrapProgram).
+
+Set `dontWrapQtApps` to stop applications from being wrapped automatically.
+Wrap programs manually with `wrapQtApp`, using the syntax of [wrapProgram](#fun-wrapProgram):
 
 ```nix
-mkDerivation {
-  # ...
+{ stdenv, lib, wrapQtAppsHook }:
 
+stdenv.mkDerivation {
+  # ...
+  nativeBuildInputs = [ wrapQtAppsHook ];
   dontWrapQtApps = true;
   preFixup = ''
       wrapQtApp "$out/bin/myapp" --prefix PATH : /path/to/bin
@@ -79,21 +80,14 @@ mkDerivation {
 }
 ```
 
-> Note: `wrapQtAppsHook` ignores files that are non-ELF executables. This means that scripts won't be automatically wrapped so you'll need to manually wrap them as previously mentioned. An example of when you'd always need to do this is with Python applications that use PyQT.
+> Note: `wrapQtAppsHook` ignores files that are non-ELF executables.
+> This means that scripts won't be automatically wrapped so you'll need to manually wrap them as previously mentioned.
+> An example of when you'd always need to do this is with Python applications that use PyQT.
 
-Libraries are built with every available version of Qt. Use the `meta.broken` attribute to disable the package for unsupported Qt versions:
-
-```nix
-mkDerivation {
-  # ...
-
-  # Disable this library with Qt &lt; 5.9.0
-  meta.broken = builtins.compareVersions qtbase.version "5.9.0" &lt; 0;
-}
-```
 ## Adding a library to Nixpkgs
-Qt libraries are added to `qt5-packages.nix` and are made available for every Qt
-version supported.
+Add Qt libraries to `qt5-packages.nix` to make them available for every
+supported Qt version.
+
 ### Example adding a Qt library {#qt-library-all-packages-nix}
 
 The following represents the contents of `qt5-packages.nix`.
@@ -106,9 +100,23 @@ The following represents the contents of `qt5-packages.nix`.
   # ...
 }
 ```
+
+Libraries are built with every available version of Qt.
+Use the `meta.broken` attribute to disable the package for unsupported Qt versions:
+
+```nix
+{ stdenv, lib, qtbase }:
+
+stdenv.mkDerivation {
+  # ...
+  # Disable this library with Qt &lt; 5.9.0
+  meta.broken = lib.versionOlder qtbase.version "5.9.0";
+}
+```
+
 ## Adding an application to Nixpkgs
-Applications that use Qt are also added to `qt5-packages.nix`. An alias is added
-in the top-level `all-packages.nix` pointing to the package with the desired Qt5 version.
+Add Qt applications to `qt5-packages.nix`. Add an alias to `all-packages.nix`
+to select the Qt 5 version used for the application.
 
 ### Example adding a Qt application {#qt-application-all-packages-nix}
 

--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -80,9 +80,11 @@ stdenv.mkDerivation {
 }
 ```
 
-> Note: `wrapQtAppsHook` ignores files that are non-ELF executables.
-> This means that scripts won't be automatically wrapped so you'll need to manually wrap them as previously mentioned.
-> An example of when you'd always need to do this is with Python applications that use PyQT.
+::: note
+`wrapQtAppsHook` ignores files that are non-ELF executables.
+This means that scripts won't be automatically wrapped so you'll need to manually wrap them as previously mentioned.
+An example of when you'd always need to do this is with Python applications that use PyQt.
+:::
 
 ## Adding a library to Nixpkgs
 Add Qt libraries to `qt5-packages.nix` to make them available for every

--- a/pkgs/applications/audio/csound/csound-qt/default.nix
+++ b/pkgs/applications/audio/csound/csound-qt/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
                  "SHARE_DIR=${placeholder "out"}/share"
                  ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "CsoundQt is a frontend for Csound with editor, integrated help, widgets and other features";
     homepage = "https://csoundqt.github.io/";

--- a/pkgs/applications/audio/keyfinder/default.nix
+++ b/pkgs/applications/audio/keyfinder/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
        --replace "\$\$[QT_INSTALL_PREFIX]" "$out"
   '';
 
+  dontWrapQtApps = true;
+
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/applications/audio/kmetronome/default.nix
+++ b/pkgs/applications/audio/kmetronome/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ alsaLib drumstick qtbase qtsvg ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://kmetronome.sourceforge.io/";
     description = "ALSA MIDI metronome with Qt interface";

--- a/pkgs/applications/audio/nootka/default.nix
+++ b/pkgs/applications/audio/nootka/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     "-DENABLE_PULSEAUDIO=ON"
   ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Application for practicing playing musical scores and ear training";
     homepage = "https://nootka.sourceforge.io/";

--- a/pkgs/applications/audio/nootka/unstable.nix
+++ b/pkgs/applications/audio/nootka/unstable.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     qtbase qtdeclarative qtquickcontrols2
   ];
 
+  dontWrapQtApps = true;
+
   cmakeFlags = [
     "-DCMAKE_INCLUDE_PATH=${libjack2}/include/jack;${libpulseaudio.dev}/include/pulse"
     "-DENABLE_JACK=ON"

--- a/pkgs/applications/audio/ocenaudio/default.nix
+++ b/pkgs/applications/audio/ocenaudio/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   dontUnpack = true;
   dontBuild = true;
   dontStrip = true;
+  dontWrapQtApps = true;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/applications/audio/playbar2/default.nix
+++ b/pkgs/applications/audio/playbar2/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     kwindowsystem
   ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Mpris2 Client for Plasma5";
     homepage = "https://github.com/audoban/PlayBar2";

--- a/pkgs/applications/audio/seq66/default.nix
+++ b/pkgs/applications/audio/seq66/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://github.com/ahlstromcj/seq66";
     description = "Loop based midi sequencer with Qt GUI derived from seq24 and sequencer64";

--- a/pkgs/applications/audio/spectmorph/default.nix
+++ b/pkgs/applications/audio/spectmorph/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Allows to analyze samples of musical instruments, and to combine them (morphing) to construct hybrid sounds";
     homepage = "http://spectmorph.org";

--- a/pkgs/applications/blockchains/bitcoin-classic.nix
+++ b/pkgs/applications/blockchains/bitcoin-classic.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   meta = {
     description = "Peer-to-peer electronic cash system (Classic client)";
     longDescription= ''

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -101,6 +101,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  dontWrapQtApps = true;
+
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   configureFlags = [

--- a/pkgs/applications/editors/code-browser/default.nix
+++ b/pkgs/applications/editors/code-browser/default.nix
@@ -39,6 +39,9 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals withQt [ "UI=qt" ]
   ++ lib.optionals withGtk [ "UI=gtk" ];
+
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Folding text editor, designed to hierarchically structure any kind of text file and especially source code";
     homepage = "https://tibleiz.net/code-browser/";

--- a/pkgs/applications/editors/kdevelop5/kdev-php.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-php.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [ kdevelop-pg-qt threadweaver ktexteditor kdevelop-unwrapped ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     maintainers = [ maintainers.aanderse ];
     platforms = platforms.linux;

--- a/pkgs/applications/editors/kdevelop5/kdev-python.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-python.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [ threadweaver ktexteditor kdevelop-unwrapped ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     maintainers = [ maintainers.aanderse ];
     platforms = platforms.linux;

--- a/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop-pg-qt.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     maintainers = [ maintainers.ambrop72 ];
     platforms = platforms.linux;

--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     export QXMLEDIT_INST_DOC_DIR="$doc"
   '';
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Simple XML editor based on qt libraries" ;
     homepage = "https://sourceforge.net/projects/qxmledit";

--- a/pkgs/applications/misc/gpsbabel/default.nix
+++ b/pkgs/applications/misc/gpsbabel/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   doCheck = true;
   preCheck = ''
     patchShebangs testo

--- a/pkgs/applications/misc/gpsbabel/gui.nix
+++ b/pkgs/applications/misc/gpsbabel/gui.nix
@@ -10,6 +10,8 @@ mkDerivation {
   nativeBuildInputs = [ qmake qttools ];
   buildInputs = [ qtwebkit ];
 
+  dontWrapQtApps = true;
+
   postPatch = ''
     substituteInPlace mainwindow.cc \
       --replace "QApplication::applicationDirPath() + \"/" "\"" \

--- a/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
+++ b/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [ plasma-framework kwindowsystem plasma-pa ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "A fork of the default volume plasmoid with a Windows 7 theme (vertical sliders)";
     homepage = "https://github.com/Zren/plasma-applet-volumewin7mixer";

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   ];
 
   dontUseQmakeConfigure = true;
+  dontWrapQtApps = true;
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated" ];
 

--- a/pkgs/applications/misc/redshift-plasma-applet/default.nix
+++ b/pkgs/applications/misc/redshift-plasma-applet/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation {
     kwindowsystem
   ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "KDE Plasma 5 widget for controlling Redshift";
     homepage = "https://github.com/kotelnik/plasma-applet-redshift-control";

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -52,6 +52,8 @@ let
 
     buildInputs = [ qtbase qtlocation libXcomposite ];
 
+    dontWrapQtApps = true;
+
     pluginsSubdir = "lib/qt-${qtbase.qtCompatVersion}/plugins";
 
     installPhase = ''

--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   preConfigure = ''
     export QMAKEFEATURES=${libcommuni}/features
   '';

--- a/pkgs/applications/office/cb2bib/default.nix
+++ b/pkgs/applications/office/cb2bib/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     runHook postConfigure
   '';
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Rapidly extract unformatted, or unstandardized bibliographic references from email alerts, journal Web pages and PDF files";
     homepage = "http://www.molspaces.com/d_cb2bib-overview.php";

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -218,6 +218,7 @@ let
     passthru
     doCheck
     dontWrapPythonPrograms
+    dontWrapQtApps
     meta
   ;
   cmakeFlags = shared.cmakeFlags
@@ -284,6 +285,7 @@ stdenv.mkDerivation rec {
     passthru
     doCheck
     dontWrapPythonPrograms
+    dontWrapQtApps
     meta
   ;
 }

--- a/pkgs/applications/radio/gnuradio/shared.nix
+++ b/pkgs/applications/radio/gnuradio/shared.nix
@@ -110,6 +110,7 @@ rec {
   };
   # Wrapping is done with an external wrapper
   dontWrapPythonPrograms = true;
+  dontWrapQtApps = true;
   # Tests should succeed, but it's hard to get LD_LIBRARY_PATH right in order
   # for it to happen.
   doCheck = false;

--- a/pkgs/applications/radio/unixcw/default.nix
+++ b/pkgs/applications/radio/unixcw/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   buildInputs = [libpulseaudio alsaLib pkg-config qt5.qtbase];
   CFLAGS   ="-lasound -lpulse-simple";
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "sound characters as Morse code on the soundcard or console speaker";
     longDescription = ''

--- a/pkgs/applications/science/logic/mcrl2/default.nix
+++ b/pkgs/applications/science/logic/mcrl2/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libGLU libGL qt5.qtbase boost ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "A toolset for model-checking concurrent systems and protocols";
     longDescription = ''

--- a/pkgs/applications/version-management/bcompare/default.nix
+++ b/pkgs/applications/version-management/bcompare/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
   dontConfigure = true;
+  dontWrapQtApps = true;
 
   meta = with lib; {
     description = "GUI application that allows to quickly and easily compare files and folders";

--- a/pkgs/applications/version-management/git-and-tools/svn-all-fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/svn-all-fast-export/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
 
   NIX_LDFLAGS = "-lsvn_fs-1";
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://github.com/svn-all-fast-export/svn2git";
     description = "A fast-import based converter for an svn repo to git repos";

--- a/pkgs/applications/video/obs-studio/obs-ndi.nix
+++ b/pkgs/applications/video/obs-studio/obs-ndi.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_CXX_FLAGS=-I${obs-studio.src}/UI/obs-frontend-api"
   ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Network A/V plugin for OBS Studio";
     homepage = "https://github.com/Palakis/obs-ndi";

--- a/pkgs/applications/video/obs-studio/v4l2sink.nix
+++ b/pkgs/applications/video/obs-studio/v4l2sink.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qtbase obs-studio ];
 
+  dontWrapQtApps = true;
+
   patches = [
     # Fixes the segfault when stopping the plugin
     (fetchpatch {

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin llvmPackages.openmp
   ;
 
+  dontWrapQtApps = true;
+
   LIBOPENSHOT_AUDIO_DIR = libopenshot-audio;
   "UNITTEST++_INCLUDE_DIR" = "${unittest-cpp}/include/UnitTest++";
 

--- a/pkgs/data/icons/maia-icon-theme/default.nix
+++ b/pkgs/data/icons/maia-icon-theme/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation {
 
   dontDropIconThemeCache = true;
 
+  dontWrapQtApps = true;
+
   postInstall = ''
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache $theme

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
       ++ optional (!stdenv.isDarwin) alsaLib
       ++ optional useSCEL emacs;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Programming language for real time audio synthesis";
     homepage = "https://supercollider.github.io";

--- a/pkgs/development/libraries/aqbanking/gwenhywfar.nix
+++ b/pkgs/development/libraries/aqbanking/gwenhywfar.nix
@@ -57,6 +57,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ gtk2 gtk3 qt5.qtbase gnutls openssl libgcrypt libgpgerror ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "OS abstraction functions used by aqbanking and related tools";
     homepage = "http://www2.aquamaniac.de/sites/download/packages.php?package=01&showall=1";

--- a/pkgs/development/libraries/audio/suil/default.nix
+++ b/pkgs/development/libraries/audio/suil/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     ++ (lib.optionals withQt4 [ qt4 ])
     ++ (lib.optionals withQt5 (with qt5; [ qtbase qttools ]));
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "http://drobilla.net/software/suil";
     description = "A lightweight C library for loading and wrapping LV2 plugin UIs";

--- a/pkgs/development/libraries/dxflib/default.nix
+++ b/pkgs/development/libraries/dxflib/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     qmake
   ];
+  dontWrapQtApps = true;
   preConfigure = ''
     sed -i 's/CONFIG += staticlib/CONFIG += shared/' dxflib.pro
   '';

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -23,6 +23,8 @@ mkDerivation rec {
   # Silence noisy warning
   CXXFLAGS = "-Wno-deprecated-copy";
 
+  dontWrapQtApps = true;
+
   cmakeFlags = [
     # Detection script is broken
     "-DQGLVIEWER_INCLUDE_DIR=${libqglviewer}/include/QGLViewer"

--- a/pkgs/development/libraries/gecode/default.nix
+++ b/pkgs/development/libraries/gecode/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
+  dontWrapQtApps = true;
   nativeBuildInputs = [ bison flex ];
   buildInputs = [ perl gmp mpfr ]
     ++ lib.optional enableGist qtbase;

--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
+  dontWrapQtApps = true;
+
   configureFlags = [
     "--enable-fixed-path=${gnupg}/bin"
     "--with-libgpg-error-prefix=${libgpgerror.dev}"

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ extra-cmake-modules ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     maintainers = with lib.maintainers; [ peterhoeg ];
     # The build requires at least Qt 5.14:

--- a/pkgs/development/libraries/libcommuni/default.nix
+++ b/pkgs/development/libraries/libcommuni/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   dontUseQmakeConfigure = true;
   configureFlags = [ "-config" "release" ];
 
+  dontWrapQtApps = true;
+
   preConfigure = ''
     sed -i -e 's|/bin/pwd|pwd|g' configure
   '';

--- a/pkgs/development/libraries/libdbusmenu-qt/default.nix
+++ b/pkgs/development/libraries/libdbusmenu-qt/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
 
   cmakeFlags = [ "-DWITH_DOC=OFF" ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Provides a Qt implementation of the DBusMenu spec";
     inherit homepage;

--- a/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
+++ b/pkgs/development/libraries/libdbusmenu-qt/qt-5.5.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DWITH_DOC=OFF" ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://launchpad.net/libdbusmenu-qt";
     description = "Provides a Qt implementation of the DBusMenu spec";

--- a/pkgs/development/libraries/libkeyfinder/default.nix
+++ b/pkgs/development/libraries/libkeyfinder/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake ];
   buildInputs = [ fftw qtbase ];
 
+  dontWrapQtApps = true;
+
   postPatch = ''
     substituteInPlace LibKeyFinder.pro \
       --replace "/usr/local" "$out" \

--- a/pkgs/development/libraries/libktorrent/default.nix
+++ b/pkgs/development/libraries/libktorrent/default.nix
@@ -27,6 +27,8 @@ in stdenv.mkDerivation rec {
     inherit mainVersion;
   };
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "A BitTorrent library used by KTorrent";
     homepage    = "https://www.kde.org/applications/internet/ktorrent/";

--- a/pkgs/development/libraries/liblastfm/default.nix
+++ b/pkgs/development/libraries/liblastfm/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ fftwSinglePrec libsamplerate qtbase ]
     ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.SystemConfiguration;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://github.com/lastfm/liblastfm";
     repositories.git = "git://github.com/lastfm/liblastfm.git";

--- a/pkgs/development/libraries/libqglviewer/default.nix
+++ b/pkgs/development/libraries/libqglviewer/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase libGLU ]
     ++ lib.optional stdenv.isDarwin AGL;
 
+  dontWrapQtApps = true;
+
   postPatch = ''
     cd QGLViewer
   '';

--- a/pkgs/development/libraries/opencsg/default.nix
+++ b/pkgs/development/libraries/opencsg/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
     rmdir $out/bin || true
   '';
 
+  dontWrapQtApps = true;
+
   postFixup = lib.optionalString stdenv.isDarwin ''
     app=$out/Applications/opencsgexample.app/Contents/MacOS/opencsgexample
     install_name_tool -change \

--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
   # on system paths being set.
   patches = [ ./gst-plugin-paths.patch ];
 
+  dontWrapQtApps = true;
+
   NIX_CFLAGS_COMPILE =
     let gstPluginPaths =
           lib.makeSearchPathOutput "lib" "/lib/gstreamer-1.0"

--- a/pkgs/development/libraries/phonon/backends/vlc.nix
+++ b/pkgs/development/libraries/phonon/backends/vlc.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
   ];
 
+  dontWrapQtApps = true;
+
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}"
   ];

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}"
   ];
 
+  dontWrapQtApps = true;
+
   preConfigure = ''
     cmakeFlags+=" -DPHONON_QT_MKSPECS_INSTALL_DIR=''${!outputDev}/mkspecs"
     cmakeFlags+=" -DPHONON_QT_IMPORTS_INSTALL_DIR=''${!outputBin}/$qtQmlPrefix"

--- a/pkgs/development/libraries/polkit-qt-1/qt-5.nix
+++ b/pkgs/development/libraries/polkit-qt-1/qt-5.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation {
 
   propagatedBuildInputs = [ polkit glib qtbase ];
 
+  dontWrapQtApps = true;
+
   postFixup = ''
     # Fix library location in CMake module
     sed -i "$dev/lib/cmake/PolkitQt5-1/PolkitQt5-1Config.cmake" \

--- a/pkgs/development/libraries/poppler/0.61.nix
+++ b/pkgs/development/libraries/poppler/0.61.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     (mkFlag qt5Support "QT5")
   ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://poppler.freedesktop.org/";
     description = "A PDF rendering library";

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     sed -i -e '1i cmake_policy(SET CMP0025 NEW)' CMakeLists.txt
   '';
 
+  dontWrapQtApps = true;
+
   cmakeFlags = [
     (mkFlag true "UNSTABLE_API_ABI_HEADERS") # previously "XPDF_HEADERS"
     (mkFlag (!minimal) "GLIB")

--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     python3 qtbase qtquickcontrols qtsvg ncurses
   ];
 
+  dontWrapQtApps = true;
+
   patches = [ ./qml-path.patch ];
   installTargets = [ "sub-src-install_subtargets" ];
 

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
                  "PYTHON_PATH=${python}/bin"
                  "PYTHON_LIB=${python}/lib"];
 
+  dontWrapQtApps = true;
+
   unpackCmd = "unzip $src";
 
   installPhase = ''

--- a/pkgs/development/libraries/qca-qt5/default.nix
+++ b/pkgs/development/libraries/qca-qt5/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl qtbase ];
   nativeBuildInputs = [ cmake pkg-config ];
 
+  dontWrapQtApps = true;
+
   # Without this patch cmake fails with a "No known features for CXX compiler"
   # error on darwin
   patches = lib.optional stdenv.isDarwin ./move-project.patch ;

--- a/pkgs/development/libraries/qmlbox2d/default.nix
+++ b/pkgs/development/libraries/qmlbox2d/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation {
   };
 
   enableParallelBuilding = true;
+  dontWrapQtApps = true;
   nativeBuildInputs = [ qmake ];
 
   buildInputs = [ qtdeclarative ];

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   meta = {
     description = "A QML port of qtermwidget";
     homepage = "https://github.com/Swordfish90/qmltermwidget";

--- a/pkgs/development/libraries/qoauth/default.nix
+++ b/pkgs/development/libraries/qoauth/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-I${qca-qt5}/include/Qca-qt5/QtCrypto";
   NIX_LDFLAGS = "-lqca-qt5";
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Qt library for OAuth authentication";
     inherit (qtbase.meta) platforms;

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -35,6 +35,7 @@ in stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  dontWrapQtApps = true;
 
   postPatch = ''
     substituteInPlace qscintilla.pro \

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -145,7 +145,7 @@ let
         patches = patches.qtbase;
         inherit bison cups harfbuzz libGL;
         withGtk3 = true; inherit dconf gtk3;
-        inherit developerBuild decryptSslTraffic;
+        inherit debug developerBuild decryptSslTraffic;
       };
 
       qtcharts = callPackage ../modules/qtcharts.nix {};

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -197,6 +197,7 @@ let
       qmake = makeSetupHook {
         deps = [ self.qtbase.dev ];
         substitutions = {
+          inherit debug;
           fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
         };
       } ../hooks/qmake-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -149,7 +149,7 @@ let
         patches = patches.qtbase;
         inherit bison cups harfbuzz libGL;
         withGtk3 = true; inherit dconf gtk3;
-        inherit developerBuild decryptSslTraffic;
+        inherit debug developerBuild decryptSslTraffic;
       };
 
       qtcharts = callPackage ../modules/qtcharts.nix {};

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -199,6 +199,7 @@ let
       qmake = makeSetupHook {
         deps = [ self.qtbase.dev ];
         substitutions = {
+          inherit debug;
           fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
         };
       } ../hooks/qmake-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -179,6 +179,7 @@ let
       qmake = makeSetupHook {
         deps = [ self.qtbase.dev ];
         substitutions = {
+          inherit debug;
           fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
         };
       } ../hooks/qmake-hook.sh;

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -3,6 +3,9 @@
 qmakeFlags=( ${qmakeFlags-} )
 
 qmakePrePhase() {
+    qmakeFlags_orig=( "${qmakeFlags[@]}" )
+
+    # These flags must be added _before_ the flags specified in the derivation.
     qmakeFlags=( \
         "PREFIX=$out" \
         "NIX_OUTPUT_OUT=$out" \
@@ -11,8 +14,15 @@ qmakePrePhase() {
         "NIX_OUTPUT_DOC=${!outputDev}/${qtDocPrefix:?}" \
         "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}" \
         "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}" \
-        "${qmakeFlags[@]}" \
     )
+
+    if [ -n "@debug@" ]; then
+        qmakeFlags+=( "CONFIG+=debug" )
+    else
+        qmakeFlags+=( "CONFIG+=release" )
+    fi
+
+    qmakeFlags+=( "${qmakeFlags_orig[@]}" )
 }
 prePhases+=" qmakePrePhase"
 

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -100,4 +100,13 @@ if [ -z "${dontPatchMkspecs-}" ]; then
     postPhases="${postPhases-}${postPhases:+ }postPatchMkspecs"
 fi
 
+qtPreHook() {
+    # Check that wrapQtAppsHook is used, or it is explicitly disabled.
+    if [[ -z "$__nix_wrapQtAppsHook" && -z "$dontWrapQtApps" ]]; then
+        echo >&2 "Error: wrapQtAppsHook is not used, and dontWrapQtApps is not set."
+        exit 1
+    fi
+}
+prePhases+=" qtPreHook"
+
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,9 +1,34 @@
+if [[ -n "${__nix_qtbase-}" ]]; then
+    # Throw an error if a different version of Qt was already set up.
+    if [[ "$__nix_qtbase" != "@dev@" ]]; then
+        echo >&2 "Error: detected mismatched Qt dependencies:"
+        echo >&2 "    @dev@"
+        echo >&2 "    $__nix_qtbase"
+        exit 1
+    fi
+else # Only set up Qt once.
+__nix_qtbase="@dev@"
+
 qtPluginPrefix=@qtPluginPrefix@
 qtQmlPrefix=@qtQmlPrefix@
 qtDocPrefix=@qtDocPrefix@
 
 . @fix_qt_builtin_paths@
 . @fix_qt_module_paths@
+
+# Disable debug symbols if qtbase was built without debugging.
+# This stops -dev paths from leaking into other outputs.
+if [ -z "@debug@" ]; then
+    NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE-}${NIX_CFLAGS_COMPILE:+ }-DQT_NO_DEBUG"
+fi
+
+# Integration with CMake:
+# Set the CMake build type corresponding to how qtbase was built.
+if [ -n "@debug@" ]; then
+    cmakeBuildType="Debug"
+else
+    cmakeBuildType="Release"
+fi
 
 providesQtRuntime() {
     [ -d "$1/$qtPluginPrefix" ] || [ -d "$1/$qtQmlPrefix" ]
@@ -19,7 +44,12 @@ export QMAKEPATH
 QMAKEMODULES=
 export QMAKEMODULES
 
+declare -Ag qmakePathSeen=()
 qmakePathHook() {
+    # Skip this path if we have seen it before.
+    # MUST use 'if' because 'qmakePathSeen[$]' may be unset.
+    if [ -n "${qmakePathSeen[$1]-}" ]; then return; fi
+    qmakePathSeen[$1]=1
     if [ -d "$1/mkspecs" ]
     then
         QMAKEMODULES="${QMAKEMODULES}${QMAKEMODULES:+:}/mkspecs"
@@ -34,7 +64,12 @@ envBuildHostHooks+=(qmakePathHook)
 # package depending on the building package. (This is necessary in case
 # the building package does not provide runtime dependencies itself and so
 # would not be propagated to the user environment.)
+declare -Ag qtEnvHostTargetSeen=()
 qtEnvHostTargetHook() {
+    # Skip this path if we have seen it before.
+    # MUST use 'if' because 'qmakePathSeen[$]' may be unset.
+    if [ -n "${qtEnvHostTargetSeen[$1]-}" ]; then return; fi
+    qtEnvHostTargetSeen[$1]=1
     if providesQtRuntime "$1" && [ "z${!outputBin}" != "z${!outputDev}" ]
     then
         propagatedBuildInputs+=" $1"
@@ -63,4 +98,6 @@ postPatchMkspecs() {
 }
 if [ -z "${dontPatchMkspecs-}" ]; then
     postPhases="${postPhases-}${postPhases:+ }postPatchMkspecs"
+fi
+
 fi

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -1,3 +1,6 @@
+if [[ -z "${__nix_wrapQtAppsHook-}" ]]; then
+__nix_wrapQtAppsHook=1  # Don't run this hook more than once.
+
 # Inherit arguments given in mkDerivation
 qtWrapperArgs=( ${qtWrapperArgs-} )
 
@@ -100,3 +103,5 @@ wrapQtAppsHook() {
 }
 
 fixupOutputHooks+=(wrapQtAppsHook)
+
+fi

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -9,8 +9,6 @@ args:
 let
   args_ = {
 
-    enableParallelBuilding = args.enableParallelBuilding or true;
-
     nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ wrapQtAppsHook ];
 
   };

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -9,9 +9,6 @@ args:
 let
   args_ = {
 
-    qmakeFlags = [ ("CONFIG+=" + (if debug then "debug" else "release")) ]
-              ++ (args.qmakeFlags or []);
-
     NIX_CFLAGS_COMPILE = toString (
       optional (!debug) "-DQT_NO_DEBUG"
       ++ lib.toList (args.NIX_CFLAGS_COMPILE or []));

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -9,16 +9,6 @@ args:
 let
   args_ = {
 
-    NIX_CFLAGS_COMPILE = toString (
-      optional (!debug) "-DQT_NO_DEBUG"
-      ++ lib.toList (args.NIX_CFLAGS_COMPILE or []));
-
-    cmakeFlags =
-      (args.cmakeFlags or [])
-      ++ [
-        ("-DCMAKE_BUILD_TYPE=" + (if debug then "Debug" else "Release"))
-      ];
-
     enableParallelBuilding = args.enableParallelBuilding or true;
 
     nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ wrapQtAppsHook ];

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -22,6 +22,7 @@
   libGL,
   buildExamples ? false,
   buildTests ? false,
+  debug ? false,
   developerBuild ? false,
   decryptSslTraffic ? false
 }:
@@ -39,6 +40,7 @@ stdenv.mkDerivation {
 
   name = "qtbase-${version}";
   inherit qtCompatVersion src version;
+  inherit debug;
 
   propagatedBuildInputs =
     [

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -34,13 +34,14 @@ let
   compareVersion = v: builtins.compareVersions version v;
   qmakeCacheName =
     if compareVersion "5.12.4" < 0 then ".qmake.cache" else ".qmake.stash";
+  debugSymbols = debug || developerBuild;
 in
 
 stdenv.mkDerivation {
 
   name = "qtbase-${version}";
   inherit qtCompatVersion src version;
-  inherit debug;
+  debug = debugSymbols;
 
   propagatedBuildInputs =
     [
@@ -243,6 +244,7 @@ stdenv.mkDerivation {
       "-I" "${icu.dev}/include"
       "-pch"
     ]
+    ++ lib.optional debugSymbols "-debug"
     ++ lib.optionals (compareVersion "5.11.0" < 0)
     [
       "-qml-debug"
@@ -398,6 +400,8 @@ stdenv.mkDerivation {
       sed -i "$dev/lib/pkgconfig/Qt5Core.pc" \
           -e "/^host_bins=/ c host_bins=$dev/bin"
     '';
+
+  dontStrip = debugSymbols;
 
   setupHook = ../hooks/qtbase-setup-hook.sh;
 

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -34,6 +34,8 @@ mkDerivation (args // {
     fixQtBuiltinPaths . '*.pr?'
   '';
 
+  dontWrapQtApps = args.dontWrapQtApps or true;
+
   postFixup = ''
     if [ -d "''${!outputDev}/lib/pkgconfig" ]; then
         find "''${!outputDev}/lib/pkgconfig" -name '*.pc' | while read pc; do

--- a/pkgs/development/libraries/qtinstaller/default.nix
+++ b/pkgs/development/libraries/qtinstaller/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   setOutputFlags = false;
   enableParallelBuilding = true;
   NIX_QT_SUBMODULE = true;
+  dontWrapQtApps = true;
 
   installPhase = ''
     mkdir -p $out/{bin,lib,share/qt-installer-framework}

--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "0h4wgngn2yl35hapbjs24amkjfbzsvnna4ixfhn87snjnq5lmjbc"; # v0.9.1
   };
 
+  dontWrapQtApps = true;
+
   patches = (if withQt5 then [] else [ ./0001-Fixes-build-with-Qt4.patch ]) ++ (if stdenv.isDarwin then [ ./0002-Fix-install-name-Darwin.patch ] else []);
 
   cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ];

--- a/pkgs/development/libraries/qtpbfimageplugin/default.nix
+++ b/pkgs/development/libraries/qtpbfimageplugin/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase protobuf ];
 
+  dontWrapQtApps = true;
+
   postPatch = ''
     # Fix plugin dir
     substituteInPlace pbfplugin.pro \

--- a/pkgs/development/libraries/qtutilities/default.nix
+++ b/pkgs/development/libraries/qtutilities/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase cpp-utilities ];
   nativeBuildInputs = [ cmake qttools ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://github.com/Martchus/qtutilities";
     description = "Common C++ classes and routines used by @Martchus' applications featuring argument parser, IO and conversion utilities";

--- a/pkgs/development/libraries/qtwebkit-plugins/default.nix
+++ b/pkgs/development/libraries/qtwebkit-plugins/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ qtwebkit hunspell ];
 
+  dontWrapQtApps = true;
+
   postPatch = ''
     sed -i "s,-lhunspell,-lhunspell-${lib.versions.majorMinor hunspell.version}," src/spellcheck/spellcheck.pri
     sed -i "s,\$\$\[QT_INSTALL_PLUGINS\],$out/$qtPluginPrefix," src/src.pro

--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Provides access to ZIP archives from Qt programs";
     license = licenses.lgpl21Plus;

--- a/pkgs/development/libraries/qwt/6.nix
+++ b/pkgs/development/libraries/qwt/6.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [ "-after doc.path=$out/share/doc/${name}" ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Qt widgets for technical applications";
     homepage = "http://qwt.sourceforge.net/";

--- a/pkgs/development/libraries/soqt/default.nix
+++ b/pkgs/development/libraries/soqt/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://github.com/coin3d/soqt";
     license = licenses.bsd3;

--- a/pkgs/development/libraries/telepathy/qt/default.nix
+++ b/pkgs/development/libraries/telepathy/qt/default.nix
@@ -20,6 +20,8 @@ in stdenv.mkDerivation rec {
   # On 0.9.7, they do not even build with QT4
   cmakeFlags = lib.optional (!doCheck) "-DENABLE_TESTS=OFF";
 
+  dontWrapQtApps = true;
+
   doCheck = false; # giving up for now
 
   meta = with lib; {

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -57,6 +57,8 @@ in stdenv.mkDerivation rec {
     export LD_LIBRARY_PATH="$(pwd)/lib";
   '';
 
+  dontWrapQtApps = true;
+
   # Shared libraries don't work, because of rpath troubles with the current
   # nixpkgs cmake approach. It wants to call a binary at build time, just
   # built and requiring one of the shared objects.

--- a/pkgs/development/python-modules/ovito/default.nix
+++ b/pkgs/development/python-modules/ovito/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = with python.pkgs; [ sphinx numpy sip pyqt5 matplotlib ase ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Scientific visualization and analysis software for atomistic simulation data";
     homepage = "https://www.ovito.org";

--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -29,8 +29,7 @@ buildPythonPackage rec {
   ];
 
   dontUseQmakeConfigure = true;
-  dontUseCmakeConfigure = true;
-
+  dontWrapQtApps =true;
   doCheck = false;
 
   postPatch = ''

--- a/pkgs/development/python-modules/poppler-qt5/default.nix
+++ b/pkgs/development/python-modules/poppler-qt5/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage rec {
   # no tests, just bindings for `poppler_qt5`
   doCheck = false;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://github.com/wbsoft/python-poppler-qt5";
     license = licenses.gpl2;

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -40,6 +40,8 @@ in buildPythonPackage rec {
 
   outputs = [ "out" "dev" ];
 
+  dontWrapQtApps = true;
+
   nativeBuildInputs = [
     pkg-config
     qmake

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -45,6 +45,8 @@ in buildPythonPackage rec {
   propagatedBuildInputs = [ pyqt5 ]
     ++ lib.optional (!isPy3k) enum34;
 
+  dontWrapQtApps = true;
+
   configurePhase = ''
     runHook preConfigure
 

--- a/pkgs/development/python-modules/pyside/default.nix
+++ b/pkgs/development/python-modules/pyside/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage rec {
 
   makeFlags = [ "QT_PLUGIN_PATH=${pysideShiboken}/lib/generatorrunner" ];
 
+  dontWrapQtApps = true;
+
   meta = {
     description = "LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";
     license = lib.licenses.lgpl21;

--- a/pkgs/development/python-modules/pyside2-tools/default.nix
+++ b/pkgs/development/python-modules/pyside2-tools/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
     "-DBUILD_TESTS=OFF"
   ];
 
+  dontWrapQtApps = true;
+
   # The upstream build system consists of a `setup.py` whichs builds three
   # different python libraries and calls cmake as a subprocess.  We call cmake
   # directly because that's easier to get working.  However, the `setup.py`

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
   ];
   propagatedBuildInputs = [ shiboken2 ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "LGPL-licensed Python bindings for Qt";
     license = licenses.lgpl21;

--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage {
   buildInputs = [ qscintilla ];
   propagatedBuildInputs = [ pyqt5 ];
 
+  dontWrapQtApps = true;
+
   postPatch = ''
     substituteInPlace Python/configure.py \
       --replace \

--- a/pkgs/development/python-modules/roboschool/default.nix
+++ b/pkgs/development/python-modules/roboschool/default.nix
@@ -44,6 +44,8 @@ buildPythonPackage rec {
     boost
   ];
 
+  dontWrapQtApps = true;
+
   NIX_CFLAGS_COMPILE="-I ${python}/include/${python.libPrefix}";
 
   patches = [

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
     "-DBUILD_TESTS=OFF"
   ];
 
+  dontWrapQtApps = true;
+
   postInstall = ''
     rm $out/bin/shiboken_tool.py
   '';

--- a/pkgs/development/tools/analysis/panopticon/default.nix
+++ b/pkgs/development/tools/analysis/panopticon/default.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage rec {
      git
   ];
 
+  dontWrapQtApps = true;
+
   cargoSha256 = "1hdsn011y9invfy7can8c02zwa7birj9y1rxhrj7wyv4gh3659i0";
   doCheck = false;
 

--- a/pkgs/development/tools/analysis/qcachegrind/default.nix
+++ b/pkgs/development/tools/analysis/qcachegrind/default.nix
@@ -12,6 +12,8 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ qmake ];
 
+  dontWrapQtApps = true;
+
   postInstall = ''
      mkdir -p $out/bin
      cp -p converters/dprof2calltree $out/bin/dprof2calltree

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -14,7 +14,7 @@
 assert withQt5 -> useQt4 == false;
 assert useQt4 -> withQt5 == false;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   pname = "cmake"
           + lib.optionalString isBootstrap "-boot"
           + lib.optionalString useNcurses "-cursesUI"
@@ -130,4 +130,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ttuegel lnl7 ];
     license = licenses.bsd3;
   };
-}
+} // (if withQt5 then { dontWrapQtApps = true; } else {})
+)

--- a/pkgs/development/tools/build-managers/qbs/default.nix
+++ b/pkgs/development/tools/build-managers/qbs/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake ];
 
+  dontWrapQtApps = true;
+
   qmakeFlags = [ "QBS_INSTALL_PREFIX=$(out)" "qbs.pro" ];
 
   buildInputs = [ qtbase qtscript ];

--- a/pkgs/development/tools/minizinc/ide.nix
+++ b/pkgs/development/tools/minizinc/ide.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation {
   sourceRoot = "source/MiniZincIDE";
 
   enableParallelBuilding = true;
+  dontWrapQtApps = true;
 
   postInstall = ''
     wrapProgram $out/bin/MiniZincIDE --prefix PATH ":" ${lib.makeBinPath [ minizinc ]}

--- a/pkgs/development/tools/misc/kdbg/default.nix
+++ b/pkgs/development/tools/misc/kdbg/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/kdbg --prefix QT_PLUGIN_PATH : ${qtbase}/${qtbase.qtPluginPrefix}
   '';
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://www.kdbg.org/";
     description = ''

--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -77,6 +77,8 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   installPhase = ''
     mkdir -p $out/share/doc/phantomjs
     cp -a bin $out

--- a/pkgs/development/tools/rgp/default.nix
+++ b/pkgs/development/tools/rgp/default.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     "${placeholder "out"}/opt/rgp/qt"
   ];
 
+  dontWrapQtApps = true;
+
   installPhase = ''
     mkdir -p $out/opt/rgp $out/bin
     cp -r . $out/opt/rgp/

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
     cp -r DwarfTherapist.app $out/Applications
   '' else null;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Tool to manage dwarves in a running game of Dwarf Fortress";
     maintainers = with maintainers; [ abbradar bendlas numinit jonringer ];

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -37,6 +37,8 @@ in stdenv.mkDerivation rec {
     ++ optional server readline
     ++ optional enableSqlite sqlite;
 
+  dontWrapQtApps = true;
+
   configureFlags = [ "--enable-shared" ]
     ++ optional sdlClient "--enable-client=sdl"
     ++ optionals qtClient [

--- a/pkgs/games/leela-zero/default.nix
+++ b/pkgs/games/leela-zero/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "Go engine modeled after AlphaGo Zero";
     homepage    = "https://github.com/gcp/leela-zero";

--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     "-DDESIRED_QT_VERSION:INT=5"
   ];
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "An unofficial open source engine reimplementation of the game Morrowind";
     homepage = "http://openmw.org";

--- a/pkgs/games/openmw/tes3mp.nix
+++ b/pkgs/games/openmw/tes3mp.nix
@@ -61,6 +61,8 @@ in openmw.overrideAttrs (oldAttrs: rec {
     "-DRakNet_LIBRARY_DEBUG=${rakNetLibrary}/lib/libRakNetLibStatic.a"
   ];
 
+  dontWrapQtApps = true;
+
   # https://github.com/TES3MP/openmw-tes3mp/issues/552
   patches = [
     ./tes3mp.patch

--- a/pkgs/misc/emulators/citra/default.nix
+++ b/pkgs/misc/emulators/citra/default.nix
@@ -14,6 +14,8 @@ mkDerivation {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ SDL2 qtbase qtmultimedia boost ];
 
+  dontWrapQtApps = true;
+
   preConfigure = ''
     # Trick configure system.
     sed -n 's,^ *path = \(.*\),\1,p' .gitmodules | while read path; do

--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ qmake ];
+  dontWrapQtApps = true;
 
   qmakeFlags = [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/pkgs/servers/web-apps/virtlyst/default.nix
+++ b/pkgs/servers/web-apps/virtlyst/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config autoPatchelfHook ];
   buildInputs = [ qtbase libvirt cutelyst grantlee ];
 
+  dontWrapQtApps = true;
+
   installPhase = ''
     mkdir -p $out/lib
     cp src/libVirtlyst.so $out/lib

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
       cp -rv ${store_path} $NIX_BUILD_TOP/$name/data/${ZHUYIN_DATA_FILE_NAME}
     '';
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     isFcitxEngine = true;
     description  = "Fcitx Wrapper for libpinyin, Library to deal with pinyin";

--- a/pkgs/tools/inputmethods/hime/default.nix
+++ b/pkgs/tools/inputmethods/hime/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   preConfigure = "patchShebangs configure";
   configureFlags = [ "--disable-lib64" "--disable-qt5-immodule" ];
-
+  dontWrapQtApps = true;
 
   meta = with lib; {
     homepage = "http://hime-ime.github.io/";

--- a/pkgs/tools/misc/ttfautohint/default.nix
+++ b/pkgs/tools/misc/ttfautohint/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "An automatic hinter for TrueType fonts";
     longDescription = ''

--- a/pkgs/tools/networking/spoofer/default.nix
+++ b/pkgs/tools/networking/spoofer/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl protobuf libpcap traceroute ]
                 ++ optional withGUI qt5.qtbase ;
 
+  dontWrapQtApps = true;
+
   meta = with lib; {
     homepage = "https://www.caida.org/projects/spoofer";
     description = "Assess and report on deployment of source address validation";

--- a/pkgs/tools/package-management/packagekit/qt.nix
+++ b/pkgs/tools/package-management/packagekit/qt.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config qttools ];
 
+  dontWrapQtApps = true;
+
   meta = packagekit.meta // {
     description = "System to facilitate installing and updating packages - Qt";
   };

--- a/pkgs/tools/security/proxmark3/default.nix
+++ b/pkgs/tools/security/proxmark3/default.nix
@@ -15,6 +15,8 @@ let
       nativeBuildInputs = [ pkg-config gcc-arm-embedded ];
       buildInputs = [ ncurses readline pcsclite qt5.qtbase ];
 
+      dontWrapQtApps = true;
+
       postPatch = ''
         substituteInPlace client/Makefile --replace '-ltermcap' ' '
         substituteInPlace liblua/Makefile --replace '-ltermcap' ' '


### PR DESCRIPTION
###### Motivation for this change

The return of #71089.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
