### PR TITLE
python3Packages.mulpyplexer: init at 0.08

### DIFF
--- a/pkgs/development/python-modules/mulpyplexer/default.nix
+++ b/pkgs/development/python-modules/mulpyplexer/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "mulpyplexer";
+  version = "0.08";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1zn5d1vyhfjp8x9z5mr9gv8m8gmi3s3jv3kqb790xzi1kqi0p4ya";
+  };
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "mulpyplexer" ];
+
+  meta = with lib; {
+    description = "Multiplex interactions with lists of Python objects";
+    homepage = "https://github.com/zardus/mulpyplexer";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4073,6 +4073,8 @@ in {
 
   mt-940 = callPackage ../development/python-modules/mt-940 { };
 
+  mulpyplexer = callPackage ../development/python-modules/mulpyplexer { };
+
   multidict = callPackage ../development/python-modules/multidict { };
 
   multi_key_dict = callPackage ../development/python-modules/multi_key_dict { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Multiplex interactions with lists of Python objects.

https://github.com/zardus/mulpyplexer

Initial PR: https://github.com/NixOS/nixpkgs/pull/68429 (was closed)

Related to to #67413

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
