### PR TITLE
nixos/openvpn: add network namespace support

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1287,6 +1287,7 @@
   ./services/networking/netbird.nix
   ./services/networking/netbird/server.nix
   ./services/networking/netclient.nix
+  ./services/networking/netns.nix
   ./services/networking/networkd-dispatcher.nix
   ./services/networking/networkmanager.nix
   ./services/networking/newt.nix

--- a/nixos/modules/services/networking/netns.nix
+++ b/nixos/modules/services/networking/netns.nix
@@ -1,0 +1,134 @@
+{
+  pkgs,
+  lib,
+  config,
+  options,
+  ...
+}:
+with lib;
+let
+  cfg = config.services.netns;
+  inherit (config) networking;
+  # Escape as required by: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+  escapeUnitName =
+    name:
+    lib.concatMapStrings (s: if lib.isList s then "-" else s) (
+      builtins.split "[^a-zA-Z0-9_.\\-]+" name
+    );
+in
+{
+  options.services.netns = {
+    namespaces = mkOption {
+      description = ''
+        Network namespaces to create.
+
+        Other services can join a network namespace named `netns` with:
+        ```
+        PrivateNetwork=true;
+        JoinsNamespaceOf="netns-''${netns}.service";
+        ```
+
+        So can `iproute2` with: `ip -n ''${netns}`
+
+        ::: {.warning}
+        You should usually create (or update via your VPN configuration's up script)
+        a file named `/etc/netns/''${netns}/resolv.conf`
+        that will be bind-mounted by `ip -n ''${netns}` onto `/etc/resolv.conf`,
+        which you'll also want to configure in the services joining this network namespace:
+        ```
+        BindReadOnlyPaths = ["/etc/netns/''${netns}/resolv.conf:/etc/resolv.conf"];
+        ```
+        :::
+      '';
+      default = { };
+      type = types.attrsOf (
+        types.submodule {
+          options.nftables = mkOption {
+            description = "Nftables ruleset within the network namespace.";
+            type = types.lines;
+            default = networking.nftables.ruleset;
+            defaultText = "config.networking.nftables.ruleset";
+          };
+          options.sysctl = options.boot.kernel.sysctl // {
+            description = "sysctl within the network namespace.";
+            default = config.boot.kernel.sysctl;
+            defaultText = literalMD "config.boot.kernel.sysctl";
+          };
+          options.service = mkOption {
+            description = "Systemd configuration specific to this netns service";
+            type = types.attrs;
+            default = { };
+          };
+        }
+      );
+    };
+  };
+  config = {
+    systemd.services = mapAttrs' (
+      name: c:
+      nameValuePair "netns-${escapeUnitName name}" (mkMerge [
+        {
+          description = "${name} network namespace";
+          before = [ "network.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            # Explanation: let systemd create the netns so that PrivateNetwork=true
+            # with JoinsNamespaceOf="netns-${name}.service" works.
+            PrivateNetwork = true;
+            # Explanation: PrivateNetwork=true implies PrivateMounts=true by default,
+            # which would prevent the persisting and sharing of /var/run/netns/$name
+            # causing `ip netns exec $name $SHELL` outside of this service to fail with:
+            # Error: Peer netns reference is invalid.
+            # As `stat -f -c %T /var/run/netns/$name` would not be "nsfs" in those mntns.
+            # See https://serverfault.com/questions/961504/cannot-create-nested-network-namespace
+            PrivateMounts = false;
+            ExecStart = [
+              # Explanation: register the netns with a binding mount
+              # to /var/run/netns/$name to keep it alive,
+              # and make sure resolv.conf can be used in BindReadOnlyPaths=
+              # For propagating changes in that file to the services bind mounting it,
+              # updating must not remove the file, but only truncate it.
+              (pkgs.writeShellScript "ip-netns-attach" ''
+                ${pkgs.iproute2}/bin/ip netns attach ${escapeShellArg name} $$
+                mkdir -p /etc/netns/${escapeShellArg name}
+                touch /etc/netns/${escapeShellArg name}/resolv.conf
+              '')
+
+              # Explanation: activating the loopback interface is almost always a good thing.
+              "${pkgs.iproute2}/bin/ip link set dev lo up"
+
+              # Explanation: use --ignore because some keys
+              # may no longer exist in that new namespace,
+              # like net.ipv6.conf.eth0.addr_gen_mode or net.core.rmem_max
+              ''
+                ${pkgs.procps}/bin/sysctl --ignore -p ${
+                  pkgs.writeScript "sysctl" (
+                    concatStrings (
+                      mapAttrsToList (
+                        n: v: optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
+                      ) c.sysctl
+                    )
+                  )
+                }
+              ''
+            ]
+            ++
+              # Description: load the nftables ruleset of this netns.
+              optional networking.nftables.enable (
+                pkgs.writeScript "nftables-ruleset" ''
+                  #!${pkgs.nftables}/bin/nft -f
+                  flush ruleset
+                  ${c.nftables}
+                ''
+              );
+            # Description: unregister the netns from the tracking mecanism of iproute2.
+            ExecStop = "${pkgs.iproute2}/bin/ip netns delete ${escapeShellArg name}";
+          };
+        }
+        c.service
+      ])
+    ) cfg.namespaces;
+    meta.maintainers = with lib.maintainers; [ julm ];
+  };
+}

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -10,57 +10,205 @@ with lib;
 let
 
   cfg = config.services.openvpn;
+  enabledServers = filterAttrs (name: srv: srv.enable) cfg.servers;
 
-  makeOpenVPNJob =
-    cfg: name:
+  inherit (pkgs) openvpn;
+
+  PATH = name: makeBinPath config.systemd.services."openvpn-${name}".path;
+
+  makeOpenVPNJob = cfg: name:
     let
 
