### PR TITLE
reckon: 0.4.4 -> 0.6.0

### DIFF
--- a/pkgs/tools/text/reckon/Gemfile.lock
+++ b/pkgs/tools/text/reckon/Gemfile.lock
@@ -2,14 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     chronic (0.10.2)
-    fastercsv (1.5.5)
-    highline (1.7.8)
-    reckon (0.4.4)
+    highline (2.0.3)
+    rchardet (1.8.0)
+    reckon (0.6.0)
       chronic (>= 0.3.0)
-      fastercsv (>= 1.5.1)
       highline (>= 1.5.2)
-      terminal-table (>= 1.4.2)
-    terminal-table (1.6.0)
+      rchardet (>= 1.8.0)
 
 PLATFORMS
   ruby

--- a/pkgs/tools/text/reckon/gemset.nix
+++ b/pkgs/tools/text/reckon/gemset.nix
@@ -7,36 +7,35 @@
     };
     version = "0.10.2";
   };
-  fastercsv = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1df3vfgw5wg0s405z0pj0rfcvnl9q6wak7ka8gn0xqg4cag1k66h";
-      type = "gem";
-    };
-    version = "1.5.5";
-  };
   highline = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1nf5lgdn6ni2lpfdn4gk3gi47fmnca2bdirabbjbz1fk9w4p8lkr";
+      remotes = ["http://rubygems.org"];
+      sha256 = "0yclf57n2j3cw8144ania99h1zinf8q3f5zrhqa754j6gl95rp9d";
       type = "gem";
     };
-    version = "1.7.8";
+    version = "2.0.3";
+  };
+  rchardet = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1isj1b3ywgg2m1vdlnr41lpvpm3dbyarf1lla4dfibfmad9csfk9";
+      type = "gem";
+    };
+    version = "1.8.0";
   };
   reckon = {
+    dependencies = ["chronic" "highline" "rchardet"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1p6w8w7vpl8fq4yfggrxbv6ph76psg7l5b4q29a8zvfbzzx6a0xw";
+      sha256 = "0zkbmwx5bp2dr54bwhkn831918ijwh022rq45qg38wz2skih7izp";
       type = "gem";
     };
-    version = "0.4.4";
-  };
-  terminal-table = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0hbmzfr17ji5ws5x5z3kypmb5irwwss7q7kkad0gs005ibqrxv0a";
-      type = "gem";
-    };
-    version = "1.6.0";
+    version = "0.6.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Some new options/features

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).