### PR TITLE
ngadmin: init at unstable

### DIFF
--- a/pkgs/applications/networking/ngadmin/default.nix
+++ b/pkgs/applications/networking/ngadmin/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchgit, autoreconfHook, readline }:
+
+stdenv.mkDerivation {
+  pname = "ngadmin";
+  version = "unstable-2017-11-17";
+
+  src = fetchgit {
+    url = "https://git.netgeek.ovh/c/ngadmin.git";
+    rev = "95240c567b5c40129d733cbd76911ba7574e4998";
+    sha256 = "052ss82fs8cxk3dqdwlh3r8q9gsm36in2lxdgwj9sljdgwg75c34";
+  };
+
+  nativeBuildInputs = [ autoreconfHook readline ];
+  enableParallelBuild = true;
+
+  meta = with lib; {
+    description = "Netgear switch (NSDP) administration tool";
+    homepage = "https://www.netgeek.ovh/wiki/projets:ngadmin";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.astro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2542,6 +2542,8 @@ in
 
   nextdns = callPackage ../applications/networking/nextdns { };
 
+  ngadmin = callPackage ../applications/networking/ngadmin { };
+
   nfdump = callPackage ../tools/networking/nfdump { };
 
   nfstrace = callPackage ../tools/networking/nfstrace { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Utility for smart-managed network switches by Netgear

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
