### PR TITLE
python3Packages.pandas: fix tests

### DIFF
--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -85,7 +85,6 @@ in buildPythonPackage rec {
   doCheck = !stdenv.isAarch64; # upstream doesn't test this architecture
 
   pytestFlagsArray = [
-    "$out/${python.sitePackages}/pandas"
     "--skip-slow"
     "--skip-network"
   ];
@@ -120,7 +119,10 @@ in buildPythonPackage rec {
     "test_clipboard"
   ];
 
+  # tests have relative paths, and need to reference compiled C extensions
+  # so change directory where `import .test` is able to be resolved
   preCheck = ''
+    cd $out/${python.sitePackages}/pandas
     export LC_ALL="en_US.UTF-8"
     PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   ''


### PR DESCRIPTION
###### Motivation for this change
Tests now have relative imports to other test files,
so pytest needs to be executed in the
$out/${python.sitePackages}/pandas directory to make
these assumptions valid

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
