### PR TITLE
ns-3: Fix hash for 3.33

### DIFF
--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitLab
+, fetchpatch
 , python
 , wafHook
 
@@ -44,7 +45,7 @@ stdenv.mkDerivation rec {
     owner = "nsnam";
     repo   = "ns-3-dev";
     rev    = "ns-3.${version}";
-    sha256 = "158yjhsrmslj1q4zcq5p16hv9i82qnxx714l7idicncn0wzrfx7k";
+    sha256 = "0ds8h0f2qcb0gc2a8bk38cbhdb122i4sbg589bjn59rblzw0hkq4";
   };
 
   nativeBuildInputs = [ wafHook python ];
@@ -96,6 +97,14 @@ stdenv.mkDerivation rec {
   checkPhase =  ''
     ${pythonEnv.interpreter} ./test.py --nowaf
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "upstream-issue-336.patch";
+      url = "https://gitlab.com/nsnam/ns-3-dev/-/commit/673004edae1112e6cb249b698aad856d728530fb.patch";
+      sha256 = "0q96ividinbh9xlws014b2ir6gaavygnln5ca9m1db06m4vfwhng";
+    })
+  ];
 
   # strictoverflow prevents clang from discovering pyembed when bindings
   hardeningDisable = [ "fortify" "strictoverflow"];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix the hash for the 3.33 version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
