### PR TITLE
coturn: 4.5.1.3 -> 4.5.2

### DIFF
--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -1,17 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, openssl, libevent }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, openssl
+, libevent
+, pkg-config
+, libprom
+, libpromhttp
+, libmicrohttpd
+}:
 
 stdenv.mkDerivation rec {
   pname = "coturn";
-  version = "4.5.1.3";
+  version = "4.5.2";
 
   src = fetchFromGitHub {
     owner = "coturn";
     repo = "coturn";
     rev = version;
-    sha256 = "1801931k4qdvc7jvaqxvjyhbh1xsvjz0pjajf6xc222n4ggar1q5";
+    sha256 = "1s7ncc82ny4bb3qkn3fqr0144xsr7h2y8xmzsf5037h6j8f7j3v8";
   };
 
-  buildInputs = [ openssl libevent ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+    libevent
+    libprom
+    libpromhttp
+    libmicrohttpd
+  ];
 
   patches = [
     ./pure-configure.patch
@@ -23,6 +40,6 @@ stdenv.mkDerivation rec {
     description = "A TURN server";
     platforms = platforms.all;
     broken = stdenv.isDarwin; # 2018-10-21
-    maintainers = [ maintainers.ralith ];
+    maintainers = with maintainers; [ ralith _0x4A6F ];
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade to [4.5.2](https://github.com/coturn/coturn/releases/tag/4.5.2).
```
Version 4.5.2 'dan Eider':
	- fix null pointer dereference in case of out of memory. (thanks to Thomas Moeller for the report)
	- merge PR 517 (by wolmi)
		* add prometheus metrics
	- merge PR 637 (by David Florness)
	    * Delete trailing whitespace in example configuration files
	- merge PR 631 (by Debabrata Deka)
	    * Add architecture ppc64le to travis build
	- merge PR 627 (by Samuel)
		* Fix misleading option in doc (prometheus)
	- merge PR 643 (by tupelo-schneck)
		* Allow RFC6062 TCP relay data to look like TLS
	- merge PR 655 (by plinss)
		* Add support for proxy protocol V1
	- merge PR 618 (by Paul Wayper)
		* Print full date and time in logs
		* Add new options: "new-log-timestamp" and "new-log-timestamp-format"
	- merge PR 599 (by Cédric Krier)
		* Do not use FIPS and remove hardcode OPENSSL_VERSION_NUMBER with LibreSSL
	- update Docker mongoDB and fix with workaround the missing systemctl
	- merge PR 660 (by Camden Narzt)
		* fix compilation on macOS Big Sur
	- merge PR 546 (by jelmd)
		* Add ACME redirect url
	- merge PR 551 (by jelmd)
		* support of --acme-redirect <URL>
	- merge PR 672 further acme fixes (by jemld)
		* fix acme security, redundancy, consistency
	- Disable binding request logging to avoid DoS attacks. (Breaking change!)
		* Add new --log-binding option to enable binding request logging
	- Fix stale-nonce documentation. Resolves 604
	- Version number is changed to semver 2.0
	- Merge PR 288 (by Hristo Venev)
		* pkg-config, and various cleanups in configure file
	- Add systemd notification for better systemd integration
	- Fix Issue 621 (by ycaibb)
		* Fix: Null pointer dereference on tcp_client_input_handler_rfc6062data function
	- Fix Issue 600 (by ycaibb)
		* Fix: use-after-free vulnerability on write_to_peerchannel function
	- Fix Issue 601 (by ycaibb)
		* Fix: use-after-free vulnerability on write_client_connection function
	- Little refactoring prometheus
		* Fix c++ support
		* Simplify (as agreed in Issue 666)
			* Remove session id/allocation labels
			* Remove per session metrics. We should later add more counters.
	- Fix CVE-2020-26262 (credits: Enable-Security)
		* Fix ipv6 ::1 loopback check
		* Not allow allocate peer address 0.0.0.0/8 and ::/128
		* For more details see the github security advisory:
			https://github.com/coturn/coturn/security/advisories/GHSA-6g6j-r9rf-cm7p
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
