### PR TITLE
git-hound: init at 1.3

### DIFF
--- a/pkgs/tools/security/git-hound/default.nix
+++ b/pkgs/tools/security/git-hound/default.nix
@@ -1,0 +1,30 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "git-hound";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "tillson";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1l2bif7qpc1yl93ih01g9jci7ba47rsnpq9js88rz216q93dzmsf";
+  };
+
+  vendorSha256 = "055hpfjbqng513c9rscb8jhnlxj7p82sr8cbsvwnzk569n71qwma";
+
+  meta = with lib; {
+    description = "Reconnaissance tool for GitHub code search";
+    longDescription = ''
+      GitHound pinpoints exposed API keys and other sensitive information
+      across all of GitHub using pattern matching, commit history searching,
+      and a unique result scoring system.
+    '';
+    homepage = "https://github.com/tillson/git-hound";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4420,6 +4420,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  git-hound = callPackage ../tools/security/git-hound { };
+
   git-hub = callPackage ../applications/version-management/git-and-tools/git-hub { };
 
   git-ignore = callPackage ../applications/version-management/git-and-tools/git-ignore { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Reconnaissance tool for GitHub code search.

https://github.com/tillson/git-hound

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
