### PR TITLE
pcem: init at 17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8879,6 +8879,12 @@
     githubId = 649832;
     name = "Teo Klestrup Röijezon";
   };
+  terin = {
+    email = "terinjokes@gmail.com";
+    github = "terinjokes";
+    githubId = 273509;
+    name = "Terin Stock";
+  };
   terlar = {
     email = "terlar@gmail.com";
     github = "terlar";

--- a/pkgs/misc/emulators/pcem/default.nix
+++ b/pkgs/misc/emulators/pcem/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchzip, wxGTK31, coreutils, SDL2, openal, alsaLib, pkg-config
+, autoreconfHook, withNetworking ? true, withALSA ? true }:
+
+stdenv.mkDerivation rec {
+  pname = "pcem";
+  version = "17";
+
+  src = fetchzip {
+    url = "https://pcem-emulator.co.uk/files/PCemV${version}Linux.tar.gz";
+    stripRoot = false;
+    sha256 = "067pbnc15h6a4pnnym82klr1w8qwfm6p0pkx93gx06wvwqsxvbdv";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ wxGTK31 coreutils SDL2 openal ]
+    ++ lib.optional withALSA alsaLib;
+
+  configureFlags = [ "--enable-release-build" ]
+    ++ lib.optional withNetworking "--enable-networking"
+    ++ lib.optional withALSA "--enable-alsa";
+
+  meta = with lib; {
+    description = "Emulator for IBM PC computers and clones";
+    homepage = "https://pcem-emulator.co.uk/";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.terin ];
+    platforms = platforms.linux ++ platforms.windows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28560,6 +28560,8 @@ in
 
   OSCAR = qt5.callPackage ../applications/misc/OSCAR { };
 
+  pcem = callPackage ../misc/emulators/pcem { };
+
   pgmanage = callPackage ../applications/misc/pgmanage { };
 
   pgadmin = callPackage ../applications/misc/pgadmin {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
