### PR TITLE
python3Packages.devolo-home-control-api: init at 0.16.0

### DIFF
--- a/pkgs/development/python-modules/devolo-home-control-api/default.nix
+++ b/pkgs/development/python-modules/devolo-home-control-api/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, aiohttp
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pytest-cov
+, pytest-mock
+, requests
+, zeroconf
+, websocket_client
+, pytest-runner
+}:
+
+buildPythonPackage rec {
+  pname = "devolo-home-control-api";
+  version = "0.16.0";
+
+  src = fetchFromGitHub {
+    owner = "2Fake";
+    repo = "devolo_home_control_api";
+    rev = "v${version}";
+    sha256 = "19zzdbx0dxlm8pq0yk00nn9gqqblgpp16fgl7z6a98hsa6459zzb";
+  };
+
+  nativeBuildInputs = [ pytest-runner ];
+
+  propagatedBuildInputs = [
+    requests
+    zeroconf
+    websocket_client
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cov
+    pytest-mock
+  ];
+
+  # Disable test that requires network access
+  disabledTests = [ "test__on_pong" ];
+  pythonImportsCheck = [ "devolo_home_control_api" ];
+
+  meta = with lib; {
+    description = "Python library to work with devolo Home Control";
+    homepage = "https://github.com/2Fake/devolo_home_control_api";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -164,7 +164,7 @@
     "device_automation" = ps: with ps; [ ];
     "device_sun_light_trigger" = ps: with ps; [ aiohttp-cors pillow ];
     "device_tracker" = ps: with ps; [ ];
-    "devolo_home_control" = ps: with ps; [ aiohttp-cors zeroconf ]; # missing inputs: devolo-home-control-api
+    "devolo_home_control" = ps: with ps; [ aiohttp-cors devolo-home-control-api zeroconf ];
     "dexcom" = ps: with ps; [ pydexcom ];
     "dht" = ps: with ps; [ ]; # missing inputs: Adafruit-DHT
     "dialogflow" = ps: with ps; [ aiohttp-cors ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1667,6 +1667,8 @@ in {
 
   detox = throw "detox is no longer maintained, and was broken since may 2019"; # added 2020-07-04
 
+  devolo-home-control-api = callPackage ../development/python-modules/devolo-home-control-api { };
+
   devpi-common = callPackage ../development/python-modules/devpi-common { };
 
   dftfit = callPackage ../development/python-modules/dftfit { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python library to work with devolo Home Control.

https://github.com/2Fake/devolo_home_control_api

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
