### PR TITLE
liquibase: support PostgreSQL JDBC driver

### DIFF
--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -1,11 +1,8 @@
-{ stdenv, fetchurl, jre, makeWrapper
-, mysqlSupport ? true, mysql_jdbc ? null }:
+{ lib, stdenv, fetchurl, jre, makeWrapper
+, mysqlSupport ? true, mysql_jdbc }:
 
-assert mysqlSupport -> mysql_jdbc != null;
-
-with stdenv.lib;
 let
-  extraJars = optional mysqlSupport mysql_jdbc;
+  extraJars = lib.optional mysqlSupport mysql_jdbc;
 in
 
 stdenv.mkDerivation rec {
@@ -47,15 +44,15 @@ stdenv.mkDerivation rec {
       # taken from the executable script in the source
       CP="$out/liquibase.jar"
       ${addJars "$out/lib"}
-      ${concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}
+      ${lib.concatStringsSep "\n" (map (p: addJars "${p}/share/java") extraJars)}
 
-      ${getBin jre}/bin/java -cp "\$CP" \$JAVA_OPTS \
+      ${lib.getBin jre}/bin/java -cp "\$CP" \$JAVA_OPTS \
         liquibase.integration.commandline.Main \''${1+"\$@"}
       EOF
       chmod +x $out/bin/liquibase
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Version Control for your database";
     homepage = "https://www.liquibase.org/";
     changelog = "https://raw.githubusercontent.com/liquibase/liquibase/v${version}/changelog.txt";

--- a/pkgs/development/tools/database/liquibase/default.nix
+++ b/pkgs/development/tools/database/liquibase/default.nix
@@ -1,8 +1,11 @@
 { lib, stdenv, fetchurl, jre, makeWrapper
-, mysqlSupport ? true, mysql_jdbc }:
+, mysqlSupport ? true, mysql_jdbc
+, postgresqlSupport ? true, postgresql_jdbc }:
 
 let
-  extraJars = lib.optional mysqlSupport mysql_jdbc;
+  extraJars =
+    lib.optional mysqlSupport mysql_jdbc
+    ++ lib.optional postgresqlSupport postgresql_jdbc;
 in
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

To support PostgreSQL in the Liquibase tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
