### PR TITLE
maude: 3.0 -> 3.1

### DIFF
--- a/pkgs/development/interpreters/maude/default.nix
+++ b/pkgs/development/interpreters/maude/default.nix
@@ -4,11 +4,11 @@
 
 let
 
-  version = "3.0";
+  version = "3.1";
 
   fullMaude = fetchurl {
-    url = "http://maude.cs.illinois.edu/w/images/0/04/Full-Maude-${version}.zip";
-    sha256 = "0gf36wlkkl343vlxgryqdhxmgyn8z0cc2zayccd7ac3inmj1iayw";
+    url = "http://maude.cs.illinois.edu/w/images/0/0a/Full-Maude-${version}.zip";
+    sha256 = "8b13af02c6243116c2ef9592622ecaa06d05dbe1dd6b1e595551ff33855948f2";
   };
 
 in
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "http://maude.cs.illinois.edu/w/images/9/92/Maude-${version}.tar.gz";
-    sha256 = "0vhn3lsck6ji9skrgm67hqrn3k4f6y442q73jbw65qqznm321k5a";
+    url = "http://maude.cs.illinois.edu/w/images/d/d3/Maude-${version}.tar.gz";
+    sha256 = "b112d7843f65217e3b5a9d40461698ef8dab7cbbe830af21216dfb924dc88a2f";
   };
 
   buildInputs = [
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
   postInstall = ''
     for n in "$out/bin/"*; do wrapProgram "$n" --suffix MAUDE_LIB ':' "$out/share/maude"; done
     unzip ${fullMaude}
-    install -D -m 444 full-maude3.maude $out/share/maude/full-maude.maude
+    install -D -m 444 full-maude31.maude $out/share/maude/full-maude.maude
   '';
 
   # bison -dv surface.yy -o surface.c


### PR DESCRIPTION
Updated Maude from 3.0 to 3.1.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
