### PR TITLE
jbang: init at 0.58.0

### DIFF
--- a/pkgs/development/tools/jbang/default.nix
+++ b/pkgs/development/tools/jbang/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchzip, jdk, makeWrapper, coreutils, curl }:
+
+stdenv.mkDerivation rec {
+  version = "0.58.0";
+  pname = "jbang";
+
+  src = fetchzip {
+    url = "https://github.com/jbangdev/jbang/releases/download/v${version}/${pname}-${version}.tar";
+    sha256 = "sha256:08haij8nzzf2759ddzx0i6808g2if0v2fc21mlz00kmggjc03xz3";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    rm bin/jbang.{cmd,ps1}
+    rmdir tmp
+    cp -r . $out
+    wrapProgram $out/bin/jbang \
+      --set JAVA_HOME ${jdk} \
+      --set PATH ${lib.makeBinPath [ coreutils jdk curl ]}
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    $out/bin/jbang --version 2>&1 | grep -q "${version}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Run java as scripts anywhere";
+    longDescription = ''
+      jbang uses the java language to build scripts similar to groovy scripts. Dependencies are automatically
+      downloaded and the java code runs.
+    '';
+    homepage = "https://https://www.jbang.dev/";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ moaxcp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11868,6 +11868,8 @@ in
 
   jbake = callPackage ../development/tools/jbake { };
 
+  jbang = callPackage ../development/tools/jbang { };
+
   jikespg = callPackage ../development/tools/parsing/jikespg { };
 
   jenkins = callPackage ../development/tools/continuous-integration/jenkins { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Initialize jbang package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
