### PR TITLE
ocamlPackages.toml: 5.0.0 → 6.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/toml/default.nix
+++ b/pkgs/development/ocaml-modules/toml/default.nix
@@ -4,12 +4,15 @@
 
 buildDunePackage rec {
   pname = "toml";
-  version = "5.0.0";
+  version = "6.0.0";
+
+  useDune2 = true;
+
   src = fetchFromGitHub {
     owner = "ocaml-toml";
     repo = "to.ml";
-    rev = "v${version}";
-    sha256 = "1505kwcwklcfaxw8wckajm8kc6yrlikmxyhi8f8cpvhlw9ys90nj";
+    rev = version;
+    sha256 = "08ywzqckllvwawl1wpgg7qzvx6jhq7d6vysa0d5hj7qdwq213ggm";
   };
 
   buildInputs = [ menhir ];


### PR DESCRIPTION
###### Motivation for this change

Major update.
Use dune2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
