### PR TITLE
ocamlPackages.bheap: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/bheap/default.nix
+++ b/pkgs/development/ocaml-modules/bheap/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchurl, stdlib-shims }:
+
+buildDunePackage rec {
+  pname = "bheap";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/backtracking/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "0dpnpla20lgiicrxl2432m2fcr6y68msw3pnjxqb11xw6yrdfhsz";
+  };
+
+  useDune2 = true;
+
+  doCheck = true;
+  checkInputs = [
+    stdlib-shims
+  ];
+
+  meta = with lib; {
+    description = "OCaml binary heap implementation by Jean-Christophe Filliatre";
+    license = licenses.lgpl21Only;
+    maintainers = [ maintainers.sternenseemann ];
+    homepage = "https://github.com/backtracking/bheap";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -52,6 +52,8 @@ let
 
     batteries = callPackage ../development/ocaml-modules/batteries { };
 
+    bheap = callPackage ../development/ocaml-modules/bheap { };
+
     bigarray-compat = callPackage ../development/ocaml-modules/bigarray-compat { };
 
     bigarray-overlap = callPackage ../development/ocaml-modules/bigarray-overlap { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Required for ocaml `git` >= 3.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
