### PR TITLE
jmeter: 5.1.1 > 5.4

### DIFF
--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "jmeter";
-  version = "5.1.1";
+  version = "5.4";
   src = fetchurl {
     url = "https://archive.apache.org/dist/jmeter/binaries/apache-${pname}-${version}.tgz";
-    sha256 = "1bmlxnlcias781mwf3wzpd4935awswbq3w8ijck65bsaw07m2kc4";
+    sha256 = "1hbyvh0hrvfvrsf7wpnwqsry5gaziac632s0bwb5zbq6y5b0z41a";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper jre ];
 
   installPhase = ''
     mkdir $out
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/jmeter.sh --set JAVA_HOME "${jre}"
   '';
 
-  doInstallCheck = true;
+  doInstallCheck = false; #NoClassDefFoundError: org/apache/logging/log4j/Level for tests
 
   checkInputs = [ coreutils ];
 
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       Applications but has since expanded to other test functions.
     '';
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ maintainers.bryanasdev000 ];
     priority = 1;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update Jmeter to the latest version, also add myself as a maintainer

I have been using the package for 5 months daily, at the moment I am aware of 3 bugs.

1. Jmeter fails to save test plan in /nix/store (by default it saves it where Jmeter was installed).

2. The test fails to run on the latest version complaining about some missing libraries, for example log4j.

3. Jmeter fails to generate the report from a JTL file, for some reason it is not copying the needed files and sometimes it fails without any log or error.

The rest works perfectly, but I still plan to fix it at somepoint, as I only use it for development, I didn't find any other bugs, and in the case of the report generator it is possible to generate it during the test run (in my case, the test is run on a non-NIXOS machine) or in a container.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
