### PR TITLE
rambox: migrate to use AppImage

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/default.nix
@@ -1,45 +1,21 @@
-{ stdenv, lib, fetchurl, xdg_utils, dpkg, makeWrapper, autoPatchelfHook
-, libXtst, libXScrnSaver, gtk3, nss, alsaLib, udev, libnotify, wrapGAppsHook
-}:
+{ stdenv, callPackage, fetchurl, lib }:
 
 let
-  version = "0.7.7";
-in stdenv.mkDerivation rec {
+  mkRambox = opts: callPackage (import ./rambox.nix opts) { };
+in mkRambox rec {
   pname = "rambox";
-  inherit version;
+  version = "0.7.7";
+
   src = {
     x86_64-linux = fetchurl {
-      url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-amd64.deb";
-      sha256 = "0bij4f1bkg94gc8pq7r6yfym5zcvwc2ymdnmnmh5m4h1pa1gk6x9";
+      url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-x86_64.AppImage";
+      sha256 = "0f82hq0dzcjicdz6lkzj8889y100yqciqrwh8wjjy9pxkhjcdini";
     };
     i686-linux = fetchurl {
-      url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-i386.deb";
-      sha256 = "1nhgqjha10jvyf9nsghvlkibg7byj8qz140639ygag9qlpd51rfs";
+      url = "https://github.com/ramboxapp/community-edition/releases/download/${version}/Rambox-${version}-linux-i386.AppImage";
+      sha256 = "1nhgqjha10jvyf9nsghvlkibg7byj8qz140639ygag9qlpd52rfs";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
-
-  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
-  buildInputs = [ libXtst libXScrnSaver gtk3 nss alsaLib ];
-  runtimeDependencies = [ (lib.getLib udev) libnotify ];
-
-  unpackPhase = "dpkg-deb -x $src .";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -r opt $out
-    ln -s $out/opt/Rambox/rambox $out/bin
-
-    # provide resources
-    cp -r usr/share $out
-    substituteInPlace $out/share/applications/rambox.desktop \
-      --replace Exec=/opt/Rambox/rambox Exec=rambox
-  '';
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix PATH : ${xdg_utils}/bin
-    )
-  '';
 
   meta = with lib; {
     description = "Free and Open Source messaging and emailing app that combines common web applications into one";

--- a/pkgs/applications/networking/instant-messengers/rambox/pro.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/pro.nix
@@ -1,56 +1,25 @@
-{ autoPatchelfHook, electron_7, fetchurl, makeDesktopItem, makeWrapper, nodePackages, nss, lib, stdenv, xdg_utils, xorg }:
+{ stdenv, callPackage, fetchurl, lib }:
 
 let
-  electron = electron_7;
-in
-stdenv.mkDerivation rec {
+  mkRambox = opts: callPackage (import ./rambox.nix opts) { };
+in mkRambox rec {
   pname = "rambox-pro";
   version = "1.4.1";
 
-  dontBuild = true;
-  dontStrip = true;
+  desktopName = "Rambox Pro";
 
-  buildInputs = [ nss xorg.libXext xorg.libxkbfile xorg.libXScrnSaver ];
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper nodePackages.asar ];
-
-  src = fetchurl {
-    url = "https://github.com/ramboxapp/download/releases/download/v${version}/RamboxPro-${version}-linux-x64.tar.gz";
-    sha256 = "1bd4fba3ac8c20fa557ebfb110f6503d36e6c3dba0401d1073529dcae2c2ec1e";
-  };
-
-  installPhase = ''
-    mkdir -p $out/{bin,resources/dist/renderer/assets/images/app,share/applications,share/icons/hicolor/256x256/apps}
-
-    asar e resources/app.asar $out/resources
-
-    substituteInPlace "$out/resources/dist/electron/main.js" \
-      --replace ",isHidden:" ",path:\"$out/bin/ramboxpro\",isHidden:"
-
-    cp $desktopItem/share/applications/* $out/share/applications
-    cp $out/resources/dist/electron/imgs/256x256.png $out/share/icons/hicolor/256x256/apps/ramboxpro.png
-    cp $out/resources/dist/electron/imgs/256x256.png $out/resources/dist/renderer/assets/images/app/icon.png
-  '';
-
-  postFixup = ''
-    makeWrapper ${electron}/bin/electron $out/bin/ramboxpro \
-      --add-flags "$out/resources --without-update" \
-      --prefix PATH : ${xdg_utils}/bin
-  '';
-
-  desktopItem = makeDesktopItem {
-    name = "rambox-pro";
-    exec = "ramboxpro";
-    icon = "ramboxpro";
-    type = "Application";
-    desktopName = "Rambox Pro";
-    categories = "Network;";
-  };
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/ramboxapp/download/releases/download/v${version}/RamboxPro-${version}-linux-x64.AppImage";
+      sha256 = "18383v3g26hd1czvw06gmjn8bdw2w9c7zb04zkfl6szgakrv26x4";
+    };
+  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
   meta = with lib; {
     description = "Messaging and emailing app that combines common web applications into one";
     homepage = "https://rambox.pro";
     license = licenses.unfree;
     maintainers = with maintainers; [ chrisaw ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/rambox/rambox.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/rambox.nix
@@ -1,0 +1,30 @@
+{ pname, version, src, meta, desktopName ? "Rambox" }:
+
+{ appimageTools, stdenv, lib, fetchurl, makeDesktopItem }:
+
+let
+  name = "${pname}-${version}";
+
+  desktopItem = (makeDesktopItem {
+    inherit desktopName;
+    name = pname;
+    exec = pname;
+    icon = pname;
+    type = "Application";
+    categories = "Network;";
+  });
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 rec {
+  inherit name src meta;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/256x256/apps
+    # CE uses rambox-<version>, Pro uses rambox
+    mv $out/bin/rambox* $out/bin/${pname}
+    install -Dm644 ${appimageContents}/usr/share/icons/hicolor/256x256/apps/rambox*.png $out/share/icons/hicolor/256x256/apps/${pname}.png
+    install -Dm644 ${desktopItem}/share/applications/* $out/share/applications
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change

The motivation comes from PR #108787: AppImage is the official and using it should avoid some issues.

Also, migrating both packages (instead of only rambox-pro like #108787) can make maintaining both packages easier. There is now a `mkRambox` function that abstract most of the build process.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
