### PR TITLE
ocamlPackages: stdenv.lib → lib

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom-async/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-async/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, angstrom, async }:
+{ lib, fetchFromGitHub, buildDunePackage, angstrom, async }:
 
 buildDunePackage rec {
   pname = "angstrom-async";
@@ -14,6 +14,6 @@ buildDunePackage rec {
   meta = {
     inherit (angstrom.meta) homepage license;
     description = "Async support for Angstrom";
-    maintainers = with stdenv.lib.maintainers; [ romildo ];
+    maintainers = with lib.maintainers; [ romildo ];
   };
 }

--- a/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, angstrom, ocaml_lwt }:
+{ lib, fetchFromGitHub, buildDunePackage, angstrom, ocaml_lwt }:
 
 buildDunePackage rec {
   pname = "angstrom-lwt-unix";
@@ -14,6 +14,6 @@ buildDunePackage rec {
   meta = {
     inherit (angstrom.meta) homepage license;
     description = "Lwt_unix support for Angstrom";
-    maintainers = with stdenv.lib.maintainers; [ romildo ];
+    maintainers = with lib.maintainers; [ romildo ];
   };
 }

--- a/pkgs/development/ocaml-modules/angstrom-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-unix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, angstrom }:
+{ lib, fetchFromGitHub, buildDunePackage, angstrom }:
 
 buildDunePackage rec {
   pname = "angstrom-unix";
@@ -14,6 +14,6 @@ buildDunePackage rec {
   meta = {
     inherit (angstrom.meta) homepage license;
     description = "Unix support for Angstrom";
-    maintainers = with stdenv.lib.maintainers; [ romildo ];
+    maintainers = with lib.maintainers; [ romildo ];
   };
 }

--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl }:
+{ stdenv, lib, fetchFromGitHub, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-apron-${version}";
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     homepage = "http://apron.cri.ensmp.fr/library/";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
     description = "Numerical abstract domain library";
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
 
 let
   # Use astring 0.8.3 for OCaml < 4.05
   param =
-    if stdenv.lib.versionAtLeast ocaml.version "4.05"
+    if lib.versionAtLeast ocaml.version "4.05"
     then {
       version = "0.8.5";
       sha256 = "1ykhg9gd3iy7zsgyiy2p9b1wkpqg9irw5pvcqs3sphq71iir4ml6";
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
       adds a few missing functions and fully exploits OCaml's newfound string
       immutability.
     '';
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, menhir, easy-format, fetchFromGitHub, buildDunePackage, which, biniou, yojson }:
+{ lib, menhir, easy-format, fetchFromGitHub, buildDunePackage, which, biniou, yojson }:
 
 buildDunePackage rec {
   pname = "atd";

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -8,11 +8,11 @@
 , z3
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.07"
+if !lib.versionAtLeast ocaml.version "4.07"
 then throw "BAP is not available for OCaml ${ocaml.version}"
 else
 
-if stdenv.lib.versionAtLeast core_kernel.version "0.13"
+if lib.versionAtLeast core_kernel.version "0.13"
 then throw "BAP needs core_kernel-0.12 (hence OCaml 4.07)"
 else
 

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, qtest, num }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, qtest, num }:
 
 let version = "3.2.0"; in
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   checkInputs = [ qtest ];
   propagatedBuildInputs = [ num ];
 
-  doCheck = stdenv.lib.versionAtLeast ocaml.version "4.04" && !stdenv.isAarch64;
+  doCheck = lib.versionAtLeast ocaml.version "4.04" && !stdenv.isAarch64;
   checkTarget = "test";
 
   createFindlibDestdir = true;
@@ -27,10 +27,10 @@ stdenv.mkDerivation {
       and comprehensive development platform for the OCaml programming
       language.
     '';
-    license = stdenv.lib.licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
+      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, ocaml_pcre }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, ocaml_pcre }:
 
 let version = "1.4"; in
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     homepage = "http://ocaml-benchmark.forge.ocamlcore.org/";
     platforms = ocaml.meta.platforms or [];
     description = "Benchmark running times of code";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = with stdenv.lib.maintainers; [ volth ];
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ volth ];
   };
 }

--- a/pkgs/development/ocaml-modules/bin_prot/default.nix
+++ b/pkgs/development/ocaml-modules/bin_prot/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, buildOcaml, fetchurl, ocaml, type_conv }:
+{ lib, buildOcaml, fetchurl, ocaml, type_conv }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "bin_prot-112.24.00 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/biniou/1.0.nix
+++ b/pkgs/development/ocaml-modules/biniou/1.0.nix
@@ -5,7 +5,7 @@ let
   webpage = "http://mjambon.com/${pname}.html";
 in
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.11";
+assert lib.versionAtLeast (lib.getVersion ocaml) "3.11";
 
 stdenv.mkDerivation rec {
 

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, easy-format }:
+{ lib, fetchFromGitHub, buildDunePackage, easy-format }:
 
 buildDunePackage rec {
   pname = "biniou";
@@ -20,7 +20,7 @@ buildDunePackage rec {
   meta = {
     inherit (src.meta) homepage;
     description = "Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildDunePackage, fetchFromGitHub, fetchpatch
+{ lib, buildDunePackage, fetchFromGitHub, fetchpatch
 , ounit, async, base64, camlzip, cfstream
 , core, ppx_jane, ppx_sexp_conv, rresult, uri, xmlm }:
 

--- a/pkgs/development/ocaml-modules/bitv/default.nix
+++ b/pkgs/development/ocaml-modules/bitv/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip, autoreconfHook, which, ocaml, findlib }:
+{ stdenv, lib, fetchzip, autoreconfHook, which, ocaml, findlib }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "bitv is not available for OCaml ${ocaml.version}"
 else
 
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A bit vector library for OCaml";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     homepage = "https://github.com/backtracking/bitv";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, which, camlp4 }:
 
-let inherit (stdenv.lib) getVersion versionAtLeast; in
+let inherit (lib) getVersion versionAtLeast; in
 
 assert versionAtLeast (getVersion ocaml) "4.00.0";
 assert versionAtLeast (getVersion findlib) "1.3.3";

--- a/pkgs/development/ocaml-modules/bos/default.nix
+++ b/pkgs/development/ocaml-modules/bos/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg
 , astring, fmt, fpath, logs, rresult
 }:
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 	meta = {
 		description = "Basic OS interaction for OCaml";
 		homepage = "https://erratique.ch/software/bos";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.isc;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/calendar/default.nix
+++ b/pkgs/development/ocaml-modules/calendar/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, lib, fetchurl, ocaml, findlib}:
 
 stdenv.mkDerivation {
   name = "ocaml-calendar-2.5";
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     license = "LGPL";
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.gal_bolle
+      lib.maintainers.gal_bolle
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, which, ocaml, findlib }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "camlpdf is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -2,7 +2,7 @@
 
 let
   param =
-    if stdenv.lib.versionAtLeast ocaml.version "4.02"
+    if lib.versionAtLeast ocaml.version "4.02"
     then {
       version = "1.10";
       url = "https://github.com/xavierleroy/camlzip/archive/rel110.tar.gz";

--- a/pkgs/development/ocaml-modules/camomile/0.8.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.2.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, ocaml, findlib, camlp4}:
+{stdenv, lib, fetchurl, ocaml, findlib, camlp4}:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.05"
+if lib.versionAtLeast ocaml.version "4.05"
 then throw "camomile-0.8.2 is not available for OCaml ${ocaml.version}"
 else
 
@@ -20,11 +20,11 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://camomile.sourceforge.net/";
     description = "A comprehensive Unicode library for OCaml";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     branch = "0.8.2";
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
+      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/camomile/0.8.5.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.5.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, fetchpatch, ocaml, findlib, camlp4}:
+{stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, camlp4}:
 
 stdenv.mkDerivation {
   pname = "camomile";
@@ -21,10 +21,10 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://github.com/yoriyuki/Camomile/tree/master/Camomile";
     description = "A comprehensive Unicode library for OCaml";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
+      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, cppo }:
+{ stdenv, lib, fetchFromGitHub, buildDunePackage, cppo }:
 
 buildDunePackage rec {
   pname = "camomile";
@@ -17,8 +17,8 @@ buildDunePackage rec {
 
 	meta = {
 		inherit (src.meta) homepage;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
-		license = stdenv.lib.licenses.lgpl21;
+		maintainers = [ lib.maintainers.vbgl ];
+		license = lib.licenses.lgpl21;
 		description = "A Unicode library for OCaml";
 	};
 }

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, buildDunePackage, cppo }:
+{ lib, fetchFromGitHub, buildDunePackage, cppo }:
 
 buildDunePackage rec {
   pname = "camomile";

--- a/pkgs/development/ocaml-modules/cfstream/default.nix
+++ b/pkgs/development/ocaml-modules/cfstream/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildDunePackage, fetchFromGitHub, m4, core_kernel, ounit }:
+{ lib, buildDunePackage, fetchFromGitHub, m4, core_kernel, ounit }:
 
 buildDunePackage rec {
   pname = "cfstream";

--- a/pkgs/development/ocaml-modules/cil/default.nix
+++ b/pkgs/development/ocaml-modules/cil/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, perl, ocaml, findlib, ocamlbuild }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "cil is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -4,10 +4,10 @@ let
   pname = "cmdliner";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
