### PR TITLE
python3Packages.pynetdicom: init at 1.5.5

### DIFF
--- a/pkgs/development/python-modules/pynetdicom/default.nix
+++ b/pkgs/development/python-modules/pynetdicom/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pydicom
+, pyfakefs
+, pytestCheckHook
+, sqlalchemy
+}:
+
+buildPythonPackage rec {
+  pname = "pynetdicom";
+  version = "1.5.5";
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0zjpscxdhlcv99py7jx5r6dw32nzbcr49isrzkdr6g3zwyxwzbfm";
+  };
+
+  propagatedBuildInputs = [
+    pydicom
+  ];
+
+  checkInputs = [
+    pyfakefs
+    pytestCheckHook
+    sqlalchemy
+  ];
+
+  disabledTests = [
+    # Some tests needs network capabilities
+    "test_str_types_empty"
+    "TestEchoSCP"
+    "TestEchoSCPCLI"
+    "TestStoreSCP"
+    "TestStoreSCPCLI"
+    "TestStoreSCU"
+    "TestStoreSCUCLI"
+    "TestQRGetServiceClass"
+    "TestQRMoveServiceClass"
+  ];
+
+  pythonImportsCheck = [ "pynetdicom" ];
+
+  meta = with lib; {
+    description = "Python implementation of the DICOM networking protocol";
+    homepage = "https://github.com/pydicom/pynetdicom";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+    # Tests are not passing on Darwin, thus it's assumed that it doesn't work
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5818,6 +5818,8 @@ in {
 
   pynest2d = callPackage ../development/python-modules/pynest2d { };
 
+  pynetdicom = callPackage ../development/python-modules/pynetdicom { };
+
   pynisher = callPackage ../development/python-modules/pynisher { };
 
   pynmea2 = callPackage ../development/python-modules/pynmea2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation of the DICOM networking protocol

https://github.com/pydicom/pynetdicom

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
