### PR TITLE
treewide: simplify pkgs.stdenv.lib -> pkgs.lib

### DIFF
--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -102,7 +102,7 @@ See the `zlib` example:
         echo "================= /testing zlib using node ================="
       '';
 
-      postPatch = pkgs.stdenv.lib.optionalString pkgs.stdenv.isDarwin ''
+      postPatch = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
         substituteInPlace configure \
           --replace '/usr/bin/libtool' 'ar' \
           --replace 'AR="libtool"' 'AR="ar"' \

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -20,7 +20,7 @@ let
   timeoutStr = if blCfg.timeout == null then "-1" else toString blCfg.timeout;
 
   isAarch64 = pkgs.stdenv.hostPlatform.isAarch64;
-  optional = pkgs.stdenv.lib.optionalString;
+  optional = pkgs.lib.optionalString;
 
   configTxt =
     pkgs.writeText "config.txt" (''

--- a/nixos/tests/3proxy.nix
+++ b/nixos/tests/3proxy.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "3proxy";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ misuzu ];
   };
 

--- a/nixos/tests/agda.nix
+++ b/nixos/tests/agda.nix
@@ -9,7 +9,7 @@ let
 in
 {
   name = "agda";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ alexarice turion ];
   };
 

--- a/nixos/tests/ammonite.nix
+++ b/nixos/tests/ammonite.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "ammonite";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "atd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bjornfor ];
   };
 

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -8,7 +8,7 @@
 # Test whether `avahi-daemon' and `libnss-mdns' work as expected.
 import ./make-test-python.nix {
   name = "avahi";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/awscli.nix
+++ b/nixos/tests/awscli.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "awscli";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/babeld.nix
+++ b/nixos/tests/babeld.nix
@@ -1,7 +1,7 @@
 
 import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "babeld";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ hexa ];
   };
 

--- a/nixos/tests/bat.nix
+++ b/nixos/tests/bat.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "bat";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   machine = { pkgs, ... }: { environment.systemPackages = [ pkgs.bat ]; };
 

--- a/nixos/tests/bcachefs.nix
+++ b/nixos/tests/bcachefs.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "bcachefs";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ chiiruno ];
+  meta.maintainers = with pkgs.lib.maintainers; [ chiiruno ];
 
   machine = { pkgs, ... }: {
     virtualisation.emptyDiskImages = [ 4096 ];

--- a/nixos/tests/bitcoind.nix
+++ b/nixos/tests/bitcoind.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "bitcoind";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ _1000101 ];
   };
 

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -35,7 +35,7 @@ in
 
 {
   name = "bittorrent";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ domenkozar eelco rob bobvanderlinden ];
   };
 

--- a/nixos/tests/bitwarden.nix
+++ b/nixos/tests/bitwarden.nix
@@ -27,7 +27,7 @@ let
   makeBitwardenTest = backend: makeTest {
     name = "bitwarden_rs-${backend}";
     meta = {
-      maintainers = with pkgs.stdenv.lib.maintainers; [ jjjollyjim ];
+      maintainers = with pkgs.lib.maintainers; [ jjjollyjim ];
     };
 
     nodes = {

--- a/nixos/tests/blockbook-frontend.nix
+++ b/nixos/tests/blockbook-frontend.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "blockbook-frontend";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ _1000101 ];
   };
 

--- a/nixos/tests/boot-stage1.nix
+++ b/nixos/tests/boot-stage1.nix
@@ -158,5 +158,5 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     machine.succeed('pgrep -a -f "^kcanary$"')
   '';
 
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ aszlig ];
+  meta.maintainers = with pkgs.lib.maintainers; [ aszlig ];
 })

--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -36,7 +36,7 @@ let
 
 in {
   name = "borgbackup";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ dotlambda ];
   };
 

--- a/nixos/tests/buildbot.nix
+++ b/nixos/tests/buildbot.nix
@@ -109,5 +109,5 @@ import ./make-test-python.nix {
         bbworker.fail("nc -z bbmaster 8011")
   '';
 
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ nand0p ];
+  meta.maintainers = with pkgs.lib.maintainers; [ nand0p ];
 } {}

--- a/nixos/tests/buildkite-agents.nix
+++ b/nixos/tests/buildkite-agents.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "buildkite-agent";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ flokli ];
   };
 

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "caddy";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ xfix Br1ght0ne ];
   };
 

--- a/nixos/tests/cadvisor.nix
+++ b/nixos/tests/cadvisor.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... } : {
   name = "cadvisor";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ offline ];
   };
 

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
 {
   name = "cage";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ matthewbauer flokli ];
   };
 

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -9,7 +9,7 @@ let
 in
 {
   name = "cagebreak";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ berbiche ];
   };
 

--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -218,7 +218,7 @@ let
   '';
 in {
   name = "basic-multi-node-ceph-cluster";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lejonet ];
   };
 

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -184,7 +184,7 @@ let
   '';
 in {
   name = "basic-single-node-ceph-cluster";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lejonet johanot ];
   };
 

--- a/nixos/tests/charliecloud.nix
+++ b/nixos/tests/charliecloud.nix
@@ -11,7 +11,7 @@ import ./make-test-python.nix ({ pkgs, ...} : let
 
 in {
   name = "charliecloud";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bzizou ];
   };
 

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -19,7 +19,7 @@ in
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "cjdns";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ehmry ];
   };
 

--- a/nixos/tests/clickhouse.nix
+++ b/nixos/tests/clickhouse.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "clickhouse";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ma27 ];
 
   machine = {
     services.clickhouse.enable = true;

--- a/nixos/tests/cloud-init.nix
+++ b/nixos/tests/cloud-init.nix
@@ -40,7 +40,7 @@ let
   };
 in makeTest {
   name = "cloud-init";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lewo ];
   };
   machine = { ... }:

--- a/nixos/tests/cockroachdb.nix
+++ b/nixos/tests/cockroachdb.nix
@@ -99,7 +99,7 @@ let
 
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "cockroachdb";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers;
+  meta.maintainers = with pkgs.lib.maintainers;
     [ thoughtpolice ];
 
   nodes = {

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -9,7 +9,7 @@ in
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-bridge";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];
   };
 

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-extra_veth";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ kampfschlaefer ];
   };
 

--- a/nixos/tests/containers-hosts.nix
+++ b/nixos/tests/containers-hosts.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-hosts";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ montag451 ];
   };
 

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-imperative";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];
   };
 

--- a/nixos/tests/containers-ip.nix
+++ b/nixos/tests/containers-ip.nix
@@ -15,7 +15,7 @@ let
 
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-ipv4-ipv6";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];
   };
 

--- a/nixos/tests/containers-macvlans.nix
+++ b/nixos/tests/containers-macvlans.nix
@@ -8,7 +8,7 @@ in
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-macvlans";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ montag451 ];
   };
 

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -1,7 +1,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-physical_interfaces";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ kampfschlaefer ];
   };
 

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -9,7 +9,7 @@ in
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-portforward";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ianwookim ];
   };
 

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -16,7 +16,7 @@ let
   };
 in {
   name = "containers-reloadable";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ danbst ];
   };
 

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -19,7 +19,7 @@ let
 in import ./make-test-python.nix ({ pkgs, ...} :
 {
   name = "containers-restart_networking";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ kampfschlaefer ];
   };
 

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-tmpfs";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ kampka ];
   };
 

