### PR TITLE
manual: Element: Fix misleading `base_url`.

### DIFF
--- a/nixos/modules/services/misc/matrix-synapse.xml
+++ b/nixos/modules/services/misc/matrix-synapse.xml
@@ -206,7 +206,7 @@ Success!
     <link linkend="opt-services.nginx.virtualHosts._name_.root">root</link> = pkgs.element-web.override {
       conf = {
         default_server_config."m.homeserver" = {
-          "base_url" = "${config.networking.domain}";
+          "base_url" = "https://${fqdn}";
           "server_name" = "${fqdn}";
         };
       };


### PR DESCRIPTION
###### Motivation for this change

Judging from `"${pkgs.element-web}/config.sample.json"`, this needs to be an `https://` URL; the same thing you've set for the nginx `virtualHosts` entry.

With the config without `https://` at the front I get from Element when loading it in the browser:

> ### Your Element is misconfigured
> Invalid base_url for m.homeserver

(Note the current approach may have been correct in the past, I didn't check that.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Ensured that relevant documentation is up to date

---

CC @Ma27 who added the manual entry in commit 849e16888f439d98ba99c6a67123033edaa56663.