+assert lib.versionAtLeast ocaml.version "4.01.0";
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
+  if lib.versionAtLeast ocaml.version "4.03" then {
     version = "1.0.4";
     sha256 = "1h04q0zkasd0mw64ggh4y58lgzkhg6yhzy60lab8k8zq9ba96ajw";
   } else {

--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildDunePackage, async, cohttp, conduit-async, uri, ppx_sexp_conv
+{ lib, buildDunePackage, async, cohttp, conduit-async, uri, ppx_sexp_conv
 , logs, magic-mime }:
 
-if !stdenv.lib.versionAtLeast cohttp.version "0.99" then
+if !lib.versionAtLeast cohttp.version "0.99" then
 	cohttp
-else if !stdenv.lib.versionAtLeast async.version "0.13" then
+else if !lib.versionAtLeast async.version "0.13" then
 	throw "cohttp-async needs async-0.13 (hence OCaml >= 4.08)"
 else
 

--- a/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildDunePackage, cohttp-lwt
+{ lib, buildDunePackage, cohttp-lwt
 , conduit-lwt-unix, ppx_sexp_conv
 , cmdliner, fmt, magic-mime
 }:
 
-if !stdenv.lib.versionAtLeast cohttp-lwt.version "0.99"
+if !lib.versionAtLeast cohttp-lwt.version "0.99"
 then cohttp-lwt
 else
 

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildDunePackage, cohttp, ocaml_lwt, uri, ppx_sexp_conv, logs }:
+{ lib, buildDunePackage, cohttp, ocaml_lwt, uri, ppx_sexp_conv, logs }:
 
-if !stdenv.lib.versionAtLeast cohttp.version "0.99"
+if !lib.versionAtLeast cohttp.version "0.99"
 then cohttp
-else if !stdenv.lib.versionAtLeast ppx_sexp_conv.version "0.13"
+else if !lib.versionAtLeast ppx_sexp_conv.version "0.13"
 then throw "cohttp-lwt is not available for ppx_sexp_conv version ${ppx_sexp_conv.version}"
 else
 

--- a/pkgs/development/ocaml-modules/comparelib/default.nix
+++ b/pkgs/development/ocaml-modules/comparelib/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcaml, fetchurl, type_conv}:
+{lib, buildOcaml, fetchurl, type_conv}:
 
 buildOcaml rec {
   name = "comparelib";

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildDunePackage, async, async_ssl, ppx_sexp_conv, conduit }:
+{ lib, buildDunePackage, async, async_ssl, ppx_sexp_conv, conduit }:
 
-if !stdenv.lib.versionAtLeast conduit.version "1.0"
+if !lib.versionAtLeast conduit.version "1.0"
 then conduit
 else
 

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage
 , ppx_sexp_conv, sexplib, astring, uri, logs
 , ipaddr, ipaddr-sexp
 }:
@@ -20,8 +20,8 @@ buildDunePackage rec {
 
   meta = {
     description = "A network connection establishment library";
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ alexfmpe vbgl ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ alexfmpe vbgl ];
     homepage = "https://github.com/mirage/ocaml-conduit";
   };
 }

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage
+{ buildDunePackage
 , conduit-lwt, ppx_sexp_conv, ocaml_lwt, uri, ipaddr, ipaddr-sexp
 , lwt_ssl, tls
 }:

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt, sexplib }:
+{ buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt, sexplib }:
 
 buildDunePackage {
 	pname = "conduit-lwt";

--- a/pkgs/development/ocaml-modules/config-file/default.nix
+++ b/pkgs/development/ocaml-modules/config-file/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, camlp4 }:
+{ stdenv, lib, fetchurl, ocaml, findlib, camlp4 }:
 
 stdenv.mkDerivation {
   name = "ocaml-config-file-1.2";
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     homepage = "http://config-file.forge.ocamlcore.org/";
     platforms = ocaml.meta.platforms or [];
     description = "An OCaml library used to manage the configuration file(s) of an application";
-    license = stdenv.lib.licenses.lgpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.lgpl2Plus;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/cpu/default.nix
+++ b/pkgs/development/ocaml-modules/cpu/default.nix
@@ -18,7 +18,7 @@ buildDunePackage rec {
 
   buildInputs = [ autoconf ];
 
-  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
+  hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
 
   meta = with lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, lib, fetchurl, ocaml, findlib}:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "cryptgps is not available for OCaml ${ocaml.version}"
 else
 
@@ -28,10 +28,10 @@ stdenv.mkDerivation {
       i.e. this is not a binding to some C library, but the implementation
       itself.
     '';
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
+      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/cstruct/1.9.0.nix
+++ b/pkgs/development/ocaml-modules/cstruct/1.9.0.nix
@@ -2,7 +2,7 @@
 , async ? null, lwt ? null
 }:
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01";
+assert lib.versionAtLeast ocaml.version "4.01";
 
 let version = "1.9.0"; in
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://github.com/mirage/ocaml-cstruct";
     description = "Map OCaml arrays onto C-like structs";
-    license = stdenv.lib.licenses.isc;
+    license = lib.licenses.isc;
     maintainers = [ maintainers.vbgl maintainers.ericbmerritt ];
     platforms = ocaml.meta.platforms or [];
   };

--- a/pkgs/development/ocaml-modules/csv/default.nix
+++ b/pkgs/development/ocaml-modules/csv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage }:
+{ lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "csv";
@@ -13,8 +13,8 @@ buildDunePackage rec {
 
 	meta = {
 		description = "A pure OCaml library to read and write CSV files";
-		license = stdenv.lib.licenses.lgpl21;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.lgpl21;
+		maintainers = [ lib.maintainers.vbgl ];
 		homepage = "https://github.com/Chris00/ocaml-csv";
 	};
 }

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchzip, ocaml, findlib, libffi, pkgconfig, ncurses, integers }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "ctypes is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/curly/default.nix
+++ b/pkgs/development/ocaml-modules/curly/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, fetchurl, ocaml
+{ stdenv, lib, buildDunePackage, fetchurl, ocaml
 , result, alcotest, cohttp-lwt-unix, odoc, curl }:
 
 buildDunePackage rec {
@@ -17,7 +17,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [ result ];
   checkInputs = [ alcotest cohttp-lwt-unix ];
   # test dependencies are only available for >= 4.08
-  doCheck = stdenv.lib.versionAtLeast ocaml.version "4.08"
+  doCheck = lib.versionAtLeast ocaml.version "4.08"
     # Some test fails in macOS sandbox
     # > Fatal error: exception Unix.Unix_error(Unix.EPERM, "bind", "")
     && !stdenv.isDarwin;

--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, menhir }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, menhir }:
 
 stdenv.mkDerivation rec {
 	name = "ocaml${ocaml.version}-dolmen-${version}";
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		description = "An OCaml library providing clean and flexible parsers for input languages";
-		license = stdenv.lib.licenses.bsd2;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.bsd2;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
 		inherit (ocaml.meta) platforms;
 	};

--- a/pkgs/development/ocaml-modules/dolog/default.nix
+++ b/pkgs/development/ocaml-modules/dolog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild }:
 
 let version = "3.0"; in
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/UnixJunkie/dolog";
     description = "Minimalistic lazy logger in OCaml";
     platforms = ocaml.meta.platforms or [];
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildDunePackage }:
+{ stdenv, lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "dtoa";
@@ -11,7 +11,7 @@ buildDunePackage rec {
     sha256 = "0zkhn0rdq82g6gamsv6nkx6i44s8104nh6jg5xydazl9jl1704xn";
   };
 
-  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
+  hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
 
   meta = with lib; {
     homepage = "https://github.com/flowtype/ocaml-dtoa";

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -1,10 +1,10 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, lib, fetchurl, ocaml, findlib}:
 
 let
   pname = "dypgen";
 in
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://dypgen.free.fr";
     description = "Dypgen GLR self extensible parser generator";
-    license = stdenv.lib.licenses.cecill-b;
+    license = lib.licenses.cecill-b;
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/eigen/default.nix
+++ b/pkgs/development/ocaml-modules/eigen/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.02";
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   propagatedBuildInputs = [ ctypes ];
 

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, gmp, mpfr, ocaml, findlib, camlidl, apron }:
+{ stdenv, lib, fetchurl, perl, gmp, mpfr, ocaml, findlib, camlidl, apron }:
 
 stdenv.mkDerivation rec {
   version = "1.1";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     "--use-opam"
     "--apron-prefix" apron
   ]
-  ++ stdenv.lib.optional stdenv.isDarwin "--absolute-dylibs"
+  ++ lib.optional stdenv.isDarwin "--absolute-dylibs"
   ;
 
   createFindlibDestdir = true;
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "ETH LIbrary for Numerical Analysis";
     homepage = "http://elina.ethz.ch/";
-    license = stdenv.lib.licenses.lgpl3;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, which, ocsigen_server, ocaml,
+{ stdenv, lib, fetchzip, which, ocsigen_server, ocaml,
   lwt_react,
   opaline, ppx_deriving, findlib
 , ppx_tools_versioned
@@ -8,7 +8,7 @@
 , lwt_ppx
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.07"
+if !lib.versionAtLeast ocaml.version "4.07"
 then throw "eliom is not available for OCaml ${ocaml.version}"
 else
 
@@ -54,8 +54,8 @@ stdenv.mkDerivation rec
     distinguish both parts and the client side is compiled to JS using
     Ocsigen Js_of_ocaml.'';
 
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
 
-    maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+    maintainers = [ lib.maintainers.gal_bolle ];
   };
 }

