### PR TITLE
python3Packages.pypykatz: init at 0.3.15

### DIFF
--- a/pkgs/development/python-modules/lsassy/default.nix
+++ b/pkgs/development/python-modules/lsassy/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, impacket
+, netaddr
+, pypykatz
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "lsassy";
+  version = "2.1.3";
+
+  src = fetchFromGitHub {
+    owner = "Hackndo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zig34ymc1h18gjc2ji0w0711im5sm9xm6nydc01c13yfpvvj1rh";
+  };
+
+  propagatedBuildInputs = [
+    impacket
+    netaddr
+    pypykatz
+  ];
+
+  # Tests require an active domain controller
+  doCheck = false;
+  pythonImportsCheck = [ "lsassy" ];
+
+  meta = with lib; {
+    description = "Python module to extract data from Local Security Authority Subsystem Service (LSASS)";
+    homepage = "https://github.com/Hackndo/lsassy";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/msldap/default.nix
+++ b/pkgs/development/python-modules/msldap/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, asn1crypto
+, asysocks
+, minikerberos
+, prompt_toolkit
+, tqdm
+, winacl
+, winsspi
+}:
+
+buildPythonPackage rec {
+  pname = "msldap";
+  version = "0.3.22";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ivq56953skql8f255nqx2sg4mm0kz2pr5b4dx62dx7jdgd1xym3";
+  };
+
+  propagatedBuildInputs = [
+    asn1crypto
+    asysocks
+    minikerberos
+    prompt_toolkit
+    tqdm
+    winacl
+    winsspi
+  ];
+
+  # Project doesn't have tests
+  doCheck = false;
+  pythonImportsCheck = [ "msldap" ];
+
+  meta = with lib; {
+    description = "Python LDAP library for auditing MS AD";
+    homepage = "https://github.com/skelsec/msldap";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pypykatz/default.nix
+++ b/pkgs/development/python-modules/pypykatz/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, aiowinreg
+, buildPythonPackage
+, fetchFromGitHub
+, minidump
+, minikerberos
+, msldap
+, winsspi
+}:
+
+buildPythonPackage rec {
+  pname = "pypykatz";
+  version = "0.3.15";
+
+  src = fetchFromGitHub {
+    owner = "skelsec";
+    repo = pname;
+    rev = version;
+    sha256 = "0bx2jdcfr1pdy3jgzg8fr5id9ffl2m1nc81dqhcplxdj8p214yri";
+  };
+
+  propagatedBuildInputs = [
+    aiowinreg
+    minikerberos
+    msldap
+    winsspi
+    minidump
+  ];
+
+  # Project doesn't have tests
+  doCheck = false;
+  pythonImportsCheck = [ "pypykatz" ];
+
+  meta = with lib; {
+    description = "Mimikatz implementation in Python";
+    homepage = "https://github.com/skelsec/pypykatz";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3711,6 +3711,8 @@ in {
 
   lsi = callPackage ../development/python-modules/lsi { };
 
+  lsassy = callPackage ../development/python-modules/lsassy { };
+
   ludios_wpull = callPackage ../development/python-modules/ludios_wpull { };
 
   luftdaten = callPackage ../development/python-modules/luftdaten { };
@@ -4073,6 +4075,8 @@ in {
   msgpack = callPackage ../development/python-modules/msgpack { };
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
+
+  msldap = callPackage ../development/python-modules/msldap { };
 
   mss = callPackage ../development/python-modules/mss { };
 
@@ -5611,6 +5615,8 @@ in {
   pypubsub = callPackage ../development/python-modules/pypubsub { };
 
   pypugjs = callPackage ../development/python-modules/pypugjs { };
+
+  pypykatz = callPackage ../development/python-modules/pypykatz { };
 
   pyqrcode = callPackage ../development/python-modules/pyqrcode { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Mimikatz implementation in Python

https://github.com/skelsec/pypykatz

Also, contains [`msldap`](https://github.com/skelsec/msldap) which is a Python LDAP library for auditing MS AD and a dependency for `pypykatz` and [`lsassy`](https://github.com/Hackndo/lsassy), a Python module to extract data from Local Security Authority Subsystem Service (LSASS).

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
