### PR TITLE
nixos-rebuild: put some important dependencies in PATH

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -1,8 +1,16 @@
-{ substituteAll, runtimeShell, jq, nix, lib }:
-
+{ substituteAll
+, runtimeShell
+, coreutils
+, gnused
+, gnugrep
+, jq
+, nix
+, lib
+}:
 let
   fallback = import ./../../../../nixos/modules/installer/tools/nix-fallback-paths.nix;
-in substituteAll {
+in
+substituteAll {
   name = "nixos-rebuild";
   src = ./nixos-rebuild.sh;
   dir = "bin";
@@ -10,5 +18,5 @@ in substituteAll {
   inherit runtimeShell nix;
   nix_x86_64_linux = fallback.x86_64-linux;
   nix_i686_linux = fallback.i686-linux;
-  path = lib.makeBinPath [ jq ];
+  path = lib.makeBinPath [ coreutils jq gnused gnugrep ];
 }


### PR DESCRIPTION
###### Motivation for this change
Currently `nixos-rebuild` depends impurely on a lot of cli tools, this attempts to rectify the situation.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
