### PR TITLE
sysklogd: fix building against musl

### DIFF
--- a/pkgs/os-specific/linux/sysklogd/default.nix
+++ b/pkgs/os-specific/linux/sysklogd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "00f2wy6f0qng7qzga4iicyzl9j8b7mp6mrpfky5jxj93ms2w2rji";
   };
 
-  patches = [ ./systemd.patch ./union-wait.patch ./fix-includes.patch ];
+  patches = [ ./systemd.patch ./union-wait.patch ./fix-includes-for-musl.patch ];
 
   NIX_CFLAGS_COMPILE = "-DSYSV";
 

--- a/pkgs/os-specific/linux/sysklogd/default.nix
+++ b/pkgs/os-specific/linux/sysklogd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "00f2wy6f0qng7qzga4iicyzl9j8b7mp6mrpfky5jxj93ms2w2rji";
   };
 
-  patches = [ ./systemd.patch ./union-wait.patch ];
+  patches = [ ./systemd.patch ./union-wait.patch ./fix-includes.patch ];
 
   NIX_CFLAGS_COMPILE = "-DSYSV";
 

--- a/pkgs/os-specific/linux/sysklogd/fix-includes-for-musl.patch
+++ b/pkgs/os-specific/linux/sysklogd/fix-includes-for-musl.patch
@@ -1,3 +1,5 @@
+# this patch both fixes some include paths as well as removes glibc
+# gates around defines that musl-libc also depends on.
 diff -u sysklogd-1.5.1.orig/klogd.c sysklogd-1.5.1/klogd.c
 --- sysklogd-1.5.1.orig/klogd.c	2014-10-04 15:47:18.000000000 -0400
 +++ sysklogd-1.5.1/klogd.c	2021-01-18 23:09:23.000000000 -0500

