### PR TITLE
crlfuzz: init at 1.4.0

### DIFF
--- a/pkgs/tools/security/crlfuzz/default.nix
+++ b/pkgs/tools/security/crlfuzz/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule
+, fetchFromGitHub
+, stdenv
+}:
+
+buildGoModule rec {
+  pname = "crlfuzz";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "dwisiswant0";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03g7z7cczn52hvg6srp1i5xhdbpia226adrh2d54cs640063bx3m";
+  };
+
+  vendorSha256 = "19cj07f7d3ksp7lh5amdjz1s8p7xmqbwal4vp61al82n8944ify8";
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Tool to scan for CRLF vulnerability";
+    homepage = "https://github.com/dwisiswant0/crlfuzz";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3026,6 +3026,8 @@ in
 
   cmt = callPackage ../applications/audio/cmt {};
 
+  crlfuzz = callPackage ../tools/security/crlfuzz {};
+
   hedgedoc = callPackage ../servers/web-apps/hedgedoc { };
 
   colord = callPackage ../tools/misc/colord { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to scan for CRLF vulnerability.

https://github.com/dwisiswant0/crlfuzz

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
