### PR TITLE
libvirt: 6.6.0 -> 6.8.0

### DIFF
--- a/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+++ b/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
@@ -1,0 +1,340 @@
+From a896b0be849455edb83a9305dfec9b41447ef3e4 Mon Sep 17 00:00:00 2001
+From: Euan Kemp <euank@euank.com>
+Date: Thu, 14 Jan 2021 00:32:00 -0800
+Subject: [PATCH] meson: patch in an install prefix for building on nix
+
+Used in the nixpkgs version of libvirt so that we can install things in
+the nix store, but read them from the root filesystem.
+---
+ meson.build                       |  9 +++++++++
+ meson_options.txt                 |  2 ++
+ src/libxl/meson.build             |  6 +++---
+ src/locking/meson.build           |  8 ++++----
+ src/lxc/meson.build               |  6 +++---
+ src/meson.build                   | 18 +++++++++---------
+ src/network/meson.build           | 12 ++++++------
+ src/nwfilter/xml/meson.build      |  2 +-
+ src/qemu/meson.build              | 14 +++++++-------
+ src/remote/meson.build            |  6 +++---
+ src/security/apparmor/meson.build |  8 ++++----
+ tools/meson.build                 |  4 ++--
+ 12 files changed, 53 insertions(+), 42 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 2e57a435df..4a72902a63 100644
+--- a/meson.build
++++ b/meson.build
+@@ -39,6 +39,8 @@ if host_machine.system() == 'windows'
+   conf.set('WINVER', '0x0600') # Win Vista / Server 2008
+ endif
+ 
++# patched in for nix
++install_prefix = get_option('install_prefix')
+ 
+ # set various paths
+ 
+@@ -57,6 +59,13 @@ else
+   sysconfdir = prefix / get_option('sysconfdir')
+ endif
+ 
++# nix: don't prefix the localstatedir; some things need to write to it, so it
++# can't be in the nix store, and that's what the prefix is.
++# We'll prefix things ourselves where needed
++localstatedir = get_option('localstatedir')
++# Same for sysconfidr
++sysconfdir = get_option('sysconfdir')
++
+ # if --prefix is /usr, don't use /usr/var for localstatedir or /usr/etc for
+ # sysconfdir as this makes a lot of things break in testing situations
+ if prefix == '/usr'
+diff --git a/meson_options.txt b/meson_options.txt
+index 74de064384..0a21eb845e 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,3 +1,5 @@
++option('install_prefix', type: 'string', value: '', description: 'prefix for nix store installation')
++
+ option('no_git', type: 'boolean', value: false, description: 'Disable git submodule update')
+ option('packager', type: 'string', value: '', description: 'Extra packager name')
+ option('packager_version', type: 'string', value: '', description: 'Extra packager version')
+diff --git a/src/libxl/meson.build b/src/libxl/meson.build
+index 3bb6cc5f2e..78d7be0ace 100644
+--- a/src/libxl/meson.build
++++ b/src/libxl/meson.build
+@@ -84,8 +84,8 @@ if conf.has('WITH_LIBXL')
+   }
+ 
+   virt_install_dirs += [
+-    localstatedir / 'lib' / 'libvirt' / 'libxl',
+-    runstatedir / 'libvirt' / 'libxl',
+-    localstatedir / 'log' / 'libvirt' / 'libxl',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'libxl',
++    install_prefix + runstatedir / 'libvirt' / 'libxl',
++    install_prefix + localstatedir / 'log' / 'libvirt' / 'libxl',
+   ]
+ endif
+diff --git a/src/locking/meson.build b/src/locking/meson.build
+index 8a28310e40..9da81cc574 100644
+--- a/src/locking/meson.build
++++ b/src/locking/meson.build
+@@ -243,14 +243,14 @@ if conf.has('WITH_LIBVIRTD')
+   }
+ 
+   virt_install_dirs += [
+-    localstatedir / 'lib' / 'libvirt' / 'lockd',
+-    localstatedir / 'lib' / 'libvirt' / 'lockd' / 'files',
+-    runstatedir / 'libvirt' / 'lockd',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'lockd',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'lockd' / 'files',
++    install_prefix + runstatedir / 'libvirt' / 'lockd',
+   ]
+ 
+   if conf.has('WITH_SANLOCK')
+     virt_install_dirs += [
+-      localstatedir / 'lib' / 'libvirt' / 'sanlock',
++      install_prefix + localstatedir / 'lib' / 'libvirt' / 'sanlock',
+     ]
+   endif
+ endif
+diff --git a/src/lxc/meson.build b/src/lxc/meson.build
+index f8e2a8852a..96d6687c5d 100644
+--- a/src/lxc/meson.build
++++ b/src/lxc/meson.build
+@@ -182,8 +182,8 @@ if conf.has('WITH_LXC')
+   }
+ 
+   virt_install_dirs += [
+-    localstatedir / 'lib' / 'libvirt' / 'lxc',
+-    runstatedir / 'libvirt' / 'lxc',
+-    localstatedir / 'log' / 'libvirt' / 'lxc',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'lxc',
++    install_prefix + runstatedir / 'libvirt' / 'lxc',
++    install_prefix + localstatedir / 'log' / 'libvirt' / 'lxc',
+   ]
+ endif
+diff --git a/src/meson.build b/src/meson.build
+index 29c8210ab2..bc960e0b69 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -669,7 +669,7 @@ endforeach
+ 
+ virt_conf_files += 'libvirt.conf'
+ 
+-install_data(virt_conf_files, install_dir: confdir)
++install_data(virt_conf_files, install_dir: install_prefix + confdir)
+ install_data(virt_aug_files, install_dir: virt_aug_dir)
+ 
+ # augeas_test_data:
+@@ -729,7 +729,7 @@ foreach data : virt_daemon_confs
+     output: '@0@.conf'.format(data['name']),
+     configuration: daemon_conf,
+     install: true,
+-    install_dir: confdir,
++    install_dir: install_prefix + confdir,
+   )
+ 
+   if data.get('with_ip', false)
+@@ -853,14 +853,14 @@ if conf.has('WITH_LIBVIRTD')
+ 
+       install_data(
+         init_file,
+-        install_dir: sysconfdir / 'init.d',
++        install_dir: install_prefix + sysconfdir / 'init.d',
+         rename: [ init['name'] ],
+       )
+ 
+       if init.has_key('confd')
+         install_data(
+           init['confd'],
+-          install_dir: sysconfdir / 'conf.d',
++          install_dir: install_prefix + sysconfdir / 'conf.d',
+           rename: [ init['name'] ],
+         )
+       endif
+@@ -872,7 +872,7 @@ if init_script != 'none'
+   foreach sysconf : sysconf_files
+     install_data(
+       sysconf['file'],
+-      install_dir: sysconfdir / 'sysconfig',
++      install_dir: install_prefix + sysconfdir / 'sysconfig',
+       rename: [ sysconf['name'] ],
+     )
+   endforeach
+@@ -897,10 +897,10 @@ endif
+ # Install empty directories
+ 
+ virt_install_dirs += [
+-  localstatedir / 'cache' / 'libvirt',
+-  localstatedir / 'lib' / 'libvirt' / 'images',
+-  localstatedir / 'lib' / 'libvirt' / 'filesystems',
+-  localstatedir / 'lib' / 'libvirt' / 'boot',
++  install_prefix + localstatedir / 'cache' / 'libvirt',
++  install_prefix + localstatedir / 'lib' / 'libvirt' / 'images',
++  install_prefix + localstatedir / 'lib' / 'libvirt' / 'filesystems',
++  install_prefix + localstatedir / 'lib' / 'libvirt' / 'boot',
+ ]
+ 
+ meson.add_install_script(
+diff --git a/src/network/meson.build b/src/network/meson.build
+index 13dd2c26b2..1be020081f 100644
+--- a/src/network/meson.build
++++ b/src/network/meson.build
+@@ -79,9 +79,9 @@ if conf.has('WITH_NETWORK')
+   }
+ 
+   virt_install_dirs += [
+-    localstatedir / 'lib' / 'libvirt' / 'network',
+-    localstatedir / 'lib' / 'libvirt' / 'dnsmasq',
+-    runstatedir / 'libvirt' / 'network',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'network',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'dnsmasq',
++    install_prefix + runstatedir / 'libvirt' / 'network',
+   ]
+ 
+   uuidgen_prog = find_program('uuidgen', required: false)
+@@ -98,7 +98,7 @@ if conf.has('WITH_NETWORK')
+       ],
+       capture: true,
+       install: true,
+-      install_dir: confdir / 'qemu' / 'networks',
++      install_dir: install_prefix + confdir / 'qemu' / 'networks',
+     )
+   else
+     configure_file(
+@@ -106,13 +106,13 @@ if conf.has('WITH_NETWORK')
+       output: '@BASENAME@',
+       copy: true,
+       install: true,
+-      install_dir: confdir / 'qemu' / 'networks',
++      install_dir: install_prefix + confdir / 'qemu' / 'networks',
+     )
+   endif
+ 
+   meson.add_install_script(
+     meson_python_prog.path(), python3_prog.path(), meson_install_symlink_prog.path(),
+-    confdir / 'qemu' / 'networks' / 'autostart',
++    install_prefix + confdir / 'qemu' / 'networks' / 'autostart',
+     '../default.xml', 'default.xml',
+   )
+ 
+diff --git a/src/nwfilter/xml/meson.build b/src/nwfilter/xml/meson.build
+index 95af75bb15..7fe99076f4 100644
+--- a/src/nwfilter/xml/meson.build
++++ b/src/nwfilter/xml/meson.build
+@@ -19,4 +19,4 @@ nwfilter_xml_files = [
+   'qemu-announce-self.xml',
+ ]
+ 
+-install_data(nwfilter_xml_files, install_dir: sysconfdir / 'libvirt' / 'nwfilter')
++install_data(nwfilter_xml_files, install_dir: install_prefix + sysconfdir / 'libvirt' / 'nwfilter')
+diff --git a/src/qemu/meson.build b/src/qemu/meson.build
+index 4e599d1e69..ba558d78f8 100644
+--- a/src/qemu/meson.build
++++ b/src/qemu/meson.build
+@@ -171,12 +171,12 @@ if conf.has('WITH_QEMU')
+   }
+ 
+   virt_install_dirs += [
+-    localstatedir / 'lib' / 'libvirt' / 'qemu',
+-    runstatedir / 'libvirt' / 'qemu',
+-    localstatedir / 'cache' / 'libvirt' / 'qemu',
+-    localstatedir / 'log' / 'libvirt' / 'qemu',
+-    localstatedir / 'lib' / 'libvirt' / 'swtpm',
+-    runstatedir / 'libvirt' / 'qemu' / 'swtpm',
+-    localstatedir / 'log' / 'swtpm' / 'libvirt' / 'qemu',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'qemu',
++    install_prefix + runstatedir / 'libvirt' / 'qemu',
++    install_prefix + localstatedir / 'cache' / 'libvirt' / 'qemu',
++    install_prefix + localstatedir / 'log' / 'libvirt' / 'qemu',
++    install_prefix + localstatedir / 'lib' / 'libvirt' / 'swtpm',
++    install_prefix + runstatedir / 'libvirt' / 'qemu' / 'swtpm',
++    install_prefix + localstatedir / 'log' / 'swtpm' / 'libvirt' / 'qemu',
+   ]
+ endif
+diff --git a/src/remote/meson.build b/src/remote/meson.build
+index 9ad2f6ab1c..429a15b326 100644
+--- a/src/remote/meson.build
++++ b/src/remote/meson.build
+@@ -245,7 +245,7 @@ if conf.has('WITH_REMOTE')
+     }
+ 
+     virt_install_dirs += [
+-      localstatedir / 'log' / 'libvirt',
++      install_prefix + localstatedir / 'log' / 'libvirt',
+     ]
+ 
+     logrotate_conf = configuration_data()
+@@ -259,7 +259,7 @@ if conf.has('WITH_REMOTE')
+       )
+       install_data(
+         log_file,
+-        install_dir: sysconfdir / 'logrotate.d',
++        install_dir: install_prefix + sysconfdir / 'logrotate.d',
+         rename: [ name ],
+       )
+     endforeach
+@@ -309,7 +309,7 @@ endif
+ if conf.has('WITH_SASL')
+   install_data(
+     'libvirtd.sasl',
+-    install_dir: sysconfdir / 'sasl2',
++    install_dir: install_prefix + sysconfdir / 'sasl2',
+     rename: [ 'libvirt.conf' ],
+   )
+ endif
+diff --git a/src/security/apparmor/meson.build b/src/security/apparmor/meson.build
+index af43780211..e2d6c812f8 100644
+--- a/src/security/apparmor/meson.build
++++ b/src/security/apparmor/meson.build
+@@ -17,22 +17,22 @@ foreach name : apparmor_gen_profiles
+     output: name,
+     configuration: apparmor_gen_profiles_conf,
+     install: true,
+-    install_dir: apparmor_dir,
++    install_dir: install_prefix + apparmor_dir,
+   )
+ endforeach
+ 
+ install_data(
+   [ 'libvirt-qemu', 'libvirt-lxc' ],
+-  install_dir: apparmor_dir / 'abstractions',
++  install_dir: install_prefix + apparmor_dir / 'abstractions',
+ )
+ 
+ install_data(
+   [ 'TEMPLATE.qemu', 'TEMPLATE.lxc' ],
+-  install_dir: apparmor_dir / 'libvirt',
++  install_dir: install_prefix + apparmor_dir / 'libvirt',
+ )
+ 
+ install_data(
+   'usr.lib.libvirt.virt-aa-helper.local',
+-  install_dir: apparmor_dir / 'local',
++  install_dir: install_prefix + apparmor_dir / 'local',
+   rename: 'usr.lib.libvirt.virt-aa-helper',
+ )
+diff --git a/tools/meson.build b/tools/meson.build
+index b8c6802f0a..dacd0ff1ce 100644
+--- a/tools/meson.build
++++ b/tools/meson.build
+@@ -115,7 +115,7 @@ if conf.has('WITH_LOGIN_SHELL')
+     install_rpath: libvirt_rpath,
+   )
+ 
+-  install_data('virt-login-shell.conf', install_dir: sysconfdir / 'libvirt')
++  install_data('virt-login-shell.conf', install_dir: install_prefix + sysconfdir / 'libvirt')
+ endif
+ 
+ if host_machine.system() == 'windows'
+@@ -274,7 +274,7 @@ configure_file(
+ if init_script == 'systemd'
+   install_data(
+     'libvirt-guests.sysconf',
+-    install_dir: sysconfdir / 'sysconfig',
++    install_dir: install_prefix + sysconfdir / 'sysconfig',
+     rename: 'libvirt-guests',
+   )
+ 
+-- 
+2.29.2
+

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -5,6 +5,7 @@
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
 , curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, dbus, libtirpc, rpcsvc-proto, darwin
+, meson, ninja, audit, cmake, bash-completion, pkg-config
 , enableXen ? false, xen ? null
 , enableIscsi ? false, openiscsi
 , enableCeph ? false, ceph
@@ -17,26 +18,24 @@ let
   buildFromTarball = stdenv.isDarwin;
 in stdenv.mkDerivation rec {
   pname = "libvirt";
-  version = "6.6.0";
+  version = "6.8.0";
 
   src =
     if buildFromTarball then
       fetchurl {
         url = "https://libvirt.org/sources/${pname}-${version}.tar.xz";
-        sha256 = "1y8y13zvh820f4b15287wb77wq7ra7kbfnpblzhm1dki5pfjvrcl";
+        sha256 = "0hhk2r0dnm9zmfwmnsnmnacm4pik6z60llp22axx7kcpqxv98nv5";
       }
     else
       fetchgit {
         url = "https://gitlab.com/libvirt/libvirt.git";
         rev = "v${version}";
-        sha256 = "09hsbm2qmx0jfmm418rf5lx374g85bwgg0kzlga62x5180jhsssn";
+        sha256 = "sha256-BQZPdmDE0g7xWd6QOHMKosP2HgVpIjsfgfohA9VxEHs=";
         fetchSubmodules = true;
       };
 
   nativeBuildInputs = [
-    makeWrapper pkgconfig docutils
-  ] ++ optionals (!buildFromTarball) [
-    autoreconfHook
+    ninja meson cmake makeWrapper pkgconfig docutils
   ] ++ optional (!stdenv.isDarwin) [
     rpcsvc-proto
   ] ++ optionals stdenv.isDarwin [
@@ -44,10 +43,11 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    bash-completion pkg-config
     libxml2 gnutls perl python2 readline gettext libtasn1 libgcrypt yajl
     libxslt xhtml1 perlPackages.XMLXPath curl libpcap glib dbus
   ] ++ optionals stdenv.isLinux [
-    libpciaccess lvm2 util-linux systemd libnl numad zfs
+    audit libpciaccess lvm2 utillinux systemd libnl numad zfs
     libapparmor libcap_ng numactl attr parted libtirpc
   ] ++ optionals (enableXen && stdenv.isLinux && stdenv.isx86_64) [
     xen
@@ -59,58 +59,58 @@ in stdenv.mkDerivation rec {
     libiconv gmp
   ];
 
-  preConfigure = ''
+  preConfigure = let
+    overrides = {
+      QEMU_BRIDGE_HELPER = "/run/wrappers/bin/qemu-bridge-helper";
+      QEMU_PR_HELPER="/run/libvirt/nix-helpers/qemu-pr-helper";
+      EBTABLES_PATH ="${ebtables}/bin/ebtables-legacy";
+    # "CFLAGS"=-I${libtirpc.dev}/include/tirpc";
+    };
+    patchBuilder = var: value: ''
+      sed -i meson.build -e "s|conf.set_quoted('${var}',.*|conf.set_quoted('${var}','${value}')|"
+    '';
+  in ''
     PATH=${stdenv.lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute iptables ebtables lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
     # the path to qemu-kvm will be stored in VM's .xml and .save files
     # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
     substituteInPlace src/lxc/lxc_conf.c \
       --replace 'lxc_path,' '"/run/libvirt/nix-emulators/libvirt_lxc",'
     patchShebangs . # fixes /usr/bin/python references
-    mkdir -p build && cd build
-  '';
-
-  configureScript = "../configure";
-
-  dontAddDisableDepTrack = true;
-
-  configureFlags = [
-    "--with-runstatedir=/run" # TODO: remove when autoconf 2.70 is released
-    "--localstatedir=/var"
-    "--sysconfdir=/var/lib"
-    "--with-libpcap"
-    "--with-qemu"
-    "--with-vmware"
-    "--with-vbox"
-    "--with-test"
-    "--with-esx"
-    "--with-remote"
-    "--with-polkit"
+  ''
+  #"QEMU_BRIDGE_HELPER" "/run/wrappers/bin/qemu-bridge-helper"
+  + (stdenv.lib.concatStringsSep "\n" (stdenv.lib.mapAttrsToList patchBuilder overrides))
+  ;
+  mesonAutoFeatures = "auto";
+  mesonFlags = let
+    opt = option: enable: "-D${option}=${if enable then "enabled" else "disabled"}";
+  in [
+    # "localstatedir=$(TMPDIR)/var"
+    # "sysconfdir=$(out)/var/lib"
+    "-Drunstatedir=/run"
+    # "-Dlocalstatedir=$(TMPDIR)/var"
+    "-Dsysconfdir=$(out)/var/lib"
+    "-Dlibpcap=enabled"
+    "-Ddriver_qemu=enabled"
+    "-Ddriver_vmware=enabled"
+    "-Ddriver_vbox=enabled"
+    "-Ddriver_test=enabled"
+    "-Ddriver_esx=enabled"
+    "-Ddriver_remote=enabled"
+    "-Dpolkit=enabled"
+    # "-Dbus=enabled"
+    (opt "storage_iscsi" enableIscsi)
   ] ++ optionals stdenv.isLinux [
-    "QEMU_BRIDGE_HELPER=/run/wrappers/bin/qemu-bridge-helper"
-    "QEMU_PR_HELPER=/run/libvirt/nix-helpers/qemu-pr-helper"
-    "EBTABLES_PATH=${ebtables}/bin/ebtables-legacy"
-    "CFLAGS=-I${libtirpc.dev}/include/tirpc"
-    "--with-attr"
-    "--with-apparmor"
-    "--with-secdriver-apparmor"
-    "--with-numad"
-    "--with-macvtap"
-    "--with-virtualport"
-    "--with-storage-disk"
-  ] ++ optionals (stdenv.isLinux && zfs != null) [
-    "--with-storage-zfs"
-  ] ++ optionals enableIscsi [
-    "--with-storage-iscsi"
-  ] ++ optionals enableCeph [
-    "--with-storage-rbd"
+    (opt "storage_zfs" (zfs != null))
+    "-Dattr=enabled"
+    "-Dapparmor=enabled"
+    "-Dsecdriver_apparmor=enabled"
+    "-Dnumad=enabled"
+    "-Dmacvtap=enabled"
+    "-Dvirtualport=enabled"
+    "-Dstorage_disk=enabled"
+    (opt "storage_rbd" enableCeph)
   ] ++ optionals stdenv.isDarwin [
-    "--with-init-script=none"
-  ];
-
-  installFlags = [
-    "runstatedir=${placeholder "out"}/run"
-    "localstatedir=$(TMPDIR)/var"
-    "sysconfdir=$(out)/var/lib"
+    "-Dinit_script=none"
   ];
 
   postInstall = let

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "6.6.0";
+  version = "6.8.0";
 
   src = assert version == libvirt.version; fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     rev = "v${version}";
-    sha256 = "0jj6b2nlx7qldwbvixz74abn3p0sq4lkf6ak74vynrv5xvlycb9v";
+    sha256 = "sha256-A3eRfzQAfubyPefDlq5bAiFJ/G90D2JKdJO2Em0wE00=";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

This PR carries forward #103309 with the same motivation (fixes a bug in libvirt that causes it to fail to start on non-btrfs setups).

###### Extra notes

There's a few odd things about this package still. The meson build patch is pretty intrusive, but I'm overall okay with that one I think.

The fact that it uses `/var/lib` instead of `/etc` for `sysconfdir` is also a little abnormal. The reason I'm leaving it like that is because the nixos module expects it, and I think it may be better to update the module separately from this meson-build-system change.

I've only done minimal testing of this, specifically the following:

1. ran libvirtd using the nixos module + this package
2. Used 'virt-manager' to run a nixos-minimal ISO, and verify it booted with the default nat networking

Of course, that's still better than 6.6.0 for me since 6.6.0 couldn't even get to the point of creating a disk image due to a bug, let alone booting something.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
