### PR TITLE
[staging] python3Packages.virtualenv: 20.2.1 -> 20.3.1

### DIFF
--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -17,11 +17,11 @@
 
 buildPythonPackage rec {
   pname = "virtualenv";
-  version = "20.2.1";
+  version = "20.3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e0aac7525e880a429764cefd3aaaff54afb5d9f25c82627563603f5d7de5a6e5";
+    sha256 = "sha256-DBEaIjaxkUIrN/6MKLjIKM7TmqtL9WJ/pcMxrv+1cNk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -1,18 +1,26 @@
 { buildPythonPackage
-, fetchPypi
-, lib
-, stdenv
-, pythonOlder
-, isPy27
 , appdirs
 , contextlib2
+, cython
 , distlib
+, fetchPypi
 , filelock
+, fish
+, flaky
 , importlib-metadata
 , importlib-resources
+, isPy27
+, lib
 , pathlib2
+, pytest-freezegun
+, pytest-mock
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
 , setuptools_scm
 , six
+, stdenv
+, xonsh
 }:
 
 buildPythonPackage rec {
@@ -47,10 +55,33 @@ buildPythonPackage rec {
     ./0001-Check-base_prefix-and-base_exec_prefix-for-Python-2.patch
   ];
 
-  meta = {
+  checkInputs = [
+    cython
+    fish
+    flaky
+    pytest-freezegun
+    pytest-mock
+    pytest-timeout
+    pytestCheckHook
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    xonsh
+  ];
+
+  preCheck = "export HOME=$(mktemp -d)";
+
+  # Ignore tests which requires network access
+  pytestFlagsArray = [
+    "--ignore tests/unit/create/test_creator.py"
+    "--ignore tests/unit/seed/embed/test_bootstrap_link_via_app_data.py"
+  ];
+
+  disabledTests = [ "test_can_build_c_extensions" ];
+  pythonImportsCheck = [ "virtualenv" ];
+
+  meta = with lib; {
     description = "A tool to create isolated Python environments";
     homepage = "http://www.virtualenv.org";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ goibhniu ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ goibhniu ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 20.3.1

Change log: https://virtualenv.pypa.io/en/latest/changelog.html#bugfixes-20-3-1

This PR also enables the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
