### PR TITLE
python3Packages.aiokef: init at 0.2.17

### DIFF
--- a/pkgs/development/python-modules/aiokef/default.nix
+++ b/pkgs/development/python-modules/aiokef/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, async-timeout
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-cov
+, pytestCheckHook
+, pytest-mypy
+, pythonOlder
+, tenacity
+}:
+
+buildPythonPackage rec {
+  pname = "aiokef";
+  version = "0.2.17";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "basnijholt";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ms0dwrpj80w55svcppbnp7vyl5ipnjfp1c436k5c7pph4q5pxk9";
+  };
+
+  propagatedBuildInputs = [
+    async-timeout
+    tenacity
+  ];
+
+  checkInputs = [
+    pytest-cov
+    pytest-mypy
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests" ];
+  pythonImportsCheck = [ "aiokef" ];
+
+  meta = with lib; {
+    description = "Python API for KEF speakers";
+    homepage = "https://github.com/basnijholt/aiokef";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -413,7 +413,7 @@
     "kankun" = ps: with ps; [ ];
     "keba" = ps: with ps; [ ]; # missing inputs: keba-kecontact
     "keenetic_ndms2" = ps: with ps; [ ]; # missing inputs: ndms2_client
-    "kef" = ps: with ps; [ getmac ]; # missing inputs: aiokef
+    "kef" = ps: with ps; [ aiokef getmac ];
     "keyboard" = ps: with ps; [ ]; # missing inputs: pyuserinput
     "keyboard_remote" = ps: with ps; [ aionotify evdev ];
     "kira" = ps: with ps; [ ]; # missing inputs: pykira

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -242,6 +242,8 @@ in {
 
   aiokafka = callPackage ../development/python-modules/aiokafka { };
 
+  aiokef = callPackage ../development/python-modules/aiokef { };
+
   aiolifx = callPackage ../development/python-modules/aiolifx { };
 
   aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for KEF speakers.

https://github.com/basnijholt/aiokef

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
