### PR TITLE
ocamlPackages: init xenstore, xenstore_transport, vchan, tls-mirage, conduit-mirage and cohttp-mirage

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/mirage.nix
+++ b/pkgs/development/ocaml-modules/cohttp/mirage.nix
@@ -1,0 +1,20 @@
+{ buildDunePackage, cohttp, cohttp-lwt
+, mirage-flow, mirage-channel, mirage-kv
+, conduit, conduit-mirage, lwt
+, astring, magic-mime
+}:
+
+buildDunePackage {
+  pname = "cohttp-mirage";
+
+  inherit (cohttp) version src minimumOCamlVersion useDune2;
+
+  propagatedBuildInputs = [
+    mirage-flow mirage-channel conduit conduit-mirage mirage-kv
+    lwt cohttp cohttp-lwt astring magic-mime
+  ];
+
+  meta = cohttp.meta // {
+    description = "CoHTTP implementation for the MirageOS unikernel";
+  };
+}

--- a/pkgs/development/ocaml-modules/conduit/mirage.nix
+++ b/pkgs/development/ocaml-modules/conduit/mirage.nix
@@ -1,0 +1,24 @@
+{ buildDunePackage, conduit-lwt
+, ppx_sexp_conv, sexplib, cstruct, mirage-stack, mirage-flow
+, mirage-flow-combinators, mirage-random, mirage-time, mirage-clock
+, dns-client, vchan, xenstore, tls, tls-mirage, ipaddr, ipaddr-sexp
+}:
+
+buildDunePackage {
+  pname = "conduit-mirage";
+
+  inherit (conduit-lwt) version src minimumOCamlVersion useDune2;
+
+  nativeBuildInputs = [ ppx_sexp_conv ];
+
+  propagatedBuildInputs = [
+    sexplib cstruct mirage-stack mirage-clock mirage-flow
+    mirage-flow-combinators mirage-random mirage-time
+    dns-client conduit-lwt vchan xenstore tls tls-mirage
+    ipaddr ipaddr-sexp
+  ];
+
+  meta = conduit-lwt.meta // {
+    description = "A network connection establishment library for MirageOS";
+  };
+}

--- a/pkgs/development/ocaml-modules/tls/mirage.nix
+++ b/pkgs/development/ocaml-modules/tls/mirage.nix
@@ -1,0 +1,29 @@
+{ buildDunePackage, tls
+, x509, lwt, fmt, mirage-flow, mirage-kv, mirage-clock, ptime
+, mirage-crypto, mirage-crypto-pk, hacl_x25519, fiat-p256
+}:
+
+buildDunePackage {
+  pname = "tls-mirage";
+
+  inherit (tls) version src useDune2 minimumOCamlVersion;
+
+  propagatedBuildInputs = [
+    tls
+    x509
+    lwt
+    fmt
+    mirage-flow
+    mirage-kv
+    mirage-clock
+    ptime
+    mirage-crypto
+    mirage-crypto-pk
+    hacl_x25519
+    fiat-p256
+  ];
+
+  meta = tls.meta // {
+    description = "Transport Layer Security purely in OCaml, MirageOS layer";
+  };
+}

--- a/pkgs/development/ocaml-modules/vchan/default.nix
+++ b/pkgs/development/ocaml-modules/vchan/default.nix
@@ -1,0 +1,47 @@
+{ lib, buildDunePackage, fetchurl
+, ppx_cstruct, ppx_sexp_conv, ounit, io-page-unix
+, lwt, cstruct, io-page, mirage-flow, xenstore, xenstore_transport
+, sexplib, cmdliner
+}:
+
+buildDunePackage rec {
+  pname = "vchan";
+  version = "6.0.0";
+
+  useDune2 = true;
+  minimumOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-vchan/releases/download/v${version}/vchan-v${version}.tbz";
+    sha256 = "7a6cc89ff8ba7144d6cef3f36722f40deedb3cefff0f7be1b2f3b7b2a2b41747";
+  };
+
+  nativeBuildInputs = [
+    ppx_cstruct
+  ];
+
+  propagatedBuildInputs = [
+    ppx_sexp_conv
+    lwt
+    cstruct
+    io-page
+    mirage-flow
+    xenstore
+    xenstore_transport
+    sexplib
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    cmdliner
+    io-page-unix
+    ounit
+  ];
+
+  meta = with lib; {
+    description = "Xen Vchan implementation";
+    homepage = "https://github.com/mirage/ocaml-vchan";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/xenstore-tool/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore-tool/default.nix
@@ -1,0 +1,13 @@
+{ buildDunePackage, xenstore_transport, xenstore, lwt }:
+
+buildDunePackage {
+  pname = "xenstore-tool";
+
+  inherit (xenstore_transport) src version useDune2 minimumOCamlVersion;
+
+  buildInputs = [ xenstore_transport xenstore lwt ];
+
+  meta = xenstore_transport.meta // {
+    description = "Command line tool for interfacing with xenstore";
+  };
+}