--- a/nixos/tests/convos.nix
+++ b/nixos/tests/convos.nix
@@ -6,7 +6,7 @@ let
 in
 {
   name = "convos";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ sgo ];
   };
 

--- a/nixos/tests/couchdb.nix
+++ b/nixos/tests/couchdb.nix
@@ -19,7 +19,7 @@ with lib;
 
 {
   name = "couchdb";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ fpletz ];
   };
 

--- a/nixos/tests/cri-o.nix
+++ b/nixos/tests/cri-o.nix
@@ -1,7 +1,7 @@
 # This test runs CRI-O and verifies via critest
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "cri-o";
-  maintainers = with pkgs.stdenv.lib.maintainers; teams.podman.members;
+  maintainers = with pkgs.lib.maintainers; teams.podman.members;
 
   nodes = {
     crio = {

--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "deluge";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ flokli ];
   };
 

--- a/nixos/tests/dnscrypt-proxy2.nix
+++ b/nixos/tests/dnscrypt-proxy2.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "dnscrypt-proxy2";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ joachifm ];
   };
 

--- a/nixos/tests/dnscrypt-wrapper/default.nix
+++ b/nixos/tests/dnscrypt-wrapper/default.nix
@@ -1,6 +1,6 @@
 import ../make-test-python.nix ({ pkgs, ... }: {
   name = "dnscrypt-wrapper";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ rnhmjoj ];
   };
 

--- a/nixos/tests/docker-edge.nix
+++ b/nixos/tests/docker-edge.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "docker";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus offline ];
   };
 

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "docker-registry";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ globin ma27 ironpinguin ];
   };
 

--- a/nixos/tests/docker-tools-cross.nix
+++ b/nixos/tests/docker-tools-cross.nix
@@ -35,7 +35,7 @@ let
 
 in {
   name = "docker-tools";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ roberth ];
   };
 

--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -3,7 +3,7 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "docker-tools-overlay";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lnl7 ];
   };
 

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "docker-tools";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lnl7 ];
   };
 

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "docker";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus offline ];
   };
 

--- a/nixos/tests/documize.nix
+++ b/nixos/tests/documize.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "documize";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ma27 ];
   };
 

--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -32,7 +32,7 @@ let
 
 in {
   name = "dokuwiki";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ _1000101 ];
   };
   machine = { ... }: {

--- a/nixos/tests/elk.nix
+++ b/nixos/tests/elk.nix
@@ -12,7 +12,7 @@ let
   mkElkTest = name : elk :
     import ./make-test-python.nix ({
     inherit name;
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ eelco offline basvandijk ];
     };
     nodes = {

--- a/nixos/tests/emacs-daemon.nix
+++ b/nixos/tests/emacs-daemon.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "emacs-daemon";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ];
   };
 

--- a/nixos/tests/engelsystem.nix
+++ b/nixos/tests/engelsystem.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix (
   { pkgs, lib, ... }:
   {
     name = "engelsystem";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ talyz ];
     };
 

--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 {
   name = "enlightenment";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ romildo ];
   };
 

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "environment";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/ergo.nix
+++ b/nixos/tests/ergo.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "ergo";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mmahut ];
   };
 

--- a/nixos/tests/etcd-cluster.nix
+++ b/nixos/tests/etcd-cluster.nix
@@ -97,7 +97,7 @@ import ./make-test-python.nix ({ pkgs, ... } : let
 in {
   name = "etcd";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ offline ];
   };
 

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -3,7 +3,7 @@
 import ./make-test-python.nix ({ pkgs, ... } : {
   name = "etcd";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ offline ];
   };
 

--- a/nixos/tests/etesync-dav.nix
+++ b/nixos/tests/etesync-dav.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
 
   name = "etesync-dav";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ _3699n ];
   };
 

--- a/nixos/tests/fenics.nix
+++ b/nixos/tests/fenics.nix
@@ -29,7 +29,7 @@ in
 {
   name = "fenics";
   meta = {
-    maintainers = with pkgs.stdenv.lib.maintainers; [ knedlsepp ];
+    maintainers = with pkgs.lib.maintainers; [ knedlsepp ];
   };
 
   nodes = {

--- a/nixos/tests/ferm.nix
+++ b/nixos/tests/ferm.nix
@@ -1,7 +1,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "ferm";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mic92 ];
   };
 

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, esr ? false, ... }: {
   name = "firefox";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco shlevy ];
   };
 

--- a/nixos/tests/firejail.nix
+++ b/nixos/tests/firejail.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "firejail";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ sgo ];
   };
 

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ( { pkgs, ... } : {
   name = "firewall";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/freeswitch.nix
+++ b/nixos/tests/freeswitch.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "freeswitch";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ misuzu ];
   };
   nodes = {

--- a/nixos/tests/gerrit.nix
+++ b/nixos/tests/gerrit.nix
@@ -9,7 +9,7 @@ let
 in {
   name = "gerrit";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ flokli zimbatm ];
   };
 

--- a/nixos/tests/git/hub.nix
+++ b/nixos/tests/git/hub.nix
@@ -1,6 +1,6 @@
 import ../make-test-python.nix ({ pkgs, ...} : {
   name = "hub";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/gitdaemon.nix
+++ b/nixos/tests/gitdaemon.nix
@@ -7,7 +7,7 @@ let
 in {
   name = "gitdaemon";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ tilpner ];
   };
 

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -5,7 +5,7 @@ let
 in
 import ./make-test-python.nix ({ pkgs, lib, ...} : with lib; {
   name = "gitlab";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ globin ];
   };
 

--- a/nixos/tests/gitolite-fcgiwrap.nix
+++ b/nixos/tests/gitolite-fcgiwrap.nix
@@ -13,7 +13,7 @@ import ./make-test-python.nix (
       {
         name = "gitolite-fcgiwrap";
 
-        meta = with pkgs.stdenv.lib.maintainers; {
+        meta = with pkgs.lib.maintainers; {
           maintainers = [ bbigras ];
         };
 

--- a/nixos/tests/gitolite.nix
+++ b/nixos/tests/gitolite.nix
@@ -51,7 +51,7 @@ in
 {
   name = "gitolite";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bjornfor ];
   };
 

--- a/nixos/tests/go-neb.nix
+++ b/nixos/tests/go-neb.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "go-neb";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ hexa maralorn ];
   };
 

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -11,7 +11,7 @@ in
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "gocd-agent";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ grahamc swarren83 ];
 
     # gocd agent needs to register with the autoregister key created on first server startup,

--- a/nixos/tests/gocd-server.nix
+++ b/nixos/tests/gocd-server.nix
@@ -6,7 +6,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
 {
   name = "gocd-server";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ swarren83 ];
   };
 

--- a/nixos/tests/google-oslogin/default.nix
+++ b/nixos/tests/google-oslogin/default.nix
@@ -11,7 +11,7 @@ let
     '';
 in {
   name = "google-oslogin";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ adisbladis flokli ];
   };
 

--- a/nixos/tests/gotify-server.nix
+++ b/nixos/tests/gotify-server.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "gotify-server";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ma27 ];
   };
 

