### PR TITLE
dune: let dune 1 install itself

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation {
 
   buildPhase = "dune build";
 
-  inherit (dune) installPhase;
+  installPhase = ''
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR
+  '';
 
   meta = with lib; {
     homepage = "https://acg.loria.fr/";

--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, dune }:
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, opaline }:
 
 if !lib.versionAtLeast ocaml.version "4.07"
 then throw "lua-ml is not available for OCaml ${ocaml.version}"
@@ -16,11 +16,14 @@ stdenv.mkDerivation rec {
     sha256 = "04lv98nxmzanvyn4c0k6k0ax29f5xfdl8qzpf5hwadslq213a044";
   };
 
+  nativeBuildInputs = [ opaline ];
   buildInputs = [ ocaml findlib ocamlbuild ];
 
   buildFlags = [ "lib" ];
 
-  inherit (dune) installPhase;
+  installPhase = ''
+    opaline -prefix $out -libdir $OCAMLFIND_DESTDIR
+  '';
 
   meta = {
     description = "An embeddable Lua 2.5 interpreter implemented in OCaml";

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -9,7 +9,9 @@ let param =
     buildInputs = [ dune ];
     extra = {
       buildPhase = "dune build -p rope";
-      inherit (dune) installPhase;
+      installPhase = ''
+        dune install --prefix $out --libdir $OCAMLFIND_DESTDIR rope
+      '';
     };
   } else {
     version = "0.5";

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -7,7 +7,11 @@ let
     url = "https://github.com/ocaml-community/yojson/releases/download/${version}/yojson-${version}.tbz";
     sha256 = "08llz96if8bcgnaishf18si76cv11zbkni0aldb54k3cn7ipiqvd";
     nativeBuildInputs = [ dune ];
-    extra = { inherit (dune) installPhase; };
+    extra = {
+      installPhase = ''
+        dune install --prefix $out --libdir $OCAMLFIND_DESTDIR ${pname}
+      '';
+    };
   } else rec {
     version = "1.2.3";
     url = "https://github.com/ocaml-community/yojson/archive/v${version}.tar.gz";

--- a/pkgs/development/tools/ocaml/dune/default.nix
+++ b/pkgs/development/tools/ocaml/dune/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, ocaml, findlib }:
+{ stdenv, lib, fetchurl, ocaml, findlib }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !lib.versionAtLeast ocaml.version "4.02"
 then throw "dune is not available for OCaml ${ocaml.version}"
 else
 
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
 
   dontAddPrefix = true;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://dune.build/";
     description = "A composable build system";
-    maintainers = [ stdenv.lib.maintainers.vbgl stdenv.lib.maintainers.marsam ];
-    license = stdenv.lib.licenses.mit;
+    maintainers = [ maintainers.vbgl maintainers.marsam ];
+    license = licenses.mit;
     inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/tools/ocaml/dune/default.nix
+++ b/pkgs/development/tools/ocaml/dune/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, opaline }:
+{ stdenv, fetchurl, ocaml, findlib }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.02"
 then throw "dune is not available for OCaml ${ocaml.version}"
@@ -15,14 +15,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ];
 
   buildFlags = [ "release" ];
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "LIBDIR=$(OCAMLFIND_DESTDIR)"
+  ];
 
   dontAddPrefix = true;
-
-  installPhase = ''
-    runHook preInstall
-    ${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR
-    runHook postInstall
-  '';
 
   meta = {
     homepage = "https://dune.build/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This removes the dependency on `opaline` and means we could use `dune` for `opam-file-format` and the likes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
