### PR TITLE
nixos/nomad: add extraSettingsPaths option to nomad service

### DIFF
--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -114,8 +114,8 @@ in
       serviceConfig = {
         DynamicUser = cfg.dropPrivileges;
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        ExecStart = "${cfg.package}/bin/nomad agent" +
-          concatMapStrings (file: " -config=${file}") (["/etc/nomad.json"] ++ cfg.settingsFiles);
+        ExecStart = "${cfg.package}/bin/nomad agent -config=/etc/nomad.json" +
+          concatMapStrings (file: " -config=${file}") cfg.settingsFiles;
         KillMode = "process";
         KillSignal = "SIGINT";
         LimitNOFILE = 65536;

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -53,8 +53,7 @@ in
         type = types.listOf types.path;
         default = [];
         description = ''
-          Additional settings files used to configure nomad. These files
-          will be watched for changes.
+          Additional settings files used to configure nomad.
         '';
         example = literalExample ''
           [ "/etc/nomad-mutable.json" "/run/keys/nomad-with-secrets.json" ]

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -101,8 +101,7 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      restartTriggers = [ config.environment.etc."nomad.json".source ]
-        ++ cfg.extraSettingsPaths;
+      restartTriggers = [ config.environment.etc."nomad.json".source ];
 
       path = cfg.extraPackages ++ (with pkgs; [
         # Client mode requires at least the following:

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -102,7 +102,7 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       restartTriggers = [ config.environment.etc."nomad.json".source ]
-        ++ cfg.settingsFiles;
+        ++ cfg.extraSettingsPaths;
 
       path = cfg.extraPackages ++ (with pkgs; [
         # Client mode requires at least the following:
@@ -115,7 +115,7 @@ in
         DynamicUser = cfg.dropPrivileges;
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStart = "${cfg.package}/bin/nomad agent -config=/etc/nomad.json" +
-          concatMapStrings (file: " -config=${file}") cfg.settingsFiles;
+          concatMapStrings (file: " -config=${file}") cfg.extraSettingsPaths;
         KillMode = "process";
         KillSignal = "SIGINT";
         LimitNOFILE = 65536;

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -53,10 +53,10 @@ in
         type = types.listOf types.path;
         default = [];
         description = ''
-          Additional settings files used to configure nomad.
+          Additional settings paths used to configure nomad. These can be files or directories.
         '';
         example = literalExample ''
-          [ "/etc/nomad-mutable.json" "/run/keys/nomad-with-secrets.json" ]
+          [ "/etc/nomad-mutable.json" "/run/keys/nomad-with-secrets.json" "/etc/nomad/config.d" ]
         '';
       };
 

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -113,7 +113,7 @@ in
         DynamicUser = cfg.dropPrivileges;
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStart = "${cfg.package}/bin/nomad agent -config=/etc/nomad.json" +
-          concatMapStrings (file: " -config=${file}") cfg.extraSettingsPaths;
+          concatMapStrings (path: " -config=${path}") cfg.extraSettingsPaths;
         KillMode = "process";
         KillSignal = "SIGINT";
         LimitNOFILE = 65536;

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -49,15 +49,15 @@ in
         '';
       };
 
-      settingsFiles = mkOption {
-        type = types.listOf (types.oneOf [ types.path types.str ]);
+      extraSettingsPaths = mkOption {
+        type = types.listOf types.path;
         default = [];
         description = ''
           Additional settings files used to configure nomad. These files
           will be watched for changes.
         '';
         example = literalExample ''
-          [ "/etc/awesome.nomad.json" ]
+          [ "/etc/nomad-mutable.json" "/run/keys/nomad-with-secrets.json" ]
         '';
       };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -272,6 +272,7 @@ in
   nginx-variants = handleTest ./nginx-variants.nix {};
   nix-ssh-serve = handleTest ./nix-ssh-serve.nix {};
   nixos-generate-config = handleTest ./nixos-generate-config.nix {};
+  nomad = handleTest ./nomad.nix {};
   novacomd = handleTestOn ["x86_64-linux"] ./novacomd.nix {};
   nsd = handleTest ./nsd.nix {};
   nzbget = handleTest ./nzbget.nix {};

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix (
   { lib, ... }: {
     name = "nomad";
     nodes = {
-      server = { config, pkgs, lib, ... }: {
+      server = { pkgs, lib, ... }: {
         networking = {
           interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [{
             address = "192.168.1.1";

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -28,7 +28,7 @@ import ./make-test-python.nix (
             };
           };
 
-          extraSettingsPaths = [ config.environment.etc."nomad.custom.json".source ];
+          extraSettingsPaths = [ "/etc/nomad.custom.json" ];
           enableDocker = false;
         };
       };

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -1,0 +1,60 @@
+import ./make-test-python.nix (
+  { lib, ... }: {
+    name = "nomad";
+    nodes = {
+      server = { config, pkgs, lib, ... }: {
+        networking = {
+          interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [{
+            address = "192.168.1.1";
+            prefixLength = 16;
+          }];
+
+          firewall = {
+            allowedTCPPorts = [ 4646 4647 4648 ];
+            allowedUDPPorts = [ 4646 4647 4648 ];
+          };
+        };
+
+        environment.etc."nomad.custom.json".source =
+          (pkgs.formats.json { }).generate "nomad.custom.json" {
+            region = "universe";
+            datacenter = "earth";
+          };
+
+        services.nomad = {
+          enable = true;
+
+          settings = {
+            data_dir = "/var/lib/nomad";
+
+            server = {
+              enabled = true;
+              bootstrap_expect = 1;
+            };
+          };
+
+          extraSettingsPaths = [ config.environment.etc."nomad.custom.json".source ];
+          enableDocker = false;
+        };
+      };
+    };
+
+    testScript = ''
+      server.wait_for_unit("nomad.service")
+
+      # wait for healthy server
+      server.wait_until_succeeds(
+          "[ $(nomad operator raft list-peers | grep true | wc -l) == 1 ]"
+      )
+
+      # wait for server liveness
+      server.succeed("[ $(nomad server members | grep -o alive | wc -l) == 1 ]")
+
+      # check the region
+      server.succeed("nomad server members | grep -o universe")
+
+      # check the datacenter
+      server.succeed("[ $(nomad server members | grep -o earth | wc -l) == 1 ]")
+    '';
+  }
+)

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -8,11 +8,6 @@ import ./make-test-python.nix (
             address = "192.168.1.1";
             prefixLength = 16;
           }];
-
-          firewall = {
-            allowedTCPPorts = [ 4646 4647 4648 ];
-            allowedUDPPorts = [ 4646 4647 4648 ];
-          };
         };
 
         environment.etc."nomad.custom.json".source =

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -20,8 +20,6 @@ import ./make-test-python.nix (
           enable = true;
 
           settings = {
-            data_dir = "/var/lib/nomad";
-
             server = {
               enabled = true;
               bootstrap_expect = 1;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add the ability to use multiple configuration files with the nomad service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
