### PR TITLE
Add options for swap discarding (TRIM)

### DIFF
--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -128,8 +128,11 @@ let
         default = false;
         type = types.bool;
         description = ''
-          Use swapon -d, and if randomEncryption, make the encrypted mapping with --allow-discards.
-          If you use encrypted.enable, add also encrypted.allowDiscards.
+          Use swapon -d, and if randomEncryption, make the encrypted mapping
+          with --allow-discards.
+
+          If you use encrypted.enable for this swap device, you should enable
+          there encrypted.allowDiscards.
         '';
       };
     };

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -124,6 +124,14 @@ let
         internal = true;
       };
 
+      discard = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Use swapon -d, and if randomEncryption, make the encrypted mapping with --allow-discards.
+          If you use encrypted.enable, add also encrypted.allowDiscards.
+        '';
+      };
     };
 
     config = rec {
@@ -204,7 +212,7 @@ in
                   fi
                 ''}
                 ${optionalString sw.randomEncryption.enable ''
-                  cryptsetup plainOpen -c ${sw.randomEncryption.cipher} -d ${sw.randomEncryption.source} ${sw.device} ${sw.deviceName}
+                  cryptsetup plainOpen -c ${sw.randomEncryption.cipher} -d ${sw.randomEncryption.source} ${sw.device} ${optionalString sw.discard "--allow-discards"} ${sw.deviceName}
                   mkswap ${sw.realDevice}
                 ''}
               '';

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -46,6 +46,12 @@ let
           so the keyfile path should usually start with "/mnt-root/".
         '';
       };
+
+      allowDiscards = mkOption {
+        default = false;
+        type = types.bool;
+        description = "cryptsetup argument --allow-discard on open";
+      };
     };
   };
 in
@@ -74,13 +80,13 @@ in
         devices =
           builtins.listToAttrs (map (dev: {
             name = dev.encrypted.label;
-            value = { device = dev.encrypted.blkDev; };
+            value = { device = dev.encrypted.blkDev; inherit (dev.encrypted) allowDiscards; };
           }) keylessEncDevs);
         forceLuksSupportInInitrd = true;
       };
       postMountCommands =
         concatMapStrings (dev:
-          "cryptsetup luksOpen --key-file ${dev.encrypted.keyFile} ${dev.encrypted.blkDev} ${dev.encrypted.label};\n"
+          "cryptsetup luksOpen --key-file ${dev.encrypted.keyFile} ${dev.encrypted.blkDev} ${dev.encrypted.label} ${optionalString dev.encrypted.allowDiscards "--allow-discards"};\n"
         ) keyedEncDevs;
     };
   };

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -50,7 +50,11 @@ let
       allowDiscards = mkOption {
         default = false;
         type = types.bool;
-        description = "cryptsetup argument --allow-discard on open";
+        description = ''
+          Whether to allow TRIM requests to the underlying device. This option
+          has security implications; please read the LUKS documentation before
+          activating it.
+        '';
       };
     };
   };

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -261,7 +261,7 @@ in
 
         # Swap devices.
         ${flip concatMapStrings config.swapDevices (sw:
-            "${sw.realDevice} none swap${prioOption sw.priority}\n"
+            "${sw.realDevice} none swap${prioOption sw.priority} ${optionalString sw.discard "discard"}\n"
         )}
       '';
 


### PR DESCRIPTION
###### Motivation for this change
swap on ssd will benefit from TRIM/discard so the writes to the ssd go faster with less wearing.

It works in my encrypted swap0.
```
lsblk -D:
sdb                    0      512B       2G         0
├─sdb1                 0      512B       2G         0
├─sdb2                 0      512B       2G         0
├─sdb3                 0      512B       2G         0
│ └─root               0      512B       2G         0
└─sdb4                 0      512B       2G         0
  └─swap0              0      512B       2G         0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
