### PR TITLE
hedgedoc: 1.7.1 -> 1.7.2, fixes CVE-2021-21259

### DIFF
--- a/pkgs/servers/web-apps/hedgedoc/default.nix
+++ b/pkgs/servers/web-apps/hedgedoc/default.nix
@@ -3,13 +3,13 @@
 
 mkYarnPackage rec {
   name = "hedgedoc";
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner  = "hedgedoc";
     repo   = "hedgedoc";
     rev    = version;
-    sha256 = "0axad5581v25pynfj6pgy0h1xp92dyllnc7mk42z6hxbs4sgkrw1";
+    sha256 = "1w3si1k27c8d9yka2v91883dlz57n0wasan4agi6gw17h9dzb1l6";
   };
 
   nativeBuildInputs = [ which makeWrapper ];

--- a/pkgs/servers/web-apps/hedgedoc/package.json
+++ b/pkgs/servers/web-apps/hedgedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HedgeDoc",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "The best platform to write and share markdown.",
   "main": "app.js",
   "license": "AGPL-3.0",

--- a/pkgs/servers/web-apps/hedgedoc/yarn.lock
+++ b/pkgs/servers/web-apps/hedgedoc/yarn.lock
@@ -8,12 +8,12 @@
   integrity sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA==
 
 "@azure/ms-rest-js@^1.8.7":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-1.9.0.tgz#5eb6516cf20e972a2eb4c589d6b48c3151bc801b"
-  integrity sha512-cB4Z2Mg7eBmet1rfbf0QSO1XbhfknRW7B+mX3IHJq0KGHaGJvCPoVTgdsJdCkazEMK1jtANFNEDDzSQacxyzbA==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz#93aef111b00bfdcc470a6bcb4520a13b36f21788"
+  integrity sha512-F1crHKhmsvFLM9fsnDyCGFd2E2KR9GEZm5oBVV5D5k2EBQ7u7idtSJlSF6RDLDIrGWtc4NnFdYwsoiW8NLlBQg==
   dependencies:
     "@types/tunnel" "0.0.0"
-    axios "^0.19.0"
+    axios "^0.21.1"
     form-data "^2.3.2"
     tough-cookie "^2.4.3"
     tslib "^1.9.2"
@@ -65,33 +65,34 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@nodelib/fs.scandir@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
-  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+"@nodelib/fs.scandir@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
+  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
   dependencies:
-    "@nodelib/fs.stat" "2.0.3"
+    "@nodelib/fs.stat" "2.0.4"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
-  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
+  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
-  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
+  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
   dependencies:
-    "@nodelib/fs.scandir" "2.1.3"
+    "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
 "@npmcli/move-file@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
-  integrity sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.0.tgz#4ef8a53d727b9e43facf35404caf55ebf92cfec8"
+  integrity sha512-Iv2iq0JuyYjKeFkSR4LPaCdDZwlGK9X2cP/01nJcp3yMJ1FjNd9vpiEYvLUgzBxKPg2SFmaOhizoQsPc0LWeOQ==
   dependencies:
     mkdirp "^1.0.4"
+    rimraf "^2.7.1"
 
 "@passport-next/passport-openid@^1.0.0":
   version "1.0.0"
@@ -106,7 +107,7 @@
   resolved "https://registry.yarnpkg.com/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz#4c0df069e2ec9262791b9ef1e23320c1d73bdb74"
   integrity sha512-2KhFjtPueJG6xVj2HnqXt9BlANOfYCVLyu+pXYjPGBDT8yk+vQwc/6tsceIj+mayKcoxMau2JimggXRPHgoc8w==
 
-"@tokenizer/token@^0.1.0", "@tokenizer/token@^0.1.1":
+"@tokenizer/token@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
   integrity sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==
@@ -125,9 +126,9 @@
     "@types/node" "*"
 
 "@types/connect@*":
-  version "3.4.33"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
-  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  version "3.4.34"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"
+  integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
   dependencies:
     "@types/node" "*"
 
@@ -136,22 +137,22 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
-"@types/express-serve-static-core@*":
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
-  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.18"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz#8371e260f40e0e1ca0c116a9afcd9426fa094c40"
+  integrity sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
 
 "@types/express@*":
-  version "4.17.9"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
-  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
+  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
+    "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -187,20 +188,15 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
   integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
 
-"@types/node@*":
-  version "14.14.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.7.tgz#8ea1e8f8eae2430cf440564b98c6dfce1ec5945d"
-  integrity sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==
+"@types/node@*", "@types/node@^14.14.7":
+  version "14.14.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
+  integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
 
 "@types/node@^12.12.17":
-  version "12.19.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.4.tgz#cdfbb62e26c7435ed9aab9c941393cc3598e9b46"
-  integrity sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w==
-
-"@types/node@^14.14.7":
-  version "14.14.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
-  integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
+  version "12.19.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.14.tgz#59e5029a3c2aea34f68b717955381692fd47cafb"
+  integrity sha512-2U9uLN46+7dv9PiS8VQJcHhuoOjiDPZOLAt0WuA1EanEknIMae+2QbMhayF7cgGqjvRVIfNpt+6jLPczJZFiRw==
 
 "@types/node@^8.0.47":
   version "8.10.66"
@@ -208,9 +204,9 @@
   integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
 
 "@types/passport@^1.0.0":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.4.tgz#1b35c4e197560d3974fa5f71711b6e9cce0711f0"
-  integrity sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.5.tgz#1ff54ec3e30fa6480c5e8b8de949c6dc40ddfa2a"
+  integrity sha512-wNL4kT/5rnZgyGkqX7V2qH/R/te+bklv+nXcvHzyX99vNggx9DGN+F8CEOW3P/gRi7Cjm991uidRgTHsYkSuMg==
   dependencies:
     "@types/express" "*"
 
@@ -238,9 +234,9 @@
     safe-buffer "*"
 
 "@types/serve-static@*":
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.7.tgz#e51b51a0becda910f9fd04c718044da69d6c492e"
-  integrity sha512-3diZWucbR+xTmbDlU+FRRxBf+31OhFew7cJXML/zh9NmvSPTNoFecAwHB66BUqFgENJtqMiyl7JAwUE/siqdLw==
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz#851129d434433c7082148574ffec263d58309c46"
+  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
   dependencies:
     "@types/mime" "*"
     "@types/node" "*"
@@ -275,18 +271,18 @@
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
 "@types/webpack-sources@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.0.0.tgz#08216ab9be2be2e1499beaebc4d469cec81e82a7"
-  integrity sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
+  integrity sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==
   dependencies:
     "@types/node" "*"
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
 "@types/webpack@^4.41.8":
-  version "4.41.25"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.25.tgz#4d3b5aecc4e44117b376280fbfd2dc36697968c4"
-  integrity sha512-cr6kZ+4m9lp86ytQc1jPOJXgINQyz3kLLunZ57jznW+WIAL0JqZbGubQk4GlD42MuQL5JGOABrxdpqqWeovlVQ==
+  version "4.41.26"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz#27a30d7d531e16489f9c7607c747be6bc1a459ef"
+  integrity sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"
@@ -658,9 +654,9 @@ archiver-utils@^2.1.0:
     readable-stream "^2.0.0"
 
 archiver@^5.0.2:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.1.0.tgz#05b0f6f7836f3e6356a0532763d2bb91017a7e37"
-  integrity sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.2.0.tgz#25aa1b3d9febf7aec5b0f296e77e69960c26db94"
+  integrity sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==
   dependencies:
     archiver-utils "^2.1.0"
     async "^3.2.0"
@@ -718,12 +714,14 @@ array-flatten@1.1.1:
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
 array-includes@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
-  integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.2.tgz#a8db03e0b88c8c6aeddc49cb132f9bcab4ebf9c8"
+  integrity sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0"
+    es-abstract "^1.18.0-next.1"
+    get-intrinsic "^1.0.1"
     is-string "^1.0.5"
 
 array-union@^2.1.0:
@@ -742,12 +740,13 @@ array-unique@^0.3.2:
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 array.prototype.flat@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
-  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
+  integrity sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
 
 arraybuffer.slice@~0.0.7:
   version "0.0.7"
@@ -847,9 +846,9 @@ atob@^2.1.2:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 aws-sdk@^2.521.0:
-  version "2.817.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.817.0.tgz#3a97b690b0ec494cf8ee927affb3973cf26abcc8"
-  integrity sha512-DZIdWpkcqbqsCz0MEskHsyFaqc6Tk9XIFqXAg1AKHbOgC8nU45bz+Y2osX77pU01JkS/G7OhGtGmlKDrOPvFwg==
+  version "2.828.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.828.0.tgz#6aa599c3582f219568f41fb287eb65753e4a9234"
+  integrity sha512-JoDujGdncSIF9ka+XFZjop/7G+fNGucwPwYj7OHYMmFIOV5p7YmqomdbVmH/vIzd988YZz8oLOinWc4jM6vvhg==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -871,12 +870,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 azure-storage@^2.7.0:
   version "2.10.3"
@@ -1480,11 +1479,6 @@ base64-arraybuffer@0.1.4:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
   integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
 
-base64-arraybuffer@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
-  integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
-
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -1532,13 +1526,6 @@ bcryptjs@^2.4.0:
   resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
   integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
 
-better-assert@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
-  integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
-  dependencies:
-    callsite "1.0.0"
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -1550,9 +1537,9 @@ binary-extensions@^1.0.0:
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 binary-extensions@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
-  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -1772,15 +1759,15 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.0.0:
-  version "4.14.7"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.7.tgz#c071c1b3622c1c2e790799a37bb09473a4351cb6"
-  integrity sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
+  integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
   dependencies:
-    caniuse-lite "^1.0.30001157"
+    caniuse-lite "^1.0.30001173"
     colorette "^1.2.1"
-    electron-to-chromium "^1.3.591"
+    electron-to-chromium "^1.3.634"
     escalade "^3.1.1"
-    node-releases "^1.1.66"
+    node-releases "^1.1.69"
 
 buffer-crc32@^0.2.1, buffer-crc32@^0.2.13:
   version "0.2.13"
@@ -1825,9 +1812,9 @@ buffer@^5.5.0:
     ieee754 "^1.1.13"
 
 bufferutil@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.2.tgz#79f68631910f6b993d870fc77dc0a2894eb96cd5"
-  integrity sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.3.tgz#66724b756bed23cd7c28c4d306d7994f9943cc6b"
+  integrity sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==
   dependencies:
     node-gyp-build "^4.2.0"
 
@@ -1837,9 +1824,9 @@ builtin-status-codes@^3.0.0:
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 bunyan@^1.8.3:
-  version "1.8.14"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.14.tgz#3d8c1afea7de158a5238c7cb8a66ab6b38dd45b4"
-  integrity sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
   optionalDependencies:
     dtrace-provider "~0.8"
     moment "^2.19.3"
@@ -1916,12 +1903,12 @@ cache-base@^1.0.1:
     unset-value "^1.0.0"
 
 call-bind@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.0.tgz#24127054bb3f9bdcb4b1fb82418186072f77b8ce"
-  integrity sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
   dependencies:
     function-bind "^1.1.1"
-    get-intrinsic "^1.0.0"
+    get-intrinsic "^1.0.2"
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -1936,11 +1923,6 @@ caller-path@^2.0.0:
   integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
   dependencies:
     caller-callsite "^2.0.0"
-
-callsite@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
-  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -1961,12 +1943,12 @@ camel-case@^3.0.0:
     upper-case "^1.1.1"
 
 camel-case@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.1.tgz#1fc41c854f00e2f7d0139dfeba1542d6896fe547"
-  integrity sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
   dependencies:
-    pascal-case "^3.1.1"
-    tslib "^1.10.0"
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
 
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
@@ -1988,10 +1970,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001157:
-  version "1.0.30001157"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz#2d11aaeb239b340bc1aa730eca18a37fdb07a9ab"
-  integrity sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001173:
+  version "1.0.30001177"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz#2c3b384933aafda03e29ccca7bb3d8c3389e1ece"
+  integrity sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2128,9 +2110,9 @@ chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.0.0, chokidar@^3.4.1:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
-  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
+  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -2140,7 +2122,7 @@ chokidar@^3.0.0, chokidar@^3.4.1:
     normalize-path "~3.0.0"
     readdirp "~3.5.0"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -2526,17 +2508,12 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
-
 cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookie@^0.4.0:
+cookie@^0.4.0, cookie@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
@@ -2588,9 +2565,9 @@ copy-webpack-plugin@6.4.1:
     webpack-sources "^1.4.3"
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2724,17 +2701,7 @@ css-select-base-adapter@^0.1.1:
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
   integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
 
-css-select@^1.1.0, css-select@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
-  dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
-
-css-select@^2.0.0:
+css-select@^2.0.0, css-select@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
   integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
