### PR TITLE
libcap: 2.44 -> 2.46, libcap_ng: 0.8 -> 0.8.2

### DIFF
--- a/pkgs/os-specific/linux/libcap-ng/default.nix
+++ b/pkgs/os-specific/linux/libcap-ng/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
   pname = "libcap-ng";
   # When updating make sure to test that the version with
   # all of the python bindings still works
-  version = "0.8";
+  version = "0.8.2";
 
   src = fetchurl {
     url = "${meta.homepage}/${pname}-${version}.tar.gz";
-    sha256 = "08cy59iassiwbmfxa5v0kb374r80290vv32f5q1mnip11av26kgi";
+    sha256 = "1sasp1n154aqy9fz0knlb966svm7xg1zjhg1vr4q839bgjvq7h2j";
   };
 
   nativeBuildInputs = [ swig ];

--- a/pkgs/os-specific/linux/libcap/default.nix
+++ b/pkgs/os-specific/linux/libcap/default.nix
@@ -34,11 +34,8 @@ stdenv.mkDerivation rec {
   ];
 
   prePatch = ''
-    # use relative bash path
-    substituteInPlace progs/capsh.c --replace "/bin/bash" "bash"
-
-    # ensure capsh can find bash in $PATH
-    substituteInPlace progs/capsh.c --replace execve execvpe
+    # use full path to bash
+    substituteInPlace progs/capsh.c --replace "/bin/bash" "${stdenv.shell}"
 
     # set prefixes
     substituteInPlace Make.Rules \

--- a/pkgs/os-specific/linux/libcap/default.nix
+++ b/pkgs/os-specific/linux/libcap/default.nix
@@ -7,11 +7,11 @@ assert usePam -> pam != null;
 
 stdenv.mkDerivation rec {
   pname = "libcap";
-  version = "2.44";
+  version = "2.46";
 
   src = fetchurl {
     url = "mirror://kernel/linux/libs/security/linux-privs/libcap2/${pname}-${version}.tar.xz";
-    sha256 = "1qf80lifygbnxwvqjf8jz5j24n6fqqx4ixnkbf76xs2vrmcq664j";
+    sha256 = "1d6q447wf0iagiyzhfdqcj4cv0dmzc49i0czwikrcv7s2cad3lsf";
   };
 
   patches = lib.optional isStatic ./no-shared-lib.patch;


### PR DESCRIPTION
###### Motivation for this change
Update `libcap` to version `2.46` and `libcap_ng` to version `0.8.2`
In libcap `CAPSH_SHELL` changed to full path bash - fixed this warning:
```
capsh.c: In function 'main':
capsh.c:787:6: warning: implicit declaration of function 'execvpe'; did you mean 'execvp'? [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
  787 |      execvpe(argv[i], argv+i, envp);
      |      ^~~~~~~
      |      execvp
capsh.c:787:6: warning: nested extern declaration of 'execvpe' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wnested-externs-Wnested-externs8;;]

```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
