### PR TITLE
linux: add nativeBuildInputs for extra build tools 

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -24,6 +24,10 @@
   # Additional make flags passed to kbuild
 , extraMakeFlags ? []
 
+, # List of packages needed to build this specific kernel extra, additionally
+  # the default tools
+  nativeBuildInputs ? []
+
 , # kernel intermediate config overrides, as a set
  structuredExtraConfig ? {}
 
@@ -112,6 +116,7 @@ let
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
     nativeBuildInputs = [ perl gmp libmpc mpfr ]
+      ++ nativeBuildInputs
       ++ lib.optionals (lib.versionAtLeast version "4.16") [ bison flex ];
 
     platformName = stdenv.hostPlatform.linux-kernel.name;
@@ -181,7 +186,7 @@ let
   }; # end of configfile derivation
 
   kernel = (callPackage ./manual-config.nix { inherit buildPackages;  }) {
-    inherit version modDirVersion src kernelPatches randstructSeed lib stdenv extraMakeFlags extraMeta configfile;
+    inherit version modDirVersion src kernelPatches randstructSeed lib stdenv extraMakeFlags extraMeta configfile nativeBuildInputs;
 
     config = { CONFIG_MODULES = "y"; CONFIG_FW_LOADER = "m"; };
   };

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -38,6 +38,9 @@ in {
   # Use defaultMeta // extraMeta
   extraMeta ? {},
 
+  # Extra build tools
+  nativeBuildInputs ? [],
+
   # for module compatibility
   isZen      ? false,
   isLibre    ? false,
@@ -313,6 +316,7 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.linux-kernel kernelPat
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr gawk zstd python3Minimal ]
+      ++ nativeBuildInputs
       ++ optional  (stdenv.hostPlatform.linux-kernel.target == "uImage") buildPackages.ubootTools
       ++ optional  (lib.versionAtLeast version "4.14" && lib.versionOlder version "5.8") libelf
       # Removed util-linuxMinimal since it should not be a dependency.


### PR DESCRIPTION
###### Motivation for this change
Create a way to add extra BuildInputs into buildLinux, so linux forks which need extra tools to build linux can use those

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
