### PR TITLE
python3Packages.pipx: 0.15.6.0 -> 0.16.0.0

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -5,12 +5,13 @@
 , userpath
 , argcomplete
 , packaging
+, importlib-metadata
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pipx";
-  version = "0.15.6.0";
+  version = "0.16.0.0";
 
   disabled = pythonOlder "3.6";
 
@@ -19,10 +20,16 @@ buildPythonPackage rec {
     owner = "pipxproject";
     repo = pname;
     rev = version;
-    sha256 = "1yffswayjfkmq86ygisja0mkg55pqj9pdml5nc0z05222sfnvn1a";
+    sha256 = "08mn7vm8iw20pg0gfn491y1jx8wcyjijps6f1hy7ipzd5ckynscn";
   };
 
-  propagatedBuildInputs = [ userpath argcomplete packaging ];
+  propagatedBuildInputs = [
+    userpath
+    argcomplete
+    packaging
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
+  ];
 
   checkInputs = [ pytestCheckHook ];
 
@@ -31,6 +38,7 @@ buildPythonPackage rec {
   '';
 
   # disable tests, which require internet connection
+  pytestFlagsArray = [ "--ignore=tests/test_install_all_packages.py" ];
   disabledTests = [
     "install"
     "inject"
@@ -38,10 +46,12 @@ buildPythonPackage rec {
     "missing_interpreter"
     "cache"
     "internet"
+    "run"
     "runpip"
     "upgrade"
     "suffix"
     "legacy_venv"
+    "determination"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the latest version: https://github.com/pipxproject/pipx/releases/tag/0.16.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
