### PR TITLE
python3Packages.roombapy: init at 1.6.2-1

### DIFF
--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, hbmqtt
+, lib
+, paho-mqtt
+, poetry
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "roombapy";
+  version = "1.6.2-1";
+
+  src = fetchFromGitHub {
+    owner = "pschmitt";
+    repo = "roombapy";
+    rev = version;
+    sha256 = "14k7bys479xwpa4alpdwphzmxm3x8kc48nfqnshn1wj94vyxc425";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = [ poetry ];
+  propagatedBuildInputs = [ paho-mqtt ];
+
+  checkInputs = [ hbmqtt pytest-asyncio pytestCheckHook ];
+  pytestFlagsArray = [ "tests/" "--ignore=tests/test_discovery.py" ];
+  pythonImportsCheck = [ "roombapy" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pschmitt/roombapy";
+    description = "Python program and library to control Wi-Fi enabled iRobot Roombas";
+    maintainers = with maintainers; [ justinas ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -682,7 +682,7 @@
     "rmvtransport" = ps: with ps; [ PyRMVtransport ];
     "rocketchat" = ps: with ps; [ ]; # missing inputs: rocketchat-API
     "roku" = ps: with ps; [ ]; # missing inputs: rokuecp
-    "roomba" = ps: with ps; [ ]; # missing inputs: roombapy
+    "roomba" = ps: with ps; [ roombapy ];
     "roon" = ps: with ps; [ ]; # missing inputs: roonapi
     "route53" = ps: with ps; [ boto3 ];
     "rova" = ps: with ps; [ ]; # missing inputs: rova

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6726,6 +6726,8 @@ in {
 
   roman = callPackage ../development/python-modules/roman { };
 
+  roombapy = callPackage ../development/python-modules/roombapy { };
+
   rope = callPackage ../development/python-modules/rope { };
 
   ROPGadget = callPackage ../development/python-modules/ROPGadget { };


### PR DESCRIPTION
###### Motivation for this change

This is a dependency of Home Assistant, namely, the [iRobot Roomba integration](https://www.home-assistant.io/integrations/roomba/).

I do not currently have a Roomba handy to fully test on. The utility commands work though, and Home Assistant seems to start up fine with the integration enabled.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
