### PR TITLE
python3Packages.vulture: 2.1 -> 2.3

### DIFF
--- a/pkgs/development/python-modules/vulture/default.nix
+++ b/pkgs/development/python-modules/vulture/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "vulture";
-  version = "2.1";
+  version = "2.3";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "933bf7f3848e9e39ecab6a12faa59d5185471c887534abac13baea6fe8138cc2";
+    sha256 = "0ryrmsm72z3fzaanyblz49q40h9d3bbl4pspn2lvkkp9rcmsdm83";
   };
 
   checkInputs = [ coverage pytest pytestcov ];

--- a/pkgs/development/python-modules/vulture/default.nix
+++ b/pkgs/development/python-modules/vulture/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPy27, coverage, pytest, pytestcov }:
+{ lib
+, buildPythonPackage
+, coverage
+, fetchPypi
+, isPy27
+, pytest-cov
+, pytestCheckHook
+, toml
+}:
 
 buildPythonPackage rec {
   pname = "vulture";
@@ -10,8 +18,15 @@ buildPythonPackage rec {
     sha256 = "0ryrmsm72z3fzaanyblz49q40h9d3bbl4pspn2lvkkp9rcmsdm83";
   };
 
-  checkInputs = [ coverage pytest pytestcov ];
-  checkPhase = "pytest";
+  propagatedBuildInputs = [ toml ];
+
+  checkInputs = [
+    coverage
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "vulture" ];
 
   meta = with lib; {
     description = "Finds unused code in Python programs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 2.3

Change log: https://github.com/jendrikseipp/vulture/releases/tag/v2.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
