### PR TITLE
linuxPackages.gvusb2: init at 2020-07-27-unstable

### DIFF
--- a/pkgs/os-specific/linux/gvusb2/Makefile.patch
+++ b/pkgs/os-specific/linux/gvusb2/Makefile.patch
@@ -1,0 +1,17 @@
+diff --git a/Makefile b/Makefile
+index e666392..e1a341b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -3,8 +3,10 @@ obj-m += gvusb2-sound.o gvusb2-video.o
+ gvusb2-sound-y := gvusb2-snd.o gvusb2-core.o
+ gvusb2-video-y := gvusb2-vid.o gvusb2-v4l2.o gvusb2-core.o gvusb2-i2c.o
+ 
++KERNEL_SOURCE_DIR := /lib/modules/$(shell uname -r)/build
++
+ all:
+-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
++	make -C $(KERNEL_SOURCE_DIR) M=$(PWD) modules
+ 
+ clean:
+-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
++	make -C $(KERNEL_SOURCE_DIR) M=$(PWD) clean

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -25,8 +25,8 @@ in stdenv.mkDerivation rec {
   ] ++ (optional (versionOlder kernel.version "5.7") ./vfl_type_grabber.patch);
 
   installPhase = ''
-    install -D {,$out/${kerneldir}/extra/}gvusb2-sound.ko
-    install -D {,$out/${kerneldir}/extra/}gvusb2-video.ko
+    install -D gvusb2-sound.ko $out/${kerneldir}/extra/gvusb2-sound.ko
+    install -D gvusb2-video.ko $out/${kerneldir}/extra/gvusb2-video.ko
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./Makefile.patch
-  ] ++ (lib.optional (lib.versionOlder lib.kernel.version "5.7") ./vfl_type_grabber.patch);
+  ] ++ (lib.optional (lib.versionOlder kernel.version "5.7") ./vfl_type_grabber.patch);
 
   installPhase = ''
     install -D gvusb2-sound.ko $out/${kerneldir}/extra/gvusb2-sound.ko

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -20,9 +20,9 @@ in stdenv.mkDerivation rec {
     "INSTALL_MOD_PATH=$(out)"
   ];
 
-  patches = with lib; [
+  patches = [
     ./Makefile.patch
-  ] ++ (optional (versionOlder kernel.version "5.7") ./vfl_type_grabber.patch);
+  ] ++ (lib.optional (lib.versionOlder lib.kernel.version "5.7") ./vfl_type_grabber.patch);
 
   installPhase = ''
     install -D gvusb2-sound.ko $out/${kerneldir}/extra/gvusb2-sound.ko

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A linux driver for the IO-DATA GV-USB2 SD capture device";
     homepage = "https://github.com/Isaac-Lozano/GV-USB2-Driver";
-    license = licenses.gpl2;
+    license = with licenses [ bsd3 gpl2Only ];
     maintainers = with maintainers; [ djanatyn ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, kernel, kmod }:
