### PR TITLE
fcitx5: 5.0.3 -> 5.0.4

### DIFF
--- a/pkgs/development/libraries/libime/default.nix
+++ b/pkgs/development/libraries/libime/default.nix
@@ -26,13 +26,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "1.0.2";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     rev = version;
-    sha256 = "hDfxuDIj9qx5d+UFwxDdP2PCboPnUV1n+VVoEIGsucM=";
+    sha256 = "sha256-Ykj4/3yKUqK0BRqW1E2zFYNgeUOXQ1DsotmKU6c8vEg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/libraries/xcb-imdkit/default.nix
+++ b/pkgs/development/libraries/xcb-imdkit/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xcb-imdkit";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "xcb-imdkit";
     rev = version;
-    sha256 = "dvax+Wj8+tHdiL6txcuugrOlRnxdIW25DYO4iNAYK8M=";
+    sha256 = "sha256-ISaVsMtDsyfhbhsAwDSWkQ7ZcpNtvC7M9NFQsWA5ju8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation rec {
     libxkbfile
   ];
 
+  passthru.updateScript = ./update.py;
+
   meta = with lib; {
     description = "Next generation of fcitx";
     homepage = "https://github.com/fcitx/fcitx5";

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -41,13 +41,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.0.3";
+  version = "5.0.4";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5";
     rev = version;
-    sha256 = "QYMH0WbhHqDKUvpj1VOB8U5sbBD89H6moLFkQBJijZA=";
+    sha256 = "sha256-2KGdR1m70Qatidzf/DZuFK3lc1t8z7sxjyhaxuc0Tqg=";
   };
 
   prePatch = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -31,13 +31,13 @@ in
 
 mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.0.2";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-chinese-addons";
     rev = version;
-    sha256 = "11UIMrwzZqO8nrQx5oubeoQN8hspL1mvHw5Dc9sVOqQ=";
+    sha256 = "sha256-kCihpRUtUXrqqf7FPQp8ZRexiygOuDVOdQwVx7tSn+c=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
@@ -6,6 +6,7 @@
 , fcitx5
 , fcitx5-qt
 , qtx11extras
+, qtquickcontrols2
 , kwidgetsaddons
 , kdeclarative
 , kirigami2
@@ -18,13 +19,13 @@
 
 mkDerivation rec {
   pname = "fcitx5-configtool";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-configtool";
     rev = version;
-    sha256 = "npSqd0R6bqKc+JxYCGcfVzgNLpuLtnHq6zM58smZ8/I=";
+    sha256 = "sha256-kw0KIbS5SVMf6kR/9xsYiChHXQBM0enSVXyh0QfiiPY=";
   };
 
   cmakeFlags = [
@@ -40,6 +41,7 @@ mkDerivation rec {
     fcitx5
     fcitx5-qt
     qtx11extras
+    qtquickcontrols2
     kirigami2
     isocodes
     xkeyboardconfig

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-gtk.nix
@@ -24,18 +24,20 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-gtk";
-  version = "5.0.1";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-gtk";
     rev = version;
-    sha256 = "rkusIqMRQMTjcpJR335as1xUQrzD9dLVB/wrLstPXPY=";
+    sha256 = "sha256-+BzXbZyzC3fvLqysufblk0zK9fAg5jslVdm/v3jz4B4=";
   };
 
   cmakeFlags = [
     "-DGOBJECT_INTROSPECTION_GIRDIR=share/gir-1.0"
     "-DGOBJECT_INTROSPECTION_TYPELIBDIR=lib/girepository-1.0"
+    # disabled since we currently don't have gtk4 in nixpkgs
+    "-DENABLE_GTK4_IM_MODULE=off"
   ] ++ lib.optional (! withGTK2) "-DENABLE_GTK2_IM_MODULE=off";
 
   buildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-lua";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-lua";
     rev = "${version}";
-    sha256 = "OiTk9ldqBqF7WT1KY71hacLD6OQQNO05F7+cSXlli40=";
+    sha256 = "sha256-lFlHn2q/kpq1EIKKhYVdJofXqtOHnpLz7PoWuNAhmhE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-lua";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-lFlHn2q/kpq1EIKKhYVdJofXqtOHnpLz7PoWuNAhmhE=";
   };
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -11,13 +11,13 @@
 
 mkDerivation rec {
   pname = "fcitx5-qt";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-qt";
     rev = version;
-    sha256 = "BVOumk2xj3vmwmm4KwiktQhWyTuUA2OFwYXNR6HgwyM=";
+    sha256 = "sha256-QylvjhjiIujYGKFtL4bKVXpobkN5t6Q2MGf16dsL24A=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-rime";
-  version = "5.0.2";
+  version = "5.0.3";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-rime";
     rev = version;
-    sha256 = "cVCTsD1Iw6OtyYFpxff3ix2CubRTnDaBevAYA4I9Ai8=";
+    sha256 = "sha256-mPNZ/B5bpxua+E1T+oz9v2QKAzGraA2cfT8oJacC35U=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-table-extra.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-table-extra.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-table-extra";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-table-extra";
     rev = version;
-    sha256 = "UHhiWm2Khh6JBB9jz0ZKFofkAJPlqn6SqHeK9etoaxs=";
+    sha256 = "sha256-Bqxdi/rjiTKqHLvVFVcQMjz/I0xxTiBgUIRkZjLuK+M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-table-other.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-table-other.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-table-other";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-table-other";
     rev = version;
-    sha256 = "hQlrjDPImDof2+3/uOtTdJ27cInevbxH9B+lNwquKbs=";
+    sha256 = "sha256-P+KaUmjAHe1CZ5rNMQAxwKSW5ZMVgQcwkgdlungXTLM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p nix-prefetch-github python3Packages.requests
+
+from nix_prefetch_github import *
+import json
+import requests
+import subprocess
+
+REPOS = [ "libime", "xcb-imdkit", "fcitx5", "fcitx5-gtk", "fcitx5-qt", "fcitx5-configtool", "fcitx5-lua",
+          "fcitx5-rime", "fcitx5-chinese-addons", "fcitx5-table-extra", "fcitx5-table-other" ]
+
+OWNER = "fcitx"
+
+def get_latest_tag(repo, owner=OWNER):
+    r = requests.get( 'https://api.github.com/repos/{}/{}/tags'.format(owner,repo)
+                    , auth=('poscat', 'db5e6fd16d0eb8c36385d3d944e058a1178b4265'))
+    return r.json()[0].get("name")
+
+def main():
+    sources = dict()
+    for repo in REPOS:
+        rev = get_latest_tag(repo)
+        if repo == "fcitx5-qt":
+            subprocess.run(["nix-update", "--commit", "--version", rev, "libsForQt5.{}".format(repo)])
+        else:
+            subprocess.run(["nix-update", "--commit", "--version", rev, repo])
+
+if __name__ == "__main__":
+    main ()


### PR DESCRIPTION
###### Things done
1. Update fcitx5 and related packages.
2. Add an update script
3. Centralize sources

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
