### PR TITLE
usbguard: 0.7.8 -> 1.0.0

### DIFF
--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -1,5 +1,4 @@
-{
-  stdenv, fetchurl, lib,
+{ stdenv, fetchFromGitHub, lib, autoreconfHook,
   pkgconfig, libxslt, libxml2, docbook_xml_dtd_45, docbook_xsl, asciidoc,
   dbus-glib, libcap_ng, libqb, libseccomp, polkit, protobuf,
   audit,
@@ -15,14 +14,16 @@ stdenv.mkDerivation rec {
   version = "1.0.0";
   pname = "usbguard";
 
-  repo = "https://github.com/USBGuard/usbguard";
-
-  src = fetchurl {
-    url = "${repo}/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-VheYbNXdGi0xEEFkihl32DbPTjOkEh1/glmfIUlqvEI=";
+  src = fetchFromGitHub {
+    owner = "USBGuard";
+    repo = pname;
+    rev = "usbguard-${version}";
+    sha256 = "sha256-CPuBQmDOpXWn0jPo4HRyDCZUpDy5NmbvUHxXoVbMd/I=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
+    autoreconfHook
     asciidoc
     pkgconfig
     libxslt # xsltproc

--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -68,6 +68,12 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "The USBGuard software framework helps to protect your computer against BadUSB";
+    longDescription = ''
+      USBGuard is a software framework for implementing USB device authorization
+      policies (what kind of USB devices are authorized) as well as method of
+      use policies (how a USB device may interact with the system). Simply put,
+      it is a USB device whitelisting tool.
+    '';
     homepage = "https://usbguard.github.io/";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.tnias ];

--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -12,14 +12,14 @@ with stdenv.lib;
 assert libgcrypt != null -> libsodium == null;
 
 stdenv.mkDerivation rec {
-  version = "0.7.8";
+  version = "1.0.0";
   pname = "usbguard";
 
   repo = "https://github.com/USBGuard/usbguard";
 
   src = fetchurl {
     url = "${repo}/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "1il5immqfxh2cj8wn1bfk7l42inflzgjf07yqprpz7r3lalbxc25";
+    sha256 = "sha256-VheYbNXdGi0xEEFkihl32DbPTjOkEh1/glmfIUlqvEI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -1,12 +1,23 @@
-{ stdenv, fetchFromGitHub, lib, autoreconfHook,
-  pkgconfig, libxslt, libxml2, docbook_xml_dtd_45, docbook_xsl, asciidoc,
-  dbus-glib, libcap_ng, libqb, libseccomp, polkit, protobuf,
-  audit,
-  libgcrypt ? null,
-  libsodium ? null
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, asciidoc
+, pkgconfig
+, libxslt
+, libxml2
+, docbook_xml_dtd_45
+, docbook_xsl
+, dbus-glib
+, libcap_ng
+, libqb
+, libseccomp
+, polkit
+, protobuf
+, audit
+, libgcrypt
+, libsodium
 }:
-
-with stdenv.lib;
 
 assert libgcrypt != null -> libsodium == null;
 
@@ -55,7 +66,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "The USBGuard software framework helps to protect your computer against BadUSB";
     homepage = "https://usbguard.github.io/";
     license = licenses.gpl2Plus;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

@tnias

Bump usbguard to `1.0.0`, build "fully" from source\*, `nixpkgs-fmt`, add `longDescription`

\* (was previously built from source + pre-bundled with the submodules and some autoconfig)
```
λ ./result/bin/usbguard --help
 Usage: usbguard [OPTIONS] <command> [COMMAND OPTIONS] ...

 Options:

 Commands:
  get-parameter <name>           Get the value of a runtime parameter.
  set-parameter <name> <value>   Set the value of a runtime parameter.
  list-devices                   List all USB devices recognized by the USBGuard daemon.
  allow-device <id|rule|p-rule>  Authorize a device to interact with the system.
  block-device <id|rule|p-rule>  Deauthorize a device.
  reject-device <id|rule|p-rule> Deauthorize and remove a device from the system.

  list-rules                     List the rule set (policy) used by the USBGuard daemon.
  append-rule <rule>             Append a rule to the rule set.
  remove-rule <id>               Remove a rule from the rule set.

  generate-policy                Generate a rule set (policy) based on the connected USB devices.
  watch                          Watch for IPC interface events and print them to stdout.
  read-descriptor                Read a USB descriptor from a file and print it in human-readable form.

  add-user <name>                Add USBGuard IPC user/group (requires root privilges)
  remove-user <name>             Remove USBGuard IPC user/group (requires root privileges)
```

Contents:

```
result
├── bin
│   ├── usbguard
│   ├── usbguard-daemon
│   ├── usbguard-dbus
│   └── usbguard-rule-parser
├── etc
│   └── usbguard
│       ├── IPCAccessControl.d
│       ├── rules.conf
│       └── usbguard-daemon.conf
├── include
│   └── usbguard
│       ├── Audit.hpp
│       ├── ConfigFile.hpp
│       ├── Device.hpp
│       ├── DeviceManagerHooks.hpp
│       ├── DeviceManager.hpp
│       ├── Exception.hpp
│       ├── Interface.hpp
│       ├── IPCClient.hpp
│       ├── IPCServer.hpp
│       ├── KeyValueParser.hpp
│       ├── Logger.hpp
│       ├── MemoryRuleSet.hpp
│       ├── Policy.hpp
│       ├── Predicates.hpp
│       ├── RuleCondition.hpp
│       ├── Rule.hpp
│       ├── RuleSet.hpp
│       ├── Typedefs.hpp
│       ├── USBGuard.hpp
│       └── USB.hpp
├── lib
│   ├── libusbguard.la
│   ├── libusbguard.so -> libusbguard.so.1.0.0
│   ├── libusbguard.so.1 -> libusbguard.so.1.0.0
│   ├── libusbguard.so.1.0.0
│   └── pkgconfig
│       └── libusbguard.pc
├── sbin -> bin
├── share
│   ├── dbus-1
│   │   ├── system.d
│   │   │   └── org.usbguard1.conf
│   │   └── system-services
│   │       └── org.usbguard1.service
│   ├── man
│   │   ├── man1
│   │   │   └── usbguard.1.gz
│   │   ├── man5
│   │   │   ├── usbguard-daemon.conf.5.gz
│   │   │   └── usbguard-rules.conf.5.gz
│   │   └── man8
│   │       ├── usbguard-daemon.8.gz
│   │       └── usbguard-dbus.8.gz
│   └── polkit-1
│       └── actions
│           └── org.usbguard1.policy
└── var
    └── log
        └── usbguard
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
