### PR TITLE
python3Packages.aresponses: 2.1.0 -> 2.1.2

### DIFF
--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -5,12 +5,13 @@
 , isPy3k
 , pytest
 , pytest-asyncio
+, pytest-cov
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "aresponses";
-  version = "2.1.0";
+  version = "2.1.2";
 
   disabled = !isPy3k;
 
@@ -18,7 +19,7 @@ buildPythonPackage rec {
     owner = "CircleUp";
     repo = pname;
     rev = version;
-    sha256 = "0dc1y4s6kpmr0ar63kkyghvisgbmb8qq5wglmjclrpzd5180mjcl";
+    sha256 = "007wrk4wdy97a81imgzxd6sm5dly9v7abmxh9fyfi0vp1p7s75bw";
   };
 
   propagatedBuildInputs = [
@@ -32,8 +33,9 @@ buildPythonPackage rec {
 
   checkInputs = [
     aiohttp
-    pytestCheckHook
     pytest-asyncio
+    pytest-cov
+    pytestCheckHook
   ];
 
   # Disable tests which requires network access
@@ -41,6 +43,8 @@ buildPythonPackage rec {
     "test_foo"
     "test_passthrough"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "aresponses" ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release

Change log: https://github.com/CircleUp/aresponses#212

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