--- a/nixos/tests/grocy.nix
+++ b/nixos/tests/grocy.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "grocy";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ma27 ];
   };
 

--- a/nixos/tests/gvisor.nix
+++ b/nixos/tests/gvisor.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "gvisor";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ andrew-d ];
   };
 

--- a/nixos/tests/haka.nix
+++ b/nixos/tests/haka.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "haka";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ tvestelind ];
   };
 

--- a/nixos/tests/handbrake.nix
+++ b/nixos/tests/handbrake.nix
@@ -9,7 +9,7 @@ in {
   name = "handbrake";
 
   meta = {
-    maintainers = with pkgs.stdenv.lib.maintainers; [ danieldk ];
+    maintainers = with pkgs.lib.maintainers; [ danieldk ];
   };
 
   machine = { pkgs, ... }: {

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... } : {
   name = "hardened";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ joachifm ];
   };
 

--- a/nixos/tests/hitch/default.nix
+++ b/nixos/tests/hitch/default.nix
@@ -1,7 +1,7 @@
 import ../make-test-python.nix ({ pkgs, ... }:
 {
   name = "hitch";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ jflanglois ];
   };
   machine = { pkgs, ... }: {

--- a/nixos/tests/hocker-fetchdocker/default.nix
+++ b/nixos/tests/hocker-fetchdocker/default.nix
@@ -1,6 +1,6 @@
 import ../make-test-python.nix ({ pkgs, ...} : {
   name = "test-hocker-fetchdocker";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ixmatus ];
     broken = true; # tries to download from registry-1.docker.io - how did this ever work?
   };

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -6,7 +6,7 @@ let
   mqttPassword = "secret";
 in {
   name = "home-assistant";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ dotlambda ];
   };
 

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -13,7 +13,7 @@ let
     in
       makeTest {
         name = "hostname-${fqdn}";
-        meta = with pkgs.stdenv.lib.maintainers; {
+        meta = with pkgs.lib.maintainers; {
           maintainers = [ primeos blitz ];
         };
 

--- a/nixos/tests/hound.nix
+++ b/nixos/tests/hound.nix
@@ -1,7 +1,7 @@
 # Test whether `houndd` indexes nixpkgs
 import ./make-test-python.nix ({ pkgs, ... } : {
   name = "hound";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ grahamc ];
   };
   machine = { pkgs, ... }: {

--- a/nixos/tests/hydra/common.nix
+++ b/nixos/tests/hydra/common.nix
@@ -19,7 +19,7 @@
       buildInputs = [ pkgs.makeWrapper ];
       installPhase = "install -m755 -D ${./create-trivial-project.sh} $out/bin/create-trivial-project.sh";
       postFixup = ''
-        wrapProgram "$out/bin/create-trivial-project.sh" --prefix PATH ":" ${pkgs.stdenv.lib.makeBinPath [ pkgs.curl ]} --set EXPR_PATH ${trivialJob}
+        wrapProgram "$out/bin/create-trivial-project.sh" --prefix PATH ":" ${pkgs.lib.makeBinPath [ pkgs.curl ]} --set EXPR_PATH ${trivialJob}
       '';
     };
   in {

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -16,7 +16,7 @@ let
 
   makeHydraTest = with pkgs.lib; name: package: makeTest {
     name = "hydra-${name}";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ pstn lewo ma27 ];
     };
 

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "i3wm";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aszlig ];
   };
 

--- a/nixos/tests/icingaweb2.nix
+++ b/nixos/tests/icingaweb2.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "icingaweb2";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ das_j ];
   };
 

--- a/nixos/tests/iftop.nix
+++ b/nixos/tests/iftop.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   name = "iftop";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ma27 ];
 
   nodes = {
     withIftop = {

--- a/nixos/tests/influxdb.nix
+++ b/nixos/tests/influxdb.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "influxdb";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ offline ];
   };
 

--- a/nixos/tests/initrd-network.nix
+++ b/nixos/tests/initrd-network.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "initrd-network";
 
-  meta.maintainers = [ pkgs.stdenv.lib.maintainers.eelco ];
+  meta.maintainers = [ pkgs.lib.maintainers.eelco ];
 
   machine = { ... }: {
     imports = [ ../modules/profiles/minimal.nix ];

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -270,7 +270,7 @@ let
     makeTest {
       inherit enableOCR;
       name = "installer-" + name;
-      meta = with pkgs.stdenv.lib.maintainers; {
+      meta = with pkgs.lib.maintainers; {
         # put global maintainers here, individuals go into makeInstallerTest fkt call
         maintainers = (meta.maintainers or []);
       };

--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "ipfs";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mguentner ];
   };
 

--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -3,7 +3,7 @@
 
 import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "ipv6";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -5,7 +5,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "jenkins";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bjornfor coconnor domenkozar eelco ];
   };
 

--- a/nixos/tests/jitsi-meet.nix
+++ b/nixos/tests/jitsi-meet.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "jitsi-meet";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = teams.jitsi.members;
   };
 

--- a/nixos/tests/jq.nix
+++ b/nixos/tests/jq.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "jq";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   nodes.jq = { pkgs, ... }: { environment.systemPackages = [ pkgs.jq ]; };
 

--- a/nixos/tests/k3s.nix
+++ b/nixos/tests/k3s.nix
@@ -31,7 +31,7 @@ let
 in
 {
   name = "k3s";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ euank ];
   };
 

--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -8,7 +8,7 @@ with pkgs.lib;
 let
   makeKafkaTest = name: kafkaPackage: (import ./make-test-python.nix ({
     inherit name;
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ nequissimus ];
     };
 

--- a/nixos/tests/kernel-latest.nix
+++ b/nixos/tests/kernel-latest.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "kernel-latest";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/kernel-lts.nix
+++ b/nixos/tests/kernel-lts.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "kernel-lts";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/kernel-testing.nix
+++ b/nixos/tests/kernel-testing.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "kernel-testing";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -10,7 +10,7 @@ let
     { pkgs, databaseType, ... }:
     {
       name = "keycloak";
-      meta = with pkgs.stdenv.lib.maintainers; {
+      meta = with pkgs.lib.maintainers; {
         maintainers = [ talyz ];
       };
 

--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -37,7 +37,7 @@ let
   '';
 in {
   name = "knot";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ hexa ];
   };
 

--- a/nixos/tests/krb5/deprecated-config.nix
+++ b/nixos/tests/krb5/deprecated-config.nix
@@ -3,7 +3,7 @@
 
 import ../make-test-python.nix ({ pkgs, ...} : {
   name = "krb5-with-deprecated-config";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ];
   };
 

--- a/nixos/tests/krb5/example-config.nix
+++ b/nixos/tests/krb5/example-config.nix
@@ -3,7 +3,7 @@
 
 import ../make-test-python.nix ({ pkgs, ...} : {
   name = "krb5-with-example-config";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ];
   };
 

--- a/nixos/tests/leaps.nix
+++ b/nixos/tests/leaps.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs,  ... }:
 
 {
   name = "leaps";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ qknight ];
   };
 

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "lightdm";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aszlig worldofpeace ];
   };
 