-      path = makeBinPath (getAttr "openvpn-${name}" config.systemd.services).path;
+      configFile = pkgs.writeText "openvpn-config-${name}" (
+        generators.toKeyValue
+          {
+            mkKeyValue = key: value:
+              if hasAttr key scripts
+              then "${key} " + pkgs.writeShellScript "openvpn-${name}-${key}" (scripts.${key} value)
+              else if builtins.isBool value
+              then optionalString value key
+              else if builtins.isPath value
+              then "${key} ${value}"
+              else if builtins.isList value
+              then concatMapStringsSep "\n" (v: "${key} ${generators.mkValueStringDefault {} v}") value
+              else "${key} ${generators.mkValueStringDefault {} value}";
+          }
+          cfg.settings
+      );
 
-      upScript = ''
-        export PATH=${path}
+      scripts = {
+        up = script:
+          let
+            init = ''
+              export PATH=${PATH name}
 
-        # For convenience in client scripts, extract the remote domain
-        # name and name server.
-        for var in ''${!foreign_option_*}; do
-          x=(''${!var})
-          if [ "''${x[0]}" = dhcp-option ]; then
-            if [ "''${x[1]}" = DOMAIN ]; then domain="''${x[2]}"
-            elif [ "''${x[1]}" = DNS ]; then nameserver="''${x[2]}"
-            fi
-          fi
-        done
+              # For convenience in client scripts, extract the remote domain
+              # name and name server.
+              for var in ''${!foreign_option_*}; do
+                x=(''${!var})
+                if [ "''${x[0]}" = dhcp-option ]; then
+                  if [ "''${x[1]}" = DOMAIN ]; then domain="''${x[2]}"
+                  elif [ "''${x[1]}" = DNS ]; then nameserver="''${x[2]}"
+                  fi
+                fi
+              done
 
-        ${cfg.up}
-        ${optionalString cfg.updateResolvConf "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
-      '';
+              ${optionalString cfg.updateResolvConf
+                 "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
+            '';
+            # Add DNS settings given in foreign DHCP options to the resolv.conf of the netns.
+            # Note that JoinsNamespaceOf="netns-${cfg.netns}.service" will not
+            # BindReadOnlyPaths=["/etc/netns/${cfg.netns}/resolv.conf:/etc/resolv.conf"];
+            # this will have to be added in each service joining the namespace.
+            setNetNSResolvConf = ''
+              mkdir -p /etc/netns/${cfg.netns}
+              # This file is normally created by netns-${cfg.netns}.service,
+              # care must be taken to not delete it but to truncate it
+              # in order to propagate the changes to bind-mounted versions.
+              : > /etc/netns/${cfg.netns}/resolv.conf
+              chmod 644 /etc/netns/${cfg.netns}/resolv.conf
+              foreign_opt_domains=
+              process_foreign_option () {
+                case "$1:$2" in
+                  dhcp-option:DNS) echo "nameserver $3" >>/etc/netns/'${cfg.netns}'/resolv.conf ;;
+                  dhcp-option:DOMAIN) foreign_opt_domains="$foreign_opt_domains $3" ;;
+                esac
+              }
+              i=1
+              while
+                eval opt=\"\''${foreign_option_$i-}\"
+                [ -n "$opt" ]
+              do
+                process_foreign_option $opt
+                i=$(( i + 1 ))
+              done
+              for d in $foreign_opt_domains; do
+                printf '%s\n' "domain $1" "search $*" \
+                  >>/etc/netns/'${cfg.netns}'/resolv.conf
+              done
+            '';
+          in
+          if cfg.netns == null
+          then ''
+            ${init}
+            ${script}
+          ''
+          else ''
+            export PATH=${PATH name}
+            set -eux
+            ${setNetNSResolvConf}
+            ip link set dev '${cfg.settings.dev}' up netns '${cfg.netns}' mtu "$tun_mtu"
+            ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-up-netns.sh" ''
+              ${init}
+              set -eux
+              export PATH=${PATH name}
 
-      downScript = ''
-        export PATH=${path}
-        ${optionalString cfg.updateResolvConf "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
-        ${cfg.down}
-      '';
+              ip link set dev lo up
 
-      configFile = pkgs.writeText "openvpn-config-${name}" ''
-        errors-to-stderr
-        ${optionalString (cfg.up != "" || cfg.down != "" || cfg.updateResolvConf) "script-security 2"}
-        ${cfg.config}
-        ${optionalString (
-          cfg.up != "" || cfg.updateResolvConf
-        ) "up ${pkgs.writeShellScript "openvpn-${name}-up" upScript}"}
-        ${optionalString (
-          cfg.down != "" || cfg.updateResolvConf
-        ) "down ${pkgs.writeShellScript "openvpn-${name}-down" downScript}"}
-        ${optionalString (cfg.authUserPass != null) (
-          if isAttrs cfg.authUserPass then
-            "auth-user-pass ${pkgs.writeText "openvpn-credentials-${name}" ''
-              ${cfg.authUserPass.username}
-              ${cfg.authUserPass.password}
-            ''}"
-          else
-            "auth-user-pass ${cfg.authUserPass}"
-        )}
-      '';
+              netmask4="''${ifconfig_netmask:-30}"
+              netbits6="''${ifconfig_ipv6_netbits:-112}"
+              if [ -n "''${ifconfig_local-}" ]; then
+                if [ -n "''${ifconfig_remote-}" ]; then
+                  ip -4 addr replace \
+                    local "$ifconfig_local" \
+                    peer "$ifconfig_remote/$netmask4" \
+                    ''${ifconfig_broadcast:+broadcast "$ifconfig_broadcast"} \
+                    dev '${cfg.settings.dev}'
+                else
+                  ip -4 addr replace \
+                    local "$ifconfig_local/$netmask4" \
+                    ''${ifconfig_broadcast:+broadcast "$ifconfig_broadcast"} \
+                    dev '${cfg.settings.dev}'
+                fi
+              fi
+              if [ -n "''${ifconfig_ipv6_local-}" ]; then
+                if [ -n "''${ifconfig_ipv6_remote-}" ]; then
+                  ip -6 addr replace \
+                    local "$ifconfig_ipv6_local" \
+                    peer "$ifconfig_ipv6_remote/$netbits6" \
+                    dev '${cfg.settings.dev}'
+                else
+                  ip -6 addr replace \
+                    local "$ifconfig_ipv6_local/$netbits6" \
+                    dev '${cfg.settings.dev}'
+                fi
+              fi
+              set +eux
+              ${script}
+            ''}
+          '';
+        route-up = script:
+          if cfg.netns == null
+          then script
+          else ''
+            export PATH=${PATH name}
+            set -eux
+            ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-route-up-netns" ''
+              export PATH=${PATH name}
+              set -eux
+              i=1
+              while
+                eval net=\"\''${route_network_$i-}\"
+                eval mask=\"\''${route_netmask_$i-}\"
+                eval gw=\"\''${route_gateway_$i-}\"
+                eval mtr=\"\''${route_metric_$i-}\"
+                [ -n "$net" ]
+              do
+                ip -4 route replace "$net/$mask" via "$gw" ''${mtr:+metric "$mtr"}
+                i=$(( i + 1 ))
+              done
+
+              if [ -n "''${route_vpn_gateway-}" ]; then
+                ip -4 route replace default via "$route_vpn_gateway"
+              fi
+
+              i=1
+              while
+                # There doesn't seem to be $route_ipv6_metric_<n>
+                # according to the manpage.
+                eval net=\"\''${route_ipv6_network_$i-}\"
+                eval gw=\"\''${route_ipv6_gateway_$i-}\"
+                [ -n "$net" ]
+              do
+                ip -6 route replace  "$net"  via "$gw"  metric 100
+                i=$(( i + 1 ))
+              done
+
+              # There's no $route_vpn_gateway for IPv6. It's not
+              # documented if OpenVPN includes default route in
+              # $route_ipv6_*. Set default route to remote VPN
+              # endpoint address if there is one. Use higher metric
+              # than $route_ipv6_* routes to give preference to a
+              # possible default route in them.
+              if [ -n "''${ifconfig_ipv6_remote-}" ]; then
+                ip -6 route replace default \
+                  via "$ifconfig_ipv6_remote" metric 200
+              fi
+              ${script}
+            ''}
+          '';
+        down = script:
+          let
+            init = ''
+              export PATH=${PATH name}
+              ${optionalString cfg.updateResolvConf
+                 "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
+            '';
+          in
+          if cfg.netns == null
+          then ''
+            ${init}
+            ${script}
+          ''
+          else ''
+            export PATH=${PATH name}
+            ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-down-netns.sh" ''
+              ${init}
+              ${script}
+            ''}
+            rm -f /etc/netns/'${cfg.netns}'/resolv.conf
+          '';
+      };
 
     in
     {
@@ -68,6 +216,8 @@ let
 
       wantedBy = optional cfg.autoStart "multi-user.target";
       after = [ "network.target" ];
+      bindsTo = optional (cfg.netns != null) "netns-${cfg.netns}.service";
+      requires = optional (cfg.netns != null) "netns-${cfg.netns}.service";
 
       path = [
         pkgs.iptables
@@ -77,6 +227,7 @@ let
 
       serviceConfig.ExecStart = "@${config.services.openvpn.package}/sbin/openvpn openvpn --suppress-timestamps --config ${configFile}";
       serviceConfig.Restart = "always";
+      serviceConfig.RestartSec = "5s";
       serviceConfig.Type = "notify";
     };
 
@@ -88,7 +239,7 @@ let
           unitNames = map (n: "openvpn-${n}.service") (builtins.attrNames cfg.servers);
         in
         "systemctl try-restart ${lib.escapeShellArgs unitNames}";
-      description = "Restart system OpenVPN connections when returning from sleep";
+      description = "Sends a signal to OpenVPN process to trigger a restart after return from sleep";
     };
   };
 
