### PR TITLE
sqlx-cli: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3455,6 +3455,12 @@
       fingerprint = "7FC7 98AB 390E 1646 ED4D  8F1F 797F 6238 68CD 00C2";
     }];
   };
+  greizgh = {
+    email = "greizgh@ephax.org";
+    github = "greizgh";
+    githubId = 1313624;
+    name = "greizgh";
+  };
   greydot = {
     email = "lanablack@amok.cc";
     github = "greydot";

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -1,0 +1,29 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sqlx-cli";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "launchbadge";
+    repo = "sqlx";
+    rev = "v${version}";
+    sha256 = "1q6p4qly9qjn333nj72sar6nbyclfdw9i9l6rnimswylj0rr9n27";
+  };
+
+  cargoSha256 = "1393mwx6iccnqrry4ia4prcnnjxhp4zjq1s3gzwzfyzsrqyad54g";
+
+  doCheck = false;
+  cargoBuildFlags = [ "-p sqlx-cli" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description =
+      "SQLx's associated command-line utility for managing databases, migrations, and enabling offline mode with sqlx::query!() and friends.";
+    homepage = "https://github.com/launchbadge/sqlx";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ greizgh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10735,6 +10735,8 @@ in
     jdk = oraclejdk;
   };
 
+  sqlx-cli = callPackage ../development/tools/rust/sqlx-cli { };
+
   squeak = callPackage ../development/compilers/squeak { };
 
   squirrel-sql = callPackage ../development/tools/database/squirrel-sql {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[sqlx-cli](https://github.com/launchbadge/sqlx/tree/master/sqlx-cli#sqlx-cli) is a development tool used in combination with sqlx library. It handles migrations and offline schema generation.

Checks are skipped because `cargo test` attempts to build all the workspaces, and one is failing.
([It doesn't seem possible for now to specify a cargo flag for tests.](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/rust/default.nix#L247))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
