### PR TITLE
draw-on-your-screen: v6 -> v10

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/draw-on-your-screen/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/draw-on-your-screen/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-draw-on-your-screen";
-  version = "6";
+  version = "10";
 
   src = fetchgit {
     url = "https://framagit.org/abakkk/DrawOnYourScreen/";
     rev = "v${version}";
-    sha256 = "05i20ii8lv6mg56rz8lng80dx35l6g45j8wr7jgbp591hg0spj1w";
+    sha256 = "07adzg3mf6k0pmd9lc358w0w3l4pr3p6374day1qhmci2p4zxq6p";
   };
 
   uuid = "drawOnYourScreen@abakkk.framagit.org";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A drawing extension for GNOME Shell";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ericdallo ];
+    maintainers = with maintainers; [ ericdallo ahuzik ];
     platforms = gnome3.gnome-shell.meta.platforms;
     homepage = "https://framagit.org/abakkk/DrawOnYourScreen";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

v6 is broken on current Gnome 3, v10 works well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
