### PR TITLE
cudatoolkit: set cmake flag CUDA_HOST_COMPILER to gcc

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -147,6 +147,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/nix-support
     echo "cmakeFlags+=' -DCUDA_TOOLKIT_ROOT_DIR=$out'" >> $out/nix-support/setup-hook
 
+    # Set the host compiler to be used by nvcc for CMake-based projects:
+    # https://cmake.org/cmake/help/latest/module/FindCUDA.html#input-variables
+    echo "cmakeFlags+=' -DCUDA_HOST_COMPILER=${gcc}/bin'" >> $out/nix-support/setup-hook
+
     # Move some libraries to the lib output so that programs that
     # depend on them don't pull in this entire monstrosity.
     mkdir -p $lib/lib

--- a/pkgs/tools/misc/ethminer/default.nix
+++ b/pkgs/tools/misc/ethminer/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  clangStdenv,
   fetchFromGitHub,
   opencl-headers,
   cmake,
@@ -17,13 +16,9 @@
   openssl,
   pkg-config,
   cli11
-}@args:
+}:
 
-# Note that this requires clang < 9.0 to build, and currently
-# clangStdenv provides clang 7.1 which satisfies the requirement.
-let stdenv = if cudaSupport then clangStdenv else args.stdenv;
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "ethminer";
   version = "0.19.0";
 
@@ -43,9 +38,11 @@ in stdenv.mkDerivation rec {
     "-DAPICORE=ON"
     "-DETHDBUS=OFF"
     "-DCMAKE_BUILD_TYPE=Release"
-  ] ++ lib.optionals (!cudaSupport) [
+  ] ++ (if cudaSupport then [
+    "-DCUDA_PROPAGATE_HOST_FLAGS=off"
+  ] else [
     "-DETHASHCUDA=OFF" # on by default
-  ];
+  ]);
 
   nativeBuildInputs = [
     cmake
@@ -81,6 +78,5 @@ in stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ nand0p atemu ];
     license = licenses.gpl3Only;
-    broken = cudaSupport;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
It seems that the FindCUDA module in cmake was populating nvcc's `-ccbin` with the latest gcc, causing cmake projects using the module to try and use the newer gcc (rather than the version specified in cudatoolkit) with nvcc to build code. 

It looks like this behavior was OK with gcc9 since that's what we used anyways, but with the gcc10 merge I imagine this has broken builds depending on this module (it has at least broken ethminer). This PR explicitly sets the relevant cmake option to force nvcc to use a compatible gcc.

This PR also fixes ethminer by not propagating clang flags to nvcc and bumps ethminer to v0.19.0.

Closes #109283.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
