### PR TITLE
python3Packages.pyinsteon: init at 1.0.8

### DIFF
--- a/pkgs/development/python-modules/pyinsteon/default.nix
+++ b/pkgs/development/python-modules/pyinsteon/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiofiles
+, aiohttp
+, async_generator
+, pypubsub
+, pyserial
+, pyserial-asyncio
+, pyyaml
+, pytestCheckHook
+, pythonOlder
+, pytest-cov
+, pytest-asyncio
+, pytest-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "pyinsteon";
+  version = "1.0.8";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "0d028fcqmdzxp0vsz7digx794s9l65ydsnsyvyx275z6577x7h4h";
+  };
+
+  propagatedBuildInputs = [
+    aiofiles
+    aiohttp
+    async_generator
+    pypubsub
+    pyserial
+    pyserial-asyncio
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-cov
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyinsteon" ];
+
+  meta = with lib; {
+    description = "Python library to support Insteon home automation projects";
+    longDescription = ''
+      This is a Python package to interface with an Insteon Modem. It has been
+      tested to work with most USB or RS-232 serial based devices such as the
+      2413U, 2412S, 2448A7 and Hub models 2242 and 2245.
+    '';
+    homepage = "https://github.com/pyinsteon/pyinsteon";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -388,7 +388,7 @@
     "input_number" = ps: with ps; [ ];
     "input_select" = ps: with ps; [ ];
     "input_text" = ps: with ps; [ ];
-    "insteon" = ps: with ps; [ ]; # missing inputs: pyinsteon
+    "insteon" = ps: with ps; [ pyinsteon ];
     "integration" = ps: with ps; [ ];
     "intent" = ps: with ps; [ aiohttp-cors ];
     "intent_script" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5392,6 +5392,8 @@ in {
 
   pyinputevent = callPackage ../development/python-modules/pyinputevent { };
 
+  pyinsteon = callPackage ../development/python-modules/pyinsteon { };
+
   pyipp = callPackage ../development/python-modules/pyipp { };
 
   pyiqvia = callPackage ../development/python-modules/pyiqvia { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a Python package to interface with an Insteon Modem. It has been
tested to work with most USB or RS-232 serial based devices such as the
2413U, 2412S, 2448A7 and Hub models 2242 and 2245.

https://github.com/pyinsteon/pyinsteon

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