--- a/pkgs/development/ocaml-modules/enumerate/default.nix
+++ b/pkgs/development/ocaml-modules/enumerate/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, type_conv, camlp4 }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, type_conv, camlp4 }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.00";
+assert lib.versionAtLeast (lib.getVersion ocaml) "4.00";
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "enumerate-111.08.00 is not available for OCaml ${ocaml.version}"
 else
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://ocaml.janestreet.com/";
     description = "Quotation expanders for enumerating finite types";
-    license = stdenv.lib.licenses.asl20;
+    license = lib.licenses.asl20;
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "erm_xml is not available for OCaml ${ocaml.version}"
 else
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/hannesm/xml";
     description = "XML Parser for discrete data";
     platforms = ocaml.meta.platforms or [];
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, camlp4, ocamlbuild
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, camlp4, ocamlbuild
 , erm_xml, mirage-crypto, mirage-crypto-rng, base64
 }:
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/hannesm/xmpp";
     description = "OCaml based XMPP implementation (fork)";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sternenseemann ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/estring/default.nix
+++ b/pkgs/development/ocaml-modules/estring/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, buildOcaml, ocaml, fetchurl }:
+{ lib, buildOcaml, ocaml, fetchurl }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "estring is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/expat/0.9.nix
+++ b/pkgs/development/ocaml-modules/expat/0.9.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, ounit, expat}:
+{stdenv, lib, fetchurl, ocaml, findlib, ounit, expat}:
 
 let
   pname = "ocaml-expat";
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.xs4all.nl/~mmzeeman/ocaml/";
     description = "An ocaml wrapper for the Expat XML parsing library";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.roconnor ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.roconnor ];
   };
 }

--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, expat, ocaml, findlib, ounit }:
+{ stdenv, lib, fetchFromGitHub, expat, ocaml, findlib, ounit }:
 
 stdenv.mkDerivation rec {
 	name = "ocaml${ocaml.version}-expat-${version}";
@@ -17,15 +17,15 @@ stdenv.mkDerivation rec {
 
 	buildInputs = [ ocaml findlib expat ounit ];
 
-	doCheck = !stdenv.lib.versionAtLeast ocaml.version "4.06";
+	doCheck = !lib.versionAtLeast ocaml.version "4.06";
 	checkTarget = "testall";
 
 	createFindlibDestdir = true;
 
 	meta = {
 		description = "OCaml wrapper for the Expat XML parsing library";
-		license = stdenv.lib.licenses.mit;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.mit;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
 		inherit (ocaml.meta) platforms;
 	};

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, ocaml, findlib, cppo, minimal ? true }:
+{ stdenv, lib, fetchurl, ocaml, findlib, cppo, minimal ? true }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.11";
+assert lib.versionAtLeast (lib.getVersion ocaml) "3.11";
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-extlib-1.7.7";
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://github.com/ygrek/ocaml-extlib";
     description = "Enhancements to the OCaml Standard Library modules";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildDunePackage, jsonm, hex, sexplib0 }:
+{ lib, fetchurl, buildDunePackage, jsonm, hex, sexplib0 }:
 
 buildDunePackage rec {
   pname = "ezjsonm";

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage, jsonm, hex, sexplib0 }:
+{ stdenv, lib, fetchurl, buildDunePackage, jsonm, hex, sexplib0 }:
 
 buildDunePackage rec {
   pname = "ezjsonm";
@@ -16,7 +16,7 @@ buildDunePackage rec {
   meta = {
     description = "An easy interface on top of the Jsonm library";
     homepage = "https://github.com/mirage/ezjsonm";
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/ezxmlm/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, buildDunePackage, xmlm }:
+{ lib, fetchFromGitHub, buildDunePackage, xmlm }:
 
 buildDunePackage rec {
   pname = "ezxmlm";

--- a/pkgs/development/ocaml-modules/faillib/default.nix
+++ b/pkgs/development/ocaml-modules/faillib/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, buildOcaml, fetchurl, ocaml, herelib, camlp4 }:
+{ lib, buildOcaml, fetchurl, ocaml, herelib, camlp4 }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "faillib-111.17.00 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/farfadet/default.nix
+++ b/pkgs/development/ocaml-modules/farfadet/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg
 , faraday
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.3"
+if !lib.versionAtLeast ocaml.version "4.3"
 then throw "farfadet is not available for OCaml ${ocaml.version}"
 else
 
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A printf-like for Faraday library";
     homepage = "https://github.com/oklm-wsh/Farfadet";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/fieldslib/default.nix
+++ b/pkgs/development/ocaml-modules/fieldslib/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, type_conv, camlp4 }:
 
-assert stdenv.lib.versionOlder "4.00" (stdenv.lib.getVersion ocaml);
+assert lib.versionOlder "4.00" (lib.getVersion ocaml);
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "fieldslib-109.20.03 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/fileutils/default.nix
+++ b/pkgs/development/ocaml-modules/fileutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, ounit }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, ounit }:
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-fileutils-0.5.3";
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     homepage = "https://forge.ocamlcore.org/projects/ocaml-fileutils/";
     platforms = ocaml.meta.platforms or [];
     description = "Library to provide pure OCaml functions to manipulate real file (POSIX like) and filename";
-    license = stdenv.lib.licenses.lgpl21Plus;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/fix/default.nix
+++ b/pkgs/development/ocaml-modules/fix/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
+assert lib.versionAtLeast (lib.getVersion ocaml) "3.12";
 
 stdenv.mkDerivation {
 

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, cmdliner, seq, stdlib-shims }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.05"
+if !lib.versionAtLeast ocaml.version "4.05"
 then throw "fmt is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/fontconfig/default.nix
+++ b/pkgs/development/ocaml-modules/fontconfig/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, fontconfig, ocaml }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig, fontconfig, ocaml }:
 
 stdenv.mkDerivation {
   name = "ocaml-fontconfig-20131103";
@@ -12,14 +12,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml fontconfig ];
   makeFlags = [
-    "OCAML_STDLIB_DIR=$(out)/lib/ocaml/${stdenv.lib.getVersion ocaml}/site-lib/"
+    "OCAML_STDLIB_DIR=$(out)/lib/ocaml/${lib.getVersion ocaml}/site-lib/"
     "OCAML_HAVE_OCAMLOPT=yes"
   ];
 
   meta = {
     description = "Fontconfig bindings for OCaml";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/fpath/default.nix
+++ b/pkgs/development/ocaml-modules/fpath/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, astring }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, astring }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.03"
 then throw "fpath is not available for OCaml ${ocaml.version}"
 else
 
@@ -20,8 +20,8 @@ stdenv.mkDerivation {
   meta = {
     description = "An OCaml module for handling file system paths with POSIX and Windows conventions";
     homepage = "https://erratique.ch/software/fpath";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -1,9 +1,9 @@
 { lib, stdenv, fetchurl, ocaml, findlib }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.11";
+assert lib.versionAtLeast (lib.getVersion ocaml) "3.11";
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
+  if lib.versionAtLeast ocaml.version "4.02" then {
     version = "0.6";
     sha256 = "18wpyxblz9jh5bfp0hpffnd0q8cq1b0dqp0f36vhqydfknlnpx8y";
   } else {

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, ounit }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, ounit }:
 
 let version = "0.5"; in
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://github.com/c-cube/gen";
     description = "Simple, efficient iterators for OCaml";
-    license = stdenv.lib.licenses.bsd3;
+    license = lib.licenses.bsd3;
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast;
+  inherit (lib) getVersion versionAtLeast;
 
   pname = "gg";
   version = "0.9.1";

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage
+{ stdenv, lib, fetchurl, buildDunePackage
 , alcotest, mtime, mirage-crypto-rng, tls, git-binary
 , angstrom, astring, cstruct, decompress, digestif, encore, duff, fmt, checkseum
 , fpath, hex, ke, logs, lru, ocaml_lwt, ocamlgraph, ocplib-endian, uri, rresult
@@ -24,7 +24,7 @@ buildDunePackage rec {
 	checkInputs = [ alcotest mtime mirage-crypto-rng tls git-binary ];
 	doCheck = !stdenv.isAarch64;
 
-	meta = with stdenv; {
+	meta = {
 		description = "Git format and protocol in pure OCaml";
 		license = lib.licenses.isc;
 		maintainers = [ lib.maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/gmetadom/default.nix
+++ b/pkgs/development/ocaml-modules/gmetadom/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, gdome2, libxslt, pkgconfig}:
+{stdenv, lib, fetchurl, ocaml, findlib, gdome2, libxslt, pkgconfig}:
 
 let
   pname = "gmetadom";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://gmetadom.sourceforge.net/";
     description = "A collection of librares, each library providing a DOM implementation";
-    license = stdenv.lib.licenses.lgpl21Plus;
-    maintainers = [ stdenv.lib.maintainers.roconnor ];
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.roconnor ];
   };
 }

--- a/pkgs/development/ocaml-modules/gsl/default.nix
+++ b/pkgs/development/ocaml-modules/gsl/default.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
   };
 
   buildInputs = [ dune-configurator gsl pkg-config ];
-  propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Accelerate ];
+  propagatedBuildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Accelerate ];
 
   meta = with lib; {
     homepage = "https://mmottl.github.io/gsl-ocaml/";

--- a/pkgs/development/ocaml-modules/gtktop/default.nix
+++ b/pkgs/development/ocaml-modules/gtktop/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, ocaml, camlp4, findlib, lablgtk-extras }:
+{ stdenv, lib, fetchurl, ocaml, camlp4, findlib, lablgtk-extras }:
 
 let pname = "gtktop-2.0"; in
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://zoggy.github.io/gtktop/";
     description = "A small OCaml library to ease the creation of graphical toplevels";
