### PR TITLE
libvirt: don't use iptables-nftables

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -2,7 +2,7 @@
 , makeWrapper, autoreconfHook, fetchpatch
 , coreutils, libxml2, gnutls, perl, python2, attr, glib, docutils
 , iproute, readline, lvm2, util-linux, systemd, libpciaccess, gettext
-, libtasn1, iptables-nftables-compat, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
+, libtasn1, iptables, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
 , dnsmasq, libnl, libpcap, libxslt, xhtml1, numad, numactl, perlPackages
 , curl, libiconv, gmp, zfs, parted, bridge-utils, dmidecode, dbus, libtirpc, rpcsvc-proto, darwin
 , meson, ninja, audit, cmake, bash-completion, pkg-config
@@ -16,6 +16,19 @@ with lib;
 # if you update, also bump <nixpkgs/pkgs/development/python-modules/libvirt/default.nix> and SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
 let
   buildFromTarball = stdenv.isDarwin;
+  # libvirt hardcodes the binary name 'ebtables', but in nixpkgs the ebtables
+  # binary we want to use is named 'ebtables-legacy'.
+  # Create a derivation to alias the binary name so that libvirt can find the right one, and use that below.
+  ebtables-compat = stdenv.mkDerivation {
+    pname = "ebtables-compat";
+    version = ebtables.version;
+    src = null;
+    buildInputs = [ ebtables ];
+    buildCommand = ''
+      mkdir -p $out/bin
+      ln -sf ${ebtables}/bin/ebtables-legacy $out/bin/ebtables
+    '';
+  };
 in stdenv.mkDerivation rec {
   pname = "libvirt";
   version = "6.8.0";
@@ -72,7 +85,7 @@ in stdenv.mkDerivation rec {
       sed -i meson.build -e "s|conf.set_quoted('${var}',.*|conf.set_quoted('${var}','${value}')|"
     '';
   in ''
-    PATH=${lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute iptables-nftables-compat lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
+    PATH=${lib.makeBinPath ([ dnsmasq ] ++ optionals stdenv.isLinux [ iproute iptables ebtables-compat lvm2 systemd numad ] ++ optionals enableIscsi [ openiscsi ])}:$PATH
     # the path to qemu-kvm will be stored in VM's .xml and .save files
     # do not use "''${qemu_kvm}/bin/qemu-kvm" to avoid bound VMs to particular qemu derivations
     substituteInPlace src/lxc/lxc_conf.c \
@@ -115,15 +128,15 @@ in stdenv.mkDerivation rec {
   ];
 
   postInstall = let
-    # iptables-nftables-compat for an 'ebtables' binary
-    binPath = [ iptables-nftables-compat iproute pmutils numad numactl bridge-utils dmidecode dnsmasq ] ++ optionals enableIscsi [ openiscsi ];
+    # Keep the legacy iptables binary for now for backwards compatibility (comment on #109332)
+    binPath = [ iptables ebtables-compat iproute pmutils numad numactl bridge-utils dmidecode dnsmasq ] ++ optionals enableIscsi [ openiscsi ];
   in ''
     substituteInPlace $out/libexec/libvirt-guests.sh \
-      --replace 'ON_BOOT=start'       'ON_BOOT=''${ON_BOOT:-start}' \
-      --replace 'ON_SHUTDOWN=suspend' 'ON_SHUTDOWN=''${ON_SHUTDOWN:-suspend}' \
-      --replace "$out/bin"            '${gettext}/bin' \
-      --replace 'lock/subsys'         'lock' \
-      --replace 'gettext.sh'          'gettext.sh
+      --replace 'ON_BOOT="start"'       'ON_BOOT=''${ON_BOOT:-start}' \
+      --replace 'ON_SHUTDOWN="suspend"' 'ON_SHUTDOWN=''${ON_SHUTDOWN:-suspend}' \
+      --replace "$out/bin"              '${gettext}/bin' \
+      --replace 'lock/subsys'           'lock' \
+      --replace 'gettext.sh'            'gettext.sh
   # Added in nixpkgs:
   gettext() { "${gettext}/bin/gettext" "$@"; }
   '


### PR DESCRIPTION
###### Motivation for this change

Per a comment on the PR that made this change, it turns out to cause
issues in some cases: https://github.com/NixOS/nixpkgs/pull/109332#issuecomment-762005163

For now, let's revert back. Presumably the issues derive from the system
iptables not matching libvirt's iptables.

In the future, #81172 should move us back into the future, and I'm
perfectly fine waiting for that PR to handle this separately.

I'm marking this as a draft until I confirm this fixes the reporter's issue.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
