### PR TITLE
darkhttpd: drive-by cleanup

### DIFF
--- a/pkgs/servers/http/darkhttpd/default.nix
+++ b/pkgs/servers/http/darkhttpd/default.nix
@@ -12,19 +12,16 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   installPhase = ''
-    # install darkhttpd
-    install -Dm755 "darkhttpd" "$out/bin/darkhttpd"
-
-    # install license
-    install -d "$out/share/licenses/darkhttpd"
-    head -n 18 darkhttpd.c > "$out/share/licenses/darkhttpd/LICENSE"
+    install -Dm555 -t $out/bin darkhttpd
+    install -Dm444 -t $out/share/doc/${pname} README
+    head -n 18 darkhttpd.c > $out/share/doc/${pname}/LICENSE
   '';
 
   meta = with lib; {
     description = "Small and secure static webserver";
-    homepage    = "https://unix4lyfe.org/darkhttpd/";
-    license     = licenses.bsd3;
+    homepage = "https://unix4lyfe.org/darkhttpd/";
+    license = licenses.bsd3;
     maintainers = with maintainers; [ bobvanderlinden ];
-    platforms   = platforms.all;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This was part of something else but I had this patch sitting around and I'm trying to get as many local changes upstreamed as possible....

Cc @bobvanderlinden 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
