### PR TITLE
steam-fhsenv: don't unshare pid

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -284,6 +284,11 @@ in buildFHSUserEnv rec {
   # this fixes certain issues where they don't render correctly
   unshareIpc = false;
 
+  # Some applications such as Natron need access to MIT-SHM or other
+  # shared memory mechanisms. Unsharing the pid namespace
+  # breaks the ability for application to reference shared memory.
+  unsharePid = false;
+
   passthru.run = buildFHSUserEnv {
     name = "steam-run";
 

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -295,6 +295,8 @@ in buildFHSUserEnv rec {
     targetPkgs = commonTargetPkgs;
     inherit multiPkgs extraBuildCommands;
 
+    inherit unshareIpc unsharePid;
+
     runScript = writeScript "steam-run" ''
       #!${runtimeShell}
       run="$1"


### PR DESCRIPTION
###### Motivation for this change

closes: #104412

Some applications such as Natron need access to MIT-SHM or other
shared memory mechanisms. Unsharing the pid namespace
breaks the ability for application to reference shared memory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
