### PR TITLE
pythonPackages.ufoprocessor: fix test execution

### DIFF
--- a/pkgs/development/python-modules/ufoprocessor/default.nix
+++ b/pkgs/development/python-modules/ufoprocessor/default.nix
@@ -26,9 +26,14 @@ buildPythonPackage rec {
     mutatormath
   ];
 
-  # tests require custom commands to run
-  doCheck = false;
-  pythonImportsCheck = [ "ufoProcessor" ];
+  checkPhase = ''
+    runHook preCheck
+    for t in Tests/*.py; do
+      # https://github.com/LettError/ufoProcessor/issues/32
+      [[ "$(basename "$t")" = "tests_fp.py" ]] || python "$t"
+    done
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Read, write and generate UFOs with designspace data";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

execute non standard test suite


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
