### PR TITLE
pythonPackages.pytest-order: init at 0.9.4

### DIFF
--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -19,14 +19,14 @@ buildPythonPackage rec {
     sha256 = "1mfw2x8r5hn4g5cd6jca92lvqrd9297gsc5bvz18dzjlrm8zlycc";
   };
 
-  propagatedBuildInputs = [
-    pytest
+  propagatedBuildInputs = [ pytest ];
+
+  checkInputs = [
+    pytestCheckHook
     pytest-xdist
     pytest-dependency
     pytest-mock
   ];
-
-  checkInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Pytest plugin that allows you to customize the order in which your tests are run";

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-order";
+  version = "0.9.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qd9zfpcbzm43knkg3ap22wssqabc2wn5ynlgg661xg6r6g6iy4k";
+  };
+
+  propagatedBuildInputs = [ pytest ];
+
+  meta = {
+    description = "Pytest plugin that allows you to customize the order in which your tests are run";
+    homepage = "https://github.com/mrbean-bremen/pytest-order";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jacg ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , lib
 , pytest
 , pytest-xdist
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pytest-order";
-  version = "0.9.3";
+  version = "0.9.4";
 
-  src = fetchFromGitHub {
-    owner = "mrbean-bremen";
-    repo = "pytest-order";
-    rev = "486e0966c651f3c57bbc2172e9914e478de55b6b";
-    sha256 = "1mfw2x8r5hn4g5cd6jca92lvqrd9297gsc5bvz18dzjlrm8zlycc";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b7i8z6rywnkb3skyg8bnfqgkjrwvkn64b4q07wfl1q7x65ksd26";
   };
+
+  checkPhase = false;
 
   propagatedBuildInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -17,8 +17,6 @@ buildPythonPackage rec {
     sha256 = "0b7i8z6rywnkb3skyg8bnfqgkjrwvkn64b4q07wfl1q7x65ksd26";
   };
 
-  checkPhase = false;
-
   propagatedBuildInputs = [ pytest ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pytest-order/default.nix
+++ b/pkgs/development/python-modules/pytest-order/default.nix
@@ -1,19 +1,32 @@
 { buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , lib
 , pytest
+, pytest-xdist
+, pytest-dependency
+, pytest-mock
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pytest-order";
   version = "0.9.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1qd9zfpcbzm43knkg3ap22wssqabc2wn5ynlgg661xg6r6g6iy4k";
+  src = fetchFromGitHub {
+    owner = "mrbean-bremen";
+    repo = "pytest-order";
+    rev = "486e0966c651f3c57bbc2172e9914e478de55b6b";
+    sha256 = "1mfw2x8r5hn4g5cd6jca92lvqrd9297gsc5bvz18dzjlrm8zlycc";
   };
 
-  propagatedBuildInputs = [ pytest ];
+  propagatedBuildInputs = [
+    pytest
+    pytest-xdist
+    pytest-dependency
+    pytest-mock
+  ];
+
+  checkInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Pytest plugin that allows you to customize the order in which your tests are run";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6050,6 +6050,8 @@ in {
 
   pytest-openfiles = callPackage ../development/python-modules/pytest-openfiles { };
 
+  pytest-order = callPackage ../development/python-modules/pytest-order { };
+
   pytest-ordering = callPackage ../development/python-modules/pytest-ordering { };
 
   pytest-pep257 = callPackage ../development/python-modules/pytest-pep257 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package not yet available in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
