### PR TITLE
doc: stdenv.lib -> lib

### DIFF
--- a/doc/languages-frameworks/lua.section.md
+++ b/doc/languages-frameworks/lua.section.md
@@ -181,7 +181,7 @@ luaposix = buildLuarocksPackage {
   disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
   propagatedBuildInputs = [ bit32 lua std_normalize ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/luaposix/luaposix/";
     description = "Lua bindings for POSIX";
     maintainers = with maintainers; [ vyp lblasc ];
@@ -243,4 +243,3 @@ Following rules should be respected:
 
 * Make sure libraries build for all Lua interpreters.
 * Commit names of Lua libraries should reflect that they are Lua libraries, so write for example `luaPackages.luafilesystem: 1.11 -> 1.12`.
-

--- a/doc/languages-frameworks/maven.section.md
+++ b/doc/languages-frameworks/maven.section.md
@@ -116,7 +116,7 @@ The first step will be to build the Maven project as a fixed-output derivation i
 > Traditionally the Maven repository is at `~/.m2/repository`. We will override this to be the `$out` directory.
 
 ```nix
-{ stdenv, maven }:
+{ stdenv, lib, maven }:
 stdenv.mkDerivation {
   name = "maven-repository";
   buildInputs = [ maven ];
@@ -139,7 +139,7 @@ stdenv.mkDerivation {
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   # replace this with the correct SHA256
-  outputHash = stdenv.lib.fakeSha256;
+  outputHash = lib.fakeSha256;
 }
 ```
 

--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -7,7 +7,7 @@ Given that most of the OCaml ecosystem is now built with dune, nixpkgs includes 
 Here is a simple package example. It defines an (optional) attribute `minimumOCamlVersion` that will be used to throw a descriptive evaluation error if building with an older OCaml is attempted. It uses the `fetchFromGitHub` fetcher to get its source. It sets the `doCheck` (optional) attribute to `true` which means that tests will be run with `dune runtest -p angstrom` after the build (`dune build -p angstrom`) is complete. It uses `alcotest` as a build input (because it is needed to run the tests) and `bigstringaf` and `result` as propagated build inputs (thus they will also be available to libraries depending on this library). The library will be installed using the `angstrom.install` file that dune generates.
 
 ```nix
-{ stdenv
+{ lib
 , fetchFromGitHub
 , buildDunePackage
 , alcotest
@@ -35,8 +35,8 @@ buildDunePackage rec {
   meta = {
     homepage = "https://github.com/inhabitedtype/angstrom";
     description = "OCaml parser combinators built for speed and memory efficiency";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sternenseemann ];
   };
 }
 ```
@@ -44,7 +44,7 @@ buildDunePackage rec {
 Here is a second example, this time using a source archive generated with `dune-release`. It is a good idea to use this archive when it is available as it will usually contain substituted variables such as a `%%VERSION%%` field. This library does not depend on any other OCaml library and no tests are run after building it.
 
 ```nix
-{ stdenv
+{ lib
 , fetchurl
 , buildDunePackage
 }:
@@ -60,7 +60,7 @@ buildDunePackage rec {
     sha256 = "1msg3vycd3k8qqj61sc23qks541cxpb97vrnrvrhjnqxsqnh6ygq";
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/flowtype/ocaml-wtf8";
     description = "WTF-8 is a superset of UTF-8 that allows unpaired surrogates.";
     license = licenses.mit;

--- a/doc/languages-frameworks/perl.section.md
+++ b/doc/languages-frameworks/perl.section.md
@@ -110,7 +110,7 @@ ClassC3Componentised = buildPerlPackage rec {
 On Darwin, if a script has too many `-Idir` flags in its first line (its “shebang line”), it will not run. This can be worked around by calling the `shortenPerlShebang` function from the `postInstall` phase:
 
 ```nix
-{ stdenv, buildPerlPackage, fetchurl, shortenPerlShebang }:
+{ stdenv, lib, buildPerlPackage, fetchurl, shortenPerlShebang }:
 
 ImageExifTool = buildPerlPackage {
   pname = "Image-ExifTool";
@@ -121,8 +121,8 @@ ImageExifTool = buildPerlPackage {
     sha256 = "0d8v48y94z8maxkmw1rv7v9m0jg2dc8xbp581njb6yhr7abwqdv3";
   };
 
-  buildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;
-  postInstall = stdenv.lib.optional stdenv.isDarwin ''
+  buildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+  postInstall = lib.optional stdenv.isDarwin ''
     shortenPerlShebang $out/bin/exiftool
   '';
 };
@@ -151,7 +151,7 @@ $ nix-generate-from-cpan XML::Simple
     propagatedBuildInputs = [ XMLNamespaceSupport XMLSAX XMLSAXExpat ];
     meta = {
       description = "An API for simple XML files";
-      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 ```

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "03wf9r2csi6jpa7v5sw5lpxkrk4wfzwmzx7k3991q3bdjzcwnnwp";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A fast line-oriented regex search tool, similar to ag and ack";
     homepage = "https://github.com/BurntSushi/ripgrep";
     license = licenses.unlicense;
@@ -58,13 +58,13 @@ then be taken from the failed build. A fake hash can be used for
 `cargoSha256` as follows:
 
 ```
-  cargoSha256 = stdenv.lib.fakeSha256;
+  cargoSha256 = lib.fakeSha256;
 ```
 
 For `cargoHash` you can use:
 
 ```
-  cargoHash = stdenv.lib.fakeHash;
+  cargoHash = lib.fakeHash;
 ```
 
 Per the instructions in the [Cargo Book](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)

--- a/doc/stdenv/meta.xml
+++ b/doc/stdenv/meta.xml
@@ -5,7 +5,7 @@
  <para>
   Nix packages can declare <emphasis>meta-attributes</emphasis> that contain information about a package such as a description, its homepage, its license, and so on. For instance, the GNU Hello package has a <varname>meta</varname> declaration like this:
 <programlisting>
-meta = with stdenv.lib; {
+meta = with lib; {
   description = "A program that produces a familiar, friendly greeting";
   longDescription = ''
     GNU Hello is a program that prints "Hello, world!" when you run it.
@@ -155,7 +155,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
       <itemizedlist>
        <listitem>
         <para>
-         Single license referenced by attribute (preferred) <literal>stdenv.lib.licenses.gpl3Only</literal>.
+         Single license referenced by attribute (preferred) <literal>lib.licenses.gpl3Only</literal>.
         </para>
        </listitem>
        <listitem>
@@ -170,7 +170,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
        </listitem>
        <listitem>
         <para>
-         Multiple licenses referenced by attribute (preferred) <literal>with stdenv.lib.licenses; [ asl20 free ofl ]</literal>.
+         Multiple licenses referenced by attribute (preferred) <literal>with lib.licenses; [ asl20 free ofl ]</literal>.
         </para>
        </listitem>
        <listitem>
@@ -211,9 +211,9 @@ hello-2.3  A program that produces a familiar, friendly greeting
      <para>
       The list of Nix platform types on which the package is supported. Hydra builds packages according to the platform specified. If no platform is specified, the package does not have prebuilt binaries. An example is:
 <programlisting>
-meta.platforms = stdenv.lib.platforms.linux;
+meta.platforms = lib.platforms.linux;
 </programlisting>
-      Attribute Set <varname>stdenv.lib.platforms</varname> defines <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/systems/doubles.nix"> various common lists</link> of platforms types.
+      Attribute Set <varname>lib.platforms</varname> defines <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/systems/doubles.nix"> various common lists</link> of platforms types.
      </para>
     </listitem>
    </varlistentry>
@@ -262,7 +262,7 @@ meta.platforms = stdenv.lib.platforms.linux;
      <para>
       The list of Nix platform types for which the Hydra instance at <literal>hydra.nixos.org</literal> will build the package. (Hydra is the Nix-based continuous build system.) It defaults to the value of <varname>meta.platforms</varname>. Thus, the only reason to set <varname>meta.hydraPlatforms</varname> is if you want <literal>hydra.nixos.org</literal> to build the package on a subset of <varname>meta.platforms</varname>, or not at all, e.g.
 <programlisting>
-meta.platforms = stdenv.lib.platforms.linux;
+meta.platforms = lib.platforms.linux;
 meta.hydraPlatforms = [];
 </programlisting>
      </para>
@@ -294,7 +294,7 @@ meta.hydraPlatforms = [];
   <title>Licenses</title>
 
   <para>
-   The <varname>meta.license</varname> attribute should preferrably contain a value from <varname>stdenv.lib.licenses</varname> defined in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix"> <filename>nixpkgs/lib/licenses.nix</filename></link>, or in-place license description of the same format if the license is unlikely to be useful in another expression.
+   The <varname>meta.license</varname> attribute should preferrably contain a value from <varname>lib.licenses</varname> defined in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix"> <filename>nixpkgs/lib/licenses.nix</filename></link>, or in-place license description of the same format if the license is unlikely to be useful in another expression.
   </para>
 
   <para>
@@ -302,7 +302,7 @@ meta.hydraPlatforms = [];
    <variablelist>
     <varlistentry>
      <term>
-      <varname>stdenv.lib.licenses.free</varname>, <varname>"free"</varname>
+      <varname>lib.licenses.free</varname>, <varname>"free"</varname>
      </term>
      <listitem>
       <para>
@@ -312,7 +312,7 @@ meta.hydraPlatforms = [];
     </varlistentry>
     <varlistentry>
      <term>
-      <varname>stdenv.lib.licenses.unfreeRedistributable</varname>, <varname>"unfree-redistributable"</varname>
+      <varname>lib.licenses.unfreeRedistributable</varname>, <varname>"unfree-redistributable"</varname>
      </term>
      <listitem>
       <para>
@@ -325,7 +325,7 @@ meta.hydraPlatforms = [];
     </varlistentry>
     <varlistentry>
      <term>
-      <varname>stdenv.lib.licenses.unfree</varname>, <varname>"unfree"</varname>
+      <varname>lib.licenses.unfree</varname>, <varname>"unfree"</varname>
      </term>
      <listitem>
       <para>
@@ -335,7 +335,7 @@ meta.hydraPlatforms = [];
     </varlistentry>
     <varlistentry>
      <term>
-      <varname>stdenv.lib.licenses.unfreeRedistributableFirmware</varname>, <varname>"unfree-redistributable-firmware"</varname>
+      <varname>lib.licenses.unfreeRedistributableFirmware</varname>, <varname>"unfree-redistributable-firmware"</varname>
      </term>
      <listitem>
       <para>

--- a/doc/stdenv/platform-notes.xml
+++ b/doc/stdenv/platform-notes.xml
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 stdenv.mkDerivation {
   name = "libfoo-1.2.3";
   # ...
-  makeFlags = stdenv.lib.optional stdenv.isDarwin "LDFLAGS=-Wl,-install_name,$(out)/lib/libfoo.dylib";
+  makeFlags = lib.optional stdenv.isDarwin "LDFLAGS=-Wl,-install_name,$(out)/lib/libfoo.dylib";
 }
 </programlisting>
    </listitem>

--- a/doc/using/configuration.xml
+++ b/doc/using/configuration.xml
@@ -157,7 +157,7 @@
      The following example configuration whitelists the licenses <literal>amd</literal> and <literal>wtfpl</literal>:
 <programlisting>
 {
-  whitelistedLicenses = with stdenv.lib.licenses; [ amd wtfpl ];
+  whitelistedLicenses = with lib.licenses; [ amd wtfpl ];
 }
 </programlisting>
     </para>
@@ -165,7 +165,7 @@
      The following example configuration blacklists the <literal>gpl3Only</literal> and <literal>agpl3Only</literal> licenses:
 <programlisting>
 {
-  blacklistedLicenses = with stdenv.lib.licenses; [ agpl3Only gpl3Only ];
+  blacklistedLicenses = with lib.licenses; [ agpl3Only gpl3Only ];
 }
 </programlisting>
     </para>


### PR DESCRIPTION
Part of: https://github.com/NixOS/nixpkgs/issues/108938

Changing the documentation to not refer to stdenv.lib is the first
step to make people use it directly.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
