### PR TITLE
ocamlPackages.{repr,ppx_repr}: init at 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/either/default.nix
+++ b/pkgs/development/ocaml-modules/either/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, fetchurl }:
+
+buildDunePackage rec {
+  pname = "either";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/either/releases/download/${version}/either-${version}.tbz";
+    sha256 = "bf674de3312dee7b7215f07df1e8a96eb3d679164b8a918cdd95b8d97e505884";
+  };
+
+  useDune2 = true;
+
+  meta = with lib; {
+    description = "Compatibility Either module";
+    license = licenses.mit;
+    homepage = "https://github.com/mirage/either";
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/repr/default.nix
+++ b/pkgs/development/ocaml-modules/repr/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchurl, fmt, uutf, jsonm, base64, either }:
+
+buildDunePackage rec {
+  pname = "repr";
+  version = "0.2.1";
+
+  minimumOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/${pname}/releases/download/${version}/${pname}-fuzz-${version}.tbz";
+    sha256 = "1cbzbawbn71mmpw8y84s1p2pbhc055w1znz64jvr00c7fdr9p8hc";
+  };
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    fmt
+    uutf
+    jsonm
+    base64
+    either
+  ];
+
+  meta = with lib; {
+    description = "Dynamic type representations. Provides no stability guarantee";
+    homepage = "https://github.com/mirage/repr";
+    license = licenses.isc;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/development/ocaml-modules/repr/ppx.nix
+++ b/pkgs/development/ocaml-modules/repr/ppx.nix
@@ -1,0 +1,23 @@
+{ buildDunePackage, repr, ppxlib, ppx_deriving, alcotest, hex }:
+
+buildDunePackage {
+  pname = "ppx_repr";
+
+  inherit (repr) src version useDune2;
+
+  propagatedBuildInputs = [
+    repr
+    ppxlib
+    ppx_deriving
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+    hex
+  ];
+
+  meta = repr.meta // {
+    description = "PPX deriver for type representations";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -277,6 +277,8 @@ let
 
     eigen = callPackage ../development/ocaml-modules/eigen { };
 
+    either = callPackage ../development/ocaml-modules/either { };
+
     elina = callPackage ../development/ocaml-modules/elina { };
 
     eliom = callPackage ../development/ocaml-modules/eliom { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -875,6 +875,8 @@ let
 
     resource-pooling = callPackage ../development/ocaml-modules/resource-pooling { };
 
+    repr = callPackage ../development/ocaml-modules/repr { };
+
     result = callPackage ../development/ocaml-modules/ocaml-result { };
 
     secp256k1 = callPackage ../development/ocaml-modules/secp256k1 {
@@ -956,6 +958,8 @@ let
 
     ppx_irmin = callPackage ../development/ocaml-modules/irmin/ppx.nix {
     };
+
+    ppx_repr = callPackage ../development/ocaml-modules/repr/ppx.nix { };
 
     ppx_tools =
       if lib.versionAtLeast ocaml.version "4.02"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Required for `git` >= 3.0.0 and other packages from the MirageOS universe.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
