### PR TITLE
nixos/modules-closure.sh: don't fail if firmware is missing

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -81,7 +81,8 @@ for module in $(cat closure); do
     for i in $(modinfo -b $kernel --set-version "$version" -F firmware $module | grep -v '^name:'); do
         mkdir -p "$out/lib/firmware/$(dirname "$i")"
         echo "firmware for $module: $i"
-        cp "$firmware/lib/firmware/$i" "$out/lib/firmware/$i" 2>/dev/null || if test -z "$allowMissing"; then exit 1; fi
+        cp "$firmware/lib/firmware/$i" "$out/lib/firmware/$i" 2>/dev/null \
+            || echo "WARNING: missing firmware $i for module $module"
     done
 done
 


### PR DESCRIPTION
###### Motivation for this change
Since fdf32154fc90698ef72ffa96ef39d920e1b9c951, we no longer allow missing modules in the initrd. Unfortunately atm the modules-closure script also fails on missing firmware, which is a very common case (e.g. xhci-pci.ko.xz lists renesas_usb_fw.mem as dependent firmware). Fix this by only issuing a warning instead.

Theoretically this change could beak things for somebody if they explicitly have `allowMissing` set and rely on the current behavior (that it reports missing firmware as well). I have a hard time imagining such a setup though, so it should be fine I think.  

###### Things done
Rebuilding my system from this branch currently. The initrd builds now (the system closure contains gpgme, which has other issues currently, so I did not boot from this yet).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
