### PR TITLE
spacevim: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/applications/editors/spacevim/default.nix
+++ b/pkgs/applications/editors/spacevim/default.nix
@@ -13,12 +13,12 @@ let
   spacevimdir = format.generate "init.toml" spacevim_config;
 in mkDerivation rec {
   pname = "spacevim";
-  version = "1.5.0";
+  version = "1.6.0";
   src = fetchFromGitHub {
     owner = "SpaceVim";
     repo = "SpaceVim";
     rev = "v${version}";
-    sha256 = "1xw4l262x7wzs1m65bddwqf3qx4254ykddsw3c3p844pb3mzqhh7";
+    sha256 = "sha256-QQdtjEdbuzmf0Rw+u2ZltLihnJt8LqkfTrLDWLAnCLE=";
   };
 
   nativeBuildInputs = [ makeWrapper vim-customized];

--- a/pkgs/applications/editors/spacevim/helptags.patch
+++ b/pkgs/applications/editors/spacevim/helptags.patch
@@ -2,7 +2,7 @@ diff --git a/autoload/SpaceVim.vim b/autoload/SpaceVim.vim
 index 16688680..fcafd6f7 100644
 --- a/autoload/SpaceVim.vim
 +++ b/autoload/SpaceVim.vim
-@@ -1255,13 +1255,6 @@ function! SpaceVim#end() abort
+@@ -1355,13 +1355,6 @@ function! SpaceVim#end() abort
      let &helplang = 'jp'
    endif
    ""


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I saw there's a new upstream release.

ping @fzakaria 

[Changelog](https://spacevim.org/SpaceVim-release-v1.6.0/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
