### PR TITLE
emacs-modes: Fix missing 'lib' arguments

### DIFF
--- a/pkgs/applications/editors/emacs-modes/cedet/default.nix
+++ b/pkgs/applications/editors/emacs-modes/cedet/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, emacs, python }:
+{ lib, fetchurl, stdenv, emacs, python }:
 
 stdenv.mkDerivation rec {
   name = "cedet-1.1";

--- a/pkgs/applications/editors/emacs-modes/ess-R-object-popup/default.nix
+++ b/pkgs/applications/editors/emacs-modes/ess-R-object-popup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit }:
+{ lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation {
   name = "ess-R-object-popup-20130302";

--- a/pkgs/applications/editors/emacs-modes/helm-words/default.nix
+++ b/pkgs/applications/editors/emacs-modes/helm-words/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit }:
+{ lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation {
   name = "helm-words-20190917";

--- a/pkgs/applications/editors/emacs-modes/hsc3/default.nix
+++ b/pkgs/applications/editors/emacs-modes/hsc3/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, emacs }:
+{ lib, stdenv, fetchurl, emacs }:
 
 # this package installs the emacs-mode which
 # resides in the hsc3 sources.

--- a/pkgs/applications/editors/emacs-modes/org-mac-link/default.nix
+++ b/pkgs/applications/editors/emacs-modes/org-mac-link/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, emacs}:
+{ lib, stdenv, fetchurl, emacs }:
 
 stdenv.mkDerivation {
   name = "org-mac-link-1.2";

--- a/pkgs/applications/editors/emacs-modes/perl-completion/default.nix
+++ b/pkgs/applications/editors/emacs-modes/perl-completion/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation {
   name = "perl-completion";

--- a/pkgs/applications/editors/emacs-modes/prolog/default.nix
+++ b/pkgs/applications/editors/emacs-modes/prolog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation {
   pname = "prolog-mode";

--- a/pkgs/applications/editors/emacs-modes/railgun/default.nix
+++ b/pkgs/applications/editors/emacs-modes/railgun/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit }:
+{ lib, stdenv, fetchgit }:
 
 stdenv.mkDerivation {
   name = "railgun-2012-10-17";

--- a/pkgs/applications/editors/emacs-modes/rect-mark/default.nix
+++ b/pkgs/applications/editors/emacs-modes/rect-mark/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, emacs}:
+{ lib, stdenv, fetchurl, emacs }:
 
 stdenv.mkDerivation {
   name = "rect-mark-1.4";

--- a/pkgs/applications/editors/emacs-modes/sunrise-commander/default.nix
+++ b/pkgs/applications/editors/emacs-modes/sunrise-commander/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchgit, emacs}:
+{ lib, stdenv, fetchgit, emacs }:
 
 stdenv.mkDerivation {
   name = "sunrise-commander-6r435";

--- a/pkgs/applications/editors/emacs-modes/tramp/default.nix
+++ b/pkgs/applications/editors/emacs-modes/tramp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, emacs, texinfo }:
+{ lib, stdenv, fetchurl, emacs, texinfo }:
 
 stdenv.mkDerivation rec {
   name = "tramp-2.4.2";

--- a/pkgs/applications/editors/emacs-modes/zeitgeist/default.nix
+++ b/pkgs/applications/editors/emacs-modes/zeitgeist/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, emacs }:
+{ lib, stdenv, fetchurl, emacs }:
 
 stdenv.mkDerivation {
   name = "zeitgeist-20120221";


### PR DESCRIPTION
###### Motivation for this change

@siraben The ongoing work on #108938 seems to have broken some emacs modes. In particular, tramp was broken for me, but I've added the argument to all other emacs-modes files touched in the same commit.

nixpkgs-review doesn't seem to do anything: `Nothing to be built.`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
