### PR TITLE
jumpnbump: init at 1.70-dev

### DIFF
--- a/pkgs/games/jumpnbump/default.nix
+++ b/pkgs/games/jumpnbump/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitLab
+, fetchzip
+, SDL2, SDL2_mixer, SDL2_net
+, gtk3, gobject-introspection
+, python3Packages
+, wrapGAppsHook
+}:
+
+let data = fetchzip {
+  url = "https://mirandir.pagesperso-orange.fr/files/additional-levels.tar.xz";
+  sha256 = "167hisscsbldrwrs54gq6446shl8h26qdqigmfg0lq3daynqycg2";
+}; in
+
+stdenv.mkDerivation rec {
+  pname = "jumpnbump";
+  version = "1.70-dev";
+
+  # By targeting the development version, we can omit the patches Arch uses
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "LibreGames";
+    repo = pname;
+    rev = "5744738211ca691444f779aafee3537fb3562516";
+    sha256 = "0f1k26jicmb95bx19wgcdpwsbbl343i7mqqqc2z9lkb8drlsyqcy";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  nativeBuildInputs = [ python3Packages.wrapPython wrapGAppsHook ];
+  buildInputs = [ SDL2 SDL2_mixer SDL2_net gtk3 gobject-introspection ];
+
+  postInstall = ''
+    make -C menu PREFIX=$out all install
+    cp -r ${data}/* $out/share/jumpnbump/
+    rm $out/share/applications/jumpnbump-menu.desktop
+    sed -ie 's+Exec=jumpnbump+Exec=jumpnbump-menu+' $out/share/applications/jumpnbump.desktop
+  '';
+
+  pythonPath = with python3Packages; [ pygobject3 pillow ];
+  preFixup = ''
+    buildPythonPath "$out $pythonPath"
+  '';
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = with stdenv.lib; {
+    description = "cute, true multiplayer platform game with bunnies";
+    homepage    = "https://libregames.gitlab.io/jumpnbump/";
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ iblech ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5084,6 +5084,8 @@ in
 
   jnettop = callPackage ../tools/networking/jnettop { };
 
+  jumpnbump = callPackage ../games/jumpnbump { };
+
   junkie = callPackage ../tools/networking/junkie { };
 
   just = callPackage ../development/tools/just { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

jumpnbump is an old and cute multiplayer platform game which was even recently modernized. It is available in Debian and Arch, this pull request adds it to nixpkgs. Levels and the level picker are included.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
