### PR TITLE
aliza: 1.98.32 -> 1.98.43

### DIFF
--- a/pkgs/applications/science/medicine/aliza/default.nix
+++ b/pkgs/applications/science/medicine/aliza/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 stdenv.mkDerivation {
   pname = "aliza";
-  version = "1.98.32";
+  version = "1.98.43";
   src = fetchurl {
     # See https://www.aliza-dicom-viewer.com/download
-    url = "https://drive.google.com/uc?export=download&id=1nggavPhY_633T-AW9PdkcAgbWtzv3QKG";
-    sha256 = "00vbgv8ca9ckgkicyyngrb01yhhcqc8hygg2bls7b44c47hcc8zz";
+    url = "https://drive.google.com/uc?export=download&id=1HiDYUVN30oSWZWt3HBp7gNRBCLLtJM1I";
+    sha256 = "0d70q67j2q0wdn4m2fxljqb97jwmscqgg3rm1rkb77fi2ik206ra";
     name = "aliza.rpm";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Old download link was dead, so I had to bump it to get it working.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
