### PR TITLE
darwin.ps: update to newer unstuck version

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
@@ -60,8 +60,6 @@ in appleDerivation {
     runHook preBuild
 
     bsdmake -C usr-share-locale.tproj
-
-    clang ${recentAdvCmds}/ps/*.c -o ps
   '';
 
   installPhase = ''
@@ -73,13 +71,11 @@ in appleDerivation {
     # install -m 0755 mklocale.tproj/mklocale $locale/bin
 
     install -d 0755 $ps/bin
-    install ps $ps/bin/ps
     touch "$out"
   '';
 
   outputs = [
     "out"
-    "ps"
     "locale"
   ];
   setOutputFlags = false;

--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/default.nix
@@ -1,6 +1,27 @@
-{ lib, stdenv, appleDerivation, xcbuild, ncurses, libutil }:
+{ lib, stdenv, appleDerivation, xcbuild, ncurses, libutil
 
-appleDerivation {
+# loop depends ps -> adv_cmds -> xcbuild -> cmake -> ps, we need a standalone ps to break the chain.
+, psOnly ? false
+}:
+
+if psOnly
+then appleDerivation {
+  setOutputFlags = false;
+  outputs = [ "out" "ps" ];
+
+  buildPhase = ''
+    cd ps
+
+    cc -Os -Wno-#warnings *.c -o ps
+  '';
+
+  installPhase = ''
+    install -D ps -t $ps/bin
+
+    touch $out
+  '';
+}
+else appleDerivation {
   # We can't just run the root build, because https://github.com/facebook/xcbuild/issues/264
 
   patchPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -193,7 +193,7 @@ let
   adv_cmds-boot = applePackage "adv_cmds/boot.nix" "osx-10.5.8" "102ssayxbg9wb35mdmhswbnw0bg7js3pfd8fcbic83c5q3bqa6c6" {};
 
   packages = {
-    inherit (adv_cmds-boot) ps locale;
+    inherit (adv_cmds-boot) locale;
     architecture    = applePackage "architecture"      "osx-10.11.6"     "1pbpjcd7is69hn8y29i98ci0byik826if8gnp824ha92h90w0fq3" {};
     bootstrap_cmds  = applePackage "bootstrap_cmds"    "dev-tools-7.0"   "1v5dv2q3af1xwj5kz0a5g54fd5dm6j4c9dd2g66n4kc44ixyrhp3" {};
     bsdmake         = applePackage "bsdmake"           "dev-tools-3.2.6" "11a9kkhz5bfgi1i8kpdkis78lhc6b5vxmhd598fcdgra1jw4iac2" {};

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -47,6 +47,8 @@ in
 
   print-reexports = callPackage ../os-specific/darwin/apple-sdk/print-reexports { };
 
+  inherit (darwin.adv_cmds.override { psOnly = true; }) ps;
+
   maloader = callPackage ../os-specific/darwin/maloader {
     inherit (darwin) opencflite;
   };


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
darwin.ps is stuck at adv_cmds-158 unnecessarily. It should update with newest adv_cmds.

cc @matthewbauer @veprbl 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
