### PR TITLE
python3Packages.waterfurnace: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/waterfurnace/default.nix
+++ b/pkgs/development/python-modules/waterfurnace/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, mock
+, pytest-runner
+, pytestCheckHook
+, requests
+, websocket_client
+}:
+
+buildPythonPackage rec {
+  pname = "waterfurnace";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "sdague";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ba247fw1fvi7zy31zj2wbjq7fajrbxhp139cl9jj67rfvxfv8xf";
+  };
+
+  propagatedBuildInputs = [
+    click
+    pytest-runner
+    requests
+    websocket_client
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "waterfurnace" ];
+
+  meta = with lib; {
+    description = "Python interface to waterfurnace geothermal systems";
+    homepage = "https://github.com/sdague/waterfurnace";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -915,7 +915,7 @@
     "wake_on_lan" = ps: with ps; [ wakeonlan ];
     "waqi" = ps: with ps; [ ]; # missing inputs: waqiasync
     "water_heater" = ps: with ps; [ ];
-    "waterfurnace" = ps: with ps; [ ]; # missing inputs: waterfurnace
+    "waterfurnace" = ps: with ps; [ waterfurnace ];
     "watson_iot" = ps: with ps; [ ]; # missing inputs: ibmiotf
     "watson_tts" = ps: with ps; [ ]; # missing inputs: ibm-watson
     "waze_travel_time" = ps: with ps; [ WazeRouteCalculator ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8009,6 +8009,8 @@ in {
 
   watchdog = callPackage ../development/python-modules/watchdog { };
 
+  waterfurnace = callPackage ../development/python-modules/waterfurnace { };
+
   WazeRouteCalculator = callPackage ../development/python-modules/WazeRouteCalculator { };
 
   wcwidth = callPackage ../development/python-modules/wcwidth { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python interface to waterfurnace geothermal systems.

https://github.com/sdague/waterfurnace

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
