### PR TITLE
python3Packages.regenmaschine: init at 3.1.1

### DIFF
--- a/pkgs/development/python-modules/regenmaschine/default.nix
+++ b/pkgs/development/python-modules/regenmaschine/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, aiohttp
+, aresponses
+, asynctest
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, pytest-aiohttp
+, pytest-asyncio
+, pytest-cov
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "regenmaschine";
+  version = "3.1.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "bachya";
+    repo = pname;
+    rev = version;
+    sha256 = "0m6i7vspp8ssdk2k32kznql1j8gkp300kzb7pk67hzvpijdy3mca";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  checkInputs = [
+    aresponses
+    asynctest
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-cov
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "regenmaschine" ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "Python library for interacting with RainMachine smart sprinkler controllers";
+    homepage = "https://github.com/bachya/regenmaschine";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -659,7 +659,7 @@
     "rainbird" = ps: with ps; [ ]; # missing inputs: pyrainbird
     "raincloud" = ps: with ps; [ ]; # missing inputs: raincloudy
     "rainforest_eagle" = ps: with ps; [ ]; # missing inputs: eagle200_reader uEagle
-    "rainmachine" = ps: with ps; [ ]; # missing inputs: regenmaschine
+    "rainmachine" = ps: with ps; [ regenmaschine ];
     "random" = ps: with ps; [ ];
     "raspihats" = ps: with ps; [ smbus-cffi ]; # missing inputs: raspihats
     "raspyrfm" = ps: with ps; [ ]; # missing inputs: raspyrfm-client

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6565,6 +6565,8 @@ in {
 
   reflink = callPackage ../development/python-modules/reflink { };
 
+  regenmaschine = callPackage ../development/python-modules/regenmaschine { };
+
   regex = callPackage ../development/python-modules/regex { };
 
   regional = callPackage ../development/python-modules/regional { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library for interacting with RainMachine smart sprinkler controllers

https://github.com/bachya/regenmaschine

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
