### PR TITLE
vista-fonts: new sha256 backport to 20.09

### DIFF
--- a/pkgs/data/fonts/vista-fonts/default.nix
+++ b/pkgs/data/fonts/vista-fonts/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip, cabextract}:
+{ stdenv, fetchzip, cabextract }:
 
 fetchzip {
   name = "vista-fonts-1";
@@ -21,7 +21,7 @@ fetchzip {
     done
   '';
 
-  sha256 = "1l27zg5jraa16zm11d3qz1w7m6f1ih3xy5avww454ylm50fw6z11";
+  sha256 = "sha256-x7JSXS9Q1fzlJTVR+MAS3f2+cmo/H0s1qkY9FPjx2zI=";
 
   meta = {
     description = "Some TrueType fonts from Microsoft Windows Vista (Calibri, Cambria, Candara, Consolas, Constantia, Corbel)";


### PR DESCRIPTION
###### Motivation for this change
upstream hash changed, package is broken until this is merged.

@cole-h 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