@@ -110,30 +261,30 @@ in
       example = literalExpression ''
         {
           server = {
-            config = '''
+            settings = {
               # Simplest server configuration: https://community.openvpn.net/openvpn/wiki/StaticKeyMiniHowto
               # server :
-              dev tun
-              ifconfig 10.8.0.1 10.8.0.2
-              secret /root/static.key
-            ''';
-            up = "ip route add ...";
-            down = "ip route del ...";
+              dev = "tun";
+              ifconfig = "10.8.0.1 10.8.0.2";
+              secret = "/root/static.key";
+              up = "ip route add ...";
+              down = "ip route del ...";
+            };
           };
 
           client = {
-            config = '''
-              client
-              remote vpn.example.org
-              dev tun
-              proto tcp-client
-              port 8080
-              ca /root/.vpn/ca.crt
-              cert /root/.vpn/alice.crt
-              key /root/.vpn/alice.key
-            ''';
-            up = "echo nameserver $nameserver | ''${pkgs.openresolv}/sbin/resolvconf -m 0 -a $dev";
-            down = "''${pkgs.openresolv}/sbin/resolvconf -d $dev";
+            settings = {
+              client = true;
+              remote = "vpn.example.org";
+              dev = "tun";
+              proto = "tcp-client";
+              port = 8080;
+              ca = "/root/.vpn/ca.crt";
+              cert = "/root/.vpn/alice.crt";
+              key = "/root/.vpn/alice.key";
+              up = "echo nameserver $nameserver | ''${pkgs.openresolv}/sbin/resolvconf -m 0 -a $dev";
+              down = "''${pkgs.openresolv}/sbin/resolvconf -d $dev";
+            };
           };
         }
       '';
@@ -147,55 +298,102 @@ in
         attribute name.
       '';
 
