### PR TITLE
tecoc: 20150606 -> unstable-2020-11-03

### DIFF
--- a/pkgs/applications/editors/tecoc/default.nix
+++ b/pkgs/applications/editors/tecoc/default.nix
@@ -1,37 +1,47 @@
-{ lib, stdenv, fetchFromGitHub
-, ncurses }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, ncurses
+}:
 
 stdenv.mkDerivation rec {
-
-  pname = "tecoc-git";
-  version = "20150606";
+  pname = "tecoc";
+  version = "unstable-2020-11-03";
 
   src = fetchFromGitHub {
     owner = "blakemcbride";
     repo = "TECOC";
-    rev = "d7dffdeb1dfb812e579d6d3b518545b23e1b50cb";
-    sha256 = "11zfa73dlx71c0hmjz5n3wqcvk6082rpb4sss877nfiayisc0njj";
+    rev = "79fcb6cfd6c5f9759f6ec46aeaf86d5806b13a0b";
+    sha256 = "sha256-JooLvoh9CxLHLOXXxE7zA7R9yglr9BGUwX4nrw2/vIw=";
   };
 
   buildInputs = [ ncurses ];
 
   makefile = if stdenv.hostPlatform.isDarwin
-  	     then "makefile.osx"
-	     else if stdenv.hostPlatform.isFreeBSD
-  	     then "makefile.bsd"
-  	     else if stdenv.hostPlatform.isOpenBSD
-  	     then "makefile.bsd"
-  	     else if stdenv.hostPlatform.isWindows
-  	     then "makefile.win"
-	     else "makefile.linux"; # I think Linux is a safe default...
+             then "makefile.osx"
+             else if stdenv.hostPlatform.isFreeBSD
+             then "makefile.bsd"
+             else if stdenv.hostPlatform.isOpenBSD
+             then "makefile.bsd"
+             else if stdenv.hostPlatform.isWindows
+             then "makefile.win"
+             else "makefile.linux"; # I think Linux is a safe default...
 
   makeFlags = [ "CC=${stdenv.cc}/bin/cc" "-C src/" ];
 
+  preInstall = ''
+    install -d $out/bin $out/share/doc/${pname}-${version} $out/lib/teco/macros
+  '';
+
   installPhase = ''
-    mkdir -p $out/bin $out/share/doc/${pname}-${version} $out/lib/teco/macros
-    cp src/tecoc $out/bin
-    cp src/aaout.txt doc/* $out/share/doc/${pname}-${version}
-    cp lib/* lib2/* $out/lib/teco/macros
+    runHook preInstall
+    install -m755 src/tecoc $out/bin
+    install -m644 src/aaout.txt doc/* $out/share/doc/${pname}-${version}
+    install -m644 lib/* lib2/* $out/lib/teco/macros
+    runHook postInstall
+  '';
+
+  postInstall = ''
     (cd $out/bin
      ln -s tecoc Make
      ln -s tecoc mung
@@ -54,9 +64,11 @@ stdenv.mkDerivation rec {
       of Editor MACroS for TECO.
 
       TECOC is a portable C implementation of TECO-11.
- '';
+    '';
     homepage = "https://github.com/blakemcbride/TECOC";
-    license = {  url = "https://github.com/blakemcbride/TECOC/tree/master/doc/readme-1st.txt"; };
+    license = {
+      url = "https://github.com/blakemcbride/TECOC/tree/master/doc/readme-1st.txt";
+    };
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
