### PR TITLE
darwin.iproute2mac: update to 1.3.0

### DIFF
--- a/pkgs/os-specific/darwin/iproute2mac/default.nix
+++ b/pkgs/os-specific/darwin/iproute2mac/default.nix
@@ -1,30 +1,29 @@
-{ lib, stdenv, fetchFromGitHub, darwin, python2 }:
+{ lib, stdenv, fetchurl, darwin, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.1";
   pname = "iproute2mac";
+  version = "1.3.0";
 
-  src = fetchFromGitHub {
-    owner = "brona";
-    repo = "iproute2mac";
-    rev = "v${version}";
-    sha256 = "1n6la7blbxza2m79cpnywsavhzsdv4gzdxrkly4dppyidjg6jy1h";
+  src = fetchurl {
+    url = "https://github.com/brona/iproute2mac/releases/download/v${version}/${pname}-${version}.tar.gz";
+    sha256 = "1drk2b2nssb9ahw6mnss9sv12qlhvp5k8jdhzman65jy1xmwxvrz";
   };
 
-  buildInputs = [ python2 ];
+  buildInputs = [ python3 ];
 
-  postPatch = ''
+  __impureHostDeps = [ "/usr/bin/sudo" ];
+
+  postPatch = with darwin; ''
     substituteInPlace src/ip.py \
-      --replace /usr/bin/python ${python2}/bin/python \
-      --replace /sbin/ifconfig ${darwin.network_cmds}/bin/ifconfig \
-      --replace /sbin/route ${darwin.network_cmds}/bin/route \
-      --replace /usr/sbin/netstat ${darwin.network_cmds}/bin/netstat \
-      --replace /usr/sbin/ndp ${darwin.network_cmds}/bin/ndp \
-      --replace /usr/sbin/arp ${darwin.network_cmds}/bin/arp \
-      --replace /usr/sbin/networksetup ${darwin.network_cmds}/bin/networksetup
+      --replace /sbin/ifconfig ${network_cmds}/bin/ifconfig \
+      --replace /sbin/route ${network_cmds}/bin/route \
+      --replace /usr/sbin/netstat ${network_cmds}/bin/netstat \
+      --replace /usr/sbin/ndp ${network_cmds}/bin/ndp \
+      --replace /usr/sbin/arp ${network_cmds}/bin/arp \
+      --replace /usr/sbin/networksetup ${network_cmds}/bin/networksetup
   '';
+
   installPhase = ''
-    mkdir -p $out/bin
     install -D -m 755 src/ip.py $out/bin/ip
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update `darwin.iproute2mac` to 1.3.0 . This may be marked as insecure because `network_cmds-osx-10.11.6` is still using `openssl-1.0.2u`, which should be fixed by #101229 .

CC @SuperSandro2000 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
