### PR TITLE
rWrapper: use symlinkJoin instead of runCommand

### DIFF
--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -1,21 +1,31 @@
-{ runCommand, R, makeWrapper, recommendedPackages, packages }:
-
-runCommand (R.name + "-wrapper") {
+{ symlinkJoin, R, makeWrapper, recommendedPackages, packages }:
+symlinkJoin {
+  name = R.name + "-wrapper";
   preferLocalBuild = true;
   allowSubstitutes = false;
 
   buildInputs = [R] ++ recommendedPackages ++ packages;
+  paths = [ R ];
 
   nativeBuildInputs = [makeWrapper];
 
+  postBuild = ''
+    cd ${R}/bin
+    for exe in *; do
+      rm "$out/bin/$exe"
+
+      makeWrapper "${R}/bin/$exe" "$out/bin/$exe" \
+        --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
+    done
+  '';
+
   # Make the list of recommended R packages accessible to other packages such as rpy2
   passthru = { inherit recommendedPackages; };
+
+    meta = R.meta // {
+      # To prevent builds on hydra
+      hydraPlatforms = [];
+      # prefer wrapper over the package
+      priority = (R.meta.priority or 0) - 1;
+    };
 }
-''
-mkdir -p $out/bin
-cd ${R}/bin
-for exe in *; do
-  makeWrapper ${R}/bin/$exe $out/bin/$exe \
-    --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
-done
-''


### PR DESCRIPTION
While trying to build a haskell-project I got:

Configuring library for inline-r-0.10.4..
cabal: The pkg-config package 'libR' version ==3.0 || >3.0 is required but it
could not be found.

the rWrapper was only bringing the R binary without its companion
library: this fixes it.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
