### PR TITLE
deadd-notification-center: 1.7.2 -> 1.7.3

### DIFF
--- a/pkgs/applications/misc/deadd-notification-center/default.nix
+++ b/pkgs/applications/misc/deadd-notification-center/default.nix
@@ -1,44 +1,46 @@
-{ lib, stdenv
-, fetchurl
+{ lib
+, stdenv
+, fetchFromGitHub
 , autoPatchelfHook
+, wrapGAppsHook
+, hicolor-icon-theme
 , gtk3
 , gobject-introspection
 , libxml2
 }:
-
-let
-  version = "1.7.2";
-
-  dbusService = fetchurl {
-    url = "https://github.com/phuhl/linux_notification_center/raw/${version}/com.ph-uhl.deadd.notification.service.in";
-    sha256 = "0jvmi1c98hm8x1x7kw9ws0nbf4y56yy44c3bqm6rjj4lrm89l83s";
-  };
-in
 stdenv.mkDerivation rec {
-  inherit version;
   pname = "deadd-notification-center";
+  version = "1.7.3";
 
-  src = fetchurl {
-    url = "https://github.com/phuhl/linux_notification_center/releases/download/${version}/${pname}";
-    sha256 = "13f15slkjiw2n5dnqj13dprhqm3nf1k11jqaqda379yhgygyp9zm";
+  src = fetchFromGitHub {
+    owner = "phuhl";
+    repo = "linux_notification_center";
+    rev = version;
+    sha256 = "QaOLrtlhQyhMOirk6JO1yMGRrgycHmF9FAdKNbN2TRk=";
   };
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+  ];
 
   buildInputs = [
     gtk3
     gobject-introspection
     libxml2
+    hicolor-icon-theme
   ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/dbus-1/services
-    cp $src $out/bin/deadd-notification-center
-    chmod +x $out/bin/deadd-notification-center
 
-    sed "s|##PREFIX##|$out|g" ${dbusService} > $out/share/dbus-1/services/com.ph-uhl.deadd.notification.service
+    cp $src/.out/${pname} $out/bin/
+    chmod +x $out/bin/${pname}
+
+    sed "s|##PREFIX##|$out|g" $src/${pname}.service.in > \
+      $out/share/dbus-1/services/com.ph-uhl.deadd.notification.service
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Deadd-notification-center was updated a couple months ago(I'm a bit late with this). Still can't build it from source(broken haskell dependencies), but I made the package a bit simpler by fetching it from github and using the binary built with github actions. Also added hicolor-icon-theme and wrapGAppsHook, not sure if the latter is necessary but it is a gtk app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
