### PR TITLE
opensmtpd: 6.7.1p1 -> 6.8.0p2

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "opensmtpd";
-  version = "6.7.1p1";
+  version = "6.8.0p2";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib libressl db pam ];
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${pname}-${version}.tar.gz";
-    sha256 = "1jh8vxfajm1mvp1v5yh6llrhjzv0n9fgab88mlwllwqynhcfjy3l";
+    sha256 = "05sd7bmq29ibnqbl2z53hiyprfxzf0qydfdaixs68rz55wqhbgsi";
   };
 
   patches = [

--- a/pkgs/servers/mail/opensmtpd/proc_path.diff
+++ b/pkgs/servers/mail/opensmtpd/proc_path.diff
@@ -1,7 +1,7 @@
-diff --git a/smtpd/smtpd.c b/smtpd/smtpd.c
+diff --git a/usr.sbin/smtpd/smtpd.c b/usr.sbin/smtpd/smtpd.c
 index e049f07c..a1bd03a0 100644
---- a/smtpd/smtpd.c
-+++ b/smtpd/smtpd.c
+--- a/usr.sbin/smtpd/smtpd.c
++++ b/usr.sbin/smtpd/smtpd.c
 @@ -1157,6 +1157,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
  	char		path[PATH_MAX];
  	char		name[PATH_MAX];
@@ -24,10 +24,10 @@ index e049f07c..a1bd03a0 100644
  	    (ssize_t)sizeof(path)) {
  		log_warn("warn: %s-proc: exec path too long", key);
  		return (-1);
-diff --git a/smtpd/table.c b/smtpd/table.c
+diff --git a/usr.sbin/smtpd/table.c b/usr.sbin/smtpd/table.c
 index 9cfdfb99..24dfcca4 100644
---- a/smtpd/table.c
-+++ b/smtpd/table.c
+--- a/usr.sbin/smtpd/table.c
++++ b/usr.sbin/smtpd/table.c
 @@ -201,6 +201,7 @@ table_create(const char *backend, const char *name, const char *tag,
  	struct table_backend	*tb;
  	char			 buf[LINE_MAX];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The 6.8.0p2 release includes the fixes for [CVE-2020-35679 and CVE-2020-35680](https://www.mail-archive.com/misc@opensmtpd.org/msg05188.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
