### PR TITLE
beats: fix missing lib in extrafiles plugin

### DIFF
--- a/pkgs/tools/audio/beets/plugins/extrafiles.nix
+++ b/pkgs/tools/audio/beets/plugins/extrafiles.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, beets, pythonPackages }:
+{ lib, fetchFromGitHub, beets, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
   pname = "beets-extrafiles";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/109434 broke this plugin.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).