### PR TITLE
Fixed broken swiftshader

### DIFF
--- a/pkgs/development/libraries/swiftshader/default.nix
+++ b/pkgs/development/libraries/swiftshader/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchgit, python3, cmake, jq, libX11, libXext }:
+{ stdenv, fetchgit, python3, cmake, jq, libX11, libXext, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "swiftshader";
-  version = "2020-06-17";
+  version = "2021-01-17";
 
   src = fetchgit {
     url = "https://swiftshader.googlesource.com/SwiftShader";
-    rev = "763957e6b4fc1aa360ab19c4109b8b26686783e8";
-    sha256 = "0sdh48swx0qyq2nfkv1nggs14am0qc7z239qrxb69p2ddqm76g1s";
+    rev = "149733cead636de93d96c5c64f30168d5f6bb03f";
+    sha256 = "1krhwybh98gp2rxbfc5gv7wjhsg3ncd2wqd8sizpy1kr7mr6c7av";
   };
 
   nativeBuildInputs = [ cmake python3 jq ];
-  buildInputs = [ libX11 libXext ];
+  buildInputs = [ libX11 libXext zlib ];
 
   # Make sure we include the drivers and icd files in the output as the cmake
   # generated install command only puts in the spirv-tools stuff.


### PR DESCRIPTION
###### Motivation for this change

Vulkan API via google's swiftshader

###### Things done

- Revision updated to 2020-01-17
- Added `zlib` to `buildInputs`
- The `vulkaninfo` util shows device info
- The `vkcube` program also works fine

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
