### PR TITLE
 slimserver: add perlPackages.NetHTTPSNB as a dependency

### DIFF
--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -44,6 +44,7 @@ perlPackages.buildPerlPackage rec {
     perlPackages.LogLog4perl
     perlPackages.LWP
     perlPackages.NetHTTP
+    perlPackages.NetHTTPSNB
     perlPackages.ProcBackground
     perlPackages.SubName
     perlPackages.TemplateToolkit

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15106,6 +15106,21 @@ let
     doCheck = false; /* wants network */
   };
 
+  NetHTTPSNB = buildPerlPackage {
+    pname = "Net-HTTPS-NB";
+    version = "0.15";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/O/OL/OLEG/Net-HTTPS-NB-0.15.tar.gz";
+      sha256 = "0kwc4z8pqnbc396wjnlgdmri10zdh91f2bi6saxkpfjzlm7wysba";
+    };
+    propagatedBuildInputs = [ IOSocketSSL NetHTTP ];
+    meta = {
+      homepage = "https://github.com/olegwtf/p5-Net-HTTPS-NB";
+      description = "Non-blocking HTTPS client";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   NetIDNEncode = buildPerlModule {
     pname = "Net-IDN-Encode";
     version = "2.500";


### PR DESCRIPTION
###### Motivation for this change

This PR fixes #108617.

`slimserver` v. 7.9.2 introduced the CPAN module `Net::HTTPS::NB` as a new dependency. Because this dependency is currently not added through the package's derivation, the installation of plugins is no longer possible because the application fails to download its plugin repository database. Instead, the server logs the following message:

```
Jan 06 07:28:49 nixos systemd[1]: Started Slim Server for Logitech Squeezebox Players.
Jan 06 07:28:50 nixos slimserver.pl[20347]: Async::HTTP: Unable to load IO::Socket::SSL, will try connecting to SSL servers in non-SSL mode
Jan 06 07:28:50 nixos slimserver.pl[20347]: Base class package "Net::HTTPS::NB" is empty.
Jan 06 07:28:50 nixos slimserver.pl[20347]:     (Perhaps you need to 'use' the module which defines that package first,
Jan 06 07:28:50 nixos slimserver.pl[20347]:     or make that module available in @INC (@INC contains: [...]).
Jan 06 07:28:50 nixos slimserver.pl[20347]:  at /nix/store/1yzk49wk4wwxd2k0dzz3lhvg0p3pslzc-perl5.32.0-slimserver-7.9.2/Slim/Networking/Async/Socket/HTTPS.pm line 16.
Jan 06 07:28:50 nixos slimserver.pl[20347]: BEGIN failed--compilation aborted at /nix/store/1yzk49wk4wwxd2k0dzz3lhvg0p3pslzc-perl5.32.0-slimserver-7.9.2/Slim/Networking/Async/Socket/HTTPS.pm line 16.
Jan 06 07:28:50 nixos slimserver.pl[20347]: Compilation failed in require at /nix/store/1yzk49wk4wwxd2k0dzz3lhvg0p3pslzc-perl5.32.0-slimserver-7.9.2/Slim/Networking/Async/HTTP.pm line 22.
Jan 06 07:28:53 nixos slimserver.pl[20347]: [21-01-06 07:28:51.8711] main::init (387) Starting Logitech Media Server (v7.9.2, TRUNK, UNKNOWN) perl 5.032000 - aarch64-linux-thread-multi
```

Note that the initial error message (`Unable to load IO::Socket::SSL [...]`) is an [explicitly logged message](https://github.com/Logitech/slimserver/blob/6430144ee8b4c942a664c7d39cae0f18f87017f2/Slim/Networking/Async/HTTP.pm#L36) that is not correct in this specific case.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
