### PR TITLE
uboot: 2020.10 -> 2021.01

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -18,10 +18,10 @@
 }:
 
 let
-  defaultVersion = "2020.10";
+  defaultVersion = "2021.01";
   defaultSrc = fetchurl {
     url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    sha256 = "08m6f1bh4pdcqbxf983qdb66ccd5vak5cbzc114yf3jwq2yinj0d";
+    sha256 = "0m04glv9kn3bhs62sn675w60wkrl4m3a4hnbnnw67s3l198y21xl";
   };
   buildUBoot = {
     version ? null
@@ -55,7 +55,10 @@ let
       dtc
       flex
       openssl
-      (buildPackages.python3.withPackages (p: [ p.libfdt ]))
+      (buildPackages.python3.withPackages (p: [
+        p.libfdt
+        p.setuptools # for pkg_resources
+      ]))
       swig
     ];
     depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
###### Motivation for this change

 - https://lists.denx.de/pipermail/u-boot/2021-January/437056.html

(Sadly they stopped doing actual changelogs)

###### Things done

I built every uboot packages:

```
 $ nix-build --keep-going --no-out-link \<nixpkgs\> -A pkgsCross.aarch64-multiplatform.ubootBananaPim64 -A pkgsCross.aarch64-multiplatform.ubootOdroidC2 -A pkgsCross.aarch64-multiplatform.ubootOrangePiZeroPlus2H5 -A pkgsCross.aarch64-multiplatform.ubootPine64 -A pkgsCross.aarch64-multiplatform.ubootPine64LTS -A pkgsCross.aarch64-multiplatform.ubootPinebook -A pkgsCross.aarch64-multiplatform.ubootPinebookPro -A pkgsCross.aarch64-multiplatform.ubootQemuAarch64 -A pkgsCross.aarch64-multiplatform.ubootROCPCRK3399 -A pkgsCross.aarch64-multiplatform.ubootRaspberryPi3_64bit -A pkgsCross.aarch64-multiplatform.ubootRaspberryPi4_64bit -A pkgsCross.aarch64-multiplatform.ubootRock64 -A pkgsCross.aarch64-multiplatform.ubootRockPi4 -A pkgsCross.aarch64-multiplatform.ubootRockPro64 -A pkgsCross.aarch64-multiplatform.ubootSopine
 $ nix-build --keep-going --no-out-link \<nixpkgs\> -A pkgsCross.armv7l-hf-multiplatform.ubootA20OlinuxinoLime -A pkgsCross.armv7l-hf-multiplatform.ubootAmx335xEVM -A pkgsCross.armv7l-hf-multiplatform.ubootBananaPi -A pkgsCross.armv7l-hf-multiplatform.ubootBananaPim3 -A pkgsCross.armv7l-hf-multiplatform.ubootBeagleboneBlack -A pkgsCross.armv7l-hf-multiplatform.ubootClearfog -A pkgsCross.armv7l-hf-multiplatform.ubootJetsonTK1 -A pkgsCross.armv7l-hf-multiplatform.ubootNovena -A pkgsCross.armv7l-hf-multiplatform.ubootOdroidXU3 -A pkgsCross.armv7l-hf-multiplatform.ubootOrangePiPc -A pkgsCross.armv7l-hf-multiplatform.ubootPcduino3Nano -A pkgsCross.armv7l-hf-multiplatform.ubootQemuArm -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi2 -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi3_32bit -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi4_32bit -A pkgsCross.armv7l-hf-multiplatform.ubootUtilite -A pkgsCross.armv7l-hf-multiplatform.ubootWandboard
```

All are building (as they did just before).

I have **not** tested it yet on hardware.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


cc @petabyteboy @Mic92 @andir (recently showed interest in u-boot)