### PR TITLE
libdrm: 2.4.103 -> 2.4.104

### DIFF
--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, lib, fetchurl, pkg-config, meson, ninja, libpthreadstubs, libpciaccess
-, withValgrind ? valgrind-light.meta.available, valgrind-light, fetchpatch
+{ stdenv, lib, fetchurl, pkg-config, meson, ninja, docutils
+, libpthreadstubs, libpciaccess
+, withValgrind ? valgrind-light.meta.available, valgrind-light
 }:
 
 stdenv.mkDerivation rec {
   pname = "libdrm";
-  version = "2.4.103";
+  version = "2.4.104";
 
   src = fetchurl {
     url = "https://dri.freedesktop.org/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "08h2nnf4w96b4ql7485mvjgbbsb8rwc0qa93fdm1cq34pbyszq1z";
+    sha256 = "1jqvx9c23hgwhq109zqj6vg3ng40pcvh3r1k2fn1a424qasxhsnn";
   };
 
   outputs = [ "out" "dev" "bin" ];
 
-  nativeBuildInputs = [ pkg-config meson ninja ];
+  nativeBuildInputs = [ pkg-config meson ninja docutils ];
   buildInputs = [ libpthreadstubs libpciaccess ]
     ++ lib.optional withValgrind valgrind-light;
 
@@ -34,12 +35,24 @@ stdenv.mkDerivation rec {
     "-Detnaviv=true"
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-Dintel=false";
 
-  enableParallelBuilding = true;
+  meta = with lib; {
+    homepage = "https://gitlab.freedesktop.org/mesa/drm";
+    downloadPage = "https://dri.freedesktop.org/libdrm/";
+    description = "Direct Rendering Manager library and headers";
+    longDescription = ''
+      A userspace library for accessing the DRM (Direct Rendering Manager) on
+      Linux, BSD and other operating systems that support the ioctl interface.
+      The library provides wrapper functions for the ioctls to avoid exposing
+      the kernel interface directly, and for chipsets with drm memory manager,
+      support for tracking relocations and buffers.
+      New functionality in the kernel DRM drivers typically requires a new
+      libdrm, but a new libdrm will always work with an older kernel.
 
-  meta = {
-    homepage = "https://dri.freedesktop.org/libdrm/";
-    description = "Library for accessing the kernel's Direct Rendering Manager";
-    license = "bsd";
-    platforms = lib.platforms.unix;
+      libdrm is a low-level library, typically used by graphics drivers such as
+      the Mesa drivers, the X drivers, libva and similar projects.
+    '';
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
   };
 }


### PR DESCRIPTION
Announcement:
https://lists.freedesktop.org/archives/dri-devel/2021-January/293654.html

Additional changes:
- docutils is a new bild-time dependency for rst2man.
- Fix the license (BSD -> MIT). The licensing is a bit complicated but
  at least the main license is MIT [0],[1],[2].
- Add myself as maintainer.
- Extend the meta information.
- Some minor cleanups and style improvements.

[0]: https://pkgs.alpinelinux.org/packages?name=libdrm
[1]: https://www.freshports.org/graphics/libdrm
[2]: https://src.fedoraproject.org/rpms/libdrm/blob/master/f/libdrm.spec

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
