### PR TITLE
fontforge: 20200314 -> 20201107

### DIFF
--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchurl, lib
-, fetchpatch
+{ stdenv, fetchFromGitHub, lib
 , cmake, perl, uthash, pkg-config, gettext
 , python, freetype, zlib, glib, libungif, libpng, libjpeg, libtiff, libxml2, cairo, pango
 , readline, woff2, zeromq, libuninameslist
@@ -15,24 +14,14 @@ assert withGTK -> withGUI;
 
 stdenv.mkDerivation rec {
   pname = "fontforge";
-  version = "20200314";
+  version = "20201107";
 
-  src = fetchurl {
-    url = "https://github.com/${pname}/${pname}/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0qf88wd6riycq56d24brybyc93ns74s0nyyavm43zp2kfcihn6fd";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Rl/5lbXaPgIndANaD0IakaDus6T53FjiBb45FIuGrvc=";
   };
-
-  patches = [
-    # Unreleased fix for https://github.com/fontforge/fontforge/issues/4229
-    # which is required to fix an uninterposated `${CMAKE_INSTALL_PREFIX}/lib`, see
-    # see https://github.com/nh2/static-haskell-nix/pull/98#issuecomment-665395399
-    # TODO: Remove https://github.com/fontforge/fontforge/pull/4232 is in a release.
-    (fetchpatch {
-      name = "fontforge-cmake-set-rpath-to-the-configure-time-CMAKE_INSTALL_PREFIX";
-      url = "https://github.com/fontforge/fontforge/commit/297ee9b5d6db5970ca17ebe5305189e79a1520a1.patch";
-      sha256 = "14qfp8pwh0vzzib4hq2nc6xhn8lc1cal1sb0lqwb2q5dijqx5kqk";
-    })
-  ];
 
   # use $SOURCE_DATE_EPOCH instead of non-deterministic timestamps
   postPatch = ''


### PR DESCRIPTION

###### Motivation for this change


###### Things done

Fontforge does have a huge amount of reverse dependencies, but the risk of breaking anything should be quite low, as it usually only generates font files.

I tested this by building `fontforge fontforge-gtk fontforge-fonttools` (against `master` though, current staging needs to rebuild lots of other stuff).

Also I checked, wether anything changes in the output of `dejavu_fonts`. Font files stay the same with the exception of `share/fonts/truetype/DejaVuMathTeXGyre.ttf`, which differs in large chunks. The new font looks good though, when viewed with `gnome-font-viewer`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
