### PR TITLE
python3Packages.pypck: init at 0.7.8

### DIFF
--- a/pkgs/development/python-modules/pypck/default.nix
+++ b/pkgs/development/python-modules/pypck/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-asyncio
+, pytest-cov
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+, stdenv
+}:
+
+buildPythonPackage rec {
+  pname = "pypck";
+  version = "0.7.8";
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "alengwenus";
+    repo = pname;
+    rev = version;
+    sha256 = "06yqyqpzpypid27z31prvsp7nzpjqzn7gjlfqwjhhxl8fdgh8hkr";
+  };
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-cov
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.isDarwin [
+    "test_connection_lost"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "pypck" ];
+
+  meta = with lib; {
+    description = "LCN-PCK library written in Python";
+    homepage = "https://github.com/alengwenus/pypck";
+    license = with licenses; [ epl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -428,7 +428,7 @@
     "lannouncer" = ps: with ps; [ ];
     "lastfm" = ps: with ps; [ pylast ];
     "launch_library" = ps: with ps; [ ]; # missing inputs: pylaunches
-    "lcn" = ps: with ps; [ ]; # missing inputs: pypck
+    "lcn" = ps: with ps; [ pypck ];
     "lg_netcast" = ps: with ps; [ ]; # missing inputs: pylgnetcast-homeassistant
     "lg_soundbar" = ps: with ps; [ ]; # missing inputs: temescal
     "life360" = ps: with ps; [ ]; # missing inputs: life360

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5565,6 +5565,8 @@ in {
 
   pypcap = callPackage ../development/python-modules/pypcap { };
 
+  pypck = callPackage ../development/python-modules/pypck { };
+
   pypdf2 = callPackage ../development/python-modules/pypdf2 { };
 
   pyPdf = callPackage ../development/python-modules/pypdf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
LCN-PCK library written in Python.

https://github.com/alengwenus/pypck

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
