### PR TITLE
python3Packages.fritzconnection: 1.2.1 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/fritzconnection/default.nix
+++ b/pkgs/development/python-modules/fritzconnection/default.nix
@@ -1,37 +1,26 @@
-{ lib, stdenv, buildPythonPackage, pythonOlder, fetchFromGitHub, pytest, requests }:
+{ lib, stdenv, buildPythonPackage, pythonOlder, fetchFromGitHub, pytestCheckHook, requests }:
 
 buildPythonPackage rec {
   pname = "fritzconnection";
-  version = "1.2.1";
+  version = "1.4.0";
 
+  # no tests on PyPI
   src = fetchFromGitHub {
     owner = "kbr";
     repo = pname;
     rev = version;
-    sha256 = "17z4shs56ci9mxmilppv5xy9gbnbp6p1h2ms6x55nkvwndacrp7x";
+    sha256 = "1p8dqcc75xfhyvc9izjzz8c7qfrdkjkrkj36j7ms5fimn5bwk70q";
   };
 
-  disabled = pythonOlder "3.5";
-
-  # Exclude test files from build, which cause ImportMismtachErrors and
-  # otherwise missing resources during tests. This patch can be dropped once
-  # https://github.com/kbr/fritzconnection/pull/39 is merged.
-  prePatch = ''
-    substituteInPlace setup.py \
-      --replace 'find_packages()' 'find_packages(exclude=["*.tests"])'
-  '';
+  disabled = pythonOlder "3.6";
 
   propagatedBuildInputs = [ requests ];
 
-  checkInputs = [ pytest ];
-
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Python-Tool to communicate with the AVM FritzBox using the TR-064 protocol";
-    homepage = "https://bitbucket.org/kbr/fritzconnection";
+    homepage = "https://github.com/kbr/fritzconnection";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda valodim ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
