### PR TITLE
darwin.bootstrap_cmds: update to 121

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/bootstrap_cmds/default.nix
@@ -5,25 +5,14 @@ appleDerivation {
 
   buildPhase = ''
     cd migcom.tproj
+
+    # redundant file, don't know why apple not removing it.
+    rm handler.c
+
     yacc -d parser.y
     flex --header-file=lexxer.yy.h -o lexxer.yy.c lexxer.l
 
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o error.o error.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o global.o global.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o handler.o header.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o header.o header.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o mig.o mig.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o routine.o routine.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o server.o server.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o statement.o statement.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o string.o string.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o type.o type.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o user.o user.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o utils.o utils.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o lexxer.yy.o lexxer.yy.c
-    cc -Os -pipe -DMIG_VERSION="" -Wall -mdynamic-no-pic -I. -c -o y.tab.o y.tab.c
-
-    cc -dead_strip -o migcom error.o global.o header.o mig.o routine.o server.o statement.o string.o type.o user.o utils.o lexxer.yy.o y.tab.o
+    cc -std=gnu99 -Os -dead_strip -DMIG_VERSION=\"$pname-$version\" -I. -o migcom *.c
   '';
 
   installPhase = ''
@@ -42,8 +31,4 @@ appleDerivation {
       --replace '/bin/rmdir' "rmdir" \
       --replace 'C=''${MIGCC}' "C=cc"
   '';
-
-  meta = {
-    platforms = lib.platforms.darwin;
-  };
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -158,8 +158,7 @@ let
   in fetchApple' pname version sha256;
 
   appleDerivation' = pname: version: sdkName: sha256: attrs: stdenv.mkDerivation ({
-    inherit pname;
-    version = "${version}-${sdkName}";
+    inherit pname version;
 
     src = if attrs ? srcs then null else (fetchApple' pname version sha256);
 

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -213,7 +213,6 @@ let
   stubPackages = {
     inherit (adv_cmds-boot) ps locale;
     architecture    = applePackage "architecture"      "osx-10.11.6"     "1pbpjcd7is69hn8y29i98ci0byik826if8gnp824ha92h90w0fq3" {};
-    bootstrap_cmds  = applePackage "bootstrap_cmds"    "dev-tools-7.0"   "1v5dv2q3af1xwj5kz0a5g54fd5dm6j4c9dd2g66n4kc44ixyrhp3" {};
     bsdmake         = applePackage "bsdmake"           "dev-tools-3.2.6" "11a9kkhz5bfgi1i8kpdkis78lhc6b5vxmhd598fcdgra1jw4iac2" {};
     CarbonHeaders   = applePackage "CarbonHeaders"     "osx-10.6.2"      "1zam29847cxr6y9rnl76zqmkbac53nx0szmqm9w5p469a6wzjqar" {};
     CommonCrypto    = applePackage "CommonCrypto"      "osx-10.12.6"     "0sgsqjcxbdm2g2zfpc50mzmk4b4ldyw7xvvkwiayhpczg1fga4ff" {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
We need to update `bootstrap_cmds` first, because it blocks updating `xnu`, which blocks updating `Libsystem`.

This PR is blocked by #108590.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
