### PR TITLE
gruvbox-dark-gtk: init at 1.0.1, gruvbox-dark-icons-gtk: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6693,6 +6693,12 @@
     githubId = 148037;
     name = "Joachim Breitner";
   };
+  nomisiv = {
+    email = "simon@nomisiv.com";
+    github = "NomisIV";
+    githubId = 47303199;
+    name = "Simon Gutgesell";
+  };
   noneucat = {
     email = "andy@lolc.at";
     github = "noneucat";

--- a/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
+++ b/pkgs/data/icons/gruvbox-dark-icons-gtk/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, gtk3, breeze-icons, gnome-icon-theme, hicolor-icon-theme }:
+
+stdenv.mkDerivation rec {
+  pname = "gruvbox-dark-icons-gtk";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jmattheis";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fks2rrrb62ybzn8gqan5swcgksrb579vk37bx4xpwkc552dz2z2";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [ breeze-icons gnome-icon-theme hicolor-icon-theme ];
+
+  installPhase = ''
+    mkdir -p $out/share/icons/oomox-gruvbox-dark
+    rm README.md
+    cp -r * $out/share/icons/oomox-gruvbox-dark
+    gtk-update-icon-cache $out/share/icons/oomox-gruvbox-dark
+  '';
+
+  dontDropIconThemeCache = true;
+
+  meta = with lib; {
+    description = "Gruvbox icons for GTK based desktop environments";
+    homepage = "https://github.com/jmattheis/gruvbox-dark-gtk";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.nomisiv ];
+  };
+}

--- a/pkgs/data/themes/gruvbox-dark-gtk/default.nix
+++ b/pkgs/data/themes/gruvbox-dark-gtk/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "gruvbox-dark-gtk";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "jmattheis";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wf4ybnjdp2kbbvz7pmqdnzk94axaqx5ws18f34hrg4y267n0w4g";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/themes/gruvbox-dark
+    rm -rf README.md LICENSE .github
+    cp -r * $out/share/themes/gruvbox-dark
+  '';
+
+  meta = with lib; {
+    description = "Gruvbox theme for GTK based desktop environments";
+    homepage = "https://github.com/jmattheis/gruvbox-dark-gtk";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.nomisiv ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20271,6 +20271,10 @@ in
 
   gruvbox-dark-gtk = callPackage ../data/themes/gruvbox-dark-gtk { };
 
+  gruvbox-dark-icons-gtk = callPackage ../data/icons/gruvbox-dark-icons-gtk {
+    inherit (plasma5Packages) breeze-icons;
+  };
+
   gubbi-font = callPackage ../data/fonts/gubbi { };
 
   gyre-fonts = callPackage ../data/fonts/gyre {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20269,6 +20269,8 @@ in
 
   greybird = callPackage ../data/themes/greybird { };
 
+  gruvbox-dark-gtk = callPackage ../data/themes/gruvbox-dark-gtk { };
+
   gubbi-font = callPackage ../data/fonts/gubbi { };
 
   gyre-fonts = callPackage ../data/fonts/gyre {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I use these packages locally, and wanted them to become official. I have got them working properly, but the icon preview in lxappearance does not work. I don't know if it's a problem with the packaging, or the project. Icons seem to work nonetheless.

Please bear in mind that I'm new to NixOS, and contributing generally, so I might have missed something

Here are the git repositories for the projects:
https://github.com/jmattheis/gruvbox-dark-gtk
https://github.com/jmattheis/gruvbox-dark-icons-gtk

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`(completed with `No diff detected, stopping review...`)
- [x] Tested execution of all binary files (usually in `./result/bin/`) (The packages successfully build, and the themes can be applied using lxappearance)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
