### PR TITLE
toplevel: stdenv.lib -> lib

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -24,7 +24,7 @@ with pkgs;
       pythonPackages = callPackage
         ({ pkgs, stdenv, python, overrides }: let
           pythonPackagesFun = import ../../../top-level/python-packages.nix {
-            inherit stdenv pkgs;
+            inherit stdenv pkgs lib;
             python = self;
           };
           otherSplices = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -284,7 +284,7 @@ mapAliases ({
   libgnome_keyring3 = libgnome-keyring3; # added 2018-02-25
   libgumbo = gumbo; # added 2018-01-21
   libGL_driver = mesa.drivers; # added 2019-05-28
-  libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || stdenv.hostPlatform.libc != "glibc") gettext; # added 2018-03-14
+  libintlOrEmpty = lib.optional (!stdenv.isLinux || stdenv.hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjpeg_drop = libjpeg_original; # added 2020-06-05
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   liblapackWithoutAtlas = lapack-reference; # added 2018-11-05

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6699,11 +6699,11 @@ in
     libcap = if stdenv.isDarwin then null else libcap;
   };
 
-  pinentry-curses = (stdenv.lib.getOutput "curses" pinentry);
-  pinentry-emacs = (stdenv.lib.getOutput "emacs" pinentry);
-  pinentry-gtk2 = (stdenv.lib.getOutput "gtk2" pinentry);
-  pinentry-qt = (stdenv.lib.getOutput "qt" pinentry);
-  pinentry-gnome = (stdenv.lib.getOutput "gnome3" pinentry);
+  pinentry-curses = (lib.getOutput "curses" pinentry);
+  pinentry-emacs = (lib.getOutput "emacs" pinentry);
+  pinentry-gtk2 = (lib.getOutput "gtk2" pinentry);
+  pinentry-qt = (lib.getOutput "qt" pinentry);
+  pinentry-gnome = (lib.getOutput "gnome3" pinentry);
 
   pinentry_mac = callPackage ../tools/security/pinentry/mac.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
@@ -9163,7 +9163,7 @@ in
       mkdir -p "$rsrc/lib"
       ln -s "${cc}/lib" "$rsrc/include"
       echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-    '' + stdenv.lib.optionalString (stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.useLLVM or false)) ''
+    '' + lib.optionalString (stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.useLLVM or false)) ''
       echo "--gcc-toolchain=${gccForLibs}" >> $out/nix-support/cc-cflags
     '';
   };
@@ -10048,7 +10048,7 @@ in
     inherit (stdenvAdapters) overrideCC;
     buildLlvmTools = buildPackages.llvmPackages_11.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_11.libraries;
-  } // stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && buildPackages.stdenv.cc.isGNU) {
+  } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && buildPackages.stdenv.cc.isGNU) {
     stdenv = gcc7Stdenv;
   });
 
@@ -10513,7 +10513,7 @@ in
       # want the C++ library to be explicitly chosen by the caller, and null by
       # default.
       libcxx ? null
-    , extraPackages ? stdenv.lib.optional (cc.isGNU or false && stdenv.targetPlatform.isMinGW) threadsCross
+    , extraPackages ? lib.optional (cc.isGNU or false && stdenv.targetPlatform.isMinGW) threadsCross
     , ...
     } @ extraArgs:
       callPackage ../build-support/cc-wrapper (let self = {
@@ -11009,7 +11009,7 @@ in
   spidermonkey_1_8_5 = callPackage ../development/interpreters/spidermonkey/1.8.5.nix { };
   spidermonkey_38 = callPackage ../development/interpreters/spidermonkey/38.nix ({
     inherit (darwin) libobjc;
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   }));
   spidermonkey_60 = callPackage ../development/interpreters/spidermonkey/60.nix { };
@@ -12594,7 +12594,7 @@ in
   arrayfire = callPackage ../development/libraries/arrayfire {};
 
   arrow-cpp = callPackage ../development/libraries/arrow-cpp ({
-  } // stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
     stdenv = overrideCC stdenv buildPackages.gcc6; # hidden symbol `__divmoddi4'
   });
 
