### PR TITLE
lagrange: init at 1.0.3

### DIFF
--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libunistring
+, openssl
+, pcre
+, SDL2
+, AppKit
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lagrange";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "skyjake";
+    repo = "lagrange";
+    rev = "v${version}";
+    sha256 = "1l9qcymjwg3wzbbi4hcyzfrxyqgz2xdy4ab3lr0zq38v025d794n";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ libunistring openssl pcre SDL2 ]
+    ++ lib.optional stdenv.isDarwin AppKit;
+
+  hardeningDisable = lib.optional (!stdenv.cc.isClang) "format";
+
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    mv Lagrange.app $out/Applications
+  '' else null;
+
+  meta = with lib; {
+    description = "A Beautiful Gemini Client";
+    homepage = "https://gmi.skyjake.fi/lagrange/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5371,6 +5371,10 @@ in
 
   kristall = libsForQt5.callPackage ../applications/networking/browsers/kristall { };
 
+  lagrange = callPackage ../applications/networking/browsers/lagrange {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
+
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };
 
   ma1sd = callPackage ../servers/ma1sd { };


### PR DESCRIPTION
###### Motivation for this change
> **[Lagrange](https://github.com/skyjake/lagrange)** is a desktop GUI client for browsing Geminispace. It offers modern conveniences familiar from web browsers, such as smooth scrolling, inline image viewing, multiple tabs, visual themes, Unicode fonts, bookmarks, history, and page outlines.

![scr0](https://user-images.githubusercontent.com/688044/104500108-05ee9a80-55ef-11eb-8129-d73b304e1630.jpg)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
