### PR TITLE
Shrink the ZFS closure by making mail support optional

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -327,7 +327,9 @@ in
     };
 
     services.zfs.zed = {
-      enableMail = mkEnableOption "ZED's ability to send emails";
+      enableMail = mkEnableOption "ZED's ability to send emails" // {
+        default = cfgZfs.package.enableMail;
+      };
 
       settings = mkOption {
         type = with types; attrsOf (oneOf [ str int bool (listOf str) ]);
@@ -362,6 +364,14 @@ in
   config = mkMerge [
     (mkIf cfgZfs.enabled {
       assertions = [
+        {
+          assertion = cfgZED.enableMail -> cfgZfs.package.enableMail;
+          message = ''
+            To allow ZED to send emails, ZFS needs to be configured to enable
+            this. To do so, one must override the `zfs` package and set
+            `enableMail` to true.
+          '';
+        }
         {
           assertion = config.networking.hostId != null;
           message = "ZFS requires networking.hostId to be set";

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -326,30 +326,34 @@ in
       };
     };
 
-    services.zfs.zed.settings = mkOption {
-      type = with types; attrsOf (oneOf [ str int bool (listOf str) ]);
-      example = literalExample ''
-        {
-          ZED_DEBUG_LOG = "/tmp/zed.debug.log";
+    services.zfs.zed = {
+      enableMail = mkEnableOption "ZED's ability to send emails";
 
-          ZED_EMAIL_ADDR = [ "root" ];
-          ZED_EMAIL_PROG = "mail";
-          ZED_EMAIL_OPTS = "-s '@SUBJECT@' @ADDRESS@";
+      settings = mkOption {
+        type = with types; attrsOf (oneOf [ str int bool (listOf str) ]);
+        example = literalExample ''
+          {
+            ZED_DEBUG_LOG = "/tmp/zed.debug.log";
 
-          ZED_NOTIFY_INTERVAL_SECS = 3600;
-          ZED_NOTIFY_VERBOSE = false;
+            ZED_EMAIL_ADDR = [ "root" ];
+            ZED_EMAIL_PROG = "mail";
+            ZED_EMAIL_OPTS = "-s '@SUBJECT@' @ADDRESS@";
 
-          ZED_USE_ENCLOSURE_LEDS = true;
-          ZED_SCRUB_AFTER_RESILVER = false;
-        }
-      '';
-      description = ''
-        ZFS Event Daemon /etc/zfs/zed.d/zed.rc content
+            ZED_NOTIFY_INTERVAL_SECS = 3600;
+            ZED_NOTIFY_VERBOSE = false;
 
-        See
-        <citerefentry><refentrytitle>zed</refentrytitle><manvolnum>8</manvolnum></citerefentry>
-        for details on ZED and the scripts in /etc/zfs/zed.d to find the possible variables
-      '';
+            ZED_USE_ENCLOSURE_LEDS = true;
+            ZED_SCRUB_AFTER_RESILVER = false;
+          }
+        '';
+        description = ''
+          ZFS Event Daemon /etc/zfs/zed.d/zed.rc content
+
+          See
+          <citerefentry><refentrytitle>zed</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+          for details on ZED and the scripts in /etc/zfs/zed.d to find the possible variables
+        '';
+      };
     };
   };
 
@@ -437,7 +441,7 @@ in
       };
 
       services.zfs.zed.settings = {
-        ZED_EMAIL_PROG = mkDefault "${pkgs.mailutils}/bin/mail";
+        ZED_EMAIL_PROG = mkIf cfgZED.enableMail (mkDefault "${pkgs.mailutils}/bin/mail");
         PATH = lib.makeBinPath [
           cfgZfs.package
           pkgs.coreutils

--- a/pkgs/tools/system/smartmontools/default.nix
+++ b/pkgs/tools/system/smartmontools/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, autoreconfHook
-, mailutils, inetutils
+, mailutils, enableMail ? true
+, inetutils
 , IOKit, ApplicationServices }:
 
 let
@@ -26,7 +27,7 @@ in stdenv.mkDerivation rec {
   postPatch = "cp -v ${driverdb} drivedb.h";
 
   configureFlags = [
-    "--with-scriptpath=${lib.makeBinPath [ mailutils inetutils ]}"
+    "--with-scriptpath=${lib.makeBinPath ([ inetutils ] ++ lib.optional enableMail mailutils)}"
   ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/83865.

```sh
# in a nixpkgs checkout
$ nix why-depends -f. zfs mariadb-connector-c
'/nix/store/7s4kkijwv4wd3sl6jgn20yjai8zvini6-zfs-user-2.0.0' does not depend on '/nix/store/1h8r94mfhlfqd2wxqqnzff5rhjbrpimf-mariadb-connector-c-3.1.8'

$ nix why-depends -f. zfs openssl.dev
'/nix/store/7s4kkijwv4wd3sl6jgn20yjai8zvini6-zfs-user-2.0.0' does not depend on '/nix/store/vrsxvbphmqnhz8fww6zv0fa5fi8xipy3-openssl-1.1.1i-dev'

$ nix why-depends -f. zfs mailutils
'/nix/store/7s4kkijwv4wd3sl6jgn20yjai8zvini6-zfs-user-2.0.0' does not depend on '/nix/store/yjj734x773ydfkz1qx1z640nni1gd9bm-mailutils-3.10'

# in my system flake
$ nixos-rebuild build --flake .#bootstrap &>/dev/null && nix why-depends ./result nixpkgs#openssl.dev
'/nix/store/y4mjgvnvrpjhkiz4kkla2m4pckmb399x-nixos-system-scadrial-21.03.20210113.dirty-cosmere' does not depend on '/nix/store/vrsxvbphmqnhz8fww6zv0fa5fi8xipy3-openssl-1.1.1i-dev
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There's probably a better way to do this, but at least this gets the ball rolling / starts the conversation. Pinged all the people who participated in the original issue.

**TODO:** write docs?