--- a/nixos/tests/limesurvey.nix
+++ b/nixos/tests/limesurvey.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "limesurvey";
-  meta.maintainers = [ pkgs.stdenv.lib.maintainers.aanderse ];
+  meta.maintainers = [ pkgs.lib.maintainers.aanderse ];
 
   machine = { ... }: {
     services.limesurvey = {

--- a/nixos/tests/locate.nix
+++ b/nixos/tests/locate.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
   let inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
   in {
     name = "locate";
-    meta.maintainers = with pkgs.stdenv.lib.maintainers; [ chkno ];
+    meta.maintainers = with pkgs.lib.maintainers; [ chkno ];
 
     nodes = rec {
       a = {

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
 
 {
   name = "login";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/lsd.nix
+++ b/nixos/tests/lsd.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "lsd";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   nodes.lsd = { pkgs, ... }: { environment.systemPackages = [ pkgs.lsd ]; };
 

--- a/nixos/tests/lxd-nftables.nix
+++ b/nixos/tests/lxd-nftables.nix
@@ -8,7 +8,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "lxd-nftables";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ patryk27 ];
   };
 

--- a/nixos/tests/lxd.nix
+++ b/nixos/tests/lxd.nix
@@ -47,7 +47,7 @@ let
 in {
   name = "lxd";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ patryk27 ];
   };
 

--- a/nixos/tests/magic-wormhole-mailbox-server.nix
+++ b/nixos/tests/magic-wormhole-mailbox-server.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "magic-wormhole-mailbox-server";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mmahut ];
   };
 

--- a/nixos/tests/magnetico.nix
+++ b/nixos/tests/magnetico.nix
@@ -5,7 +5,7 @@ let
 in
 {
   name = "magnetico";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ rnhmjoj ];
   };
 

--- a/nixos/tests/matrix-synapse.nix
+++ b/nixos/tests/matrix-synapse.nix
@@ -29,7 +29,7 @@ import ./make-test-python.nix ({ pkgs, ... } : let
 in {
 
   name = "matrix-synapse";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = teams.matrix.members;
   };
 

--- a/nixos/tests/metabase.nix
+++ b/nixos/tests/metabase.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "metabase";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mmahut ];
   };
 

--- a/nixos/tests/minecraft-server.nix
+++ b/nixos/tests/minecraft-server.nix
@@ -4,7 +4,7 @@ let
   rcon-port = 43000;
 in import ./make-test-python.nix ({ pkgs, ... }: {
   name = "minecraft-server";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   nodes.server = { ... }: {
     environment.systemPackages = [ pkgs.mcrcon ];

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -11,7 +11,7 @@ in
 with lib;
 {
   name = "miniflux";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ bricewge ];
+  meta.maintainers = with pkgs.lib.maintainers; [ bricewge ];
 
   nodes = {
     default =

--- a/nixos/tests/minio.nix
+++ b/nixos/tests/minio.nix
@@ -20,7 +20,7 @@ let
     '';
 in {
   name = "minio";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bachp ];
   };
 

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : rec {
   name = "misc";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/molly-brown.nix
+++ b/nixos/tests/molly-brown.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
   in {
 
     name = "molly-brown";
-    meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ ehmry ]; };
+    meta = with pkgs.lib.maintainers; { maintainers = [ ehmry ]; };
 
     nodes = {
 

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -26,7 +26,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
   in {
     name = "mongodb";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ bluescreen303 offline cstrahan rvl phile314 ];
     };
 

--- a/nixos/tests/morty.nix
+++ b/nixos/tests/morty.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "morty";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ leenaars ];
   };
 

--- a/nixos/tests/mosquitto.nix
+++ b/nixos/tests/mosquitto.nix
@@ -7,7 +7,7 @@ let
   topic = "test/foo";
 in {
   name = "mosquitto";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ peterhoeg ];
   };
 

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -43,7 +43,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       };
   in {
     name = "mpd";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ emmanuelrosa ];
     };
 

--- a/nixos/tests/mumble.nix
+++ b/nixos/tests/mumble.nix
@@ -14,7 +14,7 @@ let
 in
 {
   name = "mumble";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ thoughtpolice eelco ];
   };
 

--- a/nixos/tests/munin.nix
+++ b/nixos/tests/munin.nix
@@ -3,7 +3,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "munin";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ domenkozar eelco ];
   };
 
@@ -27,7 +27,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
           };
 
           # increase the systemd timer interval so it fires more often
-          systemd.timers.munin-cron.timerConfig.OnCalendar = pkgs.stdenv.lib.mkForce "*:*:0/10";
+          systemd.timers.munin-cron.timerConfig.OnCalendar = pkgs.lib.mkForce "*:*:0/10";
         };
     };
 

--- a/nixos/tests/mutable-users.nix
+++ b/nixos/tests/mutable-users.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "mutable-users";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ gleber ];
   };
 

--- a/nixos/tests/mxisd.nix
+++ b/nixos/tests/mxisd.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... } : {
 
   name = "mxisd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mguentner ];
   };
 

--- a/nixos/tests/mysql/mariadb-galera-mariabackup.nix
+++ b/nixos/tests/mysql/mariadb-galera-mariabackup.nix
@@ -6,7 +6,7 @@ let
 
 in {
   name = "mariadb-galera-mariabackup";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ izorkin ];
   };
 

--- a/nixos/tests/mysql/mariadb-galera-rsync.nix
+++ b/nixos/tests/mysql/mariadb-galera-rsync.nix
@@ -6,7 +6,7 @@ let
 
 in {
   name = "mariadb-galera-rsync";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ izorkin ];
   };
 

--- a/nixos/tests/mysql/mysql-backup.nix
+++ b/nixos/tests/mysql/mysql-backup.nix
@@ -1,7 +1,7 @@
 # Test whether mysqlBackup option works
 import ./../make-test-python.nix ({ pkgs, ... } : {
   name = "mysql-backup";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ rvl ];
   };
 

--- a/nixos/tests/mysql/mysql-replication.nix
+++ b/nixos/tests/mysql/mysql-replication.nix
@@ -7,7 +7,7 @@ in
 
 {
   name = "mysql-replication";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco shlevy ];
   };
 

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -1,6 +1,6 @@
 import ./../make-test-python.nix ({ pkgs, ...} : {
   name = "mysql";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco shlevy ];
   };
 
@@ -185,7 +185,7 @@ import ./../make-test-python.nix ({ pkgs, ...} : {
     mariadb.succeed(
         "echo 'use testdb; drop table rocksdb;' | sudo -u testuser mysql -u testuser"
     )
-  '' + pkgs.stdenv.lib.optionalString pkgs.stdenv.isx86_64 ''
+  '' + pkgs.lib.optionalString pkgs.stdenv.isx86_64 ''
     # Check if TokuDB plugin works
     mariadb.succeed(
         "echo 'use testdb; create table tokudb (test_id INT, PRIMARY KEY (test_id)) ENGINE = TokuDB;' | sudo -u testuser mysql -u testuser"

--- a/nixos/tests/nagios.nix
+++ b/nixos/tests/nagios.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix (
   { pkgs, ... }: {
     name = "nagios";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ symphorien ];
     };
 

--- a/nixos/tests/nano.nix
+++ b/nixos/tests/nano.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "nano";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ?
   {
     name = "nat" + (if withFirewall then "WithFirewall" else "Standalone")
                  + (lib.optionalString withConntrackHelpers "withConntrackHelpers");
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ eelco rob ];
     };
 

--- a/nixos/tests/ncdns.nix
+++ b/nixos/tests/ncdns.nix
@@ -24,7 +24,7 @@ in
 
 {
   name = "ncdns";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ rnhmjoj ];
   };
 

--- a/nixos/tests/ndppd.nix
+++ b/nixos/tests/ndppd.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "ndppd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ fpletz ];
   };
 

