### PR TITLE
mopidy-youtube: 3.1 -> 3.2

### DIFF
--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mopidy-youtube";
-  version = "3.1";
+  version = "3.2";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "Mopidy-YouTube";
-    sha256 = "1bn3nxianbal9f81z9wf2cxi893hndvrz2zdqvh1zpxrhs0cr038";
+    sha256 = "0wmalfqnskglssq3gj6kkrq6h6c9yab503y72afhkm7n9r5c57zz";
   };
 
   patchPhase = "sed s/bs4/beautifulsoup4/ -i setup.cfg";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

3.2 was released upstream which resolves https://github.com/natumbri/mopidy-youtube/issues/158

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've tested it using this overlay:

```nix
  let latest-mopidy-youtube = pkgs.mopidy-youtube.overrideAttrs (old: rec {
    pname = "mopidy-youtube";
    version = "3.2";

    src = pkgs.python3Packages.fetchPypi {
      inherit version;
      pname = "Mopidy-YouTube";
      sha256 = "0wmalfqnskglssq3gj6kkrq6h6c9yab503y72afhkm7n9r5c57zz";
    };
  });
```

I believe that this is not optimal for reviewing, would it be better to build using buildEnv, as I've seen in this PR https://github.com/NixOS/nixpkgs/pull/93808 ?

I've been running it for a few days and it works perfectly.