### PR TITLE
grafana-agent: init at 0.10.0

### DIFF
--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildGoModule, fetchFromGitHub, systemd }:
+
+buildGoModule rec {
+  pname = "grafana-agent";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "grafana";
+    repo = "agent";
+    sha256 = "1kliq6d3hg4bx9s5crdagirf2h3ljl0ikcyz0x0wb2ack6cgjsvm";
+  };
+
+  vendorSha256 = null;
+
+  # uses go-systemd, which uses libsystemd headers
+  # https://github.com/coreos/go-systemd/issues/351
+  NIX_CFLAGS_COMPILE = [ "-I${lib.getDev systemd}/include" ];
+
+  # tries to access /sys: https://github.com/grafana/agent/issues/333
+  preBuild = ''
+    rm pkg/integrations/node_exporter/node_exporter_test.go
+  '';
+
+  # go-systemd uses libsystemd under the hood, which does dlopen(libsystemd) at
+  # runtime.
+  # Add to RUNPATH so it can be found.
+  postFixup = ''
+    patchelf \
+      --set-rpath "${lib.makeLibraryPath [ (lib.getDev systemd) ]}:$(patchelf --print-rpath $out/bin/agent)" \
+      $out/bin/agent
+  '';
+
+  meta = with lib; {
+    description = "A lightweight subset of Prometheus and more, optimized for Grafana Cloud";
+    license = licenses.asl20;
+    homepage = "https://grafana.com/products/cloud";
+    maintainers = with maintainers; [ flokli ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17708,6 +17708,8 @@ in
   grafana = callPackage ../servers/monitoring/grafana { };
   grafanaPlugins = dontRecurseIntoAttrs (callPackage ../servers/monitoring/grafana/plugins { });
 
+  grafana-agent = callPackage ../servers/monitoring/grafana-agent { };
+
   grafana-loki = callPackage ../servers/monitoring/loki { };
 
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };


### PR DESCRIPTION
###### Motivation for this change
Push Metrics to Grafana Cloud (or anything implementing the receiving side of the `remote_write` really, like https://github.com/cortexproject/cortex or https://victoriametrics.com/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
