### PR TITLE
pinnwand, steck: update

### DIFF
--- a/pkgs/servers/pinnwand/default.nix
+++ b/pkgs/servers/pinnwand/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3, fetchFromGitHub, nixosTests, fetchpatch }:
+{ lib, python3, fetchFromGitHub, nixosTests }:
 
 let
   python = python3.override {
@@ -14,14 +14,14 @@ let
   };
 in with python.pkgs; buildPythonApplication rec {
   pname = "pinnwand";
-  version = "1.2.2";
+  version = "1.2.3";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "supakeen";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0cxdpc3lxgzakzgvdyyrn234380dm05svnwr8av5nrjp4nm9s8z4";
+    sha256 = "1p6agvp136q6km7gjfv8dpjn6x4ap770lqa40ifblyhw13bsrqlh";
   };
 
   nativeBuildInputs = [
@@ -37,19 +37,9 @@ in with python.pkgs; buildPythonApplication rec {
     sqlalchemy
   ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
 
-  checkPhase = ''
-    pytest
-  '';
-
-  patches = [
-    # Use poetry-core instead of poetry. Fixed in 1.2.3
-    (fetchpatch {
-      url = "https://github.com/supakeen/pinnwand/commit/38ff5729c59abb97e4b416d3ca66466528b0eac7.patch";
-      sha256 = "F3cZe29z/7glmS3KWzcfmZnhYmC0LrLLS0zHk7WS2rQ=";
-    })
-  ];
+  __darwinAllowLocalNetworking = true;
 
   passthru.tests = nixosTests.pinnwand;
 

--- a/pkgs/servers/pinnwand/steck.nix
+++ b/pkgs/servers/pinnwand/steck.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "steck";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "07gc5iwbyprb8nihnjjl2zd06z8p4nl3a3drzh9a8ny35ig1khq0";
+    sha256 = "1a3l427ibwck9zzzy1sp10hmjgminya08i4r9j4559qzy7lxghs1";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -18,6 +18,9 @@ python3Packages.buildPythonApplication rec {
     termcolor
     toml
   ];
+
+  # tests are not in pypi package
+  doCheck = false;
 
   passthru.tests = nixosTests.pinnwand;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream releases

https://github.com/supakeen/pinnwand/releases/tag/v1.2.3
https://github.com/supakeen/steck/releases/tag/v0.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
