### PR TITLE
python3Packages.{mocket,samsunsgtvws,segments,csvw}: update

### DIFF
--- a/pkgs/development/python-modules/csvw/default.nix
+++ b/pkgs/development/python-modules/csvw/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "csvw";
-  version = "1.8.1";
+  version = "1.10.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "cldf";
     repo = "csvw";
     rev = "v${version}";
-    sha256 = "1cafwgkspkc299shsa5x8wfzkx1d63p9rvslj9jwr68fipd1830w";
+    sha256 = "0cvfzfi1a2m1xqpm34mwp9r3bhgsnfz4pmslvgn81i42n5grbnis";
   };
 
   patchPhase = ''

--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -5,22 +5,24 @@
 , python
 , python_magic
 , six
-, urllib3 }:
+, urllib3
+, pytestCheckHook
+, pytest-mock
+, aiohttp
+, gevent
+, redis
+, requests
+, sure
+}:
 
 buildPythonPackage rec {
   pname = "mocket";
-  version = "3.9.35";
+  version = "3.9.39";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d822a2adfd8e028a2856785fbfe78e7dd8c7a3b623516298aef6d42a4c9149d1";
+    sha256 = "1mbcgfy1vfwwzn54vkq8xmfzdyc28brfpqk4d55r3a6abwwsn6a4";
   };
-
-  patchPhase = ''
-    sed -iE "s,python-magic==.*,python-magic," requirements.txt
-    sed -iE "s,urllib3==.*,urllib3," requirements.txt
-    substituteInPlace setup.py --replace 'setup_requires=["pipenv"]' "setup_requires=[]"
-  '';
 
   propagatedBuildInputs = [
     decorator
@@ -30,8 +32,36 @@ buildPythonPackage rec {
     six
   ] ++ lib.optionals (isPy27) [ six ];
 
-  # Pypi has no runtests.py, github has no requirements.txt. No way to test, no way to install.
-  doCheck = false;
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+    aiohttp
+    gevent
+    redis
+    requests
+    sure
+  ];
+
+  pytestFlagsArray = [
+    "--ignore=tests/main/test_pook.py" # pook is not packaged
+    "--ignore=tests/main/test_redis.py" # requires a live redis instance
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    # uses IsolatedAsyncioTestCase which is only available >= 3.8
+    "--ignore=tests/tests38/test_http_aiohttp.py"
+  ];
+
+  disabledTests = [
+    # tests that require network access (like DNS lookups)
+    "test_truesendall"
+    "test_truesendall_with_chunk_recording"
+    "test_truesendall_with_gzip_recording"
+    "test_truesendall_with_recording"
+    "test_wrongpath_truesendall"
+    "test_truesendall_with_dump_from_recording"
+    "test_truesendall_with_recording_https"
+    "test_truesendall_after_mocket_session"
+    "test_real_request_session"
+  ];
 
   pythonImportsCheck = [ "mocket" ];
 

--- a/pkgs/development/python-modules/samsungtvws/default.nix
+++ b/pkgs/development/python-modules/samsungtvws/default.nix
@@ -5,17 +5,13 @@
 
 buildPythonPackage rec {
   pname = "samsungtvws";
-  version = "1.5.3";
+  version = "1.6.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "054rr8hiacdjfxqssnxnd3xp9hh8350zjzzjvh1199bpps4l1l6n";
+    sha256 = "09nls4n0lbnr8nj8105lagr9h2my8lb1s2k285kmsbli36ywd8lj";
   };
-
-  patchPhase = ''
-    substituteInPlace setup.py --replace "websocket-client==" "websocket-client>="
-  '';
 
   propagatedBuildInputs = [
     websocket_client

--- a/pkgs/development/python-modules/segments/default.nix
+++ b/pkgs/development/python-modules/segments/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "segments";
-  version = "2.1.3";
+  version = "2.2.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "cldf";
     repo = pname;
     rev = "v${version}";
-    sha256 = "12lnpk834r3y7hw5x7nvswa60ddh69ylvr44k46gqcfba160hhb0";
+    sha256 = "04yc8q79zk09xj0wnal0vdg5azi9jlarfmf2iyljqyr80p79gwvv";
   };
 
   patchPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- https://github.com/xchwarze/samsung-tv-ws-api/releases/tag/v1.6.0
- https://github.com/cldf/csvw/blob/fbeb899e2af7d10221fe1230d56aba6e33fcda12/CHANGES#L14-L17
- https://github.com/mindflayer/python-mocket/releases/tag/3.9.36
  https://github.com/mindflayer/python-mocket/releases/tag/3.9.37
  https://github.com/mindflayer/python-mocket/releases/tag/3.9.38
  https://github.com/mindflayer/python-mocket/releases/tag/3.9.39
- https://github.com/cldf/segments/blob/master/CHANGES.md#220---2021-01-11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
