### PR TITLE
fish-foreign-env: remove alias to incompatible package

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -311,8 +311,8 @@
    </listitem>
    <listitem>
     <para>
-     <package>fish-foreign-env</package> is now an alias for the
-     <package>fishPlugins.foreign-env</package> package, in which the fish
+     The <package>fish-foreign-env</package> package has been replaced with
+     <package>fishPlugins.foreign-env</package>, in which the fish
      functions have been relocated to the
      <literal>vendor_functions.d</literal> directory to be loaded automatically.
     </para>

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -158,7 +158,7 @@ mapAliases ({
   firefoxWrapper = firefox;           # 2015-09
 
   firestr = throw "firestr has been removed."; # added 2019-12-08
-  fish-foreign-env = fishPlugins.foreign-env; # added 2020-12-29
+  fish-foreign-env = throw "fish-foreign-env has been replaced with fishPlugins.foreign-env"; # added 2020-12-29, modified 2021-01-10
   flameGraph = flamegraph; # added 2018-04-25
   flvtool2 = throw "flvtool2 has been removed."; # added 2020-11-03
   foldingathome = fahclient; # added 2020-09-03


### PR DESCRIPTION
###### Motivation for this change

The fish-foreign-env and the fishPlugins.foreign-env packages aren't
compatible due to changes in directory layout.

It's better to remove the alias so that the evaluation explicitly fails
instead of allowing silent runtime breakage.

GitHub: see https://github.com/NixOS/nixpkgs/pull/107834#issuecomment-756995696
GitHub: see https://github.com/LnL7/nix-darwin/issues/269
GitHub: see https://github.com/nix-community/home-manager/issues/1701
GitHub: see https://github.com/nix-community/home-manager/issues/1702


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
