### PR TITLE
Use mpi attribute consistently to provide a default MPI implementation 

### DIFF
--- a/doc/using/overlays.xml
+++ b/doc/using/overlays.xml
@@ -291,5 +291,40 @@ stdenv.mkDerivation {
 }
 </programlisting>
    </section>
+   <section xml:id="sec-overlays-alternatives-mpi">
+     <title>Switching the MPI implementation</title>
+     <para>
+       All programs that are built with
+       <link xlink:href="https://en.wikipedia.org/wiki/Message_Passing_Interface">MPI</link>
+       support use the generic attribute <varname>mpi</varname>
+       as an input. At the moment Nixpkgs natively provides two different
+       MPI implementations:
+       <itemizedlist>
+         <listitem>
+           <para>
+             <link xlink:href="https://www.open-mpi.org/">Open MPI</link>
+             (default), attribute name <varname>openmpi</varname>
+           </para>
+         </listitem>
+         <listitem>
+           <para>
+             <link xlink:href="https://www.mpich.org/">MPICH</link>,
+             attribute name <varname>mpich</varname>
+           </para>
+         </listitem>
+       </itemizedlist>
+     </para>
+     <para>
+       To provide MPI enabled applications that use <literal>MPICH</literal>, instead
+       of the default <literal>Open MPI</literal>, simply use the following overlay:
+     </para>
+     <programlisting>
+self: super:
+
+{
+  mpi = self.mpich;
+}
+     </programlisting>
+   </section>
  </section>
 </chapter>

--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -420,6 +420,26 @@ http://some.json-exporter.host:7979/probe?target=https://example.com/some/json/e
    </listitem>
    <listitem>
      <para>
+       The attribute <varname>mpi</varname> is now consistently used to
+       provide a default, system-wide MPI implementation.
+       The default implementation is openmpi, which has been used before by
+       all derivations affects by this change.
+       Note that all packages that have used <varname>mpi ? null</varname> in the input
+       for optional MPI builds, have been changed to the boolean input paramater
+       <varname>useMpi</varname> to enable building with MPI.
+
+       Building all packages with <varname>mpich</varname> instead
+       of the default <varname>openmpi</varname> can now be achived like this:
+       <programlisting>
+self: super:
+{
+ mpi = super.mpich;
+}
+       </programlisting>
+     </para>
+   </listitem>
+   <listitem>
+     <para>
       The Searx module has been updated with the ability to configure the
       service declaratively and uWSGI integration.
       The option <literal>services.searx.configFile</literal> has been renamed

