### PR TITLE
python3Packages.aioswitcher: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/aioswitcher/default.nix
+++ b/pkgs/development/python-modules/aioswitcher/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, aiohttp
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, poetry
+, pytest-aiohttp
+, pytest-asyncio
+, pytest-sugar
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aioswitcher";
+  version = "1.2.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "TomerFi";
+    repo = pname;
+    rev = version;
+    sha256 = "0wvca1jbyj4bwrpkpklbxnkvdp9zs7mrvg5b9vkx2hpyr81vyxam";
+  };
+
+  nativeBuildInputs = [ poetry ];
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [
+    asynctest
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-sugar
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "aioswitcher" ];
+
+  meta = with lib; {
+    description = "Python module to interact with Switcher water heater";
+    homepage = "https://github.com/TomerFi/aioswitcher";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -799,7 +799,7 @@
     "swisscom" = ps: with ps; [ ];
     "switch" = ps: with ps; [ ];
     "switchbot" = ps: with ps; [ ]; # missing inputs: PySwitchbot
-    "switcher_kis" = ps: with ps; [ ]; # missing inputs: aioswitcher
+    "switcher_kis" = ps: with ps; [ aioswitcher ];
     "switchmate" = ps: with ps; [ ]; # missing inputs: pySwitchmate
     "syncthru" = ps: with ps; [ ]; # missing inputs: pysyncthru url-normalize
     "synology" = ps: with ps; [ ]; # missing inputs: py-synology

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -272,6 +272,8 @@ in {
 
   aiostream = callPackage ../development/python-modules/aiostream { };
 
+  aioswitcher = callPackage ../development/python-modules/aioswitcher { };
+
   aiounifi = callPackage ../development/python-modules/aiounifi { };
 
   aiounittest = callPackage ../development/python-modules/aiounittest { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to interact with Switcher water heater

https://github.com/TomerFi/aioswitcher

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
