### PR TITLE
gnomeExtensions.noannoyance: init at unstable

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/noannoyance/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/noannoyance/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, lib
+, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "noannoyance";
+  version = "unstable-2021-01-17";
+
+  src = fetchFromGitHub {
+    owner = "BjoernDaase";
+    repo = "noannoyance";
+    rev = "f6e76916336aee2f7c4141796f3c40c870d2b347";
+    sha256 = "1iy3nif8rjjcwf83fg9ds93fi7vmhliynmlwqnx036s3msmxvgs3";
+  };
+
+  uuid = "noannoyance@daase.net";
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp metadata.json extension.js $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  meta = with lib; {
+    description = "Removes the 'Window is ready' notification and puts the window into focus";
+    homepage = "https://github.com/BjoernDaase/noannoyance";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ tu-maurice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27263,6 +27263,7 @@ in
     mpris-indicator-button = callPackage ../desktops/gnome-3/extensions/mpris-indicator-button { };
     night-theme-switcher = callPackage ../desktops/gnome-3/extensions/night-theme-switcher { };
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };
+    noannoyance = callPackage ../desktops/gnome-3/extensions/noannoyance { };
     paperwm = callPackage ../desktops/gnome-3/extensions/paperwm { };
     pidgin-im-integration = callPackage ../desktops/gnome-3/extensions/pidgin-im-integration { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a gnome extension I use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
