### PR TITLE
nixpart0: stdenv.lib -> lib

### DIFF
--- a/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/blivet.nix
@@ -1,6 +1,6 @@
 # FIXME: Unify with pkgs/development/python-modules/blivet/default.nix.
 
-{ lib, stdenv, fetchurl, buildPythonApplication, pykickstart, pyparted, pyblock
+{ lib, fetchurl, buildPythonApplication, pykickstart, pyparted, pyblock
 , libselinux, cryptsetup, multipath_tools, lsof, util-linux
 , useNixUdev ? true, systemd ? null
 # useNixUdev is here for bw compatibility
@@ -30,13 +30,13 @@ buildPythonApplication rec {
     sed -i -e 's|"lsof"|"${lsof}/bin/lsof"|' blivet/formats/fs.py
     sed -i -r -e 's|"(u?mount)"|"${util-linux.bin}/bin/\1"|' blivet/util.py
     sed -i -e '/find_library/,/find_library/ {
-      c libudev = "${stdenv.lib.getLib systemd}/lib/libudev.so.1"
+      c libudev = "${lib.getLib systemd}/lib/libudev.so.1"
     }' blivet/pyudev.py
   '';
 
   propagatedBuildInputs = [
     pykickstart pyparted pyblock libselinux cryptsetup
-  ] ++ stdenv.lib.optional useNixUdev systemd;
+  ] ++ lib.optional useNixUdev systemd;
 
   # tests are currently _heavily_ broken upstream
   doCheck = false;

--- a/pkgs/tools/filesystems/nixpart/0.4/cryptsetup.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/cryptsetup.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, lvm2, libgcrypt, libuuid, pkgconfig, popt
+{ lib, stdenv, fetchurl, fetchpatch, lvm2, libgcrypt, libuuid, pkgconfig, popt
 , enablePython ? true, python ? null
 }:
 
@@ -22,17 +22,17 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [ "--enable-cryptsetup-reencrypt" ]
-                ++ stdenv.lib.optional enablePython "--enable-python";
+                ++ lib.optional enablePython "--enable-python";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ lvm2 libgcrypt libuuid popt ]
-             ++ stdenv.lib.optional enablePython python;
+             ++ lib.optional enablePython python;
 
-  meta = {
+  meta = with lib; {
     homepage = "http://code.google.com/p/cryptsetup/";
     description = "LUKS for dm-crypt";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ ];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -10,46 +10,46 @@
 
 let
   blivet = import ./blivet.nix {
-    inherit stdenv fetchurl buildPythonApplication;
+    inherit lib fetchurl buildPythonApplication;
     inherit pykickstart pyparted pyblock cryptsetup libselinux multipath_tools;
     inherit useNixUdev;
     inherit (pkgs) lsof util-linux systemd;
   };
 
   cryptsetup = import ./cryptsetup.nix {
-    inherit stdenv fetchurl python;
+    inherit lib stdenv fetchurl python;
     inherit (pkgs) fetchpatch pkgconfig libgcrypt libuuid popt lvm2;
   };
 
   dmraid = import ./dmraid.nix {
-    inherit stdenv fetchurl lvm2;
+    inherit lib stdenv fetchurl lvm2;
   };
 
   lvm2 = import ./lvm2.nix {
-    inherit stdenv fetchurl;
+    inherit lib stdenv fetchurl;
     inherit (pkgs) fetchpatch pkgconfig util-linux systemd coreutils;
   };
 
   multipath_tools = import ./multipath-tools.nix {
-    inherit stdenv fetchurl lvm2;
+    inherit lib stdenv fetchurl lvm2;
     inherit (pkgs) fetchpatch readline systemd libaio gzip;
   };
 
   parted = import ./parted.nix {
-    inherit stdenv fetchurl;
+    inherit lib stdenv fetchurl;
     inherit (pkgs) fetchpatch util-linux readline libuuid gettext check lvm2;
   };
 
   pyblock = import ./pyblock.nix {
-    inherit stdenv fetchurl python lvm2 dmraid;
+    inherit lib stdenv fetchurl python lvm2 dmraid;
   };
 
   pykickstart = import ./pykickstart.nix {
-    inherit stdenv fetchurl python buildPythonApplication urlgrabber;
+    inherit lib fetchurl python buildPythonApplication urlgrabber;
   };
 
   pyparted = import ./pyparted.nix {
-    inherit stdenv fetchurl python buildPythonApplication parted;
+    inherit lib stdenv fetchurl python buildPythonApplication parted;
     inherit (pkgs) pkgconfig e2fsprogs;
   };
 

--- a/pkgs/tools/filesystems/nixpart/0.4/dmraid.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/dmraid.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lvm2 }:
+{ lib, stdenv, fetchurl, lvm2 }:
 
 stdenv.mkDerivation rec {
   name = "dmraid-1.0.0.rc15";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ lvm2 ];
 
