### PR TITLE
babelfish: 0.1.3 -> 1.0.0

### DIFF
--- a/pkgs/shells/fish/babelfish.nix
+++ b/pkgs/shells/fish/babelfish.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, buildGoModule, fetchFromGitHub }:
 buildGoModule rec {
   pname = "babelfish";
-  version = "0.1.3";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "bouk";
     repo = "babelfish";
     rev = "v${version}";
-    sha256 = "08i4y4fw60ynamr1jz8nkfkidxj06vcyhi1v4wxpl2macn6n4skk";
+    sha256 = "A5FUnER25FDkL/K7RCqudZI6Xd5wg9B8aLbYUw6+7BA=";
   };
 
-  vendorSha256 = "0xjy50wciw329kq1nkd7hhaipcp4fy28hhk6cdq21qwid6g21gag";
+  vendorSha256 = "T70gnmmR4yBwY2ZCiIR35LIbFYSnTRvwTGLwyDgoXnY=";
 
   meta = with lib; {
     description = "Translate bash scripts to fish";


### PR DESCRIPTION
Notably, adds support for stdout redirections and fixes a failing test.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
