### PR TITLE
zeroad: fix build

### DIFF
--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, perl, fetchurl, python2
+{ gcc9Stdenv, lib, perl, fetchurl, python2
 , pkgconfig, spidermonkey_38, boost, icu, libxml2, libpng, libsodium
 , libjpeg, zlib, curl, libogg, libvorbis, enet, miniupnpc
 , openal, libGLU, libGL, xorgproto, libX11, libXcursor, nspr, SDL2
@@ -8,7 +8,7 @@
 
 assert withEditor -> wxGTK != null;
 
-stdenv.mkDerivation rec {
+gcc9Stdenv.mkDerivation rec {
   pname = "0ad";
   version = "0.0.23b";
 

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -43,6 +43,12 @@ gcc9Stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    # workaround caching issues on the ryzen platform, remove >= 0.0.24
+    # https://trac.wildfiregames.com/ticket/4360
+    sed -e 's|ENSURE|//ENSURE|g' -i source/lib/sysdep/arch/x86_x64/cache.cpp
+  '';
+
   configurePhase = ''
     # Delete shipped libraries which we don't need.
     rm -rf libraries/source/{enet,miniupnpc,nvtt,spidermonkey}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Fails to build with GCC10, hence the downgrade.

```
Linking Collada
/nix/store/c1gipyfc161lm0fqfg65k4ak7yl2i17i-binutils-2.34/bin/ld: ../../../libraries/source/fcollada/lib/libFColladaSR.a(FAXInstanceExport.o): in function `FArchiveXML::WritePhysicsRigidBodyInstance(FCDObject*, _xmlNode*)':
FAXInstanceExport.cpp:(.text+0xc69): undefined reference to `_xmlNode* FArchiveXML::AddPhysicsParameter<FMVector3, 0>(_xmlNode*, char const*, FCDParameterAnimatableT<FMVector3, 0>&)'
/nix/store/c1gipyfc161lm0fqfg65k4ak7yl2i17i-binutils-2.34/bin/ld: FAXInstanceExport.cpp:(.text+0xc7f): undefined reference to `_xmlNode* FArchiveXML::AddPhysicsParameter<FMVector3, 0>(_xmlNode*, char const*, FCDParameterAnimatableT<FMVector3, 0>&)'
collect2: error: ld returned 1 exit status
make[1]: *** [Collada.make:98: ../../../binaries/system/libCollada.so] Error 1
make: *** [Makefile:173: Collada] Error 2
builder for '/nix/store/dj7i8mm4kjnbizni4hlgh3394979gc6s-0ad-0.0.23b.drv' failed with exit code 2
```

Also applies the patch from @zeri42 in https://github.com/NixOS/nixpkgs/issues/100256#issuecomment-707334267

###### Motivation for this change

Closes: #100256

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


