### PR TITLE
python3Packages.aioesphomeapi: 2.6.3 -> 2.6.4

### DIFF
--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -1,16 +1,14 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, attrs, protobuf, zeroconf }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k, attrs, protobuf, zeroconf }:
 
 buildPythonPackage rec {
   pname = "aioesphomeapi";
-  version = "2.6.3";
+  version = "2.6.4";
 
   disabled = !isPy3k;
 
-  src = fetchFromGitHub {
-    owner = "esphome";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1lbjxqdx63fc7qxx7xwq4b9dafmdafj7p1ggs48hyhbqfwkrv9p7";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d8def7a909c0471479e1d8b0965de6bb7644b8de315d6e578f9d848b8a6812d0";
   };
 
   propagatedBuildInputs = [ attrs protobuf zeroconf ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
@jonringer Do you remember why you used `fetchFromGitHub` in d49fc3600efc56bd557bc3ea5ff867330dabae5f?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
