### PR TITLE
go: Introduce environment variable GO_NO_VENDOR_CHECKS to relax go vendor checks

### DIFF
--- a/pkgs/development/compilers/go/1.14.nix
+++ b/pkgs/development/compilers/go/1.14.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation rec {
     ./go-1.9-skip-flaky-20072.patch
     ./skip-external-network-tests.patch
     ./skip-nohup-tests.patch
+    ./go_no_vendor_checks-1_14.patch
 
     # fix rare TestDontCacheBrokenHTTP2Conn failure
     (fetchpatch {

--- a/pkgs/development/compilers/go/1.15.nix
+++ b/pkgs/development/compilers/go/1.15.nix
@@ -152,6 +152,7 @@ stdenv.mkDerivation rec {
     ./skip-external-network-tests-1.15.patch
     ./skip-nohup-tests.patch
     ./skip-cgo-tests-1.15.patch
+    ./go_no_vendor_checks.patch
   ] ++ [
     # breaks under load: https://github.com/golang/go/issues/25628
     (if stdenv.isAarch32

--- a/pkgs/development/compilers/go/go_no_vendor_checks-1_14.patch
+++ b/pkgs/development/compilers/go/go_no_vendor_checks-1_14.patch
@@ -1,0 +1,23 @@
+Starting from go1.14, go verifes that vendor/modules.txt matches the requirements
+and replacements listed in the main module go.mod file, and it is a hard failure if
+vendor/modules.txt is missing.
+
+Relax module consistency checks and switch back to pre go1.14 behaviour if
+vendor/modules.txt is missing regardless of go version requirement in go.mod.
+
+This has been ported from FreeBSD: https://reviews.freebsd.org/D24122
+See https://github.com/golang/go/issues/37948 for discussion.
+
+diff --git a/src/cmd/go/internal/modload/init.go b/src/cmd/go/internal/modload/init.go
+index 71f68efbcc..3c566d04dd 100644
+--- a/src/cmd/go/internal/modload/init.go
++++ b/src/cmd/go/internal/modload/init.go
+@@ -133,7 +133,7 @@ func checkVendorConsistency() {
+ 	readVendorList()
+
+ 	pre114 := false
+-	if modFile.Go == nil || semver.Compare("v"+modFile.Go.Version, "v1.14") < 0 {
++	if modFile.Go == nil || semver.Compare("v"+modFile.Go.Version, "v1.14") < 0 || (os.Getenv("GO_NO_VENDOR_CHECKS") == "1" && len(vendorMeta) == 0) {
+ 		// Go versions before 1.14 did not include enough information in
+ 		// vendor/modules.txt to check for consistency.
+ 		// If we know that we're on an earlier version, relax the consistency check.

--- a/pkgs/development/compilers/go/go_no_vendor_checks.patch
+++ b/pkgs/development/compilers/go/go_no_vendor_checks.patch
@@ -1,0 +1,23 @@
+Starting from go1.14, go verifes that vendor/modules.txt matches the requirements
+and replacements listed in the main module go.mod file, and it is a hard failure if
+vendor/modules.txt is missing.
+
+Relax module consistency checks and switch back to pre go1.14 behaviour if
+vendor/modules.txt is missing regardless of go version requirement in go.mod.
+
+This has been ported from FreeBSD: https://reviews.freebsd.org/D24122
+See https://github.com/golang/go/issues/37948 for discussion.
+
+diff --git a/src/cmd/go/internal/modload/vendor.go b/src/cmd/go/internal/modload/vendor.go
+index 71f68efbcc..3c566d04dd 100644
+--- a/src/cmd/go/internal/modload/vendor.go
++++ b/src/cmd/go/internal/modload/vendor.go
+@@ -133,7 +133,7 @@ func checkVendorConsistency() {
+ 	readVendorList()
+
+ 	pre114 := false
+-	if modFile.Go == nil || semver.Compare("v"+modFile.Go.Version, "v1.14") < 0 {
++	if modFile.Go == nil || semver.Compare("v"+modFile.Go.Version, "v1.14") < 0 || (os.Getenv("GO_NO_VENDOR_CHECKS") == "1" && len(vendorMeta) == 0) {
+ 		// Go versions before 1.14 did not include enough information in
+ 		// vendor/modules.txt to check for consistency.
+ 		// If we know that we're on an earlier version, relax the consistency check.


### PR DESCRIPTION
This is used in https://github.com/tweag/gomod2nix to reconstruct a
vendor metadata file.

With the vendor checks we need a lot more metadata which isn't
relevant for building packages, especially since we've already locked
the dependency graph ahead of time

This patch has been ported from FreeBSD: https://reviews.freebsd.org/D24122.
 See https://github.com/golang/go/issues/37948 for discussion. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

### Acknowledgements

This work is done within the context of [Trustix](https://nlnet.nl/project/Trustix/) and has been sponsored by a [NLNet Foundation NGI-0 PET](https://nlnet.nl/thema/NGIZeroPET.html) grant.