@@ -13733,42 +13733,42 @@ in
   icu58 = callPackage (import ../development/libraries/icu/58.nix fetchurl) ({
     nativeBuildRoot = buildPackages.icu58.override { buildRootOnly = true; };
   } //
-    (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+    (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu59 = callPackage ../development/libraries/icu/59.nix ({
     nativeBuildRoot = buildPackages.icu59.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu60 = callPackage ../development/libraries/icu/60.nix ({
     nativeBuildRoot = buildPackages.icu60.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu63 = callPackage ../development/libraries/icu/63.nix ({
     nativeBuildRoot = buildPackages.icu63.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu64 = callPackage ../development/libraries/icu/64.nix ({
     nativeBuildRoot = buildPackages.icu64.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu65 = callPackage ../development/libraries/icu/65.nix ({
     nativeBuildRoot = buildPackages.icu65.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu66 = callPackage ../development/libraries/icu/66.nix ({
     nativeBuildRoot = buildPackages.icu66.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   }));
   icu67 = callPackage ../development/libraries/icu/67.nix ({
     nativeBuildRoot = buildPackages.icu67.override { buildRootOnly = true; };
-  } // (stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
+  } // (lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
       stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
 
@@ -17626,7 +17626,7 @@ in
 
   pulseaudio = callPackage ../servers/pulseaudio ({
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
-  } // stdenv.lib.optionalAttrs stdenv.isDarwin {
+  } // lib.optionalAttrs stdenv.isDarwin {
     # Default autoreconfHook (2.70) fails on darwin,
     # with "configure: error: *** Compiler does not support -std=gnu11"
     autoreconfHook = buildPackages.autoreconfHook269;
@@ -18812,9 +18812,9 @@ in
 
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
-    e1000e = if stdenv.lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;
+    e1000e = if lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;
 
-    intel-speed-select = if stdenv.lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
+    intel-speed-select = if lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
 
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};
 
@@ -18895,14 +18895,14 @@ in
 
     netatop = callPackage ../os-specific/linux/netatop { };
 
-    oci-seccomp-bpf-hook = if stdenv.lib.versionAtLeast kernel.version "5.4" then callPackage ../os-specific/linux/oci-seccomp-bpf-hook { } else null;
+    oci-seccomp-bpf-hook = if lib.versionAtLeast kernel.version "5.4" then callPackage ../os-specific/linux/oci-seccomp-bpf-hook { } else null;
 
     perf = callPackage ../os-specific/linux/kernel/perf.nix { };
 
-    phc-intel = if stdenv.lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null;
+    phc-intel = if lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null;
 
     # Disable for kernels 4.15 and above due to compatibility issues
-    prl-tools = if stdenv.lib.versionOlder kernel.version "4.15" then callPackage ../os-specific/linux/prl-tools { } else null;
+    prl-tools = if lib.versionOlder kernel.version "4.15" then callPackage ../os-specific/linux/prl-tools { } else null;
 
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 
@@ -21130,7 +21130,7 @@ in
   dablin = callPackage ../applications/radio/dablin { };
 
   darcs = haskell.lib.overrideCabal (haskell.lib.justStaticExecutables haskellPackages.darcs) (drv: {
-    configureFlags = (stdenv.lib.remove "-flibrary" drv.configureFlags or []) ++ ["-f-library"];
+    configureFlags = (lib.remove "-flibrary" drv.configureFlags or []) ++ ["-f-library"];
   });
 
   darktable = callPackage ../applications/graphics/darktable {
@@ -27506,7 +27506,7 @@ in
   ifstat-legacy = callPackage ../tools/networking/ifstat-legacy { };
 
   isabelle = callPackage ../applications/science/logic/isabelle {
-    polyml = stdenv.lib.overrideDerivation polyml (attrs: {
+    polyml = lib.overrideDerivation polyml (attrs: {
       configureFlags = [ "--enable-intinf-as-int" "--with-gmp" "--disable-shared" ];
     });
 

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , pkgs
 , buildDotnetPackage
 , fetchurl
@@ -363,7 +364,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
         echo 'au BufRead,BufNewFile *.bpl set filetype=boogie' > $vimdir/ftdetect/bpl.vim
     '';
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "An intermediate verification language";
       homepage = "https://github.com/boogie-org/boogie";
       longDescription = ''
@@ -437,7 +438,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
       rm -f $out/lib/dotnet/${baseName}/dafny{,-server}
     '';
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "A programming language with built-in specification constructs";
       homepage = "https://research.microsoft.com/dafny";
       maintainers = with maintainers; [ layus ];
@@ -477,9 +478,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "Excel-DNA is an independent project to integrate .NET into Excel";
       homepage = "https://excel-dna.net/";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -506,9 +507,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "This library implements helper functions to assist and modify the Excel-DNA function registration";
       homepage = "https://github.com/Excel-DNA/Registration";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -540,9 +541,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "ExtCore is an extended core library for F#";
       homepage = "https://github.com/jack-pappas/ExtCore";
-      license = stdenv.lib.licenses.asl20;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
       broken = true;
     };
   };
@@ -576,9 +577,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
         service for rich editing or 'intellisense' features for editors.
         '';
       homepage = "https://github.com/fsharp/FSharp.AutoComplete";
-      license = stdenv.lib.licenses.asl20;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -603,9 +604,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "The F# compiler services package is a component derived from the F# compiler source code that exposes additional functionality for implementing F# language bindings";
       homepage = "https://fsharp.github.io/FSharp.Compiler.Service/";
-      license = stdenv.lib.licenses.asl20;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -647,9 +648,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "F# Data: Library for Data Access";
       homepage = "https://fsharp.github.io/FSharp.Data/";
-      license = stdenv.lib.licenses.asl20;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -679,9 +680,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
   #   meta = {
   #     description = "FSharpx.Extras is a collection of libraries and tools for use with F#";
   #     homepage = "https://fsprojects.github.io/FSharpx.Extras/";
-  #     license = stdenv.lib.licenses.asl20;
-  #     maintainers = with stdenv.lib.maintainers; [ obadz ];
-  #     platforms = with stdenv.lib.platforms; linux;
+  #     license = lib.licenses.asl20;
+  #     maintainers = with lib.maintainers; [ obadz ];
+  #     platforms = with lib.platforms; linux;
   #   };
   # };
 
@@ -724,7 +725,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     outputFiles = [ "GitVersionTree/bin/Release/*" ];
     exeFiles = [ "GitVersionTree.exe" ];
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "A tool to help visualize git revisions and branches";
       homepage = "https://github.com/crc8/GitVersionTree";
       license = licenses.gpl2;
@@ -751,9 +752,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "Math.NET Numerics is an opensource numerical library for .Net, Silverlight and Mono";
       homepage = "https://numerics.mathdotnet.com/";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -785,7 +786,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
         A generic framework for creating extensible applications,
         and for creating libraries which extend those applications.
       '';
-      license = stdenv.lib.licenses.mit;
+      license = lib.licenses.mit;
     };
   };
 
@@ -840,9 +841,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
   #   meta = {
   #     description = "F# addin for MonoDevelop 5.9";
   #     homepage = "https://github.com/fsharp/fsharpbinding/tree/5.9";
-  #     license = stdenv.lib.licenses.asl20;
-  #     maintainers = with stdenv.lib.maintainers; [ obadz ];
-  #     platforms = with stdenv.lib.platforms; linux;
+  #     license = lib.licenses.asl20;
+  #     maintainers = with lib.maintainers; [ obadz ];
+  #     platforms = with lib.platforms; linux;
   #   };
   # };
 
@@ -872,9 +873,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "A callback-based program option parser for C#";
       homepage = "http://www.ndesk.org/Options";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -939,9 +940,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "A command-line tool for manipulating F# project files";
       homepage = "https://github.com/kjnilsson/projekt";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 
@@ -967,9 +968,9 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     meta = {
       description = "A declarative CLI argument/XML configuration parser for F# applications";
       homepage = "https://nessos.github.io/UnionArgParser/";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ obadz ];
+      platforms = with lib.platforms; linux;
     };
   };
 

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -178,7 +178,7 @@ rec {
         echo "================= /testing zlib using node ================="
       '';
 
-      postPatch = pkgs.stdenv.lib.optionalString pkgs.stdenv.isDarwin ''
+      postPatch = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
         substituteInPlace configure \
           --replace '/usr/bin/libtool' 'ar' \
           --replace 'AR="libtool"' 'AR="ar"' \

--- a/pkgs/top-level/haxe-packages.nix
+++ b/pkgs/top-level/haxe-packages.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchzip, fetchFromGitHub, haxe, neko, jdk, mono }:
+{ stdenv, lib, fetchzip, fetchFromGitHub, haxe, neko, jdk, mono }:
 
 let
   self = haxePackages;
   haxePackages = with self; {
 
-    withCommas = stdenv.lib.replaceChars ["."] [","];
+    withCommas = lib.replaceChars ["."] [","];
 
     # simulate "haxelib dev $libname ."
     simulateHaxelibDev = libname: ''
@@ -53,8 +53,8 @@ let
 
         meta = {
           homepage = "http://lib.haxe.org/p/${libname}";
-          license = stdenv.lib.licenses.bsd2;
-          platforms = stdenv.lib.platforms.all;
+          license = lib.licenses.bsd2;
+          platforms = lib.platforms.all;
           description = throw "please write meta.description";
         } // attrs.meta;
       });
@@ -67,7 +67,7 @@ let
         for f in $out/lib/haxe/${withCommas libname}/${withCommas version}/{,project/libs/nekoapi/}bin/Linux{,64}/*; do
           chmod +w "$f"
           patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker)   "$f" || true
-          patchelf --set-rpath ${ stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] }  "$f" || true
+          patchelf --set-rpath ${ lib.makeLibraryPath [ stdenv.cc.cc ] }  "$f" || true
         done
       '';
       meta.description = "Runtime support library for the Haxe C++ backend";
@@ -110,8 +110,8 @@ let
       installPhase = installLibHaxe { inherit libname version; };
       meta = {
         homepage = "http://lib.haxe.org/p/${libname}";
-        license = stdenv.lib.licenses.bsd2;
-        platforms = stdenv.lib.platforms.all;
+        license = lib.licenses.bsd2;
+        platforms = lib.platforms.all;
         description = "Extern definitions for node.js 6.9";
       };
     };

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -32,7 +32,7 @@ let
 
   callPackage = pkgs.newScope self;
 
-  requiredLuaModules = drvs: with stdenv.lib; let
+  requiredLuaModules = drvs: with lib; let
     modules =  filter hasLuaModule drvs;
   in unique ([lua] ++ modules ++ concatLists (catAttrs "requiredLuaModules" modules));
 
@@ -123,7 +123,7 @@ with self; {
         );
     '';
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "Lightweight UNIX I/O and POSIX binding for Lua";
       homepage = "https://www.gitano.org.uk/luxio/";
       license = licenses.mit;
@@ -151,7 +151,7 @@ with self; {
       printf "package.path = '$out/lib/lua/${lua.luaversion}/?/init.lua;' ..  package.path\nreturn require((...) .. '.init')\n" > $out/lib/lua/${lua.luaversion}/vicious.lua
     '';
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "A modular widget library for the awesome window manager";
       homepage    = "https://github.com/Mic92/vicious";
       license     = licenses.gpl2;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8,10 +8,11 @@
 
 { pkgs
 , stdenv
+, lib
 , python
 }:
 
-with pkgs.lib;
+with lib;
 
 self:
 
@@ -64,7 +65,7 @@ let
 
   # Create a PYTHONPATH from a list of derivations. This function recurses into the items to find derivations
   # providing Python modules.
-  makePythonPath = drvs: stdenv.lib.makeSearchPath python.sitePackages (requiredPythonModules drvs);
+  makePythonPath = drvs: lib.makeSearchPath python.sitePackages (requiredPythonModules drvs);
 
   removePythonPrefix = name:
     removePrefix namePrefix name;


### PR DESCRIPTION
The library does not depend on stdenv, that `stdenv` exposes `lib` is
an artifact of the ancient origins of nixpkgs.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
