### PR TITLE
dex-oidc: 2.23.0 -> 2.27.0

### DIFF
--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -1,24 +1,24 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "dex";
-  version = "2.23.0";
+  version = "2.27.0";
 
   src = fetchFromGitHub {
     owner = "dexidp";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1fr5r7d0xwj0b69jhszyyif4yc4kiy7zpfcpf83zdy12mh8f96c8";
+    sha256 = "0n66nm91qcmm00mz8f8x39xqr3y05qxk34fvka53s6xax1gxvxxi";
   };
 
-  goPackagePath = "github.com/dexidp/dex";
+  vendorSha256 = "1k87q3ic02n2b632y3lmnclac1iaidmsl3f9py61myi5r02p03lp";
 
   subPackages = [
     "cmd/dex"
   ];
 
   buildFlagsArray = [
-    "-ldflags=-w -X github.com/dexidp/dex/version.Version=${src.rev}"
+    "-ldflags=-w -s -X github.com/dexidp/dex/version.Version=${src.rev}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #109155

Addresses [CVE-2020-2690](https://nvd.nist.gov/vuln/detail/CVE-2020-26290)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
