### PR TITLE
python3Packages.hatasmota: init at 0.2.5

### DIFF
--- a/pkgs/development/python-modules/hatasmota/default.nix
+++ b/pkgs/development/python-modules/hatasmota/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, attrs
+, buildPythonPackage
+, fetchFromGitHub
+, voluptuous
+}:
+
+buildPythonPackage rec {
+  pname = "hatasmota";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "emontnemery";
+    repo = pname;
+    rev = version;
+    sha256 = "1xsqrpd0dprjfaa2yrdy1g9n4xyrw6ifnzkrh3sq5fx0yfmxbzqm";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    voluptuous
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "hatasmota" ];
+
+  meta = with lib; {
+    description = "Python module to help parse and construct Tasmota MQTT messages";
+    homepage = "https://github.com/emontnemery/hatasmota";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -816,7 +816,7 @@
     "tank_utility" = ps: with ps; [ ]; # missing inputs: tank_utility
     "tankerkoenig" = ps: with ps; [ ]; # missing inputs: pytankerkoenig
     "tapsaff" = ps: with ps; [ ]; # missing inputs: tapsaff
-    "tasmota" = ps: with ps; [ aiohttp-cors paho-mqtt ]; # missing inputs: hatasmota
+    "tasmota" = ps: with ps; [ aiohttp-cors hatasmota paho-mqtt ];
     "tautulli" = ps: with ps; [ ]; # missing inputs: pytautulli
     "tcp" = ps: with ps; [ ];
     "ted5000" = ps: with ps; [ xmltodict ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2818,6 +2818,8 @@ in {
 
   hass-nabucasa = callPackage ../development/python-modules/hass-nabucasa { };
 
+  hatasmota = callPackage ../development/python-modules/hatasmota { };
+
   hawkauthlib = callPackage ../development/python-modules/hawkauthlib { };
 
   hbmqtt = callPackage ../development/python-modules/hbmqtt { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to help parse and construct Tasmota MQTT messages

https://github.com/emontnemery/hatasmota

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
