### PR TITLE
koules: init at 1.4

### DIFF
--- a/pkgs/games/koules/default.nix
+++ b/pkgs/games/koules/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchurl
+, fetchzip
+, makeDesktopItem
+, copyDesktopItems
+, imake
+, gccmakedep
+, libX11
+, libXext
+, installShellFiles
+}:
+
+let
+  debian-extras = fetchzip {
+    url = "mirror://debian/pool/main/k/koules/koules_1.4-27.debian.tar.xz";
+    sha256 = "0bq1rr6vxqmx2k0dhyrqnwwfiw4h2ycbj576v66vwr0jaq5plil3";
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "koules";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "https://www.ucw.cz/~hubicka/koules/packages/${pname}${version}-src.tar.gz";
+    sha256 = "06x2wkpns14kii9fxmxbmj5lma371qj00hgl7fc5kggfmzz96vy3";
+  };
+
+  nativeBuildInputs = [ imake gccmakedep installShellFiles copyDesktopItems ];
+  buildInputs = [ libX11 libXext ];
+
+  # Debian maintains lots of patches for koules. Let's include all of them.
+  prePatch = ''
+    patches="$patches $(cat ${debian-extras}/patches/series | sed 's|^|${debian-extras}/patches/|')"
+  '';
+
+  postPatch = ''
+    # We do not want to depend on that particular font to be available in the
+    # xserver, hence substitute it by a font which is always available
+    sed -ie 's:-schumacher-clean-bold-r-normal--8-80-75-75-c-80-\*iso\*:fixed:' xlib/init.c
+  '';
+
+  preBuild = ''
+    cp xkoules.6 xkoules.man  # else "make" will not succeed
+    sed -ie "s:^SOUNDDIR\s*=.*:SOUNDDIR=$out/lib:" Makefile
+    sed -ie "s:^KOULESDIR\s*=.*:KOULESDIR=$out:" Makefile
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 xkoules $out/bin/xkoules
+    install -Dm755 koules.sndsrv.linux $out/lib/koules.sndsrv.linux
+    install -m644 sounds/* $out/lib/
+    install -Dm644 Koules.xpm $out/share/pixmaps/koules.xpm
+    installManPage xkoules.6
+    runHook postInstall
+  '';
+
+  desktopItems = [ (makeDesktopItem {
+    desktopName = "Koules";
+    name = "koules";
+    exec = "xkoules";
+    icon = "koules";
+    comment = "Push your enemies away, but stay away from obstacles";
+    categories = [ "Game" "ArcadeGame" ];
+  }) ];
+
+  meta = with lib; {
+    description = "Fast arcade game based on the fundamental law of body attraction";
+    homepage = "https://www.ucw.cz/~hubicka/koules/English/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.iblech ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31352,6 +31352,8 @@ with pkgs;
     useProprietaryAssets = false;
   };
 
+  koules = callPackage ../games/koules { };
+
   leela-zero = libsForQt5.callPackage ../games/leela-zero { };
 
   legendary-gl = python38Packages.callPackage ../games/legendary-gl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

koules is an old and fun arcade game based on the fundamental law of body attraction. It is available in Debian and Arch. This pull request adds it to nixpkgs.

I went through path hell for installing this correctly. :-) Even with Debian's patches, which introduce `DESTDIR`, it took me some time to get everything working (in particular the soundserver, which is a separate binary).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
