### PR TITLE
python3Packages.awsiotpythonsdk: init at 1.4.9

### DIFF
--- a/pkgs/development/python-modules/awsiotpythonsdk/default.nix
+++ b/pkgs/development/python-modules/awsiotpythonsdk/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "AWSIoTPythonSDK";
+  version = "1.4.9";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-iot-device-sdk-python";
+    rev = "v${version}";
+    sha256 = "0mbppz1lnia4br5vjz1l4z4vw47y3bzcfpckzhs9lxhj4vq6d001";
+  };
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "AWSIoTPythonSDK" ];
+
+  meta = with lib; {
+    description = "Python SDK for connecting to AWS IoT";
+    homepage = "https://github.com/aws/aws-iot-device-sdk-python";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -558,6 +558,8 @@ in {
 
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };
 
+  awsiotpythonsdk = callPackage ../development/python-modules/awsiotpythonsdk { };
+
   axis = callPackage ../development/python-modules/axis { };
 
   azure-appconfiguration = callPackage ../development/python-modules/azure-appconfiguration { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
SDK for connecting to AWS IoT from a device using Python.

https://github.com/aws/aws-iot-device-sdk-python

This is a missing dependency for `expliot` (coming soon, #81418) and could also be an indirect Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
