### PR TITLE
sshchecker: init at 1.0

### DIFF
--- a/pkgs/tools/security/sshchecker/default.nix
+++ b/pkgs/tools/security/sshchecker/default.nix
@@ -1,0 +1,29 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "sshchecker";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "lazytools";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "139b850h1w0392k8jcgj22jscsl2l60b5kk0n8378b6g57ikmis0";
+  };
+
+  vendorSha256 = "19hdaf7d6lvwrl5rc1srrjsjx57g25cy4lvw0vvs6j52impdk6ak";
+
+  meta = with lib; {
+    description = "Dedicated SSH brute-forcing tool";
+    longDescription = ''
+      sshchecker is a fast dedicated SSH brute-forcing tool to check
+      SSH login on the giving IP list.
+    '';
+    homepage = "https://github.com/lazytools/sshchecker";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1397,6 +1397,8 @@ in
 
   ssh-import-id = python3Packages.callPackage ../tools/admin/ssh-import-id { };
 
+  sshchecker = callPackage ../tools/security/sshchecker { };
+
   titaniumenv = callPackage ../development/mobile/titaniumenv { };
 
   abootimg = callPackage ../development/mobile/abootimg {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Dedicated SSH brute-forcing tool.

https://github.com/lazytools/sshchecker

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