-      type =
-        with types;
-        attrsOf (submodule {
+      type = with types; attrsOf (submodule ({ name, config, options, ... }: {
 
-          options = {
+          options = rec {
+          enable = mkEnableOption "OpenVPN server" // { default = true; };
 
-            config = mkOption {
-              type = types.lines;
-              description = ''
-                Configuration of this OpenVPN instance.  See
-                {manpage}`openvpn(8)`
-                for details.
+          settings = mkOption {
+            description = ''
+              Configuration of this OpenVPN instance.  See
+              {manpage}`openvpn(8)`
+              for details.
 
                 To import an external config file, use the following definition:
                 `config = "config /path/to/config.ovpn"`
               '';
-            };
 
-            up = mkOption {
-              default = "";
-              type = types.lines;
-              description = ''
-                Shell commands executed when the instance is starting.
-              '';
+            default = { };
+            type = types.submodule {
+              freeformType = with types;
+                attrsOf (
+                  nullOr (
+                    oneOf [
+                      bool
+                      int
+                      str
+                      path
+                      (listOf (oneOf [ bool int str path ]))
+                    ]
+                  )
+                );
+              options.dev = mkOption {
+                default = null;
+                type = types.str;
+                description = ''
+                  Shell commands executed when the instance is starting.
+                '';
+              };
+              options.down = mkOption {
+                default = "";
+                type = types.lines;
+                description = ''
+                  Shell commands executed when the instance is shutting down.
+                '';
+              };
+              options.errors-to-stderr = mkOption {
+                default = true;
+                type = types.bool;
+                description = ''
+                  Output errors to stderr instead of stdout
+                  unless log output is redirected by one of the `--log` options.
+                '';
+              };
+              options.route-up = mkOption {
+                default = "";
+                type = types.lines;
+                description = ''
+                  Run command after routes are added.
+                '';
+              };
+              options.up = mkOption {
+                default = "";
+                type = types.lines;
+                description = ''
+                  Shell commands executed when the instance is starting.
+                '';
+              };
+              options.script-security = mkOption {
+                default = 1;
+                type = types.enum [ 1 2 3 ];
+                description = ''
+                  - 1 — (Default) Only call built-in executables such as ifconfig, ip, route, or netsh.
+                  - 2 — Allow calling of built-in executables and user-defined scripts.
+                  - 3 — Allow passwords to be passed to scripts via environmental variables (potentially unsafe).
+                '';
+              };
             };
+          };
 
-            down = mkOption {
-              default = "";
-              type = types.lines;
-              description = ''
-                Shell commands executed when the instance is shutting down.
-              '';
-            };
+          autoStart = mkOption {
+            default = true;
+            type = types.bool;
+            description = "Whether this OpenVPN instance should be started automatically.";
+          };
 
-            autoStart = mkOption {
-              default = true;
-              type = types.bool;
-              description = "Whether this OpenVPN instance should be started automatically.";
-            };
+          # Legacy options
+          down = (elemAt settings.type.functor.payload.modules 0).options.down;
+          up = (elemAt settings.type.functor.payload.modules 0).options.up;
 
-            updateResolvConf = mkOption {
-              default = false;
-              type = types.bool;
-              description = ''
-                Use the script from the update-resolv-conf package to automatically
-                update resolv.conf with the DNS information provided by openvpn. The
-                script will be run after the "up" commands and before the "down" commands.
-              '';
-            };
+          updateResolvConf = mkOption {
+            default = false;
+            type = types.bool;
+            description = ''
+              Use the script from the update-resolv-conf package to automatically
+              update resolv.conf with the DNS information provided by openvpn. The
+              script will be run after the "up" commands and before the "down" commands.
+            '';
+          };
 
             authUserPass = mkOption {
               default = null;
@@ -227,9 +425,39 @@ in
                 ]
               );
             };
+
+          netns = mkOption {
+            default = null;
+            type = with types; nullOr str;
+            description = "Network namespace.";
+          };
           };
 
-        });
+        config.settings = mkMerge
+          [
+            (mkIf (config.netns != null) {
+              # Useless to setup the interface
+              # because moving it to the netns will reset it
+              ifconfig-noexec = true;
+              route-noexec = true;
+              script-security = 2;
+            })
+            (mkIf (config.authUserPass != null) {
+              auth-user-pass = pkgs.writeText "openvpn-auth-user-pass-${name}" ''
+                ${config.authUserPass.username}
+                ${config.authUserPass.password}
+              '';
+            })
+            (mkIf config.updateResolvConf {
+              script-security = 2;
+            })
+            {
+              # Aliases legacy options
+              down = modules.mkAliasAndWrapDefsWithPriority id (options.down or { });
+              up = modules.mkAliasAndWrapDefsWithPriority id (options.up or { });
+            }
+          ];
+      }));
 
     };
 
@@ -243,14 +471,11 @@ in
 
   ###### implementation
 
