### PR TITLE
gem-config: make nokogiri use pkg-config

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -390,16 +390,15 @@ in
   };
 
   nokogiri = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [
+      zlib
+      libxml2
+      libxslt
+    ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
     buildFlags = [
       "--use-system-libraries"
-      "--with-zlib-dir=${zlib.dev}"
-      "--with-xml2-lib=${libxml2.out}/lib"
-      "--with-xml2-include=${libxml2.dev}/include/libxml2"
-      "--with-xslt-lib=${libxslt.out}/lib"
-      "--with-xslt-include=${libxslt.dev}/include"
-      "--with-exslt-lib=${libxslt.out}/lib"
-      "--with-exslt-include=${libxslt.dev}/include"
-    ] ++ lib.optional stdenv.isDarwin "--with-iconv-dir=${libiconv}";
+    ];
   };
 
   opus-ruby = attrs: {


### PR DESCRIPTION
###### Motivation for this change

`nokogiri` 1.11.x is broken with current nixpkgs. This can be reproduced with:

```
nix-build --option sandbox true --expr '(import ./. {}).rubyPackages_2_7.nokogiri.override { version = "1.11.1"; source.sha256 = "1ajwkqr28hwqbyl1l3czx4a34c88acxywyqp8cjyy0zgsd6sbhj2"; }'
```

The error is that `zlib` can't be found.

###### Things done

This can be fixed by specifying the `lib` and `include` directories separately but I also took the opportunity to just make it use `pkg-config` instead. I'm not sure what the original reasons for not using it were, possibly it just didn't use `pkg-config` at the time. I've tested the build with the current version of nokogiri in nixpkgs and it builds fine as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
