### PR TITLE
emacs: disable trampoline generation when installing packages

### DIFF
--- a/pkgs/build-support/emacs/elpa.nix
+++ b/pkgs/build-support/emacs/elpa.nix
@@ -26,7 +26,9 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
   installPhase = ''
     runHook preInstall
 
-    emacs --batch -Q -l ${./elpa2nix.el} \
+    emacs --batch -Q \
+        --eval "(setq comp-enable-subr-trampolines nil)" \
+        -l ${./elpa2nix.el} \
         -f elpa2nix-install-package \
         "${src}" "$out/share/emacs/site-lisp/elpa"
 

--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -67,6 +67,7 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
     cd "$NIX_BUILD_TOP"
 
     emacs --batch -Q \
+        --eval "(setq comp-enable-subr-trampolines nil)" \
         -L "$NIX_BUILD_TOP/package-build" \
         -l "$melpa2nix" \
         -f melpa2nix-build-package \
@@ -84,6 +85,7 @@ import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
     fi
 
     emacs --batch -Q \
+        --eval "(setq comp-enable-subr-trampolines nil)" \
         -l "$elpa2nix" \
         -f elpa2nix-install-package \
         "$archive" "$out/share/emacs/site-lisp/elpa"


### PR DESCRIPTION
In gccemacs, installing packages using `elpa2nix-install-package` sometimes causes trampolines to be compiled even if we are not running `batch-native-compile`. This happens, for example, when a package does a toplevel `add-advice`. Since we do not have `EMACSNATIVELOADPATH` set up when installing packages (and I believe we do not want to have it set up because native compilation is supposed to be a separate step), there won't be an output directory for the compiled trampoline. This is blocking `emacsGcc` in the overlay, see https://github.com/nix-community/emacs-overlay/issues/74#issuecomment-758160258.

- Built on platform(s)
   - [x] NixOS