### PR TITLE
python3Packages.pyvera: init at 0.3.11

### DIFF
--- a/pkgs/development/python-modules/pyvera/default.nix
+++ b/pkgs/development/python-modules/pyvera/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, pytest-cov
+, pytest-asyncio
+, pytest-timeout
+, responses
+, pytestCheckHook
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pyvera";
+  version = "0.3.11";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pavoni";
+    repo = pname;
+    rev = version;
+    sha256 = "0yi2cjd3jag95xa0k24f7d7agi26ywb3219a0j0k8l2nsx2sdi87";
+  };
+
+  patches = [
+    (fetchpatch {
+      # build-system section is missing https://github.com/pavoni/pyvera/pull/142
+      url = "https://github.com/pavoni/pyvera/pull/142/commits/e90995a8d55107118d324e8cf189ddf1d9e3aa6c.patch";
+      sha256 = "1psq3fiwg20kcwyybzh5g17dzn5fh29lhm238npyg846innbzgs7";
+    })
+  ];
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytest-cov
+    pytestCheckHook
+    responses
+  ];
+
+  pythonImportsCheck = [ "pyvera" ];
+
+  meta = with lib; {
+    description = "Python library to control devices via the Vera hub";
+    homepage = "https://github.com/pavoni/pyvera";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -894,7 +894,7 @@
     "velbus" = ps: with ps; [ ]; # missing inputs: python-velbus
     "velux" = ps: with ps; [ ]; # missing inputs: pyvlx
     "venstar" = ps: with ps; [ ]; # missing inputs: venstarcolortouch
-    "vera" = ps: with ps; [ ]; # missing inputs: pyvera
+    "vera" = ps: with ps; [ pyvera ];
     "verisure" = ps: with ps; [ jsonpath ]; # missing inputs: vsure
     "versasense" = ps: with ps; [ ]; # missing inputs: pyversasense
     "version" = ps: with ps; [ pyhaversion ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6348,6 +6348,8 @@ in {
 
   pyvcf = callPackage ../development/python-modules/pyvcf { };
 
+  pyvera = callPackage ../development/python-modules/pyvera { };
+
   pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
 
   pyvips = callPackage ../development/python-modules/pyvips {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to control devices via the Vera hub

https://github.com/pavoni/pyvera

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
