### PR TITLE
ci: add no-channel check

### DIFF
--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -16,6 +16,6 @@ jobs:
         The nixos-* and nixpkgs-* branches are pushed to by the channel
         release script and should not be merged into directly.
 
-        Please target the equivalent release-* branch instead.
+        Please target the equivalent release-* branch or master instead.
         EOF
         exit 1

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -1,0 +1,21 @@
+name: "No channel PR"
+
+on:
+  pull_request:
+    branches:
+      - 'nixos-**'
+      - 'nixpkgs-**'
+
+jobs:
+  fail:
+    name: "This PR is is targeting a channel branch"
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        cat <<EOF
+        The nixos-* and nixpkgs-* branches are pushed to by the channel
+        release script and should not be merged into directly.
+
+        Please target the equivalent release-* branch instead.
+        EOF
+        exit 1


### PR DESCRIPTION
###### Motivation for this change

Somebody merged a change in `nixos-20.09`. See #109384

###### Proposal

This is a proposal to prevent such issues in the future.

1. Add a CI check that always fails, that contains an explanation.
2. Configure nixpkgs to require this CI status to pass on the protected branches.

Here is how the error looks like:

![image](https://user-images.githubusercontent.com/3248/104816792-2dbf4780-5815-11eb-891b-5194d501cda3.png)

And the branch protection change that would be put in place:
![image](https://user-images.githubusercontent.com/3248/104817006-788d8f00-5816-11eb-817a-a32cab8a3f04.png)
