### PR TITLE
openldap: fix typo when specifying maintainers list

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -244,7 +244,7 @@ in {
     };
   };
 
-  meta.maintainers = with lib.maintainters; [ mic92 kwohlfahrt ];
+  meta.maintainers = with lib.maintainers; [ mic92 kwohlfahrt ];
 
   config = mkIf cfg.enable {
     assertions = map (opt: {


### PR DESCRIPTION
###### Motivation for this change
Fix small typo in openldap module when specifying maintainers list.