### PR TITLE
openafs: 1.8.6 → 1.8.7 (emergency fix for unix timestamp 0x60000000)

### DIFF
--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.8.6";
+  version = "1.8.7";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "0i99klrw00v4bwd942n90xqfn16z6337m89xfm9dgv7ih0qrsklb";
+    sha256 = "0ygsrf65w9sqji2x3jbx3h31vk6513s6nalzxi7p2ryf3xb3lm2k";
   };
 
   srcs = [ src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "1s91kmxfimhdqrz7l6jgjz72j9pyalghrvg4h384fsz0ks6s4kz3";
+      sha256 = "0zri99pxmp4klh8ki5ycnjpf1h21lynn4049s6ywmap1vkpq84yn";
     })];
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes a critical upstream issue with OpenAFS clients started after 14 Jan 2021 08:25:36 AM UTC (Unix epoch time 0x60000000). See https://lists.openafs.org/pipermail/openafs-announce/2021/000539.html.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
