### PR TITLE
git-big-picture: 0.10.1 -> 1.0.0 (fixes CVE-2021-3028)

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -1,19 +1,23 @@
-{ fetchFromGitHub, python2Packages, lib, stdenv, git, graphviz }:
+{ fetchFromGitHub, python3Packages, lib, stdenv, git, graphviz }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "git-big-picture";
-  version = "0.10.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "esc";
+    owner = "git-big-picture";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0b0zdq7d7k7f6p3wwc799347fraphbr20rxd1ysnc4xi1cj4wpmi";
+    sha256 = "14yf71iwgk78nw8w0bpijsnnl4vg3bvxsw3vvypxmbrc1nh0bdha";
   };
 
   buildInputs = [ git graphviz ];
 
-  checkInputs = [ git ];
+  # NOTE: Tests are disabled due to unpackaged test dependency "Scruf".
+  #       When bumping to 1.1.0, please re-enable and use:
+  #checkInputs = [ cram git pytest ];
+  #checkPhase = "pytest test.py";
+  doCheck = false;
 
   postFixup = ''
     wrapProgram $out/bin/git-big-picture \
@@ -22,8 +26,8 @@ python2Packages.buildPythonApplication rec {
 
   meta = {
     description = "Tool for visualization of Git repositories";
-    homepage = "https://github.com/esc/git-big-picture";
-    license = lib.licenses.gpl3;
+    homepage = "https://github.com/git-big-picture/git-big-picture";
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.nthorne ];
   };


### PR DESCRIPTION
Also propagates move of repository from https://github.com/esc/git-big-picture to https://github.com/git-big-picture/git-big-picture. Upstream change log for 1.0.0 is at https://github.com/git-big-picture/git-big-picture#changelog

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix for vulnerability CVE-2021-3028 + bugfixes + new features

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
