### PR TITLE
python3Packages.pylutron: init at 0.2.6

### DIFF
--- a/pkgs/development/python-modules/pylutron/default.nix
+++ b/pkgs/development/python-modules/pylutron/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pylutron";
+  version = "0.2.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1q8qdy26s9hvfsh75pak7xiqjwrwsgq18p4d86dwf4dwmy5s4qj1";
+  };
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pylutron" ];
+
+  meta = with lib; {
+    description = "Python library for controlling a Lutron RadioRA 2 system";
+    homepage = "https://github.com/thecynic/pylutron";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -459,7 +459,7 @@
     "luci" = ps: with ps; [ openwrt-luci-rpc ];
     "luftdaten" = ps: with ps; [ luftdaten ];
     "lupusec" = ps: with ps; [ ]; # missing inputs: lupupy
-    "lutron" = ps: with ps; [ ]; # missing inputs: pylutron
+    "lutron" = ps: with ps; [ pylutron ];
     "lutron_caseta" = ps: with ps; [ ]; # missing inputs: pylutron-caseta
     "lw12wifi" = ps: with ps; [ ]; # missing inputs: lw12
     "lyft" = ps: with ps; [ ]; # missing inputs: lyft_rides

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5466,6 +5466,8 @@ in {
 
   PyLTI = callPackage ../development/python-modules/pylti { };
 
+  pylutron = callPackage ../development/python-modules/pylutron { };
+
   pymacaroons = callPackage ../development/python-modules/pymacaroons { };
 
   pymaging = callPackage ../development/python-modules/pymaging { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for controlling a Lutron RadioRA 2 system.

https://github.com/thecynic/pylutron

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   -  [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
