### PR TITLE
python3Packages.gps3: init at 0.33.3

### DIFF
--- a/pkgs/development/python-modules/gps3/default.nix
+++ b/pkgs/development/python-modules/gps3/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "gps3";
+  version = "0.33.3";
+
+  src = fetchFromGitHub {
+    owner = "onkelbeh";
+    repo = pname;
+    rev = version;
+    sha256 = "0a0qpk7d2b1cld58qcdn6bxrkil6ascs51af01dy4p83062h1hi6";
+  };
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "gps3" ];
+
+  meta = with lib; {
+    description = "Python client for GPSD";
+    homepage = "https://github.com/onkelbeh/gps3";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -317,7 +317,7 @@
     "google_travel_time" = ps: with ps; [ googlemaps ];
     "google_wifi" = ps: with ps; [ ];
     "gpmdp" = ps: with ps; [ websocket_client ];
-    "gpsd" = ps: with ps; [ ]; # missing inputs: gps3
+    "gpsd" = ps: with ps; [ gps3 ];
     "gpslogger" = ps: with ps; [ aiohttp-cors ];
     "graphite" = ps: with ps; [ ];
     "gree" = ps: with ps; [ ]; # missing inputs: greeclimate

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2674,6 +2674,8 @@ in {
 
   gprof2dot = callPackage ../development/python-modules/gprof2dot { inherit (pkgs) graphviz; };
 
+  gps3 = callPackage ../development/python-modules/gps3 { };
+
   gpsoauth = callPackage ../development/python-modules/gpsoauth { };
 
   gpxpy = callPackage ../development/python-modules/gpxpy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for GPSD

https://github.com/onkelbeh/gps3

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
