### PR TITLE
ocamlPackages.dune_2: 2.7.1 -> 2.8.1, ocamlPackages.mdx: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -4,12 +4,12 @@
 
 buildDunePackage rec {
   pname = "mdx";
-  version = "1.7.0";
+  version = "1.8.0";
   useDune2 = true;
 
   src = fetchurl {
     url = "https://github.com/realworldocaml/mdx/releases/download/${version}/mdx-${version}.tbz";
-    sha256 = "0vpc30sngl3vpychrfvjwyi93mk311x3f2azlkxasgcj69fq03i7";
+    sha256 = "1p2ip73da271as0x1gfbajik3mf1bkc8l54276vgacn1ja3saj52";
   };
 
   nativeBuildInputs = [ cppo ];

--- a/pkgs/development/tools/ocaml/dune/2.nix
+++ b/pkgs/development/tools/ocaml/dune/2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, fetchpatch }:
+{ stdenv, fetchurl, ocaml, findlib }:
 
 if stdenv.lib.versionOlder ocaml.version "4.08"
 then throw "dune is not available for OCaml ${ocaml.version}"
@@ -6,24 +6,16 @@ else
 
 stdenv.mkDerivation rec {
   pname = "dune";
-  version = "2.7.1";
+  version = "2.8.0";
 
   src = fetchurl {
     url = "https://github.com/ocaml/dune/releases/download/${version}/dune-${version}.tbz";
-    sha256 = "0pcjf209gynjwipnpplaqyvyivnawqiwhvqnivhkybisicpqyln3";
+    sha256 = "12yly2lp93ijhy7b72p6y2q3cr3yy3hk7rlmrh072py8a6d4s407";
   };
 
   buildInputs = [ ocaml findlib ];
 
   buildFlags = "release";
-
-  patches = [
-    # Fix setup.ml configure path. Remove with the next release.
-    (fetchpatch {
-      url = "https://github.com/ocaml/dune/commit/8a3d7f2f2015b71384caa07226d1a89dba9d6c25.patch";
-      sha256 = "0dw4q10030h9xcdlxw2vp7qm0hd2qpkb98rir5d55m9vn65w8j28";
-    })
-  ];
 
   dontAddPrefix = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ocaml/dune/releases/tag/2.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