@@ -2744,6 +2711,16 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.37.tgz#98bebd62c4c1d9f960ec340cf9f7522e30709a22"
@@ -2752,12 +2729,12 @@ css-tree@1.0.0-alpha.37:
     mdn-data "2.0.4"
     source-map "^0.6.1"
 
-css-tree@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.1.tgz#7726678dfe2a57993a018d9dce519bf1760e3b6d"
-  integrity sha512-WroX+2MvsYcRGP8QA0p+rxzOniT/zpAoQ/DTKDSJzh5T3IQKUkFHeIIfgIapm2uaP178GWY3Mime1qbk8GO/tA==
+css-tree@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
+  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
   dependencies:
-    mdn-data "2.0.12"
+    mdn-data "2.0.14"
     source-map "^0.6.1"
 
 css-what@2.1:
@@ -2849,11 +2826,11 @@ cssnano@^4.1.10:
     postcss "^7.0.0"
 
 csso@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.1.0.tgz#1d31193efa99b87aa6bad6c0cef155e543d09e8b"
-  integrity sha512-h+6w/W1WqXaJA4tb1dk7r5tVbOm97MsKxzwnvOR04UQ6GILroryjMWu3pmCCtL2mLaEStQ0fZgeGiy99mo7iyg==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
+  integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
-    css-tree "^1.0.0"
+    css-tree "^1.1.2"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
@@ -3191,7 +3168,7 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -3199,20 +3176,13 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
     ms "2.0.0"
 
 debug@^3.1.0, debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.0.1, debug@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
-  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.1.0:
+debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -3313,9 +3283,9 @@ delegates@^1.0.0:
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 denque@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
-  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
 depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -3431,9 +3401,9 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.2.tgz#f3b6e549201e46f588b59463dd77187131fe6971"
-  integrity sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
+  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -3470,13 +3440,13 @@ dont-sniff-mimetype@1.1.0:
   resolved "https://registry.yarnpkg.com/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz#c7d0427f8bcb095762751252af59d148b0a623b2"
   integrity sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug==
 
-dot-case@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.3.tgz#21d3b52efaaba2ea5fda875bb1aa8124521cf4aa"
-  integrity sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
   dependencies:
-    no-case "^3.0.3"
-    tslib "^1.10.0"
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 dot-prop@^5.2.0:
   version "5.3.0"
@@ -3542,10 +3512,10 @@ ejs@^2.5.5:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.591:
-  version "1.3.596"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz#c7ed98512c7ff36ddcbfed9e54e6355335c35257"
-  integrity sha512-nLO2Wd2yU42eSoNJVQKNf89CcEGqeFZd++QsnN2XIgje1s/19AgctfjLIbPORlvcCO8sYjLwX4iUgDdusOY8Sg==
+electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.634:
+  version "1.3.639"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz#0a27e3018ae3acf438a14a1dd4e41db4b8ab764e"
+  integrity sha512-bwl6/U6xb3d3CNufQU9QeO1L32ueouFwW4bWANSwdXR7LVqyLzWjNbynoKNfuC38QFB5Qn7O0l2KLqBkcXnC3Q==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -3597,10 +3567,10 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-engine.io-client@~3.4.0:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.4.4.tgz#77d8003f502b0782dd792b073a4d2cf7ca5ab967"
-  integrity sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==
+engine.io-client@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.5.0.tgz#fc1b4d9616288ce4f2daf06dcf612413dec941c7"
+  integrity sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==
   dependencies:
     component-emitter "~1.3.0"
     component-inherit "0.0.3"
@@ -3610,7 +3580,7 @@ engine.io-client@~3.4.0:
     indexof "0.0.1"
     parseqs "0.0.6"
     parseuri "0.0.6"
-    ws "~6.1.0"
+    ws "~7.4.2"
     xmlhttprequest-ssl "~1.5.4"
     yeast "0.1.2"
 
@@ -3625,22 +3595,22 @@ engine.io-parser@~2.2.0:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-engine.io@~3.4.0:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.4.2.tgz#8fc84ee00388e3e228645e0a7d3dfaeed5bd122c"
-  integrity sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==
+engine.io@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.5.0.tgz#9d6b985c8a39b1fe87cd91eb014de0552259821b"
+  integrity sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==
   dependencies:
     accepts "~1.3.4"
     base64id "2.0.0"
-    cookie "0.3.1"
+    cookie "~0.4.1"
     debug "~4.1.0"
     engine.io-parser "~2.2.0"
-    ws "^7.1.2"
+    ws "~7.4.2"
 
 enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
-  integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
+  integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
@@ -3669,9 +3639,9 @@ entity-decode@^2.0.2:
     he "^1.1.1"
 
 errno@^0.1.1, errno@^0.1.3, errno@~0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
-  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f"
+  integrity sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==
   dependencies:
     prr "~1.0.1"
 
@@ -3682,7 +3652,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
   integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
@@ -3726,7 +3696,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.45, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
   version "0.10.53"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
   integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
@@ -3757,7 +3727,7 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
-es6-weak-map@^2.0.2:
+es6-weak-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
   integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
@@ -4214,9 +4184,9 @@ fast-safe-stringify@^2.0.4:
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
 fastq@^1.6.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.9.0.tgz#e16a72f338eaca48e91b5c23593bcc2ef66b7947"
-  integrity sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.0.tgz#74dbefccade964932cdf500473ef302719c652bb"
+  integrity sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
   dependencies:
     reusify "^1.0.4"
 
@@ -4277,9 +4247,9 @@ file-saver@^1.3.3:
   integrity sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==
 
 file-type@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.1.0.tgz#1c8a4458b2103e07d2b49ae7f76384abafe86529"
-  integrity sha512-G4Klqf6tuprtG0pC4r9kni4Wv8XhAAsfHphVqsQGA+YiOlPAO40BZduDqKfv0RFsu9q9ZbFObWfwszY/NqhEZw==
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.2.0.tgz#d4f1da71ddda758db7f15f93adfaed09ce9e2715"
+  integrity sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==
   dependencies:
     readable-web-to-node-stream "^3.0.0"
     strtok3 "^6.0.3"
@@ -4430,12 +4400,10 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4582,10 +4550,10 @@ fsevents@^1.0.0, fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+fsevents@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -4628,10 +4596,10 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
-  integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
+get-intrinsic@^1.0.1, get-intrinsic@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.2.tgz#6820da226e50b24894e08859469dc68361545d49"
+  integrity sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
@@ -4766,9 +4734,9 @@ globals@^9.18.0:
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
 globby@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
-  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
+  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -5086,7 +5054,7 @@ html-webpack-plugin@4.5.0:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-"htmlparser2@>= 3.1.5 <4", htmlparser2@^3.3.0, htmlparser2@^3.9.1:
+"htmlparser2@>= 3.1.5 <4", htmlparser2@^3.10.1, htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -5179,7 +5147,7 @@ ieee754@1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -5229,9 +5197,9 @@ import-fresh@^2.0.0:
     resolve-from "^3.0.0"
 
 import-fresh@^3.0.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
-  integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -5306,9 +5274,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inquirer@^6.2.2:
   version "6.5.2"
@@ -5389,9 +5357,11 @@ is-alphanumerical@^1.0.0:
     is-decimal "^1.0.0"
 
 is-arguments@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
-  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
+  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  dependencies:
+    call-bind "^1.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -5591,9 +5561,9 @@ is-hexadecimal@^1.0.0:
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-negative-zero@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
-  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -5651,7 +5621,7 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-promise@^2.1:
+is-promise@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
@@ -5785,9 +5755,9 @@ jquery@^3.5.1:
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-beautify@^1.8.8:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.13.0.tgz#a056d5d3acfd4918549aae3ab039f9f3c51eebb2"
-  integrity sha512-/Tbp1OVzZjbwzwJQFIlYLm9eWQ+3aYbBXLSaqb1mEJzhcQAfrqMMQYtjb6io+U6KpD0ID4F+Id3/xcjH3l/sqA==
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.13.4.tgz#1cad80b9e89cfc455b3a14f0eaf4dc10b6ae1206"
+  integrity sha512-M5yEWwonlEO3kPcCZ3K3KBSpFRZAEO3FAWC6wtbIGeyg7dusStxvF0WG+HRLBoMZqREXSRSxkkqClDE865x1sg==
   dependencies:
     config-chain "^1.1.12"
     editorconfig "^0.15.3"
@@ -5820,15 +5790,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.0, js-yaml@^3.6.1:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
-  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.13.1, js-yaml@~3.14.0:
+js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1, js-yaml@~3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -6014,9 +5976,9 @@ keymaster@^1.6.2:
   integrity sha1-4a5U0OqUiPn2C2a2aPAumhlGxus=
 
 khroma@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/khroma/-/khroma-1.1.0.tgz#cc17723eb719c5245ea66d23dd577d5695452db5"
-  integrity sha512-aTO+YX22tYOLEQJYFiatAj1lc5QZ+H5sHWFRBWNCiKwc5NWNUJZyeSeiHEPeURJ2a1GEVYcmyMUwGjjLe5ec5A==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-1.2.0.tgz#46dcc9d7533923c228b51724db108f11fec108d8"
+  integrity sha512-DlKk5y243dujy8fOH02aRnnewLfiHJV0s8aXaVrCohgBf3s7fEAn6gc6LLQ21agODlFZS8ufrn+juu70uCA9Tw==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -6355,12 +6317,12 @@ lower-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
-lower-case@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
-  integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
   dependencies:
-    tslib "^1.10.0"
+    tslib "^2.0.3"
 
 lru-cache@^4.1.3, lru-cache@^4.1.5:
   version "4.1.5"
@@ -6384,7 +6346,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-queue@0.1:
+lru-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
@@ -6616,10 +6578,10 @@ mdast-util-to-string@^1.0.2:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
 
-mdn-data@2.0.12:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.12.tgz#bbb658d08b38f574bbb88f7b83703defdcc46844"
-  integrity sha512-ULbAlgzVb8IqZ0Hsxm6hHSlQl3Jckst2YEQS7fODu9ilNWy2LvcoSY7TRFIktABP2mdppBioc66va90T+NUs8Q==
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -6637,18 +6599,18 @@ media-typer@0.3.0:
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
 memoizee@^0.4.14:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.14.tgz#07a00f204699f9a95c2d9e77218271c7cd610d57"
-  integrity sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
+  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
   dependencies:
-    d "1"
-    es5-ext "^0.10.45"
-    es6-weak-map "^2.0.2"
+    d "^1.0.1"
+    es5-ext "^0.10.53"
+    es6-weak-map "^2.0.3"
     event-emitter "^0.3.5"
-    is-promise "^2.1"
-    lru-queue "0.1"
-    next-tick "1"
-    timers-ext "^0.1.5"
+    is-promise "^2.2.2"
+    lru-queue "^0.1.0"
+    next-tick "^1.1.0"
+    timers-ext "^0.1.7"
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -6788,22 +6750,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
-
-"mime-db@>= 1.43.0 < 2":
+mime-db@1.45.0, "mime-db@>= 1.43.0 < 2":
   version "1.45.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
 mime-types@^2.1.12, mime-types@^2.1.14, mime-types@^2.1.3, mime-types@~2.1.19, mime-types@~2.1.24:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  version "2.1.28"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
+  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
   dependencies:
-    mime-db "1.44.0"
+    mime-db "1.45.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -6816,9 +6773,9 @@ mime@1.6.0, mime@^1.4.1:
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.4.4:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
-  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.7.tgz#962aed9be0ed19c91fd7dc2ece5d7f4e89a90d74"
+  integrity sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -7064,15 +7021,20 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@2.1.2, ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 mustache@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz#d99beb031701ad433338e7ea65e0489416c854a2"
-  integrity sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.1.0.tgz#8c1b042238a982d2eb2d30efc6c14296ae3f699d"
+  integrity sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -7157,9 +7119,9 @@ ncp@~2.0.0:
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.2.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.2.tgz#cf1a8fce382b5a280108bba90a14993c00e4010a"
-  integrity sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
+  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
   dependencies:
     debug "^3.2.6"
     iconv-lite "^0.4.4"
@@ -7175,7 +7137,7 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-tick@1:
+next-tick@1, next-tick@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
@@ -7197,13 +7159,13 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-no-case@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.3.tgz#c21b434c1ffe48b39087e86cfb4d2582e9df18f8"
-  integrity sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
   dependencies:
-    lower-case "^2.0.1"
-    tslib "^1.10.0"
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 nocache@2.1.0:
   version "2.1.0"
@@ -7265,10 +7227,10 @@ node-pre-gyp@^0.11.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.66:
-  version "1.1.66"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz#609bd0dc069381015cd982300bae51ab4f1b1814"
-  integrity sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==
+node-releases@^1.1.69:
+  version "1.1.69"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.69.tgz#3149dbde53b781610cd8b486d62d86e26c3725f6"
+  integrity sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
 
 nomnom@^1.5.x:
   version "1.8.1"
