### PR TITLE
trillian: init at 1.3.11

### DIFF
--- a/pkgs/tools/misc/trillian/default.nix
+++ b/pkgs/tools/misc/trillian/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, buildGoModule
+, fetchFromGitHub
+}:
+let
+  pname = "trillian";
+  version = "1.3.11";
+
+in
+buildGoModule {
+  inherit pname version;
+  vendorSha256 = "0zxp1gjzcc3z6vkpc2bchbs1shwm1b28ks0jh4gf6zxpp4361j4l";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1lh19wba90y91l5jj8ilzjqxgmqqqdvyn7pzrwvmzv7iiy18wcmh";
+  };
+
+  # Remove tests that require networking
+  postPatch = ''
+    rm cmd/get_tree_public_key/main_test.go
+  '';
+
+  subPackages = [
+    "cmd/trillian_log_server"
+    "cmd/trillian_log_signer"
+    "cmd/trillian_map_server"
+    "cmd/createtree"
+    "cmd/deletetree"
+    "cmd/get_tree_public_key"
+    "cmd/updatetree"
+  ];
+
+  meta = {
+    homepage = "https://github.com/google/trillian";
+    description = "A transparent, highly scalable and cryptographically verifiable data store.";
+    license = [ lib.licenses.asl20 ];
+    maintainers = [ lib.maintainers.adisbladis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16660,6 +16660,8 @@ in
 
   tremor = callPackage ../development/libraries/tremor { };
 
+  trillian = callPackage ../tools/misc/trillian { };
+
   twolame = callPackage ../development/libraries/twolame { };
 
   udns = callPackage ../development/libraries/udns { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

#### Acknowledgement

This work is done within the context of [Trustix](https://nlnet.nl/project/Trustix/) and has been sponsored by a [NLNet Foundation NGI-0 PET](https://nlnet.nl/thema/NGIZeroPET.html) grant.