### PR TITLE
electrs: init at 0.8.6

### DIFF
--- a/pkgs/applications/blockchains/electrs.nix
+++ b/pkgs/applications/blockchains/electrs.nix
@@ -1,0 +1,30 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, llvmPackages
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "electrs";
+  version = "0.8.6";
+
+  src = fetchFromGitHub {
+    owner = "romanz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0nnblxz4xr8k083wy3whx8qxqmdzbxsh5gd91161mrnvidganvgb";
+  };
+
+  # needed for librocksdb-sys
+  nativeBuildInputs = [ llvmPackages.clang ];
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  cargoSha256 = "11xwjcfc3kqjyp94qzmyb26xwynf4f1q3ac3rp7l7qq1njly07gr";
+
+  meta = with lib; {
+    description = "An efficient re-implementation of Electrum Server in Rust";
+    homepage = "https://github.com/romanz/electrs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25766,6 +25766,8 @@ in
   dogecoin  = callPackage ../applications/blockchains/dogecoin.nix { boost = boost165; withGui = true; };
   dogecoind = callPackage ../applications/blockchains/dogecoin.nix { boost = boost165; withGui = false; };
 
+  electrs = callPackage ../applications/blockchains/electrs.nix { };
+
   ergo = callPackage ../applications/blockchains/ergo { };
 
   exodus = callPackage ../applications/blockchains/exodus { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- new package - Bitcoin indexer with Electrum API

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
