### PR TITLE
treewide: minor cleanup of packages maintained by siraben

### DIFF
--- a/pkgs/development/python-modules/swspotify/default.nix
+++ b/pkgs/development/python-modules/swspotify/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Library to get the currently playing song and artist from Spotify";
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/knightos/scas/default.nix
+++ b/pkgs/development/tools/knightos/scas/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "Assembler and linker for the Z80";
     license     = licenses.mit;
     maintainers = with maintainers; [ siraben ];
-    platforms   = platforms.unix;
+    platforms   = platforms.all;
   };
 }

--- a/pkgs/tools/misc/swaglyrics/default.nix
+++ b/pkgs/tools/misc/swaglyrics/default.nix
@@ -42,6 +42,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/SwagLyrics/SwagLyrics-For-Spotify";
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
-    platforms = lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Remove occurrences of `stdenv.lib`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
