### PR TITLE
documention corrections

### DIFF
--- a/doc/contributing/contributing-to-documentation.xml
+++ b/doc/contributing/contributing-to-documentation.xml
@@ -12,7 +12,7 @@ xlink:href="https://github.com/NixOS/nixpkgs/tree/master/doc">doc</filename> sub
 <screen>
 <prompt>$ </prompt>cd /path/to/nixpkgs/doc
 <prompt>$ </prompt>nix-shell
-<prompt>[nix-shell]$ </prompt>make
+<prompt>[nix-shell]$ </prompt>make $makeFlags
 </screen>
  <para>
   If you experience problems, run <command>make debug</command> to help understand the docbook errors.


### PR DESCRIPTION
###### Motivation for this change

Documentation about contributing to documentation has some errors.

`PANDOC_LUA_FILTERS_DIR` is set in `makeFlags` in `doc/default.nix`,
and needs to be explicitely passed to `make` when called manually.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Signed-off-by: Pamplemousse <xav.maso@gmail.com>