@@ -7398,11 +7360,6 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-component@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
-  integrity sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=
-
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -7413,17 +7370,17 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-inspect@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
-  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
+  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
 
 object-is@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.3.tgz#2e3b9e65560137455ee3bd62aec4d90a2ea1cc81"
-  integrity sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
+  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -7448,12 +7405,13 @@ object.assign@^4.1.1:
     object-keys "^1.1.1"
 
 object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz#0dfda8d108074d9c563e80490c883b6661091544"
+  integrity sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -7471,13 +7429,13 @@ object.pick@^1.3.0:
     isobject "^3.0.1"
 
 object.values@^1.1.0, object.values@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
-  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz#7a2015e06fcb0f546bd652486ce8583a4731c731"
+  integrity sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
 on-finished@~2.3.0:
@@ -7587,11 +7545,11 @@ p-limit@^2.0.0, p-limit@^2.2.0:
     p-try "^2.0.0"
 
 p-limit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
-  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
-    p-try "^2.0.0"
+    yocto-queue "^0.1.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -7658,12 +7616,12 @@ param-case@^2.1.1:
     no-case "^2.2.0"
 
 param-case@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.3.tgz#4be41f8399eff621c56eebb829a5e451d9801238"
-  integrity sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
   dependencies:
-    dot-case "^3.0.3"
-    tslib "^1.10.0"
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -7740,24 +7698,10 @@ parse5@4.0.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
 
-parseqs@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
-  integrity sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=
-  dependencies:
-    better-assert "~1.0.0"
-
 parseqs@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.6.tgz#8e4bb5a19d1cdc844a08ac974d34e273afa670d5"
   integrity sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==
-
-parseuri@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
-  integrity sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=
-  dependencies:
-    better-assert "~1.0.0"
 
 parseuri@0.0.6:
   version "0.0.6"
@@ -7769,13 +7713,13 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-pascal-case@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
-  integrity sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
   dependencies:
-    no-case "^3.0.3"
-    tslib "^1.10.0"
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -7982,10 +7926,10 @@ pdfobject@^2.0.201604172:
   resolved "https://registry.yarnpkg.com/pdfobject/-/pdfobject-2.2.4.tgz#ccb3c191129298a471e9ccb59c88a3ee0b7c7530"
   integrity sha512-r6Rw9CQWsrY6uqmKvlgFNoupmuRbSt9EsG0sZhSAy3cIk4WgOXyAVmebFSlLhqj6gA5NIEXL3lSEbwOOYfdUvw==
 
-peek-readable@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.0.tgz#250b08b7de09db8573d7fd8ea475215bbff14348"
-  integrity sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA==
+peek-readable@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.3.tgz#932480d46cf6aa553c46c68566c4fb69a82cd2b1"
+  integrity sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -8497,9 +8441,9 @@ printj@~1.1.0:
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 prismjs@^1.21.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
-  integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
   optionalDependencies:
     clipboard "^2.0.0"
 
@@ -8803,9 +8747,9 @@ readable-stream@~2.0.0:
     util-deprecate "~1.0.1"
 
 readable-web-to-node-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.0.tgz#4ca5408e70471069119d691934141a52de413955"
-  integrity sha512-HNmLb3n0SteGAs8HQlErYPGeO+y7cvL/mVUKtXeUkl0iCZ/2GIgKGrCFHyS7UXFnO8uc9U+0y3pYIzAPsjFfvA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz#3f619b1bc5dd73a4cfe5c5f9b4f6faba55dff845"
+  integrity sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==
   dependencies:
     "@types/readable-stream" "^2.3.9"
     readable-stream "^3.6.0"
@@ -9487,13 +9431,13 @@ remove-trailing-separator@^1.0.1:
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 renderkid@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.4.tgz#d325e532afb28d3f8796ffee306be8ffd6fc864c"
-  integrity sha512-K2eXrSOJdq+HuKzlcjOlGoOarUu5SDguDEhE7+Ah4zuOWL40j8A/oHvLlLob9PSTNvVnBd+/q0Er1QfpEuem5g==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.5.tgz#483b1ac59c6601ab30a7a596a5965cabccfdd0a5"
+  integrity sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==
   dependencies:
-    css-select "^1.1.0"
+    css-select "^2.0.2"
     dom-converter "^0.2"
-    htmlparser2 "^3.3.0"
+    htmlparser2 "^3.10.1"
     lodash "^4.17.20"
     strip-ansi "^3.0.0"
 
@@ -9513,11 +9457,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-replace-ext@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 request-promise-core@1.1.4:
   version "1.1.4"
@@ -9661,7 +9600,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -10063,36 +10002,16 @@ socket.io-adapter@~1.1.0:
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz#ab3f0d6f66b8fc7fca3959ab5991f82221789be9"
   integrity sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==
 
-socket.io-client@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.0.tgz#14d5ba2e00b9bcd145ae443ab96b3f86cbcc1bb4"
-  integrity sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==
-  dependencies:
-    backo2 "1.0.2"
-    base64-arraybuffer "0.1.5"
-    component-bind "1.0.0"
-    component-emitter "1.2.1"
-    debug "~4.1.0"
-    engine.io-client "~3.4.0"
-    has-binary2 "~1.0.2"
-    has-cors "1.1.0"
-    indexof "0.0.1"
-    object-component "0.0.3"
-    parseqs "0.0.5"
-    parseuri "0.0.5"
-    socket.io-parser "~3.3.0"
-    to-array "0.1.4"
-
-socket.io-client@^2.1.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.1.tgz#91a4038ef4d03c19967bb3c646fec6e0eaa78cff"
-  integrity sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==
+socket.io-client@2.4.0, socket.io-client@^2.1.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.4.0.tgz#aafb5d594a3c55a34355562fc8aea22ed9119a35"
+  integrity sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==
   dependencies:
     backo2 "1.0.2"
     component-bind "1.0.0"
     component-emitter "~1.3.0"
     debug "~3.1.0"
-    engine.io-client "~3.4.0"
+    engine.io-client "~3.5.0"
     has-binary2 "~1.0.2"
     indexof "0.0.1"
     parseqs "0.0.6"
@@ -10101,9 +10020,9 @@ socket.io-client@^2.1.1:
     to-array "0.1.4"
 
 socket.io-parser@~3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.1.tgz#f07d9c8cb3fb92633aa93e76d98fd3a334623199"
-  integrity sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
+  integrity sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
   dependencies:
     component-emitter "~1.3.0"
     debug "~3.1.0"
@@ -10119,15 +10038,15 @@ socket.io-parser@~3.4.0:
     isarray "2.0.1"
 
 socket.io@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.3.0.tgz#cd762ed6a4faeca59bc1f3e243c0969311eb73fb"
-  integrity sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.4.1.tgz#95ad861c9a52369d7f1a68acf0d4a1b16da451d2"
+  integrity sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==
   dependencies:
     debug "~4.1.0"
-    engine.io "~3.4.0"
+    engine.io "~3.5.0"
     has-binary2 "~1.0.2"
     socket.io-adapter "~1.1.0"
-    socket.io-client "2.3.0"
+    socket.io-client "2.4.0"
     socket.io-parser "~3.4.0"
 
 sort-keys@^1.0.0:
@@ -10210,9 +10129,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz#c80757383c28abf7296744998cbc106ae8b854ce"
-  integrity sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz#e9c18a410e5ed7e12442a549fbd8afa767038d65"
+  integrity sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==
 
 spin.js@^2.3.2:
   version "2.3.2"
@@ -10406,20 +10325,20 @@ string-width@^4.0.0:
     strip-ansi "^6.0.0"
 
 string.prototype.trimend@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz#6ddd9a8796bc714b489a3ae22246a208f37bfa46"
-  integrity sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
+  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
 
 string.prototype.trimstart@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz#22d45da81015309cd0cdd79787e8919fc5c613e7"
-  integrity sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
+  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
 
 string@^3.3.3:
   version "3.3.3"
@@ -10498,13 +10417,13 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 strtok3@^6.0.3:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.4.tgz#ede0d20fde5aa9fda56417c3558eaafccc724694"
-  integrity sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.8.tgz#c839157f615c10ba0f4ae35067dad9959eeca346"
+  integrity sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==
   dependencies:
     "@tokenizer/token" "^0.1.1"
     "@types/debug" "^4.1.5"
-    peek-readable "^3.1.0"
+    peek-readable "^3.1.3"
 
 stylehacks@^4.0.0:
   version "4.0.3"
@@ -10610,9 +10529,9 @@ tapable@^1.0.0, tapable@^1.1.3:
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tar-stream@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.4.tgz#c4fb1a11eb0da29b893a5b25476397ba2d053bfa"
-  integrity sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
   dependencies:
     bl "^4.0.3"
     end-of-stream "^1.4.1"
@@ -10634,9 +10553,9 @@ tar@^4:
     yallist "^3.0.3"
 
 tar@^6.0.2:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
-  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
+  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -10724,7 +10643,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-timers-ext@^0.1.5:
+timers-ext@^0.1.5, timers-ext@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
   integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
@@ -10810,12 +10729,12 @@ toidentifier@1.0.0:
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
 token-types@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.0.0.tgz#b23618af744818299c6fbf125e0fdad98bab7e85"
-  integrity sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.1.1.tgz#bd585d64902aaf720b8979d257b4b850b4d45c45"
+  integrity sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==
   dependencies:
-    "@tokenizer/token" "^0.1.0"
-    ieee754 "^1.1.13"
+    "@tokenizer/token" "^0.1.1"
+    ieee754 "^1.2.1"
 
 toobusy-js@^0.5.1:
   version "0.5.1"
@@ -10892,6 +10811,11 @@ tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.2:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -10963,15 +10887,10 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
-uglify-js@^3.1.4:
-  version "3.11.6"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.6.tgz#144b50d3e05eadd3ad4dd047c60ca541a8cd4e9c"
-  integrity sha512-oASI1FOJ7BBFkSCNDZ446EgkSuHkOZBuqRFrwXIKWCoXw8ZXQETooTQjkAcBS03Acab7ubCKsXnwuV2svy061g==
-
-uglify-js@^3.5.1:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.2.tgz#c7ae89da0ed1bb58999c7fce07190b347fdbdaba"
-  integrity sha512-rWYleAvfJPjduYCt+ELvzybNah/zIkRteGXIBO8X0lteRZPGladF61hFi8tU7qKTsF7u6DUQCtT9k00VlFOgkg==
+uglify-js@^3.1.4, uglify-js@^3.5.1:
+  version "3.12.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.4.tgz#93de48bb76bb3ec0fc36563f871ba46e2ee5c7ee"
+  integrity sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==
 
 uid-safe@~2.1.5:
   version "2.1.5"
@@ -10992,10 +10911,15 @@ umzug@^2.1.0:
   dependencies:
     bluebird "^3.7.2"
 
-underscore@1.11.x, "underscore@>= 1.3.1", underscore@^1.7.0:
+underscore@1.11.x:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.11.0.tgz#dd7c23a195db34267186044649870ff1bab5929e"
   integrity sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==
+
+"underscore@>= 1.3.1", underscore@^1.7.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.0.tgz#4814940551fc80587cef7840d1ebb0f16453be97"
+  integrity sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ==
 
 underscore@~1.6.0:
   version "1.6.0"
@@ -11060,9 +10984,9 @@ unified-lint-rule@^1.0.0:
     wrapped "^1.0.1"
 
 unified-message-control@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/unified-message-control/-/unified-message-control-3.0.1.tgz#7018855daea9af96082cbea35970d48c9c4dbbf2"
-  integrity sha512-K2Kvvp1DBzeuxYLLsumZh/gDWUTl4e2z/P3VReFirC78cfHKtQifbhnfRrSBtKtd1Uc6cvYTW0/SZIUaMAEcTg==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/unified-message-control/-/unified-message-control-3.0.2.tgz#efa316c97f39f6f54bc74a4cf35807e615694033"
+  integrity sha512-lhF8fKjDo2cIPx1re5X1QinqUonl+AN6F0XfEaab8w/hjqX7FZAhzu4P8g6pmYp09ld+HSWFwdRJj+Y8xD0q7Q==
   dependencies:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
@@ -11126,9 +11050,9 @@ unist-util-inspect@^5.0.0:
     is-empty "^1.0.0"
 
 unist-util-is@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.3.tgz#e8b44db55fc20c43752b3346c116344d45d7c91d"
