### PR TITLE
python3Packages.zeroconf: disable tests when cross-compiling

### DIFF
--- a/pkgs/development/python-modules/zeroconf/default.nix
+++ b/pkgs/development/python-modules/zeroconf/default.nix
@@ -33,6 +33,10 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "test_lots_of_names"
   ];
+
+  # disable tests requiring network when cross-compiling
+  doCheck = stdenv.buildPlatform != stdenv.hostPlatform;
+
   __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "zeroconf" ];


### PR DESCRIPTION
###### Motivation for this change

zeroconf tests requires network which is unavailable when doing emulation through qemu/binfmt

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
