### PR TITLE
nixos/plasma5: add kwinPackage option and kwin-lowlatency package

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -153,6 +153,14 @@ in
         description = "Enable the Plasma 5 (KDE 5) desktop environment.";
       };
 
+      kwinPackage = mkOption {
+        type = types.package;
+        default = pkgs.kwin;
+        defaultText = "pkgs.kwin";
+        example = literalExample "pkgs.kwin-lowlatency";
+        description = "KWin package to use.";
+      };
+
       phononBackend = mkOption {
         type = types.enum [ "gstreamer" "vlc" ];
         default = "gstreamer";
@@ -201,7 +209,7 @@ in
         kcheckpass.source = "${lib.getBin plasma5.kscreenlocker}/libexec/kcheckpass";
         start_kdeinit.source = "${lib.getBin pkgs.kdeFrameworks.kinit}/libexec/kf5/start_kdeinit";
         kwin_wayland = {
-          source = "${lib.getBin plasma5.kwin}/bin/kwin_wayland";
+          source = "${lib.getBin cfg.kwinPackage}/bin/kwin_wayland";
           capabilities = "cap_sys_nice+ep";
         };
       };
@@ -274,7 +282,6 @@ in
           kscreenlocker
           ksysguard
           kwayland
-          kwin
           kwrited
           libkscreen
           libksysguard
@@ -284,6 +291,7 @@ in
           polkit-kde-agent
           spectacle
           systemsettings
+          cfg.kwinPackage
 
           plasma-desktop
           plasma-workspace

--- a/pkgs/desktops/plasma-5/3rdparty/kwin/kwin-lowlatency.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/kwin/kwin-lowlatency.nix
@@ -3,10 +3,10 @@
 let
   pname = "kwin-lowlatency";
   version = "5.20.5";
-in kwin.overrideAttrs (o: {
+in kwin.overrideAttrs (oldAttrs: {
   name = "${pname}-${version}";
 
-  patches = (o.patches or [ ]) ++ [
+  patches = (oldAttrs.patches or [ ]) ++ [
     (fetchpatch {
       url = "https://tildearrow.org/storage/kwin-lowlatency/kwin-lowlatency-${version}.patch";
       sha256 = "14lzv38kkypqjwgdcd8f7lm7366y7cj08l3lh8qq1b49pza0zb2w";

--- a/pkgs/desktops/plasma-5/3rdparty/kwin/kwin-lowlatency.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/kwin/kwin-lowlatency.nix
@@ -1,0 +1,15 @@
+{ kwin, fetchpatch }:
+
+let
+  pname = "kwin-lowlatency";
+  version = "5.20.5";
+in kwin.overrideAttrs (o: {
+  name = "${pname}-${version}";
+
+  patches = (o.patches or [ ]) ++ [
+    (fetchpatch {
+      url = "https://tildearrow.org/storage/kwin-lowlatency/kwin-lowlatency-${version}.patch";
+      sha256 = "14lzv38kkypqjwgdcd8f7lm7366y7cj08l3lh8qq1b49pza0zb2w";
+    })
+  ];
+})

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -143,6 +143,7 @@ let
 
       thirdParty = let inherit (libsForQt5) callPackage; in {
         plasma-applet-caffeine-plus = callPackage ./3rdparty/addons/caffeine-plus.nix { };
+        kwin-lowlatency = callPackage ./3rdparty/kwin/kwin-lowlatency.nix { };
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -851,6 +851,7 @@ mapAliases ({
   ;
   inherit (plasma5.thirdParty)
     plasma-applet-caffeine-plus
+    kwin-lowlatency
     kwin-dynamic-workspaces
     kwin-tiling
     krohnkite

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15845,7 +15845,7 @@ in
     ;
 
     inherit ((plasma5.override { libsForQt5 = self; }).thirdParty)
-      plasma-applet-caffeine-plus kwin-dynamic-workspaces kwin-tiling krohnkite
+      plasma-applet-caffeine-plus kwin-lowlatency kwin-dynamic-workspaces kwin-tiling krohnkite
     ;
 
     ### KDE APPLICATIONS


### PR DESCRIPTION
###### Motivation for this change

This is my attempt at https://github.com/NixOS/nixpkgs/pull/101041, since the original PR has not been updated in a while. It introduces an option `services.xserver.desktopManager.plasma5.kwinPackage` and a new package `kwin-lowlatency`.

I've done some basic testing to make sure it works and have tried to make sure it adheres to style/naming conventions used across Nixpkgs and NixOS. However, I'm still new to contributing, and so any feedback (including nitpicks) would be appreciated.

###### Things to consider

- Is it worth having an option for this? `kwin-lowlatency` is fairly popular, but [recent changes to KWin](https://invent.kde.org/plasma/kwin/-/merge_requests/507) might make it obsolete soon (or not, I have no idea). Other KWin forks (e.g. [KWinFT](https://gitlab.com/kwinft/kwinft)) also exist, but I don't know how popular they are.
- Is this a good name for the option? Other ideas include `kwin.package` or even just `kwin`, but `kwinPackage` seemed the most obvious to me.
- Is there a good way to ensure that `kwin-lowlatency` is updated when regular `kwin` (and the rest of Plasma) is? I thought maybe it could be marked as broken if its version doesn't match the Plasma version, but I couldn't find a nice way to get the Plasma version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