--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "netdata";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ cransom ];
   };
 

--- a/nixos/tests/networking-proxy.nix
+++ b/nixos/tests/networking-proxy.nix
@@ -12,7 +12,7 @@ let default-config = {
       };
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "networking-proxy";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [  ];
   };
 

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -3,7 +3,7 @@ import ../make-test-python.nix ({ pkgs, ...}: let
   adminuser = "root";
 in {
   name = "nextcloud-basic";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ globin eqyiel ];
   };
 

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -3,7 +3,7 @@ import ../make-test-python.nix ({ pkgs, ...}: let
   adminuser = "root";
 in {
   name = "nextcloud-with-mysql-and-memcached";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ];
   };
 

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -3,7 +3,7 @@ import ../make-test-python.nix ({ pkgs, ...}: let
   adminuser = "custom-admin-username";
 in {
   name = "nextcloud-with-postgresql-and-redis";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eqyiel ];
   };
 

--- a/nixos/tests/nexus.nix
+++ b/nixos/tests/nexus.nix
@@ -5,7 +5,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "nexus";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ironpinguin ma27 ];
   };
 

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -19,7 +19,7 @@ in
 
 {
   name = "nfs";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/nginx-sandbox.nix
+++ b/nixos/tests/nginx-sandbox.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "nginx-sandbox";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ izorkin ];
   };
 

--- a/nixos/tests/nginx-sso.nix
+++ b/nixos/tests/nginx-sso.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "nginx-sso";
   meta = {
-    maintainers = with pkgs.stdenv.lib.maintainers; [ delroth ];
+    maintainers = with pkgs.lib.maintainers; [ delroth ];
   };
 
   machine = {

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -6,7 +6,7 @@
 #   3. nginx doesn't restart on configuration changes (only reloads)
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "nginx";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mbbx6spp danbst ];
   };
 

--- a/nixos/tests/novacomd.nix
+++ b/nixos/tests/novacomd.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "novacomd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ dtzWill ];
   };
 

--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -7,7 +7,7 @@ let
   };
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "nsd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aszlig ];
   };
 

--- a/nixos/tests/nzbget.nix
+++ b/nixos/tests/nzbget.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "nzbget";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aanderse flokli ];
   };
 
@@ -10,7 +10,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
       # hack, don't add (unfree) unrar to nzbget's path,
       # so we can run this test in CI
-      systemd.services.nzbget.path = pkgs.stdenv.lib.mkForce [ pkgs.p7zip ];
+      systemd.services.nzbget.path = pkgs.lib.mkForce [ pkgs.p7zip ];
     };
   };
 

--- a/nixos/tests/openarena.nix
+++ b/nixos/tests/openarena.nix
@@ -11,7 +11,7 @@ let
 
 in {
   name = "openarena";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ fpletz ];
   };
 

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -4,7 +4,7 @@ let inherit (import ./ssh-keys.nix pkgs)
       snakeOilPrivateKey snakeOilPublicKey;
 in {
   name = "openssh";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ aszlig eelco ];
   };
 

--- a/nixos/tests/opentabletdriver.nix
+++ b/nixos/tests/opentabletdriver.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ( { pkgs, ... }: {
   name = "opentabletdriver";
   meta = {
-    maintainers = with pkgs.stdenv.lib.maintainers; [ thiagokokada ];
+    maintainers = with pkgs.lib.maintainers; [ thiagokokada ];
   };
 
   machine = { pkgs, ... }:

--- a/nixos/tests/overlayfs.nix
+++ b/nixos/tests/overlayfs.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "overlayfs";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ bachp ];
+  meta.maintainers = with pkgs.lib.maintainers; [ bachp ];
 
   machine = { pkgs, ... }: {
     virtualisation.emptyDiskImages = [ 512 ];

--- a/nixos/tests/packagekit.nix
+++ b/nixos/tests/packagekit.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "packagekit";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ peterhoeg ];
   };
 

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 {
   name = "pantheon";
 
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = pkgs.pantheon.maintainers;
   };
 

--- a/nixos/tests/peerflix.nix
+++ b/nixos/tests/peerflix.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "peerflix";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ offline ];
   };
 

--- a/nixos/tests/pgmanage.nix
+++ b/nixos/tests/pgmanage.nix
@@ -6,7 +6,7 @@ let
 in
 {
   name = "pgmanage";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ basvandijk ];
   };
   nodes = {

--- a/nixos/tests/pinnwand.nix
+++ b/nixos/tests/pinnwand.nix
@@ -25,7 +25,7 @@ let
 in
 {
   name = "pinnwand";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers =[ hexa ];
   };
 

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
 {
   name = "plasma5";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ttuegel ];
   };
 

--- a/nixos/tests/postgis.nix
+++ b/nixos/tests/postgis.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "postgis";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lsix ];
   };
 

--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -23,7 +23,7 @@ let
   '';
   make-postgresql-test = postgresql-name: postgresql-package: backup-all: makeTest {
     name = postgresql-name;
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ zagy ];
     };
 

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -35,7 +35,7 @@ let
 
 in {
   name = "printing";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ domenkozar eelco matthewbauer ];
   };
 

--- a/nixos/tests/privacyidea.nix
+++ b/nixos/tests/privacyidea.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : rec {
   name = "privacyidea";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ fpletz ];
   };
 

--- a/nixos/tests/proxy.nix
+++ b/nixos/tests/proxy.nix
@@ -11,7 +11,7 @@ let
   };
 in {
   name = "proxy";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/pt2-clone.nix
+++ b/nixos/tests/pt2-clone.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "pt2-clone";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ fgaz ];
   };
 

--- a/nixos/tests/quagga.nix
+++ b/nixos/tests/quagga.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     {
       name = "quagga";
 
-      meta = with pkgs.stdenv.lib.maintainers; {
+      meta = with pkgs.lib.maintainers; {
         maintainers = [ tavyc ];
       };
 

--- a/nixos/tests/quorum.nix
+++ b/nixos/tests/quorum.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "quorum";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mmahut ];
   };
 

--- a/nixos/tests/rabbitmq.nix
+++ b/nixos/tests/rabbitmq.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "rabbitmq";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco offline ];
   };
 

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "redis";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ flokli ];
   };
 

--- a/nixos/tests/resolv.nix
+++ b/nixos/tests/resolv.nix
@@ -1,7 +1,7 @@
 # Test whether DNS resolving returns multiple records and all address families.
 import ./make-test-python.nix ({ pkgs, ... } : {
   name = "resolv";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ckauhaus ];
   };
 

