### PR TITLE
python3Packages.crccheck: 0.6 -> 1.0

### DIFF
--- a/pkgs/development/python-modules/crccheck/default.nix
+++ b/pkgs/development/python-modules/crccheck/default.nix
@@ -1,21 +1,24 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPy3k
 , nose }:
 
-buildPythonPackage rec {
+let
   pname = "crccheck";
-  version = "0.6";
+  version = "1.0";
+in buildPythonPackage {
+  inherit pname version;
 
-  buildInputs = [ nose ];
+  checkInputs = [ nose ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0ckymm6s5kw08i1j35fy2cfha1hyq94pq1kc66brb552qgjs91jn";
-    extension = "zip";
+    sha256 = "1ay9lgy80j7lklm07iw2wq7giwnv9fbv50mncblqlc39y322vi0p";
   };
+
+  disabled = !isPy3k;
 
   meta = with lib; {
     description = "Python library for CRCs and checksums";
-    homepage = "https://bitbucket.org/martin_scharrer/crccheck";
+    homepage = "https://sourceforge.net/projects/crccheck/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ etu ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Follow up on #99446 with less of the confusion and mess.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
