### PR TITLE
xsd: fix build

### DIFF
--- a/pkgs/development/libraries/xsd/default.nix
+++ b/pkgs/development/libraries/xsd/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchurl, xercesc }:
 
 let
-  fixed_paths = ''LDFLAGS="-L${xercesc}/lib" CPPFLAGS="-I${xercesc}/include"'';
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "xsd";
   version = "4.0.0";
 
@@ -14,19 +13,21 @@ stdenv.mkDerivation {
 
   patches = [ ./xsdcxx.patch ];
 
-  configurePhase = ''
+  postPatch = ''
     patchShebangs .
   '';
 
-  buildPhase = ''
-    make ${fixed_paths}
-  '';
+  enableParallelBuilding = true;
+
+  buildFlags = [
+    "LDFLAGS=-L${xercesc}/lib"
+    "CPPFLAGS=-I${xercesc}/include"
+  ];
+  installFlags = buildFlags ++ [
+    "install_prefix=${placeholder "out"}"
+  ];
 
   buildInputs = [ xercesc ];
-
-  installPhase = ''
-    make ${fixed_paths} install_prefix="$out" install
-  '';
 
   meta = {
     homepage = "http://www.codesynthesis.com/products/xsd";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25681,7 +25681,9 @@ in
 
   xrgears = callPackage ../applications/graphics/xrgears { };
 
-  xsd = callPackage ../development/libraries/xsd { };
+  xsd = callPackage ../development/libraries/xsd {
+    stdenv = gcc9Stdenv;
+  };
 
   xscope = callPackage ../applications/misc/xscope { };
 


### PR DESCRIPTION
last release 2014... does not build with gcc10<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
