### PR TITLE
cargo-readme: init at 3.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -970,6 +970,12 @@
     email = "sivaraman.balaji@gmail.com";
     name = "Balaji Sivaraman";
   };
+  baloo = {
+    email = "nixpkgs@superbaloo.net";
+    github = "baloo";
+    githubId = 59060;
+    name = "Arthur Gautier";
+  };
   balsoft = {
     email = "balsoft75@gmail.com";
     github = "balsoft";

--- a/pkgs/development/tools/rust/cargo-readme/default.nix
+++ b/pkgs/development/tools/rust/cargo-readme/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, fetchpatch }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-readme";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "livioribeiro";
+    repo = pname;
+    # Git tag is missing, see upstream issue:
+    # https://github.com/livioribeiro/cargo-readme/issues/61
+    rev = "cf66017c0120ae198210ebaf58a0be6a78372974";
+    sha256 = "sha256-/ufHHM13L83M3UYi6mjdhIjgXx7bZgzvR/X02Zsx7Fw=";
+  };
+
+  cargoSha256 = "sha256-QVRl6xCvztWi5zAs3PXYR4saTqO5nTBPIjdlMiMXFTM=";
+
+  patches = [
+    (fetchpatch {
+      # Fixup warning thrown at build when running test-suite
+      # unused return, see upstream PR:
+      # https://github.com/livioribeiro/cargo-readme/pull/62
+      url = "https://github.com/livioribeiro/cargo-readme/commit/060f2daaa2b2cf981bf490dc36bcc6527545ea03.patch";
+      sha256 = "sha256-wlAIgTI9OqtA/Jnswoqp7iOj+1zjrUZA7JpHUiF/n+s=";
+    })
+  ];
+
+  meta = with lib; {
+    description = "Generate README.md from docstrings";
+    homepage = "https://github.com/livioribeiro/cargo-readme";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ baloo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10627,6 +10627,7 @@ in
   cargo-raze = callPackage ../development/tools/rust/cargo-raze {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-readme = callPackage ../development/tools/rust/cargo-readme {};
   cargo-sweep = callPackage ../development/tools/rust/cargo-sweep { };
   cargo-sync-readme = callPackage ../development/tools/rust/cargo-sync-readme {};
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {


### PR DESCRIPTION
###### Motivation for this change

Adds cargo-readme to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
