### PR TITLE
go-cve-search: init at 0.1.3

### DIFF
--- a/pkgs/tools/security/go-cve-search/default.nix
+++ b/pkgs/tools/security/go-cve-search/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "go-cve-search";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "s-index";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0hbv829daviskwsyp9xjcvl52m22986b2cylf2rldnxw5x8zqdvd";
+  };
+
+  vendorSha256 = "0bhxk39ivbkhwjvq6415lax1pzn208b7px1id0d1nry93bk2zynd";
+
+  # Tests requires network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A lightweight CVE search tool";
+    longDescription = ''
+      go-cve-search is a lightweight tool to search CVE (Common Vulnerabilities
+      and Exposures).
+    '';
+    homepage = "https://github.com/s-index/go-cve-search";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1130,6 +1130,8 @@ in
 
   go-check = callPackage ../development/tools/check { };
 
+  go-cve-search = callPackage ../tools/security/go-cve-search { };
+
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
   claws = callPackage ../tools/misc/claws { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A lightweight CVE search tool.

https://github.com/s-index/go-cve-search

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
