### PR TITLE
python3Packages.icmplib: init at 2.0.1

### DIFF
--- a/pkgs/development/python-modules/icmplib/default.nix
+++ b/pkgs/development/python-modules/icmplib/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pbr
+, pythonOlder
+, requests
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "icmplib";
+  version = "2.0.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ValentinBELYN";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0vps4iz87f8l0z3va92srsx5v19nnd65c22hvbgvhag3vhqsxg7h";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    six
+    requests
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "icmplib" ];
+
+  meta = with lib; {
+    description = "Python implementation of the ICMP protocol";
+    homepage = "https://github.com/ValentinBELYN/icmplib";
+    license = with licenses; [ lgpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -615,7 +615,7 @@
     "picotts" = ps: with ps; [ ];
     "piglow" = ps: with ps; [ ]; # missing inputs: piglow
     "pilight" = ps: with ps; [ ]; # missing inputs: pilight
-    "ping" = ps: with ps; [ ]; # missing inputs: icmplib
+    "ping" = ps: with ps; [ icmplib ];
     "pioneer" = ps: with ps; [ ];
     "pjlink" = ps: with ps; [ ]; # missing inputs: pypjlink2
     "plaato" = ps: with ps; [ aiohttp-cors ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2985,6 +2985,8 @@ in {
 
   icecream = callPackage ../development/python-modules/icecream { };
 
+  icmplib = callPackage ../development/python-modules/icmplib { };
+
   ics = callPackage ../development/python-modules/ics { };
 
   identify = callPackage ../development/python-modules/identify { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation of the ICMP protocol.

https://github.com/ValentinBELYN/icmplib

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