-  integrity sha512-bTofCFVx0iQM8Jqb1TBDVRIQW03YkD3p66JOd/aCWuqzlLyUtx1ZAGw/u+Zw+SttKvSVcvTiKYbfrtLoLefykw==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.4.tgz#3e9e8de6af2eb0039a59f50c9b3e99698a924f50"
+  integrity sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==
 
 unist-util-position@^3.0.0:
   version "3.1.0"
@@ -11200,9 +11124,9 @@ upper-case@^1.1.1:
   integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.0.tgz#aa714261de793e8a82347a7bcc9ce74e86f28602"
-  integrity sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
@@ -11247,9 +11171,9 @@ user-home@^1.1.1:
   integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
 
 utf-8-validate@^5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.3.tgz#3b64e418ad2ff829809025fdfef595eab2f03a27"
-  integrity sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.4.tgz#72a1735983ddf7a05a43a9c6b67c5ce1c910f9b8"
+  integrity sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==
   dependencies:
     node-gyp-build "^4.2.0"
 
@@ -11392,9 +11316,9 @@ vfile-message@^2.0.0:
     unist-util-stringify-position "^2.0.0"
 
 vfile-reporter@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-6.0.1.tgz#45d4dc11df2e312196ea2ceb95e42a67fc8ce814"
-  integrity sha512-0OppK9mo8G2XUpv+hIKLVSDsoxJrXnOy73+vIm0jQUOUFYRduqpFHX+QqAQfvRHyX9B0UFiRuNJnBOjQCIsw1g==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-6.0.2.tgz#cbddaea2eec560f27574ce7b7b269822c191a676"
+  integrity sha512-GN2bH2gs4eLnw/4jPSgfBjo+XCuvnX9elHICJZjVD4+NM0nsUrMTvdjGY5Sc/XG69XVTgLwj7hknQVc6M9FukA==
   dependencies:
     repeat-string "^1.5.0"
     string-width "^4.0.0"
@@ -11414,13 +11338,12 @@ vfile-statistics@^1.1.0:
   integrity sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==
 
 vfile@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.0.tgz#26c78ac92eb70816b01d4565e003b7e65a2a0e01"
-  integrity sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
+  integrity sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
   dependencies:
     "@types/unist" "^2.0.0"
     is-buffer "^2.0.0"
-    replace-ext "1.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
@@ -11679,17 +11602,10 @@ ws@^6.0.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.1.2:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.0.tgz#a5dd76a24197940d4a8bb9e0e152bb4503764da7"
-  integrity sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==
-
-ws@~6.1.0:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
-  integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
-  dependencies:
-    async-limiter "~1.0.0"
+ws@~7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
+  integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
 wurl@^2.5.3:
   version "2.5.4"
@@ -11818,9 +11734,9 @@ xtraverse@0.1.x:
     xmldom "0.1.x"
 
 y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 yallist@^2.1.2:
   version "2.1.2"
@@ -11865,6 +11781,11 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 zip-stream@^4.0.4:
   version "4.0.4"

