### PR TITLE
sub-batch: init at 0.3.0

### DIFF
--- a/pkgs/applications/video/sub-batch/default.nix
+++ b/pkgs/applications/video/sub-batch/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sub-batch";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "kl";
+    repo = pname;
+    # Upstream doesn't tag releases.
+    rev = "631bd6e2d931f8a8e12798f4b6460739a14bcfff";
+    sha256 = "sha256-424e40v2LBxlmgDKxvsT/iuUn/IKWPKMwih0cSQ5sFE=";
+  };
+
+  cargoSha256 = "sha256-l+BTF9PGb8bG8QHhNCoBsrsVX8nlRjPlaea1ESFfMW0=";
+
+  meta = with stdenv.lib; {
+    description = "Match and rename subtitle files to video files and perform other batch operations on subtitle files";
+    homepage = "https://github.com/kl/sub-batch";
+    license = licenses.mit;
+    maintainers = with maintainers; [ erictapen ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16441,6 +16441,8 @@ in
   streamlink = callPackage ../applications/video/streamlink { pythonPackages = python3Packages; };
   streamlink-twitch-gui-bin = callPackage ../applications/video/streamlink-twitch-gui/bin.nix {};
 
+  sub-batch = callPackage ../applications/video/sub-batch { };
+
   subdl = callPackage ../applications/video/subdl { };
 
   subtitleeditor = callPackage ../applications/video/subtitleeditor { enchant = enchant1; };


### PR DESCRIPTION


###### Motivation for this change

Introduce [sub-batch](https://github.com/kl/sub-batch), a nice application for editing subtitles from the CLI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
