### PR TITLE
[staging] lvm2: 2.03.10 -> 2.03.11

### DIFF
--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -16,11 +16,11 @@ assert enableDmeventd -> enableCmdlib;
 
 stdenv.mkDerivation rec {
   pname = "lvm2" + stdenv.lib.optionalString enableDmeventd "with-dmeventd";
-  version = "2.03.10";
+  version = "2.03.11";
 
   src = fetchurl {
     url = "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz";
-    sha256 = "1l0fkn9abrgk5mfn6jfh9qhdr86b59l1c5pk6lp8jh0491d69las";
+    sha256 = "1m4xpda8vbyd89ca0w8nacvnl4j34yzsa625gn990fb5sh84ab44";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
https://github.com/lvmteam/lvm2/blob/v2_03_11/WHATS_NEW

[VDO](https://github.com/dm-vdo/vdo) support is built by default now,
but is disabled in nixpkgs, because it can't find `vdoformat`.
AFAICT the kernel support for that still isn't upstream and it still
seems kind of experimental, so I'd just ignore that for now and add it
once it's either upstream of if anyone actually wants to use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