-  config = mkIf (cfg.servers != { }) {
+  config = mkIf (enabledServers != { }) {
 
-    systemd.services =
-      (listToAttrs (
-        mapAttrsToList (
-          name: value: nameValuePair "openvpn-${name}" (makeOpenVPNJob value name)
-        ) cfg.servers
-      ))
+    systemd.services = (listToAttrs (mapAttrsToList
+      (name: value: nameValuePair "openvpn-${name}"
+        (makeOpenVPNJob value name)) enabledServers))
       // restartService;
 
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -16,28 +16,30 @@ let
 
   PATH = name: makeBinPath config.systemd.services."openvpn-${name}".path;
 
-  makeOpenVPNJob = cfg: name:
+  makeOpenVPNJob =
+    cfg: name:
     let
 
       configFile = pkgs.writeText "openvpn-config-${name}" (
-        generators.toKeyValue
-          {
-            mkKeyValue = key: value:
-              if hasAttr key scripts
-              then "${key} " + pkgs.writeShellScript "openvpn-${name}-${key}" (scripts.${key} value)
-              else if builtins.isBool value
-              then optionalString value key
-              else if builtins.isPath value
-              then "${key} ${value}"
-              else if builtins.isList value
-              then concatMapStringsSep "\n" (v: "${key} ${generators.mkValueStringDefault {} v}") value
-              else "${key} ${generators.mkValueStringDefault {} value}";
-          }
-          cfg.settings
+        generators.toKeyValue {
+          mkKeyValue =
+            key: value:
+            if hasAttr key scripts then
+              "${key} " + pkgs.writeShellScript "openvpn-${name}-${key}" (scripts.${key} value)
+            else if builtins.isBool value then
+              optionalString value key
+            else if builtins.isPath value then
+              "${key} ${value}"
+            else if builtins.isList value then
+              concatMapStringsSep "\n" (v: "${key} ${generators.mkValueStringDefault { } v}") value
+            else
+              "${key} ${generators.mkValueStringDefault { } value}";
+        } cfg.settings
       );
 
       scripts = {
-        up = script:
+        up =
+          script:
           let
             init = ''
               export PATH=${PATH name}
@@ -53,8 +55,7 @@ let
                 fi
               done
 
-              ${optionalString cfg.updateResolvConf
-                 "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
+              ${optionalString cfg.updateResolvConf "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
             '';
             # Add DNS settings given in foreign DHCP options to the resolv.conf of the netns.
             # Note that JoinsNamespaceOf="netns-${cfg.netns}.service" will not
@@ -88,126 +89,130 @@ let
               done
             '';
           in
-          if cfg.netns == null
-          then ''
-            ${init}
-            ${script}
-          ''
-          else ''
-            export PATH=${PATH name}
-            set -eux
-            ${setNetNSResolvConf}
-            ip link set dev '${cfg.settings.dev}' up netns '${cfg.netns}' mtu "$tun_mtu"
-            ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-up-netns.sh" ''
+          if cfg.netns == null then
+            ''
               ${init}
-              set -eux
+              ${script}
+            ''
+          else
+            ''
               export PATH=${PATH name}
+              set -eux
+              ${setNetNSResolvConf}
+              ip link set dev '${cfg.settings.dev}' up netns '${cfg.netns}' mtu "$tun_mtu"
+              ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-up-netns.sh" ''
+                ${init}
+                set -eux
+                export PATH=${PATH name}
 
-              ip link set dev lo up
+                ip link set dev lo up
 
-              netmask4="''${ifconfig_netmask:-30}"
-              netbits6="''${ifconfig_ipv6_netbits:-112}"
-              if [ -n "''${ifconfig_local-}" ]; then
-                if [ -n "''${ifconfig_remote-}" ]; then
-                  ip -4 addr replace \
-                    local "$ifconfig_local" \
-                    peer "$ifconfig_remote/$netmask4" \
-                    ''${ifconfig_broadcast:+broadcast "$ifconfig_broadcast"} \
-                    dev '${cfg.settings.dev}'
-                else
-                  ip -4 addr replace \
-                    local "$ifconfig_local/$netmask4" \
-                    ''${ifconfig_broadcast:+broadcast "$ifconfig_broadcast"} \
-                    dev '${cfg.settings.dev}'
+                netmask4="''${ifconfig_netmask:-30}"
+                netbits6="''${ifconfig_ipv6_netbits:-112}"
+                if [ -n "''${ifconfig_local-}" ]; then
+                  if [ -n "''${ifconfig_remote-}" ]; then
+                    ip -4 addr replace \
+                      local "$ifconfig_local" \
+                      peer "$ifconfig_remote/$netmask4" \
+                      ''${ifconfig_broadcast:+broadcast "$ifconfig_broadcast"} \
+                      dev '${cfg.settings.dev}'
+                  else
+                    ip -4 addr replace \
+                      local "$ifconfig_local/$netmask4" \
+                      ''${ifconfig_broadcast:+broadcast "$ifconfig_broadcast"} \
+                      dev '${cfg.settings.dev}'
+                  fi
                 fi
-              fi
-              if [ -n "''${ifconfig_ipv6_local-}" ]; then
+                if [ -n "''${ifconfig_ipv6_local-}" ]; then
+                  if [ -n "''${ifconfig_ipv6_remote-}" ]; then
+                    ip -6 addr replace \
+                      local "$ifconfig_ipv6_local" \
+                      peer "$ifconfig_ipv6_remote/$netbits6" \
+                      dev '${cfg.settings.dev}'
+                  else
+                    ip -6 addr replace \
+                      local "$ifconfig_ipv6_local/$netbits6" \
+                      dev '${cfg.settings.dev}'
+                  fi
+                fi
+                set +eux
+                ${script}
+              ''}
+            '';
+        route-up =
+          script:
+          if cfg.netns == null then
+            script
+          else
+            ''
+              export PATH=${PATH name}
+              set -eux
+              ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-route-up-netns" ''
+                export PATH=${PATH name}
+                set -eux
+                i=1
+                while
+                  eval net=\"\''${route_network_$i-}\"
+                  eval mask=\"\''${route_netmask_$i-}\"
+                  eval gw=\"\''${route_gateway_$i-}\"
+                  eval mtr=\"\''${route_metric_$i-}\"
+                  [ -n "$net" ]
+                do
+                  ip -4 route replace "$net/$mask" via "$gw" ''${mtr:+metric "$mtr"}
+                  i=$(( i + 1 ))
+                done
+
+                if [ -n "''${route_vpn_gateway-}" ]; then
+                  ip -4 route replace default via "$route_vpn_gateway"
+                fi
+
+                i=1
+                while
+                  # There doesn't seem to be $route_ipv6_metric_<n>
+                  # according to the manpage.
+                  eval net=\"\''${route_ipv6_network_$i-}\"
+                  eval gw=\"\''${route_ipv6_gateway_$i-}\"
+                  [ -n "$net" ]
+                do
+                  ip -6 route replace  "$net"  via "$gw"  metric 100
+                  i=$(( i + 1 ))
+                done
+
+                # There's no $route_vpn_gateway for IPv6. It's not
+                # documented if OpenVPN includes default route in
+                # $route_ipv6_*. Set default route to remote VPN
+                # endpoint address if there is one. Use higher metric
+                # than $route_ipv6_* routes to give preference to a
+                # possible default route in them.
                 if [ -n "''${ifconfig_ipv6_remote-}" ]; then
-                  ip -6 addr replace \
-                    local "$ifconfig_ipv6_local" \
-                    peer "$ifconfig_ipv6_remote/$netbits6" \
-                    dev '${cfg.settings.dev}'
-                else
-                  ip -6 addr replace \
-                    local "$ifconfig_ipv6_local/$netbits6" \
-                    dev '${cfg.settings.dev}'
+                  ip -6 route replace default \
+                    via "$ifconfig_ipv6_remote" metric 200
                 fi
-              fi
-              set +eux
-              ${script}
-            ''}
-          '';
-        route-up = script:
-          if cfg.netns == null
-          then script
-          else ''
-            export PATH=${PATH name}
-            set -eux
-            ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-route-up-netns" ''
-              export PATH=${PATH name}
-              set -eux
-              i=1
-              while
-                eval net=\"\''${route_network_$i-}\"
-                eval mask=\"\''${route_netmask_$i-}\"
-                eval gw=\"\''${route_gateway_$i-}\"
-                eval mtr=\"\''${route_metric_$i-}\"
-                [ -n "$net" ]
-              do
-                ip -4 route replace "$net/$mask" via "$gw" ''${mtr:+metric "$mtr"}
-                i=$(( i + 1 ))
-              done
-
-              if [ -n "''${route_vpn_gateway-}" ]; then
-                ip -4 route replace default via "$route_vpn_gateway"
-              fi
-
-              i=1
-              while
-                # There doesn't seem to be $route_ipv6_metric_<n>
-                # according to the manpage.
-                eval net=\"\''${route_ipv6_network_$i-}\"
-                eval gw=\"\''${route_ipv6_gateway_$i-}\"
-                [ -n "$net" ]
-              do
-                ip -6 route replace  "$net"  via "$gw"  metric 100
-                i=$(( i + 1 ))
-              done
-
-              # There's no $route_vpn_gateway for IPv6. It's not
-              # documented if OpenVPN includes default route in
-              # $route_ipv6_*. Set default route to remote VPN
-              # endpoint address if there is one. Use higher metric
-              # than $route_ipv6_* routes to give preference to a
-              # possible default route in them.
-              if [ -n "''${ifconfig_ipv6_remote-}" ]; then
-                ip -6 route replace default \
-                  via "$ifconfig_ipv6_remote" metric 200
-              fi
-              ${script}
-            ''}
-          '';
-        down = script:
+                ${script}
+              ''}
+            '';
+        down =
+          script:
           let
             init = ''
               export PATH=${PATH name}
-              ${optionalString cfg.updateResolvConf
-                 "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
+              ${optionalString cfg.updateResolvConf "${pkgs.update-resolv-conf}/libexec/openvpn/update-resolv-conf"}
             '';
           in
-          if cfg.netns == null
-          then ''
-            ${init}
-            ${script}
-          ''
-          else ''
-            export PATH=${PATH name}
-            ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-down-netns.sh" ''
+          if cfg.netns == null then
+            ''
               ${init}
               ${script}
-            ''}
-            rm -f /etc/netns/'${cfg.netns}'/resolv.conf
-          '';
+            ''
+          else
+            ''
+              export PATH=${PATH name}
+              ip netns exec '${cfg.netns}' ${pkgs.writeShellScript "openvpn-${name}-down-netns.sh" ''
+                ${init}
+                ${script}
+              ''}
+              rm -f /etc/netns/'${cfg.netns}'/resolv.conf
+            '';
       };
 
     in
