### PR TITLE
age: 1.0.0-beta5 -> 1.0.0-beta6

### DIFF
--- a/pkgs/tools/security/age/default.nix
+++ b/pkgs/tools/security/age/default.nix
@@ -2,14 +2,14 @@
 
 buildGoModule rec {
   pname = "age";
-  version = "1.0.0-beta5";
-  vendorSha256 = "0km7a2826j3fk2nrkmgc990chrkcfz006wfw14yilsa4p2hmfl7m";
+  version = "1.0.0-beta6";
+  vendorSha256 = "sha256-FTByNpLkWWHAWe5wVDRBGtKap/5+XGHeBMQAIdlPCkA=";
 
   src = fetchFromGitHub {
     owner = "FiloSottile";
     repo = "age";
     rev = "v${version}";
-    sha256 = "1hdbxd359z8zvnz7h8c4pa16nc7r8db36lx3gpks38lpi0r8hzqk";
+    sha256 = "sha256-1LCcCEf2/R0am0jpA8yKl44+AoUFkbepxp9V6/nZkBQ=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
https://github.com/FiloSottile/age/compare/v1.0.0-beta5...v1.0.0-beta6

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want to be able to use the `-R` flag (allows the usage of a recipients file to encrypt to / decrypt from multiple keys), which is only present in the latest beta6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
