### PR TITLE
Fix support for extending Dhall package set

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10615,7 +10615,7 @@ in
 
   dhall-text = haskell.lib.justStaticExecutables haskellPackages.dhall-text;
 
-  dhallPackages = callPackages ./dhall-packages.nix { };
+  dhallPackages = callPackage ./dhall-packages.nix { };
 
   duktape = callPackage ../development/interpreters/duktape { };
 

--- a/pkgs/top-level/dhall-packages.nix
+++ b/pkgs/top-level/dhall-packages.nix
@@ -19,6 +19,7 @@ let
 
     in
       { inherit
+          callPackage
           buildDhallPackage
           buildDhallGitHubPackage
           buildDhallDirectoryPackage


### PR DESCRIPTION
* Fix `dhallPackages` to be defined using `callPackage` instead of
  `callPackages`

  This enables the `pkgs.dhallPackages.override` method

* Export `pkgs.dhallPackages.callPackage`

  This is also necessary in order to easily extend `pkgs.dhallPackages` with
  new packages

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
