### PR TITLE
pythonPackages.pytest-instafail: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/pytest-instafail/default.nix
+++ b/pkgs/development/python-modules/pytest-instafail/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-instafail";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10lpr6mjcinabqynj6v85bvb1xmapnhqmg50nys1r6hg7zgky9qr";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "pytest plugin that shows failures and errors instantly instead of waiting until the end of test session";
+    homepage = "https://github.com/pytest-dev/pytest-instafail";
+    license = lib.licenses.free;
+    maintainers = [ lib.maintainers.jacg ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-instafail/default.nix
+++ b/pkgs/development/python-modules/pytest-instafail/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytestCheckHook ];
-
+  pythonImportsCheck = [ "pytest_instafail" ];
   meta = {
     description = "pytest plugin that shows failures and errors instantly instead of waiting until the end of test session";
     homepage = "https://github.com/pytest-dev/pytest-instafail";

--- a/pkgs/development/python-modules/pytest-instafail/default.nix
+++ b/pkgs/development/python-modules/pytest-instafail/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   meta = {
     description = "pytest plugin that shows failures and errors instantly instead of waiting until the end of test session";
     homepage = "https://github.com/pytest-dev/pytest-instafail";
-    license = lib.licenses.free;
+    license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.jacg ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6031,6 +6031,8 @@ in {
 
   pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
 
+  pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
+
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };
 
   pytest-lazy-fixture = callPackage ../development/python-modules/pytest-lazy-fixture { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package not yet available in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
