### PR TITLE
thrift: fix for pkgsStatic

### DIFF
--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
   # pythonFull.buildEnv.override { extraLibs = [ thrift ]; }
   pythonPath = [];
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ boost zlib libevent openssl python bison flex ]
-    ++ stdenv.lib.optional (!static) twisted;
+  nativeBuildInputs = [ cmake pkgconfig bison flex ];
+  buildInputs = [ boost zlib libevent openssl ]
+    ++ stdenv.lib.optionals (!static) [ python twisted ];
 
   preConfigure = "export PY_PREFIX=$out";
 


### PR DESCRIPTION
###### Motivation for this change

`pkgsStatic.flex` crashed so I moved `flex` and `bison` to `nativeBuildInputs`, where it should have been in the first place.
Also, building a static lib for python doesn't make a lot of sense, so it is disabled now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
