### PR TITLE
babelfish: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4666,6 +4666,12 @@
     githubId = 494012;
     name = "Kevin Cox";
   };
+  kevingriffin = {
+    email = "me@kevin.jp";
+    github = "kevingriffin";
+    githubId = 209729;
+    name = "Kevin Griffin";
+  };
   kfollesdal = {
     email = "kfollesdal@gmail.com";
     github = "kfollesdal";

--- a/pkgs/shells/fish/babelfish.nix
+++ b/pkgs/shells/fish/babelfish.nix
@@ -1,0 +1,21 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+buildGoModule rec {
+  pname = "babelfish";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "bouk";
+    repo = "babelfish";
+    rev = "v${version}";
+    sha256 = "08i4y4fw60ynamr1jz8nkfkidxj06vcyhi1v4wxpl2macn6n4skk";
+  };
+
+  vendorSha256 = "0xjy50wciw329kq1nkd7hhaipcp4fy28hhk6cdq21qwid6g21gag";
+
+  meta = with lib; {
+    description = "Translate bash scripts to fish";
+    homepage = "https://github.com/bouk/babelfish";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bouk kevingriffin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1498,6 +1498,8 @@ in
 
   babeld = callPackage ../tools/networking/babeld { };
 
+  babelfish = callPackage ../shells/fish/babelfish.nix { };
+
   badchars = python3Packages.callPackage ../tools/security/badchars { };
 
   badvpn = callPackage ../tools/networking/badvpn {};


### PR DESCRIPTION
###### Motivation for this change
The [babelfish](https://github.com/bouk/babelfish) package allows for translation of bash to fish, useful when setting up an environment or otherwise dealing with typical shell scripts. I've added it to support the generation of native fish shell setup for nixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
