### PR TITLE
fwanalyzer: init at 1.4.3

### DIFF
--- a/pkgs/tools/filesystems/fwanalyzer/default.nix
+++ b/pkgs/tools/filesystems/fwanalyzer/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, e2tools
+, makeWrapper
+, mtools
+}:
+
+buildGoModule rec {
+  pname = "fwanalyzer";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "cruise-automation";
+    repo = pname;
+    rev = version;
+    sha256 = "1pj6s7lzw7490488a30pzvqy2riprfnhb4nzxm6sh2nsp51xalzv";
+  };
+
+  vendorSha256 = "1cjbqx75cspnkx7fgc665q920dsxnsdhqgyiawkvx0i8akczbflw";
+
+  subPackages = [ "cmd/${pname}" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/fwanalyzer" --prefix PATH : "${lib.makeBinPath [ e2tools mtools ]}"
+  '';
+
+  # The tests requires an additional setup (unpacking images, etc.)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tool to analyze filesystem images";
+    homepage = "https://github.com/cruise-automation/fwanalyzer";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18731,6 +18731,8 @@ in
   fscrypt-experimental = callPackage ../os-specific/linux/fscrypt { };
   fscryptctl-experimental = callPackage ../os-specific/linux/fscryptctl { };
 
+  fwanalyzer = callPackage ../tools/filesystems/fwanalyzer { };
+
   fwupd = callPackage ../os-specific/linux/firmware/fwupd { };
 
   firmware-manager = callPackage ../os-specific/linux/firmware/firmware-manager { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to analyze filesystem images.

https://github.com/cruise-automation/fwanalyzer

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
