### PR TITLE
oraclejdk8: 8u261 -> 8u271

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -76,7 +76,7 @@ let result = stdenv.mkDerivation rec {
         i686-linux    = "linux-i586";
         x86_64-linux  = "linux-x64";
         armv7l-linux  = "linux-arm32-vfp-hflt";
-        aarch64-linux = "linux-arm64-vfp-hflt";
+        aarch64-linux = "linux-aarch64";
       }.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
     in requireFile {
       name = "jdk-${productVersion}u${patchVersion}-${platformName}.tar.gz";

--- a/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8-linux.nix
@@ -1,10 +1,10 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "261";
-  sha256.i686-linux = "1bl12hd5i53m8d4j8rwkk3bavmzw0ndr88ch5lf5syi7vs5pfjpm";
-  sha256.x86_64-linux = "0d7a92csz8ws5h0pzqmrxq3sz286s57vw0dqq3ciwsqz14df012s";
-  sha256.armv7l-linux = "13dih7zyfgj90bkhnfxhpm88d9kqqrj6w5rzpidmxrjwrsnlndp9";
-  sha256.aarch64-linux = "0zzhs4pcnjss2561b8zrrnacpkb8p49ca0lpdw7hzgsjjj1y146n";
+  patchVersion = "271";
+  sha256.i686-linux = "nC1bRTDj0BPWqClLCfNIqdUn9HywUF8Z/pIV9Kq3LG0=";
+  sha256.x86_64-linux = "66eSamg7tlxvThxQLOYkNGxCsA+1Ux3ropbyVgtFLHg=";
+  sha256.armv7l-linux = "YZKX0iUf7yqUBUhlpHtVdYw6DBEu7E/pbfcVfK7HMxM=";
+  sha256.aarch64-linux = "bFRGnfmYIdXz5b/I8wlA/YiGXhCm/cVoOAU+Hlu4F0I=";
   jceName = "jce_policy-8.zip";
   sha256JCE = "19n5wadargg3v8x76r7ayag6p2xz1bwhrgdzjs9f4i6fvxz9jr4w";
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Old package cannot be built anymore.

###### Things done
Bump version, fix hashes. Address a concern about the aarch64 source having changed name.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
