### PR TITLE
powerline-symbols: init at 2.8.1

### DIFF
--- a/pkgs/data/fonts/powerline-symbols/default.nix
+++ b/pkgs/data/fonts/powerline-symbols/default.nix
@@ -1,0 +1,18 @@
+{ lib, runCommandNoCC, powerline }:
+
+let
+  inherit (powerline) version;
+in runCommandNoCC "powerline-symbols-${version}" {
+  meta = {
+    inherit (powerline.meta) license;
+    priority = (powerline.meta.priority or 0) + 1;
+    maintainers = with lib.maintainers; [ midchildan ];
+  };
+} ''
+  install -Dm644 \
+    ${powerline.src}/font/PowerlineSymbols.otf \
+    $out/share/fonts/OTF/PowerlineSymbols.otf
+  install -Dm644 \
+    ${powerline.src}/font/10-powerline-symbols.conf \
+    $out/etc/fonts/conf.d/10-powerline-symbols.conf
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20278,6 +20278,8 @@ in
 
   powerline-fonts = callPackage ../data/fonts/powerline-fonts { };
 
+  powerline-symbols = callPackage ../data/fonts/powerline-symbols { };
+
   powerline-go = callPackage ../tools/misc/powerline-go { };
 
   powerline-rs = callPackage ../tools/misc/powerline-rs {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the powerline-symbols font. This is different from powerline-fonts, which is a collection of various patched fonts with powerline additions. This only includes the powerline symbols, and no patched fonts.

###### Result of nixpkgs-review
```console
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/midchildan/.cache/nixpkgs-review/rev-e27f7903a1e43154dee15bd99016af633a017227/nixpkgs 2032339e5bbce8a57655b8742190ecb32b7af863
Preparing worktree (detached HEAD 2032339e5bb)
Updating files: 100% (23852/23852), done.
HEAD is now at 2032339e5bb mmv-go: 0.1.2 -> 0.1.3
$ nix-env -f /home/midchildan/.cache/nixpkgs-review/rev-e27f7903a1e43154dee15bd99016af633a017227/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit e27f7903a1e43154dee15bd99016af633a017227
Updating 2032339e5bb..e27f7903a1e
Fast-forward
 pkgs/data/fonts/powerline-symbols/default.nix | 19 +++++++++++++++++++
 pkgs/top-level/all-packages.nix               |  2 ++
 2 files changed, 21 insertions(+)
 create mode 100644 pkgs/data/fonts/powerline-symbols/default.nix
$ nix-env -f /home/midchildan/.cache/nixpkgs-review/rev-e27f7903a1e43154dee15bd99016af633a017227/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package added:
powerline-symbols (init at 2.8.1)

warning: ignoring the user-specified setting 'experimental-features', because it is a restricted setting and you are not a trusted user
$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/midchildan/.cache/nixpkgs-review/rev-e27f7903a1e43154dee15bd99016af633a017227/build.nix
warning: ignoring the user-specified setting 'experimental-features', because it is a restricted setting and you are not a trusted user
warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
1 package built:
powerline-symbols

warning: ignoring the user-specified setting 'experimental-features', because it is a restricted setting and you are not a trusted user
$ nix-shell /home/midchildan/.cache/nixpkgs-review/rev-e27f7903a1e43154dee15bd99016af633a017227/shell.nix
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
