### PR TITLE
ocamlPackages.lens: 1.2.3 → 1.2.4

### DIFF
--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -1,20 +1,21 @@
-{ lib, ocaml, fetchzip, ppx_deriving, ppxfind, buildDunePackage }:
-
-if lib.versionAtLeast ocaml.version "4.10"
-then throw "lens is not available for OCaml ${ocaml.version}"
-else
+{ lib, fetchzip, ppx_deriving, ppxfind, buildDunePackage, ounit }:
 
 buildDunePackage rec {
   pname = "lens";
-  version = "1.2.3";
+  version = "1.2.4";
+
+  useDune2 = true;
 
   src = fetchzip {
     url = "https://github.com/pdonadeo/ocaml-lens/archive/v${version}.tar.gz";
-    sha256 = "09k2vhzysx91syjhgv6w1shc9mgzi0l4bhwpx1g5pi4r4ghjp07y";
+    sha256 = "18mv7n5rcix3545mc2qa2f9xngks4g4kqj2g878qj7r3cy96kklv";
   };
 
-  minimumOCamlVersion = "4.04.1";
+  minimumOCamlVersion = "4.10";
   buildInputs = [ ppx_deriving ppxfind ];
+
+  doCheck = true;
+  checkInputs = [ ounit ];
 
   meta = with lib; {
     homepage = "https://github.com/pdonadeo/ocaml-lens";


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.10
Use dune 2.

cc maintainer @kazcw

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