--- a/pkgs/os-specific/linux/sysklogd/fix-includes.patch
+++ b/pkgs/os-specific/linux/sysklogd/fix-includes.patch
@@ -1,0 +1,118 @@
+diff -u sysklogd-1.5.1.orig/klogd.c sysklogd-1.5.1/klogd.c
+--- sysklogd-1.5.1.orig/klogd.c	2014-10-04 15:47:18.000000000 -0400
++++ sysklogd-1.5.1/klogd.c	2021-01-18 23:09:23.000000000 -0500
+@@ -260,11 +260,8 @@
+ #include <unistd.h>
+ #include <signal.h>
+ #include <errno.h>
+-#include <sys/fcntl.h>
++#include <fcntl.h>
+ #include <sys/stat.h>
+-#if !defined(__GLIBC__)
+-#include <linux/time.h>
+-#endif /* __GLIBC__ */
+ #include <stdarg.h>
+ #include <paths.h>
+ #include <stdlib.h>
+@@ -277,13 +274,8 @@
+ 
+ #define __LIBRARY__
+ #include <linux/unistd.h>
+-#if !defined(__GLIBC__)
+-# define __NR_ksyslog __NR_syslog
+-_syscall3(int,ksyslog,int, type, char *, buf, int, len);
+-#else
+ #include <sys/klog.h>
+ #define ksyslog klogctl
+-#endif
+ 
+ #define LOG_BUFFER_SIZE 4096
+ #define LOG_LINE_LENGTH 1000
+diff -u sysklogd-1.5.1.orig/ksym_mod.c sysklogd-1.5.1/ksym_mod.c
+--- sysklogd-1.5.1.orig/ksym_mod.c	2014-10-04 15:47:18.000000000 -0400
++++ sysklogd-1.5.1/ksym_mod.c	2021-01-18 23:09:57.000000000 -0500
+@@ -113,12 +113,9 @@
+ #include <unistd.h>
+ #include <signal.h>
+ #include <errno.h>
+-#include <sys/fcntl.h>
++#include <fcntl.h>
+ #include <sys/stat.h>
+ #include "module.h"
+-#if !defined(__GLIBC__)
+-#include <linux/time.h>
+-#endif /* __GLIBC__ */
+ #include <stdarg.h>
+ #include <paths.h>
+ #include <linux/version.h>
+diff -u sysklogd-1.5.1.orig/pidfile.c sysklogd-1.5.1/pidfile.c
+--- sysklogd-1.5.1.orig/pidfile.c	2014-10-04 15:47:18.000000000 -0400
++++ sysklogd-1.5.1/pidfile.c	2021-01-18 23:23:55.000000000 -0500
+@@ -25,6 +25,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <fcntl.h>
+ #include <unistd.h>
+ #include <sys/stat.h>
+ #include <sys/file.h>
+diff -u sysklogd-1.5.1.orig/syslog.c sysklogd-1.5.1/syslog.c
+--- sysklogd-1.5.1.orig/syslog.c	2014-10-04 15:47:18.000000000 -0400
++++ sysklogd-1.5.1/syslog.c	2021-01-18 23:11:45.000000000 -0500
+@@ -55,7 +55,6 @@
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <sys/file.h>
+-#include <sys/signal.h>
+ #include <sys/syslog.h>
+ #if 0
+ #include "syslog.h"
+@@ -64,6 +63,8 @@
+ 
+ #include <sys/uio.h>
+ #include <sys/wait.h>
++#include <signal.h>
++#include <fcntl.h>
+ #include <netdb.h>
+ #include <string.h>
+ #include <time.h>
+diff -u sysklogd-1.5.1.orig/syslogd.c sysklogd-1.5.1/syslogd.c
+--- sysklogd-1.5.1.orig/syslogd.c	2014-10-04 15:47:18.000000000 -0400
++++ sysklogd-1.5.1/syslogd.c	2021-01-18 23:13:25.000000000 -0500
+@@ -519,9 +519,9 @@
+ #include <time.h>
+ 
+ #define SYSLOG_NAMES
++#include <errno.h>
+ #include <sys/syslog.h>
+ #include <sys/param.h>
+-#include <sys/errno.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
+@@ -818,9 +818,7 @@
+ void init();
+ void cfline(char *line, register struct filed *f);
+ int decode(char *name, struct code *codetab);
+-#if defined(__GLIBC__)
+ #define dprintf mydprintf
+-#endif /* __GLIBC__ */
+ static void dprintf(char *, ...);
+ static void allocate_log(void);
+ void sighup_handler();
+@@ -840,15 +838,9 @@
+ 	register char *p;
+ #ifndef TESTING
+ 	ssize_t msglen;
+-#endif
+-#if !defined(__GLIBC__)
+-	int len, num_fds;
+-#else /* __GLIBC__ */
+-#ifndef TESTING
+ 	socklen_t len;
+ #endif
+ 	int num_fds;
+-#endif /* __GLIBC__ */
+ 	/*
+ 	 * It took me quite some time to figure out how this is
+ 	 * supposed to work so I guess I should better write it down.

--- a/pkgs/os-specific/linux/sysklogd/systemd.patch
+++ b/pkgs/os-specific/linux/sysklogd/systemd.patch
@@ -71,9 +71,9 @@ diff -ruN -x '*~' sysklogd-1.5-old/sd-daemon.c sysklogd-1.5/sd-daemon.c
 +#include <sys/stat.h>
 +#include <sys/socket.h>
 +#include <sys/un.h>
-+#include <sys/fcntl.h>
 +#include <netinet/in.h>
 +#include <stdlib.h>
++#include <fcntl.h>
 +#include <errno.h>
 +#include <unistd.h>
 +#include <string.h>


### PR DESCRIPTION
taking guidance from alpine linux's [patch][1], removed a few ifdefs and
fixed up some includes.

[1]: https://git.alpinelinux.org/aports/tree/main/sysklogd/fix-includes.patch

Fixes #109892.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
currently, sysklogd won't build with musl-libc, due to some directives narrowly targeting glibc. with this patch, it builds and runs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