--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -1,6 +1,6 @@
 { boost, cmake, fetchFromGitHub, ffmpeg, qtbase, qtx11extras,
   qttools, qtxmlpatterns, qtsvg, gdal, gfortran, libXt, makeWrapper,
-  mkDerivation, ninja, openmpi, python3, lib, stdenv, tbb, libGLU, libGL }:
+  mkDerivation, ninja, mpi, python3, lib, stdenv, tbb, libGLU, libGL }:
 
 mkDerivation rec {
   pname = "paraview";
@@ -65,7 +65,7 @@ mkDerivation rec {
   buildInputs = [
     libGLU libGL
     libXt
-    openmpi
+    mpi
     tbb
     boost
     ffmpeg

--- a/pkgs/applications/science/biology/migrate/default.nix
+++ b/pkgs/applications/science/biology/migrate/default.nix
@@ -1,4 +1,4 @@
-{ gccStdenv, fetchurl, zlib, openmpi }:
+{ gccStdenv, fetchurl, zlib, mpi }:
 
 gccStdenv.mkDerivation rec {
   version = "3.7.2";
@@ -9,7 +9,7 @@ gccStdenv.mkDerivation rec {
     sha256 = "1p2364ffjc56i82snzvjpy6pkf6wvqwvlvlqxliscx2c303fxs8v";
   };
 
-  buildInputs = [ zlib openmpi ];
+  buildInputs = [ zlib mpi ];
   setSourceRoot = ''sourceRoot=$(echo */src)'';
   buildFlags = [ "thread" "mpis" ];
   preInstall = "mkdir -p $out/man/man1";

--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -8,7 +8,8 @@
 , readline
 , which
 , python ? null
-, mpi ? null
+, useMpi ? false
+, mpi
 , iv
 }:
 
@@ -17,7 +18,8 @@ stdenv.mkDerivation rec {
   version = "7.5";
 
   nativeBuildInputs = [ which pkg-config automake autoconf libtool ];
-  buildInputs = [ ncurses readline python mpi iv ];
+  buildInputs = [ ncurses readline python iv ]
+    ++ lib.optional useMpi mpi;
 
   src = fetchurl {
     url = "https://www.neuron.yale.edu/ftp/neuron/versions/v${version}/nrn-${version}.tar.gz";
@@ -54,7 +56,7 @@ stdenv.mkDerivation rec {
   configureFlags = with lib;
                     [ "--with-readline=${readline}" "--with-iv=${iv}" ]
                     ++  optionals (python != null)  [ "--with-nrnpython=${python.interpreter}" ]
-                    ++ (if mpi != null then ["--with-mpi" "--with-paranrn"]
+                    ++ (if useMpi then ["--with-mpi" "--with-paranrn"]
                         else ["--without-mpi"]);
 
 
@@ -84,4 +86,3 @@ stdenv.mkDerivation rec {
     platforms   = platforms.x86_64 ++ platforms.i686;
   };
 }
-

--- a/pkgs/applications/science/biology/raxml/default.nix
+++ b/pkgs/applications/science/biology/raxml/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv
 , fetchFromGitHub
-, pkgs
-, mpi ? false
+, useMpi ? false
+, mpi
 }:
 
 stdenv.mkDerivation rec {
@@ -15,16 +15,16 @@ stdenv.mkDerivation rec {
     sha256 = "1jqjzhch0rips0vp04prvb8vmc20c5pdmsqn8knadcf91yy859fh";
   };
 
-  buildInputs = lib.optionals mpi [ pkgs.openmpi ];
+  buildInputs = lib.optionals useMpi [ mpi ];
 
   # TODO darwin, AVX and AVX2 makefile targets
-  buildPhase = if mpi then ''
+  buildPhase = if useMpi then ''
       make -f Makefile.MPI.gcc
     '' else ''
       make -f Makefile.SSE3.PTHREADS.gcc
     '';
 
-  installPhase = if mpi then ''
+  installPhase = if useMpi then ''
     mkdir -p $out/bin && cp raxmlHPC-MPI $out/bin
   '' else ''
     mkdir -p $out/bin && cp raxmlHPC-PTHREADS-SSE3 $out/bin

--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitLab, cmake, gfortran, perl
 , openblas, hdf5-cpp, python3, texlive
-, armadillo, openmpi, globalarrays, openssh
+, armadillo, mpi, globalarrays, openssh
 , makeWrapper, fetchpatch
 } :
 
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
     hdf5-cpp
     python
     armadillo
-    openmpi
+    mpi
     globalarrays
     openssh
   ];

--- a/pkgs/applications/science/chemistry/quantum-espresso/default.nix
+++ b/pkgs/applications/science/chemistry/quantum-espresso/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl
 , gfortran, fftw, blas, lapack
-, mpi ? null
+, useMpi ? false
+, mpi
 }:
 
 stdenv.mkDerivation rec {
@@ -21,9 +22,9 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ fftw blas lapack gfortran ]
-    ++ (lib.optionals (mpi != null) [ mpi ]);
+    ++ (lib.optionals useMpi [ mpi ]);
 
-configureFlags = if (mpi != null) then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
+configureFlags = if useMpi then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
 
   makeFlags = [ "all" ];
 

--- a/pkgs/applications/science/chemistry/siesta/default.nix
+++ b/pkgs/applications/science/chemistry/siesta/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl
-, gfortran, blas, lapack
-, mpi ? null, scalapack
+, gfortran, blas, lapack, scalapack
+, useMpi ? false
+, mpi
 }:
 
 stdenv.mkDerivation {
@@ -17,7 +18,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ blas lapack gfortran ]
-    ++ (lib.optionals (mpi != null) [ mpi scalapack ]);
+    ++ lib.optionals useMpi [ mpi scalapack ];
 
   enableParallelBuilding = true;
 
@@ -29,7 +30,7 @@ stdenv.mkDerivation {
     cp gfortran.make arch.make
   '';
 
-  preBuild = if (mpi != null) then ''
+  preBuild = if useMpi then ''
     makeFlagsArray=(
         CC="mpicc" FC="mpifort"
         FPPFLAGS="-DMPI" MPI_INTERFACE="libmpi_f90.a" MPI_INCLUDE="."

--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -11,16 +11,15 @@
 , cmake
 , octave
 , gl2ps
+, mpi
 , withQcsxcad ? true
 , withMPI ? false
 , withHyp2mat ? true
 , qcsxcad ? null
-, openmpi ? null
 , hyp2mat ? null
 }:
 
 assert withQcsxcad -> qcsxcad != null;
-assert withMPI -> openmpi != null;
 assert withHyp2mat -> hyp2mat != null;
 
 stdenv.mkDerivation {
@@ -50,7 +49,7 @@ stdenv.mkDerivation {
     csxcad
     (octave.override { inherit hdf5; }) ]
     ++ lib.optionals withQcsxcad [ qcsxcad ]
-    ++ lib.optionals withMPI [ openmpi ]
+    ++ lib.optionals withMPI [ mpi ]
     ++ lib.optionals withHyp2mat [ hyp2mat ];
 
   postFixup = ''

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchgit, fetchFromGitHub, cmake
-, openblas, blas, lapack, opencv3, libzip, boost, protobuf, openmpi
+, openblas, blas, lapack, opencv3, libzip, boost, protobuf, mpi
 , onebitSGDSupport ? false
 , cudaSupport ? false, addOpenGLRunpath, cudatoolkit, nvidia_x11
 , cudnnSupport ? cudaSupport, cudnn
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   # Force OpenMPI to use g++ in PATH.
   OMPI_CXX = "g++";
 
-  buildInputs = [ openblas opencv3 libzip boost protobuf openmpi ]
+  buildInputs = [ openblas opencv3 libzip boost protobuf mpi ]
              ++ lib.optional cudaSupport cudatoolkit
              ++ lib.optional cudnnSupport cudnn;
 
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     "--with-openblas=${openblas}"
     "--with-boost=${boost.dev}"
     "--with-protobuf=${protobuf}"
-    "--with-mpi=${openmpi}"
+    "--with-mpi=${mpi}"
     "--cuda=${if cudaSupport then "yes" else "no"}"
     # FIXME
     "--asgd=no"

--- a/pkgs/applications/science/math/getdp/default.nix
+++ b/pkgs/applications/science/math/getdp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, cmake, gfortran, blas, lapack, openmpi, petsc, python3 }:
+{ lib, stdenv, fetchurl, cmake, gfortran, blas, lapack, mpi, petsc, python3 }:
 
 stdenv.mkDerivation rec {
   name = "getdp-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake gfortran ];
-  buildInputs = [ blas lapack openmpi petsc python3 ];
+  buildInputs = [ blas lapack mpi petsc python3 ];
 
   meta = with lib; {
     description = "A General Environment for the Treatment of Discrete Problems";

--- a/pkgs/applications/science/math/scotch/default.nix
+++ b/pkgs/applications/science/math/scotch/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchurl, bison, openmpi, flex, zlib}:
+{ lib, stdenv, fetchurl, bison, mpi, flex, zlib}:
 
 stdenv.mkDerivation rec {
   version = "6.0.4";
   pname = "scotch";
   src_name = "scotch_${version}";
 
-  buildInputs = [ bison openmpi flex zlib ];
+  buildInputs = [ bison mpi flex zlib ];
 
   src = fetchurl {
     url = "https://gforge.inria.fr/frs/download.php/file/34618/${src_name}.tar.gz";

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -3,10 +3,10 @@
 , cmake
 , hwloc
 , fftw
-, openmpi
 , perl
 , singlePrec ? true
 , mpiEnabled ? false
+, mpi
 , cpuAcceleration ? null
 }:
 
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ fftw perl hwloc ]
-  ++ (lib.optionals mpiEnabled [ openmpi ]);
+  ++ (lib.optionals mpiEnabled [ mpi ]);
 
   cmakeFlags = [
     "-DGMX_SIMD:STRING=${SIMD cpuAcceleration}"

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , libpng, gzip, fftw, blas, lapack
-, mpi ? null
+, withMPI ? false
+, mpi
 }:
 let packages = [
      "asphere" "body" "class2" "colloid" "compress" "coreshell"
@@ -8,7 +9,6 @@ let packages = [
      "opt" "peri" "qeq" "replica" "rigid" "shock" "snap" "srd" "user-reaxc"
     ];
     lammps_includes = "-DLAMMPS_EXCEPTIONS -DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64";
-    withMPI = (mpi != null);
 in
 stdenv.mkDerivation rec {
   # LAMMPS has weird versioning converted to ISO 8601 format

--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, git, gfortran, openmpi, blas, liblapack, qt4, qwt6_qt4, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, cmake, git, gfortran, mpi, blas, liblapack, qt4, qwt6_qt4, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "elmerfem";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ cmake pkg-config git ];
-  buildInputs = [ gfortran openmpi blas liblapack qt4 qwt6_qt4 ];
+  buildInputs = [ gfortran mpi blas liblapack qt4 qwt6_qt4 ];
 
   preConfigure = ''
     patchShebangs ./

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -14,7 +14,8 @@
 , enableNumpy ? false
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
 , patches ? []
-, mpi ? null
+, useMpi ? false
+, mpi
 , extraB2Args ? []
 
 # Attributes inherit from specific versions
@@ -94,7 +95,7 @@ let
     ++ optional (variant == "release") "debug-symbols=off"
     ++ optional (toolset != null) "toolset=${toolset}"
     ++ optional (!enablePython) "--without-python"
-    ++ optional (mpi != null || stdenv.hostPlatform != stdenv.buildPlatform) "--user-config=user-config.jam"
+    ++ optional (useMpi || stdenv.hostPlatform != stdenv.buildPlatform) "--user-config=user-config.jam"
     ++ optionals (stdenv.hostPlatform.libc == "msvcrt") [
     "threadapi=win32"
   ] ++ extraB2Args
@@ -140,7 +141,7 @@ stdenv.mkDerivation {
         substituteInPlace tools/build/src/tools/clang-darwin.jam \
           --replace '@rpath/$(<[1]:D=)' "$out/lib/\$(<[1]:D=)";
     fi;
-  '' + optionalString (mpi != null) ''
+  '' + optionalString useMpi ''
     cat << EOF >> user-config.jam
     using mpi : ${mpi}/bin/mpiCC ;
     EOF

--- a/pkgs/development/libraries/globalarrays/default.nix
+++ b/pkgs/development/libraries/globalarrays/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchpatch, fetchFromGitHub, autoreconfHook
-, blas, gfortran, openssh, openmpi
+, blas, gfortran, openssh, mpi
 } :
 
 let
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ openmpi blas gfortran openssh ];
+  buildInputs = [ mpi blas gfortran openssh ];
 
   preConfigure = ''
     configureFlagsArray+=( "--enable-i8" \

--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, gcc, boost, eigen, libxml2, openmpi, python3, petsc }:
+{ lib, stdenv, fetchFromGitHub, cmake, gcc, boost, eigen, libxml2, mpi, python3, petsc }:
 
 stdenv.mkDerivation rec {
   pname = "precice";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = lib.optional stdenv.isDarwin [ "-D_GNU_SOURCE" ];
 
   nativeBuildInputs = [ cmake gcc ];
-  buildInputs = [ boost eigen libxml2 openmpi python3 python3.pkgs.numpy ];
+  buildInputs = [ boost eigen libxml2 mpi python3 python3.pkgs.numpy ];
 
   meta = {
     description = "preCICE stands for Precise Code Interaction Coupling Environment";

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
     # make sure the test starts even if we have less than 4 cores
     export OMPI_MCA_rmaps_base_oversubscribe=1
 
+    # Fix to make mpich run in a sandbox
+    export HYDRA_IFACE=lo
+
     # Run single threaded
     export OMP_NUM_THREADS=1
 

--- a/pkgs/development/python-modules/cntk/default.nix
+++ b/pkgs/development/python-modules/cntk/default.nix
@@ -3,7 +3,7 @@
 , pkgs
 , numpy
 , scipy
-, openmpi
+, mpi
 , enum34
 , protobuf
 , pip
@@ -17,8 +17,8 @@ in
 buildPythonPackage {
   inherit (cntk) name version src;
 
-  nativeBuildInputs = [ swig openmpi ];
-  buildInputs = [ cntk openmpi ];
+  nativeBuildInputs = [ swig mpi ];
+  buildInputs = [ cntk mpi ];
   propagatedBuildInputs = [ numpy scipy enum34 protobuf pip ];
 
   CNTK_LIB_PATH = "${cntk}/lib";
@@ -28,7 +28,7 @@ buildPythonPackage {
 
   postPatch = ''
     cd bindings/python
-    sed -i 's,"libmpi.so.12","${openmpi}/lib/libmpi.so",g' cntk/train/distributed.py
+    sed -i 's,"libmpi.so.12","${mpi}/lib/libmpi.so",g' cntk/train/distributed.py
 
     # Remove distro and libs checks; they aren't compatible with NixOS and besides we guarantee
     # compatibility by providing a package.

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, buildPythonPackage, python,
   cudaSupport ? false, cudatoolkit ? null, cudnn ? null, nccl ? null, magma ? null,
   mklDnnSupport ? true, useSystemNccl ? true,
-  openMPISupport ? false, openmpi ? null,
+  MPISupport ? false, mpi,
   buildDocs ? false,
   cudaArchList ? null,
 
@@ -29,8 +29,6 @@
 
   isPy3k, pythonOlder }:
 
-assert !openMPISupport || openmpi != null;
-
 # assert that everything needed for cuda is present and that the correct cuda versions are used
 assert !cudaSupport || cudatoolkit != null;
 assert cudnn == null || cudatoolkit != null;
@@ -38,7 +36,7 @@ assert !cudaSupport || (let majorIs = lib.versions.major cudatoolkit.version;
                         in majorIs == "9" || majorIs == "10" || majorIs == "11");
 
 # confirm that cudatoolkits are sync'd across dependencies
-assert !(openMPISupport && cudaSupport) || openmpi.cudatoolkit == cudatoolkit;
+assert !(MPISupport && cudaSupport) || mpi.cudatoolkit == cudatoolkit;
 assert !cudaSupport || magma.cudatoolkit == cudatoolkit;
 
 let
@@ -224,7 +222,7 @@ in buildPythonPackage rec {
     typing-extensions
     # the following are required for tensorboard support
     pillow six future tensorflow-tensorboard protobuf
-  ] ++ lib.optionals openMPISupport [ openmpi ]
+  ] ++ lib.optionals MPISupport [ mpi ]
     ++ lib.optionals (pythonOlder "3.7") [ dataclasses ];
 
   checkInputs = [ hypothesis ninja psutil ];

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -11,7 +11,7 @@
 # Common deps
 , git, pybind11, which, binutils, glibcLocales, cython, perl
 # Common libraries
-, jemalloc, openmpi, gast, grpc, sqlite, boringssl, jsoncpp
+, jemalloc, mpi, gast, grpc, sqlite, boringssl, jsoncpp
 , curl, snappy, flatbuffers-core, lmdb-core, icu, double-conversion, libpng, libjpeg_turbo, giflib
 # Upsteam by default includes cuda support since tensorflow 1.15. We could do
 # that in nix as well. It would make some things easier and less confusing, but
@@ -129,7 +129,7 @@ let
 
     buildInputs = [
       jemalloc
-      openmpi
+      mpi
       glibcLocales
       git
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -237,7 +237,7 @@ let
     BayesSAE = [ pkgs.gsl_1 ];
     BayesVarSel = [ pkgs.gsl_1 ];
     BayesXsrc = [ pkgs.readline.dev pkgs.ncurses ];
-    bigGP = [ pkgs.openmpi ];
+    bigGP = [ pkgs.mpi ];
     bio3d = [ pkgs.zlib ];
     BiocCheck = [ pkgs.which ];
     Biostrings = [ pkgs.zlib ];
@@ -284,8 +284,8 @@ let
     n1qn1 = [ pkgs.gfortran ];
     odbc = [ pkgs.unixODBC ];
     pander = [ pkgs.pandoc pkgs.which ];
-    pbdMPI = [ pkgs.openmpi ];
-    pbdPROF = [ pkgs.openmpi ];
+    pbdMPI = [ pkgs.mpi ];
+    pbdPROF = [ pkgs.mpi ];
     pbdZMQ = lib.optionals stdenv.isDarwin [ pkgs.which ];
     pdftools = [ pkgs.poppler.dev ];
     phytools = [ pkgs.which ];
@@ -309,14 +309,14 @@ let
     RGtk2 = [ pkgs.gtk2.dev ];
     rhdf5 = [ pkgs.zlib ];
     Rhdf5lib = [ pkgs.zlib ];
-    Rhpc = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.openmpi pkgs.pcre.dev ];
+    Rhpc = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.mpi pkgs.pcre.dev ];
     Rhtslib = [ pkgs.zlib.dev pkgs.automake pkgs.autoconf pkgs.bzip2.dev pkgs.lzma.dev pkgs.curl.dev ];
     rjags = [ pkgs.jags ];
     rJava = [ pkgs.zlib pkgs.bzip2.dev pkgs.icu pkgs.lzma.dev pkgs.pcre.dev pkgs.jdk pkgs.libzip ];
     Rlibeemd = [ pkgs.gsl_1 ];
     rmatio = [ pkgs.zlib.dev ];
     Rmpfr = [ pkgs.gmp pkgs.mpfr.dev ];
-    Rmpi = [ pkgs.openmpi ];
+    Rmpi = [ pkgs.mpi ];
     RMySQL = [ pkgs.zlib pkgs.libmysqlclient pkgs.openssl.dev ];
     RNetCDF = [ pkgs.netcdf pkgs.udunits ];
     RODBC = [ pkgs.libiodbc ];

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides.nix
@@ -245,7 +245,7 @@ self: super:
 
   horovod = super.horovod.overridePythonAttrs (
     old: {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.openmpi ];
+      propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.mpi ];
     }
   );
 
@@ -528,14 +528,14 @@ self: super:
             { }
             {
               mpi = {
-                mpicc = "${pkgs.openmpi.outPath}/bin/mpicc";
+                mpicc = "${pkgs.mpi.outPath}/bin/mpicc";
               };
             }
         );
       };
     in
     {
-      propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.openmpi ];
+      propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.mpi ];
       enableParallelBuilding = true;
       preBuild = ''
         ln -sf ${cfg} mpi.cfg

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -5,13 +5,14 @@
 , gfortran ? null
 , zlib ? null
 , szip ? null
