### PR TITLE
python3Packages.toonapi: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/toonapi/default.nix
+++ b/pkgs/development/python-modules/toonapi/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, aiohttp
+, backoff
+, buildPythonPackage
+, fetchFromGitHub
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "toonapi";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "frenck";
+    repo = "python-toonapi";
+    rev = "v${version}";
+    sha256 = "1d4n615vlcgkvmchrfjw4h3ndav3ljmcfydxr2b41zn83mzizqdf";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    backoff
+    yarl
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "toonapi" ];
+
+  meta = with lib; {
+    description = "Python client for the Quby ToonAPI";
+    homepage = "https://github.com/frenck/python-toonapi";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -846,7 +846,7 @@
     "todoist" = ps: with ps; [ todoist ];
     "tof" = ps: with ps; [ ]; # missing inputs: RPi.GPIO VL53L1X2
     "tomato" = ps: with ps; [ ];
-    "toon" = ps: with ps; [ aiohttp-cors hass-nabucasa ]; # missing inputs: toonapi
+    "toon" = ps: with ps; [ aiohttp-cors hass-nabucasa toonapi ];
     "torque" = ps: with ps; [ aiohttp-cors ];
     "totalconnect" = ps: with ps; [ ]; # missing inputs: total_connect_client
     "touchline" = ps: with ps; [ ]; # missing inputs: pytouchline

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7647,6 +7647,8 @@ in {
   else
     callPackage ../development/python-modules/toolz/2.nix { };
 
+  toonapi = callPackage ../development/python-modules/toonapi { };
+
   toposort = callPackage ../development/python-modules/toposort { };
 
   topydo = throw "python3Packages.topydo was moved to topydo"; # 2017-09-22


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for the Quby ToonAPI.

https://github.com/frenck/python-toonapi

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
