### PR TITLE
enum4linux-ng: init at 1.0.0

### DIFF
--- a/pkgs/tools/security/enum4linux-ng/default.nix
+++ b/pkgs/tools/security/enum4linux-ng/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, impacket
+, ldap3
+, pyyaml
+, samba
+}:
+
+buildPythonApplication rec {
+  pname = "enum4linux-ng";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "cddmp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0dhg8cwbdn0vlnchhscx31ay4mgj5p6rf73wzgs8nvqg0shsawmy";
+  };
+
+  propagatedBuildInputs = [
+    impacket
+    ldap3
+    pyyaml
+    samba
+  ];
+
+  # It's only a script and not a Python module. Project has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Windows/Samba enumeration tool";
+    longDescription = ''
+      enum4linux-ng.py is a rewrite of Mark Lowe's enum4linux.pl, a tool for
+      enumerating information from Windows and Samba systems.
+    '';
+    homepage = "https://github.com/cddmp/enum4linux-ng";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -236,6 +236,8 @@ in
 
   enum4linux = callPackage ../tools/security/enum4linux {};
 
+  enum4linux-ng = python3Packages.callPackage ../tools/security/enum4linux-ng { };
+
   onesixtyone = callPackage ../tools/security/onesixtyone {};
 
   creddump = callPackage ../tools/security/creddump {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
enum4linux-ng.py is a rewrite of Mark Lowe's enum4linux.pl, a tool for
enumerating information from Windows and Samba systems.

https://github.com/cddmp/enum4linux-ng

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
