### PR TITLE
python3Packages.voluptuous-serialize: enable tests

### DIFF
--- a/pkgs/development/python-modules/voluptuous-serialize/default.nix
+++ b/pkgs/development/python-modules/voluptuous-serialize/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, buildPythonPackage, isPy3k, fetchPypi, voluptuous, pytest }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, pytestCheckHook
+, voluptuous
+}:
 
 buildPythonPackage rec  {
   pname = "voluptuous-serialize";
@@ -6,28 +12,24 @@ buildPythonPackage rec  {
 
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1r7avibzf009h5rlh7mbh1fc01daligvi2axjn5qxh810g5igfn6";
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = pname;
+    rev = version;
+    sha256 = "1km2y1xaagkdvsy3bmi1sc040x5yyfdw6llmwdv9z8nz67m9v1ya";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = [ voluptuous ];
+
+  checkInputs = [
+    pytestCheckHook
     voluptuous
   ];
 
-  checkInputs = [
-    pytest
-  ];
-
-  checkPhase = ''
-    py.test
-  '';
-
-  # no tests in PyPI tarball
-  doCheck = false;
+  pythonImportsCheck = [ "voluptuous_serialize" ];
 
   meta = with lib; {
-    homepage = "https://github.com/balloob/voluptuous-serialize";
+    homepage = "https://github.com/home-assistant-libs/voluptuous-serialize";
     license = licenses.asl20;
     description = "Convert Voluptuous schemas to dictionaries so they can be serialized";
     maintainers = with maintainers; [ etu ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Switch to GitHub as source and enable tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
