### PR TITLE
xortool: init at 1.0.0

### DIFF
--- a/pkgs/tools/security/xortool/default.nix
+++ b/pkgs/tools/security/xortool/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonApplication
+, docopt
+, fetchFromGitHub
+, importlib-metadata
+, poetry-core
+}:
+
+buildPythonApplication rec {
+  pname = "xortool";
+  version = "1.0.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "hellman";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19lfadi28r89bl5q8fhrxgjgs3nx3kgjd4rdg7wbvzi1cn29c5n7";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ docopt importlib-metadata ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "xortool" ];
+
+  meta = with lib; {
+    description = "Tool to analyze multi-byte XOR cipher";
+    homepage = "https://github.com/hellman/xortool";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29245,6 +29245,8 @@ in
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };
 
+  xortool = python3Packages.callPackage ../tools/security/xortool { };
+
   xow = callPackage ../misc/drivers/xow { };
 
   xbps = callPackage ../tools/package-management/xbps { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to analyze multi-byte XOR cipher

https://github.com/hellman/xortool

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
