### PR TITLE
python3Packages.azure-identity: mark as enabled

### DIFF
--- a/pkgs/development/python-modules/azure-identity/default.nix
+++ b/pkgs/development/python-modules/azure-identity/default.nix
@@ -18,7 +18,6 @@
 buildPythonPackage rec {
   pname = "azure-identity";
   version = "1.5.0";
-  disabled = isPy38;
 
   src = fetchPypi {
     inherit pname version;
@@ -37,11 +36,6 @@ buildPythonPackage rec {
     msrest
     msrestazure
   ];
-
-  prePatch = ''
-    substituteInPlace setup.py \
-      --replace msal-extensions~=0.1.3 msal-extensions
-  '';
 
   pythonImportsCheck = [ "azure.identity" ];
 


### PR DESCRIPTION
###### Motivation for this change
now supports 3.8, 3.9

msal patch no longer necessary

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
