### PR TITLE
pythonPackages.Nikola: fix

### DIFF
--- a/pkgs/development/python-modules/doit/default.nix
+++ b/pkgs/development/python-modules/doit/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "doit";
-  version = "0.32.0";
+  version = "0.33.1";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "033m6y9763l81kgqd07rm62bngv3dsm3k9p28nwsn2qawl8h8g9j";
+    sha256 = "37c3b35c2151647b968b2af24481112b2f813c30f695366db0639d529190a143";
   };
 
   propagatedBuildInputs = [ cloudpickle ]
@@ -30,8 +30,6 @@ buildPythonPackage rec {
   disabledTests = [
     # depends on doit-py, which has a circular dependency on doit
     "test___main__.py"
-    # https://github.com/pydoit/doit/issues/341
-    "test_not_picklable_raises_InvalidTask"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/piexif/default.nix
+++ b/pkgs/development/python-modules/piexif/default.nix
@@ -1,17 +1,27 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, pillow }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, pillow }:
 
 buildPythonPackage rec {
   pname = "piexif";
   version = "1.1.3";
 
+  # patch does not apply to PyPI sdist due to different line endings
+  src = fetchFromGitHub {
+    owner = "hMatoba";
+    repo = "Piexif";
+    rev = version;
+    sha256 = "1akmaxq1cjr8wghwaaql1bd3sajl8psshl58lprgfsigrvnklp8b";
+  };
+
+  patches = [
+    # Fix tests with Pillow >= 7.2.0: https://github.com/hMatoba/Piexif/pull/109
+    (fetchpatch {
+      url = "https://github.com/hMatoba/Piexif/commit/5209b53e9689ce28dcd045f384633378d619718f.patch";
+      sha256 = "0ak571jf76r1vszp2g3cd5c16fz2zkbi43scayy933m5qdrhd8g1";
+    })
+  ];
+
   # Pillow needed for unit tests
   checkInputs = [ pillow ];
-
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "06sz58q4mrw472p8fbnq7wsj8zpi5js5r8phm2hiwfmz0v33bjw3";
-  };
 
   meta = with lib; {
     description = "Simplify Exif manipulations with Python";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11969,7 +11969,7 @@ in
 
   doctl = callPackage ../development/tools/doctl { };
 
-  doit = callPackage ../development/tools/build-managers/doit { };
+  doit = with python3Packages; toPythonApplication doit;
 
   dolt = callPackage ../servers/sql/dolt { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1933,6 +1933,8 @@ in {
 
   dogtail = callPackage ../development/python-modules/dogtail { };
 
+  doit = callPackage ../development/python-modules/doit { };
+
   dominate = callPackage ../development/python-modules/dominate { };
 
   dopy = callPackage ../development/python-modules/dopy { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Build failure discovered in https://github.com/NixOS/nixpkgs/pull/109521#issuecomment-761680478.
Piexif's tests were broken.
Since `doit` was not packaged as a python module, Nikola could only import it for `python3`, not `python37` or `python39`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
