### PR TITLE
pwdsafety: init at 0.1.4

### DIFF
--- a/pkgs/tools/security/pwdsafety/default.nix
+++ b/pkgs/tools/security/pwdsafety/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "pwdsafety";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "edoardottt";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qnkabgc2924qg9x1ij51jq7lnxzcj1ygdp3x4mzi9gl532i191w";
+  };
+
+  vendorSha256 = "0avm4zwwqv476yrraaf5xkc1lac0mwnmzav5wckifws6r4x3xrsb";
+
+  meta = with lib; {
+    description = "Command line tool checking password safety";
+    homepage = "https://github.com/edoardottt/pwdsafety";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24169,6 +24169,8 @@ in
 
   puremapping = callPackage ../applications/audio/pd-plugins/puremapping { };
 
+  pwdsafety = callPackage ../tools/security/pwdsafety { };
+
   pybitmessage = callPackage ../applications/networking/instant-messengers/pybitmessage { };
 
   qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Command line tool checking password safety

https://github.com/edoardottt/pwdsafety

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
