### PR TITLE
mesa: 20.3.2 -> 20.3.3

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -31,7 +31,7 @@ with stdenv.lib;
 let
   # Release calendar: https://www.mesa3d.org/release-calendar.html
   # Release frequency: https://www.mesa3d.org/releasing.html#schedule
-  version = "20.3.2";
+  version = "20.3.3";
   branch  = versions.major version;
 in
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
     ];
-    sha256 = "0gakhsj5qgm4wran7nlnz7kzgg3aj0a8f4q4dfbznfnjhnv03q6c";
+    sha256 = "0mnic7mfv5lgnn3swj7lbif8bl8pi2czlgr01jhq5s9q90nj2kpp";
   };
 
   prePatch = "patchShebangs .";
@@ -64,12 +64,6 @@ stdenv.mkDerivation {
       name = "nine_debug-Make-tid-more-type-correct";
       url = "https://gitlab.freedesktop.org/mesa/mesa/commit/aebbf819df6d1e.patch";
       sha256 = "17248hyzg43d73c86p077m4lv1pkncaycr3l27hwv9k4ija9zl8q";
-    })
-    # Fix for pre macOS SDK 10.13:
-    (fetchpatch { # util: Disable memstream for Apple builds
-      # MR: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/8269
-      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/f4403f70fe5bf2ec41af5546122f0d78caffa984.patch";
-      sha256 = "03j2aj255m7ms848nkb41vj3s3yb72zb5rz3w3fzp5l9wzzargw5";
     })
   ];
 


### PR DESCRIPTION
The "util: Disable memstream for Apple builds" patch got backported:
https://gitlab.freedesktop.org/mesa/mesa/-/commit/6a006c35675636cb0d2cbfdfb1681b6639e0664d

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