+
+let
+  kerneldir = "lib/modules/${kernel.modDirVersion}";
+in stdenv.mkDerivation rec {
+  pname = "gvusb2";
+  version = "2020-07-27-unstable";
+
+  src = fetchFromGitHub {
+    owner = "Isaac-Lozano";
+    repo = pname;
+    rev = "811fb0f6ee4ef62e0e346a293bb5e3b61ad10b7d";
+    sha256 = "0sxspwizcpd6a63awnd6czxylp48rw3h22mf8hf0gh514gklyy5a";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "KERNEL_SOURCE_DIR=${kernel.dev}/${kerneldir}/build"
+    "INSTALL_MOD_PATH=$(out)"
+  ];
+
+  patches = with lib; [
+    ./Makefile.patch
+  ] ++ (optional (versionOlder kernel.version "5.7") ./vfl_type_grabber.patch);
+
+  installPhase = ''
+    install -D {,$out/${kerneldir}/extra/}gvusb2-sound.ko
+    install -D {,$out/${kerneldir}/extra/}gvusb2-video.ko
+  '';
+
+  meta = with lib; {
+    description = "A linux driver for the IO-DATA GV-USB2 SD capture device";
+    homepage = "https://github.com/Isaac-Lozano/GV-USB2-Driver";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ djanatyn ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A linux driver for the IO-DATA GV-USB2 SD capture device";
     homepage = "https://github.com/Isaac-Lozano/GV-USB2-Driver";
-    license = with licenses [ bsd3 gpl2Only ];
+    license = with licenses; [ bsd3 gpl2Only ];
     maintainers = with maintainers; [ djanatyn ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/gvusb2/default.nix
+++ b/pkgs/os-specific/linux/gvusb2/default.nix
@@ -8,7 +8,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "Isaac-Lozano";
-    repo = pname;
+    repo = "GV-USB2-Driver";
     rev = "811fb0f6ee4ef62e0e346a293bb5e3b61ad10b7d";
     sha256 = "0sxspwizcpd6a63awnd6czxylp48rw3h22mf8hf0gh514gklyy5a";
   };

--- a/pkgs/os-specific/linux/gvusb2/vfl_type_grabber.patch
+++ b/pkgs/os-specific/linux/gvusb2/vfl_type_grabber.patch
@@ -1,0 +1,13 @@
+diff --git a/gvusb2-v4l2.c b/gvusb2-v4l2.c
+index 4723b52..af1d95e 100644
+--- a/gvusb2-v4l2.c
++++ b/gvusb2-v4l2.c
+@@ -663,7 +663,7 @@ int gvusb2_video_register(struct gvusb2_vid *dev)
+ 		dev->standard);
+ 
+ 	video_set_drvdata(&dev->vdev, dev);
+-	ret = video_register_device(&dev->vdev, VFL_TYPE_VIDEO, -1);
++	ret = video_register_device(&dev->vdev, VFL_TYPE_GRABBER, -1);
+ 	if (ret < 0)
+ 		return ret;
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19149,6 +19149,8 @@ in
 
     gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
 
+    gvusb2 = callPackage ../os-specific/linux/gvusb2 {};
+
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
     e1000e = if lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a new linux driver for the I-O DATA GV-USB2 capture card:
```
❯ find $(nix-build -A linuxPackages_latest.gvusb2) -type f
/nix/store/w77k64zb6v3x6sb9mwsf0n4qpjydkr6r-gvusb2-2020-07-27-unstable/lib/modules/5.10.7/extra/gvusb2-sound.ko
/nix/store/w77k64zb6v3x6sb9mwsf0n4qpjydkr6r-gvusb2-2020-07-27-unstable/lib/modules/5.10.7/extra/gvusb2-video.ko
❯ lsmod | grep gvusb2
gvusb2_video           32768  0
videobuf2_vmalloc      20480  1 gvusb2_video
videobuf2_v4l2         28672  1 gvusb2_video
videobuf2_common       53248  2 gvusb2_video,videobuf2_v4l2
videodev              253952  3 gvusb2_video,videobuf2_v4l2,videobuf2_common
gvusb2_sound           16384  0
snd_pcm               114688  6 snd_hda_codec_hdmi,snd_hda_intel,snd_hda_codec,snd_pcm_oss,gvusb2_sound,snd_hda_core
snd                    90112  17 snd_hda_codec_generic,snd_hda_codec_hdmi,snd_hwdep,snd_hda_intel,snd_hda_codec,snd_hda_codec_realtek,snd_timer,snd_pcm_oss,snd_pcm,gvusb2_sound,snd_mixer_oss
i2c_core               86016  7 videodev,drm_kms_helper,gvusb2_video,i2c_algo_bit,amdgpu,i2c_piix4,drm
usbcore               278528  6 xhci_hcd,gvusb2_video,usbhid,btusb,xhci_pci,gvusb2_sound
```

Using the driver, I was able to play Super Mario 64 on a CRT with simultaneous playback in VLC / OBS-Studio:
```
[  226.481672] usb 1-3: new high-speed USB device number 8 using xhci_hcd
[  226.683104] usb 1-3: config 1 interface 0 altsetting 0 endpoint 0x81 has invalid wMaxPacketSize 0
[  226.724103] usb 1-3: New USB device found, idVendor=04bb, idProduct=0532, bcdDevice= 0.05
[  226.724104] usb 1-3: New USB device strings: Mfr=1, Product=2, SerialNumber=10
[  226.724105] usb 1-3: Product: I-O DATA GV-USB2
[  226.724106] usb 1-3: Manufacturer: I-O DATA
[  226.724107] usb 1-3: SerialNumber: 000000000000001
...
[  226.772110] usbcore: registered new interface driver gvusb2-snd
[  226.776674] mc: Linux media interface: v0.10
[  226.787110] videodev: Linux video capture interface: v2.00
[  226.792728] gvusb2-vid 1-3:1.0: found video at altsetting 5 endpoint 1
[  227.071151] usbcore: registered new interface driver gvusb2-vid
```

I tested with kernel `5.10.7`:
```
    boot.extraModulePackages = with linuxPackages_latest; [
      gvusb2
    ];
```

`vfl_type_grabber.patch` addresses https://github.com/Isaac-Lozano/GV-USB2-Driver/issues/2 on appropriate kernel versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