--- a/nixos/tests/restic.nix
+++ b/nixos/tests/restic.nix
@@ -19,7 +19,7 @@ import ./make-test-python.nix (
       {
         name = "restic";
 
-        meta = with pkgs.stdenv.lib.maintainers; {
+        meta = with pkgs.lib.maintainers; {
           maintainers = [ bbigras i077 ];
         };
 

--- a/nixos/tests/ripgrep.nix
+++ b/nixos/tests/ripgrep.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "ripgrep";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   nodes.ripgrep = { pkgs, ... }: { environment.systemPackages = [ pkgs.ripgrep ]; };
 

--- a/nixos/tests/robustirc-bridge.nix
+++ b/nixos/tests/robustirc-bridge.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "robustirc-bridge";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ hax404 ];
   };
 

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "roundcube";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ globin ];
   };
 

--- a/nixos/tests/rsyslogd.nix
+++ b/nixos/tests/rsyslogd.nix
@@ -9,7 +9,7 @@ with pkgs.lib;
 {
   test1 = makeTest {
     name = "rsyslogd-test1";
-    meta.maintainers = [ pkgs.stdenv.lib.maintainers.aanderse ];
+    meta.maintainers = [ pkgs.lib.maintainers.aanderse ];
 
     machine = { config, pkgs, ... }: {
       services.rsyslogd.enable = true;
@@ -25,7 +25,7 @@ with pkgs.lib;
 
   test2 = makeTest {
     name = "rsyslogd-test2";
-    meta.maintainers = [ pkgs.stdenv.lib.maintainers.aanderse ];
+    meta.maintainers = [ pkgs.lib.maintainers.aanderse ];
 
     machine = { config, pkgs, ... }: {
       services.rsyslogd.enable = true;

--- a/nixos/tests/samba-wsdd.nix
+++ b/nixos/tests/samba-wsdd.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "samba-wsdd";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ izorkin ];
+  meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
 
   nodes = {
     client_wsdd = { pkgs, ... }: {

--- a/nixos/tests/sanoid.nix
+++ b/nixos/tests/sanoid.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, ... }: let
   };
 in {
   name = "sanoid";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lopsided98 ];
   };
 

--- a/nixos/tests/sbt-extras.nix
+++ b/nixos/tests/sbt-extras.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "sbt-extras";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/sbt.nix
+++ b/nixos/tests/sbt.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "sbt";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/scala.nix
+++ b/nixos/tests/scala.nix
@@ -8,7 +8,7 @@ with pkgs.lib;
 let
   common = name: package: (import ./make-test-python.nix ({
     inherit name;
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ nequissimus ];
     };
 

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -37,7 +37,7 @@ let
 
     autoLogin = {
       name = "sddm-autologin";
-      meta = with pkgs.stdenv.lib.maintainers; {
+      meta = with pkgs.lib.maintainers; {
         maintainers = [ ttuegel ];
       };
 

--- a/nixos/tests/service-runner.nix
+++ b/nixos/tests/service-runner.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "service-runner";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ roberth ];
   };
 

--- a/nixos/tests/shadow.nix
+++ b/nixos/tests/shadow.nix
@@ -5,7 +5,7 @@ let
   password4 = "asdf123";
 in import ./make-test-python.nix ({ pkgs, ... }: {
   name = "shadow";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   nodes.shadow = { pkgs, ... }: {
     environment.systemPackages = [ pkgs.shadow ];

--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
 {
   name = "signal-desktop";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ flokli ];
   };
 

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "simple";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/smokeping.nix
+++ b/nixos/tests/smokeping.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "smokeping";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ cransom ];
   };
 

--- a/nixos/tests/snapcast.nix
+++ b/nixos/tests/snapcast.nix
@@ -6,7 +6,7 @@ let
   httpPort = 10080;
 in {
   name = "snapcast";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ hexa ];
   };
 

--- a/nixos/tests/sogo.nix
+++ b/nixos/tests/sogo.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "sogo";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ajs124 das_j ];
   };
 

--- a/nixos/tests/solr.nix
+++ b/nixos/tests/solr.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "solr";
-  meta.maintainers = [ pkgs.stdenv.lib.maintainers.aanderse ];
+  meta.maintainers = [ pkgs.lib.maintainers.aanderse ];
 
   machine =
     { config, pkgs, ... }:

--- a/nixos/tests/spike.nix
+++ b/nixos/tests/spike.nix
@@ -1,11 +1,11 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 
 let
-  riscvPkgs = import ../.. { crossSystem = pkgs.stdenv.lib.systems.examples.riscv64-embedded; };
+  riscvPkgs = import ../.. { crossSystem = pkgs.lib.systems.examples.riscv64-embedded; };
 in
 {
   name = "spike";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ blitz ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ blitz ]; };
 
   machine = { pkgs, lib, ... }: {
     environment.systemPackages = [ pkgs.spike riscvPkgs.riscv-pk riscvPkgs.hello ];

--- a/nixos/tests/sssd-ldap.nix
+++ b/nixos/tests/sssd-ldap.nix
@@ -10,7 +10,7 @@
   in import ./make-test-python.nix {
     name = "sssd-ldap";
 
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ bbigras ];
     };
 

