### PR TITLE
python3Packages.pytest-factoryboy: 2.0.3 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/pytest-factoryboy/default.nix
+++ b/pkgs/development/python-modules/pytest-factoryboy/default.nix
@@ -1,42 +1,44 @@
-{ lib, stdenv
-, fetchFromGitHub
+{ lib
 , buildPythonPackage
-, pytestCheckHook
-, pytest
-, inflection
 , factory_boy
-, pytestcache
-, pytestcov
+, fetchFromGitHub
+, inflection
 , mock
+, pytest
+, pytestcache
+, pytestCheckHook
+, pytestcov
 }:
 
 buildPythonPackage rec {
   pname = "pytest-factoryboy";
-  version = "2.0.3";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-factoryboy";
     rev = version;
-    sha256 = "0m1snyybq2k51khlydhisq300vzys897vdbsicph628iran950hn";
+    sha256 = "0v6b4ly0p8nknpnp3f4dbslfsifzzjx2vv27rfylx04kzdhg4m9p";
   };
 
-  # TODO: remove in next release, it's removed in master.
-  postPatch = "substituteInPlace tox.ini --replace '--pep8' ''";
+  propagatedBuildInputs = [
+    factory_boy
+    inflection
+    pytest
+  ];
 
-  propagatedBuildInputs = [ factory_boy inflection pytest ];
-
-  # The project uses tox, which we can't. So we simply run pytest manually.
   checkInputs = [
     mock
     pytestCheckHook
     pytestcache
     pytestcov
   ];
+
   pytestFlagsArray = [ "--ignore=docs" ];
+  pythonImportsCheck = [ "pytest_factoryboy" ];
 
   meta = with lib; {
-    description = "Integration of factory_boy into the pytest runner.";
+    description = "Integration of factory_boy into the pytest runner";
     homepage = "https://pytest-factoryboy.readthedocs.io/en/latest/";
     maintainers = with maintainers; [ winpat ];
     license = licenses.mit;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.0.

Change log: https://github.com/pytest-dev/pytest-factoryboy/blob/master/CHANGES.rst#210

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
