### PR TITLE
burpsuite: 2020.1 -> 2020.12.1

### DIFF
--- a/pkgs/tools/networking/burpsuite/default.nix
+++ b/pkgs/tools/networking/burpsuite/default.nix
@@ -1,15 +1,15 @@
-{ lib, stdenv, fetchurl, jre, runtimeShell }:
+{ lib, stdenv, fetchurl, jdk11, runtimeShell }:
 
 let
-  version = "2020.1";
+  version = "2020.12.1";
   jar = fetchurl {
     name = "burpsuite.jar";
     url = "https://portswigger.net/Burp/Releases/Download?productId=100&version=${version}&type=Jar";
-    sha256 = "12awfy0f8fyqjc0kza1gkmdx1g8bniw1xqaps2dhjimi6s0lq5jx";
+    sha256 = "1vdxwasvcyxyyidq3cfjphzkir358sxikgvxgl36czylap4hzjh1";
   };
   launcher = ''
     #!${runtimeShell}
-    exec ${jre}/bin/java -jar ${jar} "$@"
+    exec ${jdk11}/bin/java -jar ${jar} "$@"
   '';
 in stdenv.mkDerivation {
   pname = "burpsuite";
@@ -33,7 +33,7 @@ in stdenv.mkDerivation {
     homepage = "https://portswigger.net/burp/";
     downloadPage = "https://portswigger.net/burp/freedownload";
     license = [ lib.licenses.unfree ];
-    platforms = jre.meta.platforms;
+    platforms = jdk11.meta.platforms;
     hydraPlatforms = [];
     maintainers = with lib.maintainers; [ bennofs ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Also moved to Java 11 to avoid warnings when launching Burp Suite.
[Burp Suite only officially supports Java versions 9 to 14](https://portswigger.net/burp/documentation/desktop/getting-started/launching/command-line#checking-your-java-version).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
