### PR TITLE
[20.09] coturn: apply patch for CVE-2020-26262

### DIFF
--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./pure-configure.patch
+    (fetchpatch {
+      name = "CVE-2020-26262.patch";
+      url = "https://github.com/coturn/coturn/commit/abfe1fd08d78baa0947d17dac0f7411c3d948e4d.patch";
+      sha256 = "sha256-BuC5IEPWr82W8s9RTGDReYdkL0FAPPsXzDXzfHxya6Q=";
+    })
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2020-26262.patch";
       url = "https://github.com/coturn/coturn/commit/abfe1fd08d78baa0947d17dac0f7411c3d948e4d.patch";
-      sha256 = "sha256-BuC5IEPWr82W8s9RTGDReYdkL0FAPPsXzDXzfHxya6Q=";
+      sha256 = "06e0b92043d6afcd96f2cf514c60d17987642f41403cfb17cc35f37c7c726ba4";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Related to #109038

Fixes [CVE-2020-26262](https://github.com/coturn/coturn/security/advisories/GHSA-6g6j-r9rf-cm7p).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
