### PR TITLE
gnomeExtensions.clock-override: init at 12

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/clock-override/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/clock-override/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchzip, gnome3, gettext, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-clock-override";
+  version = "12";
+
+  src = fetchzip {
+    url = "https://extensions.gnome.org/extension-data/clock-overridegnomeshell.kryogenix.org.v${version}.shell-extension.zip";
+    sha256 = "1cyaszks6bwnbgacqsl1pmr24mbj05mad59d4253la9am8ibb4m6";
+    stripRoot = false;
+  };
+
+  uuid = "clock-override@gnomeshell.kryogenix.org";
+
+  nativeBuildInputs = [ gettext glib ];
+
+  buildPhase = ''
+    runHook preBuild
+    glib-compile-schemas --strict --targetdir=schemas schemas
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r {convenience.js,extension.js,format.js,locale,metadata.json,prefs.js,schemas} $out/share/gnome-shell/extensions/${uuid}
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Customize the date and time format displayed in clock in the top bar in GNOME Shell";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rhoriguchi ];
+    homepage = "https://github.com/stuartlangridge/gnome-shell-clock-override";
+    broken = versionOlder gnome3.gnome-shell.version "3.18";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26977,6 +26977,7 @@ in
     arc-menu = callPackage ../desktops/gnome-3/extensions/arc-menu { };
     caffeine = callPackage ../desktops/gnome-3/extensions/caffeine { };
     clipboard-indicator = callPackage ../desktops/gnome-3/extensions/clipboard-indicator { };
+    clock-override = callPackage ../desktops/gnome-3/extensions/clock-override { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };


### PR DESCRIPTION
###### Motivation for this change

Add support for [GNOME extension Clock Override](https://extensions.gnome.org/extension/1206/clock-override/)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
