### PR TITLE
python3Packages.swisshydrodata: init at 0.0.3

### DIFF
--- a/pkgs/development/python-modules/swisshydrodata/default.nix
+++ b/pkgs/development/python-modules/swisshydrodata/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "swisshydrodata";
+  version = "0.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1adpy6k2bknffzl5rckqpvaqyrvc00d6a4a4541438dqasx61npl";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # Tests are not releases at the moment
+  doCheck = false;
+  pythonImportsCheck = [ "swisshydrodata" ];
+
+  meta = with lib; {
+    description = "Python client to get data from the Swiss federal Office for Environment FEON";
+    homepage = "https://github.com/bouni/swisshydrodata";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -794,7 +794,7 @@
     "supervisord" = ps: with ps; [ ];
     "supla" = ps: with ps; [ ]; # missing inputs: asyncpysupla
     "surepetcare" = ps: with ps; [ ]; # missing inputs: surepy
-    "swiss_hydrological_data" = ps: with ps; [ ]; # missing inputs: swisshydrodata
+    "swiss_hydrological_data" = ps: with ps; [ swisshydrodata ];
     "swiss_public_transport" = ps: with ps; [ python-opendata-transport ];
     "swisscom" = ps: with ps; [ ];
     "switch" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7413,6 +7413,8 @@ in {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swisshydrodata = callPackage ../development/python-modules/swisshydrodata { };
+
   swspotify = callPackage ../development/python-modules/swspotify { };
 
   sybil = callPackage ../development/python-modules/sybil { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client to get data from the Swiss federal Office for Environment FEON.

https://github.com/bouni/swisshydrodata

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
