### PR TITLE
python3Packages.aresponses: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -1,12 +1,11 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-# propagatedBuildInputs
 , aiohttp
-# buildInputs
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
 , pytest
 , pytest-asyncio
-, isPy3k
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -15,9 +14,11 @@ buildPythonPackage rec {
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1jn7x7ldqsz5cd190jqjil0kqyimd1d0yxfzzp41ky0p72lvd68a";
+  src = fetchFromGitHub {
+    owner = "CircleUp";
+    repo = pname;
+    rev = version;
+    sha256 = "0dc1y4s6kpmr0ar63kkyghvisgbmb8qq5wglmjclrpzd5180mjcl";
   };
 
   propagatedBuildInputs = [
@@ -29,13 +30,24 @@ buildPythonPackage rec {
     pytest-asyncio
   ];
 
-  # tests only distributed via git repository, not pypi
-  doCheck = false;
+  checkInputs = [
+    aiohttp
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # Disable tests which requires network access
+  disabledTests = [
+    "test_foo"
+    "test_passthrough"
+  ];
+
+  pythonImportsCheck = [ "aresponses" ];
 
   meta = with lib; {
     description = "Asyncio testing server";
     homepage = "https://github.com/circleup/aresponses";
     license = licenses.mit;
-    maintainers = [ maintainers.makefu ];
+    maintainers = with maintainers; [ makefu ];
   };
 }

--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "aresponses";
-  version = "2.0.0";
+  version = "2.1.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "58693a6b715edfa830a20903ee1d1b2a791251923f311b3bebf113e8ff07bb35";
+    sha256 = "1jn7x7ldqsz5cd190jqjil0kqyimd1d0yxfzzp41ky0p72lvd68a";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyipp/default.nix
+++ b/pkgs/development/python-modules/pyipp/default.nix
@@ -1,11 +1,18 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy27
-, aiohttp, deepmerge, yarl
-, aresponses, pytest, pytest-asyncio, pytestcov }:
+{ lib
+, aiohttp
+, aresponses
+, buildPythonPackage
+, deepmerge
+, fetchFromGitHub
+, pytest-asyncio
+, pytestCheckHook
+, pytestcov
+, yarl
+}:
 
 buildPythonPackage rec {
   pname = "pyipp";
   version = "0.11.0";
-  disabled = isPy27;
 
   src = fetchFromGitHub {
    owner = "ctalkington";
@@ -22,14 +29,26 @@ buildPythonPackage rec {
 
   checkInputs = [
     aresponses
-    pytest
     pytest-asyncio
     pytestcov
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    pytest -q .
-  '';
+  # Some tests are failing due to encoding issues
+  # https://github.com/ctalkington/python-ipp/issues/121
+  disabledTests = [
+    "test_internal_session"
+    "test_request_port"
+    "est_http_error426"
+    "test_unexpected_response"
+    "test_printer"
+    "test_raw"
+    "test_ipp_request"
+    "test_request_tls"
+    "test_ipp_error_0x0503"
+  ];
+
+  pythonImportsCheck = [ "pyipp" ];
 
   meta = with lib; {
     description = "Asynchronous Python client for Internet Printing Protocol (IPP)";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.1.0

Change log: https://github.com/CircleUp/aresponses#210

Uses GitHub source now to be able to run the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
