### PR TITLE
nixos/nomad: enforce specific data_dir semantics

### DIFF
--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -137,7 +137,7 @@ in
           Restart = "on-failure";
           RestartSec = 2;
           TasksMax = "infinity";
-          User = "nomad";
+          User = optionalString cfg.dropPrivileges "nomad";
         }
         (mkIf cfg.enableDocker {
           SupplementaryGroups = "docker"; # space-separated string

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -137,7 +137,7 @@ in
           Restart = "on-failure";
           RestartSec = 2;
           TasksMax = "infinity";
-          User = optionalString cfg.dropPrivileges "nomad";
+          User = "nomad";
         }
         (mkIf cfg.enableDocker {
           SupplementaryGroups = "docker"; # space-separated string

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -71,9 +71,10 @@ in
 
           If `data_dir` is set to a value other than the default value of
           `"/var/lib/nomad"` it is the Nomad cluster manager's responsibility
-          to make sure that this directory exist and has the appropriate
-          permissions. One way to do this is with the `ExecStartPre` feature of
-          systemd.
+          to make sure that this directory exists and has the appropriate
+          permissions. One way to ensure this is the case to create the
+          directory and adjust its permissions as needed using the
+          `ExecStartPre` feature of systemd.
 
           Additionally, if `dropPrivileges` is `true` then `data_dir`
           **cannot** be customized.  Setting `dropPrivileges` to `true` enables

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -67,19 +67,19 @@ in
           Configuration for Nomad. See the <link xlink:href="https://www.nomadproject.io/docs/configuration">documentation</link>
           for supported values.
 
-          Notes about `data_dir`:
+          Notes about <literal>data_dir</literal>:
 
-          If `data_dir` is set to a value other than the default value of
-          `"/var/lib/nomad"` it is the Nomad cluster manager's responsibility
-          to make sure that this directory exists and has the appropriate
-          permissions. One way to ensure this is the case to create the
-          directory and adjust its permissions as needed using the
-          `ExecStartPre` feature of systemd.
+          If <literal>data_dir</literal> is set to a value other than the
+          default value of <literal>"/var/lib/nomad"</literal> it is the Nomad
+          cluster manager's responsibility to make sure that this directory
+          exists and has the appropriate permissions.
 
-          Additionally, if `dropPrivileges` is `true` then `data_dir`
-          **cannot** be customized.  Setting `dropPrivileges` to `true` enables
-          the `DynamicUser` feature of systemd which directly manages and
-          operates on `StateDirectory`.
+          Additionally, if <literal>dropPrivileges</literal> is
+          <literal>true</literal> then <literal>data_dir</literal>
+          <emphasis>cannot</emphasis> be customized. Setting
+          <literal>dropPrivileges</literal> to <literal>true</literal> enables
+          the <literal>DynamicUser</literal> feature of systemd which directly
+          manages and operates on <literal>StateDirectory</literal>.
         '';
         example = literalExample ''
           {

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -66,6 +66,19 @@ in
         description = ''
           Configuration for Nomad. See the <link xlink:href="https://www.nomadproject.io/docs/configuration">documentation</link>
           for supported values.
+
+          Notes about `data_dir`:
+
+          If `data_dir` is set to a value other than the default value of
+          `"/var/lib/nomad"` it is the Nomad cluster manager's responsibility
+          to make sure that this directory exist and has the appropriate
+          permissions. One way to do this is with the `ExecStartPre` feature of
+          systemd.
+
+          Additionally, if `dropPrivileges` is `true` then `data_dir`
+          **cannot** be customized.  Setting `dropPrivileges` to `true` enables
+          the `DynamicUser` feature of systemd which directly manages and
+          operates on `StateDirectory`.
         '';
         example = literalExample ''
           {

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -135,6 +135,13 @@ in
       };
     };
 
+    assertions = [
+      {
+        assertion = cfg.dropPrivileges -> cfg.settings.data_dir == "/var/lib/nomad";
+        message = "settings.data_dir must be equal to \"/var/lib/nomad\" if dropPrivileges is true";
+      }
+    ];
+
     # Docker support requires the Docker daemon to be running.
     virtualisation.docker.enable = mkIf cfg.enableDocker true;
   };

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -137,7 +137,6 @@ in
           Restart = "on-failure";
           RestartSec = 2;
           TasksMax = "infinity";
-          User = optionalString cfg.dropPrivileges "nomad";
         }
         (mkIf cfg.enableDocker {
           SupplementaryGroups = "docker"; # space-separated string

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -138,7 +138,9 @@ in
           TasksMax = "infinity";
           User = optionalString cfg.dropPrivileges "nomad";
         }
-        (mkIf cfg.enableDocker { SupplementaryGroups = "docker"; }) # space-separated string
+        (mkIf cfg.enableDocker {
+          SupplementaryGroups = "docker"; # space-separated string
+        })
         (mkIf (cfg.settings.data_dir == "/var/lib/nomad") { StateDirectory = "nomad"; })
       ];
 

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -142,7 +142,9 @@ in
         (mkIf cfg.enableDocker {
           SupplementaryGroups = "docker"; # space-separated string
         })
-        (mkIf (cfg.settings.data_dir == "/var/lib/nomad") { StateDirectory = "nomad"; })
+        (mkIf (cfg.settings.data_dir == "/var/lib/nomad") {
+          StateDirectory = "nomad";
+        })
       ];
 
       unitConfig = {

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -135,12 +135,11 @@ in
           OOMScoreAdjust = -1000;
           Restart = "on-failure";
           RestartSec = 2;
-          # Agrees with the default `data_dir = "/var/lib/nomad"` in `settings` above.
-          StateDirectory = "nomad";
           TasksMax = "infinity";
           User = optionalString cfg.dropPrivileges "nomad";
         }
         (mkIf cfg.enableDocker { SupplementaryGroups = "docker"; }) # space-separated string
