### PR TITLE
python-language-server: do not propagate flake8

### DIFF
--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     sha256 = "07x6jr4z20jxn03bxblwc8vk0ywha492cgwfhj7q97nb5cm7kx0q";
   };
 
-  propagatedBuildInputs = [ setuptools jedi pluggy future python-jsonrpc-server flake8 ujson ]
+  propagatedBuildInputs = [ setuptools jedi pluggy future python-jsonrpc-server ujson ]
     ++ lib.optional (withProvider "autopep8") autopep8
     ++ lib.optional (withProvider "mccabe") mccabe
     ++ lib.optional (withProvider "pycodestyle") pycodestyle
@@ -42,12 +42,13 @@ buildPythonPackage rec {
     ++ lib.optional isPy27 configparser
     ++ lib.optionals (pythonOlder "3.2") [ backports_functools_lru_cache futures ];
 
-
   # The tests require all the providers, disable otherwise.
   doCheck = providers == ["*"];
 
   checkInputs = [
     pytestCheckHook mock pytestcov coverage flaky
+    # Do not propagate flake8 or it will enable pyflakes implicitly
+    flake8
     # rope is technically a dependency, but we don't add it by default since we
     # already have jedi, which is the preferred option
     rope

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -1,8 +1,9 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, makeDesktopItem, intervaltree, jedi, pycodestyle,
-  psutil, pyflakes, rope, numpy, scipy, matplotlib, pylint, keyring, numpydoc,
-  qtconsole, qtawesome, nbconvert, mccabe, pyopengl, cloudpickle, pygments,
-  spyder-kernels, qtpy, pyzmq, chardet, qdarkstyle, watchdog, python-language-server
-, pyqtwebengine, atomicwrites, pyxdg, diff-match-patch, three-merge, pyls-black, pyls-spyder
+{ lib, buildPythonPackage, fetchPypi, isPy27, makeDesktopItem, intervaltree,
+  jedi, pycodestyle, psutil, pyflakes, rope, numpy, scipy, matplotlib, pylint,
+  keyring, numpydoc, qtconsole, qtawesome, nbconvert, mccabe, pyopengl,
+  cloudpickle, pygments, spyder-kernels, qtpy, pyzmq, chardet, qdarkstyle,
+  watchdog, python-language-server, pyqtwebengine, atomicwrites, pyxdg,
+  diff-match-patch, three-merge, pyls-black, pyls-spyder, flake8
 }:
 
 buildPythonPackage rec {
@@ -23,6 +24,7 @@ buildPythonPackage rec {
     numpydoc qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels
     pygments qtpy pyzmq chardet pyqtwebengine qdarkstyle watchdog python-language-server
     atomicwrites pyxdg diff-match-patch three-merge pyls-black pyls-spyder
+    flake8
   ];
 
   # There is no test for spyder


### PR DESCRIPTION
python-language-server should not propagate flake8 because flake8 in turn propagates pyflakes. This has an effect of forcibly
enabling this checker despite its absence from `providers`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Spurious error reports from python-language-server

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
