### PR TITLE
doc: rust: fix syntax error in code snippet example for declarative overlay

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -567,12 +567,13 @@ in the `~/.config/nixpkgs/overlays` directory.
 Add the following to your `configuration.nix`, `home-configuration.nix`, `shell.nix`, or similar:
 
 ```
-  nixpkgs = {
+{ pkgs ? import <nixpkgs> {
     overlays = [
       (import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz))
       # Further overlays go here
     ];
   };
+};
 ```
 
 Note that this will fetch the latest overlay version when rebuilding your system.


### PR DESCRIPTION
###### Motivation for this change

In documentation, the suggested snipped for declaring Mozilla overlay
results in an error when pasted into shell.nix:

	error: syntax error, unexpected '=', expecting $end, at /.../shell.nix:2:9

Please close PR if I'm simply doing things wrong, because I am very new to Nix.

###### Things done

Suggesting a fix to the code snippet that worked for me. 
