### PR TITLE
bypass403: init at 1.4.0

### DIFF
--- a/pkgs/tools/security/bypass403/default.nix
+++ b/pkgs/tools/security/bypass403/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "bypass403";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "drsigned";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1x3a4lnxjxbv80kaydy57809n9r7vzci9ki4f98smf3w04s86rcl";
+  };
+
+  vendorSha256 = "1bp6bf99rxlyg91pn1y228q18lawpykmvkl22cydmclms0q0n238";
+
+  meta = with lib; {
+    description = "Tool to bypass 403 Forbidden responses";
+    homepage = "https://github.com/drsigned/bypass403";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1708,6 +1708,8 @@ in
     textual-window-manager = tmux;
   };
 
+  bypass403 = callPackage ../tools/security/bypass403 { };
+
   bsh = fetchurl {
     url = "http://www.beanshell.org/bsh-2.0b5.jar";
     sha256 = "0p2sxrpzd0vsk11zf3kb5h12yl1nq4yypb5mpjrm8ww0cfaijck2";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to bypass 403 Forbidden responses

https://github.com/drsigned/bypass403

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
