### PR TITLE
pkgs/development: stdenv.lib -> lib

### DIFF
--- a/pkgs/development/arduino/arduino-ci/default.nix
+++ b/pkgs/development/arduino/arduino-ci/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  runtimePath = stdenv.lib.makeBinPath [
+  runtimePath = lib.makeBinPath [
     arduino-cli
     python3 # required by the esp8266 core
   ];

--- a/pkgs/development/arduino/arduino-cli/default.nix
+++ b/pkgs/development/arduino/arduino-cli/default.nix
@@ -21,7 +21,7 @@ let
 
     buildFlagsArray = [
       "-ldflags=-s -w -X github.com/arduino/arduino-cli/version.versionString=${version} -X github.com/arduino/arduino-cli/version.commit=unknown"
-    ] ++ stdenv.lib.optionals stdenv.isLinux [ "-extldflags '-static'" ];
+    ] ++ lib.optionals stdenv.isLinux [ "-extldflags '-static'" ];
 
     meta = with lib; {
       inherit (src.meta) homepage;

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -47,7 +47,7 @@ let
   ;
   # abiVersion 6 is default, but we need 5 for `avrdude_bin` executable
   ncurses5 = ncurses.override { abiVersion = "5"; };
-  teensy_libpath = stdenv.lib.makeLibraryPath [
+  teensy_libpath = lib.makeLibraryPath [
     atk
     cairo
     expat
@@ -76,7 +76,7 @@ let
                         else throw "${stdenv.hostPlatform.system} is not supported in teensy";
 
   flavor = (if withTeensyduino then "teensyduino" else "arduino")
-             + stdenv.lib.optionalString (!withGui) "-core";
+             + lib.optionalString (!withGui) "-core";
 in
 stdenv.mkDerivation rec {
   version = "1.8.13";
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
     zlib
     ncurses5
     readline
-  ] ++ stdenv.lib.optionals withTeensyduino [ upx ];
+  ] ++ lib.optionals withTeensyduino [ upx ];
   downloadSrcList = builtins.attrValues externalDownloads;
   downloadDstList = builtins.attrNames externalDownloads;
 
@@ -165,7 +165,7 @@ stdenv.mkDerivation rec {
     cp -r ./build/linux/work/* "$out/share/arduino/"
     echo -n ${version} > $out/share/arduino/lib/version.txt
 
-    ${stdenv.lib.optionalString withGui ''
+    ${lib.optionalString withGui ''
       mkdir -p $out/bin
       substituteInPlace $out/share/arduino/arduino \
         --replace "JAVA=java" "JAVA=$javaPath/java" \
@@ -180,7 +180,7 @@ stdenv.mkDerivation rec {
         --replace '<ICON_NAME>' "$out/share/arduino/icons/128x128/apps/arduino.png"
     ''}
 
-    ${stdenv.lib.optionalString withTeensyduino ''
+    ${lib.optionalString withTeensyduino ''
       # Back up the original jars
       mv $out/share/arduino/lib/arduino-core.jar $out/share/arduino/lib/arduino-core.jar.bak
       mv $out/share/arduino/lib/pde.jar $out/share/arduino/lib/pde.jar.bak
@@ -235,7 +235,7 @@ stdenv.mkDerivation rec {
     mkdir $out/lib/
     ln -s ${lib.makeLibraryPath [ ncurses5 ]}/libtinfo.so.5 $out/lib/libtinfo.so.5
 
-    ${stdenv.lib.optionalString withTeensyduino ''
+    ${lib.optionalString withTeensyduino ''
       # Patch the Teensy loader binary
       patchelf --debug \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \

--- a/pkgs/development/arduino/arduino-mk/default.nix
+++ b/pkgs/development/arduino/arduino-mk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, installShellFiles }:
+{ stdenv, lib, fetchFromGitHub, python3Packages, installShellFiles }:
 
 stdenv.mkDerivation rec {
   version = "1.6.0";
@@ -22,12 +22,11 @@ stdenv.mkDerivation rec {
     wrapPythonPrograms
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Makefile for Arduino sketches";
     homepage = "https://github.com/sudar/Arduino-Makefile";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.eyjhb ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.eyjhb ];
+    platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/arduino/ino/default.nix
+++ b/pkgs/development/arduino/ino/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python2Packages, picocom
+{ stdenv, lib, fetchurl, python2Packages, picocom
 , avrdude, arduino-core }:
 
 python2Packages.buildPythonApplication rec {
@@ -36,11 +36,11 @@ python2Packages.buildPythonApplication rec {
       --replace "'-C', self.e['avrdude.conf']," ""
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Command line toolkit for working with Arduino hardware";
     homepage = "http://inotool.org/";
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ antono ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ antono ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/chez-modules/chez-matchable/default.nix
+++ b/pkgs/development/chez-modules/chez-matchable/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, chez }:
+{ stdenv, lib, fetchFromGitHub, chez }:
 
 stdenv.mkDerivation rec {
   pname = "chez-matchable";
@@ -23,11 +23,11 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "This is a Library for ChezScheme providing the protable hygenic pattern matcher by Alex Shinn";
     homepage = "https://github.com/fedeinthemix/chez-matchable/";
-    maintainers = [ stdenv.lib.maintainers.jitwit ];
-    license = stdenv.lib.licenses.publicDomain;
+    maintainers = [ maintainers.jitwit ];
+    license = licenses.publicDomain;
   };
 
 }

--- a/pkgs/development/chez-modules/chez-mit/default.nix
+++ b/pkgs/development/chez-modules/chez-mit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, chez, chez-srfi }:
+{ stdenv, lib, fetchgit, chez, chez-srfi }:
 
 stdenv.mkDerivation {
   pname = "chez-mit";
@@ -22,11 +22,11 @@ stdenv.mkDerivation {
 
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "This is a MIT/GNU Scheme compatibility library for Chez Scheme";
     homepage = "https://github.com/fedeinthemix/chez-mit/";
-    maintainers = [ stdenv.lib.maintainers.jitwit ];
-    license = stdenv.lib.licenses.free;
+    maintainers = [ maintainers.jitwit ];
+    license = licenses.free;
   };
 
 }

--- a/pkgs/development/chez-modules/chez-scmutils/default.nix
+++ b/pkgs/development/chez-modules/chez-scmutils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, chez, chez-srfi, chez-mit }:
+{ stdenv, lib, fetchgit, chez, chez-srfi, chez-mit }:
 
 stdenv.mkDerivation {
   pname = "chez-scmutils";
@@ -22,11 +22,11 @@ stdenv.mkDerivation {
 
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "This is a port of the ‘MIT Scmutils’ library to Chez Scheme";
     homepage = "https://github.com/fedeinthemix/chez-scmutils/";
-    maintainers = [ stdenv.lib.maintainers.jitwit ];
-    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ maintainers.jitwit ];
+    license = licenses.gpl3;
   };
 
 }

--- a/pkgs/development/chez-modules/chez-srfi/default.nix
+++ b/pkgs/development/chez-modules/chez-srfi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, chez }:
+{ stdenv, lib, fetchgit, chez }:
 
 stdenv.mkDerivation {
   pname = "chez-srfi";
@@ -22,11 +22,11 @@ stdenv.mkDerivation {
 
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "This package provides a collection of SRFI libraries for Chez Scheme";
     homepage = "https://github.com/fedeinthemix/chez-srfi/";
-    maintainers = [ stdenv.lib.maintainers.jitwit ];
-    license = stdenv.lib.licenses.free;
+    maintainers = [ maintainers.jitwit ];
+    license = licenses.free;
   };
 
 }

--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -83,7 +83,7 @@ let
     GO111MODULE = "off";
     GOFLAGS = lib.optionals (!allowGoReference) [ "-trimpath" ];
 
-    GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+    GOARM = toString (lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
 
     configurePhase = args.configurePhase or ''
       runHook preConfigure

--- a/pkgs/development/guile-modules/guile-gnome/default.nix
+++ b/pkgs/development/guile-modules/guile-gnome/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     texinfo guile gwrap pkgconfig gconf glib gnome_vfs gtk2
     libglade libgnome libgnomecanvas libgnomeui pango guile-cairo
-  ] ++ stdenv.lib.optional doCheck guile-lib;
+  ] ++ lib.optional doCheck guile-lib;
 
   # The test suite tries to open an X display, which fails.
   doCheck = false;

--- a/pkgs/development/guile-modules/guile-reader/default.nix
+++ b/pkgs/development/guile-modules/guile-reader/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, pkgconfig
 , gperf, guile, guile-lib, libffi }:
 
-with stdenv.lib;
 stdenv.mkDerivation rec {
 
   pname = "guile-reader";

--- a/pkgs/development/idris-modules/with-packages.nix
+++ b/pkgs/development/idris-modules/with-packages.nix
@@ -1,10 +1,10 @@
 # Build a version of idris with a set of packages visible
 # packages: The packages visible to idris
-{ stdenv, idris, symlinkJoin, makeWrapper }: packages:
+{ stdenv, lib, idris, symlinkJoin, makeWrapper }: packages:
 
-let paths = stdenv.lib.closePropagation packages;
+let paths = lib.closePropagation packages;
 in
-stdenv.lib.appendToName "with-packages" (symlinkJoin {
+lib.appendToName "with-packages" (symlinkJoin {
 
   inherit (idris) name;
 

--- a/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
+++ b/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildPerlPackage, shortenPerlShebang, LWP, LWPProtocolHttps, DataDump, JSON }:
+{ stdenv, lib, fetchFromGitHub, buildPerlPackage, shortenPerlShebang, LWP, LWPProtocolHttps, DataDump, JSON }:
 
 buildPerlPackage rec {
   pname = "WWW-YoutubeViewer";
@@ -11,21 +11,21 @@ buildPerlPackage rec {
     sha256 = "16p0sa91h0zpqdpqmy348g6b9qj5f6qrbzrljn157vk00cg6mx18";
   };
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;
+  nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
   propagatedBuildInputs = [
     LWP
     LWPProtocolHttps
     DataDump
     JSON
   ];
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/youtube-viewer
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A lightweight application for searching and streaming videos from YouTube";
     homepage = "https://github.com/trizen/youtube-viewer";
-    maintainers = with stdenv.lib.maintainers; [ woffs ];
-    license = with stdenv.lib.licenses; [ artistic2 ];
+    maintainers = with maintainers; [ woffs ];
+    license = with licenses; [ artistic2 ];
   };
 }

--- a/pkgs/development/perl-modules/maatkit/default.nix
+++ b/pkgs/development/perl-modules/maatkit/default.nix
@@ -1,4 +1,4 @@
-{buildPerlPackage, stdenv, fetchurl, DBDmysql}:
+{buildPerlPackage, lib, stdenv, fetchurl, DBDmysql}:
 
 buildPerlPackage {
   pname = "maatkit";
@@ -27,7 +27,7 @@ buildPerlPackage {
     done
   '' ;
 
-  meta = {
+  meta = with lib; {
     description = "Database toolkit";
     longDescription = ''
       You can use Maatkit to prove replication is working correctly, fix
@@ -37,7 +37,7 @@ buildPerlPackage {
       In addition to MySQL, there is support for PostgreSQL, Memcached, and a
       growing variety of other databases and technologies.
     '';
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = "http://www.maatkit.org/";
   };
 }

--- a/pkgs/development/perl-modules/strip-nondeterminism/default.nix
+++ b/pkgs/development/perl-modules/strip-nondeterminism/default.nix
@@ -17,7 +17,7 @@ buildPerlPackage rec {
   # stray test failure
   doCheck = false;
 
-  nativeBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ shortenPerlShebang ];
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ shortenPerlShebang ];
   buildInputs = [ ArchiveZip ArchiveCpio file ];
 
   perlPostHook = ''
@@ -26,7 +26,7 @@ buildPerlPackage rec {
     rm $out/share/man/man1/dh_strip_nondeterminism.1.gz
   '';
 
-  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/strip-nondeterminism
   '';
 

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -1,14 +1,14 @@
-{ stdenv, R, libcxx, xvfb_run, util-linux, Cocoa, Foundation, gettext, gfortran }:
+{ stdenv, lib, R, libcxx, xvfb_run, util-linux, Cocoa, Foundation, gettext, gfortran }:
 
 { name, buildInputs ? [], requireX ? false, ... } @ attrs:
 
 stdenv.mkDerivation ({
   buildInputs = buildInputs ++ [R gettext] ++
-                stdenv.lib.optionals requireX [util-linux xvfb_run] ++
-                stdenv.lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran];
+                lib.optionals requireX [util-linux xvfb_run] ++
+                lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran];
 
   NIX_CFLAGS_COMPILE =
-    stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
+    lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -265,7 +265,7 @@ in
 
   hitimes = attrs: {
     buildInputs =
-      stdenv.lib.optionals stdenv.isDarwin
+      lib.optionals stdenv.isDarwin
         [ darwin.apple_sdk.frameworks.CoreServices ];
   };
 
@@ -514,7 +514,7 @@ in
         --replace "gobject-2.0" "${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}"
 
       substituteInPlace lib/vips.rb \
-        --replace "vips_libname = 'vips'" "vips_libname = '${stdenv.lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}'"
+        --replace "vips_libname = 'vips'" "vips_libname = '${lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}'"
     '';
   };
 
@@ -631,7 +631,7 @@ in
   };
 
   zookeeper = attrs: {
-    buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    buildInputs = lib.optionals stdenv.isDarwin [ darwin.cctools ];
     dontBuild = false;
     postPatch = ''
       sed -i ext/extconf.rb -e "4a \


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/108938

I inspected files in pkgs/development and took care of folders with 10 or less replacements needed. Others will follow in separate pull requests.

this takes care of the following folders in pkgs/development:
* arduino
* chez-modules
* go-packages
* guile-modules
* idris-modules
* perl-modules
* r-modules
* ruby-modules

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
