### PR TITLE
mycli: 1.22.2 -> 1.23.0

### DIFF
--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -1,22 +1,30 @@
 { lib
 , python3
 , glibcLocales
-, fetchpatch
 }:
 
 with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "mycli";
-  version = "1.22.2";
+  version = "1.23.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1lq2x95553vdmhw13cxcgsd2g2i32izhsb7hxd4m1iwf9b3msbpv";
+    sha256 = "sha256-k1UHpEoszThUvoL4h59vGZ71bAx26VJ0iT/YuVQk/Lk=";
   };
 
   propagatedBuildInputs = [
-    paramiko pymysql configobj sqlparse prompt_toolkit pygments click pycrypto cli-helpers
+    cli-helpers
+    click
+    configobj
+    paramiko
+    prompt_toolkit
+    pycrypto
+    pygments
+    pymysql
+    pyperclip
+    sqlparse
   ];
 
   checkInputs = [ pytest mock glibcLocales ];
@@ -28,15 +36,6 @@ buildPythonApplication rec {
     py.test \
       --ignore=mycli/packages/paramiko_stub/__init__.py
   '';
-
-  patches = [
-    # TODO: remove with next release (v1.22.3 or v1.23)
-    (fetchpatch {
-      url = "https://github.com/dbcli/mycli/commit/17f093d7b70ab2d9f3c6eababa041bf76f029aac.patch";
-      sha256 = "sha256-VwfbtzUtElV+ErH+NJb+3pRtSaF0yVK8gEWCvlzZNHI=";
-      excludes = [ "changelog.md" "mycli/AUTHORS" ];
-    })
-  ];
 
   postPatch = ''
     substituteInPlace setup.py \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
New release https://github.com/dbcli/mycli/releases/tag/v1.23.0

Also added `pyperclip` as an dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/22shxihgjpkc2y3jcmz53fhhp51hz7hi-mycli-1.22.2	  173798704
/nix/store/2v20mllkgzja7sb5f43cpv3sclnwq7la-mycli-1.23.0	  173875144
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
