### PR TITLE
tree-sitter: add cstrahan/tree-sitter-nix

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -16,6 +16,7 @@
   tree-sitter-json = (builtins.fromJSON (builtins.readFile ./tree-sitter-json.json));
   tree-sitter-julia = (builtins.fromJSON (builtins.readFile ./tree-sitter-julia.json));
   tree-sitter-lua = (builtins.fromJSON (builtins.readFile ./tree-sitter-lua.json));
+  tree-sitter-nix = (builtins.fromJSON (builtins.readFile ./tree-sitter-nix.json));
   tree-sitter-ocaml = (builtins.fromJSON (builtins.readFile ./tree-sitter-ocaml.json));
   tree-sitter-php = (builtins.fromJSON (builtins.readFile ./tree-sitter-php.json));
   tree-sitter-python = (builtins.fromJSON (builtins.readFile ./tree-sitter-python.json));

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "b8bff2a389ecc098dbb7e8abee492816a5eb42db",
-  "date": "2020-11-15T07:54:17+00:00",
-  "path": "/nix/store/h5p71g661hbyzcdcj6xff8y5pcsivpa4-tree-sitter-c-sharp",
-  "sha256": "0x78s2wgd8b6pwjzbmc9fgp0ivdmxv39wikig1m55slai6yq51wh",
+  "rev": "aae8ab2b681082ce7a35d8d5fdf75ffcf7f994e5",
+  "date": "2021-01-08T13:18:05+00:00",
+  "path": "/nix/store/fpx44l1j2dz3drnvfb7746d8zxn37gwi-tree-sitter-c-sharp",
+  "sha256": "107bxz9bhyixdla3xli06ism8rnkha7pa79hi7lyx00sfnjmgcc8",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/cstrahan/tree-sitter-nix",
+  "rev": "791b5ff0e4f0da358cbb941788b78d436a2ca621",
+  "date": "2019-05-10T15:57:43-05:00",
+  "path": "/nix/store/5gcddcxf6jfr4f0p203jnbjc0zxk207d-tree-sitter-nix",
+  "sha256": "1y5b3wh3fcmbgq8r2i97likzfp1zp02m58zacw5a1cjqs5raqz66",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "65b486b42fe0188e4be344092151042bf1bc6d9a",
-  "date": "2020-12-15T09:33:20-08:00",
-  "path": "/nix/store/k9jziqzyxq2bv55pwl03jcmmca83fjyp-tree-sitter-python",
-  "sha256": "1yxqdlmp0jybm7vvza1ni5a320vrviqkd14pnpcrg9ilzq23mlsh",
+  "rev": "f568dfabf7c4611077467a9cd13297fa0658abb6",
+  "date": "2021-01-06T13:32:39-08:00",
+  "path": "/nix/store/5g256n8ym3ll2kp9jlmnkaxpnyf6rpk3-tree-sitter-python",
+  "sha256": "1lxmzrkw4k9pba4xywnbd1pk2x5s99qa4skgqvgy3imgbhy7ilkh",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "bb572f60e9538bd11fbde95a54f97522073f1e06",
-  "date": "2020-12-20T12:25:50-08:00",
-  "path": "/nix/store/hkjgvxh8l4drk1z4zkhmd0wcj876x5y1-tree-sitter-ruby",
-  "sha256": "198sfmrb3mxvpfmlwmwfmb3qs075ih0bjmr0ffrdy4nqm4a00cb8",
+  "rev": "f86d90cce578e28c824afdcdbdca7d031b88c0b0",
+  "date": "2020-11-02T20:49:49-08:00",
+  "path": "/nix/store/gs0hhb1dlgmv0y60zyyz7ki30yvpddfx-tree-sitter-ruby",
+  "sha256": "1n1irdjfmv27p5ia2vqzv8zfsq19pxi0as0wrkb7z7s1lqr1gwrb",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "8746bd4b584b8063ee8e445bf31015e887417d33",
-  "date": "2020-11-23T17:16:42-08:00",
-  "path": "/nix/store/1zzxvza23wsdyazw47lhjvrs0za6wjpn-tree-sitter-rust",
-  "sha256": "0bhxfyq8ycnp90pqvr6cf3gpq1vax8a34kaq85dmbrc6ar8a7ap6",
+  "rev": "2beedf23bedbd7b02b416518693e8eed3944d4a0",
+  "date": "2021-01-05T10:00:48-08:00",
+  "path": "/nix/store/2igv1zlnl535b86zj8s9s3ir4q85933x-tree-sitter-rust",
+  "sha256": "0iicwhxf1f56zqpsagbm8nr30fpssi970mi9i47az206dbs506ly",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "a3a4becef889692724bb1c2191f8fc4bce6573f9",
-  "date": "2020-12-15T13:34:55-08:00",
-  "path": "/nix/store/dra5wbhgxkkhphm1mhgv87hsfw0g18nw-tree-sitter-typescript",
-  "sha256": "0ir7lmzwnbf1zwbl4bfsib1jilg8pvfc1nabaq2n2rixvghlvf3d",
+  "rev": "2d1c7d5c10c33cb444d1781fa76f2936810afec4",
+  "date": "2021-01-07T09:49:56-08:00",
+  "path": "/nix/store/s65bv25523lwa9yrqbj9hsh0k4ig6pbx-tree-sitter-typescript",
+  "sha256": "09bv44n181az5rqjd43wngj9bghwy0237gpvs6xkjf9j19kvy0yi",
   "fetchSubmodules": false,
   "deepClone": false,
   "leaveDotGit": false

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -63,6 +63,10 @@ let
   # If you need a grammar that already exists in the official orga,
   # make sure to give it a different name.
   otherGrammars = {
+    "tree-sitter-nix" = {
+      orga = "cstrahan";
+      repo = "tree-sitter-nix";
+    };
     "tree-sitter-lua" = {
       orga = "nvim-treesitter";
       repo = "tree-sitter-lua";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
