### PR TITLE
erlang: R22 -> R23

### DIFF
--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -6,12 +6,12 @@ rec {
   # Each
   interpreters = rec {
 
-    # R22 is the default version.
-    erlang = erlangR22; # The main switch to change default Erlang version.
-    erlang_odbc = erlangR22_odbc;
-    erlang_javac = erlangR22_javac;
-    erlang_odbc_javac = erlangR22_odbc_javac;
-    erlang_nox = erlangR22_nox;
+    # R23 is the default version.
+    erlang = erlangR23; # The main switch to change default Erlang version.
+    erlang_odbc = erlangR23_odbc;
+    erlang_javac = erlangR23_javac;
+    erlang_odbc_javac = erlangR23_odbc_javac;
+    erlang_nox = erlangR23_nox;
 
     # Standard Erlang versions, using the generic builder.
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,7 +1,7 @@
 { callPackage, wxGTK30, openssl_1_0_2, buildPackages }:
 
 rec {
-  lib = callPackage ../development/beam-modules/lib.nix {};
+  lib = callPackage ../development/beam-modules/lib.nix { };
 
   # Each
   interpreters = rec {
@@ -25,7 +25,8 @@ rec {
     erlangR23_odbc = erlangR23.override { odbcSupport = true; };
     erlangR23_javac = erlangR23.override { javacSupport = true; };
     erlangR23_odbc_javac = erlangR23.override {
-      javacSupport = true; odbcSupport = true;
+      javacSupport = true;
+      odbcSupport = true;
     };
     erlangR23_nox = erlangR23.override { wxSupport = false; };
 
@@ -39,7 +40,8 @@ rec {
     erlangR22_odbc = erlangR22.override { odbcSupport = true; };
     erlangR22_javac = erlangR22.override { javacSupport = true; };
     erlangR22_odbc_javac = erlangR22.override {
-      javacSupport = true; odbcSupport = true;
+      javacSupport = true;
+      odbcSupport = true;
     };
     erlangR22_nox = erlangR22.override { wxSupport = false; };
 
@@ -51,7 +53,8 @@ rec {
     erlangR21_odbc = erlangR21.override { odbcSupport = true; };
     erlangR21_javac = erlangR21.override { javacSupport = true; };
     erlangR21_odbc_javac = erlangR21.override {
-      javacSupport = true; odbcSupport = true;
+      javacSupport = true;
+      odbcSupport = true;
     };
     erlangR21_nox = erlangR21.override { wxSupport = false; };
 
@@ -63,7 +66,8 @@ rec {
     erlangR20_odbc = erlangR20.override { odbcSupport = true; };
     erlangR20_javac = erlangR20.override { javacSupport = true; };
     erlangR20_odbc_javac = erlangR20.override {
-      javacSupport = true; odbcSupport = true;
+      javacSupport = true;
+      odbcSupport = true;
     };
     erlangR20_nox = erlangR20.override { wxSupport = false; };
 
@@ -76,7 +80,8 @@ rec {
     erlangR19_odbc = erlangR19.override { odbcSupport = true; };
     erlangR19_javac = erlangR19.override { javacSupport = true; };
     erlangR19_odbc_javac = erlangR19.override {
-      javacSupport = true; odbcSupport = true;
+      javacSupport = true;
+      odbcSupport = true;
     };
     erlangR19_nox = erlangR19.override { wxSupport = false; };
 
@@ -89,28 +94,31 @@ rec {
     erlangR18_odbc = erlangR18.override { odbcSupport = true; };
     erlangR18_javac = erlangR18.override { javacSupport = true; };
     erlangR18_odbc_javac = erlangR18.override {
-      javacSupport = true; odbcSupport = true;
+      javacSupport = true;
+      odbcSupport = true;
     };
     erlangR18_nox = erlangR18.override { wxSupport = false; };
 
     # Basho fork, using custom builder.
-    erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-basho.nix {
-      autoconf = buildPackages.autoconf269;
-    };
-    erlang_basho_R16B02_odbc = erlang_basho_R16B02.override {
-      odbcSupport = true;
-    };
+    erlang_basho_R16B02 =
+      lib.callErlang ../development/interpreters/erlang/R16B02-basho.nix {
+        autoconf = buildPackages.autoconf269;
+      };
+    erlang_basho_R16B02_odbc =
+      erlang_basho_R16B02.override { odbcSupport = true; };
 
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR23.elixir`.
-    inherit (packages.erlang) elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
+    inherit (packages.erlang)
+      elixir elixir_1_11 elixir_1_10 elixir_1_9 elixir_1_8 elixir_1_7;
 
     inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };
 
   # Helper function to generate package set with a specific Erlang version.
-  packagesWith = erlang: callPackage ../development/beam-modules { inherit erlang; };
+  packagesWith = erlang:
+    callPackage ../development/beam-modules { inherit erlang; };
 
   # Each field in this tuple represents all Beam packages in nixpkgs built with
   # appropriate Erlang/OTP version.


### PR DESCRIPTION
###### Motivation for this change
Erlang 23 has been out for a while, I don't see any reason to hold back on using the latest version.
I only updated erlang to  23, using nixfmt, some lines were affected, I hope that's okay.

curious for feedback.

@FRidh 
@alyssais 
@mtanzi 
@webuhu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
