### PR TITLE
sdlpop: init at 1.21

### DIFF
--- a/pkgs/games/sdlpop/default.nix
+++ b/pkgs/games/sdlpop/default.nix
@@ -1,0 +1,68 @@
+{ lib, stdenv
+, makeWrapper
+, makeDesktopItem, copyDesktopItems
+, fetchFromGitHub
+, pkg-config
+, SDL2, SDL2_image
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sdlpop";
+  version = "1.21";
+
+  src = fetchFromGitHub {
+    owner = "NagyD";
+    repo = "SDLPoP";
+    rev = "v${version}";
+    sha256 = "1q4mnyg8v4420f1bp24v8lgi335vijdv61yi3fan14jgfzl38l7w";
+  };
+
+  nativeBuildInputs = [ pkg-config makeWrapper copyDesktopItems ];
+  buildInputs = [ SDL2 SDL2_image ];
+
+  makeFlags = [ "-C" "src" ];
+
+  preBuild = ''
+    substituteInPlace src/Makefile --replace "CC = gcc" "CC = ${stdenv.cc.targetPrefix}gcc"
+  '';
+
+  # The prince binary expects two things of the working directory it is called from:
+  # (1) There is a subdirectory "data" containing the level data.
+  # (2) The working directory is writable, so save and quicksave files can be created.
+  # Our solution is to ensure that ~/.local/share/sdlpop is the working
+  # directory, symlinking the data files into it. This is the task of the
+  # prince.sh wrapper.
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 prince $out/bin/.prince-bin
+    substituteAll ${./prince.sh} $out/bin/prince
+    chmod +x $out/bin/prince
+
+    mkdir -p $out/share/sdlpop
+    cp -r data doc mods SDLPoP.ini $out/share/sdlpop
+
+    install -Dm755 data/icon.png $out/share/icons/hicolor/32x32/apps/sdlpop.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [ (makeDesktopItem {
+    name = "sdlpop";
+    icon = "sdlpop";
+    exec = "prince";
+    desktopName = "SDLPoP";
+    comment = "An open-source port of Prince of Persia";
+    categories = "Game;AdventureGame;";
+  }) ];
+
+  meta = with lib; {
+    description = "Open-source port of Prince of Persia";
+    homepage = "https://github.com/NagyD/SDLPoP";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ iblech ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/games/sdlpop/prince.sh
+++ b/pkgs/games/sdlpop/prince.sh
@@ -1,0 +1,16 @@
+#! @shell@
+
+set -euo pipefail
+
+mkdir -p ~/.local/share/sdlpop
+cd ~/.local/share/sdlpop
+
+for i in SDLPoP.ini mods; do
+  [ -e $i ] || cp -r @out@/share/sdlpop/$i .
+done
+
+# Create the data symlink or update it (in case it is a symlink, else the user
+# has probably tinkered with it and does not want it to be recreated).
+[ ! -e data -o -L data ] && ln -sf @out@/share/sdlpop/data .
+
+exec -a "prince" @out@/bin/.prince-bin "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26711,6 +26711,8 @@ in
     inherit (gnome3) zenity;
   };
 
+  sdlpop = callPackage ../games/sdlpop { };
+
   stepmania = callPackage ../games/stepmania {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Prince of Persia is widely considered one of the best games ever. This pull requests adds sdlpop to nixpkgs, an open-source reimplementation which is also available in Arch.

I took case to ensure that games can be saved and quicksaved (not entirely trivial, since the sdlpop binary writes save files into the current working directory and also expects to read its data files from it).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
