### PR TITLE
sphinx-autobuild: init at 2020.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3741,6 +3741,12 @@
     githubId = 130903;
     name = "Ana Hobden";
   };
+  holgerpeters = {
+    name = "Holger Peters";
+    email = "holger.peters@posteo.de";
+    github = "HolgerPeters";
+    githubId = 4097049;
+  };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";

--- a/pkgs/development/python-modules/sphinx-autobuild/default.nix
+++ b/pkgs/development/python-modules/sphinx-autobuild/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, sphinx
+, livereload
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-autobuild";
+  version = "2020.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vbaf4vrxahylyp8zrlw5dx1d2faajp926c3pl5i1wlkp1yll62b";
+  };
+
+  propagatedBuildInputs = [ sphinx livereload ];
+
+  # No tests included.
+  doCheck = false;
+  pythonImportsCheck = [ "sphinx_autobuild" ];
+
+  meta = with lib; {
+    description = "Rebuild Sphinx documentation on changes, with live-reload in the browser";
+    homepage = "https://github.com/executablebooks/sphinx-autobuild";
+    license = with licenses; [ mit ];
+    maintainer = with maintainers; [holgerpeters];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7337,6 +7337,8 @@ in {
 
   sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
 
+  sphinx-autobuild = callPackage ../development/python-modules/sphinx-argparse { };
+
   sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
   sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree { };


### PR DESCRIPTION
Addresses  #109564

###### Motivation for this change

Package seems to be missing albeit useful.

Be mindful, this is my first contribution to `nixpkgs`. I build the package locally in my shell.nix setup but it isn't exactly straightforward for me to test my patch in `nixpkgs` for some reason. I tried to produce a diff that looks like other Python package definitions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
