### PR TITLE
[20.09] Firefox 84.0.2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "85.0b4";
+  version = "85.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ach/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ach/firefox-85.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "04d5c5b64e906438122cfcd13c6a06d58bb1c0a2d2eaf66f52f91e103a5534ae";
+      sha256 = "e6583b946d35db5b8d94bd33e183e397b85c6549a94961ec2cc395b30ba21b6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/af/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/af/firefox-85.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "57bdfd3e6efe3c667ddb4c1e2421c191eedc407f578ee307b1ed916815726837";
+      sha256 = "7f69bf9371454796ef6cc9469bf1ba6d6c7317a3e559fefafacb3c4d215eaa73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/an/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/an/firefox-85.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "7ceb815590071691a3faa6f1d8215963b48c54c220c512499fb9642efc1492d4";
+      sha256 = "02ce58a9be06d2632e87daeb0e832d18e896c0ae376171d0d265d108530bf8ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ar/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ar/firefox-85.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "ce8b25f9ba3d21e87f660a17a90e770417e658f7280d0e41d0a5ff41164a2d43";
+      sha256 = "04021d925774cfb01141f34a28800e339339f1b056255721d2c4aa4268156986";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ast/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ast/firefox-85.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "a220440bebd1c1179e6e2a483ae148ada05f86c3c5d68946bb3b14d301301a78";
+      sha256 = "a85bc2a3c859b9b6e005c1cc5767f1519d255fac011208563c530d28bcec8935";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/az/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/az/firefox-85.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b79a3e03d476d3667c28ed83dd84fb375013597d58e9e13f431eba13b509422f";
+      sha256 = "d84113f01e450d76eccb1f464a3e6a44c3b5fd604c74891d175f0f7565c3b911";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/be/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/be/firefox-85.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "c8e00ae8a6d66a427212c1323a0f4860c25058c1d27fc0d3bb56612f0f2b785e";
+      sha256 = "a2826a554577a666b337d95f2c46b292fbb228152282799f295994cb9f6b6563";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/bg/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/bg/firefox-85.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "cc63fb7773dfe6a9b84a7ddd80873c6f8fab3b0f12e15a0db862bac9006d86c4";
+      sha256 = "c88db099ee75755d0e60cb8230731be9fafbf5ca3c0a6d0be232cfe1f93523eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/bn/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/bn/firefox-85.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "9fdd2e50b1fd74a3cabe55c23ca44253e9b5a2791461a2f15713cab6f4700e6f";
+      sha256 = "625377e2bb881aeac0659600def64039bbc1c8518c99acd102f9e47dc956af0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/br/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/br/firefox-85.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "44d99c74041f227252989570c9fe1dc2a1519e195e6386d0dc78fbf43ec41e88";
+      sha256 = "5fd3c63066e098dc87337c6e4fb53aede9c9d817e1bc06b1fe11597d68f60f3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/bs/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/bs/firefox-85.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "7c3b4beb800c8e023fbc5655e6435b11f6ebf11c3d82a5b6a1df76df682f0666";
+      sha256 = "85745ac8ae54b559592430744ce3a08566c1b20a078b961988870e570dba6eba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ca-valencia/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ca-valencia/firefox-85.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "b0676d544d8d2cc6c37a192adcd4e61038106c0e84066e68895642afc8e158a4";
+      sha256 = "5ddd2c3244311bb975e510cefeb1c5e16f92de2d82ef7fd3f6cb6bc064fd70ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ca/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ca/firefox-85.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "8f170b9356761ec175be3f417df624a78e939af931376f52d36f19b019c05338";
+      sha256 = "e1d4f0ee1a72ea956966b07c3c48fcd089f5540ea1bf02857f41f125a9ab8762";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/cak/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/cak/firefox-85.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "ca966b90035591d3e5f886814664d2f203bc0b65e781f46566a51269811efcdd";
+      sha256 = "519c50b7994b0d2bb3c162812424188958a51bdfe40d382db2e83912fb893484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/cs/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/cs/firefox-85.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "31e19d69e03821c646d21969b48e5ba01c52b2d5d2538f7bd7e7b93c9a6f7bb8";
+      sha256 = "37aeebb7dcd6240721c7377368751f2c48b3492846ef72d09e3fb5146db0cf5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/cy/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/cy/firefox-85.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "dfe3974d2328fa535b79f3e18d699b8d62a053efd0248cc88d1152ff92604166";
+      sha256 = "5902520410a45eacf141c9f8c414994298ec108ed0d97096f34156001373dccb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/da/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/da/firefox-85.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "86ba3d548eb3a6408b9234c382389c0fb5907c98eeab25cc39e810727570d2ae";
+      sha256 = "787a26c9f978643e6afaf9dadd88f7adbc18f6d8f6b5814da4752c21faac4078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/de/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/de/firefox-85.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "1cb610280c07e7af82df2dd283a6d35c1f63afe6f11a0fd7797efc4128ad126a";
+      sha256 = "09f5f3edfca2b082ad6f96ecf7b97d336d81c3d63bf1588bc2f38ff91e2d641c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/dsb/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/dsb/firefox-85.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "555300937cd2d6e25085d5d3f4b699704ba3630ba4ce667a9ed3d67a9c9f5143";
+      sha256 = "eef50a2a7b0109b62202922041dea12beea346e98fcd8d93f402ba7f08546dff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/el/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/el/firefox-85.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b2bf744cbe21d23a1ed16310fe552197b129964a75aca4fc1c3759fb59782d7f";
+      sha256 = "5ed270355c3fca3d8ce2ba15e2b9a322fa503339ef46c935851442523f91c277";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/en-CA/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/en-CA/firefox-85.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "422cbea99fd390c31868b0cf0e6bc8344cca9dc9540dd58b8b315f519a3c53cd";
+      sha256 = "6343b55fa02570c7ed4c7eb47b6a8d6b0cbfb5cecb0199282b4cf58e5f344419";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/en-GB/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/en-GB/firefox-85.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a996f6ea769ad846a69ab692b967ea23c4de461a922add22864fce6f97d04e30";
+      sha256 = "863e118d3b6c0bf9e25bdef819ec0bb9d027802a99216640a4ee01650486ec8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/en-US/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/en-US/firefox-85.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "aefbbe66cd209bdd9a1720562127560212f257229b799c45de5feb4173f10232";
+      sha256 = "c5e58bb173cdaaf9ec09085e47d69c7601966ece7ef5aba85cffced211952e77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/eo/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/eo/firefox-85.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "8237d0bdc5a0ed6873c4178a20e77bb2c86f833f02e6872852d8e35e36978459";
+      sha256 = "a03057a3d852dbd8956aee7253e1a3b6550c843d8755d5c01fe2d72042c80c79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/es-AR/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/es-AR/firefox-85.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "6d8b15775127619f923e7c255a01afcfd81d9d7bb01c0152e3aac3ef327b9ff2";
+      sha256 = "f705f2e633f30fe83a2546847e0dcf6da76e2b9c7edb1a1cbb104c56d45610a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/es-CL/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/es-CL/firefox-85.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "26dedb44f4dd064005a2cb935444acd0f6a99a451b87263775cad4506503bccf";
+      sha256 = "1b04e80d0666900dba8356d761059bc99e39636b859059d34e79dca73bc6c97e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/es-ES/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/es-ES/firefox-85.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "96d8444ee16d78bbde1fca5a69d5f404bdb2199757c566cdf44416ef43761715";
+      sha256 = "078b7cbd04e73f2a62c60ceaeb73edf1dce4ffd656e523acc901e234eb6ff972";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/es-MX/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/es-MX/firefox-85.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "ac4a2e7490b448a2654a0999b77e4e3e6e8dcd96c4239654dc8cc748f54d2ebc";
+      sha256 = "7131fe554e6b1eaff8af3bd62a565d4db746eb5f65cc9eebe9d6a20921eae0e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/et/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/et/firefox-85.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d44ba8376fccea9feae2054a50db58a5d4abca559ebfe854821cca9342f05f42";
+      sha256 = "131340d0124292055a8a3f6a7ad86e7f1d4648c47f18bcac37db0fb48b3150cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/eu/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/eu/firefox-85.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "d7f2131c7125fa6ee78a978e11d0f5c4ebbd55f5fa9fd8ac644aa0a9f68d60bd";
+      sha256 = "a3c9eff230311f0b449f977f0304eb664614ad683467b165ee6f656530df9caf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/fa/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/fa/firefox-85.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "2f63087cb94dee9a97cdf0641478b076f119bdf30dc0e3d35b9db67dd1e75cfb";
+      sha256 = "69a84d5384d13c486c0cb9bea45ee78662d30fe12f1e46a582f55b3129be6093";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ff/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ff/firefox-85.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "e8bd39fe41b98ce4fd1e630d376e263815b60339947344d82a7fddfc4ac331d8";
+      sha256 = "e25dd52c7241b2df8d1866c118233af0cefd99d4d15011faf5a2b0429c01675a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/fi/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/fi/firefox-85.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "d743df7df584c30ab237771778df1a06a01cb8801ad57233738a9e7ee7b5a453";
+      sha256 = "1530c0d16b164a936d6b98d3ecdae44b8484d776767b307322f87f901b6c131a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/fr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/fr/firefox-85.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "9426e988190c0f65cd87cb502064cc2cfa8146e1edc15aaff7ad3a28e8c30ae0";
+      sha256 = "7589a12da470306b5212d669d5f2c527a400b4659d8a06f1e49a0a62f33f49ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/fy-NL/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/fy-NL/firefox-85.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "80896d31f83bfbee9ac2b585894fbe0332c2516c7cb9eb06b10dd8169fb0a50b";
+      sha256 = "f8a80894596182d66cf6ba9c2073619263f5262a187080e75eb2a3ce93095cb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ga-IE/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ga-IE/firefox-85.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "678c24f47dda38562f15889bfef5de79e1375a85c8158697c37846252d55f4e9";
+      sha256 = "97cf7abeaeb857fe20f0e31964eef346e4d4d9803af6b6c24bf26d436b4e42c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/gd/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/gd/firefox-85.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "87d924efdea12fa98ebbe88d42afa5944b821c4081ee0a549e66393d69c1eb53";
+      sha256 = "76a580744c26419c15862729ba1525dc2c5216b221dd74af80d1e09cfb1ffb25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/gl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/gl/firefox-85.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "61cb992a445cee2689e19415da53d5611d68f65acd8aceaada76b0999e50ec13";
+      sha256 = "6b818eee14d5e4dd857a53982de224fadb454397c7efb18123c224baf513b222";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/gn/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/gn/firefox-85.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "95c3467048e7250dddfcb018ae8b8bcdb9de78b3a01076c4e1aefc937f4bc3b1";
+      sha256 = "68dfc0c439e815242333fdc8bd9752dfeaa1d6583acdfa5cc4c7092eca637b49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/gu-IN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/gu-IN/firefox-85.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "1bdcef358bd0ac242dd0607545fc65ad98d0785898a6a53394d04c74c8ee0a22";
+      sha256 = "b529c00e2c0520b6e7362b21e9fa045838837660ebe5ba46b755164ed7e434d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/he/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/he/firefox-85.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5f240e3754fb368288cab3f37ab250d6815dd1b792b77180fa5590e4d9c6acca";
+      sha256 = "43d273ca9f65bf3584ecc98f5f2409a916957d0d70fb296aa504cbebdfe5ed75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/hi-IN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/hi-IN/firefox-85.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "9b0eb6eb03eeeeebc78c652f4e5bf511335ebad3afed9b31eeef8f5c830b0e1b";
+      sha256 = "ffeae00deb60a0db7c977dc1541ab90e948b206a59717d60271eb0f6a166ebef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/hr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/hr/firefox-85.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "53bd72eed8eda15e3dd1a070b221535bda8aee3930a713b121b84b64a2f95a3d";
+      sha256 = "f81a32c1bf88acc3e5b26e61ac6c153f1b9bbc7cde1685f8c0a366a4c4808dd4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/hsb/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/hsb/firefox-85.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e233c7ab46d0f3dece1d580c8a615156bb70df6937d47286c3a54b4d15cebac9";
+      sha256 = "87e1a2cbdcbe4a7f2aff0537ad991ad39a8b992f38b6b2a0e2c4b2f65fd6c9d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/hu/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/hu/firefox-85.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "2ffbc88d33631a5c0ebbc29b8f36c6b7f043b8faf0600398e24d48546d699eac";
+      sha256 = "88f171d4f84e3f89d7c433d793ae0032572444b322d72fa19abacdd0481c5df7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/hy-AM/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/hy-AM/firefox-85.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f6cbd70bd95642caf737684c8c429342e8f567061bfb680732382b5c5f93f1a2";
+      sha256 = "f88e6eb48e2ddc8c8a11d92fd82884fb487958cb8c54fa5268f15076774e7e4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ia/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ia/firefox-85.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "ae7c96c3120c1727c4d8ed4f9978aafe64740d49111bb6bd507e4a9e14d7dab2";
+      sha256 = "0286e665df8b07339cb2a6f609623defaf489883b8865781aa7ba238d3c19f4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/id/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/id/firefox-85.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "680f5f3dc843b7acf86c79fb3238796ce3d28b60da3b76f55a37652d1a11c176";
+      sha256 = "e71c9712d22a1d573b12a5d4274ac5fa8a91a1ce98bad9f4922f7f11c0770707";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/is/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/is/firefox-85.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "ca40b8a9e99234faa67141732a5ef70e416e9aae08b4e8cbf6fe2ada9f0b7b4e";
+      sha256 = "b61060e1f2aa2423cd9c2d9b79f8476927fa171abadd3d32885b7deeebf781ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/it/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/it/firefox-85.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "ac8f5d43fc30760e68be4802514bf09fdb4940336d48844fe833d9290a10506c";
+      sha256 = "6a2e987c69e384431cea1beff69059f0bf4259a80b318e8736c420cedf125187";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ja/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ja/firefox-85.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "13c66340765699d336926872065ce0edf7e14f43b2f16dc99aa277f5d64f2275";
+      sha256 = "109736b666fbbb54ed5bfd1755092834f9c2670362ad272802643d5a98fb80bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ka/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ka/firefox-85.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "16ef31cb13dc3c54196ed3dd6209bfdbed14460c38d3fc8cdce4ee7801322ac0";
+      sha256 = "4b1249e8634b130b6fc9021f570e375bc2c1bf74d50f1789b3a1325c0fd771ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/kab/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/kab/firefox-85.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "68aa1a647c86f2e9fe63bab675f7d851a08fb22d5ed72b10f2e6710e03e02672";
+      sha256 = "a12af8d38c868d1af24d7a23faec32b79412768bf7438d3c2548d06676bb5d92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/kk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/kk/firefox-85.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "8603847204461f9370447c6c546c4bf985926353597aa7d9ecee9d46a810ba95";
+      sha256 = "d844763e5f8475d9b2a81bc217b0b4840fc6fb18a037921266fe3ab4c835367a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/km/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/km/firefox-85.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "d552b9301ca160577d24267584fa3b8c45a1c6eb82cf540778a617eaebbff6e5";
+      sha256 = "bd2216fb6c24932738935ee9d5ae73816cf70def1dee3b3317c99faf67496cd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/kn/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/kn/firefox-85.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "b5f4259baa11d5010fdde27dbd583f56b0c9fafaeab9c7f31be87b9645478e6e";
+      sha256 = "8a49b992da59ac781246bd8e7318a815659556c29279182cac6328fbbfcd3f35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ko/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ko/firefox-85.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "e73be57006747f673e979741203537cbbd8f9fb6f4fb77cfc88a7d0c85c7a7de";
+      sha256 = "c8a81f06e4dbcfbac2a6a065faab9981dc2503025918ee363d8b908ea6732b82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/lij/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/lij/firefox-85.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "3190c816b7a2973aa7d2a0640fa4e174b02b62a62c28eed7e0df3b377242aec3";
+      sha256 = "4c0c223829b974f26d3e34bf17b15112afba6709d7654a05e7ccc1a582d8cff4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/lt/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/lt/firefox-85.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "95a68d2d1a98bdda38e86f4c14c28669d2a11792fab561d6a8295c017d1a5068";
+      sha256 = "07ad6f6accaa6246e23832e8cfb69f498ddb219d43787ac29688c99b9b359720";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/lv/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/lv/firefox-85.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3460fb2356584ad3cd02905b9b3a70a569ef78666a69bff754fbd0b0eba0cd1f";
+      sha256 = "ac9f4ffc8cdb4ee8f3d0602b0ed9de4005dded584b6896c0cf0053d9951a637c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/mk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/mk/firefox-85.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "864d8ae602b06c75ebf0d0bb4b8fcc5722840db373bac1a5656a968df7aea6d8";
+      sha256 = "a320b67f4b15d2fb5dc8ffd3dab13266810af06e0385f51b60d4ba5223ba4bbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/mr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/mr/firefox-85.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "09e63b52ae1de354e73838dd0a60de360fcffeaeedd8af316174866a43c49293";
+      sha256 = "3dade192f5234bad52a08d380d4ef8119eef5211152a1755b6c6e5fd72eee3cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ms/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ms/firefox-85.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "c1e47d112d887922d81458bba8a7afa0a706444624738df92cdbe395f4bc9d0f";
+      sha256 = "77d4d9c8b5c6d308fca3f3519dfead9f75751ba93dfc1b2d5ef9ea880a1e2111";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/my/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/my/firefox-85.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "d78413226f8b87af0ef5baecad2ab4b9ced69358cca969635b4f71df645ccacc";
+      sha256 = "25de0c8c747c3fd4093517efea1df8fb101b3a48612070f2d93c70901dee7792";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/nb-NO/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/nb-NO/firefox-85.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "5ecff68265d8ce7c5a59da0366570adafc69b8c05fc323e619a7ce08fdeb7108";
+      sha256 = "96b31f76121bdb26840c693e2b3d70ad0ef0e0c7f194f650f9c683e92d5a85e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ne-NP/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ne-NP/firefox-85.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "00824ae4fa57e98fba5fb1a46b86853a289e24341b94d2ede9e8e7d358d29e9a";
+      sha256 = "32ce40ffe03dd2695a50b43135c4fb22f06cf10b19c2067c80b962409ee1a0d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/nl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/nl/firefox-85.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a0b3a25bdc123bf9ea441456b7d1b3c6fe78ef1589b69742dc38f50d3d92d700";
+      sha256 = "672bd93968e0a3cf3b280afdd52fbfe62a1bad524dceebe2e9fc953f4509aae2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/nn-NO/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/nn-NO/firefox-85.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "00f599f8850af9df078c5d296bfd50a7bdb012f7978e83828000371fbdd93509";
+      sha256 = "2d003ab51d0531ba6f47aefbfa2f0b81fa815b378fefe318351b52a798a48e24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/oc/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/oc/firefox-85.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "d03638662bd89dfaa1af08312b5361da04d5cb9c93f6eea9b2442bdde25d1eb3";
+      sha256 = "6264b95a26189ba3e7f2490f5a122f9f42bca19cd31e6d3084b3bf2a1ea5e91f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/pa-IN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/pa-IN/firefox-85.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "2b7d9ed3aca15e5bb22f3fcc5fa0e6289729e5a88d8a43602a9adf38c4e0a8a1";
+      sha256 = "987fe7b39bc597e5bf2389f6d595fbe054dd3aff7febc48da19dcc2606454f5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/pl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/pl/firefox-85.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "afe081f1f64aee140eecf24b413f44fa04d999f3bb97a2862a8469732489e94c";
+      sha256 = "6c163f9876d53f5607867de871dad27e236c6bf0a2a46ed24425190724554579";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/pt-BR/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/pt-BR/firefox-85.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "9e643c670efe00e9144529aa65c8f10ea2c8f7d5374a2d93c439a56cabad7d2f";
+      sha256 = "71ed7be34b05652463232c449de558e9fcc4be0583516d5ab8a0fc0ae334f419";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/pt-PT/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/pt-PT/firefox-85.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "98cf63382a586b649b30685bee8591085edf46d747860fae751a5dc4ed183979";
+      sha256 = "f1ecd7e990896d3471ffaddd1997b598b8fc3482caa3b6446a750a963ae71f10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/rm/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/rm/firefox-85.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "e000820f06aef69922eb0305e4d70cdd1820f86a1bbb60cd0888cc5b5d6ce0b7";
+      sha256 = "adcad49f775b592ab65080b8310d27ed26424f4aa547736dc100655586f263a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ro/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ro/firefox-85.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "daf8f2419a8122ac4da0dd585bc466d404f9a1cceb82aea8732aa4ec112219b2";
+      sha256 = "accd50a10d75fd234b38e50908d10fef5df4e6fc1873683f15656d695ccced9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ru/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ru/firefox-85.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "c081fddcc21b73b421516d529d7abb6d463c804f1875b4b755d34c0be34cfb05";
+      sha256 = "88b2f2176d8a739a639fb52eb8d0423343e5780e79f7986f066437ac33c74aa7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/si/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/si/firefox-85.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "607f0debcaeba1a5a6bc270e4a45793b56d4fb15580da6e264659fc3d4ed6577";
+      sha256 = "c2337b0a041926adc3d82d986fdbe1dbbea22046ec149614712e806873f4b46b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/sk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/sk/firefox-85.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d3a06cb060f6ec2131705a75187dd5ca62fae91a22258c59f93c308151ff7b00";
+      sha256 = "bd67822eb7aa7253fec770b39cc7e4389fa19373cc01d3a3b9e0568584cbef41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/sl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/sl/firefox-85.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "eb9c21cb4c577500464c8fde4091207a93ab96cd4a6119feac815242e846e65d";
+      sha256 = "bb4c64f6e1a2f6b721e51ee26398a4f86cb67782eba15e9c8cfed472ff3ec597";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/son/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/son/firefox-85.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ce5449dfb0201d3a2c4891519284903af46177739feeea4353720d108107ccc6";
+      sha256 = "7a55a33a184131c74da3fc2dad0dad7bb7c1230a1740d71c19ff3752ac53c7c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/sq/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/sq/firefox-85.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "65ab1b97653e2cb416d60f65d6fd7696cf7b5f63bb3b80d13fd199829247ca58";
+      sha256 = "72e8271aef0c4d38d577c04d3927f325b13bddab57d115b553ba4015a2b5a12f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/sr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/sr/firefox-85.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "16c5e71c6dc86688d3cddc0330fcc98a7e948773833c3f1d856b194541fecc3a";
+      sha256 = "5c1bba66c4e173c9e531dd14d746a96fb4ee393db9d815cf6de8c0ff2304036e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/sv-SE/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/sv-SE/firefox-85.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "7bcae95e5c57d1b380458ab30e2dec9a7bd2c1bc6c2712fa44a9245639ac083e";
+      sha256 = "1decd5cef4fcc9faaa05a261686101338e45a0da6485144455c49c3df142d2d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ta/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ta/firefox-85.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "6f35fc2329ea0a96049c9cadaf925ed064e0f4b60bf12082029898396ab34dc6";
+      sha256 = "6a259dad0ded91cd4544f45def61570e8c06de5adeaba5b19fd3136c6f52f4f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/te/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/te/firefox-85.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "9f4c691b6943f715e6d6a1db9a36cc745614ac99a33767080157f852d8cae594";
+      sha256 = "7096e5bf97b3392543ad75c685b2a6df2796a56e59237493aa869027c06213f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/th/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/th/firefox-85.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c15b8db3bbf1bd9362bb5f024daf0aee7ef3df8cd7864dbeec6a824449722063";
+      sha256 = "52fc1ee59288de354e4dc4c1b46848651b4e462839a44157e2de101b4a538282";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/tl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/tl/firefox-85.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "98837a0ce69e67b9bcc518c9953763331757870c5cf1ecaadb1cb37cb30338b4";
+      sha256 = "bf36d8e31638ed4332d442fa5e5f020ce8282be5afa608a4ff51c7c84443a378";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/tr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/tr/firefox-85.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "cec9efb3c0ffd4f7438964efd34d78b377f117fb0f9d051e103663a676d6a6cb";
+      sha256 = "09bcb9b641a43272e4ce2f991e48b8665425763261bbc13e8a4e7d905797ca0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/trs/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/trs/firefox-85.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "151687f7ed062ad3d0b46b113a26931c41dd375d324aa7055952492fd497c445";
+      sha256 = "e146a0e6906d34958989ad0ebdef6e6c42c2844027951fe2a8aa163c8e10ff98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/uk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/uk/firefox-85.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c0335c927cb343b3a48739949c3d8d1a813eb5caad4a989dd9a3fec16e4c5688";
+      sha256 = "8ece3fb7b2f211331838d7980810a40c1b2c39dcac1bea22069ce9a303f0fdb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/ur/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/ur/firefox-85.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "5b4a20c279161d910dd6730f1691d4a4bb8319a3e365bfbcc553a47e96d9db30";
+      sha256 = "6fb0c5ad50d6002d00ece754309a1fb3074896fb5bdae482ca5170d928a1c9cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/uz/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/uz/firefox-85.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "8fd7881da8c03c3b9313509047ee453d175c271fd086e27710bd0aba3fd319d3";
+      sha256 = "769b217f7540a2a58cfb38d323dcd1647645f0e80e522ef9370dd553a2e36ae5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/vi/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/vi/firefox-85.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "7dcdea1143af2cfaf9974640d520fec1e44cc156d085432f52318b745dd21f6c";
+      sha256 = "ce69530fe87da4c2b8afe2e465709a19ae88a418e559896da7ea3958cab91808";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/xh/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/xh/firefox-85.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "f502767929505209d05830b7d0075fcf8186349afe07e793afee560eed9aafc3";
+      sha256 = "3c759f6a630200221b4bd96ddbfa363e46ec8a244c4fae1c66a6f8d66ffa4aa5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/zh-CN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/zh-CN/firefox-85.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "9d8c003da5dc117cda204487ffd0dd95d9677d7e30e5f868e3a39d3146569da1";
+      sha256 = "2d9620f5b4e34e5a9809898d739b94f9ecc0141e3a67e70da11aff8af19598ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-x86_64/zh-TW/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-x86_64/zh-TW/firefox-85.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "ebdf6822810a97381e63c6c2bb08baea4c239c35b4c75e714da367f982080863";
+      sha256 = "2fe6f83d79aa66aee1d5503a6ba6bfc37aa6e950ebfb570524c4a9ac254f4047";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ach/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ach/firefox-85.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "e63b45c8a34d286097825d2830b3697a2205fc8f62e7f7b19fa5569294d4fd3c";
+      sha256 = "74822d1537a9b3fbc1fbf413339161b6b89a2bd127ebfcd7bdfca87fac82de29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/af/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/af/firefox-85.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "93f0fa71381f937d07764ed4bbdb1ea167664fdb1ed40d063b4fb079ed485dea";
+      sha256 = "1bf48b9bfae83d997ec1adfe04bdec7bd4e3f5f6a47e5a6e6400d08ab3b78058";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/an/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/an/firefox-85.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "1ce6d8e8ba3409b7b5886f87633609a8568ceabdef45beef623ebf74e4bdbd76";
+      sha256 = "3c5baf233f01c519b053f3ad788d49d62f6dbf60746b0b31af2720fe2ac3bc23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ar/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ar/firefox-85.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "990905d68a82f3eee04a9a8df4b291eb425469e6bf045a3a126bee08af2b785d";
+      sha256 = "a1886b0394a417ac8bb840cde03b42d4fbd231e51155f7297d52eb7fefff2d3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ast/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ast/firefox-85.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "606c37c4eda9d1f55e8a8fde0f8df822186995cef190e1644bcbe465cc1a0f54";
+      sha256 = "54b7736cf05c9ba024b4df5d6403364210416279fd708326022828b799514809";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/az/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/az/firefox-85.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "0d2cd416e309ae19af4f3704823de50b560863dc1f1939e75663e9976cbb5c8f";
+      sha256 = "1d363e82907335bde45f82e2314c3624a9fd590a49ee63421d05b0fdf7f2e582";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/be/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/be/firefox-85.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "fcf922756a6830d9bf76bed71579f4b6e2e47edafbb843ee2a490552cfc88f86";
+      sha256 = "4602c533fc123382a208986694ddd00453c0eba6a15bc40c206a48121365325b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/bg/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/bg/firefox-85.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "9d40f252156d646363e65aca32ae4ebbeffe147dccb3d4989e79a57a4dca57fe";
+      sha256 = "eb44d9b866c1913cd39bbd84b6157e40ae3012c48fb7b9b8274a538fb746b57d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/bn/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/bn/firefox-85.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "9471636ffff7f11db45001af18d86ae0d930517e09cd2aebb0a850a946b44917";
+      sha256 = "07ae6203f29a8655c756469595ed25b586d20d73bee940fab2a036ded9a143c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/br/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/br/firefox-85.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "4482fe50747f7fbf4db5ffb0b3c16bc0245fc0397f582e73c609a8cbbd48c1f8";
+      sha256 = "a7b0b6f2c8bb7f8b33e8a8547ee1c1f2964947b3ed2bac05eb2a7f390475deee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/bs/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/bs/firefox-85.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "5357a4fb56a4aeeb43d98f5ace310000532da9088ca0cd06c818d3852fb38452";
+      sha256 = "5dfc013f318e2c9decf3b1782cc772509bfffdd351fdda8adc06eb3fe8a32e5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ca-valencia/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ca-valencia/firefox-85.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "1a22b215fa50f947afd5657ec702419ec708133f89f372d7667d12fe0e3b85eb";
+      sha256 = "89dcf9884269c4b50203f5eef9aaf40531bb607553c953f5bc353388ef5c0d18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ca/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ca/firefox-85.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "fd335110bb31eed1e1854d24c74c51b8ded826008e49d8ed6b1f7be85ef05753";
+      sha256 = "481d6542181678e22b0a2a8e36b1c1f8b3bd19b1e899a240b7b84aa625cf858f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/cak/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/cak/firefox-85.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "b852765dd3dc4530c1d1d00232c6a615472d721d1f69cf303ddfd6d6b26d2745";
+      sha256 = "8e158be85c9103c3013581d897d631dd4e62198756eb107a02fdf106cedea92a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/cs/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/cs/firefox-85.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "747f697ca9aca2b1982a95a3d05f4549d3f1b276cdac39e17670c0b101f8b704";
+      sha256 = "f834b4e3085f7428b511a6d8ccaf2708a003136541de45842e387aaa2d1a0137";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/cy/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/cy/firefox-85.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "4bf87e33539d8bc383715b89a5fa5e1f5d1e272a7899689585f9fdb711a5e259";
+      sha256 = "bf9d259767516e6f919c723217a83be34a2e4e390f67f3fb44c20d6f8152b62f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/da/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/da/firefox-85.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "bf9961aef493ceb1613c91d79ef1c7b718dc5e39fa3ad8dbfb012d51c16b1e5f";
+      sha256 = "4aa90c940c08f68a8b0e63eea0a4e4e52f2a50f81edc900b0efc22f3adcd33f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/de/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/de/firefox-85.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e4e85f2d49dfd9b4bf62e4ee2e77d03660f0b6ae9ce7ee827a17f2f067768b59";
+      sha256 = "e1d19e22368146eb9afbfa7535c60843583a538cd808bad2189b23f5a57d84e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/dsb/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/dsb/firefox-85.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "71a3307575c45643d8121b64a345c19a6dbfa0924fa7d91b5913d52ce7a5d663";
+      sha256 = "9a29e70939026b71eef2e3ca00d785a26d2668e5d7c0d329bc49fe6a35f9fc51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/el/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/el/firefox-85.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "75bdc62ba592d48f172af3b072158e14ce0f433c7ee3b44f9bb0f4e0f9c71834";
+      sha256 = "f3172deaa2b65bd3fe4cdd62a7fd4e81c936899cd83495c4f5e54d63fc8ba2e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/en-CA/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/en-CA/firefox-85.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c7e2bb86941274de33368c78122cb14bc52c4177de2b9cc757d269d9d7cff40d";
+      sha256 = "009768d282619a145489ba9ddb4ac5d47eb0f686e41875d6cdfa97b7102df4b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/en-GB/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/en-GB/firefox-85.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "46c5821f9e973a599c74445ab4a44ca31b3f76e18597f4e0d77479c1cd0d3841";
+      sha256 = "4ab6d704389c53da46890471f8bb0a57ba488f78ee0f87c96da9f931931992c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/en-US/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/en-US/firefox-85.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "4cd2facaa0b33b02228405e74689770516e6af6f07de8dac096bc66ca9a238bc";
+      sha256 = "afcf3c95a99fac0fd4fd6a6c2b1cfaf717b41cd5673d5016f10dbe6f5b79fb3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/eo/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/eo/firefox-85.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "6966ac14fa72fb627955e9281c6e54f23eb03b83647cd52934304d672adb6d5e";
+      sha256 = "8106ce5dcb41ed97a3deb4d98b5af23eead4651046e758ffb6ae9eeb96f05944";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/es-AR/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/es-AR/firefox-85.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "ff32191b95dfba73d85caab8aca47e32b2579f92c9fedce14f6e16a6e42c2178";
+      sha256 = "b1178b1975b132f0c524941d46e7cd357c0aa20b7ea4f4a87e6e9991b0761c7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/es-CL/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/es-CL/firefox-85.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "a7c7a9f646492e8de8474f1869075c568774ccc0118c340721b70c06e5471a5a";
+      sha256 = "923187af4eff228d5b3b99f21ae14101f1956fdf6fd2c0de80e1196333ff8baf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/es-ES/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/es-ES/firefox-85.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "71e78fc680de3dbd91b77bb13b113ee5f34463aaa4791a3b0a445a292e5d0732";
+      sha256 = "99725d0085afcf7c6afd28090b75b3605d99df52d1d06c377ca50a6d6621fc4b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/es-MX/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/es-MX/firefox-85.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "9c357beab45fad0e56f957fa73b8900a916c6cbcc8b18bd5389c0a977ddcd18e";
+      sha256 = "24f5b9a87604b82907a56071518649c535568e4ef0b5d045763459badff766c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/et/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/et/firefox-85.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a3de258fcfc4d633529566d2d8f7bb582683d6dc22cb3c9ad13a4914b84b6100";
+      sha256 = "aac17f4409ef25d6c4edceba79d446bb22b654016b0ac50ba069ddcfd023355f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/eu/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/eu/firefox-85.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "092cb149621ff664ff4462c39266ea352971b30f5dfb0db163b62cd3af4e0fcb";
+      sha256 = "fcdca8bc26eed4d49bb93007b49024d192be06508e5957fc1e3e42ef3c3b372e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/fa/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/fa/firefox-85.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "083d17daa3f86af4651cf433180750bcea6d00758ada3ade80bf2f713b3c04f7";
+      sha256 = "9bf51b0df9d3cb62ec9a8675344aeedd2b4466854cebb000abd02d7c97da3777";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ff/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ff/firefox-85.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "7de0cfa6bbdd1061cad1a72d80f5f504dd163a066c9911e1c44428f02b1942d7";
+      sha256 = "647f628344b3951a8cc3e857ae02da89a818a6f8dcfec61de006d9f5b90d51d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/fi/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/fi/firefox-85.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "d718ce1837fcf64bf2b324724603559124697e58ddce8324c79e582c7f644205";
+      sha256 = "1c49d3fd8a909c74abffb2221cd9811e15125651ca42d333d4ef5d8f322b8535";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/fr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/fr/firefox-85.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "74e2ab8182100b7e69c62698bcf5b03cb127f4e90dcbeb35bba7d66b58a711e1";
+      sha256 = "3be80ec1f775ed8c78c703ee064cfedc20aa57f948a8c732008a58ae45e946a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/fy-NL/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/fy-NL/firefox-85.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "135317f51eb93e2bbc18401c8e5fd2c070b3688fc6a9bb54e9e78bb7f37c676c";
+      sha256 = "5331c0de8436a7cf1117c92249066160930b3902ce3d157a0cca53d74a85cfdf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ga-IE/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ga-IE/firefox-85.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "77fc52e186c1f823067a7fdb549232a080753c813afdece12f49444bffa6507b";
+      sha256 = "90b6957c43d85e223ef19496208e3df53ff82f5944bcf5c6152f83d76b744a7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/gd/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/gd/firefox-85.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "abcaca790054b035687a78e9ae8151459af4b7f2d9d561d6ae41c87a0308c694";
+      sha256 = "5398cb9d6672b35b72162dfca4f5e612a813dcfbcb547bc028d6e1c6da06c199";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/gl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/gl/firefox-85.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "291adca54f86591fdb67c6a958eb7784b5d5d4996858ae8936a5615c89e2fb4a";
+      sha256 = "775e8e385654b779a7be837e0de813e23ba9a3cbf6fa8748853684601d8a898d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/gn/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/gn/firefox-85.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "0c8dc262e96c0a912cc8aae7e1ec76da36091cea47ed535eddb8039564ed24d8";
+      sha256 = "209ae5fe213270d765ec71875db6e1ae3c78ab2f704cd9077e2bdce4160db6fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/gu-IN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/gu-IN/firefox-85.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "2fb8fe3c39353ae9b03018ab17a3531ae20e1a6794871a7ff02108484f641801";
+      sha256 = "633ccd3a605887259b5a1d229c8661c4c83948e42e51ac87231457591c945efb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/he/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/he/firefox-85.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "3222cc40ba99d0833a3a8c5bd2e9e8c74ffe0e2209891899e9d37b6a35bd8e41";
+      sha256 = "09f6069395ee4f8b7efbc8efe8311abbdd247af624dc045aa00e795e0b9e74a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/hi-IN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/hi-IN/firefox-85.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "bb633eeadb00cf6913190221e5720c68da8d7a7d5e51b5f1d32621ab35fdf7ad";
+      sha256 = "9f99c34b11f0630ff93275810d686fcdd9f22ba4db6c173f6c748926d365c7cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/hr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/hr/firefox-85.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "21a8dd0e511ff658e09a5497925fba833c32d1bf6537f11e53eafb07d6bd8854";
+      sha256 = "b79dd9c64d5b57082a22a2b0c98adf1b095c9e157622054e1ea51c876beadf07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/hsb/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/hsb/firefox-85.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "c862804fc9602884bc8074631d51e091866177682a6767e5b4935a3315b2ea82";
+      sha256 = "ac1c63c2f27e2eefab8d4fd0f5d928d2f6e3511fe6ce42a05b91f93c5cf5b782";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/hu/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/hu/firefox-85.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "bf92592b0f3697e828c9b07d24c5394ef6cd980c94248ceaaeb0181a1d0ddb24";
+      sha256 = "401d74cb12c26412e7d5c31059deec4f8fd4494363f42d0c686a0711442d7c4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/hy-AM/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/hy-AM/firefox-85.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "fe5686fbc9c1a173c4ce11695675a4aab2efb7d340bccef797d8a20eedadfbc4";
+      sha256 = "ce726dae6c56bf8745037a2a303aa12d4196587562342d570914d9ac45ec3227";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ia/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ia/firefox-85.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "791423722d872ecf6c45e0f16b74626e19764c003cc5f2ac2fbe3e1bacea9422";
+      sha256 = "7846e0c8330669416025f2a80bdde899fb18662eaa319518b9ad125dad40a4bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/id/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/id/firefox-85.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "df4b06f6d4946d2dcd55130df46b7cf5e391ba433eef792854ef8338dbcd891c";
+      sha256 = "9d16ff95e831721b146f7922bff50867e29268b52142ebf7524f85c0743677dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/is/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/is/firefox-85.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "d60f08191a68e5f4cfaf5848c6d0a755c9033e853e6da08eab6b74362c220ab1";
+      sha256 = "8e26a368ae652752873a7c1989d1d2dcb7376012b576f43b126dde9f074f01c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/it/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/it/firefox-85.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "a1d38ce8785cc3f15d777e226aba48fa1448da021092d9aac340cd02ccfb5669";
+      sha256 = "8a853b8fbaf02016103ab15a44081fd0893908371813d94d2e92393009e17684";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ja/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ja/firefox-85.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "02626394737a87d0dc80365b7ff7829bb1d1191a65a063d4d079735199ce2731";
+      sha256 = "2d82c8260f92225c4138abe5bbb547ee132f24624de51ac8546fc8cc2d1c247c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ka/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ka/firefox-85.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "4581ada66c25d45db22d4cd41356e30b0b9fa88132758e219e15ed70dc4055a2";
+      sha256 = "84a767c016dcce5e425d905a67e2244d1257c77d0e17da69c4c3c1ab85feafb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/kab/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/kab/firefox-85.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "24b4d9cb927322b3805e930a54020fa84e3925d824363ef824501ff2769cb015";
+      sha256 = "c4d217ecc85d4f3c5ac5fbacbc6d37e19885d2959126465f01f45f2026db5d2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/kk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/kk/firefox-85.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "868d5959ba761e578b5a2d00a29c244cfec0108a294fd52b18682cf31173b9c4";
+      sha256 = "c2556486729ab7918eabd3fb917c71d3081e7926880712c6f78b847c868abfc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/km/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/km/firefox-85.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "e5f63ff912c920d92d7608e2746d429737f0868bc5fe33d3c460ee1f745e242b";
+      sha256 = "30a9d1df4d121c02a3c1bb0d3c1ba2ac0674586ea56870cf9b259041334b7545";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/kn/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/kn/firefox-85.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "65d45e29f289cdefecb369862fee62be698abad2b8452687507a52149b4d1de1";
+      sha256 = "740a09e9152df1770ead58c1b4cbd5be307479edd29f0a14a96a3d578f90852b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ko/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ko/firefox-85.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "83a516bbf83574f20339382778378a889016e5947c882fab63aadb728023465d";
+      sha256 = "eef655c31840dda8f5d972a1009deb7db42fef9a85f6d94fb8d7bb1080492b14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/lij/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/lij/firefox-85.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "690522d1a0d67c5538d567accde52effeba8b16cb4c36920aef230a62e1f655d";
+      sha256 = "6d5ac3729f737a0ecf115c4ba730ec12c43be59e00d9ff3e3df25eb95fa18920";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/lt/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/lt/firefox-85.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "f586dd3c96aa61d9aa19ad734f4a61c9e1f6a530795ad486a2a1ff4cb18f0854";
+      sha256 = "da9a98bf577c1402ac07023fd2957fdf83385238dc6914403b3d3473fdc84608";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/lv/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/lv/firefox-85.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "002bdcaf29f65d2c81b607e36c280f73a08cefa32f9e878ca2c834b80eb69435";
+      sha256 = "cbf2d767419494583b5a4393f4955ac5248a9f370c87006b9ff5a0b9ef2d46d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/mk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/mk/firefox-85.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "06179e95fce7f93f410983664077e4213f31272ea626a8b3fefe1e78dd0b7fa3";
+      sha256 = "8c203265e7424c68617f24b0c254846ca3c9f795f59dec2b1ee90bd2e9e24fbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/mr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/mr/firefox-85.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "532c17600a7ccc995424759043f0dcf0df5a10870bd7daa92c39f3a2a0b11c68";
+      sha256 = "2527688b01ade72c23c8a166bc3fe71ab6ebbefa53f95431ad748172c757fc32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ms/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ms/firefox-85.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "b315e64474d410e4c6c403b1083b98fe5bba5f20fa4fcb115671c58075e1ad65";
+      sha256 = "54345ecf9bac43aeb9dc5bcce2f6ab95873c30d167c9f0e25276260236349ac2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/my/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/my/firefox-85.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "848b472edef05971e5d6b003a1d3241c0d34a3f0b2a54ff97ed3a7f2ac96bdde";
+      sha256 = "7d55f9c3b0372e8df4f1efed73e7904d6ca76d42384e1d69297209aee89eb538";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/nb-NO/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/nb-NO/firefox-85.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "ca2e64f608b908b752413d9da7c8ec2cf23ab2f49df6362ce381b0d31e9caf56";
+      sha256 = "7323cac2c5cc65cf6717c8e93c81cd8aa1e42c4dc26a8fafdb01e909d0d03627";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ne-NP/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ne-NP/firefox-85.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "3386312e032b56457483fb46d935773adf12f3a3938ac4c6eb5b0c12242d93ce";
+      sha256 = "5aa7399107c721555b840632c724f0ba8ea410561b36ba278304ae2672674d13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/nl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/nl/firefox-85.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "7bbf63a4acf403611daf55e6663d796a46201349d29531245261aa5a8457e4c7";
+      sha256 = "134e77e589dde44918e383dd3e08489ba855d9e15d542283f26c465bd84a1677";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/nn-NO/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/nn-NO/firefox-85.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "f126bb842ae56504ff25f9ee0765cccf7b9a4bce1d45d382f6c13d23792bbf47";
+      sha256 = "ee6da6a70f8565cade938fadb6d3b25c8edf860dc4210e26a1b93034adcb57da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/oc/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/oc/firefox-85.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "3f4045cfe03eb4fcd16215b5693913577f6c5fc68ba74528c6575a5573528241";
+      sha256 = "9fdd1fe265330c1b070d523e1af0d6dbde077583cb1e585b718112e49d044039";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/pa-IN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/pa-IN/firefox-85.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "cd4e81e714f78303603c390b490144e27f5f83ad436e610842aa04c242c8a549";
+      sha256 = "b7fc81bc71c30f48c40ec5fb4f8318973122523515c523ddcd98126c7c3750ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/pl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/pl/firefox-85.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9147013773bab5f5da15e021becda90d63daf7f7068d7947f9d7eae3bdb0e124";
+      sha256 = "09b877af3b15dad1e25f7c04a7e94990cd6e20705a26e3cf715a30626fa10646";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/pt-BR/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/pt-BR/firefox-85.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "20efb971aaaebe780b337d1525eac527dde028eadecd5247321a5db5f0217143";
+      sha256 = "81db09ed98266347740569c02cf0993ffb532dcf9e5c814496cb3e4b23133b35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/pt-PT/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/pt-PT/firefox-85.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "765cbe09264ffc15115da555500ae376bc1a91458c872ad7e4876701aab6f10b";
+      sha256 = "94bc77310c90876b2f787c1c004212947572fc45864758a7f59d2e2ee9488a16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/rm/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/rm/firefox-85.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "93f5d6ed649d275ad4ee1f9a7075e8b4270abe6275b57eca0759b2a8efb08cff";
+      sha256 = "71ad541e5c119f05cea1ef6a730f860025d105112907f8dc6ba2a4d33f8efcd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ro/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ro/firefox-85.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "aa44ba543a08a56f46e220f41695da4aa0fc97c9569563ff0555f308117cc983";
+      sha256 = "d699396c833a48bab753a76456e653d90e62a0585a9c9ee9ffdc6b30d8958778";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ru/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ru/firefox-85.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6a17313ad121e9821a766115259a8f29ace0ae683d18a86c844073e671a4b0cc";
+      sha256 = "6bc991fd34ec649da0e85e5959197db7e92e2b52cd9b5b3abc3d631ec5cf5bd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/si/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/si/firefox-85.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "2766789c614ca35f6ec7177464c5cd2f5df5ec1ccde71e1835efd6f3635e0de5";
+      sha256 = "11de780455b3cca25ab64a58f3da00062fc29ef43973ab0d34435bb99463c23d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/sk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/sk/firefox-85.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "7de262a9caaf141c37d819f89eb3b1ee7ab932b10e345e7f9a50db7f1e8cdfa9";
+      sha256 = "773964f567fd6df114795d3f362e553664d028f5d6ef7bed5852397852f5412e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/sl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/sl/firefox-85.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "e31fdd4a192daefe7a3946976c7682e15ebb61b598c5dcf8bb7a870efd3a9e27";
+      sha256 = "284f486353dc7dd57f3dcdcc82314cb491f7a37d8aee04b2d35982f0bf9bbb0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/son/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/son/firefox-85.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "532dd0db390b3d8da03cb5f01e26dbc0752365e782e0b2d11925c14f5dfd8f0d";
+      sha256 = "e1ca542f40f91b69743ce53ba001e6b10b55a57701ad6354f025f0f6a2a66727";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/sq/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/sq/firefox-85.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "35c59d0543506c625fd6ab0c181566c5f370aee2504970fd37b50d0d34ed0e8e";
+      sha256 = "8796aa6b9641a33558f4aa2c55cd425fcc9fe7e7c08fa7de2bb68341e337944f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/sr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/sr/firefox-85.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "a6f9d8fdcfcb4b4a89e14b84e6a88bfdb0d6b578ee8e4129dc1f82bd933ecdcd";
+      sha256 = "a4aa9131f1cd1aadb550f6ca312e490142c4caaeb6cf9d3f2e81699bd9050f0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/sv-SE/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/sv-SE/firefox-85.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "664b8b51429c0267a745a69906f32757a28a4ae8b23bc2f591d3b190a3091379";
+      sha256 = "995863c51f9f91f3667f3927b7135e995d47b2ebf5bb4d8ccab28b0825af41be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ta/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ta/firefox-85.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "05679379a0abe41cf46ab182018810ca42cf8b81686f48c3c644928db85d4c76";
+      sha256 = "e0318bf4e87f2bafa43939fe3931b626501fbb5bbb91db5b50b71d946332a66d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/te/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/te/firefox-85.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "1c884e460b6e5a0e0c27e087b3f81a3c4245f6a5ba5ea2784b2b0b61114462dd";
+      sha256 = "0c1420ce0e3c4abdfe2ccbdacd1632c619438e84faa2cf29efead3a74ab437c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/th/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/th/firefox-85.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "9ea2b02fba273e970bd2140e713468b300fda7cf50451f5f4f840220b782e1d7";
+      sha256 = "db256f39058d8e6e8d8301ac0ee435ff41b1c547b9357f99c91c8de325da9298";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/tl/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/tl/firefox-85.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "ea9334cdbae5921720974575477da6310fb75c02eb068cb13d700b71df1596f9";
+      sha256 = "fa02d3cc5fdd6512b84e04a27e0af95b01986403f16abc04484dbfe873fce537";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/tr/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/tr/firefox-85.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c2314d1159313ae8d330244150cfafb5345d7515c5062c62ae31d916f69bf4ea";
+      sha256 = "3a936bfe9b169dbb4f02f5984df1ccd0c37f19c7f83c05a56fbdb8ed3b6009eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/trs/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/trs/firefox-85.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "769acc367c1dacee2617e784a98d4c546857123690f902783ed9f97c10062f8c";
+      sha256 = "b995caf1c8128d8b6b60819d0ddcc3016f4247cf83cebe8c3aa2d1747f6520f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/uk/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/uk/firefox-85.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "d9c179bc63a3c9d8ec4722afb4cf4a3cd4175d01542477fc132147521d7be0b4";
+      sha256 = "e4f53e17928fdaa1d85c8272079e5717fb9c443dc2659ac08d95524703883e2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/ur/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/ur/firefox-85.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ed365cdf1f3ca389b308a2b9ee405917da0dd0cd1536c9c7a4e13949b118a2ca";
+      sha256 = "84e7d6e01a570df7ef4b616e075cb93d1fc7fcd5da0a3adec179e99363ee5f92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/uz/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/uz/firefox-85.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "b6437d5c406edfbe0c3a114d230a5b9beaefec04e48c92d01a7cf900f6dabd56";
+      sha256 = "15bb01ebaab8ed4f022829b9bf7f16e2fb5fe90e5ca47e300e2cb2ccd66d922d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/vi/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/vi/firefox-85.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "1d6f91d852f0b20e357e1accc6c43ad93bcfe2e5a92f04a89c1d4bace70285cc";
+      sha256 = "a8fc45cc1ffc151414621d8e4f36ead409582e298f7e86bc2943ed6f20dd7f90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/xh/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/xh/firefox-85.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "597a04402d0d34f10c6e3fbd0f629eb45c6b3b8eba2c63917074bb34c47e8cf1";
+      sha256 = "ac0089e7ce04b218eae0ce40245a75626523035218cdc7ca2551a9af8a18d33b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/zh-CN/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/zh-CN/firefox-85.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "e4df77f3447615bbbcb21904f15d2d18936ef7216c047a62c6901be00343df6d";
+      sha256 = "eacf3a23fde07908effacbba3cc346d1e9af088ffde81711e3ab3e087bd86e6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b4/linux-i686/zh-TW/firefox-85.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0b6/linux-i686/zh-TW/firefox-85.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "f0d9f95b465bf5a60bb0ec5906354acb705e78ab7dcfdcf0c09a3f26e4fc7bfc";
+      sha256 = "e31a9683560465fa6bc97edc46c42071431d62ba4a55f5f066d58ea60613990e";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "84.0b4";
+  version = "85.0b6";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ach/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ach/firefox-85.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "6b548e6e2753e4a0ad2ad5968c063b6f4c7866c297314ba9e807161f7c757275";
+      sha256 = "eed87dd1f8683805d13f5d42f8d376ccc760c6c96b7b049ac6d5514e00122722";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/af/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/af/firefox-85.0b6.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "f75bfba14ae1a248918c0e433c343328305eb6372dd80aa343506437f631f2b6";
+      sha256 = "233e9d412982933e2880d2c9b790d56cfdf15b1d55e8ee1f0819ec445faca451";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/an/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/an/firefox-85.0b6.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "d2e972f7d345720a89081fce3b9257942c93bdeb2a5c7dcede3c30282407f159";
+      sha256 = "d0bfab4288fe0fb53e0e0087d68d79699774900dd79b5eb32b36d33d757043b2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ar/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ar/firefox-85.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "2731722dbd097875bb797a555e9a0ba3843deb159f7917626d8e97c1a3005e7a";
+      sha256 = "d1181d7ea7d3e27f0ff531a3e3d547611f391e5ba0bbf0de4e3df6334b4b3e75";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ast/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ast/firefox-85.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "4d626c7f293226e9e18e28d069b40f75914f9387553d54588c34e7dd70ce1ae9";
+      sha256 = "b9b08b7b267bb59b59e310b430298267d1b5ed89086b2dbe51f6f6550324e904";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/az/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/az/firefox-85.0b6.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "01a647694a6aa2bbd8ad531197565593783946ad248d34f86550d28b8be5b52b";
+      sha256 = "cfdfdf835966e03a3ca036dba3fc175282c0a8ea8c8db9ab0391837e50507e7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/be/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/be/firefox-85.0b6.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "49639180573943a4bd4d0672c5dec969850b4bfceca00c37575c6d0f2d589a7e";
+      sha256 = "f32addb95c794a87ec44ac1a575ea0b9279c6f8b4bbd72b02793a289743f5028";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/bg/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/bg/firefox-85.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "c575261553cbc6afcc60650e21605e1298a122b975f6b6b2845a35725fe2ff25";
+      sha256 = "511ecef8b5cefcdb6f7c0cfd257c156097af8f59e130b6b1d74340437014abc9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/bn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/bn/firefox-85.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "5c5ebe2bfaaa7ea16ca4285d9806f3ecef1b29b61e5018920db27e050a4ef521";
+      sha256 = "e76dd71557d5655e1fe13081511a6bb84cbfdad9bfdc7b44379c0d0dc8f38dd8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/br/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/br/firefox-85.0b6.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "29c764eff10d3756f258f0ac5cc9bec14cc46bb66d804eaca5548cebbaa067d6";
+      sha256 = "3d941653521853e57c2db3a1abeb5fadc81b11050ca69811b010d5fc63936bd6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/bs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/bs/firefox-85.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "7730a4c1e7d4d791fe35f000bba72d3652fe7289eb95f5e77b426995a63ef412";
+      sha256 = "47059e2a4a5174357be3a1e23cc8a97a0c2fa4cee6e58f437d45502ecd329197";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ca-valencia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ca-valencia/firefox-85.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "fe90ef596de4262d803fa282cce7b30c1c9bde896b31d7e47d8e862e38ca1037";
+      sha256 = "47da19182c2ca2c8dc25acbba971cec2500097e20a977387c326036c9f4da527";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ca/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ca/firefox-85.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "f435a47a36affd5b59c7a6543f1c1c7e0dfead407138967a0f295dcd6093bed6";
+      sha256 = "248fb9f284fa482307be01ac59f082b84475ab550d5d8e53168e239c74cd5892";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/cak/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/cak/firefox-85.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "ec4968ccfaea0a975a4f56aaae8290387707570cf899d078438ac2cb98244fe7";
+      sha256 = "933e6a5f026eb2e50e8d40a90fde7db56325f7abe59caa99d2edc34bcad16f37";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/cs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/cs/firefox-85.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "357c5372b6fade862671db66b90b3382749153c641bcd7c99f7b2a3c68c143fb";
+      sha256 = "7d0943dcf8716eca125409310e821b87805b036cf01a9bf7ec06400b4e97b3e9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/cy/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/cy/firefox-85.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "5ce8f5e451fb2271635a2cada6c7b54a53936a1b912b777d54ce640cecb3d37e";
+      sha256 = "d523417a57911df738d07fe6c899b95897686f8ea94e27cc778a02a21a417990";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/da/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/da/firefox-85.0b6.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "ac790fdafd2875d180be2375937b38546dd77d6e9b8428f4d44a2b780b4db14f";
+      sha256 = "dd7c7acfe40232ac66cb60ee6b3bc6a1dd84d2930f507898d74ddef8e6a60355";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/de/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/de/firefox-85.0b6.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "6c5205a4d74da62927648f95a069ed6a68ab012f2cbe0c4cded3de8d40c3d325";
+      sha256 = "51b8b9b772c901fd8b3bb61eebec4a0fd8541c51b9011be57cdb83311035e2bc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/dsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/dsb/firefox-85.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "516308e19f0373b3ff75e2e114fc7f1d2d370cd4a0f63f8bf74704eced2e0d56";
+      sha256 = "b5175eb5e72644c3e7ed6dcbb1015716f923c50c59ce8e6ff3fea49195d08478";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/el/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/el/firefox-85.0b6.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "d35a67fcfc8c5c334f55d12810bdcbaab6b9cb5fd3aaa75c79977accf7429445";
+      sha256 = "abfe077998a5f3bb2e1b4f2b69b84ca5af72e0d18dcb584bb0feae2e0023e299";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/en-CA/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/en-CA/firefox-85.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e8d36d76d791108a6e514a649eebc9c4814aa8ccd4b21728e56a4e9839eef803";
+      sha256 = "c8b8b4d9619348c9f97f03e222035eaef9d933d46526607ab2c42db7c4a5f21a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/en-GB/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/en-GB/firefox-85.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "9bb695670d7ee7a3a35d9adeef579e33f076fc1eca717149a5078134f584bf70";
+      sha256 = "9dd9aeb143c9ac871e6c1cbe16b993f765d84b7fcdf50877e4cd89bb7281948a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/en-US/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/en-US/firefox-85.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "595b1004380ac96663c2d8889f02a681ad7c5c56e0f12cde4a26a6453d0a0ec5";
+      sha256 = "df2d745d5353ad3d91d5c62c00ebabb17209e91aad52c240efeffe002e6696d6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/eo/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/eo/firefox-85.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "cb6ac56d074e91e2f5154c275c4c3a46e4392586451fdbba52fb419bbe085c64";
+      sha256 = "7fd5df96fcc3a4ca2e960e83674e3120143eadd47c5b0360f11f573540d4f59c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-AR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/es-AR/firefox-85.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "920e2aa05414fb72be7f24240636e7ce7b431776cc919c5a07c1361da3f66289";
+      sha256 = "d22f3d4b6a2f3b18b375b2592d78cb06c7c92318c6cd4a5e8c70942300bfad94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-CL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/es-CL/firefox-85.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "9db297046da02c5c8e1f6d5ba0e4f6b35ec8b8d36335dd2f7933e49d86c207b3";
+      sha256 = "a3f267296b829f6fd2344b3bc652abeba7780e0dc455f6f23fd2d7b66efdd846";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-ES/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/es-ES/firefox-85.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "ed94f3ded8f803f956290976cfa41a5c46b42da7f3158b4283445ded15fdd789";
+      sha256 = "ffc5f413b90025e5452e57b07795721456aa37e4bbb2a6784e732e8a57232e9f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/es-MX/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/es-MX/firefox-85.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "11e2a8b7084ea002c6efd92fc86529e2dd09afbe4fe52285a3165733af95e132";
+      sha256 = "c170fdce52b35551ae49d2cd330df761f0d0efc5628708edfa72aa513e89c99d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/et/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/et/firefox-85.0b6.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "0baa470895983b2c85f9ecc79f36fa1b6c8578c5bc22be76ef10d6e7f9e11ee9";
+      sha256 = "d256ade3513817ffa8d79ac652fd51578ca5a9c53043898e7f3520ffe6365829";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/eu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/eu/firefox-85.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "271141d85b5a0338445945208d515ab9ec6452253abddb1860c31cd61458de4b";
+      sha256 = "0720a63b02f38ce97c902cc221a85e41ae0e2d36ecaac47f5f661d4be89b6abc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fa/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/fa/firefox-85.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d467a6e1eff3b2edad56c6b8b58a7fe2d7fa5c07524fc0d567b660b29169ddf9";
+      sha256 = "78a4aa339dd5e56b4458ca2096b538bc27d272b953d207e44a41c8ab19de68b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ff/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ff/firefox-85.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "4f117b8bd69c01cb6d38b927ab26cfe79fcd111fc9a4a2e53ae4ef936bc9806d";
+      sha256 = "2de463eeb3f70f4d16ab677a6980c5fe229a69c1b0846804dcc58388b8679a7e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/fi/firefox-85.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "6eb9d0c0d1ef84abf0af2a873334dea463d728ef5aff398417e2ea3104a4503e";
+      sha256 = "ba880a3ff4e45c5d30d813a16e9fc088995a9c2fd2a32fda4d53c1e2ce74368f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/fr/firefox-85.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "85d4b90fabcc03d3ac396bdba0749794bc3fe447c9f2ce793962a2acfc35918f";
+      sha256 = "820cf6d9813048f95719d6599a9a4cae1862a6677dca3172b87339a0735ac37b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/fy-NL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/fy-NL/firefox-85.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "462e14991e34122e2275bedcd6776d9f8a75242c2b06d84ef3dadab08428d48d";
+      sha256 = "b2cbbac775d1b4a1d7e6930427198123e82f4959f3a65e38913d2238d6f3ad1b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ga-IE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ga-IE/firefox-85.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "b0b7def94a250ec52fda4e4fe0de931209fe71eb06ce03de13bd7309c7f78d79";
+      sha256 = "256cded01f746ed016894e7491af075b0d1ab08302ce76dc62e71b4a27e6c390";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gd/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/gd/firefox-85.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "e3bc980f579132b68cdf06b06abe2303430df239444971010ef420f5fe1599f0";
+      sha256 = "080ebf615b64afa8ae51fd198e5fcbe8bd8a9843ef5101c631c51ff880b2d46d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/gl/firefox-85.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "66b9c65dedd1b57cfa2d960a40df72dca473f39f1cc585e1406abc64d68b1ce5";
+      sha256 = "27b6a7f9d52f3fa96ec69d99ef18faacf856561c7df187ba2fb568654afb2e50";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/gn/firefox-85.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "ad707ad91336de1c0d1f26fddebb95d25a8ff405bc3d576660ad9be0f5643939";
+      sha256 = "2ad562144f3daa93ac986821b56ac8229fd89ce2820186d5d318759f4f863d17";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/gu-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/gu-IN/firefox-85.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "585c76f373ef5c3f3b86a6cef4dfcdbffe3e314ba737a3f514bcd871140e5aaf";
+      sha256 = "aaba5d2786dfe9cf2e5ef3f134a4f011deaf25f9e213c5295d905286881b4062";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/he/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/he/firefox-85.0b6.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "8f9ed5eb32fe9272f5adc22753997292cd2dab7b1368864b4f001eb0fffd7526";
+      sha256 = "fee5b30ca488d1eca1551fc645319f47af658a80a0bcb4c68509cfc5aa398784";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hi-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/hi-IN/firefox-85.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "22d8b3d494f3b0dc5e347c0fedd5ab2ba32690c02993bd2a9066a987bb87aea8";
+      sha256 = "ace82312d206cf07d54ba722ab0ed30717f8ef0c0fbe881123ce87a94f16b67b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/hr/firefox-85.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "c3a70593633985fcc8974364db75f2998e450359d4a8b621f23e95df24cf8e6b";
+      sha256 = "a017dd9dd83217affcd89d7493c91e605fee0e238ff03d3d45d10466df9a5ba4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/hsb/firefox-85.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "30701d1b25536a45a6a5613cbff8ac83bdec08d6421f1e37d9f0ae9c39ab6856";
+      sha256 = "0d3f105a01e1f17f7ae0c95772d39a134f6435aacddc0eb5b4949a923df7b4e4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/hu/firefox-85.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bcb63dc6211b5c24536062ed6f8a424edf0ad553187b298874d97f75d363b1ea";
+      sha256 = "51807ec5741e07265b090804d7ec3b4cd93c8f459ef956372981d9e150eb4eec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/hy-AM/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/hy-AM/firefox-85.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "0278018d35f7be3e4c8da080bcd86e2bf08a544bfd452136483d2b21f91c582e";
+      sha256 = "6955245256ec8ff28b0222cfd63cc9d77c2b9d4b379ef1e58293da7de0b579b0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ia/firefox-85.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "d5699f8b946bc551fea78389cc6e82a9ca58ca3a8a492cbe3b985ed655fd60d1";
+      sha256 = "3d982431b0ef12cc6cc4010d4d1bc613184968a44c1f3f6ad08d8d52bcf1ef77";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/id/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/id/firefox-85.0b6.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1e2c580382192e88094738a01bc99b7efda5a1010e1bb180e35b5701f03aef55";
+      sha256 = "8fa2ac22a1c9a1074390cf49215198a49ad781129040eb5b17fac0d0d49f816c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/is/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/is/firefox-85.0b6.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a541657165e18212f97261b2aba391434246688451cc9f2b643a57891dc0eb1a";
+      sha256 = "e39e23190108c37bf146cdd9e1c913aafce616f89946904669f7485c806c7f4f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/it/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/it/firefox-85.0b6.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "5ecf7a03bc8e8d6329db2bca4296cf0d07b943ec9c9e0cbb2ffdaa4ecffcdf3a";
+      sha256 = "3c5ec976abc93fc4b0cd2ee24babde515e92d9beb8d058ae6fd0007980210600";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ja/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ja/firefox-85.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "80d6148dbfa8e95e5292699b5326171f6a44eaa30dc4c84b233191a8505a248b";
+      sha256 = "6e9ecc227336f2e5b193678666f02eb8d82bfc13bbace4bac7a7045a691af358";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ka/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ka/firefox-85.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9f15ef55fab16e0086466e696f35dc3107451c2b9ccab9452901cf66723bf688";
+      sha256 = "0550b02dc3ad2c2e4db998b7ccb90d7add1c1562b33fed34e0aebcb0c6157a4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/kab/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/kab/firefox-85.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "762be8a3bee38ea5b939611b4fbc9fd5bfe71e80b685cb0a8937373aa19f94d6";
+      sha256 = "5d2e3692c9791a29820d424af3e219e48a9fb766544c3f658bbf779f92e3dd06";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/kk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/kk/firefox-85.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "65196c278a5a70c76315546465915626ed0c5f395af4ed1aed0ab2f27846aac4";
+      sha256 = "c5949dfe7f7050b807b43b7050270c2bd748e688a6f54c7549859fc7f7b4b22b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/km/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/km/firefox-85.0b6.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "530010cb0d3393e47324c032d048a377ac5c9da16e73888db026f6cec61c3533";
+      sha256 = "c3e1e899942db90fe8cf2accea2c6de703ddf1e1871b842d59ee5e69b0a37441";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/kn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/kn/firefox-85.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "5233a8714e24a915404b3139aa3496812a4203b866cf4d870b013b940eba41ec";
+      sha256 = "9da71516f7ac05965ee5045c957b1d2384a9e331a41db0c8ca648cce1c0bd40f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ko/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ko/firefox-85.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "5dfe6629926804ed0820d472e19e51223565b011dee3feb722a81faa58043744";
+      sha256 = "3be5d104b4d9744911ed8a16b9186d3f0b2a83acee05cb1943e7e13bd14ed84f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/lij/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/lij/firefox-85.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "4bb4bd94ac7aa845a062c366ea47871293f7b5281a460d3547fc321b6430a3ec";
+      sha256 = "02dc5a6fca7fbafd2096f452324356e271496601b0ce78f9d64436bf96d8c234";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/lt/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/lt/firefox-85.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "162d3705cbb8ef0b8036520d59e17eefd8e94bf27b9c1df027e9c0b26b3ebcca";
+      sha256 = "0b719e71748e0c31f016fd56ec0940491a950b6bd02de3b96d66106b60574931";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/lv/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/lv/firefox-85.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7498cb5bad8ccde4a82e2acf49e899a652086de5c2e0a63f833d5342e83bfa48";
+      sha256 = "8d2400f28ecf500bd132a809219b5c1d5c9a469006c965754cff1b792ff9330a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/mk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/mk/firefox-85.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "88ffd9ffb56000b42d3878654b6be2413189b93881d29809c5cfcbcd740349db";
+      sha256 = "839aeb33e727f73e80cda1e1c025b969cd876a21ee56481afe9120bf0391898f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/mr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/mr/firefox-85.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "cac6e4ea74b146d07afa79e85746d9678e6407c733a38367ed36e94821cc2f4a";
+      sha256 = "ce978edb70a7137e70d8635cb874838b613dcf2f5fcb52d88e0a55177671c91d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ms/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ms/firefox-85.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "7e5eaf47c232fd25fb5c1e2de9d81351cfcf33c88c696a193219b0ff86a3c29f";
+      sha256 = "69e4b20678c3fca5e0f9be238ddbdde264478a5d7e772299d5d2f489bb1e260e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/my/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/my/firefox-85.0b6.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "20b1756847b2cbfc98153ac0d9a646f129b83f5c1383067d7547e9c70409abfc";
+      sha256 = "4d9f58323d15af78ba5f4d168097f20a59836ba4a0d7517a617eaa2959f6214f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/nb-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/nb-NO/firefox-85.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "ac71d2e5520acaa352eba1f26576dc101b7b3a64971b36acbbfe7151b47e1344";
+      sha256 = "b22cd9999df9160ff518f8a178b8795566e3e66cc3633199526790f91f2081cb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ne-NP/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ne-NP/firefox-85.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "90ff28f5e3ed56f5472e524f37288bad57045dc5491bc84f5e76f33d1d2cb046";
+      sha256 = "648ee88b4291cc0f01c021dee76267f4a552c9a009f32dcc6649fa889e32a558";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/nl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/nl/firefox-85.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "267c1d406006feae8bc350bcb58b4f73cc2403682c5786bb500bcafca4aa1ae9";
+      sha256 = "f686a56aa16386380c04763c845aa90288bd88959e7c06e93d7120d037263b4e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/nn-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/nn-NO/firefox-85.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "815e84bf8acb3cec68dd7fc06d7849240f71e73cd710538b9f8a887df73f98da";
+      sha256 = "071f10187be11f066cbaf6e78464689799e6eea0d98cfd96a85e41557b7d9561";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/oc/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/oc/firefox-85.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "14717ad07784d231333584150f04118d22a8616fec76aab800d3208c514904fb";
+      sha256 = "512c289cadfc4d3bcf3290feba112855610eabcf04db4bf5659b9dfe67d57ae9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pa-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/pa-IN/firefox-85.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "1c1470816615bb292f51cfd1a52002b5f2ed4444be41a3521ef1a40b4e64b2b4";
+      sha256 = "5910003d1453d62747a00ad96fd08a32401729df14718695a4ca2c6d2bb3554f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/pl/firefox-85.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "872a505769aff03597c71de66121fd007559c3f1cbb22c67661930de6e193634";
+      sha256 = "15f5d9e9aeae9362857374c38e94f2dc7371b3d949ed73ee4dfb234370ebe0d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pt-BR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/pt-BR/firefox-85.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d0ef34afb32b0f6d1c266b99ea0f4a9015934112524eee0cadc66faa6898ae27";
+      sha256 = "1067c3a6c646d86f57c75ec9ca452b12c25f9dcbfa0c723cd685d494f9e79411";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/pt-PT/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/pt-PT/firefox-85.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "e0b17a97217c799e4e0067e91374e63a6a99df827442d0193fcf47320af8a737";
+      sha256 = "c743f319f5bf60758e4e9f5684378503df780eccf062e1566fbcbdc45c903116";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/rm/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/rm/firefox-85.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "0c031b6ae10918e65274f5ce95fd03d68011e36ab626e03ad9484ff40b36bc7e";
+      sha256 = "6763de605975b7ead71356aac3d239f04cad9373d1fbcd4b7e3d16c87efcde94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ro/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ro/firefox-85.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "256b81200a5b92763d368b9c5d6f29e191aa4f11b097de1773bc5557d748c3ea";
+      sha256 = "aef0bb4fccc6814f225b4e6c073f5d825b6007ac420ad4febae195ad69d5fb71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ru/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ru/firefox-85.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "734b7d94b896554d5fedfd94a84c827ad6737808cd1f7b5b13be20702d46315b";
+      sha256 = "26a7a36e9e440587173660ee5192711b4d2807a1f735395f49fbcd36029261a4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/si/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/si/firefox-85.0b6.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "d2c9fee5e64b8063c834610c2671f9c3fa49a5e02fc7e3482890b534aeb66a7a";
+      sha256 = "1a45ddfb2e3fd999e0517b6d5f2f0a645c6f6ced044d468826fb5af5513b9410";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/sk/firefox-85.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "edcdf2a8a00e0402992862e28efb33614b9f1a4cdfed16316c5d4bbc229b298f";
+      sha256 = "1431c0c4f69f68548912bd4c1ca705d2bf031d24c4789477fabcb07c81ee8190";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/sl/firefox-85.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d097a61adf0908041cb3cce76758f6da274cd7b3a006163b004f70e869947021";
+      sha256 = "c408b950a78894d3aa25c7809db91009e9c62ad8fcb46128b3fadd16c286dace";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/son/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/son/firefox-85.0b6.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "d60731c5976825f0566502f6211d8e22388ec9d02bd122272f70a0830297e1fe";
+      sha256 = "bec096139548f807eb186c7251830026e13672a7ffd6433f362718939292f28f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sq/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/sq/firefox-85.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5dffa799eec3baf2e55d7b690cf73c2b190e369bff32dd1800020c0fdf912c9d";
+      sha256 = "0f2d27abe79792a7b43757d5ba9f911c2fb4d8949dfe3575d313171af47b7ab8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/sr/firefox-85.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "abb5779af704c926ca90bd9b9a01eb8de1b1b4feae658d5911bc523739eda0d3";
+      sha256 = "ab009023546e88becac31221e77ff580d0e4afa0349cf0b757ba5791bf93da60";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/sv-SE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/sv-SE/firefox-85.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "2a228577a4d6c11a433b8c0340558aa638de175474491428b05509019920f8e1";
+      sha256 = "0abde9db34df6dfc52a8c330b5ee053b0f4e7ab9ada8aba0c73265ea18caef0c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ta/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ta/firefox-85.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "82f0bec91719e7b2a355c9b0398b924ce4cf429bb11e99d566af9836f5087acb";
+      sha256 = "eb3b06f339e147a5842290f1f81fe64a6cd962bbedd558ab6799fc2ae693a84e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/te/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/te/firefox-85.0b6.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "9e581d2dc107c385142c3bbb5476e3bd94e700cd8f9e36ead46d284d5708e9c2";
+      sha256 = "ff9defea15c81409bcd792e309acd1625befd28226135725247bd930522a0c52";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/th/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/th/firefox-85.0b6.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "096ce747a12c0b773d34517efce6aa4aaaf09385c5cf088046f7217639a7ce9e";
+      sha256 = "c1c60488aa488aacfd4e292c2ed8e89bfd16df176d9eff137bd84595cb238e42";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/tl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/tl/firefox-85.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "3fc48cd9839ba88f246fb04fe34cc5760aa9e40c8fb782ea57347e32d66030f0";
+      sha256 = "e37978b0ca1a8f1c6511ce2075ef50c2c1f562bf12fb08aaccaa6ab2a352dfc7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/tr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/tr/firefox-85.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "087c629e5aea8fc698cbc5608c270a7099607b34c5852b3b3f4091af3b7c789f";
+      sha256 = "764b92edd78a83a069ab7e0227766da90ea0c86021abed7e7a6ec107632f9699";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/trs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/trs/firefox-85.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "4df467d46c5830a3d96f87294c3dfddcc397b73a372ba566900123f7ab86a6ee";
+      sha256 = "e484d739d06204007319a209363e7246cca5649992b7473b5743ce383c8ee38c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/uk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/uk/firefox-85.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "11090c8aa00533c456ce96cbb09691c816fa2f98ac421cf581c86bd2bef5f296";
+      sha256 = "3b96a7266f2e0910b3153c1ae1edebf9e735d8f579689fc45cd5284c92d06a8f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/ur/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/ur/firefox-85.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8e7a5cc3606dc6cf71de328863a9107c36024001a381baf00daab11bebb857d7";
+      sha256 = "555ae2d93a212acfa8e4af43967d5a5935dfd6762287b3b32d475bc45a0bb1d4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/uz/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/uz/firefox-85.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "bb1846dd3b7bcf3b657d64bbd215301565dafee00eae96cee15fc71b40f49877";
+      sha256 = "bb6dbff567ee057c65fc8aef70a18a03e0bca9652e2e3ed745925069f43a9186";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/vi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/vi/firefox-85.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "375805742481f8f33adccbdc7e10f21ef0b1a0ab383c379e4dc13718c3f8fbf8";
+      sha256 = "d37b36e3d15186dd48b5a8c885cf788621964f0ab0aa0d120876a28db2018dc6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/xh/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/xh/firefox-85.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a8ce0836980441d1248f8bbd2e4bbc7a8269afe9bf8e3125bd9f4dd3acd06d7a";
+      sha256 = "e9bef37ead8534c8f3e0882361ccc1818583907bb2279eb737aa9e90c9223108";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/zh-CN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/zh-CN/firefox-85.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "8f491d8d1f61bf4a7f036efc047462bb04cf953e2a3a39cb5a326e49ed7a880e";
+      sha256 = "3624c095348dd367c99248471cb2c76ee28c491c73f7cb8d6f0f2119a21e2c30";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-x86_64/zh-TW/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-x86_64/zh-TW/firefox-85.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "dc5a8ca6f8a3f40060d0d2abaf694a066960cbfea355678ac583c3977b37cbed";
+      sha256 = "7dc0ebebaae2f4a26bfdc8524ea55ada023819d08c98554c9193d2731e88f3ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ach/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ach/firefox-85.0b6.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "f5b5a500581e52dfe5192135cfa06bf283ff23ca0b1b569db1f1bdcd359ad0b4";
+      sha256 = "a20f683f1572a71f709fc240c8c9461af8fbc0af60af32e9d057e8da8ddc954b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/af/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/af/firefox-85.0b6.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f96a13006c272edf5f60d6c04011e48729b5078fbde2238a0e5c422eb1293372";
+      sha256 = "62dc60c4ee5ffa1fbc53ee4bda855824ffbb7514d40033f4a17293462b6ee0d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/an/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/an/firefox-85.0b6.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "0bdbd429a512499dcd920ae695b61347196527ab30c601e1645385f3cdaff4ac";
+      sha256 = "5b819b75a53e78adf628598bb98d6d704b61e5f009bf3e123a38d4fe0aac0c89";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ar/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ar/firefox-85.0b6.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e0b6addd1b699c228aa353af879bbd263d1bd0e17aa033754abe864348adfc9a";
+      sha256 = "64cab2b053e80195696cd00d01075c93c00fd51a80f9346f095065d1ef4abd02";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ast/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ast/firefox-85.0b6.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "3ffbc1b67d9cae58c2b21227e6456d9e6ca8a387cdbe8b5bbae9b1db553a34b4";
+      sha256 = "1ec6ac90f4a35465d25edbace93a503026befb193ec62bd99db995d25eba7137";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/az/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/az/firefox-85.0b6.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "36c9ad3b07b6e032b38486e1d2a7a6b85b85dc84d8d0b9218fbd4c4a71e59e70";
+      sha256 = "08021bf98c2b5d0cb3c0375d955c8b3dc03b6883d0b0ca674987cdeac5b9c7d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/be/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/be/firefox-85.0b6.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "2ac1811463e482205f7dd27e4f98564146f089fb423405a8c3df8d2a10e45147";
+      sha256 = "37a47bd94f3839b805f5a7136f085c8e4c027778dab78998deabe0e7c348158f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/bg/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/bg/firefox-85.0b6.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "174d0ab72bfb1a8ea811c1b77a9eb65871f68641b1703c3bbf02bad4d298460b";
+      sha256 = "a8e779e51685ca4df1a110de3627b61e51a596a2b40f8ac7c1fcf2e923568ba8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/bn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/bn/firefox-85.0b6.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "e6d1b74e56690abd5c2f0d2d1dae0b9ac6d16b28daf1964ecd87138a5de9fadf";
+      sha256 = "7390ac3ac735a6fc9343c50591827fc90aca54ec8359c624447513759933f214";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/br/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/br/firefox-85.0b6.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "2ad97986bcdcdc2b988f1d50fef1a71d767119e03065ddc3e51ad38efc7dd351";
+      sha256 = "739a7047060a32d1ffe9945cf0411e9622c2708707bf49ee08b6935156e114f7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/bs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/bs/firefox-85.0b6.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "71c472c8dce7174ee8139360fd5b8528cba89f73dc186bdd08ed368917b8c41d";
+      sha256 = "f176298a95b26a6959cd72a8ad03a3711153746ebac9559511aa19dd14100298";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ca-valencia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ca-valencia/firefox-85.0b6.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "4e5245f658f5bf6f47d40e2437841213b03b9f6d12e83766621f5b59fb258eaa";
+      sha256 = "714c46545143ba847f0b43d1d5436ba303b4f23e666bd15fb1881a0cda1eaf55";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ca/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ca/firefox-85.0b6.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "4de924505b98c029dbba0762723a3310b3d171f18072a1a51d4f9636aaca8831";
+      sha256 = "087e0d3e8d429ddd86bb7d79a22402e782ace2deded642bc9c44ce5e66dd703d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/cak/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/cak/firefox-85.0b6.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "11fa8468ca6b3c51ed615d0375e63d85443beab66c10cbdc95fca817ada02215";
+      sha256 = "07e75aa7f99c60b2632192ccf7064099ebde5606241151cae8a4d9c094bacca1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/cs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/cs/firefox-85.0b6.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "c1bc48d54d0ea32731d4400c2b2fd817c5ed222cbe5fea20b3ee26ddeebab9d3";
+      sha256 = "3c8ae427e81be331960c329b3d964afffacd621b718dc9df114e18d3c4710e80";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/cy/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/cy/firefox-85.0b6.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "02cf2dc5bb97e9497655c53ef45dda3495f280a333c94fcc51048852bc993a53";
+      sha256 = "44be1f13ffa06c4f58af6bdf01f68a0189c30c436854c66536f2c97bbe5332bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/da/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/da/firefox-85.0b6.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "6d36d0aa1ce447770c9a149a1df2c27731a31f5784b9f20ef536836e6e42819a";
+      sha256 = "805d5d5c3ba6d60fa190b4b05210ddd655e70cfdcfecdc8096e9bdc6fd070fcf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/de/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/de/firefox-85.0b6.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "49eb555372658bf827adfc07b08c8ac46a6351f0ecd0fed0ad6d5c4975553c8e";
+      sha256 = "a894b1e6da776681f2107a122858a1a8ddb74f25e0e2f6d88c18c6e80f61e5bd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/dsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/dsb/firefox-85.0b6.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "1c358edc0e6248773103ab92ef0bf6103dfcbfa2945602bbd2f49153ebc7c690";
+      sha256 = "58123b90a6cfb155d358c3432d6ed95c1703a99896be2672d9ab6f68a020faa7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/el/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/el/firefox-85.0b6.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "a445f9806285ef0b036364a618c8d7ca226da899dfa33adbda5b2e327fe63dcb";
+      sha256 = "7b10083111ad5f9fed2138c37e53d2d226c0f2c46bf57308b1bf5b9ddae606f0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/en-CA/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/en-CA/firefox-85.0b6.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "6d2590c0cc0aa28a1443185aec54f84973a31e79beccd5ca5700abfd8deebe2c";
+      sha256 = "c363b7b16136efbfc66b8372bf8c2838bbc10db2a311668541ded0867db99595";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/en-GB/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/en-GB/firefox-85.0b6.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "71c4040c1326133f18ec7a07ea021b061b0994cf92aa113b358c5c0c10ebc59b";
+      sha256 = "3948b70f35e76adbf380bdbad84436d155e2901246ac27836e731fd8e1c1e736";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/en-US/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/en-US/firefox-85.0b6.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "af3bcd19cd78dea23deaff0c2810282a68428eee4d45e2989c75cbce5ff97098";
+      sha256 = "4e35172e333bb056f47673b7aba9986743596898377c71bd1c0b3c4658840f2c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/eo/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/eo/firefox-85.0b6.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "641def17e0d004f81cb176ccf70cbaa1df50fb204c3ff45a80800b76c21ed006";
+      sha256 = "75b58c31907f673314185829c0a399820505973a5d58cf29ec64de5441c45617";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-AR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/es-AR/firefox-85.0b6.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "0475e9de47c64b11470edf16f2819bfc1b1013f75ff6dd83da96bff1174db788";
+      sha256 = "28cc600de58b575944d8bbd50d29f9eedb353f3960bcf0151cabf6f2a1e00aad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-CL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/es-CL/firefox-85.0b6.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "0f3c14175da4f59b745473df5f0256b582800b3c3dfabaa21e124b9ef100fc72";
+      sha256 = "0b5d045b6d80925d85f8a3eb42da92ab046b1c3dc28ba3569b129c30f326d40d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-ES/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/es-ES/firefox-85.0b6.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "9a33525bcb9d10a10630d4c470877c8698f6da32671cbc47450c7fa4d2cba7de";
+      sha256 = "ccea08271b38fda0a7cf75095d44ff56fcb6e7771c1ebe3d030b509df2961581";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/es-MX/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/es-MX/firefox-85.0b6.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "ba397ac159b77c9346b58e5c9e4bdffd21b5ac3fd3d4b67a2b67931916b2f830";
+      sha256 = "8b551206bd37ebe4fb409a1d79db886466053de96a376770144769a2c9a0ad3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/et/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/et/firefox-85.0b6.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "664672b4f5f713bee16024845f16555da16f758d8db674dc5ec7f0022d2b7000";
+      sha256 = "edc27acb6ebd68dc581f33c8d89c0459c03471e1f127b5be158ec18e2edcc065";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/eu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/eu/firefox-85.0b6.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "3230da6f19116ccf848855218df3fbace86af2d9085f4109a3006476807f464d";
+      sha256 = "c5856ab6c5ebcff8befea2c2c6bd5d7eacad0dfed9570e005b1f9d52fd620b7a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fa/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/fa/firefox-85.0b6.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "faf07d08ce391b1043d4081fc650e3ee78ca067a3a11a6e3ff87916f3ac7a557";
+      sha256 = "208a7403e2a029c5d8c05ec52b84a45b307756e37e811e962ee79907516a5390";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ff/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ff/firefox-85.0b6.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "2c763d737cb112b77919594fe34061db5181a725cf518fc3cd9133be9bfd7cf6";
+      sha256 = "368558aaea92e5b4752f57c42a56c7de27b6d31010e3e978595403cf2535a781";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/fi/firefox-85.0b6.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "5a631720534e03e211936255012270e04918461112411e787ea02f138087c6b1";
+      sha256 = "0a5dc2f46d22418d7ff242630b10b7020575d8b7be65f1eb8e55c71ab0d29b26";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/fr/firefox-85.0b6.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "2b86ce004a5c42fd6f5cdda28439263357ce5428b6469440046ce6fe4d6157c2";
+      sha256 = "667581bd459553f5767f675b01eb4a7fd6f182311697bdab38399a39d05cc9d0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/fy-NL/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/fy-NL/firefox-85.0b6.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "e0e81fb1494d86abdcab4cc9feb0f789ab304172c67da013f0a09ab2c2e3e676";
+      sha256 = "39c1fd32733842767360176c9e1cc6b14f2bb985879816639f83d480f71c4281";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ga-IE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ga-IE/firefox-85.0b6.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "ffcf120a36f7268ab2ae03fb1eb6d458fb63b00d41198bf7997290c28997205b";
+      sha256 = "389f12d17bc5b2a3c9a4288e053b39109269c94d56f3cba5b804c75e05498028";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gd/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/gd/firefox-85.0b6.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "a99d3471da7fa2e985fc562a4abe086de9096d2461a50841ad5c8e5d2891bf8b";
+      sha256 = "bf1b66499533b977bfbedb74fdfea613cc6fd15809c39b2f2730a37cb29b69a9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/gl/firefox-85.0b6.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "01412502c872561564e1dac95b12d27295be5c411d2bb1ebbd53cfb4dbadee3a";
+      sha256 = "afcf26e568817414df71fb35debafe47f1c06b31cca80694b94c5a5ffdcdf523";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/gn/firefox-85.0b6.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "a73ee3448bb7888acec856e3e3369e28f5fbb9c5d203892e4992f73b319fa394";
+      sha256 = "ae79a2c5d6d8cb55642c744750b22753c09631c10b12fa28090f29eb6170fe14";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/gu-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/gu-IN/firefox-85.0b6.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "3b7904059b38eea27b7901de41be029ea8ec23c3d2a8bbe8941d8852c55cfb97";
+      sha256 = "86500091baae2bcc2d72b021c32889f4b59abd853e01dd3cb19dd7107c9cc6cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/he/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/he/firefox-85.0b6.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "0bf4d3aa4f217e12b1f204bdb189625c6daae24cf5253bf4b1cd6288f2717873";
+      sha256 = "a21cbd77270c7ac047e2b3eed1f17568dc8e3be4d99652c23f60391c5e758ec8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hi-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/hi-IN/firefox-85.0b6.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "4f95852212b0b08aa420c88e2ec7825913e3e82c1d2891fffdb11a8583bf46b8";
+      sha256 = "5c3ba65e947bec3380caa2f23b92d19e6ed3c52275b9869ac4a995b8aad4c86f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/hr/firefox-85.0b6.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e30d3274103e39241e233aee994b5b8c2b39dbd190ffa1a9da99f8494ae833b1";
+      sha256 = "cdc2fd0bbb6b94e11c9f0453473871220c92a89d92292e0bc57b2ce24c822ab4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hsb/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/hsb/firefox-85.0b6.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "f401baba947e64ef4ef02cc5137c8623a99967ec8597e4e5c8987382dbc505a4";
+      sha256 = "1d32367cc51905f2bf8682d08166ed433cb37d711ca5b299693e3899b5508628";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hu/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/hu/firefox-85.0b6.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "70ac5b24deabcaf0b250575a0454a35e127cf15023a3546ae41c01942c64c59b";
+      sha256 = "8b0daa49b706e033894ad8703dc322bf347a3fb66b03c18d0c3c0ac6da4bd0a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/hy-AM/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/hy-AM/firefox-85.0b6.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "9dfa8b99f67ce66625e0c89c37f4ee36b23421ca89d4445deb5dc82eb0eb05a7";
+      sha256 = "e0336bd76c5b1c554ee4689de92cc1eb1937d22bcae70f3132622f09d854e82a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ia/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ia/firefox-85.0b6.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "4445dc874962b72f7d9096cb46ff98987b56d9c2d3e0acd814fc8c59261363b2";
+      sha256 = "33617f175a8d2b46e4ea03a0385755a0e9ff1a311397ef200b634ae9d16c2f76";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/id/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/id/firefox-85.0b6.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "16c6550910555ddfc395b0c9626dd6e41a4bc9bd4a8ddbfb2867faa991cd4ae4";
+      sha256 = "db0ce57899c061a3065831f8188ea830b8fa3d01c43df5447c55b1fcf5b99376";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/is/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/is/firefox-85.0b6.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1c208c0b99cd008d67e8c9c1d118f7b2c8c354b4dcf740554fc2474ff93b8a7c";
+      sha256 = "920e894762732b7366d36f407562ea19a105e9a5634311bfdea7b88289527320";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/it/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/it/firefox-85.0b6.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "cac410ba1679d27565d63d3a70920d3ff262b6171dfe732c3ec7ee88d3386b14";
+      sha256 = "107698ba86e4460ca51ece41c983448dea0ac7bfd20425bb1c990f21350bdcec";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ja/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ja/firefox-85.0b6.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "0b8c20ac0a4394c8c4a106e65d83718f639453e10c54906da04f4da536a218e4";
+      sha256 = "0eca42b163a923617e757c170b5a255087d5519f4ab14279d6a3f3c42d14271e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ka/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ka/firefox-85.0b6.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "978aad2d0855ed8e364faf4a0522d7271bbd134c699da515db7e5c58dca79d49";
+      sha256 = "15b553fe56e20b8168698f409358fbb8cf7a56ba4dcf4079e8718cad2a005735";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/kab/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/kab/firefox-85.0b6.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "f32b2f9cd504a6d4d5b5d2ce47368cad4317cb1249dbd7d925d0c48098fba8be";
+      sha256 = "a56272b93828e6aff9db0769565199e107cd8864ebea666cd21d3f79ed8bfee5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/kk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/kk/firefox-85.0b6.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "38e2fef40b71d50b85be7a2d2c44bc0b0bc569410782119fbe07aba00c8193f7";
+      sha256 = "10f1289068c7613cd2611bc3e9b5e2804e77b5853e07489bb60841307fbe87af";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/km/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/km/firefox-85.0b6.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "c8a617eeaba39e138676c8412594329b00d372c40a0401a77e5bf974a407a3b1";
+      sha256 = "43f933ba3aef69d3af8987fb7b7a40ad1bdb8bc1285a6995e3706fb2731ea0c0";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/kn/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/kn/firefox-85.0b6.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "d1f19e2edfd1ee97b13b8e42c22f1409174c8fb4b024612d27cbb3ab9586ca1d";
+      sha256 = "1d31536bced9c01229e9885153ef66875d67205196eb486a823161b96a14c520";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ko/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ko/firefox-85.0b6.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "8e1f68d6bf97644616e8d8a39443061fe99df088b42e5218beb823d8cd18b8e6";
+      sha256 = "88364ae3eede1cd139077e5d7e2b588604d63deb49d6bb0933629a17209e78c2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/lij/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/lij/firefox-85.0b6.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ba22770bc65b0033f424ce30df69a7d21a728245230696b412baf44aa9a111a9";
+      sha256 = "88defc592a591dcdccc8fde193f6b03429c0be3d30291e50f3d599e88b55bc09";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/lt/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/lt/firefox-85.0b6.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "27ab65ac4ee08e2714ca7c493a4575352df4a06532773197a2bb3da86e9a18c9";
+      sha256 = "646c90f4fd53a8dc995a28ff6ee444a10a6380c37b5f8d2505e9cd401bf29895";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/lv/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/lv/firefox-85.0b6.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "4a8f6944d9b6134d664e08eb404e130a218497b4957437b56e4487a8bc205ca5";
+      sha256 = "416502c400bb436c4bf0a82c520045d44aea0968955528f8955446f4d9f3aa28";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/mk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/mk/firefox-85.0b6.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "885893b0a9ef75cd623f21c720aee07357ff3b4b21ccfbe456fc11928ef7037f";
+      sha256 = "62d6a1873b4cbf1650c731f588996d9c78bac8c286fb7bc2b22245bcdcfbdb94";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/mr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/mr/firefox-85.0b6.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "55aa8e1e4b61eb3b9a26fe9abafa804e7b6d34ac1f36efadf10ee13d2cd934a6";
+      sha256 = "cc7bbcc108a8f3b080ad957339b2a28a1733c1f4c9c9c4db226de65ed2650d3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ms/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ms/firefox-85.0b6.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "61412fde864addb40fa2d0ab42f30cb9a7e1887cd130ab59880763d675b6f7fd";
+      sha256 = "0a64005f83e01cc80d384d2ddc79fc582bf08d01c1e8ea3bd17ba9b6310db8b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/my/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/my/firefox-85.0b6.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "cd7190acda6e20c22edcb99c88c15e87b4676b2dba7de0578d2ab32a22b2bc1b";
+      sha256 = "4f0d3b2930fbfed624503bb13aa2c02b641997856f7e9a490d27371af3243908";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/nb-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/nb-NO/firefox-85.0b6.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "97f16d919eb8321c71864daba7accfcd9bd86d4948bc86df44fa86a52649ad8e";
+      sha256 = "2e037b5eebee8308034540f0944972432e6246fa6f418af3b3b17fcf407ea603";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ne-NP/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ne-NP/firefox-85.0b6.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "4ebbdfb4c75621a24b52853c3d94e178decfe3bcaaa1f8f92f42bf91eedd874f";
+      sha256 = "89b1f631a3b68f497070af726ca6a8b2e6a747c75032701c935e0309b014a4da";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/nl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/nl/firefox-85.0b6.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "4b14585bb554bc346565a69b6a4c10580345923f8e4dbda8b202e6b9e8cf1452";
+      sha256 = "e861ed42e0e133e0f7ce1e094b69dbd0abd7a346842c3ae3b4a756d0f3a0b599";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/nn-NO/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/nn-NO/firefox-85.0b6.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "408f34fb48fe1fa93850857118fc4ed972139e273ed2521cd9f7169f8d4148cc";
+      sha256 = "36dda4ae13eb19b8421e385284ec39d3ad10ac0da9530781f3a0a719a76fc92a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/oc/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/oc/firefox-85.0b6.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "0f7e1e4df86a931152206159a9f4e99b4241377c5545fb343eff86cd21869bec";
+      sha256 = "6799c6eabebf9bc677808666ca724d1bb704e171197087cb828e9ccdb345f27f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pa-IN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/pa-IN/firefox-85.0b6.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "c7f85ae2c46585cab0aed8c41117ffd686fe0dac6e0ba64eb41bc22d4b8f01c9";
+      sha256 = "3e2b342d2e12804b07497383c8e3e453851004aad50564cdb25ad9529679beef";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/pl/firefox-85.0b6.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "2669e61a0d7da09684230c67c6d43091b3b51e12f291259a62c72ce124fa4c3c";
+      sha256 = "d77d658d2040dec3453583e6fad0b1f214c924aa1f4121ca2f258211e9b8b558";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pt-BR/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/pt-BR/firefox-85.0b6.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "10ac3662c49611f73fb96a13ef464c27b4ce08c25f0f44e253e6e5ce2239a45c";
+      sha256 = "fd73d7bd16fdfc4774a3a4426cd63bc6dbc90e47ce316dea75c8483110f3015b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/pt-PT/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/pt-PT/firefox-85.0b6.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "a6e606c6d4ca032653b46966c0b90e001474907424f4fef46669e2363ffb89f1";
+      sha256 = "05a37242735661f27736384ceaaaf30bd3eeac85ea8a6b7e03d5dc07bd9db735";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/rm/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/rm/firefox-85.0b6.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "a8a8ee42020f62b38c125002ff6b5ad975d1a24df4e64f354f58fd949517e3c0";
+      sha256 = "dd57277dda625c767ed7e0f3ac15b5597f1b17c862f33724a300589bc760bbd5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ro/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ro/firefox-85.0b6.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "f405c06f8041e4c90caed14e7d6fac38467976fd71a214f06eab8c2113c386c0";
+      sha256 = "c5bcce6dc1dffe36a02b473bc100bab080991dbc85a92b5606c4b1d440a6bae1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ru/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ru/firefox-85.0b6.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "acd2c0812a24b301aafb1278246495b07e346fbd9cd699da406b988dc3d393ee";
+      sha256 = "1635583bed89c8efc3cccf6ccd294b2795defcdebac8d2faa2d0adb863200910";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/si/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/si/firefox-85.0b6.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "d444818f1e76a01a1170209497349331175ab9a761c27b31ddb89ff4d542ab9e";
+      sha256 = "bf1d180a93b0d1c2c4a9a177b906db957fa92fd1e9afc070f208c48c65921f48";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/sk/firefox-85.0b6.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "f2f3c9c4888f0055c10d1aae6cb1c40cc7f4d2bd1653e846768326e11b6ef2c6";
+      sha256 = "3c06f3513ef00756d7aa09aff5acf7da408cc02567a8187f51d01a78f016f7ad";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/sl/firefox-85.0b6.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "aeff79d992488895e47d3682d6b3661cfd1a86d39aff8c91313f057838075068";
+      sha256 = "107db384d90cf468233ffaca01bc18e332d931dfe60ade299be3b788876479ba";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/son/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/son/firefox-85.0b6.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "860900ac8f3fde5511a294a4f41e553d4853c4592d4446441399fda78a91898a";
+      sha256 = "75744dc4218b94400e480a30a93f697d5762e1d57e057ec5961ba76c0bbaa7f6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sq/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/sq/firefox-85.0b6.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "9122e1837c732b8cf242f211937b3fc445b6a48da3db01cbaa4a0d00117848a8";
+      sha256 = "a02be173b477a7accc7eb3ba61f868baa6116b2f3b6c11fbf91544d37b8b3c96";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/sr/firefox-85.0b6.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "a3c15061deb11e870d83138bf65beb5a838cc3ba96d067d3e72f816f818da3c5";
+      sha256 = "24397cab6c2f85bb59dae4b9b13136f4df73adc5d0ce1808615e96ca090b26c6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/sv-SE/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/sv-SE/firefox-85.0b6.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "cb3d2dcf7d80501a8fa38c50d0301af9562050bc64250cc1c6208467990795d6";
+      sha256 = "3a10344dd08921246dc5ffc12e7bba8524bed0fa063ad0d369a9a3f3663ffc88";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ta/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ta/firefox-85.0b6.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "4ece8a45e79aae6e535d56370f8890c5d3045d0ca78bec67fe848367e518339a";
+      sha256 = "c99dfb14a98f079a7275819bb1e7386eb1acbf9752cfa1a3c5dd7fd3b2d78cdd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/te/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/te/firefox-85.0b6.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "70996e39e5b38f7def90f1eadbdbb294992e4ad27a49d4941b3982a0d3f8421b";
+      sha256 = "ffa4a07accc7bd9515f67a8a2a7abb881b517b2c3fda5f5cf9a7399ff1aeab0d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/th/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/th/firefox-85.0b6.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "36720f87e8b3ee23f15ff48514931747d05638194e9b13b30017e601b8a5c905";
+      sha256 = "d3c3539566237f9df3236d3850771c7589fc0af6367b20bb62df3b0417954278";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/tl/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/tl/firefox-85.0b6.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "d433a22f97bcb69570933b1f371c248ebd2eb83a217bcc1989897c08175cbcd0";
+      sha256 = "e5691a1dab9000bab76f516e77f8d846e4d6ba9eccb7ffce5da7685981263be2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/tr/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/tr/firefox-85.0b6.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "0787dd09f287aab492610d2ce23d0be7bc3a2158e84d7e94345358a750ddb752";
+      sha256 = "a165c58b79094f3c28f29bab43ea8d2921099148da2247d9c3829c468a066fac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/trs/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/trs/firefox-85.0b6.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "4d3bd35ed7c43eb502f482bb60da0dbf14714b35e2996362c835a0a35008308a";
+      sha256 = "71a6466c49b1e4554ddca9798130425bf29de8ba22cb4204ee63df1399e15dd8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/uk/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/uk/firefox-85.0b6.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "8e1c371acd0bd1762c715c8e36dbc8df104351cbb3c37fab64c72b55bc98f006";
+      sha256 = "dccca6a7697d16203325c956cad9b7ccc39e45d87fe50fd0a864cb92cb33889c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/ur/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/ur/firefox-85.0b6.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "14b6149229f49406755a5ee308e0e120964595a1f9a7f2f7e9cc2979a5cf561a";
+      sha256 = "b94b825f2b70775093042ee10e3ba140ddf4882f2c54a46379790195aa932920";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/uz/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/uz/firefox-85.0b6.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a8adf840548ac5974654234956957b8e53f3e36c83cfad4fa5c840c16e9e4d5c";
+      sha256 = "eeeaf926708997925ad80bb8d62d0bb8badf464d030bde97c62239f90f9566d9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/vi/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/vi/firefox-85.0b6.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "fc9b023caaabb3a5a18a21a2d65195a7dc7b2655a5d9a1f4c75434cb1f02e4da";
+      sha256 = "c465c1dd6e4df1011deefb9e75f778f000a2a48151d9447550f4ffa30da03400";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/xh/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/xh/firefox-85.0b6.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "940b4e34e92a0efa397d3944fb6b8c5afea57f29355c9f9621accb557efd9860";
+      sha256 = "56420d01893a6ee9791f3984b4c8b676ffb0e300c734c9b90a8b2bfbbb3c3e44";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/zh-CN/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/zh-CN/firefox-85.0b6.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b1284ea7ec8e42c6139249b1958380e672dd19e7b8c21d95e256e0d3265bd095";
+      sha256 = "d19e07a9120f3de2169614c3ffa3323dd2712903bdedff446ed2063ee54ba95f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/84.0b4/linux-i686/zh-TW/firefox-84.0b4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/85.0b6/linux-i686/zh-TW/firefox-85.0b6.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "ac76d109c7817b9c06356918860216a3e2f4f776a31a8690064593ffc43139d9";
+      sha256 = "eefb93231e8603b69a793771f427de9f6520993744beb0f5de6bb1b06342b286";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "84.0.1";
+  version = "84.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ach/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ach/firefox-84.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "576e937824252ead56b4b4472aaaf8e3553107c547bbff74457a0a1d33b721fa";
+      sha256 = "00ad2b1cf208c43fef463979c39a6e1f272d360b4b539e3255aa9f17bbc115be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/af/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/af/firefox-84.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "ef9509ce8cc5f766aa3072c78750babf1bc26b4211f0f5ac7a4c88a29cdac875";
+      sha256 = "fa9b27a4e23dbad3bc87ba275df4cc87f44bfe13f009268f4ea70ff31ec6e847";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/an/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/an/firefox-84.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "7bdc125a9ed334f2b3989d40bcbbb526ef583823be5bbba590bdd7fb9562d32e";
+      sha256 = "074206329118376889a1a8f414617c821e9fbbc35a8f9b8d38f3dcd1622280cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ar/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ar/firefox-84.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "710d77fc45c4164c96194209d2dd615ce4cbe3583440f8f8eaef8697ec53a078";
+      sha256 = "8871b4c191aed7f5923f4dd64254a41e03780c66f4179c3a54768758c2f99f5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ast/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ast/firefox-84.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "910c6c17015632c3f996b4e7732fcc895eb9f966037f53934cb1810856c3e292";
+      sha256 = "a2a143d21d9381410896ac90fd359a086859183fb5e8f18a71157be4263ae481";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/az/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/az/firefox-84.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "3c636e6b006c7ffdc01bafcb048fd15de7b414e63968e278a37be8faffa89fe1";
+      sha256 = "f8493138759fbf0d2e9f13c3510c51b1b343fc2e10eef9b96d083a35e9a57a26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/be/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/be/firefox-84.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "aa691e814c2452bef9cb7f75098ab94cdbe742b3d25c456178badd68169b3b2b";
+      sha256 = "a943d5f372ab63cef96d351f52d248cd2b575756b8a53c9d17b88035c8022bad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/bg/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/bg/firefox-84.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f6aeefe5aa099ac804bdd10bdd180d101c634ced146ed42cc025180a6bb9ea69";
+      sha256 = "d3c12c9a43ae9728fffbcf016a03bcf1411fb891e8bb84a58b9f3cb5adfb9a68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/bn/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/bn/firefox-84.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "91ffef38c34407d455294fd69e93fdb40256da5d06ac6a300cb48902991fb172";
+      sha256 = "95c19322009f9f8be9f2e11d0baa530111db13fe65d93e93d97f8953e8653741";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/br/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/br/firefox-84.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "d3735936296f33773e8fce3f3beb3a183a5db1ab7d1f1163dd451ffa43bfa0d2";
+      sha256 = "20178f91bbb29ab3994db94fcb0929a15754395a6c5c1a2a5f292a3e0fe97ff6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/bs/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/bs/firefox-84.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "a2fda7eed9a3fabb46a9e3049c1560f486fabf426a868b083b3c7d11447428ac";
+      sha256 = "c61a7cf7cc981175a2041534dc90548be21973c7b520a6e4f3da45e7d8f5b509";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ca-valencia/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ca-valencia/firefox-84.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "b1430d43b273e1dbf7899c537d93dce0c0674633ad50726611eb1bbd5397843b";
+      sha256 = "a52c5fdc41d360a660330ecc055ebd2206a7ada996af17bf76d97e5a82dc552d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ca/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ca/firefox-84.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "d06da0cc13e1bbd04f9bb0659fa4745da08d410710793c2dd52086b10ea82cef";
+      sha256 = "1d827df4ff4ae8eecf1cbb888c8f011ab0320c05a878da0b24e8e0b4abfb1a59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/cak/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/cak/firefox-84.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "66cbce52e16178231cfd884e88443f4d5825079c9df74a3f6ef5ad226ec87025";
+      sha256 = "dfff83803ed04547aa8c8c9b12ee2fda7388017e8e17bab3d2d1244026779b8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/cs/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/cs/firefox-84.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "7c3243b48f437ac0d95de2f819f6088d882c52f09e74f910f8c7cd21dc57b7b4";
+      sha256 = "601b791c8829653f4eabb08c5d66fba83acddd001b1ccfe2f1f3b615808c9928";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/cy/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/cy/firefox-84.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9bda66606c45b90de3ccef2c51d3a26d3456e312d145906070923924db2ee58a";
+      sha256 = "aa14be4f6e6adebfd11e334a305355ed4cf199d3d578c7648b6f42fe73275b3d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/da/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/da/firefox-84.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "13727d086205c7ed560af7ec5fb4db2025dc24e327ad20c55244d9bcd0d54627";
+      sha256 = "dcc37cc52c473b77f9944eae767cc218330bad1d4753e3da7ae9bc1d59b6ea5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/de/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/de/firefox-84.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "50167ebb8277c08d6c13c07c5ae871222ded9f42295ba7604836ac550d3890a9";
+      sha256 = "5d7332a8b02c84afdca3fa0876087312dc8abfb4307cfd12896aa9671b6dc855";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/dsb/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/dsb/firefox-84.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "62b96a0abcdff8e1299c01fb3ef1aa8de6bd895adfd20698b52d0dc2522c0160";
+      sha256 = "a79e0512916e0258d73815fc32c343a908c2bf684a3ee55f6603ed2bff204261";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/el/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/el/firefox-84.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "6d22ca0a28bf6c752772b778239d42060ca2a9ab97f6f82c5f88a53f717d3496";
+      sha256 = "fcf89299094d3757c8cec828ea43befc02cc258d3640f7474fc24dac63bcbafa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/en-CA/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/en-CA/firefox-84.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "22b40400ffe16f3bc9e9a720170f65d58464b0f0e2ebaf9fc3217edbab5e1fa8";
+      sha256 = "7849e70478c410500f0e49cf3372e7b3395a8668e2df13641450db2e23485f0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/en-GB/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/en-GB/firefox-84.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "169edb75ae396aa19fee5472731ada83faa351a2fa0d4d291cd394fe00a9b92e";
+      sha256 = "6533bd93be6777db55a0787447b97d0cf32d770ab79dbb0a4689e528c277e807";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/en-US/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/en-US/firefox-84.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "077cb7a8954ad544692a03bde4edd31751e1a819bd229413e35508984abee5ac";
+      sha256 = "4d987bc87b56dfd2518e162401496c247750ca0a18d8c9072c9ad1ecbd67cbb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/eo/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/eo/firefox-84.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "619667619bed6f5bc99b373e779af6ec98e21218e0d0d2b0d703cb16dfb1f171";
+      sha256 = "88bcb8ff61ad19d3a9975b8a8e302b2b4f37303c04e02770e5eaa6a99dc8a1eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/es-AR/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-AR/firefox-84.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e7ae3b3415db29b8779f69ff557409f64ed7f031201c942cbee2fcd0e08abbb0";
+      sha256 = "44469a62926e451499b3f813034001dcd9228c80a05d9d69431b9918fdc6b99b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/es-CL/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-CL/firefox-84.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "7948825f75236751066a96e793b159538ee82c2315f07b9972f2204d27bd763f";
+      sha256 = "81e42f8acedd167a1f69d500fca94752a5453e096b471d07e86adcd99e29b40e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/es-ES/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-ES/firefox-84.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "3f6ea39596f93e5625d79ba544d9f476158757931f3f7c59bad85d169ef99ccc";
+      sha256 = "4b47dcf3b595b5c0011a8f8f56f938991cd68576cf4655e04e43ebec14e1256f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/es-MX/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-MX/firefox-84.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "aa220edf6cbf85e7605a0cde21fc7871939501a8459295b2142e4507e8699cab";
+      sha256 = "c54dcd581d45d273b8b6138393a662b4618e8bd181f625cda6d23ca6b9baf358";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/et/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/et/firefox-84.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "63fcb11eac26f26721d6a60c1001d867bceaa21eee2c81efbea8e00253412082";
+      sha256 = "2fa06a0e49fc69719acd018148a400c9fbfb3ad68ad13183b1c26971337474b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/eu/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/eu/firefox-84.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "f49a421799e0691f475da2419ab786ac29caf67ed7413cb5b3736d7961309d17";
+      sha256 = "9171ab64137fa21b4ee50598d244af0760898c6553ae060252109314b997fcf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/fa/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fa/firefox-84.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "ef1e5342a658923452bc839258f292619c2edff304448ab9d85d9215ace907d3";
+      sha256 = "3b16e8290e15999a29a9ac92d8294ac212e4e9e4c96fe2ebba09ca43dc66edbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ff/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ff/firefox-84.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "73ff19b083e8d8d6ba6e5ed1efd27f18caa9a285fd02bb27ae01190245eca577";
+      sha256 = "1124cd9611e9ccbfe1255afaf8cf3591b0f61d0d2e63c4cae877209b8c591ba9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/fi/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fi/firefox-84.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "c576045a05d15ae4c8d6c82fd17036546825f9be1675197a1296a7c8d431992a";
+      sha256 = "e3afa4a74b325d52b6cca0436b36d7d5c0d4e2e50755da28aeb587411f705e8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/fr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fr/firefox-84.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "428270e0c4a3d80d810a106795986f2680c3e55faf7fc975ebf56fc90c0ce797";
+      sha256 = "c5470bf4a8a71985bb356c0e56b516108ee6abd6437815bfaf6e3c2f5fe09e46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/fy-NL/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fy-NL/firefox-84.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "0e272ab1540690cd688561b4efdf7429298ad087b51afeb1b735f8b7efbaae28";
+      sha256 = "4608593cde1c810cfd1301f87fe348b5172d92863416b5b135e2adf8b41a5106";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ga-IE/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ga-IE/firefox-84.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "99e5381bfca90d1ebabbe00df75da91901f113ecd6e2aee1b16b5acef91bfaaf";
+      sha256 = "64101b561b5adc391c79347b870784d18f9b8457ea8523b5cd8448aa6f9ea80e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/gd/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gd/firefox-84.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "ddde6096a541ff100d38929cefa87c93128d10131a4cf42717e9a169b5f99caa";
+      sha256 = "1048d1f82dc14c4da5954b3e8da2b0cddfe2ec31e9cd520a60202655771f260e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/gl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gl/firefox-84.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "98019391cc205449df19365459995d9711a1f73e94db226d7ae8c2172a14c8a0";
+      sha256 = "bfd82fb48bd4e403f60acc217c48f42e2ad967f9810ad632e112354acdf6f459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/gn/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gn/firefox-84.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "ca5a642179426bed73c4e3ebfb66c287ee57b3cbbdb35df35b1aebc024c9c8ee";
+      sha256 = "bf4d24303ee087df005cf04bb1511ebed5635c0b6a27154d292d00240ac35ac4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/gu-IN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gu-IN/firefox-84.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "2c4f645de88f4db3a2274a67876372baea53e3d0bd275d6d67ef60ed2ced0ca4";
+      sha256 = "3669c53042edf83d37ad4e7ab7486f9ac3c2535811fd21fce45188b153b3eb66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/he/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/he/firefox-84.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "f2e5ad70f26d393562cf4e0c3743dc01b1dc4ab9f77d88f92419acf8072d3ff0";
+      sha256 = "cf83947396daac7bf4c53d97a58df2fc856056833a3547ca19289fb0b0f4b895";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/hi-IN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hi-IN/firefox-84.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "368a469ac2b44c0cb23adbf45c654ce2188e2674bc526a106f90159fdf35224c";
+      sha256 = "f497cd8173fe2f4b4e14921805004ce81b5e8f63f70b3a135a9be787ad34693d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/hr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hr/firefox-84.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4cc283202d36f691ed24e0295a9edd51369c996f4a6782ea2a38b57011310dff";
+      sha256 = "6e2eb6ede94ff51ab5d2c57744c16738bba50beb5cb4140d42ae1085d6a186ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/hsb/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hsb/firefox-84.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "cdce15a29c601de89923f77b334ffacf2e2f3474e054499d03aaaa95aa4285c5";
+      sha256 = "99fad7bdc3db88dd5fc2d6244f37716938f2fa44904ffabfe44a25840b390716";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/hu/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hu/firefox-84.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "0def021e54c67a80d5416cff8da4fba48b5d47f1d8c6bd673ac2fc7a64200116";
+      sha256 = "bd94dbefb12821ca1e0232dff9804ee7e1caf5fdd3a5823268f757b70f467930";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/hy-AM/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hy-AM/firefox-84.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f6a3cfbd4490d2d0cbc09f3ac15f9d723d485c64603549adb8a4c33d5af7823d";
+      sha256 = "b9497158d7cce081fd9f6c4c0eab0871ae00eee7745b59544f63026b48757c83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ia/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ia/firefox-84.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "69c93ac33a54358f1cb35204b5acbf3a818a4031737aea44684bf3bdadd93acc";
+      sha256 = "cd4f2462e64989151e4962cd89f8d3e97f295505bf1c447db6549f898ec6a38b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/id/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/id/firefox-84.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "59236a0a6024013e7b4b21394f66a9d2b3ddfb27ce54c37a227127defec2bc09";
+      sha256 = "0c0b086fc304ed4ab1f23b659999cb303b9016962d26f0509b73009a9c651ae8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/is/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/is/firefox-84.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f13500ac51becd6cbfefb43cd98d3a6530dbb92bc88ad15b1714af775bc3e1c0";
+      sha256 = "a7482f969ad5e537c1d8084cab54eb03b12860df4c084a7aaf51409577af6b49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/it/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/it/firefox-84.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "77beebceeb36f1eaa00838f3e3739dd9549a7a02e15bbbd83454a1e86bc83c9c";
+      sha256 = "2139dd8f281de5ef79c3a3671eaeb0704db0dcff286df6da44351fcc5d102864";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ja/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ja/firefox-84.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "bbb98b2bad26a554493d9fbefe1b4061f14dacf59a14cb8ccd92e728d906a676";
+      sha256 = "818b66e1e9ff60f30bceb6b44acd2c704de5f64016de7bea45a4110118341314";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ka/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ka/firefox-84.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "20fc38d941e3aba6017143ac6865a5f210450b773a9d50c195a9b951e65ccdc2";
+      sha256 = "805d101b7977061af0d5e3b99a8980b972aa4c8eb6ae9914d10c527a58a6aaed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/kab/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/kab/firefox-84.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "003d7d9d1f2b5f958e29168c698568f6c1e2c7c5c1ec652fab6f2b824828c0be";
+      sha256 = "34a75868f2e8da1fb87235b29b2b1fa7d28b55dea8351a472cc1d752c1b084dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/kk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/kk/firefox-84.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "e16d8e9f41fbefc2b863978627eb66e1c82d53a9dc4b1acac912309d633f972f";
+      sha256 = "a8c40b1ebac7d0375232518f35b854600f35e52dd6b0123e86a70cb0f3386406";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/km/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/km/firefox-84.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "e75aa98eba7a600e459e25b7e6d1311a00c16ddade46eeec18ca37b799e7a492";
+      sha256 = "3ccc2a85edec4f90c39d23ba74474e27326ed18fd020847d567ed93406ca9678";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/kn/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/kn/firefox-84.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "282f240fae65764d4e1f5d5e3e0ec775ebd66dab4589b5ae9f34bcfb81f50996";
+      sha256 = "634c0ba151f9334f4991c2f118b96de45d8a4fe359a08c3cb001f3b813d89198";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ko/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ko/firefox-84.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "2b5cc8a136b703db4fb59a2bf8ac24ab39416ff44f35836ff70b93e378727706";
+      sha256 = "d085163b35684903418648648dca8ad078e1a89f611775ab4b01fb60aa4d1b2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/lij/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/lij/firefox-84.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "4cb13be0d090d824b4b86e28f9c02d4c0875133603dec7a58b83ae67e86df30c";
+      sha256 = "b676b6f955441df571541b52b6534ad12caf5df45d16dd374b3cda19d58e990c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/lt/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/lt/firefox-84.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "b6fa373facf8e8d4a7d4bdb97955820d450748009becf166c33faf936fd34cc0";
+      sha256 = "eb5499c40bfc805599e51f490d1bd860c6c46512f927a47af3f9ae5bdb9e3fbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/lv/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/lv/firefox-84.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "5522a451edec23255b2a8fab65d2680e9b3854998290a7dd33183238cb17d33e";
+      sha256 = "935e736c0d46254d8429d87eb2a72e46c9c70c92ebdb1fd1077798e538af770f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/mk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/mk/firefox-84.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d0d96241bcbd32e000094008263a37543dfd4c5955b116f88118daff11759e0c";
+      sha256 = "310fcae105829fd03ede31c32e1f078c69d1bed7880469976159968de1f7ccfb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/mr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/mr/firefox-84.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "06593e4a56e5f76ffb765b605684349fbf31c8a0747cc90ef991c532df38d411";
+      sha256 = "acd8be31fba57a9ced68960c1dd28c9e91a88433b0b885bd3f8e2656a639e3bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ms/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ms/firefox-84.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ffa6d0f8534253c5ea94df7aba31a06cdf9e294500781d25a31b8dcad15d5132";
+      sha256 = "71a6a63883123b19e70c0bb1e6251550fa4b5035792c7b767d47839428d4e0a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/my/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/my/firefox-84.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "dafa195bca8536709110ecda82e988bed254b145f00581561b18827fa41149d7";
+      sha256 = "121264d0508aa26f9d6e89620bb1821d07763c28d5085b5cf7d0ce90704bf983";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/nb-NO/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/nb-NO/firefox-84.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "9a8e5175bb17ae3110a4ba74dcc575dd4b0fb44981f7152cc521ad017db7e2a8";
+      sha256 = "9b930c9e5e92c01ae89c7388d6a168d83b4e95f945381f1301a6137795f4e017";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ne-NP/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ne-NP/firefox-84.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "4c2081207cfbc657d8f6a5ba781098f11adc5e159414036dc8217874a2c2d8b6";
+      sha256 = "99994740252ec76e9728950d307762acec5ab6555d4b5921d89a083447bd7e70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/nl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/nl/firefox-84.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "947dc32c772a2205ab30fdd6d8bcf938642e9d734b58829d2dec5a1896ac6b4b";
+      sha256 = "cbe751edd3b72a8cd823b9cf548ce77e3a148bceac4861853d1374e79c2cf694";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/nn-NO/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/nn-NO/firefox-84.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "89096b5f2ce27ece10be949b495aa41cd882bfb4a742cc3abfc66f36130313b4";
+      sha256 = "f63c3f08d01d8963d8ec6047b69efec9f36a92d822a8ae966cc2a7d66f33f93e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/oc/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/oc/firefox-84.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "50f603507e5d276c5f3237d1554269faab573d8c194a488353227743b677ccc0";
+      sha256 = "675090877a1cb5841ddb98c5ba8ebaba9d4ad2d4de9d17c7e9559ba6a8b2e1ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/pa-IN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pa-IN/firefox-84.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "231739c85f20014f50a982b4ac0634a8a4147cb6de5ba39a9a11a944d4ff80ff";
+      sha256 = "6fd35af9216a1099c246f9e12161384d6a5d1d24e846d3aabe5bef3a55b215b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/pl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pl/firefox-84.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9487ffb5fdfc2f7040a7f9bf2585af324782e2f3dfa996db719103b20d02bf55";
+      sha256 = "54cae52178e21f0f2beabe1120746962141cbf79fb5dc6eef11ae1f2705e9e4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/pt-BR/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pt-BR/firefox-84.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "fd53dbc5724968b0bb2c2b78de96f3708d05758de63aeaa7fb942f9b64a0649f";
+      sha256 = "f1dc18aea91440dfe5e34b332c2e2b2b0241d7af1c1a8f2a979eead34db64480";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/pt-PT/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pt-PT/firefox-84.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "39211dde1b183c0453643fd6253fe6eea4dcf2b006842b1cd61e1ce142991a44";
+      sha256 = "c2159af01743f1004e3dba0b99a2670155ae3e695f0fd0208b367f910bcba642";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/rm/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/rm/firefox-84.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "29cf408b9386907dd1e8a64f56aec2e0359de243c3d17fe2531c0f1c7285c205";
+      sha256 = "211813cb32c9f2b0880c7116dc935929570c81937d3446aef506da3705172099";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ro/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ro/firefox-84.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "eced9ac8aa417dbb5dd725c952eaa977eca1b48a7271e9f8dcbe1ee46a4b1321";
+      sha256 = "a2144bde6023d4b8468128c52015849e6a8f77c0c10d4851a9255f6204a98a77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ru/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ru/firefox-84.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "7abfd2a2b30eb7744d890ba3a0589ac5017a9536c43fe3e154e60339d7b41544";
+      sha256 = "098748cde08f1d362a8eed6432353a1edabc84579abb30aca983772c5b6ac36e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/si/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/si/firefox-84.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "e9e8c21b64f7f434db99b30b6e7190fa55f3b23a63dcdef120118d228ed533aa";
+      sha256 = "41707b3e3b7dbaaea510c58ba503fe22de84963fe1979b2e4c7e00cdf1ded01a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/sk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sk/firefox-84.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "dd2e17cf612de02aa71a933a8b1f26e403e1be4da54e63530667e81441d5f6e9";
+      sha256 = "4ba12f304145102db13feaca98f84bae5e06609c721967e1b69d68643a94c1db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/sl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sl/firefox-84.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "782e612494aa907990262c7ac7189e98d90336b270a806a8e191dcc1c8266218";
+      sha256 = "2dfafc7ca5fdf0a03a8301f1daacc397fc49f3fae18f6ac6454b4110c5bdd65f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/son/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/son/firefox-84.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "7730614e4e22eb871dadcc13f62d0d2bc445aed89c1ab6eee2600aa6f7023fa1";
+      sha256 = "13139fb6bb47472c2ce47dd535bdeea6fa90521681c2a8e8ea963bebecbdd54f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/sq/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sq/firefox-84.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "6726cc2fa9c7b40e92d512b83bc0a974c3668a3854ac91aafa334b4d30b71ee7";
+      sha256 = "9710315181f78df3673b71fef597b9498c0a860b167ab4b9c4e68df9c500a6be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/sr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sr/firefox-84.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "22b443987fa62f4d753efc04ae926e3ed69ce84c56a2fc653994d886da10f9e6";
+      sha256 = "bbd69589dc5a1fe7b3a0f74c0d8e20cb4cf6b7ed771faf7c161c96301736e89c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/sv-SE/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sv-SE/firefox-84.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "3c4d26bce8cd12a6531fe15e3e7251ac9046bc7d1670df3754f0c379bb63ef50";
+      sha256 = "a5769159d0c7bc89865ffe1e2fd6b88675afdbda29752ebdaae986f0ace7d3f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ta/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ta/firefox-84.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "edbfebceb857824f331c46eb7611dfa9adbfcf6cc7b80075478059261b0de6bf";
+      sha256 = "836aef11ef967ee8c74b9c4221525c31427ee509b798952b59a43a6c7c2169f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/te/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/te/firefox-84.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "06f342dd81f0ff481de67fbbbd5bbbefda27629be688d854a226d515c872d69c";
+      sha256 = "a8e091052e0f606ad8b29b344d65cd86ee45a2b349c99e462f96cc36c08c18e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/th/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/th/firefox-84.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "1ccc1da981cd49effc811b4dd85a09bc584316b3ff50fcb05502e4618c465ea9";
+      sha256 = "17679aff5806314398ffd9568be11157f41b0820313394f7c59c8bc69af8cff2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/tl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/tl/firefox-84.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "b15095bba6ff763f01e7677359a0e8885164eedfee1836e0eb4e1822322050db";
+      sha256 = "7fd68265f2d1187dab49480004355d241fbe628cf9bce7a613ed5e048df9223d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/tr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/tr/firefox-84.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e140a2196da9ae934134bd3ad3dafcf8766aa676f410047817ba01ab831b0ad0";
+      sha256 = "0eeb30611cd3da04ef0c3439e59a3c2c46f2d38b566795691f8992041507550a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/trs/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/trs/firefox-84.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "3a8c6dd94d17c8ce892f7eec395f8f6676bf4fb18174a6dfadde41868f9d3e21";
+      sha256 = "31ed82b3b45c9f9e6a84fb57b32c23468f42d4072b04437db5dd62f1d541ea80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/uk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/uk/firefox-84.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d66bcb1f09213c34f14ec0cbd3687d8b5918afceacb2164e81ff94e681c432e0";
+      sha256 = "bee267b4822a44edfcacd11bc6aa83ed2957dce95789926ea3cf3d714fd99542";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/ur/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ur/firefox-84.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "0d9094f14a25b0bb3c7656fd524cd330c0b7a6334ab23c86a01ecd1beca14988";
+      sha256 = "1da5fbc3e3b77a102d00bd1db146944640b9e8c5a9c7c5222a3570281846d1b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/uz/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/uz/firefox-84.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "70d3cf8198442718cdb664dbd832c91d5252041fe1076faa0f790e63f0c22771";
+      sha256 = "11b92211b88db216ee17537c27d86511f827a7435bbe3cc0ea39d0c015c55c0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/vi/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/vi/firefox-84.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "17a0ee2e12c74e73fd1346257ae5f797c866f0c4081a154f6290e73f4be40f27";
+      sha256 = "29e1f625c9862cb13b5f6238ba2f72200b864abf66ff44af11ca991c67a742d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/xh/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/xh/firefox-84.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "7383a176b5afc8319781586ece3eba752739499be2c6944050b57ef5b7b620f7";
+      sha256 = "6e859ba83b1fcc2930db6ac53ddc5f36ec2bc325b034337c33a2e5b531f905d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/zh-CN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/zh-CN/firefox-84.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "08881c7f4043a6e4bac11b4de388da773a374a6c83068723318ab6e1eb981fdf";
+      sha256 = "afa32b9e1560aff7c7a6dd9d3c627690ee70c20ea5748f1754cc8ebdffeccb15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-x86_64/zh-TW/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/zh-TW/firefox-84.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "ed3bb049a2a80cf294b4b4c4ca0e980b38b6f18c4e931a63ff78e5707fc2daf3";
+      sha256 = "5f0ec2ca348b788590ec4eb552d34c204612895145521eb53a3b1dd73c34eafc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ach/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ach/firefox-84.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "4bdaa5921976290cc5bb11f981d2f6559751a693a2bbe512b9e80eb5148b2e37";
+      sha256 = "f003b9197505256cefcc96a07a3314ee9438a5024048d9815691d5f149233e67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/af/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/af/firefox-84.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "853d005f8ac8e2e5e31e3a24057b458f1441d6ac97a41f414c0831295b91fcd2";
+      sha256 = "67b9eecc70db21a150ad45682be637e3c6187cd8b0ca3fab9c20e12517372925";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/an/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/an/firefox-84.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "6409ce28faf1dd18f079891e373a61f0b1eb730b3d1c7559a13784192367577b";
+      sha256 = "08fe11419370ed3e8a47819f22bed8f5cc4cadd3296dd69304a4fb5f5a7a5dd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ar/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ar/firefox-84.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "9c9da9daad627f4c5dbe5588667cdf90fe8a582adaff962c674c483a5d80dd6f";
+      sha256 = "fb85564a9037ee9168dfb14ed9f743affa5cd7829e2f2637f75184713db93712";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ast/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ast/firefox-84.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "609de4719323b676dc1a15da8d0295d3c67bb4ee271f70f28db97dacaae87f4f";
+      sha256 = "89c659c314dfe2674ce65a37793c151db5c127452e786f77772c1db7b0fc1aa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/az/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/az/firefox-84.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "f411a4a560d1a6db4daee06ee3a29d6a14cb5e6e1914aac54c19918b93569e3d";
+      sha256 = "9062c6fcd28afd070baff45df8320aab43e61e7d6343945bd1304a2b8fcf78ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/be/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/be/firefox-84.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "46d73bb13f113dd6dda069ba571e623b3f20f2b6e76f55f307690ee01eb4dba7";
+      sha256 = "0043bb412b2ad9c4bd5f60199f8e3c3e1d81b8bd35d687c909ea65cf0a1eaedd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/bg/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/bg/firefox-84.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "0bbab0465efeac3cc3f72749242310e1456dbee915bfb08b7ff7e5f5c2fff0e8";
+      sha256 = "97ebda162b20aefad89ea918896a1d0a2b7546a67b577000f4ddb6cb93bc5a32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/bn/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/bn/firefox-84.0.2.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "c1d47ac9ed0e01a0ec77776bb6131ae38faa17a3da2d8bea723679e3cd158074";
+      sha256 = "705b8e97ca21e14343f16c39ac5a081d866f7b422be154eb55cc4ebe728ef9a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/br/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/br/firefox-84.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "b205df6c0016b2c3984b33c00c2153688c7ac162df1a3748b23ce081a87d46cb";
+      sha256 = "8a61f457be78003ba212b9921a657428d117bdc978e1f62eb4ba2b2cfd553b13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/bs/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/bs/firefox-84.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "85093f59d815cc1d45e6aa6f8ea6ea2972102248aa4973b4386e265f985c85a8";
+      sha256 = "074a4153395b6397ffa5b2a74bb22b456e15357a760003a4dfc2c5974e8efa1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ca-valencia/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ca-valencia/firefox-84.0.2.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "57b5054db2cb6987db174c1a32c5e87bc37f1de3ff3e1046421962fb50204af4";
+      sha256 = "87109dec410e6f57199743666d46e81a42fe6364cb55742e24391d922bd8c0dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ca/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ca/firefox-84.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "f57a9469122e99537dfe11984c11425008d81b738fb939297be2c1104858d52f";
+      sha256 = "7ab7be9dd01b25f119de9a432b1487a506d5b8306b7c516614feb9a559de6cdc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/cak/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/cak/firefox-84.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6a8d4e9b3555ebb7020e347bb59d426fb5ab0cb1fb5012fdd99d0e978675b994";
+      sha256 = "e5518707de8deffc05024f76248711b59037f994a1b6883e65243a01a82076c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/cs/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/cs/firefox-84.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "15d8e1ec0e3719228cd0d4f17667a08d4fadffdf2cae91abe47ddfe511d81046";
+      sha256 = "682add587e420149a34cdba03a0b91a7190a33753bb40972836c8e12110ea356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/cy/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/cy/firefox-84.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "412d19fa8e4c47c892780b225e6d320bc24b3adf482cb023964599ac35350433";
+      sha256 = "396764a821b7333aae3dfa6924e5246ac6aeb613470e5098ff542aa5d7dca65d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/da/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/da/firefox-84.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "8116eb1c33d26e589c7cc3b7999159f7893018f7bdcf627d9b892b0f96a55e9f";
+      sha256 = "28aa6f2f3ae2fd19b5b6d149c1bf735ae55c56ff3bee0646bef98dcdfcbf3dff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/de/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/de/firefox-84.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "433b02ea3b1d50e9a8287e6e264d518520f656fcbb9851068de1240599e4c512";
+      sha256 = "eefb48753ea89ebbd27e7357a22ae7246086093d7054b684ed8f2ed1dbd66835";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/dsb/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/dsb/firefox-84.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5d55fdf5976a0c1f3a79058b1993923ae67c063b6643695dee8bcb4faed06c74";
+      sha256 = "65c947541d4c6125b292b6e5ac61486bb434b56a824e304c343464d4a8ac4021";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/el/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/el/firefox-84.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "668a9f735be42cdd57a8b7395c37703e6e1b30264aaf9201a801efe711dd008e";
+      sha256 = "86d20281cd16436acc0c015b2a72775ab3beaf1f52348181131c210448dd9ccd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/en-CA/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/en-CA/firefox-84.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9c20e6c096e1a7ab910d91380083e400f35052ed9ae72860b8ba66ac750c5fee";
+      sha256 = "d71c02929a7e4b08bfe1d83eaa577755d7dd1074f2328c428bea73c1bdd82920";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/en-GB/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/en-GB/firefox-84.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "4de8ea0ba0e599529abde78983e04c509229bbae756c633fa929833b385f9519";
+      sha256 = "5ef6635f57a34fab6dcc54462b621721063ab354798d8924e8621895fc3ed4ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/en-US/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/en-US/firefox-84.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "6cf9fc509ef21c004a70810c8cd4c428593642edbdd5d4f4c455345391ba4def";
+      sha256 = "7008acb0a5112d22b02f75fa8b46ecdb46dc2cb0ab691791595f2ac45187d6e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/eo/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/eo/firefox-84.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "1ed7915f1cafa19d36465bb0d5f9fca8e57b7f0f8652dabcf90a4e232c0cccdd";
+      sha256 = "e9dadf0b2b655bbcee8557805ee1b93cfef911c9c1a60d63b31afc84f06f9021";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/es-AR/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-AR/firefox-84.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "359234b846e364352a6af0a262db06b6e9f4a911c407bf35f1ad2f8460eff7ab";
+      sha256 = "3ca485c3eda6a0d2cf348d2870fa708ad374dc0fc830696484e0c2ff5ef3c967";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/es-CL/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-CL/firefox-84.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "eae445daf305820692b7ee9d20dbd69f0da509716925db6c12eb7c2e7a521416";
+      sha256 = "e69f6b048f42ff8eac54176d5b3c85cd31ce02794f22bce2a09fd262d62789a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/es-ES/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-ES/firefox-84.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "36a2f4eca19bff55f998e8e36718d4a4bdad0eea5c53af1825f857834dc6a1d7";
+      sha256 = "1cf1ea30406e16564fabd54b339ebd2111498eecbf25ec93c7401e2143e1d456";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/es-MX/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-MX/firefox-84.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "7f7f384bbe156e37af25cdc19a49ddf225692a2579ce5c7df37b8684f0318102";
+      sha256 = "94a8ea4e1fb63470a46a83678f71698b151ebf9c57794a086a8982d29edc0706";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/et/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/et/firefox-84.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "39288f46064d259f4ac1f11481480b189d945608d4b3ece922b774ca31fbf95e";
+      sha256 = "b4fde31f58defe8b35d4c9325f1485093bfb155c73f6d3c02fa3cdcbc8393105";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/eu/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/eu/firefox-84.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "7693f969f356f87db5d48266ac20a152bbb8946486ee60f5efa0225a83a25493";
+      sha256 = "d84a2bdc2f55b57c612abbb0208ef4b7683ef7d696739e9b1a36238daf61ab9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/fa/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fa/firefox-84.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "ff189730d71b2ad0e2694a364bc0c0ee4de50efe30f44935b1cef0d89488f8f2";
+      sha256 = "054e6269745c8ae120daab489a9157618956bf2ecbc309bc64b7fb2f73400766";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ff/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ff/firefox-84.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "b6f39b27d000fe98510da1d5be6b591e3a7cd1b6e2d2502bbe7e67b124822ed1";
+      sha256 = "1ebef6026207141e0d3d37533ecff2b22a4e936e27a58939fbaa72d723078049";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/fi/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fi/firefox-84.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "ec33e3bc8a549c1c2d5bdc0f45113d96d3c959d1d9232d08417c09821cbd8e42";
+      sha256 = "9a8609ae113b392d3bcee30ae48c1e8b4ce6a1fc180c7f936c52934fa1911429";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/fr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fr/firefox-84.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "43e80f221e53db14a57da940d6ad98d639bffc94c71e08ff39501aafe319c3a3";
+      sha256 = "afcc5075d8455d32360d5045125290c8b843e48f4b774ab48d5c2f49e1cd9fe2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/fy-NL/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fy-NL/firefox-84.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "dbbe3af347ec5e8e856e4580889f99709231eb07631862ad4e8deb095f098390";
+      sha256 = "232dd4a17ff87945b1ea11183fea8711c572e31d34898d15b378a54697c720b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ga-IE/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ga-IE/firefox-84.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4d5c8fec2f370840cf79c19774976585af0d8e09f13abcb4a594f3ebf9c52558";
+      sha256 = "c68e57472d6837074bb8180063ce6eebf0396b187aa3d47ee9bccf1cd1529459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/gd/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gd/firefox-84.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "7ea8febc7443e1f7c732e07cc8bd027ed0a82eea018b6bf7c5979820821701ea";
+      sha256 = "ed6ab375a3e487ee3c6f2d4017f8bde6c3ff29978a8b2f125b58e3ca2472ce38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/gl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gl/firefox-84.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "207dfe2ed822245d089a4f1848fcf6c92e27715b4463bcdcdea2127e8ac8fae3";
+      sha256 = "28993fb518753a241abb2e6a22583f8a318bfeeca4e0eca76bedfb2aa0a01e07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/gn/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gn/firefox-84.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "a07d734191885b4e5e66c1a5b2f64cbdcc133dd9a1cf8fdaea882a3a1ceec7ba";
+      sha256 = "370637503e0fa36b937f32867bd68a300fe1bd8d99188ab86ad9392ab5b8a8b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/gu-IN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gu-IN/firefox-84.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "af4146f86e4f5aa81d10067e21653e657620d9b0b51d564dca83c4435f6cca82";
+      sha256 = "1fc77e276cf34424e3c7522af9bfb5d3dd43e33357ce01b696655c2a91a8f2a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/he/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/he/firefox-84.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "608652ef032ccbd0d61070a32a2931764b86ea0d25afb12617338136f3f29e42";
+      sha256 = "b1ffe2fcfd55fff2b696dd40d3292ad9cf2cde1179bd8c9c7103df9c902b276e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/hi-IN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hi-IN/firefox-84.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "1724879537c0472762dd93a2206f31767938881ab4113946076205342f8f5f7a";
+      sha256 = "d13f74a4a45e7a20a1ec3354dce98f33bef647d6153aed2539cf567a6eb3fcfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/hr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hr/firefox-84.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "727f4a1d3ef4e531027c5188798b8fd1aeab98bffe4c1f7f67d919aa8855e6bb";
+      sha256 = "f0a288dc290d2665948e3536b7b52b799461bf060be38b957aff7cd52aac02ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/hsb/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hsb/firefox-84.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6efd8dd2cf6f82b688632095a16c5e488578ac08227cbbcf2613f9b2852c9445";
+      sha256 = "e395166b3039027e56eb6d2d7f97b121c1bd947cd6266829b949b221cbb2cb74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/hu/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hu/firefox-84.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "458e8452d89e61f8f4ac3d1ca3e41583fd26cfa897c4b36e0888a2174c853508";
+      sha256 = "666b47226545e9e8f45ff09e3428d6317fbe67a197e13ada814b6a4f72544a98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/hy-AM/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hy-AM/firefox-84.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "b58af31a6ab2e224f9f50e88c1e97c8f4af273f5189c59f025c10d5589fc2d41";
+      sha256 = "779111633101f8b7da4c84d3d085ab1e8e3502d255316d17eca653b0481d0885";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ia/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ia/firefox-84.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "de6bab3cc3e08fed14584d57a58b9310829ce17906561d880c06968d3ca6a879";
+      sha256 = "e27ac7b8e8d2f3c4f453563d2d2efd3005b12be1696de453182a53a3de490ab1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/id/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/id/firefox-84.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "31cd054f01b8050fe70a95def464b76bfddff2277993c759395e13c3829c2c70";
+      sha256 = "86dcf72326ea283bcfd612cbec0ea095be72fe16d446a317a31c886d91f5b452";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/is/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/is/firefox-84.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "fbb17534672c6b7c89dc51eca97ac9c0f807fce84a68bbf75f077ce1c6202725";
+      sha256 = "17305f92a16967d941df34a59706f90b94b8c671d01e8aab768fbfd473a81f78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/it/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/it/firefox-84.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "9fcfd33025b3d7b88238e6c51472a06b1b6bef56d1275a1aeecb66224f8d6d9b";
+      sha256 = "4b2804d9c52c4f9202e867f2540523cc45675b5d34e46a8d59b044c88a840f5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ja/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ja/firefox-84.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "37a234db4a8618cb125215ef51700fe72e29f2ac9328c4f5a319516f32eac7f4";
+      sha256 = "6a8bc7abc0c320a31d7fac4e457bd46a3fe7379f795e8cb2f36b2de70bf048f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ka/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ka/firefox-84.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "0875616e42bb71c79427a31c5adac9e1d9112c0bbeae866725ae9bd87ca915f8";
+      sha256 = "de6b6be1696d20148cb94cfacaee0fe5ec128550de006a6f64723885d47a1352";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/kab/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/kab/firefox-84.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "88b6430577c73965bc229cc2875b138db1cc47ab27c7aed6c6004559f296d819";
+      sha256 = "a898355c71d00c72aedb87901184f69d0598fabc4827c9070ebb900a48dbf152";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/kk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/kk/firefox-84.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "6de277b39e76394245aaab0dfd4ccdcea4af5812fce20ff61faf9d62c22bd34f";
+      sha256 = "1945b3526a8f52cc7cbaa30e344333c43c7d228d557a249fa4f41a8bb91eb4b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/km/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/km/firefox-84.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "25c0e6752716e6fc4ed02b465b820661ec59ebf997bfaebdbfe172e2a18dc387";
+      sha256 = "3e033fae06700495784b4eaa911309d250d3e55a94139a65f44248975c414980";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/kn/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/kn/firefox-84.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "f61cf632f934daada5d6d2164279981b5536d078ddb5b19e7146a7beb0917e23";
+      sha256 = "b70553b460d0604bff55ea29657e74b1133995ae93bb958b6b20af366cce2eeb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ko/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ko/firefox-84.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "9e9000032c24fd20dd188c9306364ad79fc2d47b3433d36914a2caea716ff230";
+      sha256 = "0ed0d1a0219ef92c0de45578c3674da0ba0e8fd9ed2e00afc01b05d53ea28112";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/lij/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/lij/firefox-84.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "1fd2f5ec8c3074845a27072d8eddf364384e7ce7494739af331a739249c34e4b";
+      sha256 = "5fa837001b3bc5d9138ed14e22720933f28fedef63a7dd473976348448cebb30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/lt/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/lt/firefox-84.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "e8b43ae1a3e3cf7d5fb955cfa772f5fbec525fc9c3deb0e81390b8fc53b70176";
+      sha256 = "b54990d4737b71dfa235d20ee2f87367b72f0a1245585135a9918d2755b3d1cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/lv/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/lv/firefox-84.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "00908977f480f6829761822a4f6f9800c3940faeac0362c46433813788ce1391";
+      sha256 = "06ece913374b567ea10cd9377485d0793a12a151e9e3ba08e3c5433a5e772151";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/mk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/mk/firefox-84.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "cc6a8e52d7e3940e2664b4659f4a33d452b1bea56d3d53c88c28afd604731118";
+      sha256 = "dc69547cdf414f783017ebb8931dd24ad1b899f19bac20bca4d21ebe91963a0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/mr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/mr/firefox-84.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "4a16e203e5b02b146879722a1fe909bd964d712795841cbbd268acc34d5073c6";
+      sha256 = "f503a40041ba0f4e44791f8d2e38c41f25698fd970457fd8cafd92d2d3e64102";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ms/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ms/firefox-84.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "2ebf161faa958992d3dbb9f7d70f7df058b93bc0627a4585fb3226a744c23ef6";
+      sha256 = "07491c18e9fe0d7f97b24c8bcf571ede2c4effda58ceacb0395fb7ce9eae1eb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/my/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/my/firefox-84.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "43255bc0c5a5adc89bb89ea9267b3d4b38d7432555c7285722228b174bf909a2";
+      sha256 = "19d57112de4c6429e915568ae317c3bef2ef6d58d0c57d5a07be0cb2f1bc11d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/nb-NO/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/nb-NO/firefox-84.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "153783b507cf3ec449e8a3d7db6ec523e956c23e1c01f9e26c0e6fc7547353b0";
+      sha256 = "72e6576c3a725675c2514d39b3ea4497590410037aca696c5f3f3dd5109b3c09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ne-NP/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ne-NP/firefox-84.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "8a3b9e8607565e6031f15a94ae4bcc6e6681d1705408f79483406cdfc04e6c4c";
+      sha256 = "fb624e1ea63aca7f481024c40e7b5a47e504ea545169566f86e7ca24e36e7582";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/nl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/nl/firefox-84.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "7d87b9188f74dc3f910761fc0e1c493c121ed6ab077a0fcf1c88af94fbca22a5";
+      sha256 = "a1aab7534d0dde0c61c48bf0f33fb336c12b5d8c644e41188dad7c138531bbf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/nn-NO/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/nn-NO/firefox-84.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "5d0177a4c13faa2cf9aa0edacbbd381d1ff5eb9ad17ae44ab507f3c8e582c360";
+      sha256 = "d1c645cd0b65f8b48b0497b1a16b25a2e11d8de70bb3e37baf6f05c5750525cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/oc/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/oc/firefox-84.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "cf8cd276252fccf07990c0a294e4628566ff3884cc062f26d6510dc042c6b5af";
+      sha256 = "f110c97c8e464ace6026ddb3da15c13177455bcba067a54d4c531329a4cdfdab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/pa-IN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pa-IN/firefox-84.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "75ab886eb9fe8d0a2cb9b0544090bd4b818e510ae4c3b137323782237d1a2a77";
+      sha256 = "4931270889eb97b55b3bea7177e778422045bfcebc25e4bc05019ffbde438c78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/pl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pl/firefox-84.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9a2007a58e264731fbc1691213cf4aba07f360e5c3ee455c6a9abd85078f447f";
+      sha256 = "c0438fb22ef1c610afc16bfd689d1843d6099e91e6b8a30b03a2f692b609eb4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/pt-BR/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pt-BR/firefox-84.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "71b833c745a4fb334fc1aaa250b67d701cac46c3decec7b839e7554c30e4fbec";
+      sha256 = "df61ec134c161d0f44ad0805bda8d1baa37d21c618c4f4d165e40996d7ba5956";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/pt-PT/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pt-PT/firefox-84.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "a56ada11b7681238a17c3e02c90122d4632070d8385624b34e03ebd2803328e7";
+      sha256 = "a09341dc8284b77fa3bd1c7d5fbc377a93cd21109e1330b0a2260613df3c4e5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/rm/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/rm/firefox-84.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c0cadeebef45884e11a67e1f45f0b36754fc6e2537b2575f06ec539a43986bce";
+      sha256 = "19016551888f5104227e3cfed6c66b7ca11e11a31d9c007c3d00f6821126fd03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ro/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ro/firefox-84.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "386f7557754cfb2887c7ff2be165d8b4cdc4cc4303fd26539b2d09de440b8c0f";
+      sha256 = "d5cacf3a2c3cf9c3c6fe182005c038094fb6b8ae58ea169123e6289f7a2c5457";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ru/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ru/firefox-84.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "62ee54d895760e7a024fc4836096ad97b95b9bc0ca9d5900d551f86b16071aeb";
+      sha256 = "8907175fd858dc243dafd4216b3602f154ce824a2388b714cee9352322781f39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/si/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/si/firefox-84.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "37b2bf998d61de9ee9b372548d8ccc0a2b4cd098e26c7773829267379cf5bfc0";
+      sha256 = "19be977d9110dddb944e0ca713aa986fb3c005a4f39bde23a4a0b907cb7d39df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/sk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sk/firefox-84.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "30429ca6601f9276339f925614fd79b03ac54573564307ea84f0f87359bac7f3";
+      sha256 = "2a7a5dfacaa016ae6d2dbb52d0803a8a27f74061a6bf71fcbac5fe2e10834374";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/sl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sl/firefox-84.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "412e8aed7694adc1870d4e2bd8eeef74eb63ba0699e815b1d2ec65d38de9b4ff";
+      sha256 = "61c65884ba57fa5fd37919a390b8af4cb0d7abf31ead557f2967049c35a4bc72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/son/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/son/firefox-84.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "864e49755554df5ba8d5669f1b3d683517f2eb44039a35097e3acada4b22171d";
+      sha256 = "be825ca5923ec9aa37417d4d4842bd82ee4271ec201bb317e0b58f654fe8a7c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/sq/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sq/firefox-84.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "1449ff4fac39eb2c3f959a899d773e77e457639ebc4cb26dd9c4188395b9c831";
+      sha256 = "c7ab49257d5e44bb96e8f39bb586e51a100b899fb6e595a86bf41ebc25b55021";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/sr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sr/firefox-84.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "51813e4ef930533045632fa516752303430ea9fdb848653c1233ddd9ef6d26c5";
+      sha256 = "b22e12526457dfaaf976eb94262965c3bd46edf4a99380a430d75b2324ad654a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/sv-SE/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sv-SE/firefox-84.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "82e3ce190978b83da1f88b175bcf4f1c95a1539e15375c856c54516333b8fc5d";
+      sha256 = "5e024fc41d9287480ab09ea45d46e9dc358be53adce325826d9820b6cf3ab8ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ta/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ta/firefox-84.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "09f104627061c25c188d6e945dc1915ac43af31c6a0a0a05e70f051915f3d2bc";
+      sha256 = "529afecbbdfa2f934d755f80c7a0bc9d4bac5053cc0c6421c1687ab16e5b1f02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/te/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/te/firefox-84.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "a58503877b476f20e176abfa0ca2e5406b8ae8877954924f63f6490c5be19526";
+      sha256 = "d90b59759a4f24f9142250f6fe5853fa0e6afdc30bff7e735fc5b70a3b76f555";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/th/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/th/firefox-84.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "722f4194231fb315a07e0efcc922c6d62a8969321eadfccf2f6b74754b563d2a";
+      sha256 = "023f86d83e23371bbbe68bb586a08e81a58cec027a44c0ddeb217ea1343b5cd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/tl/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/tl/firefox-84.0.2.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "6299ac5b4b505549cea0dd465059191adbee72346cfec46b94c67e7f5e9bc399";
+      sha256 = "2fd3a1f80900f16eac1de89c8a7a4f93cafef144a24d9c261b09549a3b659448";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/tr/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/tr/firefox-84.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "3e4755c497512bcb225a6e35e426db6772f263008f9d6c8495a8311d6d5ebfd4";
+      sha256 = "1144aa3437ae67c6921ddeeceb59dad5767d1d59c7932fa0da460c64a4f5577f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/trs/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/trs/firefox-84.0.2.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "d6bc24f33f73fea25675a1bcb53a40d4dc123b6496f0087c25b4bd7f6ca717f0";
+      sha256 = "1f3e1d5fec2b4d9b11c3c0ded1a68aa7e36d13fae472ce782fd820d4fd32a7c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/uk/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/uk/firefox-84.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "37b48b8cf2e57a3bacc2d3a5c139ac1d465e246a68fd33b87891e8c844af0088";
+      sha256 = "165dfdd03c178af49d3f3139a0c9032431f92cf91e79d6842b5e0b006c73490c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/ur/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ur/firefox-84.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "b3a45eb2ad18d1af426e82163b426ceba5adc47957ff771121ee4b172037b53b";
+      sha256 = "6a91871a99188c0bc6a956d92382c800543d95a4d917e64d3295d9b1fe8971e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/uz/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/uz/firefox-84.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "67539a5475aa12d25f8b83655cddc804d46b980e03908bb44f5378753abb649f";
+      sha256 = "ade7a34f46893e3367384b414322895f5cd9ce0d341b7a7ddeb191fcc7679e5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/vi/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/vi/firefox-84.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ad894dd659f5c86e0b094b709d0d336516e29dea1d1d9ff35f264e6606e59938";
+      sha256 = "aca136daf5a8d71b55e479a37a1d42569ee6c9086ac96bf98587948eb23c5f59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/xh/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/xh/firefox-84.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "a43b653ad3a3d865c410103ccb66d3603a08cc37177d5279a1b326381631dcf5";
+      sha256 = "6993f823fd76b8974334b37ebe9c683d43fd2524ea1c485ef0c53db993db15ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/zh-CN/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/zh-CN/firefox-84.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "73e877c33aa5553f90ffc0c68b7416bb988477e55f53632d9f78526ca11a89ba";
+      sha256 = "b179fb98b0eb374e28574a4eb61f86df8765ee5bac033e93ad6c3e71d010e7cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.1/linux-i686/zh-TW/firefox-84.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/zh-TW/firefox-84.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7f448ee87156e73cba4a9edcdd52299f6f70ef7660bad9ee6b7c60375d83e1e6";
+      sha256 = "0c51a4e5afa22fac0c98e2e960168fb5625a29d2d9e1565ecd08080d83e72d73";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -31,10 +31,10 @@ rec {
 
   firefox-esr-78 = common rec {
     pname = "firefox-esr";
-    ffversion = "78.5.0esr";
+    ffversion = "78.6.1esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "20h53cn7p4dds1yfm166iwbjdmw4fkv5pfk4z0pni6x8ddjvg19imzs6ggmpnfhaji8mnlknm7xp5j7x9vi24awvdxdds5n88rh25hd";
+      sha512 = "3kq9vb0a8qblqk995xqhghw5d694mr1cjd5alkkwxbdjhpc1mck0ayn40xjph0znga6qdcq8l366p0by8ifbsdhv0x39ng8nvx9jvdf";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "84.0.1";
+    ffversion = "84.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "0sl93h7pjiznabv6865pdbal08nlqncnv3g40l02mgwbphjh5iqrr1bz14khaf58h4v1la090cj7z0gmd0c10xfrx6z7wngm152zz75";
+      sha512 = "2cxybnrcr0n75hnw18rrymw1jsd5crqfgnpk10hywbmnkdc72fx5sk51cg890pzwfiagicxfxsacnm3f6g8135k0wsz4294xjjwkm1z";
     };
 
     meta = {


### PR DESCRIPTION

###### Motivation for this change

Backport https://github.com/NixOS/nixpkgs/pull/108770.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
