### PR TITLE
checkmake: init at 0.1.0-2020.11.30

### DIFF
--- a/pkgs/development/tools/checkmake/default.nix
+++ b/pkgs/development/tools/checkmake/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, git, pandoc, lib }:
+
+buildGoPackage rec {
+  pname = "checkmake";
+  version = "0.1.0-2020.11.30";
+
+  goPackagePath = "github.com/mrtazz/checkmake";
+
+  src = fetchFromGitHub {
+    owner = "mrtazz";
+    repo = pname;
+    rev = "575315c9924da41534a9d0ce91c3f0d19bb53ffc";
+    sha256 = "121rsl9mh3wwadgf8ggi2xnb050pak6ma68b2sw5j8clmxbrqli3";
+  };
+
+  nativeBuildInputs = [ pandoc ];
+
+  preBuild =
+    let
+      buildVars = {
+        version = version;
+        buildTime = "N/A";
+        builder = "nix";
+        goversion = "$(go version | egrep -o 'go[0-9]+[.][^ ]*')";
+      };
+      buildVarsFlags = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "-X main.${k}=${v}") buildVars);
+    in
+    ''
+      buildFlagsArray+=("-ldflags=${buildVarsFlags}")
+    '';
+
+  postInstall = ''
+    pandoc -s -t man -o checkmake.1 go/src/${goPackagePath}/man/man1/checkmake.1.md
+    mkdir -p $out/share/man/man1
+    mv checkmake.1 $out/share/man/man1/checkmake.1
+  '';
+
+  meta = with lib; {
+    description = "Experimental tool for linting and checking Makefiles";
+    homepage = https://github.com/mrtazz/checkmake;
+    license = licenses.mit;
+    maintainers = with maintainers; [ vidbina ];
+    platforms = platforms.linux;
+    longDescription = ''
+      checkmake is an experimental tool for linting and checking
+      Makefiles. It may not do what you want it to.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3011,6 +3011,8 @@ in
 
   checkinstall = callPackage ../tools/package-management/checkinstall { };
 
+  checkmake = callPackage ../development/tools/checkmake { };
+
   chit = callPackage ../development/tools/chit { };
 
   chkrootkit = callPackage ../tools/security/chkrootkit { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Wanted to add checkmake as a tool to dev envs managed through nix-shells

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
