### PR TITLE
beets.plugins.{alternative,copyartifacts}: fix evaluation

### DIFF
--- a/pkgs/tools/audio/beets/plugins/alternatives.nix
+++ b/pkgs/tools/audio/beets/plugins/alternatives.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, beets, pythonPackages }:
+{ lib, stdenv, fetchFromGitHub, beets, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
   pname = "beets-alternatives";

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, beets, pythonPackages, glibcLocales }:
+{ lib, stdenv, fetchFromGitHub, beets, pythonPackages, glibcLocales }:
 
 pythonPackages.buildPythonApplication {
   name = "beets-copyartifacts";


### PR DESCRIPTION
###### Motivation for this change

Commit 8c5d37129fc5097d9fb52e95fb07de75392d1c3c apparently did not confirm that all its alterations resulted in evaluatable expressions, meaning that these files became unevaluatable:

    error: undefined variable 'lib' at
    /var/nixup/nixpkgs/pkgs/tools/audio/beets/plugins/alternatives.nix:22:21

The fix is simply to make sure the required value is available as a function argument.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
