### PR TITLE
nixos/libinput: separate settings by mouse/touchpad

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -186,7 +186,7 @@
    The driver has many options (see <xref linkend="ch-options"/>). For
    instance, the following disables tap-to-click behavior:
 <programlisting>
-<xref linkend="opt-services.xserver.libinput.tapping"/> = false;
+<xref linkend="opt-services.xserver.libinput.touchpad.tapping"/> = false;
 </programlisting>
    Note: the use of <literal>services.xserver.synaptics</literal> is deprecated
    since NixOS 17.09.

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -430,6 +430,17 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
       dynamically allocated uid.
     </para>
    </listitem>
+   <listitem>
+     <para>
+      The libinput module has been updated with the ability to configure mouse and touchpad settings separately.
+      The options in <literal>services.xserver.libinput</literal> have been renamed to <literal>services.xserver.libinput.touchpad</literal>,
+      while there is a new <literal>services.xserver.libinput.mouse</literal> for mouse related configuration.
+     </para>
+     <para>
+      Since touchpad options no longer apply to all devices, you may want to replicate your touchpad configuration in
+      mouse section.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -3,23 +3,18 @@
 with lib;
 
 let cfg = config.services.xserver.libinput;
+
     xorgBool = v: if v then "on" else "off";
-in {
 
-  options = {
-
-    services.xserver.libinput = {
-
-      enable = mkEnableOption "libinput";
-
+    mkConfigForDevice = deviceType: {
       dev = mkOption {
         type = types.nullOr types.str;
         default = null;
         example = "/dev/input/event0";
         description =
           ''
-            Path for touchpad device.  Set to null to apply to any
-            auto-detected touchpad.
+            Path for ${deviceType} device.  Set to null to apply to any
+            auto-detected ${deviceType}.
           '';
       };
 
@@ -185,14 +180,63 @@ in {
           Option "DragLockButtons" "L1 B1 L2 B2"
         '';
         description = ''
-          Additional options for libinput touchpad driver. See
+          Additional options for libinput ${deviceType} driver. See
           <citerefentry><refentrytitle>libinput</refentrytitle><manvolnum>4</manvolnum></citerefentry>
           for available options.";
         '';
       };
-
     };
 
+    mkX11ConfigForDevice = deviceType: matchIs: ''
+        Identifier "libinput ${deviceType} configuration"
+        MatchDriver "libinput"
+        MatchIs${matchIs} "${xorgBool true}"
+        ${optionalString (cfg.${deviceType}.dev != null) ''MatchDevicePath "${cfg.${deviceType}.dev}"''}
+        Option "AccelProfile" "${cfg.${deviceType}.accelProfile}"
+        ${optionalString (cfg.${deviceType}.accelSpeed != null) ''Option "AccelSpeed" "${cfg.${deviceType}.accelSpeed}"''}
+        ${optionalString (cfg.${deviceType}.buttonMapping != null) ''Option "ButtonMapping" "${cfg.${deviceType}.buttonMapping}"''}
+        ${optionalString (cfg.${deviceType}.calibrationMatrix != null) ''Option "CalibrationMatrix" "${cfg.${deviceType}.calibrationMatrix}"''}
+        ${optionalString (cfg.${deviceType}.clickMethod != null) ''Option "ClickMethod" "${cfg.${deviceType}.clickMethod}"''}
+        Option "LeftHanded" "${xorgBool cfg.${deviceType}.leftHanded}"
+        Option "MiddleEmulation" "${xorgBool cfg.${deviceType}.middleEmulation}"
+        Option "NaturalScrolling" "${xorgBool cfg.${deviceType}.naturalScrolling}"
+        ${optionalString (cfg.${deviceType}.scrollButton != null) ''Option "ScrollButton" "${toString cfg.${deviceType}.scrollButton}"''}
+        Option "ScrollMethod" "${cfg.${deviceType}.scrollMethod}"
+        Option "HorizontalScrolling" "${xorgBool cfg.${deviceType}.horizontalScrolling}"
+        Option "SendEventsMode" "${cfg.${deviceType}.sendEventsMode}"
+        Option "Tapping" "${xorgBool cfg.${deviceType}.tapping}"
+        Option "TappingDragLock" "${xorgBool cfg.${deviceType}.tappingDragLock}"
+        Option "DisableWhileTyping" "${xorgBool cfg.${deviceType}.disableWhileTyping}"
+        ${cfg.${deviceType}.additionalOptions}
+  '';
+in {
+
+  imports =
+    (map (option: mkRenamedOptionModule ([ "services" "xserver" "libinput" option ]) [ "services" "xserver" "libinput" "touchpad" option ]) [
+      "accelProfile"
+      "accelSpeed"
+      "buttonMapping"
+      "calibrationMatrix"
+      "clickMethod"
+      "leftHanded"
+      "middleEmulation"
+      "naturalScrolling"
+      "scrollButton"
+      "scrollMethod"
+      "horizontalScrolling"
+      "sendEventsMode"
+      "tapping"
+      "disableWhileTyping"
+      "additionalOptions"
+    ]);
+
+  options = {
+
+    services.xserver.libinput = {
+      enable = mkEnableOption "libinput";
+      mouse = mkConfigForDevice "mouse";
+      touchpad = mkConfigForDevice "touchpad";
+    };
   };
 
 
@@ -212,32 +256,10 @@ in {
 
     services.udev.packages = [ pkgs.libinput.out ];
 
-    services.xserver.config =
-      ''
-        # General libinput configuration.
-        # See CONFIGURATION DETAILS section of man:libinput(4).
-        Section "InputClass"
-          Identifier "libinputConfiguration"
-          MatchDriver "libinput"
-          ${optionalString (cfg.dev != null) ''MatchDevicePath "${cfg.dev}"''}
-          Option "AccelProfile" "${cfg.accelProfile}"
-          ${optionalString (cfg.accelSpeed != null) ''Option "AccelSpeed" "${cfg.accelSpeed}"''}
-          ${optionalString (cfg.buttonMapping != null) ''Option "ButtonMapping" "${cfg.buttonMapping}"''}
-          ${optionalString (cfg.calibrationMatrix != null) ''Option "CalibrationMatrix" "${cfg.calibrationMatrix}"''}
-          ${optionalString (cfg.clickMethod != null) ''Option "ClickMethod" "${cfg.clickMethod}"''}
-          Option "LeftHanded" "${xorgBool cfg.leftHanded}"
-          Option "MiddleEmulation" "${xorgBool cfg.middleEmulation}"
-          Option "NaturalScrolling" "${xorgBool cfg.naturalScrolling}"
-          ${optionalString (cfg.scrollButton != null) ''Option "ScrollButton" "${toString cfg.scrollButton}"''}
-          Option "ScrollMethod" "${cfg.scrollMethod}"
-          Option "HorizontalScrolling" "${xorgBool cfg.horizontalScrolling}"
-          Option "SendEventsMode" "${cfg.sendEventsMode}"
-          Option "Tapping" "${xorgBool cfg.tapping}"
-          Option "TappingDragLock" "${xorgBool cfg.tappingDragLock}"
-          Option "DisableWhileTyping" "${xorgBool cfg.disableWhileTyping}"
-          ${cfg.additionalOptions}
-        EndSection
-      '';
+    services.xserver.inputClassSections = [
+      (mkX11ConfigForDevice "mouse" "Pointer")
+      (mkX11ConfigForDevice "touchpad" "Touchpad")
+    ];
 
     assertions = [
       # already present in synaptics.nix


### PR DESCRIPTION
This PR deprecates `services.xserver.libinput` for multiple settings, one for each kind of device:

- `services.xserver.libinput.mouse`
- `services.xserver.libinput.touchpad`

Looking at `man 4 libinput`, they basically have the same options so I simply replicated them, even if some options doesn't make sense for mouse (`tapping` for example).

With this commit this is now possible:

```nix
{
  services.xserver.libinput = {
    enable = true;
    mouse = {
      accelProfile = "flat";
    };
    touchpad = {
      naturalScrolling = true;
    };
  };
}
```

And you will have a mouse with no natural scrolling but with accel profile flat, while touchpad will have natural scrolling but accel profile adaptative (default).

It is possible to support more device types (tablets/keyboards/touchscreens), but at least looking at the
libinput manual for those devices it doesn't seem that it has any configuration options for them. They can still be configured using `services.xserver.inputClassSections` though, and this will work now since there is no rule by default that matches them.

Closes issue #75007, while also making configuration of mouses and touchpads using Nix attrs possible like said in PR #73785.

Alternative for #107676. This is a more elegant solution, but the other PR is much simpler, so I think both approaches are valid. So I will keep both, and closes the other one after one is merged.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
