### PR TITLE
mysql80: 8.0.17 -> 8.0.22

### DIFF
--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -6,11 +6,11 @@
 let
 self = stdenv.mkDerivation rec {
   pname = "mysql";
-  version = "8.0.21";
+  version = "8.0.22";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${self.mysqlVersion}/${pname}-${version}.tar.gz";
-    sha256 = "0d00k55rkzdgn5wj32vxankjk5x3ywfqw62zxzg3m503xrg56mmd";
+    sha256 = "9fd85bb243940ef8234d21384ef421a0962fd4d13406fc1420efa902115ce17a";
   };
 
   patches = [

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -1,27 +1,31 @@
 { lib, stdenv, fetchurl, bison, cmake, pkgconfig
-, boost, icu, libedit, libevent, lz4, ncurses, openssl, protobuf, re2, readline, zlib
+, boost, icu, libedit, libevent, lz4, ncurses, openssl, protobuf, re2, readline, zlib, zstd
 , numactl, perl, cctools, CoreServices, developer_cmds, libtirpc, rpcsvc-proto
 }:
 
 let
 self = stdenv.mkDerivation rec {
   pname = "mysql";
-  version = "8.0.17";
+  version = "8.0.21";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${self.mysqlVersion}/${pname}-${version}.tar.gz";
-    sha256 = "1mjrlxn8vigi69r0r674j2dibdnkaar01ji5965gsyx7k60z7qy6";
+    sha256 = "0d00k55rkzdgn5wj32vxankjk5x3ywfqw62zxzg3m503xrg56mmd";
   };
 
   patches = [
     ./abi-check.patch
-    ./libutils.patch
   ];
 
   nativeBuildInputs = [ bison cmake pkgconfig rpcsvc-proto ];
 
+  postPatch = ''
+    substituteInPlace cmake/libutils.cmake --replace /usr/bin/ ""
+  '';
+
   buildInputs = [
     boost icu libedit libevent lz4 ncurses openssl protobuf re2 readline zlib
+    zstd
   ] ++ lib.optionals stdenv.isLinux [
     numactl libtirpc
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -19,8 +19,10 @@ self = stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ bison cmake pkgconfig rpcsvc-proto ];
 
+  ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
   postPatch = ''
-    substituteInPlace cmake/libutils.cmake --replace /usr/bin/ ""
+    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
+    substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
   '';
 
   buildInputs = [

--- a/pkgs/servers/sql/mysql/libutils.patch
+++ b/pkgs/servers/sql/mysql/libutils.patch
@@ -1,5 +1,0 @@
---- a/cmake/libutils.cmake
-+++ b/cmake/libutils.cmake
-@@ -345 +345 @@ MACRO(MERGE_CONVENIENCE_LIBRARIES)
--      COMMAND /usr/bin/libtool -static -o $<TARGET_FILE:${TARGET}>
-+      COMMAND libtool -static -o $<TARGET_FILE:${TARGET}>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17805,7 +17805,7 @@ in
   mysql80 = callPackage ../servers/sql/mysql/8.0.x.nix {
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
-    boost = boost169; # Configure checks for specific version.
+    boost = boost172; # Configure checks for specific version.
     protobuf = protobuf3_7;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17805,7 +17805,7 @@ in
   mysql80 = callPackage ../servers/sql/mysql/8.0.x.nix {
     inherit (darwin) cctools developer_cmds;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
-    boost = boost172; # Configure checks for specific version.
+    boost = boost173; # Configure checks for specific version.
     protobuf = protobuf3_7;
   };
 


### PR DESCRIPTION
###### Motivation for this change

This is an updated variation of @alyssais's #93371 for upgrading mysql80:

* Rebase and resolve merge-conflict
* Update a little further (8.0.22)
* Update another problematic reference to `/usr/bin/libtool` that appears in more recent versions. (I believe this was the cause of the prior build failure on `darwin`. It now builds on my local `darwin` box.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
