### PR TITLE
python3Packages.pymata-express: init at 1.19

### DIFF
--- a/pkgs/development/python-modules/pymata-express/default.nix
+++ b/pkgs/development/python-modules/pymata-express/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyserial
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pymata-express";
+  version = "1.19";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "MrYsLab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0gfjmqcxwsnfjgll6ql5xd1n3xp4klf4fcaajaivh053i02p0a79";
+  };
+
+  propagatedBuildInputs = [ pyserial ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "pymata_express" ];
+
+  meta = with lib; {
+    description = "Python Asyncio Arduino Firmata Client";
+    longDescription = ''
+      Pymata-Express is a Python Firmata Protocol client. When used in conjunction
+      with an Arduino Firmata sketch, it permits you to control and monitor Arduino
+      hardware remotely over a serial link.
+    '';
+    homepage = "https://mryslab.github.io/pymata-express/";
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -253,7 +253,7 @@
     "filter" = ps: with ps; [ aiohttp-cors sqlalchemy ];
     "fints" = ps: with ps; [ fints ];
     "fireservicerota" = ps: with ps; [ ]; # missing inputs: pyfireservicerota
-    "firmata" = ps: with ps; [ ]; # missing inputs: pymata-express
+    "firmata" = ps: with ps; [ pymata-express ];
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
     "fixer" = ps: with ps; [ fixerio ];
     "fleetgo" = ps: with ps; [ ]; # missing inputs: ritassist

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5536,6 +5536,8 @@ in {
 
   pymaging_png = callPackage ../development/python-modules/pymaging_png { };
 
+  pymata-express = callPackage ../development/python-modules/pymata-express { };
+
   pymatgen = callPackage ../development/python-modules/pymatgen { };
 
   pymatgen-lammps = callPackage ../development/python-modules/pymatgen-lammps { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python Asyncio Arduino Firmata Client

https://mryslab.github.io/pymata-express/

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
