### PR TITLE
gitea: add sqlite_unlock_notify build tag

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -37,7 +37,7 @@ buildGoPackage rec {
 
   preBuild = let
     tags = optional pamSupport "pam"
-        ++ optional sqliteSupport "sqlite";
+        ++ optional sqliteSupport "sqlite sqlite_unlock_notify";
     tagsString = concatStringsSep " " tags;
   in ''
     export buildFlagsArray=(


### PR DESCRIPTION
###### Motivation for this change

Fix #109004

When building Gitea with sqlite support the sqlite_unlock_notify tag must also be added otherwise there will be frequent error reports of database is locked.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
