### PR TITLE
chisel: init at 1.7.3

### DIFF
--- a/pkgs/tools/networking/chisel/default.nix
+++ b/pkgs/tools/networking/chisel/default.nix
@@ -1,0 +1,35 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "chisel";
+  version = "1.7.3";
+
+  src = fetchFromGitHub {
+    owner = "jpillora";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0dayc0mbvybsydx2r170m5cfmf0p4896vk9xawpk7gncxclrwpv6";
+  };
+
+  vendorSha256 = "01wh8fn76jn8hnf7gj759k8dwqrr0p36xmsxfc8dayzinpl10fqv";
+
+  # tests require access to the network
+  doCheck = false;
+
+  meta = with lib; {
+    description = "TCP/UDP tunnel over HTTP";
+    longDescription = ''
+      Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via
+      SSH. Single executable including both client and server. Chisel is
+      mainly useful for passing through firewalls, though it can also be
+      used to provide a secure endpoint into your network.
+    '';
+    homepage = "https://github.com/jpillora/chisel";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1806,6 +1806,8 @@ in
 
   chelf = callPackage ../tools/misc/chelf { };
 
+  chisel = callPackage ../tools/networking/chisel { };
+
   cht-sh = callPackage ../tools/misc/cht.sh { };
 
   ckbcomp = callPackage ../tools/X11/ckbcomp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via
SSH. Single executable including both client and server. Chisel is
mainly useful for passing through firewalls, though it can also be
used to provide a secure endpoint into your network.

https://github.com/jpillora/chisel

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