-  meta = {
+  meta = with lib; {
     description = "Old-style RAID configuration utility";
     longDescription = ''
       Old RAID configuration utility (still under development, though).
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       its volumes. May be needed for rescuing an older system or nuking
       the metadata when reformatting.
     '';
-    maintainers = [ stdenv.lib.maintainers.raskin ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/lvm2.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/lvm2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, systemd, util-linux, coreutils }:
+{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, systemd, util-linux, coreutils }:
 
 let
   v = "2.02.106";
@@ -68,9 +68,9 @@ stdenv.mkDerivation {
       cp scripts/lvm2_activation_generator_systemd_red_hat $out/lib/systemd/system-generators
     '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://sourceware.org/lvm2/";
     description = "Tools to support Logical Volume Management (LVM) on Linux";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/multipath-tools.nix
@@ -1,6 +1,6 @@
 # FIXME: unify with pkgs/os-specific/linux/multipath-tools/default.nix.
 
-{ stdenv, fetchurl, fetchpatch, lvm2, libaio, gzip, readline, systemd }:
+{ lib, stdenv, fetchurl, fetchpatch, lvm2, libaio, gzip, readline, systemd }:
 
 stdenv.mkDerivation rec {
   name = "multipath-tools-0.4.9";
@@ -36,8 +36,8 @@ stdenv.mkDerivation rec {
       substituteInPlace kpartx/kpartx.rules --replace /sbin/kpartx $out/sbin/kpartx
       substituteInPlace kpartx/kpartx_id --replace /sbin/dmsetup ${lvm2}/sbin/dmsetup
 
-      substituteInPlace libmultipath/defaults.h --replace /lib/udev/scsi_id ${stdenv.lib.getLib systemd}/lib/udev/scsi_id
-      substituteInPlace libmultipath/hwtable.c --replace /lib/udev/scsi_id ${stdenv.lib.getLib systemd}/lib/udev/scsi_id
+      substituteInPlace libmultipath/defaults.h --replace /lib/udev/scsi_id ${lib.getLib systemd}/lib/udev/scsi_id
+      substituteInPlace libmultipath/hwtable.c --replace /lib/udev/scsi_id ${lib.getLib systemd}/lib/udev/scsi_id
 
       sed -i -re '
          s,^( *#define +DEFAULT_MULTIPATHDIR\>).*,\1 "'"$out/lib/multipath"'",
@@ -45,9 +45,9 @@ stdenv.mkDerivation rec {
 
     '';
 
-  meta = {
+  meta = with lib; {
     description = "Tools for the Linux multipathing driver";
     homepage = "http://christophe.varoqui.free.fr/";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/parted.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/parted.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, lvm2, libuuid, gettext, readline
+{ lib,stdenv, fetchurl, fetchpatch, lvm2, libuuid, gettext, readline
 , util-linux, check
 , enableStatic ? stdenv.hostPlatform.isStatic
 }:
@@ -21,21 +21,21 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ libuuid ]
-    ++ stdenv.lib.optional (readline != null) readline
-    ++ stdenv.lib.optional (gettext != null) gettext
-    ++ stdenv.lib.optional (lvm2 != null) lvm2;
+    ++ lib.optional (readline != null) readline
+    ++ lib.optional (gettext != null) gettext
+    ++ lib.optional (lvm2 != null) lvm2;
 
   configureFlags =
        (if (readline != null)
         then [ "--with-readline" ]
         else [ "--without-readline" ])
-    ++ stdenv.lib.optional (lvm2 == null) "--disable-device-mapper"
-    ++ stdenv.lib.optional enableStatic "--enable-static";
+    ++ lib.optional (lvm2 == null) "--disable-device-mapper"
+    ++ lib.optional enableStatic "--enable-static";
 
   doCheck = true;
   checkInputs = [ check util-linux ];
 
-  meta = {
+  meta = with lib; {
     description = "Create, destroy, resize, check, and copy partitions";
 
     longDescription = ''
@@ -49,13 +49,13 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://www.gnu.org/software/parted/";
-    license = stdenv.lib.licenses.gpl3Plus;
+    license = licenses.gpl3Plus;
 
     maintainers = [
       # Add your name here!
     ];
 
     # GNU Parted requires libuuid, which is part of util-linux-ng.
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyblock.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, lvm2, dmraid }:
+{ lib, stdenv, fetchurl, python, lvm2, dmraid }:
 
 stdenv.mkDerivation rec {
   pname = "pyblock";
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
     "SITELIB=$(out)/lib/${python.libPrefix}/site-packages"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Interface for working with block devices";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pykickstart.nix
@@ -1,4 +1,4 @@
-{ stdenv, python, buildPythonApplication, fetchurl, urlgrabber }:
+{ lib, python, buildPythonApplication, fetchurl, urlgrabber }:
 
 buildPythonApplication rec {
   pname = "pykickstart";
@@ -22,9 +22,9 @@ buildPythonApplication rec {
     ${python}/bin/${python.executable} tests/baseclass.py -vv
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://fedoraproject.org/wiki/Pykickstart";
     description = "Read and write Fedora kickstart files";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
   };
 }

--- a/pkgs/tools/filesystems/nixpart/0.4/pyparted.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/pyparted.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, python, buildPythonApplication, parted, e2fsprogs }:
+{ lib, stdenv, fetchurl, pkgconfig, python, buildPythonApplication, parted, e2fsprogs }:
 
 buildPythonApplication rec {
   pname = "pyparted";
@@ -14,7 +14,7 @@ buildPythonApplication rec {
     sed -i -e '
       s|e\.path\.startswith("/tmp/temp-device-")|"temp-device-" in e.path|
     ' tests/test__ped_ped.py
-  '' + stdenv.lib.optionalString stdenv.isi686 ''
+  '' + lib.optionalString stdenv.isi686 ''
     # remove some integers in this test case which overflow on 32bit systems
     sed -i -r -e '/class *UnitGetSizeTestCase/,/^$/{/[0-9]{11}/d}' \
       tests/test__ped_ped.py
@@ -33,10 +33,10 @@ buildPythonApplication rec {
     make test PYTHON=${python.executable}
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://fedorahosted.org/pyparted/";
     description = "Python interface for libparted";
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes an evaluation error introduced by #108978:
```
error: --- TypeError ------------------------------------------------------------------------------------------------------------------------- nix
at: (12:12) in file: /nix/store/d6ydr6nsv9hra4ncdgpmg6x16744sb3m-source/pkgs/tools/filesystems/nixpart/0.4/default.nix

    11| let
    12|   blivet = import ./blivet.nix {
      |            ^
    13|     inherit stdenv fetchurl buildPythonApplication;

anonymous function at /nix/store/d6ydr6nsv9hra4ncdgpmg6x16744sb3m-source/pkgs/tools/filesystems/nixpart/0.4/blivet.nix:3:1 called without required argument 'lib'
```

The package currently can't be build for either `python3` because it's disabled or `python2` because `pycurl` doesn't support `python2`anymore.

```
$ nix build -f . python3Packages.nixpart0
error: --- ThrownError -------------------------------------------------------------------------- nix
nixpart-0.4.1 not supported for interpreter python3.8

$ nix build -f . pythonPackages.nixpart0
error: --- ThrownError -------------------------------------------------------------------------- nix
pycurl-7.43.0.6 not supported for interpreter python2.7
```

Despite the fact this package can't be build, I replaced all the remaining `stdenv.lib` references.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
