### PR TITLE
pkgs/os-specific/windows: fix evaluation after stdenv.lib -> lib

### DIFF
--- a/pkgs/os-specific/windows/cygwin-setup/default.nix
+++ b/pkgs/os-specific/windows/cygwin-setup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchcvs, autoconf, automake, libtool, flex, bison, pkg-config
+{ lib, stdenv, fetchcvs, autoconf, automake, libtool, flex, bison, pkg-config
 , zlib, bzip2, lzma, libgcrypt
 }:
 

--- a/pkgs/os-specific/windows/jom/default.nix
+++ b/pkgs/os-specific/windows/jom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, qt48, qmake4Hook, flex }:
+{ lib, stdenv, fetchgit, qt48, qmake4Hook, flex }:
 
 # At the time of committing this, the expression fails for me to cross-build in
 # both mingw32 and mingw64.

--- a/pkgs/os-specific/windows/libgnurx/default.nix
+++ b/pkgs/os-specific/windows/libgnurx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 let
   version = "2.5.1";

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, windows, fetchurl }:
+{ lib, stdenv, windows, fetchurl }:
 
 let
   version = "6.0.0";

--- a/pkgs/os-specific/windows/wxMSW-2.8/default.nix
+++ b/pkgs/os-specific/windows/wxMSW-2.8/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, compat24 ? false, compat26 ? true, unicode ? true }:
+{ lib, stdenv, fetchurl, compat24 ? false, compat26 ? true, unicode ? true }:
 
 stdenv.mkDerivation {
   name = "wxMSW-2.8.11";


### PR DESCRIPTION
###### Motivation for this change
Fixes the evaluation of packages in pkgs/os-specific/windows that
weren't updated to include a new lib parameter after the refactor from
stdenv.lib -> lib (#109490).

I originally only intended this change to fix
`pkgsCross.mingw32.buildPackages.gcc` & `pkgsCross.mingwW64.buildPackages.gcc`
to support building wine with `mingwSupport`, but I noticed this was
an issue for all updated windows packages. Most of these other
packages fail to build for other reasons.

@siraben @Ericson2314

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).