### PR TITLE
cifs-utils: missing python3 dependency for smbinfo

### DIFF
--- a/nixos/tests/cifs-utils.nix
+++ b/nixos/tests/cifs-utils.nix
@@ -1,0 +1,12 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "cifs-utils";
+
+  machine = { pkgs, ... }: { environment.systemPackages = [ pkgs.cifs-utils ]; };
+
+  testScript = ''
+    machine.succeed("smbinfo -h")
+    machine.succeed("smb2-quota -h")
+    assert "${pkgs.cifs-utils.version}" in machine.succeed("cifs.upcall -v")
+    assert "${pkgs.cifs-utils.version}" in machine.succeed("mount.cifs -V")
+  '';
+})

--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, autoreconfHook, docutils, pkg-config
-, kerberos, keyutils, pam, talloc }:
+, kerberos, keyutils, pam, talloc, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "cifs-utils";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook docutils pkg-config ];
 
-  buildInputs = [ kerberos keyutils pam talloc ];
+  buildInputs = [ kerberos keyutils pam talloc python3 ];
 
   configureFlags = [ "ROOTSBINDIR=$(out)/sbin" ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Since cifs-utils 6.12, smbinfo needs Python to be usable.

Issue introduced in 033208fd46e03178655f3c4a59add1d9dbf57731.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