--- a/nixos/tests/sssd.nix
+++ b/nixos/tests/sssd.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "sssd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bbigras ];
   };
   machine = { pkgs, ... }: {

--- a/nixos/tests/strongswan-swanctl.nix
+++ b/nixos/tests/strongswan-swanctl.nix
@@ -31,7 +31,7 @@ let
   proposals     = [ "aes128-sha256-x25519" ];
 in {
   name = "strongswan-swanctl";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ basvandijk ];
+  meta.maintainers = with pkgs.lib.maintainers; [ basvandijk ];
   nodes = {
 
     alice = { ... } : {

--- a/nixos/tests/sudo.nix
+++ b/nixos/tests/sudo.nix
@@ -6,7 +6,7 @@ let
 in
   import ./make-test-python.nix ({ pkgs, ...} : {
     name = "sudo";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ lschuermann ];
     };
 

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "switch-test";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ gleber ];
   };
 

--- a/nixos/tests/syncthing-init.nix
+++ b/nixos/tests/syncthing-init.nix
@@ -4,7 +4,7 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: let
 
 in {
   name = "syncthing-init";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ lassulus ];
+  meta.maintainers = with pkgs.lib.maintainers; [ lassulus ];
 
   machine = {
     services.syncthing = {

--- a/nixos/tests/syncthing-relay.nix
+++ b/nixos/tests/syncthing-relay.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ lib, pkgs, ... }: {
   name = "syncthing-relay";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ delroth ];
+  meta.maintainers = with pkgs.lib.maintainers; [ delroth ];
 
   machine = {
     environment.systemPackages = [ pkgs.jq ];

--- a/nixos/tests/syncthing.nix
+++ b/nixos/tests/syncthing.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ lib, pkgs, ... }: {
   name = "syncthing";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ chkno ];
+  meta.maintainers = with pkgs.lib.maintainers; [ chkno ];
 
   nodes = rec {
     a = {

--- a/nixos/tests/systemd-analyze.nix
+++ b/nixos/tests/systemd-analyze.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, latestKernel ? false, ... }:
 
 {
   name = "systemd-analyze";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ raskin ];
   };
 

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -18,7 +18,7 @@ in
 {
   basic = makeTest {
     name = "systemd-boot";
-    meta.maintainers = with pkgs.stdenv.lib.maintainers; [ danielfullmer ];
+    meta.maintainers = with pkgs.lib.maintainers; [ danielfullmer ];
 
     machine = common;
 
@@ -42,7 +42,7 @@ in
   # Boot without having created an EFI entry--instead using default "/EFI/BOOT/BOOTX64.EFI"
   fallback = makeTest {
     name = "systemd-boot-fallback";
-    meta.maintainers = with pkgs.stdenv.lib.maintainers; [ danielfullmer ];
+    meta.maintainers = with pkgs.lib.maintainers; [ danielfullmer ];
 
     machine = { pkgs, lib, ... }: {
       imports = [ common ];
@@ -68,7 +68,7 @@ in
 
   update = makeTest {
     name = "systemd-boot-update";
-    meta.maintainers = with pkgs.stdenv.lib.maintainers; [ danielfullmer ];
+    meta.maintainers = with pkgs.lib.maintainers; [ danielfullmer ];
 
     machine = common;
 

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "systemd-journal";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lewo ];
   };
 

--- a/nixos/tests/systemd-networkd-dhcpserver.nix
+++ b/nixos/tests/systemd-networkd-dhcpserver.nix
@@ -3,7 +3,7 @@
 # reachable via the DHCP allocated address.
 import ./make-test-python.nix ({pkgs, ...}: {
   name = "systemd-networkd-dhcpserver";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ tomfitzhenry ];
   };
   nodes = {

--- a/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
+++ b/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
@@ -9,7 +9,7 @@
 
 import ./make-test-python.nix ({pkgs, ...}: {
   name = "systemd-networkd-ipv6-prefix-delegation";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ andir ];
   };
   nodes = {

--- a/nixos/tests/systemd-networkd.nix
+++ b/nixos/tests/systemd-networkd.nix
@@ -61,7 +61,7 @@ let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
     };
 in import ./make-test-python.nix ({pkgs, ... }: {
   name = "networkd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ninjatrappeur ];
   };
   nodes = {

--- a/nixos/tests/teeworlds.nix
+++ b/nixos/tests/teeworlds.nix
@@ -10,7 +10,7 @@ let
 
 in {
   name = "teeworlds";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ hax404 ];
   };
 

--- a/nixos/tests/telegraf.nix
+++ b/nixos/tests/telegraf.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "telegraf";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mic92 ];
   };
 

--- a/nixos/tests/trac.nix
+++ b/nixos/tests/trac.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trac";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mmahut ];
   };
 

--- a/nixos/tests/traefik.nix
+++ b/nixos/tests/traefik.nix
@@ -2,7 +2,7 @@
 # and a Docker container.
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "traefik";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ joko ];
   };
 

--- a/nixos/tests/transmission.nix
+++ b/nixos/tests/transmission.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "transmission";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ coconnor ];
   };
 

--- a/nixos/tests/trezord.nix
+++ b/nixos/tests/trezord.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trezord";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ mmahut _1000101 ];
   };
   nodes = {

--- a/nixos/tests/trickster.nix
+++ b/nixos/tests/trickster.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "trickster";
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     maintainers = with maintainers; [ _1000101 ];
   };
 

--- a/nixos/tests/tuptime.nix
+++ b/nixos/tests/tuptime.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "tuptime";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ evils ];
   };
 

--- a/nixos/tests/ucg.nix
+++ b/nixos/tests/ucg.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "ucg";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ AndersonTorres ];
   };
 

--- a/nixos/tests/udisks2.nix
+++ b/nixos/tests/udisks2.nix
@@ -11,7 +11,7 @@ in
 
 {
   name = "udisks2";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ eelco ];
   };
 

--- a/nixos/tests/unbound.nix
+++ b/nixos/tests/unbound.nix
@@ -38,7 +38,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
   in
   {
     name = "unbound";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ andir ];
     };
 

--- a/nixos/tests/upnp.nix
+++ b/nixos/tests/upnp.nix
@@ -15,7 +15,7 @@ let
 in
 {
   name = "upnp";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ bobvanderlinden ];
   };
 

--- a/nixos/tests/uwsgi.nix
+++ b/nixos/tests/uwsgi.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "uwsgi";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lnl7 ];
   };
 

--- a/nixos/tests/vault.nix
+++ b/nixos/tests/vault.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "vault";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lnl7 ];
   };
   machine = { pkgs, ... }: {

--- a/nixos/tests/vector.nix
+++ b/nixos/tests/vector.nix
@@ -7,7 +7,7 @@ with pkgs.lib;
 {
   test1 = makeTest {
     name = "vector-test1";
-    meta.maintainers = [ pkgs.stdenv.lib.maintainers.happysalada ];
+    meta.maintainers = [ pkgs.lib.maintainers.happysalada ];
 
     machine = { config, pkgs, ... }: {
       services.vector = {

--- a/nixos/tests/victoriametrics.nix
+++ b/nixos/tests/victoriametrics.nix
@@ -2,7 +2,7 @@
 
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "victoriametrics";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ yorickvp ];
   };
 

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -402,7 +402,7 @@ let
       # (keep black happy)
     '';
 
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ aszlig cdepillabout ];
     };
   };

--- a/nixos/tests/wasabibackend.nix
+++ b/nixos/tests/wasabibackend.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "wasabibackend";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ mmahut ];
   };
 

