### PR TITLE
Adding new VSCode extensions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8671,6 +8671,12 @@
     githubId = 2666479;
     name = "Y Nguyen";
   };
+  superherointj = {
+    name = "Sérgio G.";
+    email = "5861043+superherointj@users.noreply.github.com";
+    github = "superherointj";
+    githubId = 5861043;
+  };
   SuperSandro2000 = {
     email = "sandro.jaeckel@gmail.com";
     github = "SuperSandro2000";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -223,6 +223,23 @@ let
         };
       };
 
+      freebroccolo.reasonml = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/freebroccolo.reasonml/changelog";
+          description = "Reason support for Visual Studio Code";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=freebroccolo.reasonml";
+          homepage = "https://github.com/reasonml-editor/vscode-reasonml";
+          license = licenses.asl20;
+          maintainers = with maintainers; [ superherointj ];
+        };
+        mktplcRef = {
+          name = "reasonml";
+          publisher = "freebroccolo";
+          version = "1.0.38";
+          sha256 = "1nay6qs9vcxd85ra4bv93gg3aqg3r2wmcnqmcsy9n8pg1ds1vngd";
+        };
+      };
+
       github.github-vscode-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "github-vscode-theme";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -148,6 +148,23 @@ let
         meta = { license = stdenv.lib.licenses.mit; };
       };
 
+      donjayamanne.githistory = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/donjayamanne.githistory/changelog";
+          description = "View git log, file history, compare branches or commits";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=donjayamanne.githistory";
+          homepage = "https://github.com/DonJayamanne/gitHistoryVSCode/";
+          license = licenses.mit;
+          maintainers = with maintainers; [ superherointj ];
+        };
+        mktplcRef = {
+          name = "githistory";
+          publisher = "donjayamanne";
+          version = "0.6.14";
+          sha256 = "11x116hzqnhgbryp2kqpki1z5mlnwxb0ly9r1513m5vgbisrsn0i";
+        };
+      };
+
       formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "auto-close-tag";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -305,14 +305,19 @@ let
       };
 
       jnoortheen.nix-ide = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/jnoortheen.nix-ide/changelog";
+          description = "Nix language support with formatting and error report";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=jnoortheen.nix-ide";
+          homepage = "https://github.com/jnoortheen/vscode-nix-ide";
+          license = licenses.mit;
+          maintainers = with maintainers; [ superherointj ];
+        };
         mktplcRef = {
           name = "nix-ide";
           publisher = "jnoortheen";
           version = "0.1.7";
           sha256 = "1bw4wyq9abimxbhl7q9g8grvj2ax9qqq6mmqbiqlbsi2arvk0wrm";
-        };
-        meta =  {
-          license = stdenv.lib.licenses.mit;
         };
       };
 

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -415,6 +415,23 @@ let
 
       matklad.rust-analyzer = callPackage ./rust-analyzer {};
 
+      ocamllabs.ocaml-platform = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/ocamllabs.ocaml-platform/changelog";
+          description = "Official OCaml Support from OCamlLabs";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform";
+          homepage = "https://github.com/ocamllabs/vscode-ocaml-platform";
+          license = licenses.isc;
+          maintainers = with maintainers; [ superherointj ];
+        };
+        mktplcRef = {
+          name = "ocaml-platform";
+          publisher = "ocamllabs";
+          version = "1.5.1";
+          sha256 = "0jkxpcrbr8xmwfl8jphmarjz2jk54hvmc24ww89d4bgx1awayqfh";
+        };
+      };
+
       pkief.material-icon-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "material-icon-theme";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -165,6 +165,23 @@ let
         };
       };
 
+      esbenp.prettier-vscode = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/esbenp.prettier-vscode/changelog";
+          description = "Code formatter using prettier";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode";
+          homepage = "https://github.com/prettier/prettier-vscode";
+          license = licenses.mit;
+          maintainers = with maintainers; [ superherointj ];
+        };
+        mktplcRef = {
+          name = "prettier-vscode";
+          publisher = "esbenp";
+          version = "5.8.0";
+          sha256 = "0h7wc4pffyq1i8vpj4a5az02g2x04y7y1chilmcfmzg2w42xpby7";
+        };
+      };
+
       formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "auto-close-tag";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -182,6 +182,23 @@ let
         };
       };
 
+      file-icons.file-icons = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/file-icons.file-icons/changelog";
+          description = "File-specific icons in VSCode for improved visual grepping.";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=file-icons.file-icons";
+          homepage = "https://github.com/file-icons/vscode";
+          license = licenses.mit;
+          maintainers = with maintainers; [ superherointj ];
+        };
+        mktplcRef = {
+          name = "file-icons";
+          publisher = "file-icons";
+          version = "1.0.28";
+          sha256 = "1lyx0l42xhi2f3rdnjddc3mw7m913kjnchawi98i6vqsx3dv7091";
+        };
+      };
+
       formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "auto-close-tag";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -99,6 +99,23 @@ let
         };
       };
 
+      CoenraadS.bracket-pair-colorizer = buildVscodeMarketplaceExtension {
+        meta = with lib; {
+          changelog = "https://marketplace.visualstudio.com/items/CoenraadS.bracket-pair-colorizer/changelog";
+          description = "A customizable extension for colorizing matching brackets";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer";
+          homepage = "https://github.com/CoenraadS/BracketPair";
+          license = licenses.mit;
+          maintainers = with maintainers; [ superherointj ];
+        };
+        mktplcRef = {
+          name = "bracket-pair-colorizer";
+          publisher = "CoenraadS";
+          version = "1.0.61";
+          sha256 = "0r3bfp8kvhf9zpbiil7acx7zain26grk133f0r0syxqgml12i652";
+        };
+      };
+
       coenraads.bracket-pair-colorizer-2 = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "bracket-pair-colorizer-2";


### PR DESCRIPTION
* It respects alphabetical order so data can be normalized.

List of changes:
CoenraadS.bracket-pair-colorizer: init at 1.0.61
donjayamanne.githistory: init at 0.6.14
esbenp.prettier-vscode: init at 5.8.0
file-icons.file-icons: init at 1.0.28
freebroccolo.reasonml: init at 1.0.38
jnoortheen.nix-ide: updated metadata
ocamllabs.ocaml-platform: init at 1.5.1