### PR TITLE
matrix-synapse-rest-password-provider: init at unstable-2020-08-02, matrix-synapse-ldap3, matrix-synapse-pam: Add metadata

### DIFF
--- a/pkgs/servers/matrix-synapse/plugins/default.nix
+++ b/pkgs/servers/matrix-synapse/plugins/default.nix
@@ -3,4 +3,5 @@
 {
   matrix-synapse-ldap3 = callPackage ./ldap3.nix { };
   matrix-synapse-pam = callPackage ./pam.nix { };
+  matrix-synapse-rest-password-provider = callPackage ./rest-password-provider.nix { };
 }

--- a/pkgs/servers/matrix-synapse/plugins/ldap3.nix
+++ b/pkgs/servers/matrix-synapse/plugins/ldap3.nix
@@ -14,4 +14,11 @@ buildPythonPackage rec {
   # ldaptor is not ready for py3 yet
   doCheck = !isPy3k;
   checkInputs = [ ldaptor mock ];
+
+  meta = with lib; {
+    homepage = "https://github.com/matrix-org/matrix-synapse-ldap3";
+    description = "Allows synapse to use LDAP as a password provider";
+    maintainers = teams.matrix.members;
+    license = licenses.asl20;
+  };
 }

--- a/pkgs/servers/matrix-synapse/plugins/pam.nix
+++ b/pkgs/servers/matrix-synapse/plugins/pam.nix
@@ -12,4 +12,11 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ twisted python-pam ];
+
+  meta = with lib; {
+    homepage = "https://github.com/14mRh4X0r/matrix-synapse-pam";
+    description = "Allows Synapse to use UNIX accounts through PAM";
+    maintainers = teams.matrix.members;
+    license = licenses.eupl11;
+  };
 }

--- a/pkgs/servers/matrix-synapse/plugins/rest-password-provider.nix
+++ b/pkgs/servers/matrix-synapse/plugins/rest-password-provider.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "matrix-synapse-rest-password-provider";
+  version = "unstable-2020-08-02";
+
+  src = fetchFromGitHub {
+    owner = "ma1uta";
+    repo = pname;
+    rev = "c782c84aeab1872e73b6c29aadb99d3852e26bbd";
+    sha256 = "0v9900d6919yq05s08ihrc8jclpaixfm8mwi60vhxalmddgwlhjy";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/ma1uta/matrix-synapse-rest-password-provider";
+    description = "Synapse password provider which allows you to validate a password for a given username and return a user profile using an existing backend";
+    maintainers = teams.matrix.members;
+    license = licenses.agpl3Only;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Useful coupled with matrix-corporal

Also adds metadata to the other synapse plugins

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
