### PR TITLE
crystal: fix darwin builds

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -57,6 +57,7 @@ let
     buildCommand = ''
       mkdir -p $out
       tar --strip-components=1 -C $out -xf ${src}
+      patchShebangs $out
     '';
   };
 

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -151,6 +151,11 @@ let
         # crystal used to build this one.
         CRYSTAL_LIBRARY_PATH = "${placeholder "lib"}/crystal";
 
+        postBuild = ''
+          install -dm755 $lib/crystal
+          cp -r src/* $lib/crystal/
+        '';
+
         # We *have* to add `which` to the PATH or crystal is unable to build
         # stuff later if which is not available.
         installPhase = ''
@@ -163,8 +168,6 @@ let
             --suffix CRYSTAL_LIBRARY_PATH : ${
               lib.makeLibraryPath (commonBuildInputs extraBuildInputs)
             }
-          install -dm755 $lib/crystal
-          cp -r src/* $lib/crystal/
 
           install -dm755 $out/share/doc/crystal/api
           cp -r docs/* $out/share/doc/crystal/api/


### PR DESCRIPTION
###### Motivation for this change

Darwin builds for Crystal are currently failing because of a test not passing anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
