### PR TITLE
phpExtensions.protobuf: fix build with PHP 8

### DIFF
--- a/pkgs/development/php-packages/protobuf/default.nix
+++ b/pkgs/development/php-packages/protobuf/default.nix
@@ -1,4 +1,4 @@
-{ buildPecl, lib, pcre' }:
+{ buildPecl, lib, pcre', fetchpatch }:
 
 buildPecl {
   pname = "protobuf";
@@ -7,6 +7,23 @@ buildPecl {
   sha256 = "1ldc4s28hq61cfg8l4c06pgicj0ng7k37f28a0dnnbs7xkr7cibd";
 
   buildInputs = [ pcre' ];
+
+  patches = [
+    # TODO: remove with next update
+    (fetchpatch {
+      url = "https://github.com/protocolbuffers/protobuf/commit/823f351448f7c432bed40b89ee3309e0a94c1855.patch";
+      sha256 = "sha256-ozHtO8s9zvmh/+wBEge3Yn3n0pbpR3dAojJcuAg/G3s=";
+      stripLen = 4;
+      includes = [
+        "array.c"
+        "def.c"
+        "map.c"
+        "message.c"
+        "protobuf.h"
+        "wkt.inc"
+      ];
+    })
+  ];
 
   meta = with lib; {
     description = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Wanted to try PHP 8 with an application from work which uses the protobuf extension. The build fails with:

```
builder for '/nix/store/7nci6jwbp0lcvggknpbfn3lv53synxdx-php-protobuf-3.14.0.drv' failed with exit code 2; last 10 log lines:
  /nix/store/kl6lr3czkbnr6m5crcy8ffwfzbj8a22i-bash-4.4-p23/bin/bash /build/protobuf-3.14.0/libtool --mode=compile gcc -I. -I/build/protobuf-3.14.0 -I/build/protobuf-3.14.0/include -I/build/protobuf-3.14.0/main -I/build/protobuf-3.14.0 -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/main -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/TSRM -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/Zend -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -std=gnu99 -c /build/protobuf-3.14.0/arena.c -o arena.lo
  mkdir .libs
   gcc -I. -I/build/protobuf-3.14.0 -I/build/protobuf-3.14.0/include -I/build/protobuf-3.14.0/main -I/build/protobuf-3.14.0 -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/main -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/TSRM -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/Zend -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext/date/lib -DHAVE_CONFIG_H -g -O2 -std=gnu99 -c /build/protobuf-3.14.0/arena.c  -fPIC -DPIC -o .libs/arena.o
  /nix/store/kl6lr3czkbnr6m5crcy8ffwfzbj8a22i-bash-4.4-p23/bin/bash /build/protobuf-3.14.0/libtool --mode=compile gcc -I. -I/build/protobuf-3.14.0 -I/build/protobuf-3.14.0/include -I/build/protobuf-3.14.0/main -I/build/protobuf-3.14.0 -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/main -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/TSRM -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/Zend -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -std=gnu99 -c /build/protobuf-3.14.0/array.c -o array.lo
   gcc -I. -I/build/protobuf-3.14.0 -I/build/protobuf-3.14.0/include -I/build/protobuf-3.14.0/main -I/build/protobuf-3.14.0 -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/main -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/TSRM -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/Zend -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext -I/nix/store/xy3fdbc89l3p91dg5yafbmwrmsrm25ip-php-8.0.1-dev/include/php/ext/date/lib -DHAVE_CONFIG_H -g -O2 -std=gnu99 -c /build/protobuf-3.14.0/array.c  -fPIC -DPIC -o .libs/array.o
  /build/protobuf-3.14.0/array.c: In function 'Array_ModuleInit':
  /build/protobuf-3.14.0/array.c:639:4: error: 'zend_object_handlers' {aka 'struct _zend_object_handlers'} has no member named 'compare_objects'
    639 |   h->compare_objects = RepeatedField_compare_objects;
        |    ^~
  make: *** [Makefile:210: array.lo] Error 1
```

Grabbed the changes from https://github.com/protocolbuffers/protobuf/pull/8105

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>php73Extensions.protobuf</li>
    <li>php74Extensions.protobuf</li>
    <li>php80Extensions.protobuf</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
