### PR TITLE
rizin: init at unstable-2021-01-13

### DIFF
--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchFromGitHub
+, ninja, meson
+, libzip, openssl, xxHash, zlib
+}:
+
+stdenv.mkDerivation {
+  pname = "rizin";
+  version = "unstable-2021-01-13";
+
+  src = fetchFromGitHub {
+    owner = "rizinorg";
+    repo = "rizin";
+    rev = "ca2471ae9596176c656f065ed74c480f13784e1b";
+    sha256 = "0qigy1px0jy74c5ig73dc2fqjcy6vcy76i25dx9r3as6zfpkkaxj";
+  };
+
+  postPatch = let
+    capstone = fetchFromGitHub {
+      owner = "aquynh";
+      repo = "capstone";
+      # version from $sourceRoot/shlr/Makefile
+      rev = "4.0.2";
+      sha256 = "0y5g74yjyliciawpn16zhdwya7bd3d7b1cccpcccc2wg8vni1k2w";
+    };
+  in ''
+    mkdir -p build/shlr
+    cp -r ${capstone} capstone-${capstone.rev}
+    chmod -R +w capstone-${capstone.rev}
+    tar -czvf shlr/capstone-${capstone.rev}.tar.gz capstone-${capstone.rev}
+  '';
+
+  configureFlags = [
+    "--with-syszip"
+    "--with-sysxxhash"
+    "--with-openssl"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ openssl zlib ];
+
+  propagatedBuildInputs = [ libzip xxHash ];
+
+  meta = {
+    description = "unix-like reverse engineering framework and commandline tools";
+    homepage = "https://rizin.re/";
+    license = stdenv.lib.licenses.lgpl3Only;
+    maintainers = with stdenv.lib.maintainers; [ pamplemousse ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12236,6 +12236,8 @@ in
     lua = lua5;
   } // (config.radare or {}))) radare2 r2-for-cutter;
 
+  rizin = callPackage ../development/tools/analysis/rizin { };
+
   radare2-cutter = libsForQt515.callPackage ../development/tools/analysis/radare2/cutter.nix { };
 
   ragel = ragelStable;


### PR DESCRIPTION
###### Motivation for this change

[rizin](https://rizin.re/) is a fork of [radare2](https://radare.org/n/).
And the software powering [Cutter](https://cutter.re/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Signed-off-by: Pamplemousse <xav.maso@gmail.com>