--- a/pkgs/servers/web-apps/hedgedoc/yarn.nix
+++ b/pkgs/servers/web-apps/hedgedoc/yarn.nix
@@ -10,11 +10,11 @@
       };
     }
     {
-      name = "_azure_ms_rest_js___ms_rest_js_1.9.0.tgz";
+      name = "_azure_ms_rest_js___ms_rest_js_1.9.1.tgz";
       path = fetchurl {
-        name = "_azure_ms_rest_js___ms_rest_js_1.9.0.tgz";
-        url  = "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-1.9.0.tgz";
-        sha1 = "5eb6516cf20e972a2eb4c589d6b48c3151bc801b";
+        name = "_azure_ms_rest_js___ms_rest_js_1.9.1.tgz";
+        url  = "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz";
+        sha1 = "93aef111b00bfdcc470a6bcb4520a13b36f21788";
       };
     }
     {
@@ -66,35 +66,35 @@
       };
     }
     {
-      name = "_nodelib_fs.scandir___fs.scandir_2.1.3.tgz";
+      name = "_nodelib_fs.scandir___fs.scandir_2.1.4.tgz";
       path = fetchurl {
-        name = "_nodelib_fs.scandir___fs.scandir_2.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz";
-        sha1 = "3a582bdb53804c6ba6d146579c46e52130cf4a3b";
+        name = "_nodelib_fs.scandir___fs.scandir_2.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz";
+        sha1 = "d4b3549a5db5de2683e0c1071ab4f140904bbf69";
       };
     }
     {
-      name = "_nodelib_fs.stat___fs.stat_2.0.3.tgz";
+      name = "_nodelib_fs.stat___fs.stat_2.0.4.tgz";
       path = fetchurl {
-        name = "_nodelib_fs.stat___fs.stat_2.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz";
-        sha1 = "34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3";
+        name = "_nodelib_fs.stat___fs.stat_2.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz";
+        sha1 = "a3f2dd61bab43b8db8fa108a121cfffe4c676655";
       };
     }
     {
-      name = "_nodelib_fs.walk___fs.walk_1.2.4.tgz";
+      name = "_nodelib_fs.walk___fs.walk_1.2.6.tgz";
       path = fetchurl {
-        name = "_nodelib_fs.walk___fs.walk_1.2.4.tgz";
-        url  = "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz";
-        sha1 = "011b9202a70a6366e436ca5c065844528ab04976";
+        name = "_nodelib_fs.walk___fs.walk_1.2.6.tgz";
+        url  = "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz";
+        sha1 = "cce9396b30aa5afe9e3756608f5831adcb53d063";
       };
     }
     {
-      name = "_npmcli_move_file___move_file_1.0.1.tgz";
+      name = "_npmcli_move_file___move_file_1.1.0.tgz";
       path = fetchurl {
-        name = "_npmcli_move_file___move_file_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz";
-        sha1 = "de103070dac0f48ce49cf6693c23af59c0f70464";
+        name = "_npmcli_move_file___move_file_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.0.tgz";
+        sha1 = "4ef8a53d727b9e43facf35404caf55ebf92cfec8";
       };
     }
     {
@@ -138,11 +138,11 @@
       };
     }
     {
-      name = "_types_connect___connect_3.4.33.tgz";
+      name = "_types_connect___connect_3.4.34.tgz";
       path = fetchurl {
-        name = "_types_connect___connect_3.4.33.tgz";
-        url  = "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz";
-        sha1 = "31610c901eca573b8713c3330abc6e6b9f588546";
+        name = "_types_connect___connect_3.4.34.tgz";
+        url  = "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz";
+        sha1 = "170a40223a6d666006d93ca128af2beb1d9b1901";
       };
     }
     {
@@ -154,19 +154,19 @@
       };
     }
     {
-      name = "_types_express_serve_static_core___express_serve_static_core_4.17.13.tgz";
+      name = "_types_express_serve_static_core___express_serve_static_core_4.17.18.tgz";
       path = fetchurl {
-        name = "_types_express_serve_static_core___express_serve_static_core_4.17.13.tgz";
-        url  = "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz";
-        sha1 = "d9af025e925fc8b089be37423b8d1eac781be084";
+        name = "_types_express_serve_static_core___express_serve_static_core_4.17.18.tgz";
+        url  = "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz";
+        sha1 = "8371e260f40e0e1ca0c116a9afcd9426fa094c40";
       };
     }
     {
-      name = "_types_express___express_4.17.9.tgz";
+      name = "_types_express___express_4.17.11.tgz";
       path = fetchurl {
-        name = "_types_express___express_4.17.9.tgz";
-        url  = "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz";
-        sha1 = "f5f2df6add703ff28428add52bdec8a1091b0a78";
+        name = "_types_express___express_4.17.11.tgz";
+        url  = "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz";
+        sha1 = "debe3caa6f8e5fcda96b47bd54e2f40c4ee59545";
       };
     }
     {
@@ -218,27 +218,19 @@
       };
     }
     {
-      name = "_types_node___node_14.14.7.tgz";
+      name = "_types_node___node_14.14.21.tgz";
       path = fetchurl {
-        name = "_types_node___node_14.14.7.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.14.7.tgz";
-        sha1 = "8ea1e8f8eae2430cf440564b98c6dfce1ec5945d";
+        name = "_types_node___node_14.14.21.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz";
+        sha1 = "d934aacc22424fe9622ebf6857370c052eae464e";
       };
     }
     {
-      name = "_types_node___node_12.19.4.tgz";
+      name = "_types_node___node_12.19.14.tgz";
       path = fetchurl {
-        name = "_types_node___node_12.19.4.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-12.19.4.tgz";
-        sha1 = "cdfbb62e26c7435ed9aab9c941393cc3598e9b46";
-      };
-    }
-    {
-      name = "_types_node___node_14.14.14.tgz";
-      path = fetchurl {
-        name = "_types_node___node_14.14.14.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz";
-        sha1 = "f7fd5f3cc8521301119f63910f0fb965c7d761ae";
+        name = "_types_node___node_12.19.14.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-12.19.14.tgz";
+        sha1 = "59e5029a3c2aea34f68b717955381692fd47cafb";
       };
     }
     {
@@ -250,11 +242,11 @@
       };
     }
     {
-      name = "_types_passport___passport_1.0.4.tgz";
+      name = "_types_passport___passport_1.0.5.tgz";
       path = fetchurl {
-        name = "_types_passport___passport_1.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.4.tgz";
-        sha1 = "1b35c4e197560d3974fa5f71711b6e9cce0711f0";
+        name = "_types_passport___passport_1.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.5.tgz";
+        sha1 = "1ff54ec3e30fa6480c5e8b8de949c6dc40ddfa2a";
       };
     }
     {
@@ -290,11 +282,11 @@
       };
     }
     {
-      name = "_types_serve_static___serve_static_1.13.7.tgz";
+      name = "_types_serve_static___serve_static_1.13.8.tgz";
       path = fetchurl {
-        name = "_types_serve_static___serve_static_1.13.7.tgz";
-        url  = "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.7.tgz";
-        sha1 = "e51b51a0becda910f9fd04c718044da69d6c492e";
+        name = "_types_serve_static___serve_static_1.13.8.tgz";
+        url  = "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz";
+        sha1 = "851129d434433c7082148574ffec263d58309c46";
       };
     }
     {
@@ -338,19 +330,19 @@
       };
     }
     {
-      name = "_types_webpack_sources___webpack_sources_2.0.0.tgz";
+      name = "_types_webpack_sources___webpack_sources_2.1.0.tgz";
       path = fetchurl {
-        name = "_types_webpack_sources___webpack_sources_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.0.0.tgz";
-        sha1 = "08216ab9be2be2e1499beaebc4d469cec81e82a7";
+        name = "_types_webpack_sources___webpack_sources_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz";
+        sha1 = "8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10";
       };
     }
     {
-      name = "_types_webpack___webpack_4.41.25.tgz";
+      name = "_types_webpack___webpack_4.41.26.tgz";
       path = fetchurl {
-        name = "_types_webpack___webpack_4.41.25.tgz";
-        url  = "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.25.tgz";
-        sha1 = "4d3b5aecc4e44117b376280fbfd2dc36697968c4";
+        name = "_types_webpack___webpack_4.41.26.tgz";
+        url  = "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz";
+        sha1 = "27a30d7d531e16489f9c7607c747be6bc1a459ef";
       };
     }
     {
@@ -778,11 +770,11 @@
       };
     }
     {
-      name = "archiver___archiver_5.1.0.tgz";
+      name = "archiver___archiver_5.2.0.tgz";
       path = fetchurl {
-        name = "archiver___archiver_5.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/archiver/-/archiver-5.1.0.tgz";
-        sha1 = "05b0f6f7836f3e6356a0532763d2bb91017a7e37";
+        name = "archiver___archiver_5.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/archiver/-/archiver-5.2.0.tgz";
+        sha1 = "25aa1b3d9febf7aec5b0f296e77e69960c26db94";
       };
     }
     {
@@ -850,11 +842,11 @@
       };
     }
     {
-      name = "array_includes___array_includes_3.1.1.tgz";
+      name = "array_includes___array_includes_3.1.2.tgz";
       path = fetchurl {
-        name = "array_includes___array_includes_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz";
-        sha1 = "cdd67e6852bdf9c1215460786732255ed2459348";
+        name = "array_includes___array_includes_3.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.2.tgz";
+        sha1 = "a8db03e0b88c8c6aeddc49cb132f9bcab4ebf9c8";
       };
     }
     {
@@ -882,11 +874,11 @@
       };
     }
     {
-      name = "array.prototype.flat___array.prototype.flat_1.2.3.tgz";
+      name = "array.prototype.flat___array.prototype.flat_1.2.4.tgz";
       path = fetchurl {
-        name = "array.prototype.flat___array.prototype.flat_1.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz";
-        sha1 = "0de82b426b0318dbfdb940089e38b043d37f6c7b";
+        name = "array.prototype.flat___array.prototype.flat_1.2.4.tgz";
+        url  = "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz";
+        sha1 = "6ef638b43312bd401b4c6199fdec7e2dc9e9a123";
       };
     }
     {
@@ -1026,11 +1018,11 @@
       };
     }
     {
-      name = "aws_sdk___aws_sdk_2.817.0.tgz";
+      name = "aws_sdk___aws_sdk_2.828.0.tgz";
       path = fetchurl {
-        name = "aws_sdk___aws_sdk_2.817.0.tgz";
-        url  = "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.817.0.tgz";
-        sha1 = "3a97b690b0ec494cf8ee927affb3973cf26abcc8";
+        name = "aws_sdk___aws_sdk_2.828.0.tgz";
+        url  = "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.828.0.tgz";
+        sha1 = "6aa599c3582f219568f41fb287eb65753e4a9234";
       };
     }
     {
@@ -1050,11 +1042,11 @@
       };
     }
     {
-      name = "axios___axios_0.19.2.tgz";
+      name = "axios___axios_0.21.1.tgz";
       path = fetchurl {
-        name = "axios___axios_0.19.2.tgz";
-        url  = "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz";
-        sha1 = "3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27";
+        name = "axios___axios_0.21.1.tgz";
+        url  = "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz";
+        sha1 = "22563481962f4d6bde9a76d516ef0e5d3c09b2b8";
       };
     }
     {
@@ -1562,14 +1554,6 @@
       };
     }
     {
-      name = "base64_arraybuffer___base64_arraybuffer_0.1.5.tgz";
-      path = fetchurl {
-        name = "base64_arraybuffer___base64_arraybuffer_0.1.5.tgz";
-        url  = "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz";
-        sha1 = "73926771923b5a19747ad666aa5cd4bf9c6e9ce8";
-      };
-    }
-    {
       name = "base64_js___base64_js_1.5.1.tgz";
       path = fetchurl {
         name = "base64_js___base64_js_1.5.1.tgz";
@@ -1626,14 +1610,6 @@
       };
     }
     {
-      name = "better_assert___better_assert_1.0.2.tgz";
-      path = fetchurl {
-        name = "better_assert___better_assert_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz";
-        sha1 = "40866b9e1b9e0b55b481894311e68faffaebc522";
-      };
-    }
-    {
       name = "big.js___big.js_5.2.2.tgz";
       path = fetchurl {
         name = "big.js___big.js_5.2.2.tgz";
@@ -1650,11 +1626,11 @@
       };
     }
     {
-      name = "binary_extensions___binary_extensions_2.1.0.tgz";
+      name = "binary_extensions___binary_extensions_2.2.0.tgz";
       path = fetchurl {
-        name = "binary_extensions___binary_extensions_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz";
-        sha1 = "30fa40c9e7fe07dbc895678cd287024dea241dd9";
+        name = "binary_extensions___binary_extensions_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz";
+        sha1 = "75f502eeaf9ffde42fc98829645be4ea76bd9e2d";
       };
     }
     {
@@ -1882,11 +1858,11 @@
       };
     }
     {
-      name = "browserslist___browserslist_4.14.7.tgz";
+      name = "browserslist___browserslist_4.16.1.tgz";
       path = fetchurl {
-        name = "browserslist___browserslist_4.14.7.tgz";
-        url  = "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.7.tgz";
-        sha1 = "c071c1b3622c1c2e790799a37bb09473a4351cb6";
+        name = "browserslist___browserslist_4.16.1.tgz";
+        url  = "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz";
+        sha1 = "bf757a2da376b3447b800a16f0f1c96358138766";
       };
     }
     {
@@ -1946,11 +1922,11 @@
       };
     }
     {
-      name = "bufferutil___bufferutil_4.0.2.tgz";
+      name = "bufferutil___bufferutil_4.0.3.tgz";
       path = fetchurl {
-        name = "bufferutil___bufferutil_4.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.2.tgz";
-        sha1 = "79f68631910f6b993d870fc77dc0a2894eb96cd5";
+        name = "bufferutil___bufferutil_4.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.3.tgz";
+        sha1 = "66724b756bed23cd7c28c4d306d7994f9943cc6b";
       };
     }
     {
@@ -1962,11 +1938,11 @@
       };
     }
     {
-      name = "bunyan___bunyan_1.8.14.tgz";
+      name = "bunyan___bunyan_1.8.15.tgz";
       path = fetchurl {
-        name = "bunyan___bunyan_1.8.14.tgz";
-        url  = "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.14.tgz";
-        sha1 = "3d8c1afea7de158a5238c7cb8a66ab6b38dd45b4";
+        name = "bunyan___bunyan_1.8.15.tgz";
+        url  = "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz";
+        sha1 = "8ce34ca908a17d0776576ca1b2f6cbd916e93b46";
       };
     }
     {
@@ -2010,11 +1986,11 @@
       };
     }
     {
-      name = "call_bind___call_bind_1.0.0.tgz";
+      name = "call_bind___call_bind_1.0.2.tgz";
       path = fetchurl {
-        name = "call_bind___call_bind_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.0.tgz";
-        sha1 = "24127054bb3f9bdcb4b1fb82418186072f77b8ce";
+        name = "call_bind___call_bind_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz";
+        sha1 = "b1d4e89e688119c3c9a903ad30abb2f6a919be3c";
       };
     }
     {
@@ -2031,14 +2007,6 @@
         name = "caller_path___caller_path_2.0.0.tgz";
         url  = "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz";
         sha1 = "468f83044e369ab2010fac5f06ceee15bb2cb1f4";
-      };
-    }
-    {
-      name = "callsite___callsite_1.0.0.tgz";
-      path = fetchurl {
-        name = "callsite___callsite_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz";
-        sha1 = "280398e5d664bd74038b6f0905153e6e8af1bc20";
       };
     }
     {
@@ -2066,11 +2034,11 @@
       };
     }
     {
-      name = "camel_case___camel_case_4.1.1.tgz";
+      name = "camel_case___camel_case_4.1.2.tgz";
       path = fetchurl {
-        name = "camel_case___camel_case_4.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.1.tgz";
-        sha1 = "1fc41c854f00e2f7d0139dfeba1542d6896fe547";
+        name = "camel_case___camel_case_4.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz";
+        sha1 = "9728072a954f805228225a6deea6b38461e1bd5a";
       };
     }
     {
@@ -2098,11 +2066,11 @@
       };
     }
     {
-      name = "caniuse_lite___caniuse_lite_1.0.30001157.tgz";
+      name = "caniuse_lite___caniuse_lite_1.0.30001177.tgz";
       path = fetchurl {
-        name = "caniuse_lite___caniuse_lite_1.0.30001157.tgz";
-        url  = "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz";
-        sha1 = "2d11aaeb239b340bc1aa730eca18a37fdb07a9ab";
+        name = "caniuse_lite___caniuse_lite_1.0.30001177.tgz";
+        url  = "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz";
+        sha1 = "2c3b384933aafda03e29ccca7bb3d8c3389e1ece";
       };
     }
     {
@@ -2226,11 +2194,11 @@
       };
     }
     {
-      name = "chokidar___chokidar_3.4.3.tgz";
+      name = "chokidar___chokidar_3.5.0.tgz";
       path = fetchurl {
-        name = "chokidar___chokidar_3.4.3.tgz";
-        url  = "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz";
-        sha1 = "c1df38231448e45ca4ac588e6c79573ba6a57d5b";
+        name = "chokidar___chokidar_3.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz";
+        sha1 = "458a4816a415e9d3b3caa4faec2b96a6935a9e65";
       };
     }
     {
@@ -2706,14 +2674,6 @@
       };
     }
     {
-      name = "cookie___cookie_0.3.1.tgz";
-      path = fetchurl {
-        name = "cookie___cookie_0.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz";
-        sha1 = "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb";
-      };
-    }
-    {
       name = "cookie___cookie_0.4.0.tgz";
       path = fetchurl {
         name = "cookie___cookie_0.4.0.tgz";
@@ -2770,11 +2730,11 @@
       };
     }
     {
-      name = "core_js___core_js_2.6.11.tgz";
+      name = "core_js___core_js_2.6.12.tgz";
       path = fetchurl {
-        name = "core_js___core_js_2.6.11.tgz";
-        url  = "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz";
-        sha1 = "38831469f9922bded8ee21c9dc46985e0399308c";
+        name = "core_js___core_js_2.6.12.tgz";
+        url  = "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz";
+        sha1 = "d9333dfa7b065e347cc5682219d6f690859cc2ec";
       };
     }
     {
@@ -2890,19 +2850,19 @@
       };
     }
     {
-      name = "css_select___css_select_1.2.0.tgz";
-      path = fetchurl {
-        name = "css_select___css_select_1.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz";
-        sha1 = "2b3a110539c5355f1cd8d314623e870b121ec858";
-      };
-    }
-    {
       name = "css_select___css_select_2.1.0.tgz";
       path = fetchurl {
         name = "css_select___css_select_2.1.0.tgz";
         url  = "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz";
         sha1 = "6a34653356635934a81baca68d0255432105dbef";
+      };
+    }
+    {
+      name = "css_select___css_select_1.2.0.tgz";
+      path = fetchurl {
+        name = "css_select___css_select_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz";
+        sha1 = "2b3a110539c5355f1cd8d314623e870b121ec858";
       };
     }
     {
@@ -2914,11 +2874,11 @@
       };
     }
     {
-      name = "css_tree___css_tree_1.0.1.tgz";
+      name = "css_tree___css_tree_1.1.2.tgz";
       path = fetchurl {
-        name = "css_tree___css_tree_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.1.tgz";
-        sha1 = "7726678dfe2a57993a018d9dce519bf1760e3b6d";
+        name = "css_tree___css_tree_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz";
+        sha1 = "9ae393b5dafd7dae8a622475caec78d3d8fbd7b5";
       };
     }
     {
@@ -3002,11 +2962,11 @@
       };
     }
     {
-      name = "csso___csso_4.1.0.tgz";
+      name = "csso___csso_4.2.0.tgz";
       path = fetchurl {
-        name = "csso___csso_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/csso/-/csso-4.1.0.tgz";
-        sha1 = "1d31193efa99b87aa6bad6c0cef155e543d09e8b";
+        name = "csso___csso_4.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz";
+        sha1 = "ea3a561346e8dc9f546d6febedd50187cf389529";
       };
     }
     {
@@ -3378,19 +3338,11 @@
       };
     }
     {
-      name = "debug___debug_3.2.6.tgz";
+      name = "debug___debug_3.2.7.tgz";
       path = fetchurl {
-        name = "debug___debug_3.2.6.tgz";
-        url  = "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz";
-        sha1 = "e83d17de16d8a7efb7717edbe5fb10135eee629b";
-      };
-    }
-    {
-      name = "debug___debug_4.2.0.tgz";
-      path = fetchurl {
-        name = "debug___debug_4.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz";
-        sha1 = "7f150f93920e94c58f5574c2fd01a3110effe7f1";
+        name = "debug___debug_3.2.7.tgz";
+        url  = "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz";
+        sha1 = "72580b7e9145fb39b6676f9c5e5fb100b934179a";
       };
     }
     {
@@ -3522,11 +3474,11 @@
       };
     }
     {
-      name = "denque___denque_1.4.1.tgz";
+      name = "denque___denque_1.5.0.tgz";
       path = fetchurl {
-        name = "denque___denque_1.4.1.tgz";
-        url  = "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz";
-        sha1 = "6744ff7641c148c3f8a69c307e51235c1f4a37cf";
+        name = "denque___denque_1.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz";
+        sha1 = "773de0686ff2d8ec2ff92914316a47b73b1c73de";
       };
     }
     {
@@ -3682,11 +3634,11 @@
       };
     }
     {
-      name = "domelementtype___domelementtype_2.0.2.tgz";
+      name = "domelementtype___domelementtype_2.1.0.tgz";
       path = fetchurl {
-        name = "domelementtype___domelementtype_2.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.2.tgz";
-        sha1 = "f3b6e549201e46f588b59463dd77187131fe6971";
+        name = "domelementtype___domelementtype_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz";
+        sha1 = "a851c080a6d1c3d94344aed151d99f669edf585e";
       };
     }
     {
@@ -3730,11 +3682,11 @@
       };
     }
     {
-      name = "dot_case___dot_case_3.0.3.tgz";
+      name = "dot_case___dot_case_3.0.4.tgz";
       path = fetchurl {
-        name = "dot_case___dot_case_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.3.tgz";
-        sha1 = "21d3b52efaaba2ea5fda875bb1aa8124521cf4aa";
+        name = "dot_case___dot_case_3.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz";
+        sha1 = "9b2b670d00a431667a8a75ba29cd1b98809ce751";
       };
     }
     {
@@ -3810,11 +3762,11 @@
       };
     }
     {
-      name = "electron_to_chromium___electron_to_chromium_1.3.596.tgz";
+      name = "electron_to_chromium___electron_to_chromium_1.3.639.tgz";
       path = fetchurl {
-        name = "electron_to_chromium___electron_to_chromium_1.3.596.tgz";
-        url  = "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz";
-        sha1 = "c7ed98512c7ff36ddcbfed9e54e6355335c35257";
+        name = "electron_to_chromium___electron_to_chromium_1.3.639.tgz";
+        url  = "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz";
+        sha1 = "0a27e3018ae3acf438a14a1dd4e41db4b8ab764e";
       };
     }
     {
@@ -3882,11 +3834,11 @@
       };
     }
     {
-      name = "engine.io_client___engine.io_client_3.4.4.tgz";
+      name = "engine.io_client___engine.io_client_3.5.0.tgz";
       path = fetchurl {
-        name = "engine.io_client___engine.io_client_3.4.4.tgz";
-        url  = "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.4.4.tgz";
-        sha1 = "77d8003f502b0782dd792b073a4d2cf7ca5ab967";
+        name = "engine.io_client___engine.io_client_3.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.5.0.tgz";
+        sha1 = "fc1b4d9616288ce4f2daf06dcf612413dec941c7";
       };
     }
     {
@@ -3898,19 +3850,19 @@
       };
     }
     {
-      name = "engine.io___engine.io_3.4.2.tgz";
+      name = "engine.io___engine.io_3.5.0.tgz";
       path = fetchurl {
-        name = "engine.io___engine.io_3.4.2.tgz";
-        url  = "https://registry.yarnpkg.com/engine.io/-/engine.io-3.4.2.tgz";
-        sha1 = "8fc84ee00388e3e228645e0a7d3dfaeed5bd122c";
+        name = "engine.io___engine.io_3.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/engine.io/-/engine.io-3.5.0.tgz";
+        sha1 = "9d6b985c8a39b1fe87cd91eb014de0552259821b";
       };
     }
     {
-      name = "enhanced_resolve___enhanced_resolve_4.3.0.tgz";
+      name = "enhanced_resolve___enhanced_resolve_4.5.0.tgz";
       path = fetchurl {
-        name = "enhanced_resolve___enhanced_resolve_4.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz";
-        sha1 = "3b806f3bfafc1ec7de69551ef93cca46c1704126";
+        name = "enhanced_resolve___enhanced_resolve_4.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz";
+        sha1 = "2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec";
       };
     }
     {
@@ -3946,11 +3898,11 @@
       };
     }
     {
-      name = "errno___errno_0.1.7.tgz";
+      name = "errno___errno_0.1.8.tgz";
       path = fetchurl {
-        name = "errno___errno_0.1.7.tgz";
-        url  = "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz";
-        sha1 = "4684d71779ad39af177e3f007996f7c67c852618";
+        name = "errno___errno_0.1.8.tgz";
+        url  = "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz";
+        sha1 = "8bb3e9c7d463be4976ff888f76b4809ebc2e811f";
       };
     }
     {
@@ -4458,11 +4410,11 @@
       };
     }
     {
-      name = "fastq___fastq_1.9.0.tgz";
+      name = "fastq___fastq_1.10.0.tgz";
       path = fetchurl {
-        name = "fastq___fastq_1.9.0.tgz";
-        url  = "https://registry.yarnpkg.com/fastq/-/fastq-1.9.0.tgz";
-        sha1 = "e16a72f338eaca48e91b5c23593bcc2ef66b7947";
+        name = "fastq___fastq_1.10.0.tgz";
+        url  = "https://registry.yarnpkg.com/fastq/-/fastq-1.10.0.tgz";
+        sha1 = "74dbefccade964932cdf500473ef302719c652bb";
       };
     }
     {
@@ -4538,11 +4490,11 @@
       };
     }
     {
-      name = "file_type___file_type_16.1.0.tgz";
+      name = "file_type___file_type_16.2.0.tgz";
       path = fetchurl {
-        name = "file_type___file_type_16.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/file-type/-/file-type-16.1.0.tgz";
-        sha1 = "1c8a4458b2103e07d2b49ae7f76384abafe86529";
+        name = "file_type___file_type_16.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/file-type/-/file-type-16.2.0.tgz";
+        sha1 = "d4f1da71ddda758db7f15f93adfaed09ce9e2715";
       };
     }
     {
@@ -4690,11 +4642,11 @@
       };
     }
     {
-      name = "follow_redirects___follow_redirects_1.5.10.tgz";
+      name = "follow_redirects___follow_redirects_1.13.1.tgz";
       path = fetchurl {
-        name = "follow_redirects___follow_redirects_1.5.10.tgz";
-        url  = "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz";
-        sha1 = "7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a";
+        name = "follow_redirects___follow_redirects_1.13.1.tgz";
+        url  = "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz";
+        sha1 = "5f69b813376cee4fd0474a3aba835df04ab763b7";
       };
     }
     {
@@ -4874,11 +4826,11 @@
       };
     }
     {
-      name = "fsevents___fsevents_2.1.3.tgz";
+      name = "fsevents___fsevents_2.3.1.tgz";
       path = fetchurl {
-        name = "fsevents___fsevents_2.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz";
-        sha1 = "fb738703ae8d2f9fe900c33836ddebee8b97f23e";
+        name = "fsevents___fsevents_2.3.1.tgz";
+        url  = "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz";
+        sha1 = "b209ab14c61012636c8863507edf7fb68cc54e9f";
       };
     }
     {
@@ -4930,11 +4882,11 @@
       };
     }
     {
-      name = "get_intrinsic___get_intrinsic_1.0.1.tgz";
+      name = "get_intrinsic___get_intrinsic_1.0.2.tgz";
       path = fetchurl {
-        name = "get_intrinsic___get_intrinsic_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz";
-        sha1 = "94a9768fcbdd0595a1c9273aacf4c89d075631be";
+        name = "get_intrinsic___get_intrinsic_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.2.tgz";
+        sha1 = "6820da226e50b24894e08859469dc68361545d49";
       };
     }
     {
@@ -5066,11 +5018,11 @@
       };
     }
     {
-      name = "globby___globby_11.0.1.tgz";
+      name = "globby___globby_11.0.2.tgz";
       path = fetchurl {
-        name = "globby___globby_11.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz";
-        sha1 = "9a2bf107a068f3ffeabc49ad702c79ede8cfd357";
+        name = "globby___globby_11.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz";
+        sha1 = "1af538b766a3b540ebfb58a32b2e2d5897321d83";
       };
     }
     {
@@ -5578,11 +5530,11 @@
       };
     }
     {
-      name = "import_fresh___import_fresh_3.2.2.tgz";
+      name = "import_fresh___import_fresh_3.3.0.tgz";
       path = fetchurl {
-        name = "import_fresh___import_fresh_3.2.2.tgz";
-        url  = "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz";
-        sha1 = "fc129c160c5d68235507f4331a6baad186bdbc3e";
+        name = "import_fresh___import_fresh_3.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz";
+        sha1 = "37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b";
       };
     }
     {
@@ -5682,11 +5634,11 @@
       };
     }
     {
-      name = "ini___ini_1.3.5.tgz";
+      name = "ini___ini_1.3.8.tgz";
       path = fetchurl {
-        name = "ini___ini_1.3.5.tgz";
-        url  = "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz";
-        sha1 = "eee25f56db1c9ec6085e0c22778083f596abf927";
+        name = "ini___ini_1.3.8.tgz";
+        url  = "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz";
+        sha1 = "a29da425b48806f34767a4efce397269af28432c";
       };
     }
     {
@@ -5778,11 +5730,11 @@
       };
     }
     {
-      name = "is_arguments___is_arguments_1.0.4.tgz";
+      name = "is_arguments___is_arguments_1.1.0.tgz";
       path = fetchurl {
-        name = "is_arguments___is_arguments_1.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz";
-        sha1 = "3faf966c7cba0ff437fb31f6250082fcf0448cf3";
+        name = "is_arguments___is_arguments_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz";
+        sha1 = "62353031dfbee07ceb34656a6bde59efecae8dd9";
       };
     }
     {
@@ -6042,11 +5994,11 @@
       };
     }
     {
-      name = "is_negative_zero___is_negative_zero_2.0.0.tgz";
+      name = "is_negative_zero___is_negative_zero_2.0.1.tgz";
       path = fetchurl {
-        name = "is_negative_zero___is_negative_zero_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz";
-        sha1 = "9553b121b0fac28869da9ed459e20c7543788461";
+        name = "is_negative_zero___is_negative_zero_2.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz";
+        sha1 = "3de746c18dda2319241a53675908d8f766f11c24";
       };
     }
     {
@@ -6330,11 +6282,11 @@
       };
     }
     {
-      name = "js_beautify___js_beautify_1.13.0.tgz";
+      name = "js_beautify___js_beautify_1.13.4.tgz";
       path = fetchurl {
-        name = "js_beautify___js_beautify_1.13.0.tgz";
-        url  = "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.13.0.tgz";
-        sha1 = "a056d5d3acfd4918549aae3ab039f9f3c51eebb2";
+        name = "js_beautify___js_beautify_1.13.4.tgz";
+        url  = "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.13.4.tgz";
+        sha1 = "1cad80b9e89cfc455b3a14f0eaf4dc10b6ae1206";
       };
     }
     {
@@ -6375,14 +6327,6 @@
         name = "js_tokens___js_tokens_3.0.2.tgz";
         url  = "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz";
         sha1 = "9866df395102130e38f7f996bceb65443209c25b";
-      };
-    }
-    {
-      name = "js_yaml___js_yaml_3.14.0.tgz";
-      path = fetchurl {
-        name = "js_yaml___js_yaml_3.14.0.tgz";
-        url  = "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz";
-        sha1 = "a7a34170f26a21bb162424d8adacb4113a69e482";
       };
     }
     {
@@ -6586,11 +6530,11 @@
       };
     }
     {
-      name = "khroma___khroma_1.1.0.tgz";
+      name = "khroma___khroma_1.2.0.tgz";
       path = fetchurl {
-        name = "khroma___khroma_1.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/khroma/-/khroma-1.1.0.tgz";
-        sha1 = "cc17723eb719c5245ea66d23dd577d5695452db5";
+        name = "khroma___khroma_1.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/khroma/-/khroma-1.2.0.tgz";
+        sha1 = "46dcc9d7533923c228b51724db108f11fec108d8";
       };
     }
     {
@@ -6994,11 +6938,11 @@
       };
     }
     {
-      name = "lower_case___lower_case_2.0.1.tgz";
+      name = "lower_case___lower_case_2.0.2.tgz";
       path = fetchurl {
-        name = "lower_case___lower_case_2.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz";
-        sha1 = "39eeb36e396115cc05e29422eaea9e692c9408c7";
+        name = "lower_case___lower_case_2.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz";
+        sha1 = "6fa237c63dbdc4a82ca0fd882e4722dc5e634e28";
       };
     }
     {
@@ -7338,11 +7282,11 @@
       };
     }
     {
-      name = "mdn_data___mdn_data_2.0.12.tgz";
+      name = "mdn_data___mdn_data_2.0.14.tgz";
       path = fetchurl {
-        name = "mdn_data___mdn_data_2.0.12.tgz";
-        url  = "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.12.tgz";
-        sha1 = "bbb658d08b38f574bbb88f7b83703defdcc46844";
+        name = "mdn_data___mdn_data_2.0.14.tgz";
+        url  = "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz";
+        sha1 = "7113fc4281917d63ce29b43446f701e68c25ba50";
       };
     }
     {
@@ -7370,11 +7314,11 @@
       };
     }
     {
-      name = "memoizee___memoizee_0.4.14.tgz";
+      name = "memoizee___memoizee_0.4.15.tgz";
       path = fetchurl {
-        name = "memoizee___memoizee_0.4.14.tgz";
-        url  = "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.14.tgz";
-        sha1 = "07a00f204699f9a95c2d9e77218271c7cd610d57";
+        name = "memoizee___memoizee_0.4.15.tgz";
+        url  = "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz";
+        sha1 = "e6f3d2da863f318d02225391829a6c5956555b72";
       };
     }
     {
@@ -7506,14 +7450,6 @@
       };
     }
     {
-      name = "mime_db___mime_db_1.44.0.tgz";
-      path = fetchurl {
-        name = "mime_db___mime_db_1.44.0.tgz";
-        url  = "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz";
-        sha1 = "fa11c5eb0aca1334b4233cb4d52f10c5a6272f92";
-      };
-    }
-    {
       name = "mime_db___mime_db_1.45.0.tgz";
       path = fetchurl {
         name = "mime_db___mime_db_1.45.0.tgz";
@@ -7522,11 +7458,11 @@
       };
     }
     {
-      name = "mime_types___mime_types_2.1.27.tgz";
+      name = "mime_types___mime_types_2.1.28.tgz";
       path = fetchurl {
-        name = "mime_types___mime_types_2.1.27.tgz";
-        url  = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz";
-        sha1 = "47949f98e279ea53119f5722e0f34e529bec009f";
+        name = "mime_types___mime_types_2.1.28.tgz";
+        url  = "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz";
+        sha1 = "1160c4757eab2c5363888e005273ecf79d2a0ecd";
       };
     }
     {
@@ -7546,11 +7482,11 @@
       };
     }
     {
-      name = "mime___mime_2.4.6.tgz";
+      name = "mime___mime_2.4.7.tgz";
       path = fetchurl {
-        name = "mime___mime_2.4.6.tgz";
-        url  = "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz";
-        sha1 = "e5b407c90db442f2beb5b162373d07b69affa4d1";
+        name = "mime___mime_2.4.7.tgz";
+        url  = "https://registry.yarnpkg.com/mime/-/mime-2.4.7.tgz";
+        sha1 = "962aed9be0ed19c91fd7dc2ece5d7f4e89a90d74";
       };
     }
     {
@@ -7802,11 +7738,19 @@
       };
     }
     {
-      name = "mustache___mustache_4.0.1.tgz";
+      name = "ms___ms_2.1.3.tgz";
       path = fetchurl {
-        name = "mustache___mustache_4.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz";
-        sha1 = "d99beb031701ad433338e7ea65e0489416c854a2";
+        name = "ms___ms_2.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz";
+        sha1 = "574c8138ce1d2b5861f0b44579dbadd60c6615b2";
+      };
+    }
+    {
+      name = "mustache___mustache_4.1.0.tgz";
+      path = fetchurl {
+        name = "mustache___mustache_4.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/mustache/-/mustache-4.1.0.tgz";
+        sha1 = "8c1b042238a982d2eb2d30efc6c14296ae3f699d";
       };
     }
     {
@@ -7898,11 +7842,11 @@
       };
     }
     {
-      name = "needle___needle_2.5.2.tgz";
+      name = "needle___needle_2.6.0.tgz";
       path = fetchurl {
-        name = "needle___needle_2.5.2.tgz";
-        url  = "https://registry.yarnpkg.com/needle/-/needle-2.5.2.tgz";
-        sha1 = "cf1a8fce382b5a280108bba90a14993c00e4010a";
+        name = "needle___needle_2.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz";
+        sha1 = "24dbb55f2509e2324b4a99d61f413982013ccdbe";
       };
     }
     {
@@ -7954,11 +7898,11 @@
       };
     }
     {
-      name = "no_case___no_case_3.0.3.tgz";
+      name = "no_case___no_case_3.0.4.tgz";
       path = fetchurl {
-        name = "no_case___no_case_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/no-case/-/no-case-3.0.3.tgz";
-        sha1 = "c21b434c1ffe48b39087e86cfb4d2582e9df18f8";
+        name = "no_case___no_case_3.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz";
+        sha1 = "d361fd5c9800f558551a8369fc0dcd4662b6124d";
       };
     }
     {
@@ -8002,11 +7946,11 @@
       };
     }
     {
-      name = "node_releases___node_releases_1.1.66.tgz";
+      name = "node_releases___node_releases_1.1.69.tgz";
       path = fetchurl {
-        name = "node_releases___node_releases_1.1.66.tgz";
-        url  = "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz";
-        sha1 = "609bd0dc069381015cd982300bae51ab4f1b1814";
+        name = "node_releases___node_releases_1.1.69.tgz";
+        url  = "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.69.tgz";
+        sha1 = "3149dbde53b781610cd8b486d62d86e26c3725f6";
       };
     }
     {
@@ -8162,14 +8106,6 @@
       };
     }
     {
-      name = "object_component___object_component_0.0.3.tgz";
-      path = fetchurl {
-        name = "object_component___object_component_0.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz";
-        sha1 = "f0c69aa50efc95b866c186f400a33769cb2f1291";
-      };
-    }
-    {
       name = "object_copy___object_copy_0.1.0.tgz";
       path = fetchurl {
         name = "object_copy___object_copy_0.1.0.tgz";
@@ -8178,19 +8114,19 @@
       };
     }
     {
-      name = "object_inspect___object_inspect_1.8.0.tgz";
+      name = "object_inspect___object_inspect_1.9.0.tgz";
       path = fetchurl {
-        name = "object_inspect___object_inspect_1.8.0.tgz";
-        url  = "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz";
-        sha1 = "df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0";
+        name = "object_inspect___object_inspect_1.9.0.tgz";
+        url  = "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz";
+        sha1 = "c90521d74e1127b67266ded3394ad6116986533a";
       };
     }
     {
-      name = "object_is___object_is_1.1.3.tgz";
+      name = "object_is___object_is_1.1.4.tgz";
       path = fetchurl {
-        name = "object_is___object_is_1.1.3.tgz";
-        url  = "https://registry.yarnpkg.com/object-is/-/object-is-1.1.3.tgz";
-        sha1 = "2e3b9e65560137455ee3bd62aec4d90a2ea1cc81";
+        name = "object_is___object_is_1.1.4.tgz";
+        url  = "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz";
+        sha1 = "63d6c83c00a43f4cbc9434eb9757c8a5b8565068";
       };
     }
     {
@@ -8218,11 +8154,11 @@
       };
     }
     {
-      name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.1.0.tgz";
+      name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.1.1.tgz";
       path = fetchurl {
-        name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz";
-        sha1 = "369bf1f9592d8ab89d712dced5cb81c7c5352649";
+        name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz";
+        sha1 = "0dfda8d108074d9c563e80490c883b6661091544";
       };
     }
     {
@@ -8242,11 +8178,11 @@
       };
     }
     {
-      name = "object.values___object.values_1.1.1.tgz";
+      name = "object.values___object.values_1.1.2.tgz";
       path = fetchurl {
-        name = "object.values___object.values_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz";
-        sha1 = "68a99ecde356b7e9295a3c5e0ce31dc8c953de5e";
+        name = "object.values___object.values_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz";
+        sha1 = "7a2015e06fcb0f546bd652486ce8583a4731c731";
       };
     }
     {
@@ -8370,11 +8306,11 @@
       };
     }
     {
-      name = "p_limit___p_limit_3.0.2.tgz";
+      name = "p_limit___p_limit_3.1.0.tgz";
       path = fetchurl {
-        name = "p_limit___p_limit_3.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz";
-        sha1 = "1664e010af3cadc681baafd3e2a437be7b0fb5fe";
+        name = "p_limit___p_limit_3.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz";
+        sha1 = "e1daccbe78d0d1388ca18c64fea38e3e57e3706b";
       };
     }
     {
@@ -8458,11 +8394,11 @@
       };
     }
     {
-      name = "param_case___param_case_3.0.3.tgz";
+      name = "param_case___param_case_3.0.4.tgz";
       path = fetchurl {
-        name = "param_case___param_case_3.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/param-case/-/param-case-3.0.3.tgz";
-        sha1 = "4be41f8399eff621c56eebb829a5e451d9801238";
+        name = "param_case___param_case_3.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz";
+        sha1 = "7d17fe4aa12bde34d4a77d91acfb6219caad01c5";
       };
     }
     {
@@ -8538,27 +8474,11 @@
       };
     }
     {
-      name = "parseqs___parseqs_0.0.5.tgz";
-      path = fetchurl {
-        name = "parseqs___parseqs_0.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz";
-        sha1 = "d5208a3738e46766e291ba2ea173684921a8b89d";
-      };
-    }
-    {
       name = "parseqs___parseqs_0.0.6.tgz";
       path = fetchurl {
         name = "parseqs___parseqs_0.0.6.tgz";
         url  = "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.6.tgz";
         sha1 = "8e4bb5a19d1cdc844a08ac974d34e273afa670d5";
-      };
-    }
-    {
-      name = "parseuri___parseuri_0.0.5.tgz";
-      path = fetchurl {
-        name = "parseuri___parseuri_0.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz";
-        sha1 = "80204a50d4dbb779bfdc6ebe2778d90e4bce320a";
       };
     }
     {
@@ -8578,11 +8498,11 @@
       };
     }
     {
-      name = "pascal_case___pascal_case_3.1.1.tgz";
+      name = "pascal_case___pascal_case_3.1.2.tgz";
       path = fetchurl {
-        name = "pascal_case___pascal_case_3.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz";
-        sha1 = "5ac1975133ed619281e88920973d2cd1f279de5f";
+        name = "pascal_case___pascal_case_3.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz";
+        sha1 = "b48e0ef2b98e205e7c1dae747d0b1508237660eb";
       };
     }
     {
@@ -8826,11 +8746,11 @@
       };
     }
     {
-      name = "peek_readable___peek_readable_3.1.0.tgz";
+      name = "peek_readable___peek_readable_3.1.3.tgz";
       path = fetchurl {
-        name = "peek_readable___peek_readable_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.0.tgz";
-        sha1 = "250b08b7de09db8573d7fd8ea475215bbff14348";
+        name = "peek_readable___peek_readable_3.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/peek-readable/-/peek-readable-3.1.3.tgz";
+        sha1 = "932480d46cf6aa553c46c68566c4fb69a82cd2b1";
       };
     }
     {
@@ -9378,11 +9298,11 @@
       };
     }
     {
-      name = "prismjs___prismjs_1.22.0.tgz";
+      name = "prismjs___prismjs_1.23.0.tgz";
       path = fetchurl {
-        name = "prismjs___prismjs_1.22.0.tgz";
-        url  = "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz";
-        sha1 = "73c3400afc58a823dd7eed023f8e1ce9fd8977fa";
+        name = "prismjs___prismjs_1.23.0.tgz";
+        url  = "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz";
+        sha1 = "d3b3967f7d72440690497652a9d40ff046067f33";
       };
     }
     {
@@ -9730,11 +9650,11 @@
       };
     }
     {
-      name = "readable_web_to_node_stream___readable_web_to_node_stream_3.0.0.tgz";
+      name = "readable_web_to_node_stream___readable_web_to_node_stream_3.0.1.tgz";
       path = fetchurl {
-        name = "readable_web_to_node_stream___readable_web_to_node_stream_3.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.0.tgz";
-        sha1 = "4ca5408e70471069119d691934141a52de413955";
+        name = "readable_web_to_node_stream___readable_web_to_node_stream_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz";
+        sha1 = "3f619b1bc5dd73a4cfe5c5f9b4f6faba55dff845";
       };
     }
     {
@@ -10298,11 +10218,11 @@
       };
     }
     {
-      name = "renderkid___renderkid_2.0.4.tgz";
+      name = "renderkid___renderkid_2.0.5.tgz";
       path = fetchurl {
-        name = "renderkid___renderkid_2.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.4.tgz";
-        sha1 = "d325e532afb28d3f8796ffee306be8ffd6fc864c";
+        name = "renderkid___renderkid_2.0.5.tgz";
+        url  = "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.5.tgz";
+        sha1 = "483b1ac59c6601ab30a7a596a5965cabccfdd0a5";
       };
     }
     {
@@ -10327,14 +10247,6 @@
         name = "repeating___repeating_2.0.1.tgz";
         url  = "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz";
         sha1 = "5214c53a926d3552707527fbab415dbc08d06dda";
-      };
-    }
-    {
-      name = "replace_ext___replace_ext_1.0.0.tgz";
-      path = fetchurl {
-        name = "replace_ext___replace_ext_1.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz";
-        sha1 = "de63128373fcbf7c3ccfa4de5a480c45a67958eb";
       };
     }
     {
@@ -10962,27 +10874,19 @@
       };
     }
     {
-      name = "socket.io_client___socket.io_client_2.3.0.tgz";
+      name = "socket.io_client___socket.io_client_2.4.0.tgz";
       path = fetchurl {
-        name = "socket.io_client___socket.io_client_2.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.0.tgz";
-        sha1 = "14d5ba2e00b9bcd145ae443ab96b3f86cbcc1bb4";
+        name = "socket.io_client___socket.io_client_2.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.4.0.tgz";
+        sha1 = "aafb5d594a3c55a34355562fc8aea22ed9119a35";
       };
     }
     {
-      name = "socket.io_client___socket.io_client_2.3.1.tgz";
+      name = "socket.io_parser___socket.io_parser_3.3.2.tgz";
       path = fetchurl {
-        name = "socket.io_client___socket.io_client_2.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.1.tgz";
-        sha1 = "91a4038ef4d03c19967bb3c646fec6e0eaa78cff";
-      };
-    }
-    {
-      name = "socket.io_parser___socket.io_parser_3.3.1.tgz";
-      path = fetchurl {
-        name = "socket.io_parser___socket.io_parser_3.3.1.tgz";
-        url  = "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.1.tgz";
-        sha1 = "f07d9c8cb3fb92633aa93e76d98fd3a334623199";
+        name = "socket.io_parser___socket.io_parser_3.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz";
+        sha1 = "ef872009d0adcf704f2fbe830191a14752ad50b6";
       };
     }
     {
@@ -10994,11 +10898,11 @@
       };
     }
     {
-      name = "socket.io___socket.io_2.3.0.tgz";
+      name = "socket.io___socket.io_2.4.1.tgz";
       path = fetchurl {
-        name = "socket.io___socket.io_2.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/socket.io/-/socket.io-2.3.0.tgz";
-        sha1 = "cd762ed6a4faeca59bc1f3e243c0969311eb73fb";
+        name = "socket.io___socket.io_2.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/socket.io/-/socket.io-2.4.1.tgz";
+        sha1 = "95ad861c9a52369d7f1a68acf0d4a1b16da451d2";
       };
     }
     {
@@ -11098,11 +11002,11 @@
       };
     }
     {
-      name = "spdx_license_ids___spdx_license_ids_3.0.6.tgz";
+      name = "spdx_license_ids___spdx_license_ids_3.0.7.tgz";
       path = fetchurl {
-        name = "spdx_license_ids___spdx_license_ids_3.0.6.tgz";
-        url  = "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz";
-        sha1 = "c80757383c28abf7296744998cbc106ae8b854ce";
+        name = "spdx_license_ids___spdx_license_ids_3.0.7.tgz";
+        url  = "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz";
+        sha1 = "e9c18a410e5ed7e12442a549fbd8afa767038d65";
       };
     }
     {
@@ -11330,19 +11234,19 @@
       };
     }
     {
-      name = "string.prototype.trimend___string.prototype.trimend_1.0.2.tgz";
+      name = "string.prototype.trimend___string.prototype.trimend_1.0.3.tgz";
       path = fetchurl {
-        name = "string.prototype.trimend___string.prototype.trimend_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz";
-        sha1 = "6ddd9a8796bc714b489a3ae22246a208f37bfa46";
+        name = "string.prototype.trimend___string.prototype.trimend_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz";
+        sha1 = "a22bd53cca5c7cf44d7c9d5c732118873d6cd18b";
       };
     }
     {
-      name = "string.prototype.trimstart___string.prototype.trimstart_1.0.2.tgz";
+      name = "string.prototype.trimstart___string.prototype.trimstart_1.0.3.tgz";
       path = fetchurl {
-        name = "string.prototype.trimstart___string.prototype.trimstart_1.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz";
-        sha1 = "22d45da81015309cd0cdd79787e8919fc5c613e7";
+        name = "string.prototype.trimstart___string.prototype.trimstart_1.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz";
+        sha1 = "9b4cb590e123bb36564401d59824298de50fd5aa";
       };
     }
     {
@@ -11442,11 +11346,11 @@
       };
     }
     {
-      name = "strtok3___strtok3_6.0.4.tgz";
+      name = "strtok3___strtok3_6.0.8.tgz";
       path = fetchurl {
-        name = "strtok3___strtok3_6.0.4.tgz";
-        url  = "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.4.tgz";
-        sha1 = "ede0d20fde5aa9fda56417c3558eaafccc724694";
+        name = "strtok3___strtok3_6.0.8.tgz";
+        url  = "https://registry.yarnpkg.com/strtok3/-/strtok3-6.0.8.tgz";
+        sha1 = "c839157f615c10ba0f4ae35067dad9959eeca346";
       };
     }
     {
@@ -11546,11 +11450,11 @@
       };
     }
     {
-      name = "tar_stream___tar_stream_2.1.4.tgz";
+      name = "tar_stream___tar_stream_2.2.0.tgz";
       path = fetchurl {
-        name = "tar_stream___tar_stream_2.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.4.tgz";
-        sha1 = "c4fb1a11eb0da29b893a5b25476397ba2d053bfa";
+        name = "tar_stream___tar_stream_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz";
+        sha1 = "acad84c284136b060dc3faa64474aa9aebd77287";
       };
     }
     {
@@ -11562,11 +11466,11 @@
       };
     }
     {
-      name = "tar___tar_6.0.5.tgz";
+      name = "tar___tar_6.1.0.tgz";
       path = fetchurl {
-        name = "tar___tar_6.0.5.tgz";
-        url  = "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz";
-        sha1 = "bde815086e10b39f1dcd298e89d596e1535e200f";
+        name = "tar___tar_6.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz";
+        sha1 = "d1724e9bcc04b977b18d5c573b333a2207229a83";
       };
     }
     {
@@ -11746,11 +11650,11 @@
       };
     }
     {
-      name = "token_types___token_types_2.0.0.tgz";
+      name = "token_types___token_types_2.1.1.tgz";
       path = fetchurl {
-        name = "token_types___token_types_2.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/token-types/-/token-types-2.0.0.tgz";
-        sha1 = "b23618af744818299c6fbf125e0fdad98bab7e85";
+        name = "token_types___token_types_2.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/token-types/-/token-types-2.1.1.tgz";
+        sha1 = "bd585d64902aaf720b8979d257b4b850b4d45c45";
       };
     }
     {
@@ -11858,6 +11762,14 @@
       };
     }
     {
+      name = "tslib___tslib_2.1.0.tgz";
+      path = fetchurl {
+        name = "tslib___tslib_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz";
+        sha1 = "da60860f1c2ecaa5703ab7d39bc05b6bf988b97a";
+      };
+    }
+    {
       name = "tty_browserify___tty_browserify_0.0.0.tgz";
       path = fetchurl {
         name = "tty_browserify___tty_browserify_0.0.0.tgz";
@@ -11954,19 +11866,11 @@
       };
     }
     {
-      name = "uglify_js___uglify_js_3.11.6.tgz";
+      name = "uglify_js___uglify_js_3.12.4.tgz";
       path = fetchurl {
-        name = "uglify_js___uglify_js_3.11.6.tgz";
-        url  = "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.6.tgz";
-        sha1 = "144b50d3e05eadd3ad4dd047c60ca541a8cd4e9c";
-      };
-    }
-    {
-      name = "uglify_js___uglify_js_3.12.2.tgz";
-      path = fetchurl {
-        name = "uglify_js___uglify_js_3.12.2.tgz";
-        url  = "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.2.tgz";
-        sha1 = "c7ae89da0ed1bb58999c7fce07190b347fdbdaba";
+        name = "uglify_js___uglify_js_3.12.4.tgz";
+        url  = "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.4.tgz";
+        sha1 = "93de48bb76bb3ec0fc36563f871ba46e2ee5c7ee";
       };
     }
     {
@@ -11999,6 +11903,14 @@
         name = "underscore___underscore_1.11.0.tgz";
         url  = "https://registry.yarnpkg.com/underscore/-/underscore-1.11.0.tgz";
         sha1 = "dd7c23a195db34267186044649870ff1bab5929e";
+      };
+    }
+    {
+      name = "underscore___underscore_1.12.0.tgz";
+      path = fetchurl {
+        name = "underscore___underscore_1.12.0.tgz";
+        url  = "https://registry.yarnpkg.com/underscore/-/underscore-1.12.0.tgz";
+        sha1 = "4814940551fc80587cef7840d1ebb0f16453be97";
       };
     }
     {
@@ -12050,11 +11962,11 @@
       };
     }
     {
-      name = "unified_message_control___unified_message_control_3.0.1.tgz";
+      name = "unified_message_control___unified_message_control_3.0.2.tgz";
       path = fetchurl {
-        name = "unified_message_control___unified_message_control_3.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/unified-message-control/-/unified-message-control-3.0.1.tgz";
-        sha1 = "7018855daea9af96082cbea35970d48c9c4dbbf2";
+        name = "unified_message_control___unified_message_control_3.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/unified-message-control/-/unified-message-control-3.0.2.tgz";
+        sha1 = "efa316c97f39f6f54bc74a4cf35807e615694033";
       };
     }
     {
@@ -12122,11 +12034,11 @@
       };
     }
     {
-      name = "unist_util_is___unist_util_is_4.0.3.tgz";
+      name = "unist_util_is___unist_util_is_4.0.4.tgz";
       path = fetchurl {
-        name = "unist_util_is___unist_util_is_4.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.3.tgz";
-        sha1 = "e8b44db55fc20c43752b3346c116344d45d7c91d";
+        name = "unist_util_is___unist_util_is_4.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.4.tgz";
+        sha1 = "3e9e8de6af2eb0039a59f50c9b3e99698a924f50";
       };
     }
     {
@@ -12218,11 +12130,11 @@
       };
     }
     {
-      name = "uri_js___uri_js_4.4.0.tgz";
+      name = "uri_js___uri_js_4.4.1.tgz";
       path = fetchurl {
-        name = "uri_js___uri_js_4.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.0.tgz";
-        sha1 = "aa714261de793e8a82347a7bcc9ce74e86f28602";
+        name = "uri_js___uri_js_4.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz";
+        sha1 = "9b1a52595225859e55f669d928f88c6c57f2a77e";
       };
     }
     {
@@ -12274,11 +12186,11 @@
       };
     }
     {
-      name = "utf_8_validate___utf_8_validate_5.0.3.tgz";
+      name = "utf_8_validate___utf_8_validate_5.0.4.tgz";
       path = fetchurl {
-        name = "utf_8_validate___utf_8_validate_5.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.3.tgz";
-        sha1 = "3b64e418ad2ff829809025fdfef595eab2f03a27";
+        name = "utf_8_validate___utf_8_validate_5.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.4.tgz";
+        sha1 = "72a1735983ddf7a05a43a9c6b67c5ce1c910f9b8";
       };
     }
     {
@@ -12458,11 +12370,11 @@
       };
     }
     {
-      name = "vfile_reporter___vfile_reporter_6.0.1.tgz";
+      name = "vfile_reporter___vfile_reporter_6.0.2.tgz";
       path = fetchurl {
-        name = "vfile_reporter___vfile_reporter_6.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-6.0.1.tgz";
-        sha1 = "45d4dc11df2e312196ea2ceb95e42a67fc8ce814";
+        name = "vfile_reporter___vfile_reporter_6.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-6.0.2.tgz";
+        sha1 = "cbddaea2eec560f27574ce7b7b269822c191a676";
       };
     }
     {
@@ -12482,11 +12394,11 @@
       };
     }
     {
-      name = "vfile___vfile_4.2.0.tgz";
+      name = "vfile___vfile_4.2.1.tgz";
       path = fetchurl {
-        name = "vfile___vfile_4.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/vfile/-/vfile-4.2.0.tgz";
-        sha1 = "26c78ac92eb70816b01d4565e003b7e65a2a0e01";
+        name = "vfile___vfile_4.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz";
+        sha1 = "03f1dce28fc625c625bc6514350fbdb00fa9e624";
       };
     }
     {
@@ -12746,19 +12658,11 @@
       };
     }
     {
-      name = "ws___ws_7.4.0.tgz";
+      name = "ws___ws_7.4.2.tgz";
       path = fetchurl {
-        name = "ws___ws_7.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/ws/-/ws-7.4.0.tgz";
-        sha1 = "a5dd76a24197940d4a8bb9e0e152bb4503764da7";
-      };
-    }
-    {
-      name = "ws___ws_6.1.4.tgz";
-      path = fetchurl {
-        name = "ws___ws_6.1.4.tgz";
-        url  = "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz";
-        sha1 = "5b5c8800afab925e94ccb29d153c8d02c1776ef9";
+        name = "ws___ws_7.4.2.tgz";
+        url  = "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz";
+        sha1 = "782100048e54eb36fe9843363ab1c68672b261dd";
       };
     }
     {
@@ -12930,11 +12834,11 @@
       };
     }
     {
-      name = "y18n___y18n_4.0.0.tgz";
+      name = "y18n___y18n_4.0.1.tgz";
       path = fetchurl {
-        name = "y18n___y18n_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz";
-        sha1 = "95ef94f85ecc81d007c264e190a120f0a3c8566b";
+        name = "y18n___y18n_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz";
+        sha1 = "8db2b83c31c5d75099bb890b23f3094891e247d4";
       };
     }
     {
@@ -12983,6 +12887,14 @@
         name = "yeast___yeast_0.1.2.tgz";
         url  = "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz";
         sha1 = "008e06d8094320c372dbc2f8ed76a0ca6c8ac419";
+      };
+    }
+    {
+      name = "yocto_queue___yocto_queue_0.1.0.tgz";
+      path = fetchurl {
+        name = "yocto_queue___yocto_queue_0.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz";
+        sha1 = "0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b";
       };
     }
     {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/hedgedoc/hedgedoc/releases/tag/1.7.2

CVE-2021-21259:
https://github.com/hedgedoc/hedgedoc/security/advisories/GHSA-44w9-vm8p-3cxw

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Deployed to an existing HedgeDoc instance