### PR TITLE
linux-pam: fix cross compilation on Darwin

### DIFF
--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPackages, fetchurl, fetchpatch, flex, cracklib, db4
+{ lib, stdenv, buildPackages, fetchurl, fetchpatch, flex, cracklib, db4, gettext
 , nixosTests
 }:
 
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" "man" /* "modules" */ ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ flex ];
+  nativeBuildInputs = [ flex ]
+    ++ lib.optional stdenv.buildPlatform.isDarwin gettext;
 
   buildInputs = [ cracklib db4 ];
 


### PR DESCRIPTION
I need to cross compile some Linux packages on Darwin for use in a VM. Linux-PAM requires this fix, which I believe is straightforward. The reason is: during the PAM documentation build, a tool is created to run on the build machine. The code includes `libintl.h`. On Linux, this header comes with `glibc`, but on Darwin, `gettext` is needed.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).