### PR TITLE
quake3hires: init at 2020-05-07

### DIFF
--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchzip }:
+
+stdenv.mkDerivation {
+  pname = "quake3hires";
+  version = "2020-01-20"; # Unknown version, used the date of web.archive.org capture.
+
+  src = fetchzip {
+    url = "https://web.archive.org/web/20200120024216/http://ioquake3.org/files/xcsv_hires.zip";
+    sha256 = "09vhrray8mh1ic2qgcwv0zlmsnz789y32dkkvrz1vdki4yqkf717";
+    stripRoot = false;
+  };
+
+  buildCommand = ''
+    mkdir -p $out/baseq3
+    install -Dm444 $src/xcsv_bq3hi-res.pk3 $out/baseq3/xcsv_bq3hi-res.pk3
+  '';
+
+  preferLocalBuild = true;
+
+  meta = with lib; {
+    description = "Quake 3 high-resolution textures";
+    license = licenses.cc0;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26666,6 +26666,8 @@ in
 
   quake3pointrelease = callPackage ../games/quake3/content/pointrelease.nix { };
 
+  quake3hires = callPackage ../games/quake3/content/hires.nix { };
+
   quakespasm = callPackage ../games/quakespasm { };
   vkquake = callPackage ../games/quakespasm/vulkan.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
High resolution texture pack for Quake3 from https://ioquake3.org/extras/replacement_content/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).