@@ -298,166 +303,187 @@ in
         attribute name.
       '';
 
-      type = with types; attrsOf (submodule ({ name, config, options, ... }: {
-
-          options = rec {
-          enable = mkEnableOption "OpenVPN server" // { default = true; };
-
-          settings = mkOption {
-            description = ''
-              Configuration of this OpenVPN instance.  See
-              {manpage}`openvpn(8)`
-              for details.
-
-                To import an external config file, use the following definition:
-                `config = "config /path/to/config.ovpn"`
-              '';
-
-            default = { };
-            type = types.submodule {
-              freeformType = with types;
-                attrsOf (
-                  nullOr (
-                    oneOf [
-                      bool
-                      int
-                      str
-                      path
-                      (listOf (oneOf [ bool int str path ]))
-                    ]
-                  )
-                );
-              options.dev = mkOption {
-                default = null;
-                type = types.str;
-                description = ''
-                  Shell commands executed when the instance is starting.
-                '';
-              };
-              options.down = mkOption {
-                default = "";
-                type = types.lines;
-                description = ''
-                  Shell commands executed when the instance is shutting down.
-                '';
-              };
-              options.errors-to-stderr = mkOption {
-                default = true;
-                type = types.bool;
-                description = ''
-                  Output errors to stderr instead of stdout
-                  unless log output is redirected by one of the `--log` options.
-                '';
-              };
-              options.route-up = mkOption {
-                default = "";
-                type = types.lines;
-                description = ''
-                  Run command after routes are added.
-                '';
-              };
-              options.up = mkOption {
-                default = "";
-                type = types.lines;
-                description = ''
-                  Shell commands executed when the instance is starting.
-                '';
-              };
-              options.script-security = mkOption {
-                default = 1;
-                type = types.enum [ 1 2 3 ];
-                description = ''
-                  - 1 — (Default) Only call built-in executables such as ifconfig, ip, route, or netsh.
-                  - 2 — Allow calling of built-in executables and user-defined scripts.
-                  - 3 — Allow passwords to be passed to scripts via environmental variables (potentially unsafe).
-                '';
-              };
-            };
-          };
-
-          autoStart = mkOption {
-            default = true;
-            type = types.bool;
-            description = "Whether this OpenVPN instance should be started automatically.";
-          };
-
-          # Legacy options
-          down = (elemAt settings.type.functor.payload.modules 0).options.down;
-          up = (elemAt settings.type.functor.payload.modules 0).options.up;
-
-          updateResolvConf = mkOption {
-            default = false;
-            type = types.bool;
-            description = ''
-              Use the script from the update-resolv-conf package to automatically
-              update resolv.conf with the DNS information provided by openvpn. The
-              script will be run after the "up" commands and before the "down" commands.
-            '';
-          };
-
-            authUserPass = mkOption {
-              default = null;
-              description = ''
-                This option can be used to store the username / password credentials
-                with the "auth-user-pass" authentication method.
-
-                You can either provide an attribute set of `username` and `password`,
-                or the path to a file containing the credentials on two lines.
-
-                WARNING: If you use an attribute set, this option will put the credentials WORLD-READABLE into the Nix store!
-              '';
-              type = types.nullOr (
-                types.oneOf [
-                  types.singleLineStr
-                  (types.submodule {
-                    options = {
-                      username = mkOption {
-                        description = "The username to store inside the credentials file.";
-                        type = types.str;
-                      };
-
-                      password = mkOption {
-                        description = "The password to store inside the credentials file.";
-                        type = types.str;
-                      };
-                    };
-                  })
-                ]
-              );
-            };
-
-          netns = mkOption {
-            default = null;
-            type = with types; nullOr str;
-            description = "Network namespace.";
-          };
-          };
-
-        config.settings = mkMerge
-          [
-            (mkIf (config.netns != null) {
-              # Useless to setup the interface
-              # because moving it to the netns will reset it
-              ifconfig-noexec = true;
-              route-noexec = true;
-              script-security = 2;
-            })
-            (mkIf (config.authUserPass != null) {
-              auth-user-pass = pkgs.writeText "openvpn-auth-user-pass-${name}" ''
-                ${config.authUserPass.username}
-                ${config.authUserPass.password}
-              '';
-            })
-            (mkIf config.updateResolvConf {
-              script-security = 2;
-            })
+      type =
+        with types;
+        attrsOf (
+          submodule (
             {
-              # Aliases legacy options
-              down = modules.mkAliasAndWrapDefsWithPriority id (options.down or { });
-              up = modules.mkAliasAndWrapDefsWithPriority id (options.up or { });
+              name,
+              config,
+              options,
+              ...
+            }:
+            {
+
+              options = rec {
+                enable = mkEnableOption "OpenVPN server" // {
+                  default = true;
+                };
+
+                settings = mkOption {
+                  description = ''
+                    Configuration of this OpenVPN instance.  See
+                    {manpage}`openvpn(8)`
+                    for details.
+
+                      To import an external config file, use the following definition:
+                      `config = "config /path/to/config.ovpn"`
+                  '';
+
+                  default = { };
+                  type = types.submodule {
+                    freeformType =
+                      with types;
+                      attrsOf (
+                        nullOr (oneOf [
+                          bool
+                          int
+                          str
+                          path
+                          (listOf (oneOf [
+                            bool
+                            int
+                            str
+                            path
+                          ]))
+                        ])
+                      );
+                    options.dev = mkOption {
+                      default = null;
+                      type = types.str;
+                      description = ''
+                        Shell commands executed when the instance is starting.
+                      '';
+                    };
+                    options.down = mkOption {
+                      default = "";
+                      type = types.lines;
+                      description = ''
+                        Shell commands executed when the instance is shutting down.
+                      '';
+                    };
+                    options.errors-to-stderr = mkOption {
+                      default = true;
+                      type = types.bool;
+                      description = ''
+                        Output errors to stderr instead of stdout
+                        unless log output is redirected by one of the `--log` options.
+                      '';
+                    };
+                    options.route-up = mkOption {
+                      default = "";
+                      type = types.lines;
+                      description = ''
+                        Run command after routes are added.
+                      '';
+                    };
+                    options.up = mkOption {
+                      default = "";
+                      type = types.lines;
+                      description = ''
+                        Shell commands executed when the instance is starting.
+                      '';
+                    };
+                    options.script-security = mkOption {
+                      default = 1;
+                      type = types.enum [
+                        1
+                        2
+                        3
+                      ];
+                      description = ''
+                        - 1 — (Default) Only call built-in executables such as ifconfig, ip, route, or netsh.
+                        - 2 — Allow calling of built-in executables and user-defined scripts.
+                        - 3 — Allow passwords to be passed to scripts via environmental variables (potentially unsafe).
+                      '';
+                    };
+                  };
+                };
+
+                autoStart = mkOption {
+                  default = true;
+                  type = types.bool;
+                  description = "Whether this OpenVPN instance should be started automatically.";
+                };
+
+                # Legacy options
+                down = (elemAt settings.type.functor.payload.modules 0).options.down;
+                up = (elemAt settings.type.functor.payload.modules 0).options.up;
+
+                updateResolvConf = mkOption {
+                  default = false;
+                  type = types.bool;
+                  description = ''
+                    Use the script from the update-resolv-conf package to automatically
+                    update resolv.conf with the DNS information provided by openvpn. The
+                    script will be run after the "up" commands and before the "down" commands.
+                  '';
+                };
+
+                authUserPass = mkOption {
+                  default = null;
+                  description = ''
+                    This option can be used to store the username / password credentials
+                    with the "auth-user-pass" authentication method.
+
+                    You can either provide an attribute set of `username` and `password`,
+                    or the path to a file containing the credentials on two lines.
+
+                    WARNING: If you use an attribute set, this option will put the credentials WORLD-READABLE into the Nix store!
+                  '';
+                  type = types.nullOr (
+                    types.oneOf [
+                      types.singleLineStr
+                      (types.submodule {
+                        options = {
+                          username = mkOption {
+                            description = "The username to store inside the credentials file.";
+                            type = types.str;
+                          };
+
+                          password = mkOption {
+                            description = "The password to store inside the credentials file.";
+                            type = types.str;
+                          };
+                        };
+                      })
+                    ]
+                  );
+                };
+
+                netns = mkOption {
+                  default = null;
+                  type = with types; nullOr str;
+                  description = "Network namespace.";
+                };
+              };
+
+              config.settings = mkMerge [
+                (mkIf (config.netns != null) {
+                  # Useless to setup the interface
+                  # because moving it to the netns will reset it
+                  ifconfig-noexec = true;
+                  route-noexec = true;
+                  script-security = 2;
+                })
+                (mkIf (config.authUserPass != null) {
+                  auth-user-pass = pkgs.writeText "openvpn-auth-user-pass-${name}" ''
+                    ${config.authUserPass.username}
+                    ${config.authUserPass.password}
+                  '';
+                })
+                (mkIf config.updateResolvConf {
+                  script-security = 2;
+                })
+                {
+                  # Aliases legacy options
+                  down = modules.mkAliasAndWrapDefsWithPriority id (options.down or { });
+                  up = modules.mkAliasAndWrapDefsWithPriority id (options.up or { });
+                }
+              ];
             }
-          ];
-      }));
+          )
+        );
 
     };
 
