### PR TITLE
botan2: add aarch64-linux to platforms

### DIFF
--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     inherit version;
     description = "Cryptographic algorithms library";
     maintainers = with maintainers; [ raskin ];
-    platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+    platforms = platforms.unix;
     license = licenses.bsd2;
   };
   passthru.updateInfo.downloadPage = "http://files.randombit.net/botan/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I added the `aarch64-linux` platform for the botan2 package, as I need it and it compiles and seems to work perfectly.

Maybe we should open the paclage for even more platforms. I cannot tell because I don't know the original reason for allowing only so few platforms and if it still applies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
