### PR TITLE
deemix: init at 2.0.16

### DIFF
--- a/pkgs/development/python-modules/deemix/default.nix
+++ b/pkgs/development/python-modules/deemix/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, click
+, pycryptodomex
+, mutagen
+, requests
+, spotipy
+, deezer-py
+}:
+
+buildPythonPackage rec {
+  pname = "deemix";
+  version = "2.0.16";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "CYKcblb8nRTpmdPUqOxZxF9hZZa+CMGfmF0oQEr/tmA=";
+  };
+
+  propagatedBuildInputs = [
+    click
+    pycryptodomex
+    mutagen
+    requests
+    spotipy
+    deezer-py
+  ];
+
+  doCheck = false; # tcp: protocol not found
+  pythonImportsCheck = [ "deemix" ];
+
+  meta = with lib; {
+    description = "deezer downloader built from the ashes of Deezloader Remix";
+    homepage = "https://git.rip/RemixDev/deemix";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ luc65r ];
+  };
+}

--- a/pkgs/development/python-modules/deezer-py/default.nix
+++ b/pkgs/development/python-modules/deezer-py/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, eventlet
+}:
+
+buildPythonPackage rec {
+  pname = "deezer-py";
+  version = "0.0.15";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2g/GbJ/XMzyT2SDGaBXkf0LZrebvqFzW8yGsEBzK5Gk=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    eventlet
+  ];
+
+  doCheck = false; # tcp: protocol not found
+
+  meta = with lib; {
+    description = "A wrapper for all Deezer's APIs";
+    homepage = "https://git.rip/RemixDev/deezer-py";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ luc65r ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3816,6 +3816,8 @@ in
 
   debootstrap = callPackage ../tools/misc/debootstrap { };
 
+  deemix = with python3Packages; toPythonApplication deemix;
+
   deer = callPackage ../shells/zsh/zsh-deer { };
 
   delta = callPackage ../applications/version-management/git-and-tools/delta {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1729,6 +1729,8 @@ in {
 
   decorator = callPackage ../development/python-modules/decorator { };
 
+  deemix = callPackage ../development/python-modules/deemix { };
+
   deep_merge = callPackage ../development/python-modules/deep_merge { };
 
   deepdiff = callPackage ../development/python-modules/deepdiff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1737,6 +1737,12 @@ in {
 
   deeptoolsintervals = callPackage ../development/python-modules/deeptoolsintervals { };
 
+  deezer-py = callPackage ../development/python-modules/deezer-py {
+    eventlet = self.eventlet.override {
+      dnspython = self.dnspython_1;
+    };
+  };
+
   deezer-python = callPackage ../development/python-modules/deezer-python { };
 
   defcon = callPackage ../development/python-modules/defcon { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I will package deemix-pyweb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
