### PR TITLE
nix-generate-from-cpan: quote homepage, stdenv.lib -> lib

### DIFF
--- a/maintainers/scripts/nix-generate-from-cpan.pl
+++ b/maintainers/scripts/nix-generate-from-cpan.pl
@@ -309,7 +309,7 @@ sub render_license {
     # "GPL v2" or to "GPL v2 or later".
     my $amb = 0;
 
-    # Whether the license is available inside `stdenv.lib.licenses`.
+    # Whether the license is available inside `lib.licenses`.
     my $in_set = 1;
 
     my $nix_license = $LICENSE_MAP{$cpan_license};
@@ -331,7 +331,7 @@ sub render_license {
         # Avoid defining the license line.
     }
     elsif ($in_set) {
-        my $lic = 'stdenv.lib.licenses';
+        my $lic = 'lib.licenses';
         if ( @$licenses == 1 ) {
             $license_line = "$lic.$licenses->[0]";
         }
@@ -449,7 +449,7 @@ print <<EOF;
     meta = {
 EOF
 print <<EOF if defined $homepage;
-      homepage = $homepage;
+      homepage = "$homepage";
 EOF
 print <<EOF if defined $description && $description ne "Unknown";
       description = "$description";


### PR DESCRIPTION
###### Motivation for this change

- Replace `stdenv.lib.licenses` with `lib.licenses`, re: https://github.com/NixOS/nixpkgs/pull/108927
- Quote URL in `meta.homepage` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([niux.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