-    license = stdenv.lib.licenses.lgpl3;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ vbgl ];
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -14,7 +14,7 @@ buildOcaml rec {
   meta = with lib; {
     homepage = "https://github.com/janestreet/herelib";
     description = "Syntax extension for inserting the current location";
-    license = stdenv.lib.licenses.asl20;
+    license = licenses.asl20;
     maintainers = [ maintainers.ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcaml, fetchurl}:
+{lib, buildOcaml, fetchurl}:
 
 buildOcaml rec {
   version = "112.35.00";

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildDunePackage, bigarray-compat, cstruct }:
+{ lib, fetchurl, buildDunePackage, bigarray-compat, cstruct }:
 
 buildDunePackage rec {
   pname = "hex";

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage, bigarray-compat, cstruct }:
+{ stdenv, lib, fetchurl, buildDunePackage, bigarray-compat, cstruct }:
 
 buildDunePackage rec {
   pname = "hex";
@@ -19,7 +19,7 @@ buildDunePackage rec {
   meta = {
     description = "Mininal OCaml library providing hexadecimal converters";
     homepage = "https://github.com/mirage/ocaml-hex";
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/http/default.nix
+++ b/pkgs/development/ocaml-modules/http/default.nix
@@ -1,6 +1,6 @@
 {lib, stdenv, fetchurl, ocaml_pcre, ocamlnet, ocaml, findlib, camlp4}:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "ocaml-http is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/inifiles/default.nix
+++ b/pkgs/development/ocaml-modules/inifiles/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, ocaml, findlib, ocaml_pcre }:
+{ stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, ocaml_pcre }:
 
 stdenv.mkDerivation {
 	name = "ocaml${ocaml.version}-inifiles-1.2";
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
 	meta = {
 		description = "A small OCaml library to read and write .ini files";
-		license = stdenv.lib.licenses.lgpl21Plus;
+		license = lib.licenses.lgpl21Plus;
 		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, ocamlbuild
+{ stdenv, lib, fetchFromGitHub, fetchpatch, ocaml, findlib, ocamlbuild
 , ocaml_lwt # optional lwt support
 , ounit, fileutils # only for tests
 }:
@@ -23,9 +23,9 @@ stdenv.mkDerivation rec {
 	checkInputs = [ ounit fileutils ];
 
 	configureFlags = [ "--enable-lwt"
-	  (stdenv.lib.optionalString doCheck "--enable-tests") ];
+	  (lib.optionalString doCheck "--enable-tests") ];
 
-	postConfigure = stdenv.lib.optionalString doCheck ''
+	postConfigure = lib.optionalString doCheck ''
 	  echo '<lib_test/test_inotify_lwt.*>: pkg_threads' | tee -a _tags
 	'';
 
@@ -36,9 +36,9 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		description = "Bindings for Linux’s filesystem monitoring interface, inotify";
-		license = stdenv.lib.licenses.lgpl21;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.lgpl21;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		platforms = stdenv.lib.platforms.linux;
+		platforms = lib.platforms.linux;
 	};
 }

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, buildDunePackage, cstruct, bigarray-compat, ounit }:
+{ lib, fetchurl, buildDunePackage, cstruct, bigarray-compat, ounit }:
 
 buildDunePackage rec {
   pname = "io-page";

--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildDunePackage, cstruct, bigarray-compat, ounit }:
+{ stdenv, lib, fetchurl, buildDunePackage, cstruct, bigarray-compat, ounit }:
 
 buildDunePackage rec {
   pname = "io-page";
@@ -18,8 +18,8 @@ buildDunePackage rec {
 
   meta = {
     homepage = "https://github.com/mirage/io-page";
-    license = stdenv.lib.licenses.isc;
+    license = lib.licenses.isc;
     description = "IO memory page library for Mirage backends";
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/iri/default.nix
+++ b/pkgs/development/ocaml-modules/iri/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitLab, ocaml, findlib
+{ stdenv, lib, fetchFromGitLab, ocaml, findlib
 , sedlex, uunf, uutf
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.03"
 then throw "iri is not available for OCaml ${ocaml.version}"
 else
 
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "IRI (RFC3987) native OCaml implementation";
-    license = stdenv.lib.licenses.lgpl3;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/iso8601/default.nix
+++ b/pkgs/development/ocaml-modules/iso8601/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild }:
 
 let version = "0.2.4"; in
 
@@ -16,8 +16,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://ocaml-community.github.io/ISO8601.ml/";
     description = "ISO 8601 and RFC 3999 date parsing for OCaml";
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
+++ b/pkgs/development/ocaml-modules/janestreet/async-rpc-kernel.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane, async_kernel, bin_prot, core_kernel,
+{lib, buildOcamlJane, async_kernel, bin_prot, core_kernel,
  fieldslib, ppx_assert, ppx_bench, ppx_driver, ppx_expect, ppx_inline_test,
  ppx_jane, sexplib, typerep, variantslib}:
 

--- a/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/bin_prot.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane, type_conv}:
+{lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
   name = "bin_prot";

--- a/pkgs/development/ocaml-modules/janestreet/core_bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/core_bench.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib
 , buildOcamlJane
 , core
 , core_extended

--- a/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/fieldslib.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, type_conv, buildOcamlJane }:
+{ lib, type_conv, buildOcamlJane }:
 
 buildOcamlJane {
   name = "fieldslib";

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.11.0" }:
+{ stdenv, lib, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.11.0" }:
 
 { pname, version ? defaultVersion, hash, ...}@args:
 
@@ -14,6 +14,6 @@ buildDunePackage (args // {
     sha256 = hash;
   };
 
-  meta.license = stdenv.lib.licenses.asl20;
+  meta.license = lib.licenses.asl20;
   meta.homepage = "https://github.com/janestreet/${pname}";
 })

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.11.0" }:
+{ lib, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.11.0" }:
 
 { pname, version ? defaultVersion, hash, ...}@args:
 

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildOcaml, fetchurl, ocaml_oasis, opaline }:
+{ lib, buildOcaml, fetchurl, ocaml_oasis, opaline }:
 
 buildOcaml rec {
   name = "js-build-tools";

--- a/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-assert.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_compare, ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools, ppx_type_conv, sexplib}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bench.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_inline_test, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-bin-prot.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools, ppx_type_conv, bin_prot}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-compare.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-custom-printf.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-enumerate.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-expect.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_assert, ppx_compare, ppx_core, ppx_custom_printf, ppx_driver,
  ppx_fields_conv, ppx_here, ppx_inline_test, ppx_sexp_conv, ppx_tools,
  ppx_variants_conv, re, sexplib, variantslib, fieldslib}:

--- a/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-fields-conv.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools, ppx_type_conv}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-here.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-inline-test.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-jane.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_assert,
  ppx_bench, ppx_bin_prot, ppx_compare, ppx_custom_printf, ppx_driver,
  ppx_enumerate, ppx_expect, ppx_fail, ppx_fields_conv, ppx_here,

--- a/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-let.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-optcomp.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-pipebang.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-conv.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools, ppx_type_conv, sexplib}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-message.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-sexp-value.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_driver, ppx_here, ppx_sexp_conv, ppx_tools}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-typerep-conv.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools, ppx_type_conv, typerep}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
+++ b/pkgs/development/ocaml-modules/janestreet/ppx-variants-conv.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane,
+{lib, buildOcamlJane,
  ppx_core, ppx_tools, ppx_type_conv, sexplib, variantslib}:
 
 buildOcamlJane {

--- a/pkgs/development/ocaml-modules/janestreet/sexplib.nix
+++ b/pkgs/development/ocaml-modules/janestreet/sexplib.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane, type_conv}:
+{lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
   minimumSupportedOcamlVersion = "4.02";

--- a/pkgs/development/ocaml-modules/janestreet/typerep.nix
+++ b/pkgs/development/ocaml-modules/janestreet/typerep.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcamlJane, type_conv}:
+{lib, buildOcamlJane, type_conv}:
 
 buildOcamlJane {
   name = "typerep";

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -2,7 +2,7 @@
 , camlzip, extlib
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.04"
+if !lib.versionAtLeast ocaml.version "4.04"
 then throw "javalib is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, uutf }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, uutf }:
 
 let version = "1.0.1"; in
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation {
   meta = {
     description = "An OCaml non-blocking streaming codec to decode and encode the JSON data format";
     homepage = "https://erratique.ch/software/jsonm";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vbgl ];
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
+{ stdenv, lib, fetchurl, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
 
 stdenv.mkDerivation {
   name = "ocaml-lablgtk-extras-1.4";
@@ -14,10 +14,10 @@ stdenv.mkDerivation {
 
   meta = {
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
     homepage = "http://gtk-extras.forge.ocamlcore.org/";
     description = "A collection of libraries and modules useful when developing OCaml/LablGtk2 applications";
-    license = stdenv.lib.licenses.lgpl2Plus;
+    license = lib.licenses.lgpl2Plus;
     branch = "1.4";
   };
 }

--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, camlp4, config-file, lablgtk, xmlm }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02";
+assert lib.versionAtLeast (lib.getVersion ocaml) "4.02";
 
 stdenv.mkDerivation rec {
   version = "1.6";
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
     homepage = "http://gtk-extras.forge.ocamlcore.org/";
     description = "A collection of libraries and modules useful when developing OCaml/LablGtk2 applications";
-    license = stdenv.lib.licenses.lgpl2Plus;
+    license = lib.licenses.lgpl2Plus;
   };
 }

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview, camlp4 }:
+{ stdenv, lib, fetchurl, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview, camlp4 }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.04"
+if lib.versionAtLeast ocaml.version "4.04"
 then throw "lablgtk-2.14 is not available for OCaml ${ocaml.version}" else
 
 let
@@ -31,11 +31,11 @@ stdenv.mkDerivation (rec {
     branch = "2.14";
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
-      stdenv.lib.maintainers.roconnor
+      lib.maintainers.maggesi
+      lib.maintainers.roconnor
     ];
     homepage = "http://wwwfun.kurims.kyoto-u.ac.jp/soft/lsl/lablgtk.html";
     description = "LablGTK is is an Objective Caml interface to GTK";
-    license = stdenv.lib.licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
   };
 })

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchFromGitHub, ocaml, findlib, pkgconfig, gtk2, libgnomecanvas, libglade, gtksourceview }:
 
 let param =
