### PR TITLE
treewide: remove kampka as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1699,16 +1699,6 @@
     githubId = 46303707;
     name = "Christian Lütke-Stetzkamp";
   };
-  kampka = {
-    email = "christian@kampka.net";
-    github = "kampka";
-    githubId = 422412;
-    name = "Christian Kampka";
-    keys = [{
-      longkeyid = "ed25519/0x1CBE9645DD68E915";
-      fingerprint = "F7FA 0BD0 8775 337C F6AB  4A14 1CBE 9645 DD68 E915";
-    }];
-  };
   ckauhaus = {
     email = "kc@flyingcircus.io";
     github = "ckauhaus";

--- a/nixos/modules/services/web-apps/trilium.nix
+++ b/nixos/modules/services/web-apps/trilium.nix
@@ -85,7 +85,7 @@ in
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
   {
-    meta.maintainers = with lib.maintainers; [ kampka ];
+    meta.maintainers = with lib.maintainers; [ ];
 
     users.groups.trilium = {};
     users.users.trilium = {

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -3,7 +3,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-tmpfs";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ kampka ];
+    maintainers = [ ];
   };
 
   machine =

--- a/nixos/tests/zsh-history.nix
+++ b/nixos/tests/zsh-history.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ...} : {
   name = "zsh-history";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ kampka ];
+    maintainers = [ ];
   };
 
   nodes.default = { ... }: {

--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -44,7 +44,7 @@ let
           homepage = "https://github.com/kubernetes/kops";
           changelog = "https://github.com/kubernetes/kops/tree/master/docs/releases";
           license = licenses.asl20;
-          maintainers = with maintainers; [ offline zimbatm kampka ];
+          maintainers = with maintainers; [ offline zimbatm ];
           platforms = platforms.unix;
         };
       } // attrs';

--- a/pkgs/applications/networking/cluster/spacegun/default.nix
+++ b/pkgs/applications/networking/cluster/spacegun/default.nix
@@ -21,7 +21,7 @@ nodePackages."${packageName}".override {
 
   meta = with lib; {
     description = "Version controlled multi-cluster deployment manager for kubernetes";
-    maintainers = with maintainers; [ kampka ];
+    maintainers = with maintainers; [ ];
     license = licenses.mit;
   };
 }

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -16,7 +16,7 @@ let
     homepage = "https://github.com/zadam/trilium";
     license = licenses.agpl3;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ emmanuelrosa dtzWill kampka ];
+    maintainers = with maintainers; [ emmanuelrosa dtzWill ];
   };
 
   version = "0.43.3";

--- a/pkgs/servers/matrix-synapse/matrix-appservice-slack/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-slack/default.nix
@@ -19,7 +19,7 @@ nodePackages."${packageName}".override {
 
   meta = with lib; {
     description = "A Matrix <--> Slack bridge";
-    maintainers = with maintainers; [ kampka ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
   };
 }

--- a/pkgs/shells/zsh/zsh-history/default.nix
+++ b/pkgs/shells/zsh/zsh-history/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
     license = licenses.mit;
     homepage = "https://github.com/b4b4r07/history";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ kampka ];
+    maintainers = with maintainers; [ ];
   };
 
   passthru.tests = {

--- a/pkgs/tools/networking/gandi-cli/default.nix
+++ b/pkgs/tools/networking/gandi-cli/default.nix
@@ -21,6 +21,6 @@ buildPythonApplication rec {
     description = "Command-line interface to the public Gandi.net API";
     homepage = "https://cli.gandi.net/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ kampka ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

In my observation, it has become increasingly difficult to become meaningful code review in a timely fashion.
This leads to packages not receiving even simple version updates for month, even half a year, after a PR is filed.
To me, it feels increasingly frustrating to see my name next to a package that in all practical sense not maintained at all.

In addition, I often test packages against non-x86 architectures with non-GCC, non-glibc stdenvs, which often take a long time to build from scratch since hydra does not populate a cache for these. That makes re-testing a PR, if only for a rebase, a time consuming task. The fact committers may choose to reject your PR months later for something as mediocre as a (subjectively) misplaced whitespace just adds insult to injury.
Hence, I decided to step down as a maintainer and remove myself from the list. I'd advice to remove the packages I maintained as they will likely end up abandoned, but I leave that decision up to the remaining maintainer team.
