### PR TITLE
sway: remove swaybg from path

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper
+{ lib, stdenv, fetchFromGitHub, substituteAll, swaybg
 , meson, ninja, pkg-config, wayland, scdoc
 , libxkbcommon, pcre, json_c, dbus, libevdev
 , pango, cairo, libinput, libcap, pam, gdk-pixbuf, librsvg
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./sway-config-no-nix-store-references.patch
     ./load-configuration-from-etc.patch
+
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit swaybg;
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/sway/fix-paths.patch
+++ b/pkgs/applications/window-managers/sway/fix-paths.patch
@@ -1,0 +1,11 @@
+--- a/sway/config.c
++++ b/sway/config.c
+@@ -276,7 +276,7 @@
+ 
+ 	if (!(config->active_bar_modifiers = create_list())) goto cleanup;
+ 
+-	if (!(config->swaybg_command = strdup("swaybg"))) goto cleanup;
++	if (!(config->swaybg_command = strdup("@swaybg@/bin/swaybg"))) goto cleanup;
+ 
+ 	if (!(config->config_chain = create_list())) goto cleanup;
+ 	config->current_config_path = NULL;

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, sway-unwrapped, swaybg
+, sway-unwrapped
 , makeWrapper, symlinkJoin, writeShellScriptBin
 , withBaseWrapper ? true, extraSessionCommands ? "", dbus
 , withGtkWrapper ? false, wrapGAppsHook, gdk-pixbuf, glib, gtk3
@@ -42,7 +42,6 @@ in symlinkJoin {
     ${optionalString withGtkWrapper "gappsWrapperArgsHook"}
 
     wrapProgram $out/bin/sway \
-      --prefix PATH : "${swaybg}/bin" \
       ${optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
       ${optionalString (extraOptions != []) "${concatMapStrings (x: " --add-flags " + x) extraOptions}"}
   '';


### PR DESCRIPTION
Avoids polluting the environment for sway's children.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).