### PR TITLE
python3Packages.axis: init at 42

### DIFF
--- a/pkgs/development/python-modules/axis/default.nix
+++ b/pkgs/development/python-modules/axis/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, attrs
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, packaging
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "axis";
+  version = "42";
+
+  src = fetchFromGitHub {
+    owner = "Kane610";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1144zkgyf63qlw4dfn1zqcbgaksmxvjc4115jhzi98z0fkvlk34p";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    httpx
+    packaging
+    xmltodict
+  ];
+
+  # Tests requires a server on localhost
+  doCheck = false;
+  pythonImportsCheck = [ "axis" ];
+
+  meta = with lib; {
+    description = "Python library for communicating with devices from Axis Communications";
+    homepage = "https://github.com/Kane610/axis";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/respx/default.nix
+++ b/pkgs/development/python-modules/respx/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, attrs
+, buildPythonPackage
+, fetchFromGitHub
+, httpcore
+, httpx
+, pytest-asyncio
+, pytest-cov
+, pytestCheckHook
+, trio
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "respx";
+  version = "0.16.3";
+
+  src = fetchFromGitHub {
+    owner = "lundberg";
+    repo = pname;
+    rev = version;
+    sha256 = "0if9sg83rznl37hsjw6pfk78jpxi421g9p21wd92jcd6073g4nbd";
+  };
+
+  # Coverage is under 100 % due to the excluded tests
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "--cov-fail-under 100" ""
+  '';
+
+  propagatedBuildInputs = [ httpx ];
+
+  checkInputs = [
+    httpcore
+    httpx
+    pytest-asyncio
+    pytest-cov
+    pytestCheckHook
+    trio
+  ];
+
+  disabledTests = [ "test_pass_through" ];
+  pythonImportsCheck = [ "respx" ];
+
+  meta = with lib; {
+    description = "Python library for mocking HTTPX";
+    homepage = "https://lundberg.github.io/respx/";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -64,7 +64,7 @@
     "avion" = ps: with ps; [ ]; # missing inputs: avion
     "awair" = ps: with ps; [ ]; # missing inputs: python_awair
     "aws" = ps: with ps; [ aiobotocore ];
-    "axis" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: axis
+    "axis" = ps: with ps; [ aiohttp-cors axis paho-mqtt ];
     "azure_devops" = ps: with ps; [ ]; # missing inputs: aioazuredevops
     "azure_event_hub" = ps: with ps; [ ]; # missing inputs: azure-eventhub
     "azure_service_bus" = ps: with ps; [ azure-servicebus ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -558,6 +558,8 @@ in {
 
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };
 
+  axis = callPackage ../development/python-modules/axis { };
+
   azure-appconfiguration = callPackage ../development/python-modules/azure-appconfiguration { };
 
   azure-applicationinsights = callPackage ../development/python-modules/azure-applicationinsights { };
@@ -6618,6 +6620,8 @@ in {
   resampy = callPackage ../development/python-modules/resampy { };
 
   responses = callPackage ../development/python-modules/responses { };
+
+  respx = callPackage ../development/python-modules/respx { };
 
   restrictedpython = callPackage ../development/python-modules/restrictedpython { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for communicating with devices from Axis Communications

https://github.com/Kane610/axis

This is a Home Assistant dependency.

`respx` is a test dependency of `axis`. I added it even if the tests of `axis` are not run for now. `httpx` is the new kid on the block and `respx` will be needed sooner or later anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
