### PR TITLE
setup-hooks/multiple-outputs.sh: fallback to REMOVE if out isn't in outputs

### DIFF
--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -29,15 +29,18 @@ _overrideFirst() {
 # The variables are global to be usable anywhere during the build.
 # Typical usage in package is defining outputBin = "dev";
 
-_overrideFirst outputDev "dev" "out"
-_overrideFirst outputBin "bin" "out"
+# Typically out is in outputs, but for split packages it's not. In that case
+# maintainer should handle outputs themself, so fallback removing default outputs.
+
+_overrideFirst outputDev "dev" "out" REMOVE
+_overrideFirst outputBin "bin" "out" REMOVE
 
 _overrideFirst outputInclude "$outputDev"
 
 # so-libs are often among the main things to keep, and so go to $out
-_overrideFirst outputLib "lib" "out"
+_overrideFirst outputLib "lib" "out" REMOVE
 
-_overrideFirst outputDoc "doc" "out"
+_overrideFirst outputDoc "doc" "out" REMOVE
 _overrideFirst outputDevdoc "devdoc" REMOVE # documentation for developers
 # man and info pages are small and often useful to distribute with binaries
 _overrideFirst outputMan "man" "$outputBin"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Typically out is in outputs, but for split packages it's not. In that case maintainer should handle outputs themself, so fallback removing default outputs.

This could also avoid the `touch $out` trick.

Fix #16182

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
