### PR TITLE
python3Packages.teslajsonpy: init at 0.10.4

### DIFF
--- a/pkgs/development/python-modules/teslajsonpy/default.nix
+++ b/pkgs/development/python-modules/teslajsonpy/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, aiohttp
+, backoff
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, wrapt
+}:
+
+buildPythonPackage rec {
+  pname = "teslajsonpy";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "zabuldon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "18frynmy47i9c24mdy819y2dnjwmhnmkly5mbmhikpbmm6d0yjf1";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    backoff
+    wrapt
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # Not all Home Assistant related check pass
+  disabledTests = [ "test_values_on_init" ];
+  pythonImportsCheck = [ "teslajsonpy" ];
+
+  meta = with lib; {
+    description = "Python library to work with Tesla API";
+    homepage = "https://github.com/zabuldon/teslajsonpy";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -828,7 +828,7 @@
     "temper" = ps: with ps; [ ]; # missing inputs: temperusb
     "template" = ps: with ps; [ ];
     "tensorflow" = ps: with ps; [ numpy pillow tensorflow-build_2 ]; # missing inputs: pycocotools tf-models-official
-    "tesla" = ps: with ps; [ ]; # missing inputs: teslajsonpy
+    "tesla" = ps: with ps; [ teslajsonpy ];
     "tfiac" = ps: with ps; [ ]; # missing inputs: pytfiac
     "thermoworks_smoke" = ps: with ps; [ stringcase ]; # missing inputs: thermoworks_smoke
     "thethingsnetwork" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7420,6 +7420,8 @@ in {
 
   termstyle = callPackage ../development/python-modules/termstyle { };
 
+  teslajsonpy = callPackage ../development/python-modules/teslajsonpy { };
+
   tess = callPackage ../development/python-modules/tess { };
 
   tesserocr = callPackage ../development/python-modules/tesserocr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to work with Tesla API.

https://github.com/zabuldon/teslajsonpy

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
