### PR TITLE
resholve: don't propagate, 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib
 , callPackage
 , python27Packages
 , installShellFiles
@@ -11,12 +11,12 @@
 , doCheck ? true
 }:
 let
-  version = "0.4.0";
+  version = "0.4.1";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-wfxcX3wMZqoi5bWjXYRa21UDDJmTDfE+21p4mL2IJog=";
+    hash = "sha256-VK7r+kdtWvS9d4B90Hq7fhLfWT/B/Y9zppvOX9tPt5g=";
   };
   deps = callPackage ./deps.nix {
     /*
@@ -55,13 +55,19 @@ python27Packages.buildPythonApplication {
 
   inherit doCheck;
   checkInputs = [ bats ];
-  RESHOLVE_PATH = "${stdenv.lib.makeBinPath [ file findutils gettext ]}";
+  RESHOLVE_PATH = "${lib.makeBinPath [ file findutils gettext ]}";
 
   checkPhase = ''
     # explicit interpreter for test suite
     export INTERP="${bash}/bin/bash" PATH="$out/bin:$PATH"
     patchShebangs .
     ./test.sh
+  '';
+
+  # Do not propagate Python; may be obsoleted by nixos/nixpkgs#102613
+  # for context on why, see abathur/resholve#20
+  postFixup = ''
+    rm $out/nix-support/propagated-build-inputs
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

While using resholvePackage on a project with a python3.8 component, I noticed resholve's propagated dependencies were leaking into that build environment. There's a little more information about the error and the solution used here (😍 @jtojnar) in abathur/resholve#20.

###### Things done
- [x] Tested in resholve's CI @ https://github.com/abathur/resholve/actions/runs/479039322
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
