### PR TITLE
ffmpeg-full: disable rav1e by default (in favor of svt-av1)

### DIFF
--- a/pkgs/tools/video/svt-av1/default.nix
+++ b/pkgs/tools/video/svt-av1/default.nix
@@ -15,8 +15,23 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "AV1-compliant encoder/decoder library core";
-    homepage = "https://github.com/AOMediaCodec/SVT-AV1";
-    license = licenses.bsd2;
+    longDescription = ''
+      The Scalable Video Technology for AV1 (SVT-AV1 Encoder and Decoder) is an
+      AV1-compliant encoder/decoder library core. The SVT-AV1 encoder
+      development is a work-in-progress targeting performance levels applicable
+      to both VOD and Live encoding / transcoding video applications. The
+      SVT-AV1 decoder implementation is targeting future codec research
+      activities.
+    '';
+    inherit (src.meta) homepage;
+    changelog = "https://github.com/AOMediaCodec/SVT-AV1/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [
+      bsd2
+      {
+        fullName = "Alliance for Open Media Patent License 1.0";
+        url = "https://aomedia.org/license/patent-license/";
+      }
+    ];
     platforms = platforms.unix;
     broken = stdenv.isAarch64; # undefined reference to `cpuinfo_arm_linux_init'
     maintainers = with maintainers; [ chiiruno ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13158,6 +13158,7 @@ in
 
   ffmpeg-full = callPackage ../development/libraries/ffmpeg-full {
     svt-av1 = if stdenv.isAarch64 then null else svt-av1;
+    rav1e = null; # We already have SVT-AV1 for faster encoding
     # The following need to be fixed on Darwin
     libjack2 = if stdenv.isDarwin then null else libjack2;
     libmodplug = if stdenv.isDarwin then null else libmodplug;


### PR DESCRIPTION
Since c378a33 we have a patch to add svt-av1 support to
ffmpeg-full. The default AV1 encoder is still libaom but svt-av1 has a
higher priority than rav1e (see libavcodec/allcodecs.c). And since
svt-av1 is much faster than rav1e (which in turn should be faster than
libaom) we don't really need rav1e support by default anymore (I guess
it can be useful but overall svt-av1 should currently be the best
option).
And because rav1e's build did break a few times in the past and needs a
lot of Rust dependencies (including cargo-c to make it C-ABI
compatible) it might be best to simply disable it for now.

Benchmarks (though it is difficult to compare them that way):
- https://openbenchmarking.org/test/pts/svt-av1
- https://openbenchmarking.org/test/pts/rav1e
- https://openbenchmarking.org/test/pts/aom-av1

###### Motivation for this change

@chiiruno (svt-av1), @codyopel (ffmpeg-full): Any opinions/objections?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
