### PR TITLE
bats: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -1,29 +1,37 @@
-{ stdenv, fetchzip, coreutils, gnugrep }:
+{ stdenv, lib, fetchzip, bash, makeWrapper, coreutils, gnugrep, doCheck ? true }:
 
 stdenv.mkDerivation rec {
   pname = "bats";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchzip {
     url = "https://github.com/bats-core/bats-core/archive/v${version}.tar.gz";
-    sha256 = "0f59zh4d4pa1a7ybs5zl6h0csbqqv11lbnq0jl1dgwm1s6p49bsq";
+    hash = "sha256-grB/rJaDU0fuw4Hm3/9nI2px8KZnSWqRjTJPd7Mmb7s=";
   };
 
-  patchPhase = ''
-    patchShebangs ./install.sh
+  nativeBuildInputs = [ makeWrapper ];
 
-    substituteInPlace ./libexec/bats-core/bats \
-        --replace 'type -p greadlink readlink' 'type -p ${coreutils}/bin/readlink'
-    substituteInPlace ./libexec/bats-core/bats-format-tap-stream \
-        --replace grep ${gnugrep}/bin/grep
+  patchPhase = ''
+    patchShebangs .
   '';
 
-  installPhase = "./install.sh $out";
+  installPhase = ''
+    ./install.sh $out
+    wrapProgram $out/bin/bats --suffix PATH : "${lib.makeBinPath [ bash coreutils gnugrep ]}"
+  '';
 
-  meta = with stdenv.lib; {
+  inherit doCheck;
+  checkPhase = ''
+    # test generates file with absolute shebang dynamically
+    substituteInPlace test/install.bats --replace \
+      "/usr/bin/env bash" "${bash}/bin/bash"
+    bin/bats test
+  '';
+
+  meta = with lib; {
     homepage = "https://github.com/bats-core/bats-core";
     description = "Bash Automated Testing System";
-    maintainers = [ maintainers.lnl7 ];
+    maintainers = with maintainers; [ abathur ];
     license = licenses.mit;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change

Update bats for new setup/teardown_file fixtures :)

See inline notes for the two patchPhase items removed.

@LnL7 I am hoping you have some private projects that exercise this? It looks like resholve is the only one in nixpkgs that does.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
