### PR TITLE
Fix header for generated Dhall documentation

### DIFF
--- a/pkgs/development/interpreters/dhall/build-dhall-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-package.nix
@@ -85,6 +85,6 @@ in
     ${lib.optionalString (documentationRoot != null) ''
     mkdir -p $out/${dataDhall}
 
-    XDG_DATA_HOME=$out/${data} ${dhall-docs}/bin/dhall-docs --input '${documentationRoot}' --output-link $out/docs
+    XDG_DATA_HOME=$out/${data} ${dhall-docs}/bin/dhall-docs --input '${documentationRoot}' --package-name '${name}' --output-link $out/docs
     ''}
   ''


### PR DESCRIPTION
By default, `dhall-docs` uses the name of the input directory
as the initial component of the documentation header.  However,
since the input directory is built using Nix the header contains
the Nix store hash in the name, which then appears in the
generated documentation.

The fix is to override this default behavior by supplying the
`--package-name` flag to `dhall-docs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
