### PR TITLE
h2: 1.4.193 -> 1.4.199

### DIFF
--- a/pkgs/servers/h2/default.nix
+++ b/pkgs/servers/h2/default.nix
@@ -2,11 +2,11 @@
 stdenv.mkDerivation rec {
   pname = "h2";
 
-  version = "1.4.193";
+  version = "1.4.199";
 
   src = fetchzip {
-    url = "https://www.h2database.com/h2-2016-10-31.zip";
-    sha256 = "1da1qcfwi5gvh68i6w6y0qpcqp3rbgakizagkajmjxk2ryc4b3z9";
+    url = "https://h2database.com/h2-2019-03-13.zip";
+    sha256 = "0pdvbnx7nqfqs7x1zkwz2q34331l55jknpk6arf6dksvnd71hinj";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
Update h2 database version


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
