### PR TITLE
firefox-unwrapped: fix drmSupport option

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -306,7 +306,7 @@ buildStdenv.mkDerivation ({
   ++ flag gssSupport "negotiateauth"
   ++ flag webrtcSupport "webrtc"
   ++ flag crashreporterSupport "crashreporter"
-  ++ lib.optional drmSupport "--enable-eme=widevine"
+  ++ lib.optional (!drmSupport) "--disable-eme"
 
   ++ (if debugBuild then [ "--enable-debug" "--enable-profiling" ]
                     else [ "--disable-debug" "--enable-release"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

EME is enabled by default, so adding --enable-eme=widevine is a noop. This means that firefox was always being built with DRM support, even with drmSupport set to false.

I’ve been sitting on this commit for two years, because I’m not sure what the right thing to do about this now.  In the years it’s been broken, people have probably come to expect the Firefox in Nixpkgs to have DRM enabled by default.  Especially since AIUI Firefox still prompts the user to agree before downloading the Widevine blob on Linux.

On the other hand, there’s this comment:

https://github.com/alyssais/nixpkgs/blob/464dee9a9beb22f651c1ddb95fd32ab38870c304/pkgs/applications/networking/browsers/firefox/common.nix#L35

This commit currently errs on the side of following the intended functionality of the code by disabling DRM at compile time, even though that’s not the result it’s actually produced (at least for a long time).

Whichever of those two options we pick, the status quo is clearly not right, because we have a drmSupport option that doesn’t actually do anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
