### PR TITLE
Minimalist iOS fixes

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -65,6 +65,7 @@ let
     && libcxx == null
     && !(stdenv.targetPlatform.useLLVM or false)
     && !(stdenv.targetPlatform.useAndroidPrebuilt or false)
+    && !(stdenv.targetPlatform.isiOS or false)
     && gccForLibs != null;
 
   # older compilers (for example bootstrap's GCC 5) fail with -march=too-modern-cpu

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11870,7 +11870,6 @@ in
     # Can only do this is in the native case, otherwise we might get infinite
     # recursion if `targetPackages.stdenv.cc.cc` itself uses `gccForLibs`.
       then targetPackages.stdenv.cc.cc
-    else if targetPlatform.isiOS then null
     else gcc.cc;
 
   libstdcxx5 = callPackage ../development/libraries/gcc/libstdc++/5.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11624,6 +11624,7 @@ in
   bingrep = callPackage ../development/tools/analysis/bingrep { };
 
   binutils-unwrapped = callPackage ../development/tools/misc/binutils {
+    autoreconfHook = if targetPlatform.isiOS then autoreconfHook269 else autoreconfHook;
     # FHS sys dirs presumably only have stuff for the build platform
     noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
   };
@@ -11869,6 +11870,7 @@ in
     # Can only do this is in the native case, otherwise we might get infinite
     # recursion if `targetPackages.stdenv.cc.cc` itself uses `gccForLibs`.
       then targetPackages.stdenv.cc.cc
+    else if targetPlatform.isiOS then null
     else gcc.cc;
 
   libstdcxx5 = callPackage ../development/libraries/gcc/libstdc++/5.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix errors encountered when executing
```
NIXPKGS_ALLOW_UNFREE=1 nix-build -A pkgsCross.iphone64.hello
```

Will also require #100687 to do a full iOS build with modern XCode. I've tried to constrain the changes to iOS as much as possible.

