### PR TITLE
gperftools: drop an option that seems no longer supported

### DIFF
--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, autoreconfHook, libunwind }:
+{ stdenv, lib, fetchurl, fetchpatch, autoreconfHook, libunwind }:
 
 stdenv.mkDerivation rec {
   name = "gperftools-2.8";
@@ -20,20 +20,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   # tcmalloc uses libunwind in a way that works correctly only on non-ARM linux
-  buildInputs = stdenv.lib.optional (stdenv.isLinux && !(stdenv.isAarch64 || stdenv.isAarch32)) libunwind;
+  buildInputs = lib.optional (stdenv.isLinux && !(stdenv.isAarch64 || stdenv.isAarch32)) libunwind;
 
   # Disable general dynamic TLS on AArch to support dlopen()'ing the library:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1483558
-  configureFlags = stdenv.lib.optional (stdenv.isAarch32 || stdenv.isAarch64)
+  configureFlags = lib.optional (stdenv.isAarch32 || stdenv.isAarch64)
     "--disable-general-dynamic-tls";
 
-  prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+  prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace Makefile.am --replace stdc++ c++
     substituteInPlace Makefile.in --replace stdc++ c++
     substituteInPlace libtool --replace stdc++ c++
   '';
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin
     "-D_XOPEN_SOURCE";
 
   # some packages want to link to the static tcmalloc_minimal
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/gperftools/gperftools";
     description = "Fast, multi-threaded malloc() and nifty performance analysis tools";
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/development/libraries/gperftools/default.nix
+++ b/pkgs/development/libraries/gperftools/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin
-    "-D_XOPEN_SOURCE -Wno-aligned-allocation-unavailable";
+    "-D_XOPEN_SOURCE";
 
   # some packages want to link to the static tcmalloc_minimal
   # to drop the runtime dependency on gperftools


### PR DESCRIPTION
> warning: unknown warning option '-Wno-aligned-allocation-unavailable';
>   did you mean '-Wno-debug-compression-unavailable'? [-Wunknown-warning-option]

- - -
Only darwin gets rebuilt, but it needs to be tested.