### PR TITLE
tangram: Use pkg-config instead of pkgconfig

### DIFF
--- a/pkgs/applications/networking/instant-messengers/tangram/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tangram/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub, appstream-glib, desktop-file-utils, gdk-pixbuf
 , gettext, gjs, glib, gobject-introspection, gsettings-desktop-schemas, gtk3
-, hicolor-icon-theme, meson, ninja, pkgconfig, python3, webkitgtk, wrapGAppsHook
+, hicolor-icon-theme, meson, ninja, pkg-config, python3, webkitgtk, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
     meson
     ninja
-    pkgconfig
+    pkg-config
     python3
     wrapGAppsHook
   ];


### PR DESCRIPTION
###### Motivation for this change

@jonringer This new package seems to have crossed paths with #109887

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
