### PR TITLE
darwin: add impure-cmds

### DIFF
--- a/pkgs/os-specific/darwin/impure-cmds/default.nix
+++ b/pkgs/os-specific/darwin/impure-cmds/default.nix
@@ -1,0 +1,34 @@
+{ lib, runCommandLocal }:
+
+# On darwin, there are some commands neither opensource nor able to build in nixpkgs.
+# We have no choice but to use those system-shipped impure ones.
+
+let
+  commands = {
+    ditto = "/usr/bin/ditto"; # ditto is not opensource
+    sudo  = "/usr/bin/sudo";  # sudo must be owned by uid 0 and have the setuid bit set
+  };
+
+  mkImpureDrv = name: path:
+    runCommandLocal "${name}-impure-darwin" {
+      __impureHostDeps = [ path ];
+
+      meta = {
+        platforms = lib.platforms.darwin;
+      };
+    } ''
+      if ! [ -x ${path} ]; then
+        echo Cannot find command ${path}
+        exit 1
+      fi
+
+      mkdir -p $out/bin
+      ln -s ${path} $out/bin
+
+      manpage="/usr/share/man/man1/${name}.1"
+      if [ -f $manpage ]; then
+        mkdir -p $out/share/man/man1
+        ln -s $manpage $out/share/man/man1
+      fi
+    '';
+in lib.mapAttrs mkImpureDrv commands

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7901,7 +7901,7 @@ in
 
   subsurface = libsForQt514.callPackage ../applications/misc/subsurface { };
 
-  sudo = callPackage ../tools/security/sudo { };
+  sudo = if stdenv.isDarwin then darwin.sudo else callPackage ../tools/security/sudo { };
 
   suidChroot = callPackage ../tools/system/suid-chroot { };
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -4,9 +4,11 @@
 
 let
   apple-source-releases = callPackage ../os-specific/darwin/apple-source-releases { };
+
+  impure-cmds = callPackage ../os-specific/darwin/impure-cmds { };
 in
 
-(apple-source-releases // {
+(impure-cmds // apple-source-releases // {
 
   callPackage = newScope (darwin.apple_sdk.frameworks // darwin);
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

On darwin, there are some commands neither opensource nor able to build in nixpkgs.
We have no choice but to use those system-shipped impure ones.

cc @matthewbauer @veprbl 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
