### PR TITLE
python3Packages.transformers: 4.1.1 -> 4.2.2

### DIFF
--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -41,8 +41,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "tokenizers == 0.9.4" "tokenizers"
+    sed -ri 's/tokenizers==[0-9.]+/tokenizers/g' setup.py
   '';
 
   pythonImportsCheck = [ "transformers" ];

--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -16,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "transformers";
-  version = "4.2.1";
+  version = "4.2.2";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0yf5s878i6v298wxm4cwkb33qyxz5bdr75jmsnldpdw4ml31c3nn";
+    hash = "sha256-sBMCzEgYX6HQbzoEIYnmMdpYecCCsQjTdl2mO1Veu9M=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -1,32 +1,28 @@
 { buildPythonPackage
 , lib, stdenv
 , fetchFromGitHub
-, isPy39
+, pythonOlder
 , cookiecutter
 , filelock
+, importlib-metadata
 , regex
 , requests
 , numpy
-, pandas
-, parameterized
 , protobuf
 , sacremoses
-, timeout-decorator
 , tokenizers
 , tqdm
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "transformers";
-  version = "4.1.1";
-  disabled = isPy39;
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1l1gxdsakjmzsgggypq45pnwm87brhlccjfzafs43460pz0wbd6k";
+    sha256 = "0yf5s878i6v298wxm4cwkb33qyxz5bdr75jmsnldpdw4ml31c3nn";
   };
 
   propagatedBuildInputs = [
@@ -39,63 +35,17 @@ buildPythonPackage rec {
     sacremoses
     tokenizers
     tqdm
-  ];
+  ] ++ stdenv.lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
-  checkInputs = [
-    pandas
-    parameterized
-    pytestCheckHook
-    timeout-decorator
-  ];
+  # Many tests require internet access.
+  doCheck = false;
 
   postPatch = ''
     substituteInPlace setup.py \
       --replace "tokenizers == 0.9.4" "tokenizers"
   '';
 
-  preCheck = ''
-    export HOME="$TMPDIR"
-
-    # This test requires the `datasets` module to download test
-    # data. However, since we cannot download in the Nix sandbox
-    # and `dataset` is an optional dependency for transformers
-    # itself, we will just remove the tests files that import
-    # `dataset`.
-    rm tests/test_retrieval_rag.py
-    rm tests/test_trainer.py
-  '';
-
-  # We have to run from the main directory for the tests. However,
-  # letting pytest discover tests leads to errors.
-  pytestFlagsArray = [ "tests" ];
-
-  # Disable tests that require network access.
-  disabledTests = [
-    "BlenderbotSmallTokenizerTest"
-    "Blenderbot3BTokenizerTests"
-    "GetFromCacheTests"
-    "TokenizationTest"
-    "TestTokenizationBart"
-    "test_all_tokenizers"
-    "test_batch_encoding_is_fast"
-    "test_batch_encoding_pickle"
-    "test_batch_encoding_word_to_tokens"
-    "test_config_from_model_shortcut"
-    "test_config_model_type_from_model_identifier"
-    "test_from_pretrained_use_fast_toggle"
-    "test_hf_api"
-    "test_outputs_can_be_shorter"
-    "test_outputs_not_longer_than_maxlen"
-    "test_padding_accepts_tensors"
-    "test_pretokenized_tokenizers"
-    "test_tokenizer_equivalence_en_de"
-    "test_tokenizer_from_model_type"
-    "test_tokenizer_from_model_type"
-    "test_tokenizer_from_pretrained"
-    "test_tokenizer_from_tokenizer_class"
-    "test_tokenizer_identifier_with_correct_config"
-    "test_tokenizer_identifier_non_existent"
-  ];
+  pythonImportsCheck = [ "transformers" ];
 
   meta = with lib; {
     homepage = "https://github.com/huggingface/transformers";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:
https://github.com/huggingface/transformers/releases/tag/v4.2.0
https://github.com/huggingface/transformers/releases/tag/v4.2.1

Changes to the derivation:

- Enable on Python 3.9.
- Disable checks and use pythonImportsCheck instead. The list of
  excluded tests was getting silly. The vast majority of tests
  require internet access (to download models). I guess at this
  point we just have to accept that it is not practical to run
  the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
