### PR TITLE
opentabletdriver: 0.4.2 -> 0.5.0

### DIFF
--- a/nixos/tests/opentabletdriver.nix
+++ b/nixos/tests/opentabletdriver.nix
@@ -1,4 +1,6 @@
-import ./make-test-python.nix ( { pkgs, ... }: {
+import ./make-test-python.nix ( { pkgs, ... }: let
+  testUser = "alice";
+in {
   name = "opentabletdriver";
   meta = {
     maintainers = with pkgs.lib.maintainers; [ thiagokokada ];
@@ -10,7 +12,7 @@ import ./make-test-python.nix ( { pkgs, ... }: {
         ./common/user-account.nix
         ./common/x11.nix
       ];
-      test-support.displayManager.auto.user = "alice";
+      test-support.displayManager.auto.user = testUser;
       hardware.opentabletdriver.enable = true;
     };
 
@@ -18,10 +20,11 @@ import ./make-test-python.nix ( { pkgs, ... }: {
     ''
       machine.start()
       machine.wait_for_x()
-      machine.wait_for_unit("opentabletdriver.service", "alice")
+      machine.wait_for_unit("opentabletdriver.service", "${testUser}")
 
-      machine.succeed("cat /etc/udev/rules.d/30-opentabletdriver.rules")
+      machine.succeed("cat /etc/udev/rules.d/99-opentabletdriver.rules")
       # Will fail if service is not running
-      machine.succeed("otd detect")
+      # Needs to run as the same user that started the service
+      machine.succeed("su - ${testUser} -c 'otd detect'")
     '';
 })

--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -23,18 +23,18 @@
 
 stdenv.mkDerivation rec {
   pname = "OpenTabletDriver";
-  version = "0.4.2";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "InfinityGhost";
     repo = "OpenTabletDriver";
     rev = "v${version}";
-    sha256 = "048y7gjlk2yw4vh62px1d9w0va6ap1a0cndcpbirlyj9q6b8jxax";
+    sha256 = "1xi97nn5zb4fs3pyyqznvxnz07j30j3p967s7jigjmlm9321vkqp";
   };
 
   debPkg = fetchurl {
     url = "https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${version}/OpenTabletDriver.deb";
-    sha256 = "13gg0dhvjy88h9lhcrp30fjiwgb9dzjsgk1k760pi1ki71a5vz2r";
+    sha256 = "06m2g5qvc02ga9f98f2ssa7wr2b7b2qm90qwaf17fz5z8rr0qmp0";
   };
 
   nativeBuildInputs = [
@@ -134,8 +134,8 @@ stdenv.mkDerivation rec {
     install -Dm644 $src/OpenTabletDriver.UX/Assets/otd.png -t $out/share/pixmaps
 
     # TODO: Ideally this should be build from OpenTabletDriver/OpenTabletDriver-udev instead
-    dpkg-deb --fsys-tarfile ${debPkg} | tar xf - ./usr/lib/udev/rules.d/30-opentabletdriver.rules
-    install -Dm644 ./usr/lib/udev/rules.d/30-opentabletdriver.rules -t $out/lib/udev/rules.d
+    dpkg-deb --fsys-tarfile ${debPkg} | tar xf - ./usr/lib/udev/rules.d/99-opentabletdriver.rules
+    install -Dm644 ./usr/lib/udev/rules.d/99-opentabletdriver.rules -t $out/lib/udev/rules.d
 
     runHook postInstall
   '';

--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -155,8 +155,11 @@ stdenv.mkDerivation rec {
   dontWrapGApps = true;
   dontStrip = true;
 
-  passthru.tests = {
-    otd-runs = nixosTests.opentabletdriver;
+  passthru = {
+    updateScript = ./update.sh;
+    tests = {
+      otd-runs = nixosTests.opentabletdriver;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/tools/X11/opentabletdriver/deps.nix
+++ b/pkgs/tools/X11/opentabletdriver/deps.nix
@@ -11,13 +11,13 @@
   })
   (fetchNuGet {
     name = "Eto.Forms";
-    version = "2.5.6";
-    sha256 = "035ny8jlanchwq16gcq0xb6ywabjl71c7qbpv26sjwg96na8vz51";
+    version = "2.5.10";
+    sha256 = "1d71wglk4ixfqfbm6sxmj753x5iwbar8i9zzjy3bh64fy1dn8lz7";
   })
   (fetchNuGet {
     name = "Eto.Platform.Gtk";
-    version = "2.5.6";
-    sha256 = "1ijkjd3lc7x59yk369kxipzgk1zhyr9g6k319wc0n033vij26mwl";
+    version = "2.5.10";
+    sha256 = "1pkqvlfx7bzracnw19bl50i9jg4ym376vihmy9qq7m5z5nfdqn4g";
   })
   (fetchNuGet {
     name = "GdkSharp";
@@ -41,8 +41,8 @@
   })
   (fetchNuGet {
     name = "HidSharpCore";
-    version = "1.1.0";
-    sha256 = "122s5j3wrv8hcgnbxrnjqydvcfz7gdm8xq0wlwzrgwdjk44lr45a";
+    version = "1.2.1";
+    sha256 = "0vcw38skr9g691gxbzv3cf6y9rk11vh5pvcyjshdgii2z1z8a4g2";
   })
   (fetchNuGet {
     name = "MessagePack.Annotations";
@@ -120,9 +120,9 @@
     sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
   })
   (fetchNuGet {
-    name = "Newtonsoft.Json";
-    version = "12.0.3";
-    sha256 = "17dzl305d835mzign8r15vkmav2hq8l6g7942dfjpnzr17wwl89x";
+    name = "Octokit";
+    version = "0.48.0";
+    sha256 = "17ria1shx04rb6knbaswpqndmwam6v3r3lsfsd486q584798ccn8";
   })
   (fetchNuGet {
     name = "PangoSharp";
@@ -205,6 +205,11 @@
     sha256 = "1x0g58pbpjrmj2x2qw17rdwwnrcl0wvim2hdwz48lixvwvp22n9c";
   })
   (fetchNuGet {
+    name = "SharpZipLib";
+    version = "1.3.1";
+    sha256 = "09zypjfils38143da507s5fi4hzvdlz32wfav219hksnpl35y8x0";
+  })
+  (fetchNuGet {
     name = "StreamJsonRpc";
     version = "2.6.121";
     sha256 = "0xzvpk17w2skndzdg47j7gkrrvw6521db4mv8lc3v8hm97vs9m76";
@@ -228,11 +233,6 @@
     name = "System.CommandLine";
     version = "2.0.0-beta1.20253.1";
     sha256 = "16saf1fm9q80bb624fkqz0ksrwpnbw9617d7xg3jib7a2wgagm2r";
-  })
-  (fetchNuGet {
-    name = "System.CommandLine";
-    version = "2.0.0-beta1.20303.1";
-    sha256 = "0isnz8ipqlqim06hf56zlaq2vnsy5facvf5nvq6kzm5h1dm3l2vn";
   })
   (fetchNuGet {
     name = "System.ComponentModel.Annotations";
@@ -318,11 +318,6 @@
     name = "System.Net.WebSockets";
     version = "4.3.0";
     sha256 = "1gfj800078kggcgl0xyl00a6y5k4wwh2k2qm69rjy22wbmq7fy4p";
-  })
-  (fetchNuGet {
-    name = "System.Numerics.Vectors";
-    version = "4.5.0";
-    sha256 = "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59";
   })
   (fetchNuGet {
     name = "System.Reflection.Emit.Lightweight";

--- a/pkgs/tools/X11/opentabletdriver/update.sh
+++ b/pkgs/tools/X11/opentabletdriver/update.sh
@@ -14,6 +14,14 @@ if [[ "$new_version" == "$old_version" ]]; then
   [[ "${1}" != "--force" ]] && exit 0
 fi
 
+# Updating the hash of deb package manually since there seems to be no way to do it automatically
+oldDebPkgUrl="https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${old_version}/OpenTabletDriver.deb";
+newDebPkgUrl="https://github.com/InfinityGhost/OpenTabletDriver/releases/download/v${new_version}/OpenTabletDriver.deb";
+oldDebSha256=$(nix-prefetch-url "$oldDebPkgUrl")
+newDebSha256=$(nix-prefetch-url "$newDebPkgUrl")
+echo "oldDebSha256: $oldDebSha256 newDebSha256: $newDebSha256"
+sed -i ./default.nix -re "s|\"$oldDebSha256\"|\"$newDebSha256\"|"
+
 cd ../../../..
 update-source-version opentabletdriver "$new_version"
 store_src="$(nix-build . -A opentabletdriver.src --no-out-link)"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/InfinityGhost/OpenTabletDriver/releases/tag/v0.5.0

Also, did some improvements in `./update.sh` script making it finally possible to set it in `passthru.updateScript`.

~~Had to disable testing the `otd` binary for now, but the rest of the test seems fine and I also did a manual testing in my machine.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
