### PR TITLE
pythonPackages.minikerberos: 0.2.7 -> 0.2.8

### DIFF
--- a/pkgs/development/python-modules/asysocks/default.nix
+++ b/pkgs/development/python-modules/asysocks/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "asysocks";
-  version = "0.0.10";
+  version = "0.0.11";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1h9awwnn4dr3ppdlnjb4abhyw873n1iddipw6wkwjpw7nnaqqr6i";
+    sha256 = "11ygrhkqm524i4qp2myjvpsmg1lsn32nsqxqla96sbj84qfnhv0q";
   };
 
   # Upstream hasn't release the tests yet

--- a/pkgs/development/python-modules/minikerberos/default.nix
+++ b/pkgs/development/python-modules/minikerberos/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "minikerberos";
-  version = "0.2.7";
+  version = "0.2.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "08ngf55pbnzyqkgffzxix6ldal9l38d2jjn9rvxkg88ygxsalfvm";
+    sha256 = "16bbyihap2ygsi7xg58rwdn14ms1j0jy2kxbdljpg39s9q1rz6ps";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.2.8

Requires also a update of `asysocks`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