```
building '/nix/store/cib8df7j0qr45fsh04dyp7m0hy1q51p6-aarch64-apple-ios-binutils-2.35.1.drv'...
unpacking sources
unpacking source archive /nix/store/d4lh03b725krh9f398aqqmym17v017jv-binutils-2.35.1.tar.bz2
source root is binutils-2.35.1
setting SOURCE_DATE_EPOCH to timestamp 1600512050 of file binutils-2.35.1/md5.sum
patching sources
applying patch /nix/store/sqbhaaayam0xw3a3164ks1vvbrdhl9vq-deterministic.patch
patching file ld/ldlang.c
Hunk #1 succeeded at 3459 with fuzz 2 (offset 364 lines).
applying patch /nix/store/wilglaz00r3zpqy6j5awrzia446lzmk9-disambiguate-arm-targets.patch
patching file bfd/elf32-arm.c
Hunk #1 succeeded at 20324 with fuzz 2 (offset 739 lines).
Hunk #2 succeeded at 20947 with fuzz 2 (offset 970 lines).
applying patch /nix/store/pa83jbilxjpv5d4f62l3as4wg2fri7r7-always-search-rpath.patch
patching file ld/genscripts.sh
Hunk #1 succeeded at 171 (offset 46 lines).
applying patch /nix/store/v59hxkx5s235akv3gyvi4y2hcj0qpn40-support-ios.patch
patching file bfd/config.bfd
Hunk #1 succeeded at 223 with fuzz 1 (offset -15 lines).
Hunk #2 succeeded at 329 (offset -29 lines).
Hunk #3 succeeded at 589 with fuzz 2 (offset -89 lines).
Hunk #4 succeeded at 642 (offset -120 lines).
Hunk #5 succeeded at 1113 (offset -289 lines).
patching file configure.ac
Hunk #1 succeeded at 515 (offset 5 lines).
Hunk #2 succeeded at 689 (offset -11 lines).
Hunk #3 succeeded at 777 (offset -11 lines).
Hunk #4 succeeded at 802 (offset 5 lines).
Hunk #5 succeeded at 921 (offset 5 lines).
Hunk #6 succeeded at 1241 (offset 15 lines).
Hunk #7 succeeded at 1729 (offset 32 lines).
Hunk #8 succeeded at 1740 (offset 32 lines).
Hunk #9 succeeded at 2622 (offset 32 lines).
autoreconfPhase
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force
configure.ac:34: error: Please use exactly Autoconf 2.69 instead of 2.70.
config/override.m4:12: _GCC_AUTOCONF_VERSION_CHECK is expanded from...
configure.ac:34: the top level
autom4te: error: /nix/store/6whqq3syk9i3lp5c913d07gpacc3n12h-gnum4-1.4.18/bin/m4 failed with exit status: 1
aclocal: error: /nix/store/x7rbmrkmakawrjspgx1402szd1gx9g34-autoconf-2.70/bin/autom4te failed with exit status: 1
autoreconf: error: aclocal failed with exit status: 1
builder for '/nix/store/cib8df7j0qr45fsh04dyp7m0hy1q51p6-aarch64-apple-ios-binutils-2.35.1.drv' failed with exit code 1
```
```
patching script interpreter paths in ./gcc/configure                                                                                                                                                                                                                                                                                                                    [762/1815]
./gcc/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./zlib/configure
./zlib/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./gnattools/configure
./gnattools/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libstdc++-v3/configure
./libstdc++-v3/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libphobos/configure
./libphobos/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libgo/configure
./libgo/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libitm/configure
patching script interpreter paths in ./libgomp/configure
./libgomp/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./gotools/configure
./gotools/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libcc1/configure
./libcc1/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./lto-plugin/configure
./lto-plugin/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./fixincludes/configure
./fixincludes/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libdecnumber/configure
./libdecnumber/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libvtv/configure
./libvtv/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libquadmath/configure
./libquadmath/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libffi/configure
./libffi/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
patching script interpreter paths in ./libcpp/configure
./libcpp/configure: interpreter directive changed from " /bin/sh" to "/nix/store/fb2pkc446jgwxn98hgabhsjkj7scb57y-bash-4.4-p23/bin/sh"
fixing the `GLIBC_DYNAMIC_LINKER', `UCLIBC_DYNAMIC_LINKER', and `MUSL_DYNAMIC_LINKER' macros...
  fixing `gcc/config/kfreebsd-gnu.h'...
  fixing `gcc/config/kopensolaris-gnu.h'...
  fixing `gcc/config/aarch64/aarch64-freebsd.h'...
  fixing `gcc/config/aarch64/aarch64-linux.h'...
  fixing `gcc/config/alpha/linux-elf.h'...
  fixing `gcc/config/arc/linux.h'...
  fixing `gcc/config/arm/freebsd.h'...
  fixing `gcc/config/arm/linux-eabi.h'...
  fixing `gcc/config/arm/linux-elf.h'...
  fixing `gcc/config/c6x/uclinux-elf.h'...
  fixing `gcc/config/cris/linux.h'...
  fixing `gcc/config/csky/csky-linux-elf.h'...
  fixing `gcc/config/frv/linux.h'...
  fixing `gcc/config/i386/dragonfly.h'...
  fixing `gcc/config/i386/freebsd.h'...
  fixing `gcc/config/i386/freebsd64.h'...
  fixing `gcc/config/i386/gnu-user.h'...
  fixing `gcc/config/i386/gnu-user64.h'...
  fixing `gcc/config/i386/gnu.h'...
  fixing `gcc/config/i386/kfreebsd-gnu.h'...
  fixing `gcc/config/i386/kfreebsd-gnu64.h'...
  fixing `gcc/config/i386/linux.h'...
  fixing `gcc/config/i386/linux64.h'...
  fixing `gcc/config/ia64/freebsd.h'...
  fixing `gcc/config/ia64/linux.h'...
  fixing `gcc/config/m32r/linux.h'...
  fixing `gcc/config/m68k/linux.h'...
  fixing `gcc/config/microblaze/linux.h'...
  fixing `gcc/config/mips/gnu-user.h'...
  fixing `gcc/config/mips/linux.h'...
  fixing `gcc/config/mn10300/linux.h'...
  fixing `gcc/config/nds32/linux.h'...
  fixing `gcc/config/nios2/linux.h'...
  fixing `gcc/config/or1k/linux.h'...
  fixing `gcc/config/pa/pa-linux.h'...
  fixing `gcc/config/riscv/freebsd.h'...
  fixing `gcc/config/riscv/linux.h'...
  fixing `gcc/config/rs6000/freebsd64.h'...
  fixing `gcc/config/rs6000/linux.h'...
  fixing `gcc/config/rs6000/linux64.h'...
  fixing `gcc/config/rs6000/sysv4.h'...
  fixing `gcc/config/rs6000/sysv4le.h'...
  fixing `gcc/config/s390/linux.h'...
  fixing `gcc/config/sh/linux.h'...
  fixing `gcc/config/sparc/freebsd.h'...
  fixing `gcc/config/sparc/linux.h'...
  fixing `gcc/config/sparc/linux64.h'...
  fixing `gcc/config/xtensa/linux.h'...
configuring
configure flags: --prefix=/nix/store/9ri3ki02y0g3xra4q89wkyicwsm7fw60-aarch64-apple-ios-stage-final-gcc-debug-9.3.0 --with-gmp-include=/nix/store/5vd8zlhqw1r72skk3q4w5xqs9lsy51jc-gmp-6.2.1-dev/include --with-gmp-lib=/nix/store/n4aza7g2h3zczw2m6f5p9zhq1fxiksig-gmp-6.2.1/lib --with-mpfr-include=/nix/store/n9afyjrs4vs5h2fjf36jpmz9f563y9yb-mpfr-4.1.0-dev/include --with-mp
fr-lib=/nix/store/80y0bfq12lbp0r85v8k7xjv7wp14czh6-mpfr-4.1.0/lib --with-mpc=/nix/store/bmr3bd594kx554ws1bh6dz7vdk3pfdg5-libmpc-1.2.0 --with-libelf=/nix/store/0pwj6h661yyzq6cdlx2jlr05cyd2v7wr-libelf-0.8.13 --with-native-system-header-dir=/nix/store/3p9zc7f67s0a7vi0midqp4dyzlfchv7k-Libsystem-osx-10.12.6/include --enable-lto --disable-libstdcxx-pch --without-included-ge
ttext --with-system-zlib --enable-static --enable-languages=c\,c++\,objc\,obj-c++\,objc\,obj-c++ --disable-multilib --enable-plugin --with-isl=/nix/store/62xw0v5w8x4y41xmsasis3whh8j95gyp-isl-0.20 --with-as=/nix/store/24la5i00inffpfjwsv09fncl90s2zf92-aarch64-apple-ios-cctools-binutils-darwin-wrapper-949.0.1/bin/aarch64-apple-ios-as --with-ld=/nix/store/24la5i00inffpfjw
sv09fncl90s2zf92-aarch64-apple-ios-cctools-binutils-darwin-wrapper-949.0.1/bin/aarch64-apple-ios-ld --with-sysroot=/nix/store/vvswvml33cj44ly90jyxmp85q6gj0l26-libSystem-prebuilt/share/sysroot --enable-__cxa_atexit --enable-long-long --enable-threads=posix --enable-nls --disable-decimal-float --disable-bootstrap --with-specs=%\{\!fno-common:%\{\!fcommon:-fcommon\}\} --
build=x86_64-apple-darwin --host=x86_64-apple-darwin --target=aarch64-apple-ios
checking build system type... x86_64-apple-darwin
checking host system type... x86_64-apple-darwin
checking target system type... aarch64-apple-ios
checking for a BSD-compatible install... /nix/store/la203av8kn0ys79yykjbwkiip7li95c1-coreutils-8.32/bin/install -c
checking whether ln works... yes
checking whether ln -s works... yes
checking for a sed that does not truncate output... /nix/store/z7l0bq1fcz60v6h57xb4ad8wllma29hm-gnused-4.8/bin/sed
checking for gawk... gawk
checking for libatomic support... no
checking for libitm support... no
checking for libsanitizer support... no
checking for libvtv support... no
checking for libhsail-rt support... no
checking for libphobos support... no
checking for x86_64-apple-darwin-gcc... clang
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether clang accepts -g... yes
checking for clang option to accept ISO C89... none needed
checking whether we are using the GNU C++ compiler... yes
checking whether clang++ accepts -g... yes
checking whether g++ accepts -static-libstdc++ -static-libgcc... no
checking for x86_64-apple-darwin-gnatbind... no
checking for gnatbind... no
checking for x86_64-apple-darwin-gnatmake... no
checking for gnatmake... no
checking whether compiler driver understands Ada... no
checking how to compare bootstrapped objects... cmp --ignore-initial=16 $$f1 $$f2
checking for objdir... .libs
checking for the correct version of gmp.h... yes
checking for the correct version of mpfr.h... yes
checking for the correct version of mpc.h... yes
checking for the correct version of the gmp/mpfr/mpc libraries... yes
checking for isl 0.15 or later... yes
configure: error:
The following requested languages could not be built: objc,obj-c++
Supported languages are: c,brig,c,c++,d,fortran,go,lto,objc,obj-c++
builder for '/nix/store/12ckg02rdg613c4k2kim1kvhfk2wvrcg-aarch64-apple-ios-stage-final-gcc-debug-9.3.0.drv' failed with exit code 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [*] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
