### PR TITLE
hdf5-blosc: init at 1.0.0

### DIFF
--- a/pkgs/development/libraries/hdf5-blosc/blosc_filter.pc.in
+++ b/pkgs/development/libraries/hdf5-blosc/blosc_filter.pc.in
@@ -1,0 +1,13 @@
+prefix=@out@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: blosc_filter
+Description: Blosc Filter
+URL: http://blosc.org/
+Version: @version@
+Requires: \
+  blosc \
+  hdf5
+Cflags: -isystem${includedir}
+Libs: -L${libdir} -Wl,-rpath,${libdir} -lblosc_filter

--- a/pkgs/development/libraries/hdf5-blosc/default.nix
+++ b/pkgs/development/libraries/hdf5-blosc/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, c-blosc, cmake, hdf5, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "hdf5-blosc";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Blosc";
+    repo = pname;
+    rev =  "v${version}";
+    sha256 = "1nj2bm1v6ymm3fmyvhbn6ih5fgdiapavlfghh1pvbmhw71cysyqs";
+  };
+
+  patches = [ ./no-external-blosc.patch ];
+
+  outputs = [ "out" "dev" "plugin" ];
+
+  buildInputs = [ c-blosc cmake hdf5 ];
+
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt --replace 'set(BLOSC_INSTALL_DIR "''${CMAKE_CURRENT_BINARY_DIR}/blosc")' 'set(BLOSC_INSTALL_DIR "${c-blosc}")'
+  '';
+
+  cmakeFlags = [
+    "-DPLUGIN_INSTALL_PATH=${placeholder "plugin"}/hdf5/lib/plugin"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    substituteAll ${./blosc_filter.pc.in} $out/lib/pkgconfig/blosc_filter.pc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Filter for HDF5 that uses the Blosc compressor";
+    homepage = "https://github.com/Blosc/hdf5-blosc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/development/libraries/hdf5-blosc/no-external-blosc.patch
+++ b/pkgs/development/libraries/hdf5-blosc/no-external-blosc.patch
@@ -1,0 +1,26 @@
+--- a/CMakeLists.txt      2019-10-11 12:12:27.445417039 -0400
++++ b/CMakeLists.txt      2019-10-11 12:27:26.630691742 -0400
+@@ -22,14 +22,6 @@
+ message("BLOSC_CMAKE_ARGS='${BLOSC_CMAKE_ARGS}'")
+ message("GIT_EXECUTABLE='${GIT_EXECUTABLE}'")
+
+-ExternalProject_Add(project_blosc
+-  PREFIX ${BLOSC_PREFIX}
+-  GIT_REPOSITORY https://github.com/Blosc/c-blosc.git
+-  INSTALL_DIR ${BLOSC_INSTALL_DIR}
+-  CMAKE_ARGS ${BLOSC_CMAKE_ARGS}
+-)
+-
+-
+ # sources
+ set(SOURCES src/blosc_filter.c)
+ set(PLUGIN_SOURCES src/blosc_filter.c src/blosc_plugin.c )
+@@ -53,7 +45,6 @@
+ # add blosc libraries
+ add_library(blosc_shared SHARED IMPORTED)
+ set_property(TARGET blosc_shared PROPERTY IMPORTED_LOCATION ${BLOSC_INSTALL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}blosc${CMAKE_SHARED_LIBRARY_SUFFIX})
+-add_dependencies(blosc_shared project_blosc)
+ include_directories(${BLOSC_INSTALL_DIR}/include)
+
+ add_library(blosc_filter_shared SHARED ${SOURCES})
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4788,6 +4788,8 @@ in
       configureFlags = oldAttrs.configureFlags ++ ["--enable-threadsafe" "--disable-hl" ];
   }));
 
+  hdf5-blosc = callPackage ../development/libraries/hdf5-blosc { };
+
   hdfview = callPackage ../tools/misc/hdfview {
     javac = jdk8; # TODO: https://github.com/NixOS/nixpkgs/pull/89731
   };


### PR DESCRIPTION
###### Motivation for this change
This is a library/plugin used for the HDF5 data model utilities that integrates the high-throughput BLOSC compression scheme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
