### PR TITLE
nixos-rebuild: add option `--use-remote-sudo-activate`

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -538,10 +538,24 @@
     </term>
     <listitem>
      <para>
-      When set, nixos-rebuild prefixes remote commands that run on
+      When set, nixos-rebuild prefixes ALL remote commands that run on
       the <option>--build-host</option> and <option>--target-host</option>
-      systems with <command>sudo</command>. Setting this option allows
-      deploying as a non-root user.
+      systems with <command>sudo</command>. This is an legacy option and
+      is kind of over-powered. <option>--use-remote-sudo-activate</option>
+      is enough for most of cases.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--use-remote-sudo-activate</option>
+    </term>
+    <listitem>
+     <para>
+      When set, nixos-rebuild prefixes only activation commands that run on
+      the <option>--target-host</option> systems with <command>sudo</command>.
+      Setting this option allows deploying as a non-root user.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Current option `--use-remote-sudo` doesn't work when remote `sudo` asking for password.
And it also cause all command to be prefixed by `sudo`, including commands for building, copying and querying,
which usually doesn't need root permission at all.

In this PR:
- Added an option `--use-remote-sudo-activate` for minimal usage of sudo, which only acquire root permission on activation related commands.
- Added `-t` for ssh when `sudo` is used. This is needed when `sudo` asking for password.

Tested commands `test` and `boot` with `--target-host --use-remote-sudo-activate`.

Related commits:
- [nixos-rebuild: add explicit option to enable (remote) sudo](https://github.com/NixOS/nixpkgs/commit/2c09cfc097daef5b85d21fe906441b5702bb2101) (https://github.com/NixOS/nixpkgs/pull/71849)
- [nixos-rebuild: fix the maybeSudo usage](https://github.com/NixOS/nixpkgs/commit/ab10bac1b177832b5e6b883ba95bf35f87229267)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
