### PR TITLE
languagetool: 5.1 -> 5.2

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "LanguageTool";
-  version = "5.1";
+  version = "5.2";
 
   src = fetchzip {
     url = "https://www.languagetool.org/download/${pname}-${version}.zip";
-    sha256 = "07a2cxsa04lzifphlf5mv88xpnixalmryd0blawblxsmdyhmvg3y";
+    sha256 = "1fz3rxqg5z2jxbalraz8lwkzj0jh69zzfmf3vpwywilvl7xlhdrd";
   };
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre ];
 
   installPhase = ''
     mkdir -p $out/share
-    mv * $out/share/
+    mv -- * $out/share/
 
     for lt in languagetool{,-commandline,-server};do
       makeWrapper ${jre}/bin/java $out/bin/$lt \
@@ -27,9 +27,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://languagetool.org";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [
-      edwtjo
-    ];
+    maintainers = with maintainers; [ edwtjo ];
     platforms = jre.meta.platforms;
     description = "A proofreading program for English, French German, Polish, and more";
   };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/languagetool-org/languagetool/blob/v5.2/languagetool-standalone/CHANGES.md

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).