### PR TITLE
factorio-headless-experimental, factorio-experimental, factorio-demo-experimental: 1.1.8 -> 1.1.10

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.8.tar.xz",
+        "name": "factorio_alpha_x64-1.1.10.tar.xz",
         "needsAuth": true,
-        "sha256": "1zvjmdmvp05yr8lln4hsa184hl115sv9xz1dwxa3cb827f5ndd6m",
+        "sha256": "1vz0av669l6li87sld59v1yjlfxkzwdprbh152wnaym7sgszp3lq",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.8/alpha/linux64",
-        "version": "1.1.8"
+        "url": "https://factorio.com/get-download/1.1.10/alpha/linux64",
+        "version": "1.1.10"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.0.0.tar.xz",
@@ -20,12 +20,12 @@
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.0.0.tar.xz",
+        "name": "factorio_demo_x64-1.1.10.tar.xz",
         "needsAuth": false,
-        "sha256": "0h9cqbp143w47zcl4qg4skns4cngq0k40s5jwbk0wi5asjz8whqn",
+        "sha256": "151crxb5xihj9fygf5n335g342mjmqi9fs1nblx6nspk2s4firwm",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.0.0/demo/linux64",
-        "version": "1.0.0"
+        "url": "https://factorio.com/get-download/1.1.10/demo/linux64",
+        "version": "1.1.10"
       },
       "stable": {
         "name": "factorio_demo_x64-1.0.0.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.8.tar.xz",
+        "name": "factorio_headless_x64-1.1.10.tar.xz",
         "needsAuth": false,
-        "sha256": "1j2nmm61c99qis8fkc1gp5i3fj3vmc2mfds7lw4gfr9kr956cjhf",
+        "sha256": "1132spanr8w71v6y6ynd9ciy22nk60mz4vdaxgdnwmjd8yfbg1d7",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.8/headless/linux64",
-        "version": "1.1.8"
+        "url": "https://factorio.com/get-download/1.1.10/headless/linux64",
+        "version": "1.1.10"
       },
       "stable": {
         "name": "factorio_headless_x64-1.0.0.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* 1.1.9: https://forums.factorio.com/94351
* 1.1.10: https://forums.factorio.com/94371

Factorio demo appears to now have an experimental branch; but it's not packaged in nixpkgs and I think it was (probably?) unintentionally released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
