### PR TITLE
ocamlPackages.nonstd: fix fetch error by using fetchzip

### DIFF
--- a/pkgs/development/ocaml-modules/nonstd/default.nix
+++ b/pkgs/development/ocaml-modules/nonstd/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromBitbucket, buildDunePackage }:
+{ lib, fetchzip, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "nonstd";
@@ -6,10 +6,8 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.02";
 
-  src = fetchFromBitbucket {
-    owner = "smondet";
-    repo = pname;
-    rev = "${pname}.${version}";
+  src = fetchzip {
+    url = "https://bitbucket.org/smondet/${pname}/get/${pname}.${version}.tar.gz";
     sha256 = "0ccjwcriwm8fv29ij1cnbc9win054kb6pfga3ygzdbjpjb778j46";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`fetchFromBitbucket` got confused with unpacking the archive apparently, so we use fetchzip and the archive listed in the opam repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
