### PR TITLE
python3Packages.python-hpilo: init at 4.4.3

### DIFF
--- a/pkgs/development/python-modules/python-hpilo/default.nix
+++ b/pkgs/development/python-modules/python-hpilo/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, utils
+}:
+
+buildPythonPackage rec {
+  pname = "python-hpilo";
+  version = "4.4.3";
+
+  src = fetchFromGitHub {
+    owner = "seveas";
+    repo = pname;
+    rev = version;
+    sha256 = "1dk5xswydw7nmn9hlna1xca1mzcas9qv2kmid5yx8kvk3hjqci9v";
+  };
+
+  # Most tests requires an actual iLO to run
+  doCheck = false;
+  pythonImportsCheck = [ "hpilo" ];
+
+  meta = with lib; {
+    description = "Python module to access the HP iLO XML interface";
+    homepage = "https://seveas.github.io/python-hpilo/";
+    license = with licenses; [ asl20 gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/utils/default.nix
+++ b/pkgs/development/python-modules/utils/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "utils";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "haaksmash";
+    repo = "pyutils";
+    rev = version;
+    sha256 = "07pr39cfw5ayzkp6h53y7lfpd0w19pphsdzsf100fsyy3npavgbr";
+  };
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "utils" ];
+
+  meta = with lib; {
+    description = "Python set of utility functions and objects";
+    homepage = "https://github.com/haaksmash/pyutils";
+    license = with licenses; [ lgpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -357,7 +357,7 @@
     "homeworks" = ps: with ps; [ ]; # missing inputs: pyhomeworks
     "honeywell" = ps: with ps; [ ]; # missing inputs: somecomfort
     "horizon" = ps: with ps; [ ]; # missing inputs: horimote
-    "hp_ilo" = ps: with ps; [ ]; # missing inputs: python-hpilo
+    "hp_ilo" = ps: with ps; [ python-hpilo ];
     "html5" = ps: with ps; [ aiohttp-cors pywebpush ];
     "http" = ps: with ps; [ aiohttp-cors ];
     "htu21d" = ps: with ps; [ smbus-cffi ]; # missing inputs: i2csense

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6151,6 +6151,8 @@ in {
 
   python-hosts = callPackage ../development/python-modules/python-hosts { };
 
+  python-hpilo = callPackage ../development/python-modules/python-hpilo { };
+
   python-igraph = callPackage ../development/python-modules/python-igraph {
     pkgconfig = pkgs.pkgconfig;
     igraph = pkgs.igraph;
@@ -7900,6 +7902,8 @@ in {
   user-agents = callPackage ../development/python-modules/user-agents { };
 
   userpath = callPackage ../development/python-modules/userpath { };
+
+  utils = callPackage ../development/python-modules/utils { };
 
   uuid = callPackage ../development/python-modules/uuid { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module to access the HP iLO XML interface

https://seveas.github.io/python-hpilo/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
