### PR TITLE
_3270font: 2.1.0 -> 2.2.1

### DIFF
--- a/pkgs/data/fonts/3270font/default.nix
+++ b/pkgs/data/fonts/3270font/default.nix
@@ -1,24 +1,25 @@
 { lib, fetchzip }:
 let
-  version = "2.1.0";
+  version = "2.2.1";
 in
 fetchzip {
   name = "3270font-${version}";
 
-  url = "https://github.com/rbanffy/3270font/releases/download/v.${version}/3270_fonts_fba25eb.zip";
+  url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_70de9c7.zip";
 
-  sha256 = "04xqgiznd6d3c1rdbbdmd87rjy9bnhh00lm8xzmal1zidcr2g0n9";
+  sha256 = "0spz9abp87r3bncjim6hs47fmhg86qbgips4x6nfpqzg5qh2xd2m";
 
   postFetch = ''
     mkdir -p $out/share/fonts/
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff
+    unzip -j $downloadedFile \*.afm -d $out/share/fonts/type1
   '';
 
   meta = with lib; {
     description = "Monospaced font based on IBM 3270 terminals";
     homepage = "https://github.com/rbanffy/3270font";
+    changelog = "https://github.com/rbanffy/3270font/blob/v${version}/CHANGELOG.md";
     license = [ licenses.bsd3 licenses.ofl ];
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/rbanffy/3270font/releases/tag/v2.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
