### PR TITLE
RFC: enable split-object compilation for static build

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -122,6 +122,20 @@ rec {
     # ++ lib.optional (stdenv.hostPlatform.libc == "glibc") ((lib.flip overrideInStdenv) [ self.stdenv.glibc.static ])
   );
 
+  # Make compiler output object file in format that allows linker to
+  # only pick symbols it needs. By default, object file in static
+  # library is included fully if it provides at least one symbol
+  # required.
+  makeSplitObjects = stdenv: stdenv //
+    {
+      mkDerivation = args: stdenv.mkDerivation (args // {
+        NIX_CFLAGS_COMPILE = (args.NIX_CFLAGS_COMPILE or "")
+          + " -ffunction-sections -fdata-sections ";
+         NIX_CFLAGS_LINK = (args.NIX_CFLAGS_LINK or "")
+           + " -Wl,--gc-sections ";
+      });
+    };
+
 
   /* Modify a stdenv so that all buildInputs are implicitly propagated to
      consuming derivations


### PR DESCRIPTION
Create new adapter that passes extra flags through NIX_CFLAGS_COMPILE
and NIX_CFLAGS_LINK that instruct linker to eliminate unused symbols (as
opposed to unused objects).

Disk usage save varies greatly: pkgsStatic.mmh won a lot (9.4Mb -> 8.2Mb),
pkgsStatic.coreutils improvement is around 10Kb out of 9Mb.

This patch is imperfect and does not seem to cause rebuild of musl libc,
so improvement may be bigger. Another problem is that it breaks packages
that seems to do partial linkage, e.g busybox:

    GEN     include/applet_tables.h include/NUM_APPLETS.h
    HOSTCC  applets/usage_pod
    CC      applets/applets.o
    LD      applets/built-in.o
  /nix/store/f7b0y2q80kgnqjkjmh7cng048wsy6mw9-x86_64-unknown-linux-musl-binutils-2.31.1/bin/x86_6
4-unknown-linux-musl-ld: gc-sections requires either an entry or an undefined symbol
  collect2: error: ld returned 1 exit status
  make[1]: *** [scripts/Makefile.build:264: applets/built-in.o] Error 1
  make: *** [Makefile:372: applets_dir] Error 2

So I am looking for advice where and how to apply these changes.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).