### PR TITLE
stdenv: support meta.broken as a string to explain why it's broken

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -163,7 +163,7 @@ meta.hydraPlatforms = [];
 
 ### `broken` {#var-meta-broken}
 
-If set to `true`, the package is marked as "broken", meaning that it won’t show up in `nix-env -qa`, and cannot be built or installed. Such packages should be removed from Nixpkgs eventually unless they are fixed.
+If set to `true`, the package is marked as "broken", meaning that it won’t show up in `nix-env -qa`, and cannot be built or installed. The same happens when set to a non empty string value, in which case the text will be included in the error message shown when trying to build this package. Such packages should be removed from Nixpkgs eventually unless they are fixed.
 
 ### `updateWalker` {#var-meta-updateWalker}
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -97,12 +97,6 @@
 
 , ... } @ attrs:
 
-
-# Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-if disabled
-then throw "${name} not supported for interpreter ${python.executable}"
-else
-
 let
   inherit (python) stdenv;
 
@@ -176,6 +170,7 @@ let
       # default to python's platforms
       platforms = python.meta.platforms;
       isBuildPythonPackage = python.meta.platforms;
+      broken = lib.optionalString disabled "interpreter ${python.executable} is not supported by this version";
     } // meta;
   } // lib.optionalAttrs (attrs?checkPhase) {
     # If given use the specified checkPhase, otherwise use the setup hook.

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -66,7 +66,7 @@ in buildPythonPackage {
     platform = if stdenv.isDarwin then "mac" else "linux";
     unit = if cudaSupport then "gpu" else "cpu";
     key = "${platform}_py_${pyVerNoDot}_${unit}";
-  in fetchurl packages.${key};
+  in fetchurl packages.${key} or { };
 
   propagatedBuildInputs = [
     astunparse


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This draft is based on the idea of @FRidh in #48663 to add a new `meta.disabledBecause` attribute which can describe why a Python package can't be build. Instead of adding a new attribute with a similar purpose as an existing one (`meta.broken`), I tried to add the wanted feature to the existing attribute.

~~`meta.brokenBecause` allows to add a custom text to the current `Package ... is marked as broken ...` message. Setting a message also implies `broken = true` to reduce the chance of only setting a message, but not actually marking the package as broken.~~

Instead of only booleans, `meta.broken` can now also be set to a `string` containing a descriptive message which will be included in the `Package ... is marked as broken ...` message.

For example the message for disabled Python would look like this:
```
Package ‘python2.7-sqlparse-0.4.1’ in /.../pkgs/development/python-modules/sqlparse/default.nix:29 is marked as broken because interpreter python2.7 is not supported by this version, refusing to evaluate.

a) To temporarily allow broken packages, you can use an environment variable
...
```

I included the `buildPythonPackage` change in this PR to show the potential usage of the attribute. It can be split off when needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
