### PR TITLE
nixos/snapper: improve config example

### DIFF
--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -48,6 +48,8 @@ in
           subvolume = "/home";
           extraConfig = ''
             ALLOW_USERS="alice"
+            TIMELINE_CREATE=yes
+            TIMELINE_CLEANUP=yes
           '';
         };
       };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In the default snapper module configuration we have timers for creating and deleting snapper snapshots, and it looks like if we just create configs with correct mountpoints we will get automatic snapshots. This either used to be true, or seems to be only true on Archlinux according to their wiki: https://wiki.archlinux.org/index.php/Snapper#Enable/disable , "If you have a cron daemon, this feature should start automatically. To disable it, edit the configuration file corresponding with the subvolume you do not want to have this feature and set TIMELINE_CREATE=no"). It is not true on current NixOS.

Options TIMELINE_CREATE and TIMELINE_CLEANUP are set to "no" by default (according to snapper-configs(5)), so just providing configs won't be enough for having automatic backups, which are the main use case for snapper. It is especially important to have it in our docs, as on other linux distributions you would use `snapper create-config` to generate configs for partitions, and you'd see that TIMELINE_CREATE and TIMELINE_CLEANUP are set to no. Also, my guess is that it might be set to no by default purely for safety reasons in regular distros, so that the config won't be actioned upon until the user finishes customizing it.

###### Things done

Added TIMELINE_CREATE=yes and TIMELINE_CLEANUP=yes into snapper service config example.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
