### PR TITLE
ubootNanoPCT4: Init at 2021.01

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -178,6 +178,13 @@ in {
     '';
   };
 
+  ubootNanoPCT4 = buildUBoot {
+    defconfig = "nanopc-t4-rk3399_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31="${armTrustedFirmwareRK3399}/bl31.elf";
+    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+  };
+
   ubootNovena = buildUBoot {
     defconfig = "novena_defconfig";
     extraMeta.platforms = ["armv7l-linux"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19680,6 +19680,7 @@ in
     ubootClearfog
     ubootGuruplug
     ubootJetsonTK1
+    ubootNanoPCT4
     ubootNovena
     ubootOdroidC2
     ubootOdroidXU3


### PR DESCRIPTION
###### Motivation for this change

For @tmountain, do not merge without their approval of the PR.

Assuming this board doesn't do anything extremely weird, it should work just like every other RK3399 board with mainline u-boot.

To test:

```
 $ nix-build -A pkgsCross.aarch64-multiplatform.ubootNanoPCT4
[...]
  CFGCHK  u-boot.cfg
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/fpryf9d42kayllzwv619rzmsjlgdclvw-uboot-nanopc-t4-rk3399_defconfig-2021.01-aarch64-unknown-linux-gnu
patching script interpreter paths in /nix/store/fpryf9d42kayllzwv619rzmsjlgdclvw-uboot-nanopc-t4-rk3399_defconfig-2021.01-aarch64-unknown-linux-gnu
checking for references to /build/ in /nix/store/fpryf9d42kayllzwv619rzmsjlgdclvw-uboot-nanopc-t4-rk3399_defconfig-2021.01-aarch64-unknown-linux-gnu...
/nix/store/fpryf9d42kayllzwv619rzmsjlgdclvw-uboot-nanopc-t4-rk3399_defconfig-2021.01-aarch64-unknown-linux-gnu

 $ dd if=result/idbloader.img of=/dev/mmcblkX conv=fsync,notrunc bs=512 seek=64

 $ dd if=result/u-boot.itb of=/dev/mmcblkX conv=fsync,notrunc bs=512 seek=16384
```

It is unknown to me if the HDMI output during u-boot should or should not be working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ Lacking hardware!
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
