### PR TITLE
gnomeExtensions.unite-shell: rename to gnomeExtensions.unite

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/unite/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/unite/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, gnome3, fetchFromGitHub, xprop, glib, coreutils }:
 stdenv.mkDerivation rec {
-  pname = "gnome-shell-extension-unite-shell";
+  pname = "gnome-shell-extension-unite";
   version = "44";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -730,6 +730,9 @@ mapAliases ({
   youtubeDL = youtube-dl;  # added 2014-10-26
   ytop = throw "ytop has been abandoned by upstream. Consider switching to bottom instead";
   zdfmediathk = mediathekview; # added 2019-01-19
+  gnomeExtensions = gnomeExtensions // {
+    unite-shell = gnomeExtensions.unite; # added 2021-01-19
+  };
   gnome_user_docs = gnome-user-docs; # added 2019-11-20
   # spidermonkey is not ABI upwards-ompatible, so only allow this for nix-shell
   spidermonkey = spidermonkey_78; # added 2020-10-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27283,7 +27283,7 @@ in
     tilingnome = callPackage ../desktops/gnome-3/extensions/tilingnome { };
     timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
-    unite-shell = callPackage ../desktops/gnome-3/extensions/unite-shell { };
+    unite = callPackage ../desktops/gnome-3/extensions/unite { };
     window-corner-preview = callPackage ../desktops/gnome-3/extensions/window-corner-preview { };
     window-is-ready-remover = callPackage ../desktops/gnome-3/extensions/window-is-ready-remover { };
     workspace-matrix = callPackage ../desktops/gnome-3/extensions/workspace-matrix { };


### PR DESCRIPTION
###### Motivation for this change

After using the `gnome-shell-extension-prefs` i realized this package should be named `unite`.

On [GitHub repository](https://github.com/hardpixel/unite-shell) the extension is mentioned under the name `Unite` also the header in the demo images is also `Unite`.

> Unite is a GNOME Shell extension which makes a few layout tweaks to the top panel and removes window decorations to make it look like Ubuntu Unity Shell.

![image](https://raw.githubusercontent.com/hardpixel/unite-shell/master/settings.png)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
