### PR TITLE
python3Packages.diskcache: 4.1.0 -> 5.1.0

### DIFF
--- a/pkgs/development/python-modules/diskcache/default.nix
+++ b/pkgs/development/python-modules/diskcache/default.nix
@@ -1,7 +1,8 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytest
+, pytestCheckHook
 , pytestcov
 , pytest_xdist
 , pytest-django
@@ -11,28 +12,25 @@
 
 buildPythonPackage rec {
   pname = "diskcache";
-  version = "4.1.0";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "grantjenks";
     repo = "python-diskcache";
     rev = "v${version}";
-    sha256 = "0xy2vpk4hixb4gg871d9sx9wxdz8pi0pmnfdwg4bf8jqfjg022w8";
+    sha256 = "0xwqw60dbn1x2294galcs08vm6ydcr677lr8slqz8a3ry6sgkhn9";
   };
 
   checkInputs = [
-    pytest
+    pytestCheckHook
     pytestcov
     pytest_xdist
     pytest-django
     mock
   ];
 
-  disabled = lib.versionAtLeast django.version "2.0";
-
-  checkPhase = ''
-    pytest
-  '';
+  # Darwin sandbox causes most tests to fail.
+  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     description = "Disk and file backed persistent cache";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

update + unbreak on python3.8+

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
