### PR TITLE
[staging] python3Packages.paramiko: 2.7.1 -> 2.7.2, python3Packages.sshtunnel: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -1,7 +1,6 @@
 { pkgs
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , cryptography
 , bcrypt
 , invoke
@@ -14,20 +13,13 @@
 
 buildPythonPackage rec {
   pname = "paramiko";
-  version = "2.7.1";
+  version = "2.7.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f";
+    sha256 = "7f36f4ba2c0d81d219f4595e35f70d56cc94f9ac40a6acdf51d6ca210ce65035";
   };
 
-  patches = [
-    # fix RSA key loading with cryptography 3.1, remove >2.7.1
-    (fetchpatch {
-      url = "https://github.com/paramiko/paramiko/commit/81064206bf3cec2ca4372257ff138481e1227b91.patch";
-      sha256 = "01b87ffgyvd6rilp1w1kf7lk29z706ch39nwl21ifklqpjhmazww";
-    })
-  ];
   checkInputs = [ invoke pytest mock pytest-relaxed ];
   propagatedBuildInputs = [ bcrypt cryptography pynacl pyasn1 ];
 

--- a/pkgs/development/python-modules/sshtunnel/default.nix
+++ b/pkgs/development/python-modules/sshtunnel/default.nix
@@ -5,12 +5,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.3.1";
+  version = "0.4.0";
   pname = "sshtunnel";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e0cac8a6a154c7a9651b42038e3f6cf35bb88c8ee4b94822b28a5b2fe7140f95";
+    sha256 = "sha256-58sOp3Tbgb+RhE2yLecqQKro97D5u5ug9mbUdO9r+fw=";
   };
 
   propagatedBuildInputs = [ paramiko ];


### PR DESCRIPTION
###### Motivation for this change
Updating packages I maintain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
