### PR TITLE
haste-client: replace bundlerEnv with cleaner bundlerApp

### DIFF
--- a/pkgs/tools/misc/haste-client/Gemfile
+++ b/pkgs/tools/misc/haste-client/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gemspec
+gem 'haste'

--- a/pkgs/tools/misc/haste-client/Gemfile.lock
+++ b/pkgs/tools/misc/haste-client/Gemfile.lock
@@ -1,38 +1,19 @@
-PATH
-  remote: .
-  specs:
-    haste (0.2.3)
-      faraday (~> 0.9)
-      json
-
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.4.4)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    json (2.3.1)
+    haste (0.2.3)
+      faraday (~> 0.9)
+      json
+    json (2.5.1)
     multipart-post (2.1.1)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  haste!
-  rspec
+  haste
 
 BUNDLED WITH
    2.1.4

--- a/pkgs/tools/misc/haste-client/default.nix
+++ b/pkgs/tools/misc/haste-client/default.nix
@@ -1,25 +1,13 @@
 { lib
-, bundlerEnv
+, bundlerApp
 , buildRubyGem
 , ruby
 }:
 
-let 
-  version = "0.2.3";
-  deps = bundlerEnv rec {
-    name = "haste-client-${version}";
-    inherit ruby;
-    gemdir = ./.;
-  };
-in
-buildRubyGem rec {
-  name = "haste-client-${version}";
-  inherit version;
-  gemName = "haste";
-
-  source.sha256 = "0jaq0kvlxwvd0jq9pl707saqnaaal3dis13mqwfjbj121gr4hq4q";
-
-  propagatedBuildInputs = [ deps ];
+bundlerApp rec {
+  pname = "haste";
+  gemdir = ./.;
+  exes = [ "haste" ];
 
   meta = with lib; {
     description = "Command line interface to the AnyStyle Parser and Finder";

--- a/pkgs/tools/misc/haste-client/gemset.nix
+++ b/pkgs/tools/misc/haste-client/gemset.nix
@@ -1,14 +1,4 @@
 {
-  diff-lcs = {
-    groups = ["default" "development"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0m925b8xc6kbpnif9dldna24q1szg4mk0fvszrki837pfn46afmz";
-      type = "gem";
-    };
-    version = "1.4.4";
-  };
   faraday = {
     dependencies = ["multipart-post"];
     groups = ["default"];
@@ -172,159 +162,11 @@
   haste = {
     dependencies = ["faraday" "json"];
     groups = ["default"];
-    platforms = [{
-      engine = "maglev";
-    } {
-      engine = "maglev";
-    } {
-      engine = "maglev";
-      version = "1.8";
-    } {
-      engine = "maglev";
-      version = "1.8";
-    } {
-      engine = "maglev";
-      version = "1.9";
-    } {
-      engine = "maglev";
-      version = "1.9";
-    } {
-      engine = "maglev";
-      version = "2.0";
-    } {
-      engine = "maglev";
-      version = "2.0";
-    } {
-      engine = "maglev";
-      version = "2.1";
-    } {
-      engine = "maglev";
-      version = "2.1";
-    } {
-      engine = "maglev";
-      version = "2.2";
-    } {
-      engine = "maglev";
-      version = "2.2";
-    } {
-      engine = "maglev";
-      version = "2.3";
-    } {
-      engine = "maglev";
-      version = "2.3";
-    } {
-      engine = "maglev";
-      version = "2.4";
-    } {
-      engine = "maglev";
-      version = "2.4";
-    } {
-      engine = "maglev";
-      version = "2.5";
-    } {
-      engine = "maglev";
-      version = "2.5";
-    } {
-      engine = "maglev";
-      version = "2.6";
-    } {
-      engine = "maglev";
-      version = "2.6";
-    } {
-      engine = "rbx";
-    } {
-      engine = "rbx";
-    } {
-      engine = "rbx";
-      version = "1.8";
-    } {
-      engine = "rbx";
-      version = "1.9";
-    } {
-      engine = "rbx";
-      version = "2.0";
-    } {
-      engine = "rbx";
-      version = "2.1";
-    } {
-      engine = "rbx";
-      version = "2.2";
-    } {
-      engine = "rbx";
-      version = "2.3";
-    } {
-      engine = "rbx";
-      version = "2.4";
-    } {
-      engine = "rbx";
-      version = "2.5";
-    } {
-      engine = "rbx";
-      version = "2.6";
-    } {
-      engine = "ruby";
-    } {
-      engine = "ruby";
-    } {
-      engine = "ruby";
-    } {
-      engine = "ruby";
-      version = "1.8";
-    } {
-      engine = "ruby";
-      version = "1.8";
-    } {
-      engine = "ruby";
-      version = "1.9";
-    } {
-      engine = "ruby";
-      version = "1.9";
-    } {
-      engine = "ruby";
-      version = "2.0";
-    } {
-      engine = "ruby";
-      version = "2.0";
-    } {
-      engine = "ruby";
-      version = "2.1";
-    } {
-      engine = "ruby";
-      version = "2.1";
-    } {
-      engine = "ruby";
-      version = "2.2";
-    } {
-      engine = "ruby";
-      version = "2.2";
-    } {
-      engine = "ruby";
-      version = "2.3";
-    } {
-      engine = "ruby";
-      version = "2.3";
-    } {
-      engine = "ruby";
-      version = "2.4";
-    } {
-      engine = "ruby";
-      version = "2.4";
-    } {
-      engine = "ruby";
-      version = "2.5";
-    } {
-      engine = "ruby";
-      version = "2.5";
-    } {
-      engine = "ruby";
-      version = "2.6";
-    } {
-      engine = "ruby";
-      version = "2.6";
-    }];
+    platforms = [];
     source = {
-      path = ./.;
-      type = "path";
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jaq0kvlxwvd0jq9pl707saqnaaal3dis13mqwfjbj121gr4hq4q";
+      type = "gem";
     };
     version = "0.2.3";
   };
@@ -482,10 +324,10 @@
     }];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "158fawfwmv2sq4whqqaksfykkiad2xxrrj0nmpnc6vnlzi1bp7iz";
+      sha256 = "0lrirj0gw420kw71bjjlqkqhqbrplla61gbv1jzgsz6bv90qr3ci";
       type = "gem";
     };
-    version = "2.3.1";
+    version = "2.5.1";
   };
   multipart-post = {
     groups = ["default"];
@@ -645,59 +487,5 @@
       type = "gem";
     };
     version = "2.1.1";
-  };
-  rspec = {
-    dependencies = ["rspec-core" "rspec-expectations" "rspec-mocks"];
-    groups = ["development"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1hzsig4pi9ybr0xl5540m1swiyxa74c8h09225y5sdh2rjkkg84h";
-      type = "gem";
-    };
-    version = "3.9.0";
-  };
-  rspec-core = {
-    dependencies = ["rspec-support"];
-    groups = ["default" "development"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1xndkv5cz763wh30x7hdqw6k7zs8xfh0f86amra9agwn44pcqs0y";
-      type = "gem";
-    };
-    version = "3.9.2";
-  };
-  rspec-expectations = {
-    dependencies = ["diff-lcs" "rspec-support"];
-    groups = ["default" "development"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1bxkv25qmy39jqrdx35bfgw00g24qkssail9jlljm7hywbqvr9bb";
-      type = "gem";
-    };
-    version = "3.9.2";
-  };
-  rspec-mocks = {
-    dependencies = ["diff-lcs" "rspec-support"];
-    groups = ["default" "development"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "19vmdqym1v2g1zbdnq37zwmyj87y9yc9ijwc8js55igvbb9hx0mr";
-      type = "gem";
-    };
-    version = "3.9.1";
-  };
-  rspec-support = {
-    groups = ["default" "development"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0dandh2fy1dfkjk8jf9v4azbbma6968bhh06hddv0yqqm8108jir";
-      type = "gem";
-    };
-    version = "3.9.3";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/135345997

###### Things done
Fixed gem packaging and more by using bundlerApp.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
