### PR TITLE
ocamlPackages.mimic: init at 0.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mimic/default.nix
+++ b/pkgs/development/ocaml-modules/mimic/default.nix
@@ -1,0 +1,47 @@
+{ lib, buildDunePackage, fetchurl
+, fmt, mirage-flow, result, rresult, cstruct, logs, ke
+, alcotest, alcotest-lwt, bigstringaf, bigarray-compat
+}:
+
+buildDunePackage rec {
+  pname = "mimic";
+  version = "0.0.1";
+
+  minimumOCamlVersion = "4.08";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/${pname}-${pname}-v${version}.tbz";
+    sha256 = "0j4l99sgm5mdmv67vakkz2pw45l6i89bpza88xqkgmskfk50c5pk";
+  };
+
+  # don't install changelogs for other packages
+  postPatch = ''
+    rm -f CHANGES.md CHANGES.carton.md
+  '';
+
+  propagatedBuildInputs = [
+    fmt
+    mirage-flow
+    result
+    rresult
+    cstruct
+    logs
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    alcotest-lwt
+    bigstringaf
+    bigarray-compat
+    ke
+  ];
+
+  meta = with lib; {
+    description = "A simple protocol dispatcher";
+    license = licenses.isc;
+    homepage = "https://github.com/mirage/ocaml-git";
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -574,6 +574,8 @@ let
 
     mezzo = callPackage ../development/compilers/mezzo { };
 
+    mimic = callPackage ../development/ocaml-modules/mimic { };
+
     minisat = callPackage ../development/ocaml-modules/minisat { };
 
     mirage = callPackage ../development/ocaml-modules/mirage { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New package which is required for `git` >= 3.0.0, but is versioned independently from `git`.

<https://github.com/mirage/ocaml-git/releases/tag/mimic-v0.0.1>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
