### PR TITLE
urn-timer: init at unstable-2017-08-20

### DIFF
--- a/pkgs/tools/misc/urn-timer/default.nix
+++ b/pkgs/tools/misc/urn-timer/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, unstableGitUpdater
+, xxd
+, pkg-config
+, imagemagick
+, wrapGAppsHook
+, gtk3
+, jansson
+}:
+
+stdenv.mkDerivation {
+  pname = "urn-timer";
+  version = "unstable-2017-08-20";
+
+  src = fetchFromGitHub {
+    owner = "3snowp7im";
+    repo = "urn";
+    rev = "246a7a642fa7a673166c1bd281585d0fc22e75b2";
+    sha256 = "0bniwf3nhsqapsss9m9y9ylh38v6v7q45999wa1qcsddpa72k0i0";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # https://github.com/3snowp7im/urn/pull/50
+    (fetchpatch {
+      name = "stop-hardcoding-prefix";
+      url = "https://github.com/3snowp7im/urn/commit/6054ee62dcd6095e31e8fb2a229155dbbcb39f68.patch";
+      sha256 = "1xdkylbqlqjwqx4pb9v1snf81ag7b6q8vybirz3ibsv6iy79v9pk";
+    })
+    # https://github.com/3snowp7im/urn/pull/53
+    (fetchpatch {
+      name = "create-installation-directories";
+      url = "https://github.com/3snowp7im/urn/commit/fb032851b9c5bebb5066d306f5366f0be34f0797.patch";
+      sha256 = "0jjhcz4n8bm3hl56rvjzkvxr6imc05qlyavzjrlafa19hf036g4a";
+    })
+  ];
+
+  postPatch = ''substituteInPlace GNUmakefile --replace 'rsync -a --exclude=".*"' 'cp -r' '';
+
+  nativeBuildInputs = [
+    xxd
+    pkg-config
+    imagemagick
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    jansson
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/3snowp7im/urn.git";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/3snowp7im/urn";
+    description = "Split tracker / timer for speedrunning with GTK+ frontend";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8073,6 +8073,8 @@ in
 
   urlview = callPackage ../applications/misc/urlview {};
 
+  urn-timer = callPackage ../tools/misc/urn-timer { };
+
   ursadb = callPackage ../servers/ursadb {};
 
   usbmuxd = callPackage ../tools/misc/usbmuxd {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

There are no speedrunning timers in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Without a split file the program will only show a file dialog. If you want to test this, use this file: https://github.com/3snowp7im/urn/blob/master/splits/sotn.json
