### PR TITLE
zoom-us: Make update script get exact version

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
@@ -3,6 +3,8 @@
 
 set -eu -o pipefail
 
-version="$(curl -Ls https://zoom.us/download\?os\=linux | pup '.linux-ver-text text{}' | cut -d' ' -f2)"
+version="$(curl -Ls https://zoom.us/download\?os\=linux | \
+  pup '.linux-ver-text text{}' | \
+  awk -F'[ ().]' '{printf $2"."$3"."$6"."$7"\n"}')"
 
 update-source-version zoom-us "$version"


### PR DESCRIPTION
Their website has changed the format in which they display the version,
into something a bit more sophisticated.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
