### PR TITLE
google-fonts: 2019-07-14 -> unstable-2021-01-19

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -1,16 +1,18 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   pname = "google-fonts";
-  version = "2019-07-14";
+  version = "unstable-2021-01-19";
 
   outputs = [ "out" "adobeBlank" ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
-    rev = "f113126dc4b9b1473d9354a86129c9d7b837aa1a";
-    sha256 = "0safw5prpa63mqcyfw3gr3a535w4c9hg5ayw5pkppiwil7n3pyxs";
+    rev = "a3a831f0fe44cd58465c6937ea06873728f2ba0d";
+    sha256 = "19abx2bj7mkysv2ihr43m3kpyf6kv6v2qjlm1skxc82rb72xqhix";
   };
 
   phases = [ "unpackPhase" "patchPhase" "installPhase" ];
@@ -21,18 +23,9 @@ stdenv.mkDerivation {
     # directories. This causes non-determinism in the install since
     # the installation order of font files with the same name is not
     # fixed.
-    rm -rv ofl/alefhebrew \
-      ofl/misssaintdelafield \
-      ofl/mrbedford \
-      ofl/siamreap \
-      ofl/terminaldosislight
-
-    # See comment above, the structure of these is a bit odd
-    # We keep the ofl/<font>/static/ variants
-    rm -rv ofl/comfortaa/*.ttf \
-      ofl/mavenpro/*.ttf \
-      ofl/muli/*.ttf \
-      ofl/oswald/*.ttf
+    rm -rv ofl/cabincondensed \
+           ofl/signikanegative \
+           ofl/signikanegativesc
 
     if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then
       echo "error: duplicate font names"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #109245

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
