### PR TITLE
python3Packages.hug: disable broken marshmallow tests

### DIFF
--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -1,6 +1,5 @@
 { lib , buildPythonPackage, fetchFromGitHub, isPy27
 , falcon
-, pytestrunner
 , requests
 , pytestCheckHook
 , marshmallow
@@ -22,7 +21,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ falcon requests ];
 
-  checkInputs = [ mock marshmallow pytestCheckHook pytestrunner numpy ];
+  checkInputs = [ mock marshmallow pytestCheckHook numpy ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace '"pytest-runner"' ""
+  '';
 
   preCheck = ''
     # some tests need the `hug` CLI on the PATH

--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -2,7 +2,7 @@
 , falcon
 , pytestrunner
 , requests
-, pytest
+, pytestCheckHook
 , marshmallow
 , mock
 , numpy
@@ -20,19 +20,29 @@ buildPythonPackage rec {
     sha256 = "05rsv16g7ph100p8kl4l2jba0y4wcpp3xblc02mfp67zp1279vaq";
   };
 
-  nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ falcon requests ];
 
-  checkInputs = [ mock marshmallow pytest numpy ];
-  checkPhase = ''
-    mv hug hug.hidden
-    # some tests attempt network access
-    PATH=$out/bin:$PATH pytest -k "not (test_request or test_datagram_request)"
+  checkInputs = [ mock marshmallow pytestCheckHook pytestrunner numpy ];
+
+  preCheck = ''
+    # some tests need the `hug` CLI on the PATH
+    export PATH=$out/bin:$PATH
   '';
+
+  disabledTests = [
+    # some tests attempt network access
+    "test_datagram_request"
+    "test_request"
+    # these tests use an unstable test dependency (https://github.com/hugapi/hug/issues/859)
+    "test_marshmallow_custom_context"
+    "test_marshmallow_schema"
+    "test_transform"
+    "test_validate_route_args_negative_case"
+  ];
 
   meta = with lib; {
     description = "A Python framework that makes developing APIs as simple as possible, but no simpler";
-    homepage = "https://github.com/timothycrosley/hug";
+    homepage = "https://github.com/hugapi/hug";
     license = licenses.mit;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This change fixes [this build failure](https://hydra.nixos.org/build/134827324).

###### Things done

Built the package on NixOS aarch64 (in addition to x86-64 Linux).

Output of `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`:
```
3 packages updated:
python3.7-hug python3.8-hug python3.9-hug

3 packages built:
python37Packages.hug python38Packages.hug python39Packages.hug

```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
