### PR TITLE
Reenable working clfswm

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -955,6 +955,7 @@
   ./services/x11/urxvtd.nix
   ./services/x11/window-managers/awesome.nix
   ./services/x11/window-managers/default.nix
+  ./services/x11/window-managers/clfswm.nix
   ./services/x11/window-managers/fluxbox.nix
   ./services/x11/window-managers/icewm.nix
   ./services/x11/window-managers/bspwm.nix

--- a/nixos/modules/services/x11/window-managers/clfswm.nix
+++ b/nixos/modules/services/x11/window-managers/clfswm.nix
@@ -15,10 +15,10 @@ in
     services.xserver.windowManager.session = singleton {
       name = "clfswm";
       start = ''
-        ${pkgs.clfswm}/bin/clfswm &
+        ${pkgs.lispPackages.clfswm}/bin/clfswm &
         waitPID=$!
       '';
     };
-    environment.systemPackages = [ pkgs.clfswm ];
+    environment.systemPackages = [ pkgs.lispPackages.clfswm ];
   };
 }

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -13,6 +13,7 @@ in
     ./berry.nix
     ./bspwm.nix
     ./cwm.nix
+    ./clfswm.nix
     ./dwm.nix
     ./evilwm.nix
     ./exwm.nix

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/clfswm.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/clfswm.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''clfswm'';
+  version = ''20161204-git'';
+
+  description = ''CLFSWM: Fullscreen Window Manager'';
+
+  deps = [ args."clx" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/clfswm/2016-12-04/clfswm-20161204-git.tgz'';
+    sha256 = ''1jgz127721dgcv3qm1knc335gy04vzh9gl0hshp256rxi82cpp73'';
+  };
+
+  packageName = "clfswm";
+
+  asdFilesToKeep = ["clfswm.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM clfswm DESCRIPTION CLFSWM: Fullscreen Window Manager SHA256
+    1jgz127721dgcv3qm1knc335gy04vzh9gl0hshp256rxi82cpp73 URL
+    http://beta.quicklisp.org/archive/clfswm/2016-12-04/clfswm-20161204-git.tgz
+    MD5 dc976785ef899837ab0fc50a4ed6b740 NAME clfswm FILENAME clfswm DEPS
+    ((NAME clx FILENAME clx)) DEPENDENCIES (clx) VERSION 20161204-git SIBLINGS
+    NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -81,7 +81,7 @@ in
       postInstall = ((x.overrides y).postInstall or "") + ''
         export NIX_LISP_ASDF_PATHS="$NIX_LISP_ASDF_PATHS
 $out/lib/common-lisp/query-fs"
-	export HOME=$PWD
+        export HOME=$PWD
         export NIX_LISP_PRELAUNCH_HOOK="nix_lisp_build_system query-fs \
                     '(function query-fs:run-fs-with-cmdline-args)' '$linkedSystems'"
         "$out/bin/query-fs-lisp-launcher.sh"

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -231,4 +231,14 @@ $out/lib/common-lisp/query-fs"
   cl-cffi-gtk-gdk = addNativeLibs [pkgs.gtk3];
   cl-cffi-gtk-gtk3 = addNativeLibs [pkgs.gtk3];
   cl-webkit2 = addNativeLibs [pkgs.webkitgtk];
+  clfswm = x: {
+    overrides = y: (x.overrides y) // {
+      postInstall = ''
+        export NIX_LISP_PRELAUNCH_HOOK="nix_lisp_build_system clfswm '(function clfswm:main)'"
+        "$out/bin/clfswm-lisp-launcher.sh"
+
+        cp "$out/lib/common-lisp/clfswm/clfswm" "$out/bin"
+      '';
+    };
+  };
 }

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -82,6 +82,7 @@ cl-utilities
 cl-vectors
 cl-webkit2
 cl-who
+clfswm
 clx
 collectors
 command-line-arguments

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -2848,6 +2848,13 @@ let quicklisp-to-nix-packages = rec {
            "fiasco" = quicklisp-to-nix-packages."fiasco";
        }));
 
+  "clfswm" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."clfswm" or (x: {}))
+       (import ./quicklisp-to-nix-output/clfswm.nix {
+         inherit fetchurl;
+           "clx" = quicklisp-to-nix-packages."clx";
+       }));
 
   "cl-who" = buildLispPackage
     ((f: x: (x // (f x)))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I'm interested in trying out Common Lisp window managers, specifically CLFSWM. It appears that this window manager was never moved over to using quicklisp, as StumpWM (another Common Lisp window manager) was.

###### Things done
Added CLFSWM through quicklisp.
Added the 'clfswm' nixos module back in.
Updated the 'clfswm' nixos module to use the quicklisp CLFSWM, and not the normal (broken) CLFSWM package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
