### PR TITLE
gnomeExtensions.dynamic-panel-transparency: init at 35

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/dynamic-panel-transparency/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dynamic-panel-transparency/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, gnome3, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-dynamic-panel-transparency";
+  version = "35";
+
+  src = fetchFromGitHub {
+    owner = "ewlsh";
+    repo = "dynamic-panel-transparency";
+    rev = "0800c0a921bb25f51f6a5ca2e6981b1669a69aec";
+    sha256 = "0200mx861mlsi9lf7h108yam02jfqqw55r521chkgmk4fy6z99pq";
+  };
+
+  uuid = "dynamic-panel-transparency@rockon999.github.io";
+
+  nativeBuildInputs = [ glib ];
+
+  buildPhase = ''
+    runHook preBuild
+    glib-compile-schemas --strict --targetdir=${uuid}/schemas/ ${uuid}/schemas
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r ${uuid} $out/share/gnome-shell/extensions
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "This extension fades your top panel to nothingness when there are no maximized windows present";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ rhoriguchi ];
+    homepage = "https://github.com/ewlsh/dynamic-panel-transparency";
+    broken = versionOlder gnome3.gnome-shell.version "3.36";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27264,6 +27264,7 @@ in
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
     draw-on-your-screen = callPackage ../desktops/gnome-3/extensions/draw-on-your-screen { };
     drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
+    dynamic-panel-transparency = callPackage ../desktops/gnome-3/extensions/dynamic-panel-transparency { };
     easyScreenCast = callPackage ../desktops/gnome-3/extensions/EasyScreenCast { };
     emoji-selector = callPackage ../desktops/gnome-3/extensions/emoji-selector { };
     freon = callPackage ../desktops/gnome-3/extensions/freon { };


### PR DESCRIPTION
###### Motivation for this change

Add support for [GNOME extension Dynamic Panel Transparency](https://github.com/ewlsh/dynamic-panel-transparency)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
