### PR TITLE
python3Packages.aiohttp-remotes: 0.1.2 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/aiohttp-remotes/default.nix
+++ b/pkgs/development/python-modules/aiohttp-remotes/default.nix
@@ -4,19 +4,12 @@
 
 buildPythonPackage rec {
   pname = "aiohttp_remotes";
-  version = "0.1.2";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "43c3f7e1c5ba27f29fb4dbde5d43b900b5b5fc7e37bf7e35e6eaedabaec4a3fc";
+    sha256 = "1vv2ancxsaxlls9sinigjnrqyx95n7cphq37m8nwifkhvs0idv6a";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/aio-libs/aiohttp-remotes/commit/188772abcea038c31dae7d607e487eeed44391bc.patch";
-      sha256 = "0pb1y4jb8ar1szhnjiyj2sdmdk6z9h6c3wrxw59nv9kr3if5igvs";
-    })
-  ];
 
   propagatedBuildInputs = [ aiohttp ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
