### PR TITLE
notcurses: 2.1.0 -> 2.1.5

### DIFF
--- a/pkgs/development/libraries/notcurses/default.nix
+++ b/pkgs/development/libraries/notcurses/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, cmake, pkg-config, pandoc, libunistring, ncurses, ffmpeg,
+{ stdenv, cmake, pkg-config, pandoc, libunistring, ncurses, ffmpeg, readline,
   fetchFromGitHub, lib,
   multimediaSupport ? true
 }:
 let
-  version = "2.1.0";
+  version = "2.1.5";
 in
 stdenv.mkDerivation {
   pname = "notcurses";
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake pkg-config pandoc ];
 
-  buildInputs = [ libunistring ncurses ]
+  buildInputs = [ libunistring ncurses readline ]
     ++ lib.optional multimediaSupport ffmpeg;
 
   cmakeFlags =
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     owner  = "dankamongmen";
     repo   = "notcurses";
     rev    = "v${version}";
-    sha256 = "0jvngg40c1sqf85kqy6ya0vflpxsj7j4g6cw609992rifaghxiny";
+    sha256 = "02x9a0z7mbgry2wsfai1l3jwb2zpcg4gq6a2w5d920ap2fixzy8b";
   };
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15665,7 +15665,9 @@ in
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };
 
-  notcurses = callPackage ../development/libraries/notcurses { };
+  notcurses = callPackage ../development/libraries/notcurses {
+    readline = readline80;
+  };
 
   ncurses5 = ncurses.override {
     abiVersion = "5";


### PR DESCRIPTION
###### Motivation for this change
Bring Notcurses up-to-date in NixOS. 2.1.0 was the first version packaged, and it took a few iterations to get there, hence the distance from head. Future updates ought span fewer versions. This is my first NixOS submission, so please be gentle =].

https://github.com/dankamongmen/notcurses/issues/1290

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
