### PR TITLE
pythonPackages.cert-chain-resolver: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/cert-chain-resolver/default.nix
+++ b/pkgs/development/python-modules/cert-chain-resolver/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, pytestCheckHook
+, pytest-mock
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "cert-chain-resolver";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "rkoopmans";
+    repo = "python-certificate-chain-resolver";
+    rev = version;
+    sha256 = "1kmig4ksbx1wvgcjn4r9jjg2pn1ag5rq871bjwxkp9kslb3x3d1l";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  checkInputs = [ pytestCheckHook pytest-mock ];
+
+  # online tests
+  disabledTests = [
+    "test_cert_returns_completed_chain"
+    "test_display_flag_is_properly_formatted"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/rkoopmans/python-certificate-chain-resolver";
+    description = "Resolve / obtain the certificate intermediates of a x509 certificate";
+    license = licenses.mit;
+    maintainers = with maintainers; [ veehaitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1161,6 +1161,8 @@ in {
 
   cerberus = callPackage ../development/python-modules/cerberus { };
 
+  cert-chain-resolver = callPackage ../development/python-modules/cert-chain-resolver { };
+
   certbot = callPackage ../development/python-modules/certbot { };
 
   certbot-dns-cloudflare = callPackage ../development/python-modules/certbot-dns-cloudflare { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolve / obtain the certificate intermediates of a x509 certificate.

Website: https://github.com/rkoopmans/python-certificate-chain-resolver

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).