### PR TITLE
beefi: Init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9305,6 +9305,12 @@
     githubId = 303489;
     name = "Manuel Bärenz";
   };
+  tu-maurice = {
+    email = "valentin.gehrke+nixpkgs@zom.bi";
+    github = "tu-maurice";
+    githubId = 16151097;
+    name = "Valentin Gehrke";
+  };
   tv = {
     email = "tv@krebsco.de";
     github = "4z3";

--- a/pkgs/os-specific/linux/beefi/default.nix
+++ b/pkgs/os-specific/linux/beefi/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, installShellFiles
+, binutils-unwrapped
+, systemd }:
+
+stdenv.mkDerivation rec {
+  pname = "beefi";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jfeick";
+    repo = "beefi";
+    rev = version;
+    sha256 = "1180avalbw414q1gnfqdgc9zg3k9y0401kw9qvcn51qph81d04v5";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [
+    binutils-unwrapped
+    systemd
+  ];
+
+  patchPhase = ''
+    substituteInPlace beefi \
+      --replace objcopy ${binutils-unwrapped}/bin/objcopy \
+      --replace /usr/lib/systemd ${systemd}/lib/systemd
+  '';
+
+  installPhase = ''
+    install -Dm755 beefi $out/bin/beefi
+    installManPage beefi.1
+  '';
+
+  meta = with lib; {
+    description = "A small script to create bootable EFISTUB kernel images";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tu-maurice ];
+    homepage = "https://github.com/jfeick/beefi";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18362,6 +18362,8 @@ in
 
   batctl = callPackage ../os-specific/linux/batman-adv/batctl.nix { };
 
+  beefi = callPackage ../os-specific/linux/beefi { };
+
   blktrace = callPackage ../os-specific/linux/blktrace { };
 
   bluez5 = callPackage ../os-specific/linux/bluez { };


### PR DESCRIPTION
###### Motivation for this change
Closes #108996

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
