### PR TITLE
python3Packages.orvibo: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/orvibo/default.nix
+++ b/pkgs/development/python-modules/orvibo/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, mock
+, pytest-runner
+, pytestCheckHook
+, requests
+, websocket_client
+}:
+
+buildPythonPackage rec {
+  pname = "orvibo";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "happyleavesaoc";
+    repo = "python-orvibo";
+    rev = version;
+    sha256 = "042prd5yxqvlfija7ii1xn424iv1p7ndhxv6m67ij8cbvspwx356";
+  };
+
+  # Project as no tests
+  doCheck = false;
+  pythonImportsCheck = [ "orvibo" ];
+
+  meta = with lib; {
+    description = "Python client to work with Orvibo devices";
+    homepage = "https://github.com/happyleavesaoc/python-orvibo";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -594,7 +594,7 @@
     "opple" = ps: with ps; [ ]; # missing inputs: pyoppleio
     "orangepi_gpio" = ps: with ps; [ ]; # missing inputs: OPi.GPIO
     "oru" = ps: with ps; [ ]; # missing inputs: oru
-    "orvibo" = ps: with ps; [ ]; # missing inputs: orvibo
+    "orvibo" = ps: with ps; [ orvibo ];
     "osramlightify" = ps: with ps; [ ]; # missing inputs: lightify
     "otp" = ps: with ps; [ pyotp ];
     "ovo_energy" = ps: with ps; [ ]; # missing inputs: ovoenergy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4501,6 +4501,8 @@ in {
 
   ortools = (toPythonModule (pkgs.or-tools.override { inherit (self) python; })).python;
 
+  orvibo = callPackage ../development/python-modules/orvibo { };
+
   osc = callPackage ../development/python-modules/osc { };
 
   oscrypto = callPackage ../development/python-modules/oscrypto { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client to work with Orvibo devices.

https://github.com/happyleavesaoc/python-orvibo

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