-  let check = stdenv.lib.versionAtLeast ocaml.version; in
+  let check = lib.versionAtLeast ocaml.version; in
   if check "4.06" then rec {
     version = "2.18.10";
     src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, fetchzip, ocaml, findlib, tcl, tk }:
+{ stdenv, lib, fetchurl, fetchzip, ocaml, findlib, tcl, tk }:
 
-let OCamlVersionAtLeast = stdenv.lib.versionAtLeast ocaml.version; in
+let OCamlVersionAtLeast = lib.versionAtLeast ocaml.version; in
 
 if !OCamlVersionAtLeast "4.04"
 then throw "labltk is not available for OCaml ${ocaml.version}"
@@ -80,8 +80,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "OCaml interface to Tcl/Tk, including OCaml library explorer OCamlBrowser";
     homepage = "http://labltk.forge.ocamlcore.org/";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     inherit (ocaml.meta) platforms;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/lacaml/default.nix
+++ b/pkgs/development/ocaml-modules/lacaml/default.nix
@@ -19,7 +19,7 @@ buildDunePackage rec {
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ lapack blas ] ++
-    stdenv.lib.optionals stdenv.isDarwin
+    lib.optionals stdenv.isDarwin
       [ darwin.apple_sdk.frameworks.Accelerate ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/linenoise/default.nix
+++ b/pkgs/development/ocaml-modules/linenoise/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, result }:
+{ lib, fetchFromGitHub, buildDunePackage, result }:
 
 buildDunePackage rec {
   pname = "linenoise";
@@ -17,8 +17,8 @@ buildDunePackage rec {
 
   meta = {
     description = "OCaml bindings to linenoise";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchpatch, python, cmake, llvm, ocaml, findlib, ctypes }:
+{ stdenv, lib, fetchpatch, python, cmake, llvm, ocaml, findlib, ctypes }:
 
-let version = stdenv.lib.getVersion llvm; in
+let version = lib.getVersion llvm; in
 
 stdenv.mkDerivation {
   pname = "ocaml-llvm";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DLLVM_OCAML_OUT_OF_TREE=TRUE"
     "-DLLVM_OCAML_INSTALL_PATH=${placeholder "out"}/ocaml"
-    "-DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=${stdenv.lib.getLib llvm}/lib"
+    "-DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=${lib.getLib llvm}/lib"
   ];
 
   buildFlags = [ "ocaml_all" ];
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     inherit (llvm.meta) license homepage;
     platforms = ocaml.meta.platforms or [];
     description = "OCaml bindings distributed with LLVM";
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 
 }

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -5,7 +5,7 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.03"
 then throw "logs is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, dune }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, dune }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.07"
+if !lib.versionAtLeast ocaml.version "4.07"
 then throw "lua-ml is not available for OCaml ${ocaml.version}"
 else
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     description = "An embeddable Lua 2.5 interpreter implemented in OCaml";
     inherit (src.meta) homepage;
     inherit (ocaml.meta) platforms;
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/lwt_log/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_log/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, lwt }:
+{ lib, fetchFromGitHub, buildDunePackage, lwt }:
 
 buildDunePackage rec {
   pname = "lwt_log";
@@ -18,7 +18,7 @@ buildDunePackage rec {
   meta = {
     description = "Lwt logging library (deprecated)";
     homepage = "https://github.com/aantron/lwt_log";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/lwt_ssl/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_ssl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, buildDunePackage, ssl, lwt }:
+{ lib, fetchzip, buildDunePackage, ssl, lwt }:
 
 buildDunePackage rec {
   pname = "lwt_ssl";
@@ -16,7 +16,7 @@ buildDunePackage rec {
   meta = {
     homepage = "https://github.com/aantron/lwt_ssl";
     description = "OpenSSL binding with concurrent I/O";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/magic-mime/default.nix
+++ b/pkgs/development/ocaml-modules/magic-mime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild }:
 
 let version = "1.0.0"; in
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/mirage/ocaml-magic-mime";
     description = "Convert file extensions to MIME types";
     platforms = ocaml.meta.platforms or [];
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/magick/default.nix
+++ b/pkgs/development/ocaml-modules/magick/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, which, pkgconfig, ocaml, findlib, imagemagick }:
+{ stdenv, lib, fetchurl, which, pkgconfig, ocaml, findlib, imagemagick }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "magick is not available for OCaml ${ocaml.version}"
 else
 
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/";
     description = "ImageMagick Binding for OCaml";
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     platforms = imagemagick.meta.platforms;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild
-, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20190626" else "20140422"
+, version ? if lib.versionAtLeast (lib.getVersion ocaml) "4.02" then "20190626" else "20140422"
 }@args:
 
 let

--- a/pkgs/development/ocaml-modules/mlgmp/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmp/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, ocaml, findlib, gmp, mpfr, ncurses }:
+{stdenv, lib, fetchurl, ocaml, findlib, gmp, mpfr, ncurses }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.03"
+if lib.versionAtLeast ocaml.version "4.03"
 then throw "mlgmp is not available for OCaml ${ocaml.version}" else
 
 let

--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl, ocaml, findlib, camlidl, gmp, mpfr }:
+{ stdenv, lib, fetchFromGitHub, perl, ocaml, findlib, camlidl, gmp, mpfr }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-mlgmpidl-${version}";
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "OCaml interface to the GMP library";
     homepage = "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlgmpidl/";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     inherit (ocaml.meta) platforms;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/mparser/default.nix
+++ b/pkgs/development/ocaml-modules/mparser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild }:
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-mparser-1.2.3";
@@ -17,9 +17,9 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A simple monadic parser combinator OCaml library";
-    license = stdenv.lib.licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
     homepage = "https://github.com/cakeplus/mparser";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   buildInputs = [ findlib topkg ]
-  ++ stdenv.lib.optional jsooSupport js_of_ocaml;
+  ++ optional jsooSupport js_of_ocaml;
 
   buildPhase = "${topkg.buildPhase} --with-js_of_ocaml ${boolToString jsooSupport}";
 

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, ocaml, findlib, libmysqlclient }:
+{ stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, libmysqlclient }:
 
 # TODO: la versione stabile da' un errore di compilazione dovuto a
 # qualche cambiamento negli header .h
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://ocaml-mysql.forge.ocamlcore.org";
     description = "Bindings for interacting with MySQL databases from ocaml";
-    license = stdenv.lib.licenses.lgpl21Plus;
-    maintainers = [ stdenv.lib.maintainers.roconnor ];
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.roconnor ];
   };
 }

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, topkg
+{ stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, topkg
 , cpuid, ocb-stubblr, sexplib
 , cstruct, zarith, ppx_sexp_conv, ppx_deriving, writeScriptBin
 , cstruct-lwt ? null
 }:
 
-with stdenv.lib;
+with lib;
 let
   withLwt = cstruct-lwt != null;
   # the build system will call 'cc' with no way to override
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/mirleft/ocaml-nocrypto";
     description = "Simplest possible crypto to support TLS";
-    license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ocb-stubblr
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, ocb-stubblr
 , result, uucp, uuseg, uutf
 , lwt     ? null }:
 
-with stdenv.lib;
+with lib;
 
 if !versionAtLeast ocaml.version "4.05"
 then throw "notty is not available for OCaml ${ocaml.version}"

--- a/pkgs/development/ocaml-modules/num/default.nix
+++ b/pkgs/development/ocaml-modules/num/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		description = "Legacy Num library for arbitrary-precision integer and rational arithmetic";
-		license = stdenv.lib.licenses.lgpl21;
+		license = lib.licenses.lgpl21;
 		inherit (ocaml.meta) platforms;
 		inherit (src.meta) homepage;
 	};

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -1,10 +1,10 @@
-{stdenv, fetchurl, automake, ocaml, autoconf, gnum4, pkgconfig, freetype, lablgtk, unzip, cairo, findlib, gdk-pixbuf, gtk2, pango }:
+{stdenv, lib, fetchurl, automake, ocaml, autoconf, gnum4, pkgconfig, freetype, lablgtk, unzip, cairo, findlib, gdk-pixbuf, gtk2, pango }:
 
 let
   pname = "ocaml-cairo";
 in
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://cairographics.org/cairo-ocaml";
     description = "ocaml bindings for cairo library";