-, mpi ? null
+, mpiSupport ? false
+, mpi
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
 # cpp and mpi options are mutually exclusive
 # (--enable-unsupported could be used to force the build)
-assert !cpp || mpi == null;
+assert !cpp || !mpiSupport;
 
 let inherit (lib) optional optionals; in
 
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    mpiSupport = (mpi != null);
+    inherit mpiSupport;
     inherit mpi;
   };
 
@@ -38,13 +39,13 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = []
     ++ optional (zlib != null) zlib
-    ++ optional (mpi != null) mpi;
+    ++ optional mpiSupport mpi;
 
   configureFlags = []
     ++ optional cpp "--enable-cxx"
     ++ optional (gfortran != null) "--enable-fortran"
     ++ optional (szip != null) "--with-szlib=${szip}"
-    ++ optionals (mpi != null) ["--enable-parallel" "CC=${mpi}/bin/mpicc"]
+    ++ optionals mpiSupport ["--enable-parallel" "CC=${mpi}/bin/mpicc"]
     ++ optional enableShared "--enable-shared";
 
   patches = [

--- a/pkgs/tools/misc/hpcg/default.nix
+++ b/pkgs/tools/misc/hpcg/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openmpi } :
+{ lib, stdenv, fetchurl, mpi } :
 
 stdenv.mkDerivation rec {
   pname = "hpcg";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ openmpi ];
