### PR TITLE
pyopenssl: skip test that fails on 32-bit architectures

### DIFF
--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -56,7 +56,7 @@ let
     optionals (versionAtLeast (getVersion openssl.name) "1.1") failingOpenSSL_1_1Tests
   ) ++ (
     # https://github.com/pyca/pyopenssl/issues/974
-    optionals stdenv.isi686 [ "test_verify_with_time" ]
+    optionals stdenv.is32bit [ "test_verify_with_time" ]
   );
 
   # Compose the final string expression, including the "-k" and the single quotes.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Followup of #106810 to fix the build on other 32-bit architectures, like `armv7l`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
