### PR TITLE
ns-3: 3.32 -> 3.33

### DIFF
--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -38,7 +38,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ns-3";
-  version = "32";
+  version = "33";
 
   src = fetchFromGitLab {
     owner = "nsnam";
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     sha256 = "158yjhsrmslj1q4zcq5p16hv9i82qnxx714l7idicncn0wzrfx7k";
   };
 
-  nativeBuildInputs = [ wafHook ];
+  nativeBuildInputs = [ wafHook python ];
 
   outputs = [ "out" ] ++ lib.optional pythonSupport "py";
 
@@ -60,8 +60,6 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs doc/ns3_html_theme/get_version.sh
-    # FIX/Remove when https://github.com/NixOS/nixpkgs/pull/69310 gets merged
-    sed -i 's/program.ns3_module_dependencies.copy()/program.ns3_module_dependencies[:]/g' wscript
   '';
 
   wafConfigureFlags = with stdenv.lib; [
@@ -107,6 +105,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     description = "A discrete time event network simulator";
     platforms = with platforms; unix;
-    maintainers = with maintainers; [ teto ];
+    maintainers = with maintainers; [ teto rgrunbla ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updating the ns-3 package and removing temporary fix because wafHook was fixed. Adding myself to maintainers as I plan to regularly use this program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
