### PR TITLE
nix-linter: fix build

### DIFF
--- a/pkgs/development/tools/analysis/nix-linter/default.nix
+++ b/pkgs/development/tools/analysis/nix-linter/default.nix
@@ -40,8 +40,8 @@ mkDerivation rec {
   patches = [
     # raise upper bound on hnix https://github.com/Synthetica9/nix-linter/pull/46
     (fetchpatch {
-      url = "https://github.com/Synthetica9/nix-linter/commit/b406024e525977b3c69d78d6a94a683e2ded121f.patch";
-      sha256 = "0viwbprslcmy70bxy3v27did79nqhlc0jcx4kp0lycswaccvnp1j";
+      url = "https://patch-diff.githubusercontent.com/raw/Synthetica9/nix-linter/pull/46.patch";
+      sha256 = "1ck1y3809bz7i6sx7whyay1bj8sjb1fh5qikca7wgcbsmzws2vqq";
     })
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).