### PR TITLE
nix-prefetch: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -7,32 +7,18 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "nix-prefetch";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "msteen";
     repo = "nix-prefetch";
     rev = version;
-    sha256 = "15h6f743nn6sdq8l771sjxh92cyzqznkcs7szrc7nm066xvx8rd4";
+    sha256 = "sha256-x2OoUfyKXVOvCib+C/Bni/oy9W/cm7aFMiCzpmCEbAo=";
     # the stat call has to be in a subshell or we get the current date
     extraPostFetch = ''
       echo $(stat -c %Y $out) > $out/.timestamp
     '';
   };
-
-  patches = [
-    # Fix compatibility with nixUnstable
-    # https://github.com/msteen/nix-prefetch/pull/9
-    (fetchpatch {
-      url = "https://github.com/msteen/nix-prefetch/commit/2722cda48ab3f4795105578599b29fc99518eff4.patch";
-      sha256 = "037m388sbl72kyqnk86mw7lhjhj9gzfglw3ri398ncfmmkq8b7r4";
-    })
-    # https://github.com/msteen/nix-prefetch/pull/12
-    (fetchpatch {
-      url = "https://github.com/msteen/nix-prefetch/commit/de96564e9f28df82bccd0584953094e7dbe87e20.patch";
-      sha256 = "0mxai6w8cfs7k8wfbsrpg5hwkyb0fj143nm0v142am0ky8ahn0d9";
-    })
-  ];
 
   postPatch = ''
     lib=$out/lib/${pname}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes incompatibility with nixUnstable and hence needs to be backported.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
