### PR TITLE
php80.extensions.oci8: 2.2.0 -> 3.0.1

### DIFF
--- a/pkgs/development/php-packages/oci8/default.nix
+++ b/pkgs/development/php-packages/oci8/default.nix
@@ -1,10 +1,8 @@
-{ buildPecl, lib, pkgs }:
-
+{ buildPecl, lib, pkgs, version, sha256 }:
 buildPecl {
   pname = "oci8";
 
-  version = "2.2.0";
-  sha256 = "0jhivxj1nkkza4h23z33y7xhffii60d7dr51h1czjk10qywl7pyd";
+  inherit version sha256;
 
   buildInputs = [ pkgs.oracle-instantclient ];
   configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient.lib}/lib" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -78,7 +78,13 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     mongodb = callPackage ../development/php-packages/mongodb { };
 
-    oci8 = callPackage ../development/php-packages/oci8 { };
+    oci8 = callPackage ../development/php-packages/oci8 ({
+      version = "2.2.0";
+      sha256 = "0jhivxj1nkkza4h23z33y7xhffii60d7dr51h1czjk10qywl7pyd";
+    } // lib.optionalAttrs (lib.versionAtLeast php.version "8.0") {
+      version = "3.0.1";
+      sha256 = "108ds92620dih5768z19hi0jxfa7wfg5hdvyyvpapir87c0ap914";
+    });
 
     pcov = callPackage ../development/php-packages/pcov { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version bump for `php80`.

https://pecl.php.net/package/oci8
> Use 'pecl install oci8' to install for PHP 8.
Use 'pecl install oci8-2.2.0' to install for PHP 7.
Use 'pecl install oci8-2.0.12' to install for PHP 5.2 - PHP 5.6.
Use 'pecl install oci8-1.4.10' to install for PHP 4.3.9 - PHP 5.1.

@jtojnar even though not relevant for would you be willing to accept minor `oci8` PRs for the `fossar` `php` repository, even though `fossar` doesn't care about `oci8`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
