### PR TITLE
Fix fcitx5

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -41,7 +41,6 @@ mkDerivation rec {
     qtx11extras
     libxcb
     libXdmcp
-    qtbase
   ];
 
   meta = with lib; {

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -7,6 +7,7 @@
 , qtx11extras
 , libxcb
 , libXdmcp
+, qtbase
 }:
 
 mkDerivation rec {
@@ -20,8 +21,14 @@ mkDerivation rec {
     sha256 = "BVOumk2xj3vmwmm4KwiktQhWyTuUA2OFwYXNR6HgwyM=";
   };
 
+  preConfigure = ''
+    substituteInPlace qt5/platforminputcontext/CMakeLists.txt \
+      --replace \$"{CMAKE_INSTALL_QT5PLUGINDIR}" $out/${qtbase.qtPluginPrefix}
+  '';
+
   cmakeFlags = [
     "-DENABLE_QT4=0"
+    "-DENABLE_QT6=0"
   ];
 
   nativeBuildInputs = [
@@ -34,6 +41,7 @@ mkDerivation rec {
     qtx11extras
     libxcb
     libXdmcp
+    qtbase
   ];
 
   meta = with lib; {

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -12,6 +12,14 @@ symlinkJoin {
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
       --suffix PATH : "$out/bin"
+
+    desktop=share/applications/org.fcitx.Fcitx5.desktop
+    autostart=etc/xdg/autostart/org.fcitx.Fcitx5.desktop
+    rm $out/$desktop
+    rm $out/$autostart
+    cp ${fcitx5}/$desktop $out/$desktop
+    sed -i $out/$desktop -e "s|^Exec=.*|Exec=$out/bin/fcitx5|g"
+    cp $out/$desktop $out/$autostart
   '';
 
   meta = fcitx5.meta;

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -19,7 +19,7 @@ symlinkJoin {
     rm $out/$autostart
     cp ${fcitx5}/$desktop $out/$desktop
     sed -i $out/$desktop -e "s|^Exec=.*|Exec=$out/bin/fcitx5|g"
-    cp $out/$desktop $out/$autostart
+    ln -s $out/$desktop $out/$autostart
   '';
 
   meta = fcitx5.meta;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #109631

This PR fixes two bugs in fcitx5 packaging:

* libfcitx5platforminputcontextplugin.so was not captured, resulting in missing input method module for Qt5
* .desktop files pointed to unwrapped executables before symlinkJoin, leading to failure of addons  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @poscat0x04 