### PR TITLE
pytmx: 3.22.0 -> 3.24.0

### DIFF
--- a/pkgs/development/python-modules/pytmx/default.nix
+++ b/pkgs/development/python-modules/pytmx/default.nix
@@ -1,21 +1,28 @@
-{ lib, fetchFromGitHub, isPy3k, buildPythonPackage, pygame, pyglet, pysdl2, six }:
+{ lib, fetchFromGitHub
+, python, buildPythonPackage, isPy27
+, pygame, pyglet, pysdl2, six
+}:
 
 buildPythonPackage rec {
   pname = "pytmx";
-  version = "3.22.0";
+  version = "3.24.0";
+
+  disabled = isPy27;
 
   src = fetchFromGitHub {
     # The release was not git tagged.
     owner = "bitcraft";
     repo = "PyTMX";
-    rev = "187fd429dadcdc5828e78e6748a983aa1434e4d2";
-    sha256 = "0480pr61v54bwdyzb983sk0fqkyfbcgrdn8k11yf1yck4zb119gc";
+    rev = "eb96efea30d57b731654b2a167d86b8b553b147d";
+    sha256 = "1g1j4w75zw76p5f8m5v0hdigdlva2flf0ngyk8nvqcwzcl5vq5wc";
   };
 
   propagatedBuildInputs = [ pygame pyglet pysdl2 six ];
 
   checkPhase = ''
-    python -m unittest tests.pytmx.test_pytmx
+    # Change into the test directory due to a relative resource path.
+    cd tests/pytmx
+    ${python.interpreter} -m unittest test_pytmx
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Bump the package to its latest version. Also drop the Python 2.7 support, as they did upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