-    license = stdenv.lib.licenses.gpl2;
+    license = lib.licenses.gpl2;
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-syntax-shims/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-syntax-shims/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildDunePackage, fetchurl }:
+{ lib, buildDunePackage, fetchurl }:
 
 buildDunePackage rec {
   minimumOCamlVersion = "4.02.3";

--- a/pkgs/development/ocaml-modules/ocaml-text/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-text/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, libiconv, ocaml, findlib, ocamlbuild, ncurses }:
+{ stdenv, lib, fetchzip, libiconv, ocaml, findlib, ocamlbuild, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "ocaml-text";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://ocaml-text.forge.ocamlcore.org/";
     description = "A library for convenient text manipulation";
-    license = stdenv.lib.licenses.bsd3;
+    license = lib.licenses.bsd3;
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, camlidl, fuse }:
+{ stdenv, lib, buildDunePackage, fetchFromGitHub, camlidl, fuse }:
 
 buildDunePackage {
   pname = "ocamlfuse";
@@ -16,8 +16,8 @@ buildDunePackage {
   meta = {
     homepage = "https://sourceforge.net/projects/ocamlfuse";
     description = "OCaml bindings for FUSE";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ bennofs ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bennofs ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildDunePackage, fetchFromGitHub, camlidl, fuse }:
+{ lib, buildDunePackage, fetchFromGitHub, camlidl, fuse }:
 
 buildDunePackage {
   pname = "ocamlfuse";

--- a/pkgs/development/ocaml-modules/ocamlgraph/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlgraph/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib
+{ stdenv, lib, fetchurl, ocaml, findlib
 , gtkSupport ? true
 , lablgtk
 }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ocaml findlib ]
-  ++ stdenv.lib.optional gtkSupport lablgtk
+  ++ lib.optional gtkSupport lablgtk
   ;
 
   createFindlibDestdir = true;
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildFlags =  [ "all" ];
   installTargets = [ "install-findlib" ];
 
-  postInstall = stdenv.lib.optionalString gtkSupport ''
+  postInstall = lib.optionalString gtkSupport ''
     mkdir -p $out/bin
     cp dgraph/dgraph.opt $out/bin/graph-viewer
     cp editor/editor.opt $out/bin/graph-editor
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://ocamlgraph.lri.fr/";
     description = "Graph library for Objective Caml";
-    license = stdenv.lib.licenses.gpl2Oss;
+    license = lib.licenses.gpl2Oss;
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.kkallio
+      lib.maintainers.kkallio
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlmake/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlmake/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{stdenv, lib, fetchurl}:
 
 let
 
@@ -25,6 +25,6 @@ in stdenv.mkDerivation {
     homepage = "http://www.ocaml.info/home/ocaml_sources.html";
     description = "Generic OCaml Makefile for GNU Make";
     license = "LGPL";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlnat/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnat/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "OCaml native toplevel";
     homepage = "http://benediktmeurer.de/ocamlnat/";
-    license = stdenv.lib.licenses.qpl;
+    license = lib.licenses.qpl;
     longDescription = ''
       The ocamlnat project provides a new native code OCaml toplevel
       ocamlnat, which is mostly compatible to the byte code toplevel ocaml,
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     '';
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
+      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, ncurses, ocaml, findlib, ocaml_pcre, camlzip
+{ stdenv, lib, fetchurl, pkgconfig, ncurses, ocaml, findlib, ocaml_pcre, camlzip
 , gnutls, nettle
 }:
 
-if stdenv.lib.versionOlder ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "ocamlnet is not available for OCaml ${ocaml.version}"
 else
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     license = "Most Ocamlnet modules are released under the zlib/png license. The HTTP server module Nethttpd is, however, under the GPL.";
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.maggesi
+      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocamlsdl/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlsdl/default.nix
@@ -1,10 +1,10 @@
-{stdenv, fetchurl, ocaml, pkgconfig, findlib, SDL, SDL_image, SDL_mixer, SDL_ttf, SDL_gfx, lablgl }: 
+{stdenv, lib, fetchurl, ocaml, pkgconfig, findlib, SDL, SDL_image, SDL_mixer, SDL_ttf, SDL_gfx, lablgl }: 
 
 let
   pname = "ocamlsdl";
 in
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://ocamlsdl.sourceforge.net/";
     description = "OCaml bindings for SDL 1.2";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
   };
 }

--- a/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
+++ b/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, topkg, astring }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, topkg, astring }:
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-ocb-stubblr-0.1.0";
@@ -19,8 +19,8 @@ stdenv.mkDerivation {
   meta = {
     description = "OCamlbuild plugin for C stubs";
     homepage = "https://github.com/pqwy/ocb-stubblr";
-    license = stdenv.lib.licenses.isc;
+    license = lib.licenses.isc;
     inherit (ocaml.meta) platforms;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocf/default.nix
+++ b/pkgs/development/ocaml-modules/ocf/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, ppx_tools, yojson }:
 
-if stdenv.lib.versionOlder ocaml.version "4.03"
-|| stdenv.lib.versionAtLeast ocaml.version "4.08"
+if lib.versionOlder ocaml.version "4.03"
+|| lib.versionAtLeast ocaml.version "4.08"
 then throw "ocf not supported for ocaml ${ocaml.version}"
 else
 stdenv.mkDerivation rec {

--- a/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
+++ b/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, astring, pprint }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, astring, pprint }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "ocp-ocamlres is not available for OCaml ${ocaml.version}"
 else
 
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		description = "A simple tool and library to embed files and directories inside OCaml executables";
-		license = stdenv.lib.licenses.lgpl3Plus;
+		license = lib.licenses.lgpl3Plus;
 		homepage = "https://www.typerex.org/ocp-ocamlres.html";
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/ocplib-endian/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-endian/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, cppo }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, cppo }:
 
 let version = "1.0"; in
 
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
   meta = {
     description = "Optimised functions to read and write int16/32/64";
     homepage = "https://github.com/OCamlPro/ocplib-endian";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, ocaml, findlib }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, ocaml, findlib }:
 
 let
   pname = "ocplib-simplex";
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     description = "An OCaml library implementing a simplex algorithm, in a functional style, for solving systems of linear inequalities";
     homepage = "https://github.com/OCamlPro-Iguernlala/ocplib-simplex";
     inherit (ocaml.meta) platforms;
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, oasis, ocaml_optcomp, camlp4
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, oasis, ocaml_optcomp, camlp4
 , num
 }:
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.03"
+  if lib.versionAtLeast ocaml.version "4.03"
   then {
     version = "0.8.1";
     sha256 = "03vzrybdpjydbpil97zmir71kpsn2yxkjnzysma7fvybk8ll4zh9";
@@ -32,9 +32,9 @@ stdenv.mkDerivation {
   meta =  {
     homepage = "https://github.com/ocsigen/deriving";
     description = "Extension to OCaml for deriving functions from type declarations";
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [
+    maintainers = with lib.maintainers; [
       gal_bolle vbgl
     ];
   };

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, which, ocaml, findlib, lwt_react, ssl, lwt_ssl
+{ stdenv, lib, fetchFromGitHub, which, ocaml, findlib, lwt_react, ssl, lwt_ssl
 , lwt_log, ocamlnet, ocaml_pcre, cryptokit, tyxml, xml-light, ipaddr
 , pgocaml, camlzip, ocaml_sqlite3
 , makeWrapper, fetchpatch
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.06.1"
+if !lib.versionAtLeast ocaml.version "4.06.1"
 then throw "ocsigenserver is not available for OCaml ${ocaml.version}"
 else
 
@@ -58,9 +58,9 @@ stdenv.mkDerivation rec {
     longDescription =''
       A full featured Web server. It implements most features of the HTTP protocol, and has a very powerful extension mechanism that make very easy to plug your own OCaml modules for generating pages.
       '';
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     platforms = ocaml.meta.platforms or [];
-    maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+    maintainers = [ lib.maintainers.gal_bolle ];
   };
 
 }

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
 , cohttp-lwt-unix
 , resource-pooling
 }:
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
     longDescription =''
      An Eliom application skeleton, ready to use to build your own application with users, (pre)registration, notifications, etc.
       '';
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     inherit (ocaml.meta) platforms;
-    maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+    maintainers = [ lib.maintainers.gal_bolle ];
   };
 
 }

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, opaline
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, opaline
 , calendar, eliom, js_of_ocaml-ppx_deriving_json
 }:
 
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://ocsigen.org/ocsigen-toolkit/";
     description = " User interface widgets for Ocsigen applications";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.gal_bolle ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.gal_bolle ];
     inherit (ocaml.meta) platforms;
   };
 

