### PR TITLE
reddsaver: init at 0.2.2

### DIFF
--- a/pkgs/applications/misc/reddsaver/default.nix
+++ b/pkgs/applications/misc/reddsaver/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, openssl
+, pkg-config
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  version = "0.2.2";
+  pname = "reddsaver";
+
+  src = fetchFromGitHub {
+    owner = "manojkarthick";
+    repo = "reddsaver";
+    rev = "v${version}";
+    sha256 = "0802jz503jhyz5q6mg1fj2bvkl4nggvs8y03zddd298ymplx5dbx";
+  };
+
+  cargoSha256 = "0z8q187331j3rxj8hzym25pwrikxbd0r829v29y8w6v5n0hb47fs";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+  # package does not contain tests as of v0.2.2
+  docCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "CLI tool to download saved images from Reddit";
+    homepage = "https://github.com/manojkarthick/reddsaver";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = [ maintainers.manojkarthick ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24250,6 +24250,10 @@ in
 
   recode = callPackage ../tools/text/recode { };
 
+  reddsaver = callPackage ../applications/misc/reddsaver {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   rednotebook = python3Packages.callPackage ../applications/editors/rednotebook { };
 
   remotebox = callPackage ../applications/virtualization/remotebox { };


### PR DESCRIPTION
###### Motivation for this change
Command line tool to download saved images from Reddit
GitHub: https://github.com/manojkarthick/reddsaver


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
