### PR TITLE
kakounePlugins.quickscope-kak: Fix stdenv.lib -> lib breakage

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/quickscope.kak.nix
+++ b/pkgs/applications/editors/kakoune/plugins/quickscope.kak.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, lua5_3 }:
+{ lib, stdenv, fetchgit, lua5_3 }:
 
 stdenv.mkDerivation rec {
   pname = "quickscope-kak";


### PR DESCRIPTION
###### Motivation for this change

The plugin stopped working at commit badf51221.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @siraben