### PR TITLE
gomuks: patch out hardcoded path

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gomuks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gomuks/default.nix
@@ -55,7 +55,7 @@ buildGoModule rec {
     homepage = "https://maunium.net/go/gomuks/";
     description = "A terminal based Matrix client written in Go";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ tilpner emily ];
+    maintainers = with maintainers; [ charvp emily ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/gomuks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gomuks/default.nix
@@ -1,4 +1,15 @@
-{ lib, stdenv, buildGoModule, fetchFromGitHub, olm, makeDesktopItem }:
+{ lib
+, stdenv
+, substituteAll
+, buildGoModule
+, fetchFromGitHub
+, makeDesktopItem
+, makeWrapper
+, libnotify
+, olm
+, pulseaudio
+, sound-theme-freedesktop
+}:
 
 buildGoModule rec {
   pname = "gomuks";
@@ -15,7 +26,13 @@ buildGoModule rec {
 
   doCheck = false;
 
-  buildInputs = [ olm ];
+  buildInputs = [ makeWrapper olm ];
+
+  # Upstream issue: https://github.com/tulir/gomuks/issues/260
+  patches = lib.optional stdenv.isLinux (substituteAll {
+    src = ./hardcoded_path.patch;
+    soundTheme = sound-theme-freedesktop;
+  });
 
   postInstall = ''
     cp -r ${
@@ -30,6 +47,8 @@ buildGoModule rec {
       }
     }/* $out/
     substituteAllInPlace $out/share/applications/*
+    wrapProgram $out/bin/gomuks \
+      --prefix PATH : "${lib.makeBinPath (lib.optionals stdenv.isLinux [ libnotify pulseaudio ])}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/gomuks/hardcoded_path.patch
+++ b/pkgs/applications/networking/instant-messengers/gomuks/hardcoded_path.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/notification/notify_linux.go b/lib/notification/notify_linux.go
+index f93a95f..da6a61d 100644
+--- a/lib/notification/notify_linux.go
++++ b/lib/notification/notify_linux.go
+@@ -32,7 +32,7 @@ func Send(title, text string, critical, sound bool) error {
+ 		if critical {
+ 			soundName = "complete"
+ 		}
+-		exec.Command("paplay", "/usr/share/sounds/freedesktop/stereo/"+soundName+".oga").Run()
++		exec.Command("paplay", "@soundTheme@/share/sounds/freedesktop/stereo/"+soundName+".oga").Run()
+ 	}
+ 	return exec.Command("notify-send", args...).Run()
+ }


### PR DESCRIPTION
###### Motivation for this change

I didn't get any notification sounds, and I didn't like that.

###### Things done

Verified that I now do get notification sounds.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
