### PR TITLE
libvirt: correct localstatedir

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -88,8 +88,8 @@ in stdenv.mkDerivation rec {
   in [
     "--sysconfdir=/var/lib"
     "-Dinstall_prefix=${placeholder "out"}"
-    "-Dlocalstatedir=/var/lib"
-    "-Drunstatedir=/var/run"
+    "-Dlocalstatedir=/var"
+    "-Drunstatedir=/run"
     "-Dlibpcap=enabled"
     "-Ddriver_qemu=enabled"
     "-Ddriver_vmware=enabled"


### PR DESCRIPTION
###### Motivation for this change

This is a followup to #109332 where I got this wrong.

It was supposed to be '/var' rather than '/var/lib'. This fixes an issue
where some tools didn't connect to the right socket (because they were
connecting to '$localstatedir/run/libvirt...' instead of
'$runstatedir/libvirt...').
Concretely, before this change vagrant's libvirt plugin failed and virsh and virt-manager succeeded. After this change, they all find the right socket.

Also change runstatedir to just be '/run' since it avoids a log line
complaining about that.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
