### PR TITLE
uthenticode: init at 1.0.4

### DIFF
--- a/pkgs/development/libraries/uthenticode/default.nix
+++ b/pkgs/development/libraries/uthenticode/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, gtest, openssl, pe-parse }:
+
+stdenv.mkDerivation rec {
+  pname = "uthenticode";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "uthenticode";
+    rev = "v${version}";
+    sha256 = "16j91cki63zk4d7wzwvq8al98l8hmvcdil3vfp44ink4q4bfswkx";
+  };
+
+  patches = [
+    # adds USE_SYSTEM_GTEST cmake flag, the patch won't be necessary in next versions
+    (fetchpatch {
+      url = "https://github.com/trailofbits/uthenticode/commit/7a4c5499c8e5ea7bfae1c620e1f96c112866b1dd.patch";
+      sha256 = "17637j5zwp71jmi803mv1z04arld3k3kmrm8nvrkpg08q5kizh28";
+    })
+  ];
+
+  cmakeFlags = [ "-DBUILD_TESTS=1" "-DUSE_SYSTEM_GTEST=1" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ pe-parse openssl gtest ];
+
+  doCheck = true;
+  checkPhase = "test/uthenticode_test";
+
+  meta = with lib; {
+    description = "A small cross-platform library for verifying Authenticode digital signatures.";
+    homepage = "https://github.com/trailofbits/uthenticode";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ arturcygan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16702,6 +16702,8 @@ in
 
   uthash = callPackage ../development/libraries/uthash { };
 
+  uthenticode = callPackage ../development/libraries/uthenticode { };
+
   utmps = skawarePackages.utmps;
 
   ucommon = ucommon_openssl;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
