### PR TITLE
nerdctl: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/applications/networking/cluster/nerdctl/default.nix
+++ b/pkgs/applications/networking/cluster/nerdctl/default.nix
@@ -14,16 +14,16 @@ let
 in
 buildGoModule rec {
   pname = "nerdctl";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "AkihiroSuda";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vjcbvd5yrasw97hd5mrn6cdjvfv2r03z7g1wczlszlcs8gr6nxw";
+    sha256 = "sha256-lSvYiTh67gK9kJls7VsayV8T3H6RzFEEKe49BOWnUBw=";
   };
 
-  vendorSha256 = "181lp9l4i0qpiqm8wbxa4ldi1j5bm3ygmanz1xh3mkjanl0pwqjr";
+  vendorSha256 = "sha256-qywiaNoO3pI7sfyPbwWR8BLd86RvJ2xSWwCJUsm3RkM=";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump nerdctl to `0.5.0`

https://github.com/AkihiroSuda/nerdctl/releases/tag/v0.5.0

nerdctl has added a couple new features. Converting an image into the stargz format and running it worked fine.

```
λ sudo ./result/bin/nerdctl pull kubesec/kubesec:4423063
docker.io/kubesec/kubesec:4423063:                                                resolved       |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:872c9714ee29d3c3c1612de6ab3cb0b7c280e36c803cb5776b15594a6f115f1e: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:69b89a0b05c6a1d122f59bda262c707caf2c2759af660e9db5347f69c8afa015:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:6d86d77bbc34395397c43c4a597c2d2f322f21f1edf7b80b753ca4fab468ea1b:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:9ad85155a1f9edb01c502b175372a11f1368b75a549057995d5a945029fb7eae:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:daae948c2c65122b148d83341bef169dca2010b40e1d2ee502b65b7f92d996a8:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:c63654b79c0b89141dd8d56da082d941252ffe37b3cb89db19087abbb6bb0335:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 8.8 s                                                                    total:  25.3 M (2.9 MiB/s)
λ sudo ./result/bin/nerdctl image convert --estargz --oci kubesec/kubesec:4423063 bob
sha256:43fa2f7d68af443e9cf133a708e9facea266ea21e49ca24237b2b9ce1fc8b79d
λ sudo ./result/bin/nerdctl images
REPOSITORY                   TAG                                                                 IMAGE ID        CREATED           SIZE
docker.io/kubesec/kubesec    4423063                                                             872c9714ee29    59 seconds ago    25.3 MiB
alpine                       latest                                                              c0e9560cda11    5 weeks ago       2.7 MiB
bob                          latest                                                              43fa2f7d68af    10 seconds ago    27.5 MiB
overlayfs@sha256             2be755139c98745b23098d3baeb76b4108ff3cfc9321f9c3a0fdac3f5a30af9d    2be755139c98    5 weeks ago       25.3 MiB
```

It now *optionally* requires a new isolation plugin which isn't upstream in cni-plugins yet. https://github.com/containernetworking/plugins/issues/573

But it's just a warning
`WARN[0001] To isolate bridge networks, CNI plugin "isolation" needs to be installed in CNI_PATH ("/nix/store/p72q8ijawqhmgv35hswl9bkzq4c600dg-cni-plugins-0.9.0/bin"), see https://github.com/AkihiroSuda/cni-isolation`

---

~I think it's highly likely it'll be merged in soon so I'm happy to wait for the next release of cni-plugins to merge this rather than packaging it separately and creating a new cni-plugins + cni-isolation-plugin dir.~
Since it works perfectly without the plugin I'm happy to merge now. Once the plugin is added upstream it will begin to work without any changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
