### PR TITLE
various: mark as broken or fix

### DIFF
--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -84,6 +84,7 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
+    broken = true;  # Dashboard broken, other build failures.
     description = "A hyperparameter optimization framework";
     homepage = "https://optuna.org/";
     license = licenses.mit;

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -122,9 +122,10 @@ in buildPythonPackage {
   '';
 
   meta = with lib; {
+    broken = true;  # tf-probability 0.8.0 is not compatible with tensorflow 2.3.2
     description = "Library for probabilistic reasoning and statistical analysis";
     homepage = "https://www.tensorflow.org/probability/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ timokau ];
+    maintainers = with maintainers; [];  # This package is maintainerless.
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27821,6 +27821,7 @@ in
 
   mxnet = callPackage ../applications/science/math/mxnet {
     inherit (linuxPackages) nvidia_x11;
+    stdenv = gcc9Stdenv;
   };
 
   wxmaxima = callPackage ../applications/science/math/wxmaxima { wxGTK = wxGTK30; };


### PR DESCRIPTION
###### Motivation for this change

This either marks as broken or fixes various packages which are failing in nixpkgs-review builds of #108741, which are also broken at HEAD.

* mxnet: fix build since GCC10 stdenv bump by reverting to GCC9 to avoid linker errors (fix)
* python3Packages.cliff: remove version constraint on PrettyTable, add which to checkInputs (fix)
* python3Packages.tensorflow-probability: broken by a tensorflow upgrade, non-trivial to update (mark as broken)
* python3Packages,optuna: broken by lapack/BLAS changes, as well as sklearn upgrade (mark as broken)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
