### PR TITLE
gerrit: 3.2.3 -> 3.3.1

### DIFF
--- a/pkgs/applications/version-management/gerrit/default.nix
+++ b/pkgs/applications/version-management/gerrit/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gerrit";
-  version = "3.2.3";
+  version = "3.3.1";
 
   src = fetchurl {
     url = "https://gerrit-releases.storage.googleapis.com/gerrit-${version}.war";
-    sha256 = "0hdxbn5qqqjzpqfcydz33nc351zanxp0j2k0ivizx4dn40fnavd7";
+    sha256 = "0swj3lmxwh4a0gnkirqrh7znzizsizy3cnlinhhsi319qns2szb1";
   };
 
   buildCommand = ''


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/109167
Addresses CVE-2020-8919
Addresses CVE-2020-8920

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
