### PR TITLE
socat: 1.7.3.4 -> 1.7.4.1

### DIFF
--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -1,11 +1,19 @@
-{ stdenv, fetchurl, openssl, readline, which, nettools }:
+{ lib
+, fetchurl
+, nettools
+, openssl
+, readline
+, stdenv
+, which
+}:
 
 stdenv.mkDerivation rec {
-  name = "socat-1.7.3.4";
+  pname = "socat";
+  version = "1.7.4.1";
 
   src = fetchurl {
-    url = "http://www.dest-unreach.org/socat/download/${name}.tar.bz2";
-    sha256 = "1z7xgnwiqpcv1j6aghhj9nqbx7cg3gpc4n9j7vi9hm7nhv5788wp";
+    url = "http://www.dest-unreach.org/socat/download/${pname}-${version}.tar.bz2";
+    sha256 = "1sbmqqvni3ss9wyay6ik5v81kxffkra80mh4ypgj74g82iba5b1z";
   };
 
   postPatch = ''
@@ -22,12 +30,12 @@ stdenv.mkDerivation rec {
   checkInputs = [ which nettools ];
   doCheck = false; # fails a bunch, hangs
 
-  meta = {
-    description = "A utility for bidirectional data transfer between two independent data channels";
+  meta = with lib; {
+    description = "Utility for bidirectional data transfer between two independent data channels";
     homepage = "http://www.dest-unreach.org/socat/";
     repositories.git = "git://repo.or.cz/socat.git";
-    platforms = stdenv.lib.platforms.unix;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    platforms = platforms.unix;
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ eelco ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 1.7.4.1

Changelog :https://repo.or.cz/socat.git/blob/HEAD:/CHANGES

Also, follow the new pattern for meta.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