+  buildInputs = [ mpi ];
 
   makeFlags = [ "arch=Linux_MPI" ];
 

--- a/pkgs/tools/system/ior/default.nix
+++ b/pkgs/tools/system/ior/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, openmpi, perl, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, mpi, perl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "ior";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ openmpi perl ];
+  buildInputs = [ mpi perl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4975,12 +4975,11 @@ in
   hdf5 = callPackage ../tools/misc/hdf5 {
     gfortran = null;
     szip = null;
-    mpi = null;
   };
 
   hdf5-mpi = appendToName "mpi" (hdf5.override {
     szip = null;
-    mpi = pkgs.openmpi;
+    mpiSupport = true;
   });
 
   hdf5-cpp = appendToName "cpp" (hdf5.override {
@@ -7215,6 +7214,8 @@ in
   rtmidi = callPackage ../development/libraries/audio/rtmidi { };
 
   openmpi = callPackage ../development/libraries/openmpi { };
+
+  mpi = openmpi; # this attribute should used to build MPI applications
 
   ucx = callPackage ../development/libraries/ucx {};
 
@@ -22092,9 +22093,7 @@ in
 
   fractal = callPackage ../applications/networking/instant-messengers/fractal { };
 
-  freecad = libsForQt5.callPackage ../applications/graphics/freecad {
-    mpi = openmpi;
-  };
+  freecad = libsForQt5.callPackage ../applications/graphics/freecad { };
 
   freemind = callPackage ../applications/misc/freemind {
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
@@ -22480,7 +22479,7 @@ in
 
   hpcg = callPackage ../tools/misc/hpcg/default.nix { };
 
-  hpl = callPackage ../tools/misc/hpl { mpi = openmpi; };
+  hpl = callPackage ../tools/misc/hpl { };
 
   hpmyroom = libsForQt5.callPackage ../applications/networking/hpmyroom { };
 
@@ -27254,15 +27253,11 @@ in
 
   quantum-espresso = callPackage ../applications/science/chemistry/quantum-espresso { };
 
-  quantum-espresso-mpi = callPackage ../applications/science/chemistry/quantum-espresso {
-     mpi = openmpi;
-  };
+  quantum-espresso-mpi = callPackage ../applications/science/chemistry/quantum-espresso { useMpi = true; };
 
   siesta = callPackage ../applications/science/chemistry/siesta { };
 
-  siesta-mpi = callPackage ../applications/science/chemistry/siesta {
-     mpi = openmpi;
-  };
+  siesta-mpi = callPackage ../applications/science/chemistry/siesta { useMpi = true; };
 
   ### SCIENCE/GEOMETRY
 
@@ -27393,7 +27388,7 @@ in
   };
 
   neuron-mpi = appendToName "mpi" (neuron.override {
-    mpi = pkgs.openmpi;
+    useMpi = true;
   });
 
   neuron-full = neuron-mpi.override { inherit python; };
@@ -27445,7 +27440,7 @@ in
   raxml = callPackage ../applications/science/biology/raxml { };
 
   raxml-mpi = appendToName "mpi" (raxml.override {
-    mpi = true;
+    useMpi = true;
   });
 
   sambamba = callPackage ../applications/science/biology/sambamba { };
@@ -27567,9 +27562,7 @@ in
 
   planarity = callPackage ../development/libraries/science/math/planarity { };
 
-  scalapack = callPackage ../development/libraries/science/math/scalapack {
-    mpi = openmpi;
-  };
+  scalapack = callPackage ../development/libraries/science/math/scalapack { };
 
   rankwidth = callPackage ../development/libraries/science/math/rankwidth { };
 
@@ -27599,9 +27592,7 @@ in
 
   petsc = callPackage ../development/libraries/science/math/petsc { };
 
-  parmetis = callPackage ../development/libraries/science/math/parmetis {
-    mpi = openmpi;
-  };
+  parmetis = callPackage ../development/libraries/science/math/parmetis { };
 
   QuadProgpp = callPackage ../development/libraries/science/math/QuadProgpp { };
 
@@ -27631,17 +27622,13 @@ in
 
   ### SCIENCE/MOLECULAR-DYNAMICS
 
-  dl-poly-classic-mpi = callPackage ../applications/science/molecular-dynamics/dl-poly-classic {
-    mpi = openmpi;
-  };
+  dl-poly-classic-mpi = callPackage ../applications/science/molecular-dynamics/dl-poly-classic { };
 
   lammps = callPackage ../applications/science/molecular-dynamics/lammps {
     fftw = fftw;
   };
 
-  lammps-mpi = lowPrio (lammps.override {
-    mpi = openmpi;
-  });
+  lammps-mpi = lowPrio (lammps.override { withMPI = true; });
 
   gromacs = callPackage ../applications/science/molecular-dynamics/gromacs {
     singlePrec = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2184,7 +2184,6 @@ in {
 
   fenics = callPackage ../development/libraries/science/math/fenics {
     inherit (pkgs) pkg-config;
-    mpi = pkgs.openmpi;
     pytest = self.pytest_4;
   };
 
@@ -3486,7 +3485,7 @@ in {
 
   labelbox = callPackage ../development/python-modules/labelbox { };
 
-  lammps-cython = callPackage ../development/python-modules/lammps-cython { mpi = pkgs.openmpi; };
+  lammps-cython = callPackage ../development/python-modules/lammps-cython { mpi = pkgs.mpi; };
 
   langcodes = callPackage ../development/python-modules/langcodes { };
 
@@ -4120,7 +4119,7 @@ in {
 
   mpd = callPackage ../development/python-modules/mpd { };
 
-  mpi4py = callPackage ../development/python-modules/mpi4py { mpi = pkgs.openmpi; };
+  mpi4py = callPackage ../development/python-modules/mpi4py { mpi = pkgs.mpi; };
 
   mplleaflet = callPackage ../development/python-modules/mplleaflet { };
 


### PR DESCRIPTION
###### Motivation for this change
All programs that need MPI libraries are using `openmpi` at the moment. However, some use `openmpi` directly while recent additions tended to use `mpi = openmpi` as input parameter. The change in this PR now makes consistent use of `mpi` as an input parameter for all derivations that use MPI. This allows for an easy, system-wide switch by simply overriding the `mpi`attribute via overlays, e.g.:
```
self: super:
{
  mpi = self.mpich;
}
```
This follows the idea of  https://github.com/NixOS/nixpkgs/pull/83888.

###### Things done
* Replaced all inputs openmpi -> mpi
* added `mpi = openmpi;` to `top-level/all-packages.nix`
* Where `mpi ? null` for optional building has been used, the option `useMpi ? false` has been added.
* Added a comment to the release notes, as the change from the previous point may break private overlays.
* Added a paragraph to the nixpkgs manual. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 Run `mpi = openmpi` and partially for `mpi = mpich`.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
