### PR TITLE
metapixel: init at 1.0.2

### DIFF
--- a/pkgs/tools/graphics/metapixel/default.nix
+++ b/pkgs/tools/graphics/metapixel/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, libpng, libjpeg, giflib, perl, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "metapixel";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "schani";
+    repo = pname;
+    rev = "98ee9daa093b6c334941242e63f90b1c2876eb4f";
+    fetchSubmodules = true;
+    sha256 = "0r7n3a6bvcxkbpda4mwmrpicii09iql5z69nkjqygkwxw7ny3309";
+  };
+
+  makeFlags = [ "metapixel" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libpng libjpeg giflib perl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp metapixel $out/bin/metapixel
+    cp metapixel-prepare $out/bin/metapixel-prepare
+    cp metapixel-sizesort $out/bin/metapixel-sizesort
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/schani/metapixel";
+    description = "Tool for generating photomosaics";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -713,6 +713,8 @@ in
 
   albert = libsForQt5.callPackage ../applications/misc/albert {};
 
+  metapixel = callPackage ../tools/graphics/metapixel { };
+
   ### APPLICATIONS/TERMINAL-EMULATORS
 
   alacritty = callPackage ../applications/terminal-emulators/alacritty {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I needed this program, and though it is a little old it is working and available in many other distros:
https://repology.org/project/metapixel/versions

###### Things done

Package installs, but the manual page is not compiled. The Makefile wants to read a docbook from some path in /usr/lib and I don't know enough about how manuals are supposed work to fix that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
