### PR TITLE
lxqt: fix themes and translations

### DIFF
--- a/pkgs/desktops/lxqt/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/liblxqt/default.nix
@@ -39,6 +39,9 @@ mkDerivation rec {
     xorg.libXScrnSaver
   ];
 
+  # convert name of wrapped binary, e.g. .lxqt-whatever-wrapped to the original name, e.g. lxqt-whatever so binaries can find their resources
+  patches = [ ./fix-application-path.patch ];
+
   postPatch = ''
     sed -i "s|\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}|''${out}/share/polkit-1/actions|" CMakeLists.txt
   '';

--- a/pkgs/desktops/lxqt/liblxqt/fix-application-path.patch
+++ b/pkgs/desktops/lxqt/liblxqt/fix-application-path.patch
@@ -1,0 +1,23 @@
+--- a/lxqtapplication.cpp
++++ b/lxqtapplication.cpp
+@@ -77,7 +77,7 @@ Application::Application(int &argc, char** argv, bool handleQuitSignals)
+ 
+ void Application::updateTheme()
+ {
+-    const QString styleSheetKey = QFileInfo(applicationFilePath()).fileName();
++    const QString styleSheetKey = QFileInfo(applicationFilePath()).fileName().mid(1).chopped(8);
+     setStyleSheet(lxqtTheme.qss(styleSheetKey));
+     Q_EMIT themeChanged();
+ }
+
+--- a/lxqttranslator.cpp
++++ b/lxqttranslator.cpp
+@@ -147,7 +147,7 @@ bool Translator::translateApplication(const QString &applicationName)
+     if (!applicationName.isEmpty())
+         return translate(applicationName);
+     else
+-        return translate(QFileInfo(QCoreApplication::applicationFilePath()).baseName());
++        return translate(QFileInfo(QCoreApplication::applicationFilePath()).baseName().mid(1).chopped(8));
+ }
+ 
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

LXQt binaries look for their themes and translations based on the name of the binary, which is changed by the wrapper script. This patches liblxqt to recover the original name from the wrapped binary name. This is intended to fix #70780.

I don't know if this is the best or most general solution to the problem. The root cause is that `QCoreApplication::applicationFilePath()` reads `/proc/self/exe` to determine the binary name, which points to the renamed wrapped binary, instead of using `argv[0]`, which points to the originally named wrapper script.

I'm not familiar with Qt, so I'm not sure what applications generally expect to use the path for. If it's mostly for locating resources relative to the binary, then I wonder if it would be better to patch Qt to read `argv[0]`. Consider that because of `wrapQtAppsHook`, `/proc/self/exe` will never be the original name of the binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