@@ -473,9 +499,12 @@ in
 
   config = mkIf (enabledServers != { }) {
 
-    systemd.services = (listToAttrs (mapAttrsToList
-      (name: value: nameValuePair "openvpn-${name}"
-        (makeOpenVPNJob value name)) enabledServers))
+    systemd.services =
+      (listToAttrs (
+        mapAttrsToList (
+          name: value: nameValuePair "openvpn-${name}" (makeOpenVPNJob value name)
+        ) enabledServers
+      ))
       // restartService;
 
     environment.systemPackages = [ cfg.package ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This is working enough for me so far but may benefit from reviews and tests before being merged.
I am not sure how to handle the `DNS` option from `DHCP`, currently `/etc/netns/${netns}/resolv.conf` is always set (`ip netns` bind mounting it onto `/etc/resolv.conf`) but maybe it should be guarded by a NixOS option. I've also not tested the interaction with `updateResolvConf`.

###### Motivation for this change
Add [network namespace](https://www.man7.org/linux/man-pages/man8/ip-netns.8.html) support to OpenVPN.
This enables to move the OpenVPN interface and selected systemd services in a dedicated network namespace without the physical network interfaces.

###### Things done
- [X] Add `services.netns` module to create network namespaces and have systemd services depend upon it.
- [X] Add `services.netns.${netns}.sysctl` to configure `sysctl`s within network namespaces, and inherit defaults from `boot.kernel.sysctl`.
- [X] Add `services.netns.${netns}.nftables` to configure the firewall using `nftables` within network namespaces, iif. `networking.nftables.enable` is `true`.
- [X] Move to `services.openvpn.settings` option using `freeformType`.
- [X] Add option `services.openvpn.server.${server}.netns`. Note that this requires `script-security = 2` because after `ip link` has moved `openvpn`'s device the network configuration has to be done from scratch within the network namespace.
- [X] Alias `services.openvpn.server.${server}.{up,down}` to `services.openvpn.server.${server}.settings.{up,down}`, using `mkAliasAndWrapDefsWithPriority`.
- [X] Add `services.openvpn.server.${server}.enable`.

###### Example
This creates the `riseup` network namespace, start an `openvpn` in the initial network namespace, and then move `openvpn`'s interface to that `riseup` network namespace.
```nix
{ pkgs, lib, config, ... }:
let
  netns = "riseup";
  inherit (config.services) openvpn;
  apiUrl = "https://api.black.riseup.net/3/cert";
  ca = pkgs.fetchurl {
    url = "https://black.riseup.net/ca.crt";
    hash = "sha256-Zdvnfz2k7iWlbgmmcUJrpJZ1dp7o0qXeJhP0HWJD7ro=";
  } + "";
  key-cert = "/run/openvpn-${netns}/key+cert.pem";
in
{
services.openvpn.servers.${netns} = {
  inherit netns;
  settings = {
    remote =
      # amsterdam
      ["212.83.182.127" "212.83.165.160" "212.129.4.141"] ++
      # miami
      ["37.218.244.249" "37.218.244.251"] ++
      # montreal
      ["199.58.83.10" "199.58.83.10" "199.58.83.12"] ++
      # new-york
      ["185.220.103.12"] ++
      # paris
      ["212.83.146.228" "212.83.143.67" "163.172.126.44"] ++
      # seattle
      ["198.252.153.28" "198.252.153.28"] ++
      [];
    remote-random = true;
    port = "443";
    proto = "tcp";
    inherit ca;
    key = key-cert;
    cert = key-cert;

    auth = "SHA1";
    cipher = "AES-128-CBC";
    client = true;
    dev = "ov-${netns}";
    dev-type = "tun";
    keepalive = "10 30";
    nobind = true;
    persist-key = true;
    persist-tun = true;
    remote-cert-tls = "server";
    reneg-sec = 0;
    script-security = 2;
    tls-cipher = "DHE-RSA-AES128-SHA";
    tls-client = true;
    tun-ipv6 = true;
    up-restart = true;
    verb = 3;
  };
};
systemd.services."openvpn-${netns}" = {
  preStart = ''
    set -e
    ${pkgs.curl}/bin/curl -X POST --cacert ${ca} -o ${key-cert} -Ls ${apiUrl}
    chmod 700 ${key-cert}
  '';
  serviceConfig = {
    RuntimeDirectory = [ "openvpn-${netns}" ];
    RuntimeDirectoryMode = "0700";
  };
};
networking.nftables.ruleset = ''
  add rule inet filter fw2net meta skuid root tcp dport 443 counter accept comment "OpenVPN Riseup"
'';
services.netns.namespaces.${netns} = {
  nftables = ''
    include "${../../../../networking/nftables.txt}"
    table inet filter {
      chain input {
        type filter hook input priority filter
        policy drop
        iifname lo accept
        jump check-tcp
        ct state { established, related } accept
        jump accept-connectivity-input
        jump check-broadcast
        ct state invalid drop
      }
      chain forward {
        type filter hook forward priority filter
        policy drop
        jump accept-connectivity-forward
      }
      chain output {
        type filter hook output priority filter
        policy drop
        oifname lo accept
        ct state { related, established } accept
        jump accept-connectivity-output
      }
    }
  '';
};
}
```

This excerpt puts `transmission` in that `riseup` network namespace.
```nix
let
  netns = "riseup";
  inherit (config.services) transmission;
in
{                         
  systemd.services.transmission = {
    after = [ "netns-${netns}.service" ];
    requires = [ "netns-${netns}.service" ];
    unitConfig.JoinsNamespaceOf = ["netns-${netns}.service"];
    # Alternatively: serviceConfig.NetworkNamespacePath = "/var/run/netns/${netns}";
    serviceConfig.BindReadOnlyPaths = ["/etc/netns/${netns}/resolv.conf:/etc/resolv.conf"];
    serviceConfig.PrivateNetwork = true;
  };
  # Open the firewall within the riseup network namespace.
  services.netns.namespaces.${netns}.nftables = ''
    table inet filter {
      chain input {
        meta l4proto { tcp, udp } th dport ${toString transmission.settings.peer-port} counter accept comment "Transmission"
      }
      chain output {
        meta skuid ${transmission.user} counter accept comment "Transmission"
      }
    }
  '';
}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
