### PR TITLE
psw: init at 0.1.2

### DIFF
--- a/pkgs/tools/misc/psw/default.nix
+++ b/pkgs/tools/misc/psw/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "psw";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "Wulfsta";
+    repo = pname;
+    rev = version;
+    sha256 = "10raj4899i01f5v13w0wxdnjjicql2wjblkq1zcagrfv3ly3d0fy";
+  };
+
+  cargoSha256 = "1w18rym0xnjk7vhrb2dc4cvhg659zbq5d2153gw2snxcbs7gh7r1";
+
+  meta = with lib; {
+    description = "A command line tool to write random bytes to stdout";
+    homepage = "https://github.com/Wulfsta/psw";
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ wulfsta ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6882,6 +6882,8 @@ in
     openssl = openssl_1_0_2;
   };
 
+  psw = callPackage ../tools/misc/psw { };
+
   pws = callPackage ../tools/misc/pws { };
 
   cntlm = callPackage ../tools/networking/cntlm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add `psw`. Full disclosure, I wrote this tool. I needed a source of randomness quicker than `/dev/urandom` that was not suited for cryptographic purposes, and since I packaged it for NixOS I figured I'd submit a PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
