### PR TITLE
networking-ts-cxx: init at 2019-02-27

### DIFF
--- a/pkgs/development/libraries/networking-ts-cxx/default.nix
+++ b/pkgs/development/libraries/networking-ts-cxx/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "networking-ts-cxx";
+  version = "2019-02-27";
+
+  # Used until https://github.com/chriskohlhoff/networking-ts-impl/issues/17 is
+  # resolved and we can generate in Nix.
+  src = fetchFromGitHub {
+    owner = "chriskohlhoff";
+    repo = "networking-ts-impl";
+    rev = "c97570e7ceef436581be3c138868a19ad96e025b";
+    sha256 = "12b5lg989nn1b8v6x9fy3cxsf3hs5hr67bd1mfyh8pjikir7zv6j";
+  };
+
+  installPhase = ''
+    mkdir -p $out/{include,lib/pkgconfig}
+    cp -r include $out/
+    substituteAll ${./networking_ts.pc.in} $out/lib/pkgconfig/networking_ts.pc
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Experimental implementation of the C++ Networking Technical Specification";
+    homepage = "https://github.com/chriskohlhoff/networking-ts-impl";
+    license = licenses.boost;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/development/libraries/networking-ts-cxx/networking_ts.pc.in
+++ b/pkgs/development/libraries/networking-ts-cxx/networking_ts.pc.in
@@ -1,0 +1,8 @@
+prefix=@out@
+includedir=${prefix}/include
+
+Name: networking_ts
+Description: Experimental implementation of the C++ Networking Technical Specification
+URL: https://github.com/chriskohlhoff/networking-ts-impl
+Version: ${networking_ts_version}
+Cflags: -isystem${includedir}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6283,6 +6283,8 @@ in
 
   netcdffortran = callPackage ../development/libraries/netcdf-fortran { };
 
+  networking-ts-cxx = callPackage ../development/libraries/networking-ts-cxx { };
+
   nco = callPackage ../development/libraries/nco { };
 
   ncftp = callPackage ../tools/networking/ncftp { };


### PR DESCRIPTION
###### Motivation for this change
Although this entire package is actually included in the [asio library](https://github.com/chriskohlhoff/asio), which is already present in Nixpkgs, there is a valid reason for introducing it as a standalone package:

The headers implement a proposed C++ standard for networking. asio in fact provides these interfaces, but namespaced under asio, which leaks implementation details. Until [this issue](https://github.com/chriskohlhoff/networking-ts-impl/issues/17) is resolved, we are best off using this generated code as it's unclear how to get asio to export the exact interface from the standard ourselves.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
