### PR TITLE
vorbis-tools: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/applications/audio/vorbis-tools/default.nix
+++ b/pkgs/applications/audio/vorbis-tools/default.nix
@@ -1,26 +1,17 @@
-{ lib, stdenv, fetchurl, fetchzip, libogg, libvorbis, libao, pkg-config, curl
-, speex, flac }:
+{ lib, stdenv, fetchurl, libogg, libvorbis, libao, pkg-config, curl
+, speex, flac
+, autoreconfHook }:
 
-let
-  debPatch = fetchzip {
-    url = "mirror://debian/pool/main/v/vorbis-tools/vorbis-tools_1.4.0-11.debian.tar.xz";
-    sha256 = "0kvmd5nslyqplkdb7pnmqj47ir3y5lmaxd12wmrnqh679a8jhcyi";
-  };
-in
-stdenv.mkDerivation {
-  name = "vorbis-tools-1.4.0";
+stdenv.mkDerivation rec {
+  pname = "vorbis-tools";
+  version = "1.4.2";
+
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/vorbis/vorbis-tools-1.4.0.tar.gz";
-    sha256 = "1g12bnh5ah08v529y72kfdz5lhvy75iaz7f9jskyby23m9dkk2d3";
+    url = "http://downloads.xiph.org/releases/vorbis/vorbis-tools-${version}.tar.gz";
+    sha256 = "1c7h4ivgfdyygz2hyh6nfibxlkz8kdk868a576qkkjgj5gn78xyv";
   };
 
-  postPatch = ''
-    for patch in $(ls "${debPatch}"/patches/*.{diff,patch} | grep -v debian_subdir)
-    do patch -p1 < "$patch"
-    done
-  '';
-
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ libogg libvorbis libao curl speex flac ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25426,7 +25426,9 @@ in
 
   volnoti = callPackage ../applications/misc/volnoti { };
 
-  vorbis-tools = callPackage ../applications/audio/vorbis-tools { };
+  vorbis-tools = callPackage ../applications/audio/vorbis-tools {
+    autoreconfHook = buildPackages.autoreconfHook269;
+  };
 
   vscode = callPackage ../applications/editors/vscode/vscode.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #56371

The [upstream issue](https://gitlab.xiph.org/xiph/vorbis-tools/issues/2324) @vcunat created, calling for a new release after a literal decade, was closed and [this commit](https://gitlab.xiph.org/xiph/vorbis-tools/-/commit/4ba87d43d177d66bac8bd1fc75dbd64d352b0e71) says 1.4.1 is now released.

Some of the debian patches stopped applying, but I'm not sure if all of them can be dropped. Debian hasn't updated (and [accroding to repology](https://repology.org/project/vorbis-tools/versions) nobody else either), so we can't just follow what they're doing, right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
