### PR TITLE
python3Packages.pubnubsub-handler: init at 1.0.9

### DIFF
--- a/pkgs/development/python-modules/pubnub/default.nix
+++ b/pkgs/development/python-modules/pubnub/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, cbor2
+, fetchFromGitHub
+, pycryptodomex
+, pytestCheckHook
+, pyyaml
+, pytest-vcr
+, pytest-asyncio
+, requests
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "pubnub";
+  version = "4.8.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "python";
+    rev = "v${version}";
+    sha256 = "16wjal95042kh5fxhvji0rwmw892pacqcnyms520mw15wcwilqir";
+  };
+
+  propagatedBuildInputs = [
+    cbor2
+    pycryptodomex
+    requests
+    six
+  ];
+
+  checkInputs = [
+    aiohttp
+    pycryptodomex
+    pytest-asyncio
+    pytestCheckHook
+    pytest-vcr
+
+  ];
+
+  # Some tests don't pass with recent releases of tornado/twisted
+  pytestFlagsArray = [
+    "--ignore tests/integrational"
+    "--ignore tests/manual/asyncio"
+    "--ignore tests/manual/tornado/test_reconnections.py"
+  ];
+
+  pythonImportsCheck = [ "pubnub" ];
+
+  meta = with lib; {
+    description = "Python-based APIs for PubNub";
+    homepage = "https://github.com/pubnub/python";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pubnubsub-handler/default.nix
+++ b/pkgs/development/python-modules/pubnubsub-handler/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pubnub
+, pycryptodomex
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "pubnubsub-handler";
+  version = "1.0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:1c44x19zi709sazgl060nkqa7vbaf3iyhwcnwdykhsbipvp6bscy";
+  };
+
+  propagatedBuildInputs = [
+    pubnub
+    pycryptodomex
+    requests
+  ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pubnubsubhandler" ];
+
+  meta = with lib; {
+    description = "PubNub subscription between PubNub and Home Assistant";
+    homepage = "https://github.com/w1ll1am23/pubnubsub-handler";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-vcr/default.nix
+++ b/pkgs/development/python-modules/pytest-vcr/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pytest
+, vcrpy
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-vcr";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "ktosiek";
+    repo = pname;
+    rev = version;
+    sha256 = "1i6fin91mklvbi8jzfiswvwf1m91f43smpj36a17xrzk4gisfs6i";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    vcrpy
+   ];
+
+  # Tests are using an obsolete attribute 'config'
+  # https://github.com/ktosiek/pytest-vcr/issues/43
+  doCheck = false;
+  pythonImportsCheck = [ "pytest_vcr" ];
+
+  meta = with lib; {
+    description = "Integration VCR.py into pytest";
+    homepage = "https://github.com/ktosiek/pytest-vcr";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -927,7 +927,7 @@
     "whois" = ps: with ps; [ python-whois ];
     "wiffi" = ps: with ps; [ ]; # missing inputs: wiffi
     "wilight" = ps: with ps; [ pywilight ];
-    "wink" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pubnubsub-handler python-wink
+    "wink" = ps: with ps; [ aiohttp-cors pubnubsub-handler ]; # missing inputs: python-wink
     "wirelesstag" = ps: with ps; [ ]; # missing inputs: wirelesstagpy
     "withings" = ps: with ps; [ aiohttp-cors ]; # missing inputs: withings-api
     "wled" = ps: with ps; [ wled ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5023,6 +5023,10 @@ in {
 
   publicsuffix = callPackage ../development/python-modules/publicsuffix { };
 
+  pubnub = callPackage ../development/python-modules/pubnub { };
+
+  pubnubsub-handler = callPackage ../development/python-modules/pubnubsub-handler { };
+
   pudb = callPackage ../development/python-modules/pudb { };
 
   pulp = callPackage ../development/python-modules/pulp { };
@@ -6074,6 +6078,8 @@ in {
   pytest-trio = callPackage ../development/python-modules/pytest-trio { };
 
   pytest-twisted = callPackage ../development/python-modules/pytest-twisted { };
+
+  pytest-vcr = callPackage ../development/python-modules/pytest-vcr { };
 
   pytest-virtualenv = callPackage ../development/python-modules/pytest-virtualenv { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
PubNub subscription between PubNub and Home Assistant.

https://github.com/w1ll1am23/pubnubsub-handler

This is a Home Assistant dependency.

This PR includes the needed dependencies for `pubnubsub-handler`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
