### PR TITLE
dune-release: fix tests for newer git versions

### DIFF
--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -32,9 +32,14 @@ in buildDunePackage rec {
     # to have a fixed path to the binary in nix store
     sed -i '/must_exist (Cmd\.v "curl"/d' lib/github.ml
 
-    # set bogus user info in git so git commit doesn't fail
-    sed -i '/git init/ a \    $ git config user.name test; git config user.email "pseudo@pseudo.invalid"' \
-      tests/bin/{delegate_info,errors,tag,no_doc,x-commit-hash}/run.t
+    # fix problems with git invocations in tests
+    for f in tests/bin/{delegate_info,errors,tag,no_doc,x-commit-hash}/run.t; do
+      # set bogus user info in git so git commit doesn't fail
+      sed -i '/git init/ a \    $ git config user.name test; git config user.email "pseudo@pseudo.invalid"' "$f"
+      # surpress hint to set default branch name
+      substituteInPlace "$f" --replace "git init" "git init -b main"
+    done
+
     # ignore weird yes error message
     sed -i 's/yes |/yes 2>\/dev\/null |/' tests/bin/no_doc/run.t
   '';


### PR DESCRIPTION
Newer git versions show a hint when calling `git init` to set the
default initial branch to something like 'main'. This obviously is
printed to stderr and thus not hidden by `> /dev/null`. We fix the
ensuing test failure by setting a branch in the invocation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