+        (mkIf (cfg.settings.data_dir == "/var/lib/nomad") { StateDirectory = "nomad"; })
       ];
 
       unitConfig = {

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -2,7 +2,7 @@ import ./make-test-python.nix (
   { lib, ... }: {
     name = "nomad";
     nodes = {
-      server = { pkgs, lib, ... }: {
+      default_server = { pkgs, lib, ... }: {
         networking = {
           interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [{
             address = "192.168.1.1";
@@ -30,24 +30,68 @@ import ./make-test-python.nix (
           enableDocker = false;
         };
       };
+
+      custom_state_dir_server = { pkgs, lib, ... }: {
+        networking = {
+          interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [{
+            address = "192.168.1.1";
+            prefixLength = 16;
+          }];
+        };
+
+        environment.etc."nomad.custom.json".source =
+          (pkgs.formats.json { }).generate "nomad.custom.json" {
+            region = "universe";
+            datacenter = "earth";
+          };
+
+        services.nomad = {
+          enable = true;
+          dropPrivileges = false;
+
+          settings = {
+            data_dir = "/nomad/data/dir";
+            server = {
+              enabled = true;
+              bootstrap_expect = 1;
+            };
+          };
+
+          extraSettingsPaths = [ "/etc/nomad.custom.json" ];
+          enableDocker = false;
+        };
+
+        systemd.services.nomad.serviceConfig.ExecStartPre = "${pkgs.writeShellScript "mk_data_dir" ''
+          set -euxo pipefail
+
+          ${pkgs.coreutils}/bin/mkdir -p /nomad/data/dir
+        ''}";
+      };
     };
 
     testScript = ''
-      server.wait_for_unit("nomad.service")
+      def test_nomad_server(server):
+          server.wait_for_unit("nomad.service")
 
-      # wait for healthy server
-      server.wait_until_succeeds(
-          "[ $(nomad operator raft list-peers | grep true | wc -l) == 1 ]"
-      )
+          # wait for healthy server
+          server.wait_until_succeeds(
+              "[ $(nomad operator raft list-peers | grep true | wc -l) == 1 ]"
+          )
 
-      # wait for server liveness
-      server.succeed("[ $(nomad server members | grep -o alive | wc -l) == 1 ]")
+          # wait for server liveness
+          server.succeed("[ $(nomad server members | grep -o alive | wc -l) == 1 ]")
 
-      # check the region
-      server.succeed("nomad server members | grep -o universe")
+          # check the region
+          server.succeed("nomad server members | grep -o universe")
 
-      # check the datacenter
-      server.succeed("[ $(nomad server members | grep -o earth | wc -l) == 1 ]")
+          # check the datacenter
+          server.succeed("[ $(nomad server members | grep -o earth | wc -l) == 1 ]")
+
+
+      servers = [default_server, custom_state_dir_server]
+
+      for server in servers:
+          test_nomad_server(server)
     '';
   }
 )


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR enforces the semantics discussed here: https://github.com/NixOS/nixpkgs/pull/105739#discussion_r557689413

In summary, the `data_dir` value of the nomad service must be set to
a specific value if `dropPrivileges` is set to `true`.

The updated unit also includes additional documentation describing
the responsibilities of the nomad cluster manager given these
constraints as well as a suggestion for how to go about satisfying them.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
