### PR TITLE
sqlar: fix build error

### DIFF
--- a/pkgs/development/libraries/sqlite/sqlar.nix
+++ b/pkgs/development/libraries/sqlite/sqlar.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ fuse zlib ];
 
-  buildFlags = [ "sqlar" "sqlarfs" ];
+  buildFlags = [ "sqlar" "sqlarfs" "CFLAGS=-Wno-error" ];
 
   installPhase = ''
     install -D -t $out/bin sqlar sqlarfs


### PR DESCRIPTION
###### Motivation for this change
This fixes the broken `sqlar` package.  This is the broken build:
https://hydra.nixos.org/build/134856172

This is probably a regression from the recent gcc 10 bump.

cc @dtzWill 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
