### PR TITLE
gnomeExtensions.fuzzy-app-search: init at 4

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/fuzzy-app-search/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/fuzzy-app-search/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitLab, gnome3, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-fuzzy-app-search";
+  version = "4";
+
+  src = fetchFromGitLab {
+    owner = "Czarlie";
+    repo = "gnome-fuzzy-app-search";
+    rev = "da9c15d39958d9c3b38df3b616fd40b85aed24e5";
+    sha256 = "1r3qha530s97x818znn1wi76f4x9bhlgi7jlxfwjnrwys62cv5fn";
+  };
+
+  uuid = "gnome-fuzzy-app-search@gnome-shell-extensions.Czarlie.gitlab.com";
+
+  nativeBuildInputs = [ glib ];
+
+  patches = [ ./fix-desktop-file-paths.patch ];
+
+  makeFlags = [ "INSTALL_PATH=$(out)/share/gnome-shell/extensions" ];
+
+  meta = with lib; {
+    description = "Fuzzy application search results for Gnome Search";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ rhoriguchi ];
+    homepage = "https://gitlab.com/Czarlie/gnome-fuzzy-app-search";
+    broken = versionOlder gnome3.gnome-shell.version "3.18";
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/fuzzy-app-search/fix-desktop-file-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/fuzzy-app-search/fix-desktop-file-paths.patch
@@ -1,0 +1,50 @@
+diff --git a/applicationsUtils.js b/applicationsUtils.js
+index 728223b..aa9f291 100644
+--- a/applicationsUtils.js
++++ b/applicationsUtils.js
+@@ -44,27 +44,24 @@ var Search = new Lang.Class({
+      * @return {Void}
+      */
+     _init: function () {
+-        let dir = [
+-            "/usr/share/applications",
+-            GLib.get_home_dir() + "/.local/share/applications",
+-        ];
+-
+-        // listen object - file/monitor list
+-        this._listen = dir.map((path) => {
+-            let file = Gio.File.new_for_path(path);
+-            let monitor = file.monitor(Gio.FileMonitorFlags.NONE, null);
+-
+-            // refresh on each directory change
+-            monitor.connect(
+-                "changed",
+-                Lang.bind(this, this._handleMonitorChanged)
+-            );
+-
+-            return {
+-                file: file,
+-                monitor: monitor,
+-            };
+-        });
++        this._listen = [...new Set(GLib.get_system_data_dirs())]
++            .filter((path) => path.endsWith("/share"))
++            .map((path) => Gio.File.new_for_path(path + "/applications"))
++            .filter((file) => file.query_exists(null))
++            .map((file) => {
++                let monitor = file.monitor(Gio.FileMonitorFlags.NONE, null);
++
++                // refresh on each directory change
++                monitor.connect(
++                    "changed",
++                    Lang.bind(this, this._handleMonitorChanged)
++                );
++
++                return {
++                    file: file,
++                    monitor: monitor,
++                };
++            });
+         this._interval = null;
+         this._data = {};
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27267,6 +27267,7 @@ in
     easyScreenCast = callPackage ../desktops/gnome-3/extensions/EasyScreenCast { };
     emoji-selector = callPackage ../desktops/gnome-3/extensions/emoji-selector { };
     freon = callPackage ../desktops/gnome-3/extensions/freon { };
+    fuzzy-app-search = callPackage ../desktops/gnome-3/extensions/fuzzy-app-search { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience { };


### PR DESCRIPTION
###### Motivation for this change

Add support for [GNOME extension Fuzzy App Search](https://gitlab.com/Czarlie/gnome-fuzzy-app-search)

The patch is necessary because Nix doesn't use `/usr/share/applications` and `~/.local/share/applications`. I've opened a [PR](https://gitlab.com/Czarlie/gnome-fuzzy-app-search/-/merge_requests/1) to apply this patch to the extension.

Example in [README](https://gitlab.com/Czarlie/gnome-fuzzy-app-search/-/blob/master/README.md) works:

![image](https://user-images.githubusercontent.com/6047658/105093686-6d9b5e80-5aa3-11eb-8481-5924726fb828.png)


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
