### PR TITLE
fig2dev: 3.2.7b -> 3.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5128,6 +5128,12 @@
     githubId = 42153076;
     name = "Alexey Nikashkin";
   };
+  lesuisse = {
+    email = "thomas@gerbet.me";
+    github = "LeSuisse";
+    githubId = 737767;
+    name = "Thomas Gerbet";
+  };
   lethalman = {
     email = "lucabru@src.gnome.org";
     github = "lethalman";

--- a/pkgs/applications/graphics/fig2dev/default.nix
+++ b/pkgs/applications/graphics/fig2dev/default.nix
@@ -1,26 +1,32 @@
-{ lib, stdenv, fetchurl, ghostscript, libpng } :
+{ lib, stdenv, fetchurl, ghostscript, libpng, makeWrapper
+, coreutils, bc, gnugrep, gawk, gnused } :
 
-let
-  version = "3.2.7b";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "fig2dev";
-  inherit version;
+  version = "3.2.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/mcj/fig2dev-${version}.tar.xz";
-    sha256 = "1ck8gnqgg13xkxq4hrdy706i4xdgrlckx6bi6wxm1g514121pp27";
+    sha256 = "0zg29yqknfafyzmmln4k7kydfb2dapk3r8ffvlqhj3cm8fp5h4lk";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpng ];
 
   GSEXE="${ghostscript}/bin/gs";
+
+  postInstall = ''
+    wrapProgram $out/bin/fig2ps2tex \
+        --set PATH ${lib.makeBinPath [ coreutils bc gnugrep gawk ]}
+    wrapProgram $out/bin/pic2tpic \
+        --set PATH ${lib.makeBinPath [ gnused ]}
+  '';
 
   meta = with lib; {
     description = "Tool to convert Xfig files to other formats";
     homepage = "http://mcj.sourceforge.net/";
     license = licenses.xfig;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ lesuisse ];
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes the fig2ps2tex and pic2tpic scripts.
Fixes CVE-2019-19746.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