--- a/pkgs/development/ocaml-modules/octavius/default.nix
+++ b/pkgs/development/ocaml-modules/octavius/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.03"
 then throw "octavius is not available for OCaml ${ocaml.version}" else
 
 stdenv.mkDerivation {
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
 	meta = {
 		description = "Ocamldoc comment syntax parser";
 		homepage = "https://github.com/ocaml-doc/octavius";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.isc;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pkgconfig, ocaml, findlib, fetchurl, curl, ncurses }:
+{ stdenv, lib, pkgconfig, ocaml, findlib, fetchurl, curl, ncurses }:
 
-if stdenv.lib.versionOlder ocaml.version "4.02"
+if lib.versionOlder ocaml.version "4.02"
 then throw "ocurl is not available for OCaml ${ocaml.version}"
 else
 
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
   meta = {
     description = "OCaml bindings to libcurl";
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     homepage = "http://ygrek.org.ua/p/ocurl/";
-    maintainers = with stdenv.lib.maintainers; [ bennofs ];
+    maintainers = with lib.maintainers; [ bennofs ];
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, type_conv, ounit, camlp4 }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "ocaml-data-notation is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/omd/default.nix
+++ b/pkgs/development/ocaml-modules/omd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild }:
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-omd-1.3.1";
@@ -16,8 +16,8 @@ stdenv.mkDerivation {
   meta = {
     description = "Extensible Markdown library and tool in OCaml";
     homepage = "https://github.com/ocaml/omd";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/opam-file-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-file-format/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib }:
 
 stdenv.mkDerivation rec {
   version = "2.0.0";
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Parser and printer for the opam file syntax";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/optcomp/default.nix
+++ b/pkgs/development/ocaml-modules/optcomp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, camlp4 }:
+{ stdenv, lib, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, camlp4 }:
 
 stdenv.mkDerivation {
   name = "ocaml-optcomp-1.6";
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   };
 
   patches =
-    let inherit (stdenv.lib) optional versionAtLeast; in
+    let inherit (lib) optional versionAtLeast; in
     optional (versionAtLeast ocaml.version "4.02") (fetchpatch {
       url = "https://github.com/diml/optcomp/commit/b7f809360c9794b383a4bc0492f6df381276b429.patch";
       sha256 = "1n095lk94jq1rwi0l24g2wbgms7249wdd31n0ji895dr6755s93y";
@@ -37,10 +37,10 @@ stdenv.mkDerivation {
   meta =  {
     homepage = "https://github.com/diml/optcomp";
     description = "Optional compilation for OCaml with cpp-like directives";
-    license = stdenv.lib.licenses.bsd3;
+    license = lib.licenses.bsd3;
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.gal_bolle
+      lib.maintainers.gal_bolle
     ];
   };
 

--- a/pkgs/development/ocaml-modules/opti/default.nix
+++ b/pkgs/development/ocaml-modules/opti/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildDunePackage }:
+{ lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "opti";

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -6,7 +6,7 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
+assert lib.versionAtLeast ocaml.version "4.01.0";
 
 stdenv.mkDerivation {
 

--- a/pkgs/development/ocaml-modules/pa_bench/default.nix
+++ b/pkgs/development/ocaml-modules/pa_bench/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcaml, fetchurl, type_conv, pa_ounit}:
+{lib, buildOcaml, fetchurl, type_conv, pa_ounit}:
 
 buildOcaml rec {
   name = "pa_bench";
@@ -17,7 +17,7 @@ buildOcaml rec {
   meta = with lib; {
     homepage = "https://github.com/janestreet/pa_bench";
     description = "Syntax extension for inline benchmarks";
-    license = stdenv.lib.licenses.asl20;
+    license = licenses.asl20;
     maintainers = [ maintainers.ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/pa_ounit/default.nix
+++ b/pkgs/development/ocaml-modules/pa_ounit/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, buildOcaml, ocaml, fetchurl, ounit }:
+{ lib, buildOcaml, ocaml, fetchurl, ounit }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "pa_ounit is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcaml, fetchurl}:
+{lib, buildOcaml, fetchurl}:
 
 buildOcaml rec {
   name = "pipebang";

--- a/pkgs/development/ocaml-modules/pprint/default.nix
+++ b/pkgs/development/ocaml-modules/pprint/default.nix
@@ -1,9 +1,9 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
+assert lib.versionAtLeast (lib.getVersion ocaml) "3.12";
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02"
+  if lib.versionAtLeast ocaml.version "4.02"
   then {
     version = "20171003";
     sha256 = "06zwsskri8kaqjdszj9360nf36zvwh886xwf033aija8c9k4w6cx";

--- a/pkgs/development/ocaml-modules/ppx_derivers/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_derivers/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage }:
+{ lib, fetchFromGitHub, buildDunePackage }:
 
 buildDunePackage rec {
 	pname = "ppx_derivers";
@@ -15,8 +15,8 @@ buildDunePackage rec {
 
 	meta = {
 		description = "Shared [@@deriving] plugin registry";
-		license = stdenv.lib.licenses.bsd3;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.bsd3;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
 	};
 }

--- a/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_gen_rec/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildDunePackage, ocaml-migrate-parsetree }:
+{ lib, fetchurl, buildDunePackage, ocaml-migrate-parsetree }:
 
 buildDunePackage rec {
   pname = "ppx_gen_rec";

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -46,7 +46,7 @@ let src = fetchFromGitHub {
       maintainers = with maintainers; [ vbgl ];
     };
 in
-if stdenv.lib.versionAtLeast param.version "6.0"
+if lib.versionAtLeast param.version "6.0"
 then
   buildDunePackage {
     inherit pname src meta;

--- a/pkgs/development/ocaml-modules/process/default.nix
+++ b/pkgs/development/ocaml-modules/process/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-process-${version}";
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Easy process control in OCaml";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
+++ b/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, ocaml, findlib, menhir }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, ocaml, findlib, menhir }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.03"
 then throw "psmt2-frontend is not available for OCaml ${ocaml.version}"
 else
 
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A simple parser and type-checker for polomorphic extension of the SMT-LIB 2 language";
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, result, js_of_ocaml }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, result, js_of_ocaml }:
 
 stdenv.mkDerivation rec {
   version = "0.8.5";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
       Ptime is not a calendar library.
     '';
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ sternenseemann ];
   };
 }

--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, react, opaline }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.04"
+if !lib.versionAtLeast ocaml.version "4.04"
 then throw "reactiveData is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, dune, benchmark }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, dune, benchmark }:
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.03"
+  if lib.versionAtLeast ocaml.version "4.03"
   then rec {
     version = "0.6.2";
     url = "https://github.com/Chris00/ocaml-rope/releases/download/${version}/rope-${version}.tbz";
@@ -33,7 +33,7 @@ stdenv.mkDerivation ({
     homepage = "http://rope.forge.ocamlcore.org/";
     platforms = ocaml.meta.platforms or [];
     description = ''Ropes ("heavyweight strings") in OCaml'';
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = with stdenv.lib.maintainers; [ volth ];
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ volth ];
   };
 } // param.extra)

--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
 
 stdenv.mkDerivation rec {
 	name = "ocaml${ocaml.version}-rresult-${version}";
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
 	inherit (topkg) buildPhase installPhase;
 
 	meta = {
-		license = stdenv.lib.licenses.isc;
+		license = lib.licenses.isc;
 		homepage = "https://erratique.ch/software/rresult";
 		description = "Result value combinators for OCaml";
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -6,7 +6,7 @@ let
   webpage = "http://sawja.inria.fr/";
 in
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.07"
+if !lib.versionAtLeast ocaml.version "4.07"
 then throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/secp256k1/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, buildDunePackage, base, stdio, dune-configurator, secp256k1 }:
+{ lib, fetchFromGitHub, buildDunePackage, base, stdio, dune-configurator, secp256k1 }:
 
 buildDunePackage rec {
   pname = "secp256k1";

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip, ocaml, findlib, gen, ppx_tools_versioned, ocaml-migrate-parsetree }:
+{ stdenv, lib, fetchzip, ocaml, findlib, gen, ppx_tools_versioned, ocaml-migrate-parsetree }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "sedlex is not available for OCaml ${ocaml.version}"
 else
 
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/ocaml-community/sedlex";
     description = "An OCaml lexer generator for Unicode";
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     inherit (ocaml.meta) platforms;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/seq/default.nix
+++ b/pkgs/development/ocaml-modules/seq/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 stdenv.mkDerivation ({
   version = "0.1";
   name = "ocaml${ocaml.version}-seq-0.1";
 
   meta = {
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
     homepage = "https://github.com/c-cube/seq";
     inherit (ocaml.meta) platforms;
   };
 
-} // (if stdenv.lib.versionOlder ocaml.version "4.07" then {
+} // (if lib.versionOlder ocaml.version "4.07" then {
 
   src = fetchFromGitHub {
     owner = "c-cube";

--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, ctypes, libsodium }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.10"
+if lib.versionAtLeast ocaml.version "4.10"
 then throw "sodium is not available for OCaml ${ocaml.version}"
 else
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
+  hardeningDisable = lib.optional stdenv.isDarwin "strictoverflow";
 
   meta = with lib; {
     homepage = "https://github.com/dsheets/ocaml-sodium";

--- a/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, twt, ocaml_sqlite3 }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
+assert lib.versionAtLeast (lib.getVersion ocaml) "3.12";
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "sqlite3EZ is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/stringext/default.nix
+++ b/pkgs/development/ocaml-modules/stringext/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, ounit, qcheck
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, ounit, qcheck
 # Optionally enable tests; test script use OCaml-4.01+ features
-, doCheck ? stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.01"
+, doCheck ? lib.versionAtLeast (lib.getVersion ocaml) "4.01"
 }:
 
 let version = "1.4.3"; in
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ocamlbuild ounit qcheck ];
 
   configurePhase = "ocaml setup.ml -configure --prefix $out"
-  + stdenv.lib.optionalString doCheck " --enable-tests";
+  + lib.optionalString doCheck " --enable-tests";
   buildPhase = "ocaml setup.ml -build";
   inherit doCheck;
   checkPhase = "ocaml setup.ml -test";
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/rgrinberg/stringext";
     platforms = ocaml.meta.platforms or [];
     description = "Extra string functions for OCaml";
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/syslog/default.nix
+++ b/pkgs/development/ocaml-modules/syslog/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, ocaml, findlib }:
 
-assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.03.0";
+assert lib.versionAtLeast (lib.getVersion ocaml) "4.03.0";
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-syslog";

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -5,11 +5,11 @@ The `buildPhase` and `installPhase` attributes can be reused directly
 in many cases. When more fine-grained control on how to run the “topkg”
 build system is required, the attribute `run` can be used.
 */
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, result, opaline }:
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, result, opaline }:
 
 let
   param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.03" then {
+  if lib.versionAtLeast ocaml.version "4.03" then {
     version = "1.0.3";
     sha256 = "0b77gsz9bqby8v77kfi4lans47x9p2lmzanzwins5r29maphb8y6";
   } else {
@@ -46,8 +46,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://erratique.ch/software/topkg";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
     description = "A packager for distributing OCaml software";
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ctypes, result, SDL2, pkgconfig, ocb-stubblr }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.03"
 then throw "tsdl is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
@@ -1,7 +1,7 @@
 {lib, stdenv, fetchurl, ocaml, findlib, camlp4}:
 
-if !stdenv.lib.versionAtLeast ocaml.version "3.12"
-|| stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "3.12"
+|| lib.versionAtLeast ocaml.version "4.03"
 then throw "type_conv-108.08.00 is not available for OCaml ${ocaml.version}" else
 
 stdenv.mkDerivation {

--- a/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchurl, ocaml, findlib, camlp4}:
+{stdenv, lib, fetchurl, ocaml, findlib, camlp4}:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.00"
-|| stdenv.lib.versionAtLeast ocaml.version "4.03"
+if !lib.versionAtLeast ocaml.version "4.00"
+|| lib.versionAtLeast ocaml.version "4.03"
 then throw "type_conv-109.60.01 is not available for OCaml ${ocaml.version}" else
 
 stdenv.mkDerivation {
@@ -19,8 +19,8 @@ stdenv.mkDerivation {
   meta = {
     homepage = "http://forge.ocamlcore.org/projects/type-conv/";
     description = "Support library for OCaml preprocessor type conversions";
-    license = stdenv.lib.licenses.lgpl21;
+    license = lib.licenses.lgpl21;
     platforms = ocaml.meta.platforms or [];
-    maintainers = with stdenv.lib.maintainers; [ maggesi ];
+    maintainers = with lib.maintainers; [ maggesi ];
   };
 }

--- a/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, buildOcaml}:
+{ lib, fetchurl, buildOcaml}:
 
 buildOcaml rec {
   minimumSupportedOcamlVersion = "4.02";
@@ -14,7 +14,7 @@ buildOcaml rec {
   meta = {
     homepage = "https://github.com/janestreet/type_conv/";
     description = "Support library for preprocessor type conversions";
-    license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ maggesi ericbmerritt ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ maggesi ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/typerep/default.nix
+++ b/pkgs/development/ocaml-modules/typerep/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, buildOcaml, fetchurl, type_conv}:
+{lib, buildOcaml, fetchurl, type_conv}:
 
 buildOcaml rec {
   name = "typerep";

--- a/pkgs/development/ocaml-modules/uchar/default.nix
+++ b/pkgs/development/ocaml-modules/uchar/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation {
   meta = {
     description = "Compatibility library for OCaml’s Uchar module";
     inherit (ocaml.meta) platforms license;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, camlp4 }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, camlp4 }:
 
 let
   pname = "ulex";
   param =
-    if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
+    if lib.versionAtLeast ocaml.version "4.02" then {
       version = "1.2";
       sha256 = "08yf2x9a52l2y4savjqfjd2xy4pjd1rpla2ylrr9qrz1drpfw4ic";
     } else {
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
   meta = {
     inherit (src.meta) homepage;
     description = "A lexer generator for Unicode and OCaml";
-    license = stdenv.lib.licenses.mit;
+    license = lib.licenses.mit;
     platforms = ocaml.meta.platforms or [];
-    maintainers = [ stdenv.lib.maintainers.roconnor ];
+    maintainers = [ lib.maintainers.roconnor ];
   };
 }

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -6,7 +6,7 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01";
+assert lib.versionAtLeast ocaml.version "4.01";
 
 stdenv.mkDerivation {
 

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -21,7 +21,7 @@ let
   };
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.03";
+assert lib.versionAtLeast ocaml.version "4.03";
 
 stdenv.mkDerivation {
   name = "ocaml-${pname}-${version}";

--- a/pkgs/development/ocaml-modules/variantslib/default.nix
+++ b/pkgs/development/ocaml-modules/variantslib/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, buildOcaml, ocaml, fetchurl, type_conv }:
 
-if stdenv.lib.versionAtLeast ocaml.version "4.06"
+if lib.versionAtLeast ocaml.version "4.06"
 then throw "variantslib-109.15.03 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/variantslib/default.nix
+++ b/pkgs/development/ocaml-modules/variantslib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildOcaml, ocaml, fetchurl, type_conv }:
+{ lib, buildOcaml, ocaml, fetchurl, type_conv }:
 
 if lib.versionAtLeast ocaml.version "4.06"
 then throw "variantslib-109.15.03 is not available for OCaml ${ocaml.version}"

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -8,7 +8,7 @@
 with lib;
 
 let
-  inherit (stdenv.lib) optionals versionAtLeast;
+  inherit (lib) optionals versionAtLeast;
 
   pname = "vg";
   version = "0.9.4";

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "wasm is not available for OCaml ${ocaml.version}"
 else
 
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An executable and OCaml library to run, read and write Web Assembly (wasm) files and manipulate their AST";
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
     homepage = "https://github.com/WebAssembly/spec/tree/master/interpreter";
     inherit (ocaml.meta) platforms;
   };

--- a/pkgs/development/ocaml-modules/webbrowser/default.nix
+++ b/pkgs/development/ocaml-modules/webbrowser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg
 , astring, bos, cmdliner, rresult
 }:
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 	meta = {
 		description = "Open and reload URIs in browsers from OCaml";
 		homepage = "https://erratique.ch/software/webbrowser";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.isc;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{stdenv, lib, fetchurl, ocaml, findlib}:
 let
   pname = "xml-light";
   version = "2.4";
@@ -36,8 +36,8 @@ stdenv.mkDerivation {
       library.
     '';
     homepage = "http://tech.motion-twin.com/xmllight.html";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.romildo ];
     platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -4,7 +4,7 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "xmlm is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitLab, ocaml, findlib, iri, ppx_tools, js_of_ocaml
 , js_of_ocaml-ppx, re }:
 
-if stdenv.lib.versionOlder ocaml.version "4.03"
-|| stdenv.lib.versionAtLeast ocaml.version "4.11"
+if lib.versionOlder ocaml.version "4.03"
+|| lib.versionAtLeast ocaml.version "4.11"
 then throw "xtmpl not supported for ocaml ${ocaml.version}"
 else
 stdenv.mkDerivation rec {

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -2,7 +2,7 @@
 let
   pname = "yojson";
   param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then rec {
+  if lib.versionAtLeast ocaml.version "4.02" then rec {
     version = "1.7.0";
     url = "https://github.com/ocaml-community/yojson/releases/download/${version}/yojson-${version}.tbz";
     sha256 = "08llz96if8bcgnaishf18si76cv11zbkni0aldb54k3cn7ipiqvd";

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let source =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02"
+  if lib.versionAtLeast ocaml.version "4.02"
   then {
     version = "1.11";
     url = "https://github.com/ocaml/Zarith/archive/release-1.11.tar.gz";

--- a/pkgs/development/ocaml-modules/zed/default.nix
+++ b/pkgs/development/ocaml-modules/zed/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, camomile, react, dune, charInfo_width }:
+{ stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, camomile, react, dune, charInfo_width }:
 
 let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02" then
+  if lib.versionAtLeast ocaml.version "4.02" then
   {
     version = "3.1.0";
     sha256 = "04vr1a94imsghm98iigc35rhifsz0rh3qz2qm0wam2wvp6vmrx0p";
@@ -42,10 +42,10 @@ stdenv.mkDerivation (rec {
     To support efficient text edition capabilities, Zed provides macro recording and cursor management facilities.
     '';
     homepage = "https://github.com/diml/zed";
-    license = stdenv.lib.licenses.bsd3;
+    license = lib.licenses.bsd3;
     platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.gal_bolle
+      lib.maintainers.gal_bolle
     ];
   };
 } // param.extra)


### PR DESCRIPTION
This change was produced by searching for remaining occurrences of
stdenv.lib and replacing them manually.

Reference #108938.

Will need to verify the change now.

* [ ] Run ofborg checks locally

cc @Profpatsch @vbgl

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
