### PR TITLE
fcitx5-mozc: init at 2.26.4220.102

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1084,6 +1084,12 @@
     githubId = 75972;
     name = "Ben Booth";
   };
+  berberman = {
+    email = "berberman@yandex.com";
+    github = "berberman";
+    githubId = 26041945;
+    name = "Potato Hatsue";
+  };
   berce = {
     email = "bert.moens@gmail.com";
     github = "berce";

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -42,6 +42,7 @@ in
           <itemizedlist>
           <listitem><para>ibus: The intelligent input bus, extra input engines can be added using <literal>i18n.inputMethod.ibus.engines</literal>.</para></listitem>
           <listitem><para>fcitx: A customizable lightweight input method, extra input engines can be added using <literal>i18n.inputMethod.fcitx.engines</literal>.</para></listitem>
+          <listitem><para>fcitx5: The next generation of fcitx, addons (including engines, dictionaries, skins) can be added using <literal>i18n.inputMethod.fcitx5.addons</literal>.</para></listitem>
           <listitem><para>nabi: A Korean input method based on XIM. Nabi doesn't support Qt 5.</para></listitem>
           <listitem><para>uim: The universal input method, is a library with a XIM bridge. uim mainly support Chinese, Japanese and Korean.</para></listitem>
           <listitem><para>hime: An extremely easy-to-use input method framework.</para></listitem>

--- a/pkgs/development/misc/breakpad/default.nix
+++ b/pkgs/development/misc/breakpad/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchgit }:
+let
+  lss = fetchgit {
+    url = "https://chromium.googlesource.com/linux-syscall-support";
+    rev = "d9ad2969b369a9f1c455fef92d04c7628f7f9eb8";
+    sha256 = "952dv+ZE1ge/WF5RyHmEqht+AofoRHKAeFmGasVF9BA=";
+  };
+in stdenv.mkDerivation {
+  pname = "breakpad";
+
+  version = "unstable-3b3469e";
+
+  src = fetchgit {
+    url = "https://chromium.googlesource.com/breakpad/breakpad";
+    rev = "3b3469e9ed0de3d02e4450b9b95014a4266cf2ff";
+    sha256 = "bRGOBrGPK+Zxp+KK+E5MFkYlDUNVhVeInVSwq+eCAF0=";
+  };
+
+  postUnpack = ''
+    ln -s ${lss} $sourceRoot/src/third_party/lss
+  '';
+
+  meta = with lib; {
+    description = "An open-source multi-platform crash reporting system";
+    homepage = "https://chromium.googlesource.com/breakpad";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ berberman ];
+    platforms = with platforms; linux ++ darwin ++ windows;
+  };
+}