--- a/nixos/tests/web-servers/unit-php.nix
+++ b/nixos/tests/web-servers/unit-php.nix
@@ -4,7 +4,7 @@ import ../make-test-python.nix ({pkgs, ...}:
 
 in {
   name = "unit-php-test";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ izorkin ];
+  meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
 
   machine = { config, lib, pkgs, ... }: {
     services.unit = {

--- a/nixos/tests/wireguard/basic.nix
+++ b/nixos/tests/wireguard/basic.nix
@@ -6,7 +6,7 @@ import ../make-test-python.nix ({ pkgs, lib, ...} :
   in
   {
     name = "wireguard";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ ma27 ];
     };
 

--- a/nixos/tests/wireguard/generated.nix
+++ b/nixos/tests/wireguard/generated.nix
@@ -1,7 +1,7 @@
 { kernelPackages ? null }:
 import ../make-test-python.nix ({ pkgs, lib, ... } : {
   name = "wireguard-generated";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ma27 grahamc ];
   };
 

--- a/nixos/tests/wireguard/namespaces.nix
+++ b/nixos/tests/wireguard/namespaces.nix
@@ -17,7 +17,7 @@ in
 
 import ../make-test-python.nix ({ pkgs, lib, ... } : {
   name = "wireguard-with-namespaces";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ asymmetric ];
   };
 

--- a/nixos/tests/wireguard/wg-quick.nix
+++ b/nixos/tests/wireguard/wg-quick.nix
@@ -7,7 +7,7 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
   in
   {
     name = "wg-quick";
-    meta = with pkgs.stdenv.lib.maintainers; {
+    meta = with pkgs.lib.maintainers; {
       maintainers = [ xwvvvvwx ];
     };
 

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "wordpress";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [
       flokli
       grahamc # under duress!

--- a/nixos/tests/xautolock.nix
+++ b/nixos/tests/xautolock.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   name = "xautolock";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ma27 ];
 
   nodes.machine = {
     imports = [ ./common/x11.nix ./common/user-account.nix ];

--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "xmonad";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/xmpp/ejabberd.nix
+++ b/nixos/tests/xmpp/ejabberd.nix
@@ -1,6 +1,6 @@
 import ../make-test-python.nix ({ pkgs, ... }: {
   name = "ejabberd";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ajs124 ];
   };
   nodes = {

--- a/nixos/tests/xrdp.nix
+++ b/nixos/tests/xrdp.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "xrdp";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ volth ];
   };
 

--- a/nixos/tests/xss-lock.nix
+++ b/nixos/tests/xss-lock.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   name = "xss-lock";
-  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
+  meta.maintainers = with pkgs.lib.maintainers; [ ma27 ];
 
   nodes = {
     simple = {

--- a/nixos/tests/xterm.nix
+++ b/nixos/tests/xterm.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "xterm";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ];
   };
 

--- a/nixos/tests/yabar.nix
+++ b/nixos/tests/yabar.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   name = "yabar";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ ma27 ];
   };
 

--- a/nixos/tests/yggdrasil.nix
+++ b/nixos/tests/yggdrasil.nix
@@ -23,7 +23,7 @@ let
 
 in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "yggdrasil";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ gazally ];
   };
 

--- a/nixos/tests/yq.nix
+++ b/nixos/tests/yq.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "yq";
-  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ nequissimus ]; };
+  meta = with pkgs.lib.maintainers; { maintainers = [ nequissimus ]; };
 
   nodes.yq = { pkgs, ... }: { environment.systemPackages = with pkgs; [ jq yq ]; };
 

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -14,7 +14,7 @@ let
     }:
     makeTest {
       name = "zfs-" + name;
-      meta = with pkgs.stdenv.lib.maintainers; {
+      meta = with pkgs.lib.maintainers; {
         maintainers = [ adisbladis ];
       };
 

--- a/nixos/tests/zookeeper.nix
+++ b/nixos/tests/zookeeper.nix
@@ -5,7 +5,7 @@ let
 
 in {
   name = "zookeeper";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ nequissimus ztzg ];
   };
 

--- a/nixos/tests/zsh-history.nix
+++ b/nixos/tests/zsh-history.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "zsh-history";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ kampka ];
   };
 

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -23,7 +23,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     wingpanel-indicator-session wingpanel-indicator-sound
   ];
 
-  maintainers = with pkgs.stdenv.lib.maintainers; [ worldofpeace ];
+  maintainers = with pkgs.lib.maintainers; [ worldofpeace ];
 
   mutter = pkgs.gnome3.mutter334;
 

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -92,7 +92,7 @@ self: super:
          base template-haskell ghcjs-base split containers text ghc-prim
        ];
        description = "FFI QuasiQuoter for GHCJS";
-       license = pkgs.stdenv.lib.licenses.mit;
+       license = pkgs.lib.licenses.mit;
      }) {};
   # experimental
   ghcjs-vdom = self.callPackage
@@ -112,7 +112,7 @@ self: super:
         base ghc-prim ghcjs-ffiqq ghcjs-base ghcjs-prim containers split
         template-haskell
       ];
-      license = pkgs.stdenv.lib.licenses.mit;
+      license = pkgs.lib.licenses.mit;
       description = "bindings for https://github.com/Matt-Esch/virtual-dom";
     }) {};
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -711,7 +711,7 @@ self: super: builtins.intersectAttrs super {
 
   # mplayer-spot uses mplayer at runtime.
   mplayer-spot =
-    let path = pkgs.stdenv.lib.makeBinPath [ pkgs.mplayer ];
+    let path = pkgs.lib.makeBinPath [ pkgs.mplayer ];
     in overrideCabal (addBuildTool super.mplayer-spot pkgs.makeWrapper) (oldAttrs: {
       postInstall = ''
         wrapProgram $out/bin/mplayer-spot --prefix PATH : "${path}"
@@ -723,7 +723,7 @@ self: super: builtins.intersectAttrs super {
   primitive_0_7_1_0 = dontCheck super.primitive_0_7_1_0;
 
   cut-the-crap =
-    let path = pkgs.stdenv.lib.makeBinPath [ pkgs.ffmpeg_3 pkgs.youtube-dl ];
+    let path = pkgs.lib.makeBinPath [ pkgs.ffmpeg_3 pkgs.youtube-dl ];
     in overrideCabal (addBuildTool super.cut-the-crap pkgs.makeWrapper) (_drv: {
       postInstall = ''
         wrapProgram $out/bin/cut-the-crap \

--- a/pkgs/development/interpreters/erlang/R16B02-basho.nix
+++ b/pkgs/development/interpreters/erlang/R16B02-basho.nix
@@ -59,7 +59,7 @@ mkDerivation {
     knownVulnerabilities = [ "CVE-2017-1000385" ];
 
     platforms = ["x86_64-linux" "x86_64-darwin"];
-    license = pkgs.stdenv.lib.licenses.asl20;
-    maintainers = with pkgs.stdenv.lib.maintainers; [ mdaiter ];
+    license = pkgs.lib.licenses.asl20;
+    maintainers = with pkgs.lib.maintainers; [ mdaiter ];
   };
 }

--- a/pkgs/development/tools/misc/ctags/wrapped.nix
+++ b/pkgs/development/tools/misc/ctags/wrapped.nix
@@ -1,6 +1,6 @@
 { pkgs, ctags }:
 
-with pkgs.stdenv.lib;
+with pkgs.lib;
 
 # define some ctags wrappers adding support for some not that common languages
 # customization:

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -407,7 +407,7 @@ self: super:
         export LLVM_CONFIG=${pkgs.llvm}/bin/llvm-config
       '';
 
-      __impureHostDeps = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "/usr/lib/libm.dylib" ];
+      __impureHostDeps = pkgs.lib.optionals pkgs.stdenv.isDarwin [ "/usr/lib/libm.dylib" ];
 
       passthru = old.passthru // { llvm = pkgs.llvm; };
     }

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -265,7 +265,7 @@ in
           meta = {
             description = "PageSpeed module for Nginx";
             homepage    = "https://developers.google.com/speed/pagespeed/module/";
-            license     = pkgs.stdenv.lib.licenses.asl20;
+            license     = pkgs.lib.licenses.asl20;
           };
         }
         ''

--- a/pkgs/servers/zigbee2mqtt/default.nix
+++ b/pkgs/servers/zigbee2mqtt/default.nix
@@ -15,7 +15,7 @@ package.override rec {
 
   passthru.tests.zigbee2mqtt = nixosTests.zigbee2mqtt;
 
-  meta = with pkgs.stdenv.lib; {
+  meta = with pkgs.lib; {
     description = "Zigbee to MQTT bridge using zigbee-shepherd";
     license = licenses.gpl3;
     homepage = https://github.com/Koenkk/zigbee2mqtt;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/108834

I chose the special `pkgs.stdenv.lib` case, because there should be no issues with `lib` not being in scope.