### PR TITLE
ytcc: 1.8.4 -> 2.0.1

### DIFF
--- a/pkgs/tools/networking/ytcc/default.nix
+++ b/pkgs/tools/networking/ytcc/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ytcc";
-  version = "1.8.4";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "woefe";
@@ -13,23 +13,23 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ gettext ];
 
-  propagatedBuildInputs = with python3Packages; [ feedparser lxml sqlalchemy youtube-dl ];
+  propagatedBuildInputs = with python3Packages; [ click feedparser lxml sqlalchemy youtube-dl ];
 
-  checkInputs = with python3Packages; [ nose pytest ];
+  checkInputs = with python3Packages; [ nose pytestCheckHook ];
 
   # Disable tests that touch network or shell out to commands
-  checkPhase = ''
-    pytest . -k "not get_channels \
-                 and not play_video \
-                 and not download_videos \
-                 and not update_all \
-                 and not add_channel_duplicate"
-  '';
+  disabledTests = [
+    "get_channels"
+    "play_video"
+    "download_videos"
+    "update_all"
+    "add_channel_duplicate"
+  ];
 
   meta = {
     description = "Command Line tool to keep track of your favourite YouTube channels without signing up for a Google account";
     homepage = "https://github.com/woefe/ytcc";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ marius851000 ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
saw this in nixpkgs-update logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
