### PR TITLE
python3Packages.unifiled: init at 1.1

### DIFF
--- a/pkgs/development/python-modules/unifiled/default.nix
+++ b/pkgs/development/python-modules/unifiled/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, requests
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "unifiled";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "florisvdk";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1nmqxxhwa0isxdb889nhbp7w4axj1mcrwd3pr9d8nhpw4yj9h3vq";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    urllib3
+  ];
+
+  # Project doesn't have any tests
+  doCheck = false;
+  pythonImportsCheck = [ "unifiled" ];
+
+  meta = with lib; {
+    description = "Python module for Ubiquiti Unifi LED controller";
+    homepage = "https://github.com/florisvdk/unifiled";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -875,7 +875,7 @@
     "uk_transport" = ps: with ps; [ ];
     "unifi" = ps: with ps; [ aiounifi ];
     "unifi_direct" = ps: with ps; [ pexpect ];
-    "unifiled" = ps: with ps; [ ]; # missing inputs: unifiled
+    "unifiled" = ps: with ps; [ unifiled ];
     "universal" = ps: with ps; [ ];
     "upb" = ps: with ps; [ ]; # missing inputs: upb_lib
     "upc_connect" = ps: with ps; [ connect-box ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7737,6 +7737,8 @@ in {
 
   unifi = callPackage ../development/python-modules/unifi { };
 
+  unifiled = callPackage ../development/python-modules/unifiled { };
+
   units = callPackage ../development/python-modules/units { };
 
   unittest2 = callPackage ../development/python-modules/unittest2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for Ubiquiti Unifi LED controller.

https://github.com/florisvdk/unifiled

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
