### PR TITLE
python3Packages.dnachisel: 3.2.5 -> 3.2.6

### DIFF
--- a/pkgs/development/python-modules/dnachisel/default.nix
+++ b/pkgs/development/python-modules/dnachisel/default.nix
@@ -1,21 +1,27 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , biopython
 , docopt
 , flametree
 , numpy
 , proglog
+, pytestCheckHook
 , python-codon-tables
- }:
+, primer3
+, genome-collector
+, matplotlib
+}:
 
 buildPythonPackage rec {
   pname = "dnachisel";
   version = "3.2.6";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1i49cfpvjvf9610gg4jz06dl5clc8vmcpjmhnm2d1j7lhpp1ksbb";
+  src = fetchFromGitHub {
+    owner = "Edinburgh-Genome-Foundry";
+    repo = "DnaChisel";
+    rev = "v${version}";
+    sha256 = "0m88biw7sycjwsmncdybj9n3yf4n9cyvifv9zv7irm8ha3scchji";
   };
 
   propagatedBuildInputs = [
@@ -27,9 +33,24 @@ buildPythonPackage rec {
     python-codon-tables
   ];
 
-  # no tests in tarball
-  doCheck = false;
+  checkInputs = [
+    primer3
+    genome-collector
+    matplotlib
+    pytestCheckHook
+  ];
 
+  # Disable tests which requires network access
+  disabledTests = [
+    "test_circular_sequence_optimize_with_report"
+    "test_constraints_reports"
+    "test_optimize_with_report"
+    "test_optimize_with_report_no_solution"
+    "test_avoid_blast_matches_with_list"
+    "test_avoid_phage_blast_matches"
+    "test_avoid_matches_with_list"
+    "test_avoid_matches_with_phage"
+   ];
   pythonImportsCheck = [ "dnachisel" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dnachisel/default.nix
+++ b/pkgs/development/python-modules/dnachisel/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "dnachisel";
-  version = "3.2.5";
+  version = "3.2.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "35301c5eda0baca5902403504e0b5a22eb65da92c2bbd23199d95c4a6bf0ef37";
+    sha256 = "1i49cfpvjvf9610gg4jz06dl5clc8vmcpjmhnm2d1j7lhpp1ksbb";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/genome-collector/default.nix
+++ b/pkgs/development/python-modules/genome-collector/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, appdirs
+, biopython
+, fetchPypi
+, proglog
+}:
+
+buildPythonPackage rec {
+  pname = "genome_collector";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0023ihrz0waxbhq28xh1ymvk51ih882y9psg4glm6s9d1zmqvdph";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    biopython
+    proglog
+  ];
+
+  # Project hasn't released the tests yet
+  doCheck = false;
+  pythonImportsCheck = [ "genome_collector" ];
+
+  meta = with lib; {
+    description = "Genomes and build BLAST/Bowtie indexes in Python";
+    homepage = "https://github.com/Edinburgh-Genome-Foundry/genome_collector";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/primer3/default.nix
+++ b/pkgs/development/python-modules/primer3/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, click
+}:
+
+buildPythonPackage rec {
+  pname = "primer3";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "libnano";
+    repo = "primer3-py";
+    rev = version;
+    sha256 = "1glybwp9w2m1ydvaphr41gj31d8fvlh40s35galfbjqa563si72g";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  # pytestCheckHook leads to a circular import issue
+  checkInputs = [ click ];
+
+  pythonImportsCheck = [ "primer3" ];
+
+  meta = with lib; {
+    description = "Oligo analysis and primer design";
+    homepage = "https://github.com/libnano/primer3-py";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2422,6 +2422,8 @@ in {
 
   genanki = callPackage ../development/python-modules/genanki { };
 
+  genome-collector = callPackage ../development/python-modules/genome-collector { };
+
   genpy = callPackage ../development/python-modules/genpy { };
 
   genshi = callPackage ../development/python-modules/genshi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4899,6 +4899,8 @@ in {
   else
     callPackage ../development/python-modules/prettytable/1.nix { };
 
+  primer3 = callPackage ../development/python-modules/primer3 { };
+
   priority = callPackage ../development/python-modules/priority { };
 
   prison = callPackage ../development/python-modules/prison { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 3.2.6

Change log: https://github.com/Edinburgh-Genome-Foundry/DnaChisel/releases/tag/v3.2.6

Enable tests which requires additional modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
