### PR TITLE
fira-code: only extract the variable font

### DIFF
--- a/pkgs/data/fonts/fira-code/default.nix
+++ b/pkgs/data/fonts/fira-code/default.nix
@@ -7,12 +7,13 @@ in fetchzip {
 
   url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
 
+  # only extract the variable font because everything else is a duplicate
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile '*-VF.ttf' -d $out/share/fonts/truetype
   '';
 
-  sha256 = "16v62wj872ba4w7qxn4l6zjgqh7lrpwh1xax1bp1x9dpz08mnq06";
+  sha256 = "1wbfjgvr9m5azl5w49y0hpqzgcraw6spd1wnxgxlzfx57x6gcw0k";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/tonsky/FiraCode";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fira Code includes a [variable font][1] file that packs all the variants in a single file. Including both variable and non-variable fonts would be redundant and cause the system to list the same font twice, as can be seen in the screenshot below:

![Screenshot from 2021-01-10 13-30-45](https://user-images.githubusercontent.com/7343721/104114471-2fd26380-5348-11eb-97e8-188f372d9547.png)

~I've also appended a package revision number `_1` to the package name to invalidate the current package. Otherwise, the current package would continue to be used unchanged because it shares the same SHA256 hash.~ This was a mistake.

[1]: https://en.wikipedia.org/wiki/Variable_fonts

###### Result of nixpkgs-review
Retried after `nix-collect-garbage`. (The initial run complained about missing build logs probably due to the fact that it was already built)
```console
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
these paths will be fetched (3.26 MiB download, 15.58 MiB unpacked):
  /nix/store/1l5k3pjf0ddmqj510dk45xgi47izj6h7-nix-2.4pre20201201_5a6ddb3-man
  /nix/store/200injw4k6mzr96pszd8fzxn3fj6l10l-nixpkgs-review-2.5.0
  /nix/store/25qhsb4lx6h9qxd2zs5y0vzqvqmj3njm-bash-interactive-4.4-p23-info
  /nix/store/7d2w3lafm8cla7n6ii5jskhsnqg4zv3a-stdenv-linux
  /nix/store/83zz05y2rh15y108ydkcmz3pl7bddccz-bash-interactive-4.4-p23-doc
  /nix/store/bwxxmzqfnzdpkljsdw94sygi82fmjslb-bash-interactive-4.4-p23-dev
  /nix/store/g4c5gpchg4k21wwb99d224qqlp5wwrhh-bash-interactive-4.4-p23-man
  /nix/store/khc1ydy0ldqsra7x8snkbzrway4ydw6w-nlohmann_json-3.9.1
  /nix/store/yaim29qmv9m4pf3jwrlyczik58cyxfvn-nix-2.4pre20201201_5a6ddb3
copying path '/nix/store/83zz05y2rh15y108ydkcmz3pl7bddccz-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/25qhsb4lx6h9qxd2zs5y0vzqvqmj3njm-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/g4c5gpchg4k21wwb99d224qqlp5wwrhh-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/bwxxmzqfnzdpkljsdw94sygi82fmjslb-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/1l5k3pjf0ddmqj510dk45xgi47izj6h7-nix-2.4pre20201201_5a6ddb3-man' from 'https://cache.nixos.org'...
copying path '/nix/store/khc1ydy0ldqsra7x8snkbzrway4ydw6w-nlohmann_json-3.9.1' from 'https://cache.nixos.org'...
copying path '/nix/store/7d2w3lafm8cla7n6ii5jskhsnqg4zv3a-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/yaim29qmv9m4pf3jwrlyczik58cyxfvn-nix-2.4pre20201201_5a6ddb3' from 'https://cache.nixos.org'...
copying path '/nix/store/200injw4k6mzr96pszd8fzxn3fj6l10l-nixpkgs-review-2.5.0' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/midchildan/.cache/nixpkgs-review/rev-96ad00e205768ea4f3ed615dfe2073c41daaa3ae-1/nixpkgs 2032339e5bbce8a57655b8742190ecb32b7af863
Preparing worktree (detached HEAD 2032339e5bb)
Updating files: 100% (23852/23852), done.
HEAD is now at 2032339e5bb mmv-go: 0.1.2 -> 0.1.3
$ nix-env -f /home/midchildan/.cache/nixpkgs-review/rev-96ad00e205768ea4f3ed615dfe2073c41daaa3ae-1/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 96ad00e205768ea4f3ed615dfe2073c41daaa3ae
Updating 2032339e5bb..96ad00e2057
Fast-forward
 pkgs/data/fonts/fira-code/default.nix | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
$ nix-env -f /home/midchildan/.cache/nixpkgs-review/rev-96ad00e205768ea4f3ed615dfe2073c41daaa3ae-1/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package updated:
fira-code (5.2 → 5.2_1)

warning: ignoring the user-specified setting 'experimental-features', because it is a restricted setting and you are not a trusted user
$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/midchildan/.cache/nixpkgs-review/rev-96ad00e205768ea4f3ed615dfe2073c41daaa3ae-1/build.nix
warning: ignoring the user-specified setting 'experimental-features', because it is a restricted setting and you are not a trusted user
warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
1 package built:
fira-code

warning: ignoring the user-specified setting 'experimental-features', because it is a restricted setting and you are not a trusted user
$ nix-shell /home/midchildan/.cache/nixpkgs-review/rev-96ad00e205768ea4f3ed615dfe2073c41daaa3ae-1/shell.nix
these 7 paths will be fetched (1.96 MiB download, 11.67 MiB unpacked):
  /nix/store/8fmzmylr9l60yir9qzixyksrfdshnan6-bash-interactive-4.4-p23-doc
  /nix/store/bblhggm7z21fmxpna2la3k0d3sviw2n1-bash-interactive-4.4-p23
  /nix/store/d8248i42qg03smfvyhiw57vd8mkc2f42-ncurses-6.2
  /nix/store/i539vammbyynzv6rh55aq5l79k79awcx-bash-interactive-4.4-p23-dev
  /nix/store/j9bq7mdvqrncsk9bprbc47gcwr422k94-bash-interactive-4.4-p23-man
  /nix/store/l0izrdj1mlf0yvilp5qxszi8ms3ni66z-readline-7.0p5
  /nix/store/qd5vfykrf9cag5swl66rg5b10jlpzmwb-bash-interactive-4.4-p23-info
copying path '/nix/store/qd5vfykrf9cag5swl66rg5b10jlpzmwb-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/8fmzmylr9l60yir9qzixyksrfdshnan6-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/j9bq7mdvqrncsk9bprbc47gcwr422k94-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/d8248i42qg03smfvyhiw57vd8mkc2f42-ncurses-6.2' from 'https://cache.nixos.org'...
copying path '/nix/store/l0izrdj1mlf0yvilp5qxszi8ms3ni66z-readline-7.0p5' from 'https://cache.nixos.org'...
copying path '/nix/store/bblhggm7z21fmxpna2la3k0d3sviw2n1-bash-interactive-4.4-p23' from 'https://cache.nixos.org'...
copying path '/nix/store/i539vammbyynzv6rh55aq5l79k79awcx-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
