### PR TITLE
lualdap: init at 1.2.5

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -56,6 +56,7 @@ luaevent,,,,,
 luaexpat,,,1.3.0-1,,arobyn flosse
 luaffi,,http://luarocks.org/dev,,,
 luafilesystem,,,1.7.0-2,,flosse
+lualdap,,,,,
 lualogging,,,,,
 luaossl,,,,lua5_1,
 luaposix,,,,,vyp lblasc

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1064,6 +1064,23 @@ luafilesystem = buildLuarocksPackage {
     license.fullName = "MIT/X11";
   };
 };
+lualdap = buildLuarocksPackage {
+  pname = "lualdap";
+  version = "1.2.4.rc1-0";
+
+  src = fetchurl {
+    url    = "mirror://luarocks/lualdap-1.2.4.rc1-0.src.rock";
+    sha256 = "1a46nvkzhsayczj7dxxd7hmacm0wz3dg1vmyh0m0f5k5dz8dlvci";
+  };
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with lib; {
+    homepage = "https://github.com/bdellegrazie/lualdap";
+    description = "Simple interface from Lua to an LDAP Client";
+    license.fullName = "MIT";
+  };
+};
 lualogging = buildLuarocksPackage {
   pname = "lualogging";
   version = "1.3.0-1";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -222,6 +222,27 @@ with super;
     disabled = luaOlder "5.1" || luaAtLeast "5.4" || isLuaJIT;
   });
 
+  lualdap = super.lualdap.override rec {
+    inherit (super.lualdap) pname;
+    version = "1.2.5";
+    # the repo from luarocks is archived, this was updated recently
+    src = pkgs.fetchFromGitHub {
+      owner = pname;
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "0ynjkf636k6xnk65pv8b2l24dk498ccsa1wzak53rji8pwc2q29c";
+    };
+    knownRockspec = "lualdap-${version}-1.rockspec";
+    preConfigure = ''
+      sed -e 's_dev_${version}_g' rockspecs/lualdap/lualdap-${version}.rockspec > lualdap-${version}-1.rockspec
+    '';
+
+    externalDeps = [
+      { name = "LBER"; dep = pkgs.openldap; }
+      { name = "LDAP"; dep = pkgs.openldap; }
+    ];
+  };
+
   luaossl = super.luaossl.override({
     externalDeps = [
       { name = "CRYPTO"; dep = pkgs.openssl; }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
