### PR TITLE
squashfsTools: unconditionally build with lz4Support

### DIFF
--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -1,10 +1,7 @@
 { stdenv, fetchFromGitHub, zlib, xz
-, lz4 ? null
-, lz4Support ? false
+, lz4
 , zstd
 }:
-
-assert lz4Support -> (lz4 != null);
 
 stdenv.mkDerivation {
   pname = "squashfs";
@@ -24,15 +21,13 @@ stdenv.mkDerivation {
     ./4k-align.patch
   ] ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
 
-  buildInputs = [ zlib xz zstd ]
-    ++ stdenv.lib.optional lz4Support lz4;
+  buildInputs = [ zlib xz zstd lz4 ];
 
   preBuild = "cd squashfs-tools";
 
   installFlags = [ "INSTALL_DIR=\${out}/bin" ];
 
-  makeFlags = [ "XZ_SUPPORT=1" "ZSTD_SUPPORT=1" ]
-    ++ stdenv.lib.optional lz4Support "LZ4_SUPPORT=1";
+  makeFlags = [ "XZ_SUPPORT=1" "ZSTD_SUPPORT=1" "LZ4_SUPPORT=1" ];
 
   meta = {
     homepage = "http://squashfs.sourceforge.net/";


### PR DESCRIPTION
Can't think of a reason to not enable that.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>51 packages built:</summary>
  <ul>
    <li>Sylk</li>
    <li>_1password-gui</li>
    <li>appimage-run</li>
    <li>appimagekit</li>
    <li>chrysalis</li>
    <li>deltachat-electron</li>
    <li>devdocs-desktop</li>
    <li>diffoscope</li>
    <li>distrobuilder</li>
    <li>electronplayer</li>
    <li>irccloud</li>
    <li>jitsi-meet-electron</li>
    <li>joplin-desktop</li>
    <li>keeweb</li>
    <li>ledger-live-desktop</li>
    <li>lens</li>
    <li>lunar-client</li>
    <li>lxd</li>
    <li>marktext</li>
    <li>minetime</li>
    <li>molotov</li>
    <li>mycrypto</li>
    <li>notable</li>
    <li>nuclear</li>
    <li>p3x-onenote</li>
    <li>pcloud</li>
    <li>plexamp</li>
    <li>python37Packages.binwalk</li>
    <li>python37Packages.binwalk-full</li>
    <li>python38Packages.binwalk</li>
    <li>python38Packages.binwalk-full</li>
    <li>python39Packages.binwalk</li>
    <li>python39Packages.binwalk-full</li>
    <li>radicle-upstream</li>
    <li>ripcord</li>
    <li>runwayml</li>
    <li>singularity</li>
    <li>soulseekqt</li>
    <li>spotify</li>
    <li>spotify-unwrapped</li>
    <li>spotifywm</li>
    <li>squashfsTools</li>
    <li>ssb-patchwork</li>
    <li>standardnotes</li>
    <li>station</li>
    <li>timeular</li>
    <li>tusk</li>
    <li>unityhub</li>
    <li>wootility</li>
    <li>zettlr</li>
    <li>zulip</li>
  </ul>
</details>
