### PR TITLE
lensfun: update lensfun databases

### DIFF
--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -3,6 +3,16 @@
 let
   version = "0.3.95";
   pname = "lensfun";
+
+  # Fetch a more recent version of the repo containing a more recent lens
+  # database
+  lensfunDatabase = fetchFromGitHub {
+    owner = "lensfun";
+    repo = "lensfun";
+    rev = "4672d765a17bfef7bc994ca7008cb717c61045d5";
+    sha256 = "00x35xhpn55j7f8qzakb6wl1ccbljg1gqjb93jl9w3mha2bzsr41";
+  };
+
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -13,6 +23,12 @@ stdenv.mkDerivation {
     rev = "v${version}";
     sha256 = "0isli0arns8bmxqpbr1jnbnqh5wvspixdi51adm671f9ngng7x5r";
   };
+
+  # replace database with a more recent snapshot
+  postUnpack = ''
+    rm -R source/data/db
+    cp -R ${lensfunDatabase}/data/db source/data
+  '';
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ glib zlib libpng ];

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ flokli ];
     license = stdenv.lib.licenses.lgpl3;
     description = "An opensource database of photographic lenses and their characteristics";
     homepage = "https://lensfun.github.io";

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ glib zlib libpng ];
 
-  configureFlags = [ "-v" ];
+  cmakeFlags = [ "-DINSTALL_HELPER_SCRIPTS=OFF" ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -1,15 +1,20 @@
-{ stdenv, fetchurl, pkgconfig, glib, zlib, libpng, cmake }:
+{ stdenv, fetchFromGitHub, pkg-config, glib, zlib, libpng, cmake }:
 
-stdenv.mkDerivation rec {
+let
   version = "0.3.95";
   pname = "lensfun";
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/lensfun/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0218f3xrlln0jmh4gcf1zbpvi2bidgl3b2mblf6c810n7j1rrhl2";
+  src = fetchFromGitHub {
+    owner = "lensfun";
+    repo = "lensfun";
+    rev = "v${version}";
+    sha256 = "0isli0arns8bmxqpbr1jnbnqh5wvspixdi51adm671f9ngng7x5r";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ glib zlib libpng ];
 
   configureFlags = [ "-v" ];

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -19,6 +19,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
     license = stdenv.lib.licenses.lgpl3;
     description = "An opensource database of photographic lenses and their characteristics";
-    homepage = "http://lensfun.sourceforge.net/";
+    homepage = "https://lensfun.github.io";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
 - Provide a more recent lensfun database, so things like https://github.com/NixOS/nixpkgs/issues/107304 won't happen.
 - Remove the broken lensfun database updater from the output (as described in https://github.com/NixOS/nixpkgs/issues/99009#issuecomment-752794803)
 - add myself as a maintainer

Built Darktable with this PR and verified Sony A7 III is visible in the list.

Closes https://github.com/NixOS/nixpkgs/issues/99009

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @expipiplus1 @cnnrro @cillianderoiste @flosse @mrVanDalo @danieldk @adisbladis