### PR TITLE
i3, i3-gaps: 4.18.3 -> 4.19

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,18 +1,18 @@
-{ fetchurl, lib, stdenv, which, pkgconfig, makeWrapper, installShellFiles, libxcb, xcbutilkeysyms
+{ fetchurl, lib, stdenv, pkg-config, makeWrapper, meson, ninja, installShellFiles, libxcb, xcbutilkeysyms
 , xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre, libev
 , yajl, xcb-util-cursor, perl, pango, perlPackages, libxkbcommon
 , xorgserver, xvfb_run }:
 
 stdenv.mkDerivation rec {
   pname = "i3";
-  version = "4.18.3";
+  version = "4.19";
 
   src = fetchurl {
-    url = "https://i3wm.org/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "03dijnwv2n8ak9jq59fhq0rc80m5wjc9d54fslqaivnnz81pkbjk";
+    url = "https://i3wm.org/downloads/${pname}-${version}.tar.xz";
+    sha256 = "0wjq6lkidg0g474xsln1fhbxci7zclq3748sda10f1n7q01qp95c";
   };
 
-  nativeBuildInputs = [ which pkgconfig makeWrapper installShellFiles ];
+  nativeBuildInputs = [ pkg-config makeWrapper meson ninja installShellFiles ];
 
   buildInputs = [
     libxcb xcbutilkeysyms xcbutil xcbutilwm xcbutilxrm libxkbcommon

--- a/pkgs/applications/window-managers/i3/gaps.nix
+++ b/pkgs/applications/window-managers/i3/gaps.nix
@@ -3,17 +3,12 @@
 i3.overrideAttrs (oldAttrs : rec {
 
   name = "i3-gaps-${version}";
-  version = "4.18.3";
+  version = "4.19";
 
   src = fetchurl {
-    url = "https://github.com/Airblader/i3/releases/download/${version}/i3-${version}.tar.bz2";
-    sha256 = "1hcakwyz78lgp8mhqv7pw86jlb3m415pfql1q19rkijnhm3fn3ci";
+    url = "https://github.com/Airblader/i3/releases/download/${version}/i3-${version}.tar.xz";
+    sha256 = "0j19kj05fpjfnj50vyykk6jsr07hq9l26y8na55bb7yfrra8yp4h";
   };
-
-  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ autoreconfHook ];
-
-  # fatal error: GENERATED_config_enums.h: No such file or directory
-  enableParallelBuilding = false;
 
   meta = with lib; {
     description = "A fork of the i3 tiling window manager with some additional features";


### PR DESCRIPTION
Upstream switched from the autotools build system to the meson build system.
Also the source archive format switched from tar.bz2 to tar.xz
The build now supports application documentation in /share/doc/i3/
https://i3wm.org/downloads/RELEASE-NOTES-4.19.txt

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New features and fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
