### PR TITLE
treewide: stdenv.*lib -> lib

### DIFF
--- a/pkgs/applications/misc/cura/lulzbot/curaengine.nix
+++ b/pkgs/applications/misc/cura/lulzbot/curaengine.nix
@@ -1,4 +1,4 @@
-{ gcc8Stdenv, callPackage, fetchgit, fetchpatch, cmake, libarcusLulzbot, stb, protobuf }:
+{ lib, gcc8Stdenv, callPackage, fetchgit, fetchpatch, cmake, libarcusLulzbot, stb, protobuf }:
 
 gcc8Stdenv.mkDerivation rec {
   pname = "curaengine-lulzBot";
@@ -17,7 +17,7 @@ gcc8Stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DCURA_ENGINE_VERSION=${version}" ];
 
-  meta = with gcc8Stdenv.lib; {
+  meta = with lib; {
     description = "A powerful, fast and robust engine for processing 3D models into 3D printing instruction";
     homepage = "https://code.alephobjects.com/source/curaengine-lulzbot/";
     license = licenses.agpl3;

--- a/pkgs/data/icons/bibata-cursors/default.nix
+++ b/pkgs/data/icons/bibata-cursors/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
+{ lib, stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
 
 let
   py = python3.withPackages(ps: [ ps.pillow ]);
@@ -41,7 +41,7 @@ in stdenvNoCC.mkDerivation rec {
     done
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "Material Based Cursor";
     homepage = "https://github.com/KaizIqbal/Bibata_Cursor";
     license = licenses.gpl3;

--- a/pkgs/data/icons/bibata-cursors/extra.nix
+++ b/pkgs/data/icons/bibata-cursors/extra.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
+{ lib, stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
 
 let
   py = python3.withPackages(ps: [ ps.pillow ]);
@@ -41,7 +41,7 @@ in stdenvNoCC.mkDerivation rec {
     done
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "Cursors Based on Bibata";
     homepage = "https://github.com/KaizIqbal/Bibata_Extra_Cursor";
     license = licenses.gpl3;

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
+{ lib, stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "bibata-cursors-translucent";
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
     cp -pr Bibata_* $out/share/icons/
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "Translucent Varient of the Material Based Cursor";
     homepage = "https://github.com/Silicasandwhich/Bibata_Cursor_Translucent";
     license = licenses.gpl3;

--- a/pkgs/data/machine-learning/mnist/default.nix
+++ b/pkgs/data/machine-learning/mnist/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 let
   srcs = {
     train-images = fetchurl {
@@ -30,7 +30,7 @@ in
       ln -s "${srcs.test-labels}" "$out/${srcs.test-labels.name}"
     '';
     phases = [ "installPhase" ];
-    meta = with stdenvNoCC.lib; {
+    meta = with lib; {
       description = "A large database of handwritten digits";
       longDescription = ''
         The MNIST database (Modified National Institute of Standards and

--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -1,4 +1,5 @@
-{ stdenvNoCC
+{ lib
+, stdenvNoCC
 , coreutils
 }:
 
@@ -10,7 +11,7 @@
 stdenvNoCC.mkDerivation {
   inherit patches src version;
 
-  pname = "fedora${stdenvNoCC.lib.versions.major version}-backgrounds";
+  pname = "fedora${lib.versions.major version}-backgrounds";
 
   dontBuild = true;
 
@@ -32,7 +33,7 @@ stdenvNoCC.mkDerivation {
     "DESTDIR=$(out)"
   ];
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     homepage = "https://github.com/fedoradesign/backgrounds";
     description = "A set of default and supplemental wallpapers for Fedora";
     license = licenses.cc-by-sa-40;

--- a/pkgs/games/dwarf-fortress/lazy-pack.nix
+++ b/pkgs/games/dwarf-fortress/lazy-pack.nix
@@ -38,7 +38,7 @@ buildEnv {
     ++ lib.optional enableDwarfTherapist dwarf-therapist
     ++ lib.optional enableLegendsBrowser legends-browser;
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "An opinionated wrapper for Dwarf Fortress";
     maintainers = with maintainers; [ Baughn numinit ];
     license = licenses.mit;

--- a/pkgs/games/dwarf-fortress/legends-browser/default.nix
+++ b/pkgs/games/dwarf-fortress/legends-browser/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, buildEnv, writeShellScriptBin, fetchurl, jre }:
+{ lib, stdenvNoCC, buildEnv, writeShellScriptBin, fetchurl, jre }:
 
 let
   name = "legends-browser-${version}";
@@ -26,7 +26,7 @@ buildEnv {
   inherit name;
   paths = [ script ];
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "A multi-platform, open source, java-based legends viewer for dwarf fortress";
     maintainers = with maintainers; [ Baughn ];
     license = licenses.mit;

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -80,7 +80,7 @@ stdenvNoCC.mkDerivation rec {
     cp -a *.png $art/data/art/
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "A plugin for Dwarf Fortress / DFHack that improves various aspects the game interface.";
     maintainers = with maintainers; [ Baughn numinit ];
     license = licenses.mit;

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
@@ -1,4 +1,4 @@
-{ clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, gyp, which, ninja,
+{ lib, clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, gyp, which, ninja,
   python, pkgconfig, protobuf, gtk2, zinnia, qt5, libxcb, tegaki-zinnia-japanese,
   fcitx, gettext }:
 let
@@ -100,7 +100,7 @@ in clangStdenv.mkDerivation rec {
     install    -m 644 fcitx-mozc-icons/*.png                 $out/share/fcitx/mozc/icon/
   '';
 
-  meta = with clangStdenv.lib; {
+  meta = with lib; {
     isFcitxEngine = true;
     description   = "Fcitx engine for Google japanese input method";
     homepage      = "https://github.com/google/mozc";

--- a/pkgs/tools/misc/loadlibrary/default.nix
+++ b/pkgs/tools/misc/loadlibrary/default.nix
@@ -1,4 +1,4 @@
-{ cabextract, fetchFromGitHub, readline, stdenv_32bit }:
+{ lib, cabextract, fetchFromGitHub, readline, stdenv_32bit }:
 
 # stdenv_32bit is needed because the program depends upon 32-bit libraries and does not have
 # support for 64-bit yet: it requires libc6-dev:i386, libreadline-dev:i386.
@@ -21,7 +21,7 @@ stdenv_32bit.mkDerivation rec {
     cp mpclient $out/bin/
   '';
 
-  meta = with stdenv_32bit.lib; {
+  meta = with lib; {
     homepage = "https://github.com/taviso/loadlibrary";
     description = "Porting Windows Dynamic Link Libraries to Linux";
     platforms = platforms.linux;

--- a/pkgs/tools/typesetting/tex/latexrun/default.nix
+++ b/pkgs/tools/typesetting/tex/latexrun/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub, python3 }:
+{ lib, stdenvNoCC, fetchFromGitHub, python3 }:
 
 stdenvNoCC.mkDerivation {
   pname = "latexrun";
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation {
     chmod +x $out/bin/latexrun
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "A 21st century LaTeX wrapper";
     homepage = "https://github.com/aclements/latexrun";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
Part 3 or such, this time focusing on `stdenvNoCC.lib` and `stdenvClang.lib`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
