### PR TITLE
abuse: init at 0.8

### DIFF
--- a/pkgs/games/abuse/abuse.sh
+++ b/pkgs/games/abuse/abuse.sh
@@ -1,0 +1,18 @@
+#! @shell@
+
+if grep datadir ~/.abuse/abuserc &>/dev/null; then
+  if [ ! -d "$(grep datadir ~/.abuse/abuserc | cut -d= -f2)" ]; then
+    echo "Warning: ~/.abuse/abuserc references a datadir which is not existent." >&2
+    echo "Try removing ~/.abuse/abuserc, else abuse will most likely not run." >&2
+    echo >&2
+    # This can happen if the build hash of abuse changes and the older version
+    # is garbage-collected. The correct path of the datadir is compiled into
+    # the binary, but unfortunately abuse writes out the path into abuserc on
+    # first start. This entry may later become stale.
+  fi
+fi
+
+# The timidity bundled into SDL_mixer looks in . and in several global places
+# like /etc for its configuration file.
+cd @out@/etc
+exec @out@/bin/.abuse-bin "$@"

--- a/pkgs/games/abuse/default.nix
+++ b/pkgs/games/abuse/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchurl, makeDesktopItem, copyDesktopItems, SDL, SDL_mixer, freepats }:
+
+stdenv.mkDerivation rec {
+  pname   = "abuse";
+  version = "0.8";
+
+  src = fetchurl {
+    url    = "http://abuse.zoy.org/raw-attachment/wiki/download/${pname}-${version}.tar.gz";
+    sha256 = "0104db5fd2695c9518583783f7aaa7e5c0355e27c5a803840a05aef97f9d3488";
+  };
+
+  configureFlags = [
+    "--with-x"
+    "--with-assetdir=$(out)/orig"
+    # The "--enable-debug" is to work around a segfault on start, see https://bugs.archlinux.org/task/52915.
+    "--enable-debug"
+  ];
+
+  desktopItems = [ (makeDesktopItem {
+    name = "abuse";
+    exec = "abuse";
+    icon = "abuse";
+    desktopName = "Abuse";
+    comment     = "Side-scroller action game that pits you against ruthless alien killers";
+    categories  = "Game;ActionGame;";
+  }) ];
+
+  postInstall = ''
+    mkdir $out/etc
+    echo -e "dir ${freepats}\nsource ${freepats}/freepats.cfg" > $out/etc/timidity.cfg
+
+    mv $out/bin/abuse $out/bin/.abuse-bin
+    substituteAll "${./abuse.sh}" $out/bin/abuse
+    chmod +x $out/bin/abuse
+
+    install -Dm644 doc/abuse.png $out/share/pixmaps/abuse.png
+  '';
+
+  nativeBuildInputs = [ copyDesktopItems ];
+  buildInputs       = [ SDL SDL_mixer freepats ];
+
+  meta = with lib; {
+    description = "Side-scroller action game that pits you against ruthless alien killers";
+    homepage    = "http://abuse.zoy.org/";
+    license     = with licenses; [ unfree ];
+    # Most of abuse is free (public domain, GPL2+, WTFPL), however the creator
+    # of its sfx and music only gave Debian permission to redistribute the
+    # files. Our friends from Debian thought about it some more:
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=648272
+    maintainers = with maintainers; [ iblech ];
+    platforms   = platforms.unix;
+    broken      = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25955,6 +25955,8 @@ in
 
   abbaye-des-morts = callPackage ../games/abbaye-des-morts { };
 
+  abuse = callPackage ../games/abuse { };
+
   adom = callPackage ../games/adom { };
 
   airstrike = callPackage ../games/airstrike { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

abuse is an old action side-scrolling game available in Arch. This pull request adds it to nixpkgs.

Getting music to play was not entirely trivial, as the timidity bundled by SDL_mixer expects a valid configuration in /etc/timidity.cfg or several other places.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
