### PR TITLE
salut_a_toi: fix evaluation error + stdenv.lib -> lib

### DIFF
--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
@@ -3,7 +3,7 @@
 let
   inherit (python27Packages) python;
   requirements = (import ./requirements.nix {
-    inherit stdenv fetchurl;
+    inherit lib fetchurl;
     pythonPackages = python27Packages;
   });
 

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix
@@ -1,5 +1,5 @@
 { fetchurl
-, lib, stdenv
+, lib
 , pythonPackages
 }:
 
@@ -8,7 +8,7 @@ let
 
   xe = buildPythonPackage rec {
     url = "http://www.blarg.net/%7Esteveha/xe-0.7.4.tar.gz";
-    name = stdenv.lib.nameFromURL url ".tar";
+    name = lib.nameFromURL url ".tar";
     src = fetchurl {
       inherit url;
       sha256 = "0v9878cl0y9cczdsr6xjy8v9l139lc23h4m5f86p4kpf2wlnpi42";
@@ -28,7 +28,7 @@ in {
   pyfeed = (buildPythonPackage rec {
     url = "http://www.blarg.net/%7Esteveha/pyfeed-0.7.4.tar.gz";
 
-    name = stdenv.lib.nameFromURL url ".tar";
+    name = lib.nameFromURL url ".tar";
 
     src = fetchurl {
       inherit url;
@@ -49,7 +49,7 @@ in {
 
   wokkel = buildPythonPackage (rec {
     url = "http://wokkel.ik.nu/releases/0.7.0/wokkel-0.7.0.tar.gz";
-    name = stdenv.lib.nameFromURL url ".tar";
+    name = lib.nameFromURL url ".tar";
     src = fetchurl {
       inherit url;
       sha256 = "0rnshrzw8605x05mpd8ndrx3ri8h6cx713mp8sl4f04f4gcrz8ml";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This fixes an evaluation error introduced by #108978:

```
at: (5:19) in file: /home/.../nixpkgs/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix

     4|   inherit (python27Packages) python;
     5|   requirements = (import ./requirements.nix {
      |                   ^
     6|     inherit stdenv fetchurl;

anonymous function at /home/.../nixpkgs/pkgs/applications/networking/instant-messengers/salut-a-toi/requirements.nix:1:1 called without required argument 'lib'
```

The package still can't be build because of broken dependencies:
```
$ nix build -f . salut_a_toi
error: --- ThrownError ----------------------------------------------------------------------- nix
urwid-2.1.2 not supported for interpreter python2.7
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
