### PR TITLE
scponly: init at 4.8

### DIFF
--- a/pkgs/shells/scponly/default.nix
+++ b/pkgs/shells/scponly/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, openssh, debugLevel ? 0 }:
+
+stdenv.mkDerivation {
+  pname = "scponly";
+  version = "4.8";
+
+  src = fetchFromGitHub {
+    owner = "scponly";
+    repo = "scponly";
+    rev = "d8ca58257b9905186aa5706f35813d5f80ea07c1";
+    sha256 = "U0K7lOp18ytNjh3KVFmc6vL+/tG4ETnwLEPQEhM4lXE=";
+  };
+
+  patches = [ ./scponly-fix-make.patch ];
+
+  buildInputs = [ openssh ];
+
+  # Add path to sftp-server so configure finds it
+  preConfigure = "export PATH=$PATH:${openssh}/libexec";
+
+  # chroot doesn't seem to work, so not enabling
+  # rsync could also be optionally enabled
+  configureFlags = [ "--enable-winscp-compat" ];
+
+  postInstall = lib.optionalString (debugLevel > 0) ''
+    mkdir -p $out/etc/scponly && echo ${
+      toString debugLevel
+    } > $out/etc/scponly/debuglevel
+  '';
+
+  passthru.shellPath = "/bin/scponly";
+
+  meta = with lib; {
+    description = "A shell that only permits scp and sftp-server";
+    homepage = "https://github.com/scponly/scponly";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ wmertens ];
+  };
+}

--- a/pkgs/shells/scponly/scponly-fix-make.patch
+++ b/pkgs/shells/scponly/scponly-fix-make.patch
@@ -1,0 +1,21 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -41,14 +41,14 @@
+ 	${INSTALL} -d ${DESTDIR}${bindir}
+ 	${INSTALL} -d ${DESTDIR}${mandir}/man8
+ 	${INSTALL} -d ${DESTDIR}${CONFDIR}
+-	${INSTALL} -o 0 -g 0 scponly ${DESTDIR}${bindir}/scponly
+-	${INSTALL} -o 0 -g 0 -m 0644 scponly.8 ${DESTDIR}${mandir}/man8/scponly.8
+-	${INSTALL} -o 0 -g 0 -m 0644 debuglevel ${DESTDIR}${DEBUGFILE}
++	${INSTALL} scponly ${DESTDIR}${bindir}/scponly
++	${INSTALL} -m 0644 scponly.8 ${DESTDIR}${mandir}/man8/scponly.8
++	${INSTALL} -m 0644 debuglevel ${DESTDIR}${DEBUGFILE}
+ 	if test "x${CHROOTED_NAME}" != "x"; then			\
+ 		${INSTALL} -d ${DESTDIR}${sbindir};				\
+ 		rm -f ${DESTDIR}${sbindir}/${CHROOTED_NAME};			\
+ 		cp scponly ${CHROOTED_NAME};				\
+-		${INSTALL} -o 0 -g 0 -m 4755 ${CHROOTED_NAME} ${DESTDIR}${sbindir}/${CHROOTED_NAME};	\
++		${INSTALL} ${CHROOTED_NAME} ${DESTDIR}${sbindir}/${CHROOTED_NAME};	\
+ 	fi
+ 
+ debuglevel:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9168,6 +9168,8 @@ in
 
   pash = callPackage ../shells/pash { };
 
+  scponly = callPackage ../shells/scponly { };
+
   tcsh = callPackage ../shells/tcsh { };
 
   rush = callPackage ../shells/rush { };


### PR DESCRIPTION
###### Motivation for this change

This allows setting the shell of a user to `${pkgs.scponly}/bin/scponly", after which they can only use scp and sftp.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
