### PR TITLE
python3Packages.pyblackbird: init at 0.5

### DIFF
--- a/pkgs/development/python-modules/pyblackbird/default.nix
+++ b/pkgs/development/python-modules/pyblackbird/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pyserial-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "pyblackbird";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "koolsb";
+    repo = pname;
+    rev = version;
+    sha256 = "0m1yd1cb3z8011x7nicxpf091bdcwghcphn0l21c65f71rabzg6s";
+  };
+
+  propagatedBuildInputs = [
+    pyserial
+    pyserial-asyncio
+  ];
+
+  # Test setup try to create a serial port
+  doCheck = false;
+  pythonImportsCheck = [ "pyblackbird" ];
+
+  meta = with lib; {
+    description = "Python implementation for Monoprice Blackbird units";
+    homepage = "https://github.com/koolsb/pyblackbird";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -77,7 +77,7 @@
     "binary_sensor" = ps: with ps; [ ];
     "bitcoin" = ps: with ps; [ blockchain ];
     "bizkaibus" = ps: with ps; [ ]; # missing inputs: bizkaibus
-    "blackbird" = ps: with ps; [ ]; # missing inputs: pyblackbird
+    "blackbird" = ps: with ps; [ pyblackbird ];
     "blebox" = ps: with ps; [ ]; # missing inputs: blebox_uniapi
     "blink" = ps: with ps; [ ]; # missing inputs: blinkpy
     "blinksticklight" = ps: with ps; [ BlinkStick ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5139,6 +5139,8 @@ in {
 
   pybindgen = callPackage ../development/python-modules/pybindgen { };
 
+  pyblackbird = callPackage ../development/python-modules/pyblackbird { };
+
   pyblake2 = callPackage ../development/python-modules/pyblake2 { };
 
   pyblock = callPackage ../development/python-modules/pyblock { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python implementation for Monoprice Blackbird units.

https://github.com/koolsb/pyblackbird

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
