### PR TITLE
linuxPackages.isgx: init at 2.11

### DIFF
--- a/pkgs/os-specific/linux/isgx/default.nix
+++ b/pkgs/os-specific/linux/isgx/default.nix
@@ -25,14 +25,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 isgx.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/intel/sgx
+    install -D isgx.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/intel/sgx
     runHook postInstall
   '';
 

--- a/pkgs/os-specific/linux/isgx/default.nix
+++ b/pkgs/os-specific/linux/isgx/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "isgx-${version}-${kernel.version}";
+  version = "2.11";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "linux-sgx-driver";
+    rev = "sgx_driver_${version}";
+    hash = "sha256-zZ0FgCx63LCNmvQ909O27v/o4+93gefhgEE/oDr/bHw=";
+  };
+
+  patches = [
+    # Fixes build with kernel >= 5.8
+    (fetchpatch {
+      url = "https://github.com/intel/linux-sgx-driver/commit/276c5c6a064d22358542f5e0aa96b1c0ace5d695.patch";
+      sha256 = "sha256-PmchqYENIbnJ51G/tkdap/g20LUrJEoQ4rDtqy6hj24=";
+    })
+  ];
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 isgx.ko -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/intel/sgx
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Intel SGX Linux Driver";
+    homepage = "https://github.com/intel/linux-sgx-driver";
+    license = with licenses; [ bsd3 gpl2 ];
+    maintainers = with maintainers; [ oxalica ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/isgx/default.nix
+++ b/pkgs/os-specific/linux/isgx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, kernel, kernelAtLeast }:
 
 stdenv.mkDerivation rec {
   name = "isgx-${version}-${kernel.version}";
@@ -35,9 +35,19 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Intel SGX Linux Driver";
+    longDescription = ''
+      The linux-sgx-driver project (isgx) hosts an out-of-tree driver
+      for the Linux* Intel(R) SGX software stack, which would be used
+      until the driver upstreaming process is complete (before 5.11.0).
+
+      It is used to support Enhanced Privacy Identification (EPID)
+      based attestation on the platforms without Flexible Launch Control.
+    '';
     homepage = "https://github.com/intel/linux-sgx-driver";
-    license = with licenses; [ bsd3 gpl2 ];
+    license = with licenses; [ bsd3 /* OR */ gpl2Only ];
     maintainers = with maintainers; [ oxalica ];
     platforms = platforms.linux;
+    # The driver is already in kernel >= 5.11.0.
+    broken = kernelAtLeast "5.11.0";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19200,6 +19200,8 @@ in
 
     sch_cake = callPackage ../os-specific/linux/sch_cake { };
 
+    isgx = callPackage ../os-specific/linux/isgx { };
+
     sysdig = callPackage ../os-specific/linux/sysdig {};
 
     systemtap = callPackage ../development/tools/profiling/systemtap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add Linux driver for [Intel Software Guard Extention (SGX)](https://01.org/intel-softwareguard-extensions).
Repository [url](https://github.com/intel/linux-sgx-driver).


When loaded on supported CPU with SGX enabled in BIOS,  `/dev/{isgx,mei0}` will be available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - There is only an `isgx.ko`. Tested to be loaded and it works.
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - 98.0K
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