--- a/pkgs/development/misc/breakpad/default.nix
+++ b/pkgs/development/misc/breakpad/default.nix
@@ -25,6 +25,6 @@ in stdenv.mkDerivation {
     homepage = "https://chromium.googlesource.com/breakpad";
     license = licenses.bsd3;
     maintainers = with maintainers; [ berberman ];
-    platforms = with platforms; linux ++ darwin ++ windows;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -1,0 +1,117 @@
+{ lib, clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, fetchgit
+, python3Packages, mesa, ninja, pkg-config, protobuf, zinnia, qt5, fcitx5
+, jsoncpp, gtest, which, gtk2, unzip, abseil-cpp, breakpad }:
+let
+  inherit (python3Packages) python gyp six;
+  japanese_usage_dictionary = fetchFromGitHub {
+    owner = "hiroyuki-komatsu";
+    repo = "japanese-usage-dictionary";
+    rev = "e5b3425575734c323e1d947009dd74709437b684";
+    sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
+  };
+  # abseil-cpp in nixpkgs is too old
+  abseil-cpp_2020923 = abseil-cpp.overrideAttrs (old: rec {
+    version = "20200923.2";
+    src = fetchFromGitHub {
+      owner = "abseil";
+      repo = "abseil-cpp";
+      rev = version;
+      sha256 = "G+wkaC4IPtyc/xCUyVFJOcHppPFU7KkhIHjv6uhVKGU=";
+    };
+    cmakeFlags = [ "-DCMAKE_CXX_STANDARD=17" "-DBUILD_SHARED_LIBS=ON" ];
+  });
+  zipcode_rel = "202011";
+  jigyosyo = fetchurl {
+    url = "https://osdn.net/projects/ponsfoot-aur/storage/mozc/jigyosyo-${zipcode_rel}.zip";
+    sha256 = "j7MkNtd4+QTi91EreVig4/OV0o5y1+KIjEJBEmLK/mY=";
+  };
+  x-ken-all = fetchurl {
+    url =
+      "https://osdn.net/projects/ponsfoot-aur/storage/mozc/x-ken-all-${zipcode_rel}.zip";
+    sha256 = "ExS0Cg3rs0I9IOVbZHLt8UEfk8/LmY9oAHPVVlYuTPw=";
+  };
+
+in clangStdenv.mkDerivation rec {
+  pname = "fcitx5-mozc";
+  version = "2.26.4220.102";
+
+  src = fetchFromGitHub {
+    owner = "fcitx";
+    repo = "mozc";
+    rev = "1882e33b61673b66d63277f82b4c80ae4e506c10";
+    sha256 = "R+w0slVFpqtt7PIr1pyupJjRoQsABVZiMdZ9fKGKAqw=";
+  };
+
+  nativeBuildInputs = [ gyp ninja mesa python pkg-config qt5.wrapQtAppsHook six which unzip ];
+
+  buildInputs = [ protobuf zinnia qt5.qtbase fcitx5 abseil-cpp_2020923 jsoncpp gtest gtk2 ];
+
+  patches = [
+    # Support linking system abseil-cpp
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/mozc/-/raw/debian/sid/debian/patches/0007-Update-src-base-absl.gyp.patch";
+      sha256 = "UiS0UScDKyAusXOhc7Bg8dF8ARQQiVTylEhAOxqaZt8=";
+    })
+
+  ];
+
+  postUnpack = ''
+    unzip ${x-ken-all} -d $sourceRoot/src/
+    unzip ${jigyosyo} -d $sourceRoot/src/
+
+    rmdir $sourceRoot/src/third_party/breakpad/
+    ln -s ${breakpad} $sourceRoot/src/third_party/breakpad
+    rmdir $sourceRoot/src/third_party/gtest/
+    ln -s ${gtest} $sourceRoot/src/third_party/gtest
+    rmdir $sourceRoot/src/third_party/gyp/
+    ln -s ${gyp} $sourceRoot/src/third_party/gyp
+    rmdir $sourceRoot/src/third_party/japanese_usage_dictionary/
+    ln -s ${japanese_usage_dictionary} $sourceRoot/src/third_party/japanese_usage_dictionary
+  '';
+
+  # Copied from https://github.com/archlinux/svntogit-community/blob/packages/fcitx5-mozc/trunk/PKGBUILD
+  configurePhase = ''
+    cd src
+    export GYP_DEFINES="document_dir=$out/share/doc/mozc use_libzinnia=1 use_libprotobuf=1 use_libabseil=1"
+
+    # disable fcitx4
+    rm unix/fcitx/fcitx.gyp
+
+    # gen zip code seed
+    PYTHONPATH="$PWD:$PYTHONPATH" python dictionary/gen_zip_code_seed.py --zip_code="x-ken-all.csv" --jigyosyo="JIGYOSYO.CSV" >> data/dictionary_oss/dictionary09.txt
+
+    # use libstdc++ instead of libc++
+    sed "/stdlib=libc++/d;/-lc++/d" -i gyp/common.gypi
+
+    # run gyp
+    python build_mozc.py gyp --gypdir=${gyp}/bin --server_dir=$out/lib/mozc
+  '';
+
+  buildPhase = ''
+    python build_mozc.py build -c Release \
+      server/server.gyp:mozc_server \
+      gui/gui.gyp:mozc_tool \
+      unix/fcitx5/fcitx5.gyp:fcitx5-mozc
+  '';
+
+  installPhase = ''
+    export PREFIX=$out
+    export _bldtype=Release
+    ../scripts/install_server
+    install -d $out/share/licenses/fcitx5-mozc
+    head -n 29 server/mozc_server.cc > $out/share/licenses/fcitx5-mozc/LICENSE
+    install -m644 data/installer/*.html $out/share/licenses/fcitx5-mozc/
+    install -d $out/share/fcitx5/addon
+    install -d $out/share/fcitx5/inputmethod
+    install -d $out/lib/fcitx5
+    ../scripts/install_fcitx5
+  '';
+
+  meta = with lib; {
+    description = "Fcitx5 Module of A Japanese Input Method for Chromium OS, Windows, Mac and Linux (the Open Source Edition of Google Japanese Input)";
+    homepage = "https://github.com/fcitx/mozc";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ berberman ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -156,6 +156,8 @@ in
 
   bacnet-stack = callPackage ../tools/networking/bacnet-stack {};
 
+  breakpad = callPackage ../development/misc/breakpad {};
+
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
   # ValueError: ZIP does not support timestamps before 1980
   ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -156,7 +156,7 @@ in
 
   bacnet-stack = callPackage ../tools/networking/bacnet-stack {};
 
-  breakpad = callPackage ../development/misc/breakpad {};
+  breakpad = callPackage ../development/misc/breakpad { };
 
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
   # ValueError: ZIP does not support timestamps before 1980
@@ -4016,6 +4016,8 @@ in
   fcitx5-with-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/with-addons.nix { };
 
   fcitx5-chinese-addons = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
+
+  fcitx5-mozc = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-mozc.nix { };
 
   fcitx5-configtool = libsForQt5.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fcitx5-mozc is a Japanese input method engine based on mozc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