--- a/pkgs/development/ocaml-modules/xenstore/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchurl
+, cstruct, ppx_cstruct, lwt, ounit
+}:
+
+buildDunePackage rec {
+  pname = "xenstore";
+  version = "2.1.1";
+
+  minimumOCamlVersion = "4.04";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-xenstore/releases/download/${version}/xenstore-${version}.tbz";
+    sha256 = "283814ea21adc345c4d59cfcb17b2f7c1185004ecaecc3871557c961874c84f5";
+  };
+
+  nativeBuildInputs = [ ppx_cstruct ];
+  propagatedBuildInputs = [ cstruct lwt ];
+
+  doCheck = true;
+  checkInputs = [ ounit ];
+
+  meta = with lib; {
+    description = "Xenstore protocol in pure OCaml";
+    license = licenses.lgpl21Only;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/mirage/ocaml-xenstore";
+  };
+}

--- a/pkgs/development/ocaml-modules/xenstore_transport/default.nix
+++ b/pkgs/development/ocaml-modules/xenstore_transport/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub, xenstore, lwt }:
+
+buildDunePackage rec {
+  pname = "xenstore_transport";
+  version = "1.3.0";
+
+  minimumOCamlVersion = "4.04";
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "xapi-project";
+    repo = "ocaml-xenstore-clients";
+    rev = "v${version}";
+    sha256 = "1kxxd9i4qiq98r7sgvl59iq2ni7y6drnv48qj580q5cyiyyc85q3";
+  };
+
+  propagatedBuildInputs = [ xenstore lwt ];
+
+  # requires a mounted xenfs and xen server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Low-level libraries for connecting to a xenstore service on a xen host";
+    license = licenses.lgpl21Only;
+    homepage = "http://github.com/xapi-project/ocaml-xenstore-clients";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -903,6 +903,8 @@ let
 
     tls = callPackage ../development/ocaml-modules/tls { };
 
+    tls-mirage = callPackage ../development/ocaml-modules/tls/mirage.nix { };
+
     torch = callPackage ../development/ocaml-modules/torch {
       inherit (pkgs.python3Packages) pytorch;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1073,6 +1073,8 @@ let
 
     variantslib_p4 = callPackage ../development/ocaml-modules/variantslib { };
 
+    vchan = callPackage ../development/ocaml-modules/vchan { };
+
     vg = callPackage ../development/ocaml-modules/vg { };
 
     visitors = callPackage ../development/ocaml-modules/visitors { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -154,6 +154,8 @@ let
 
     conduit-lwt-unix = callPackage ../development/ocaml-modules/conduit/lwt-unix.nix { };
 
+    conduit-mirage = callPackage ../development/ocaml-modules/conduit/mirage.nix { };
+
     config-file = callPackage ../development/ocaml-modules/config-file { };
 
     containers = callPackage ../development/ocaml-modules/containers { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -146,6 +146,8 @@ let
 
     cohttp-lwt-unix = callPackage ../development/ocaml-modules/cohttp/lwt-unix.nix { };
 
+    cohttp-mirage = callPackage ../development/ocaml-modules/cohttp/mirage.nix { };
+
     conduit = callPackage ../development/ocaml-modules/conduit { };
 
     conduit-async = callPackage ../development/ocaml-modules/conduit/async.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1093,6 +1093,8 @@ let
 
     xenstore = callPackage ../development/ocaml-modules/xenstore { };
 
+    xenstore_transport = callPackage ../development/ocaml-modules/xenstore_transport { };
+
     xmlm = callPackage ../development/ocaml-modules/xmlm { };
 
     xml-light = callPackage ../development/ocaml-modules/xml-light { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1091,6 +1091,8 @@ let
 
     x509 = callPackage ../development/ocaml-modules/x509 { };
 
+    xenstore = callPackage ../development/ocaml-modules/xenstore { };
+
     xmlm = callPackage ../development/ocaml-modules/xmlm { };
 
     xml-light = callPackage ../development/ocaml-modules/xml-light { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1095,6 +1095,8 @@ let
 
     xenstore_transport = callPackage ../development/ocaml-modules/xenstore_transport { };
 
+    xenstore-tool = callPackage ../development/ocaml-modules/xenstore-tool { };
+
     xmlm = callPackage ../development/ocaml-modules/xmlm { };
 
     xml-light = callPackage ../development/ocaml-modules/xml-light { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Reference #23955.

Add more MirageOS packages which also are required for `git-mirage` >= 3.0.0:

* xenstore
* xenstore_transport
* tls-mirage
* vchan
* conduit-mirage
* cohttp-mirage

Where the last package depends on all of the packages listed before.

We also add `xenstore-tool` which is shipped with `xenstore_transport`. We could also consider putting it into top level as it is a simple cli that doesn't ship with an OCaml library of any kind.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
