### PR TITLE
rpi-imager: init at 1.5

### DIFF
--- a/pkgs/tools/misc/rpi-imager/default.nix
+++ b/pkgs/tools/misc/rpi-imager/default.nix
@@ -1,0 +1,55 @@
+{ mkDerivation,
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  curl,
+  libarchive,
+  util-linux,
+  qtbase,
+  qtdeclarative,
+  qtsvg,
+  qttools,
+  qtquickcontrols2,
+  qtgraphicaleffects
+}:
+
+mkDerivation rec {
+  pname = "rpi-imager";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0596c7rpkykmjr3gsz9yczqsj7fzq04kc97s0rqkygjnwiqh2rwz";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    curl
+    libarchive
+    util-linux
+    qtbase
+    qtdeclarative
+    qtsvg
+    qttools
+    qtquickcontrols2
+    qtgraphicaleffects
+  ];
+
+  /* By default, the builder checks for JSON support in lsblk by running "lsblk --json",
+    but that throws an error, as /sys/dev doesn't exist in the sandbox.
+    This patch removes the check. */
+  patches = [ ./lsblkCheckFix.patch ];
+
+  meta = with lib; {
+    description = "Raspberry Pi Imaging Utility";
+    homepage = "https://www.raspberrypi.org/software/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ymarkus ];
+    platforms = platforms.all;
+    # does not build on darwin
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/tools/misc/rpi-imager/lsblkCheckFix.patch
+++ b/pkgs/tools/misc/rpi-imager/lsblkCheckFix.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3d7fc79..8ce72b9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -229,11 +229,6 @@ else()
+         if (NOT LSBLK)
+             message(FATAL_ERROR "Unable to locate lsblk (used for disk enumeration)")
+         endif()
+-
+-        execute_process(COMMAND "${LSBLK}" "--json" RESULT_VARIABLE ret)
+-        if (ret EQUAL "1")
+-            message(FATAL_ERROR "util-linux package too old. lsblk does not support --json (used for disk enumeration)")
+-        endif()
+     endif()
+ 
+     configure_file(

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7439,6 +7439,8 @@ in
 
   rpPPPoE = callPackage ../tools/networking/rp-pppoe { };
 
+  rpi-imager = libsForQt5.callPackage ../tools/misc/rpi-imager { };
+
   rpiboot-unstable = callPackage ../development/misc/rpiboot/unstable.nix { };
 
   rpm = callPackage ../tools/package-management/rpm {


### PR DESCRIPTION
###### Motivation for this change
#108538 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
