### PR TITLE
pythonPackages.ldaptor: run tests

### DIFF
--- a/pkgs/development/python-modules/ldaptor/default.nix
+++ b/pkgs/development/python-modules/ldaptor/default.nix
@@ -3,12 +3,13 @@
 , fetchPypi
 , twisted
 , passlib
-, pycrypto
 , pyopenssl
 , pyparsing
 , service-identity
 , zope_interface
 , isPy3k
+, pythonAtLeast
+, python
 }:
 
 buildPythonPackage rec {
@@ -21,13 +22,15 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    twisted passlib pycrypto pyopenssl pyparsing service-identity zope_interface
+    twisted passlib pyopenssl pyparsing service-identity zope_interface
   ];
 
-  disabled = isPy3k;
+  # https://github.com/twisted/ldaptor/pull/210
+  disabled = !isPy3k || pythonAtLeast "3.9";
 
-  # TypeError: None is neither bytes nor unicode
-  doCheck = false;
+  checkPhase = ''
+    ${python.interpreter} -m twisted.trial ldaptor
+  '';
 
   meta = {
     description = "A Pure-Python Twisted library for LDAP";

--- a/pkgs/development/python-modules/privacyidea/ldap-proxy.nix
+++ b/pkgs/development/python-modules/privacyidea/ldap-proxy.nix
@@ -1,8 +1,11 @@
-{ lib, buildPythonPackage, fetchFromGitHub, twisted, ldaptor, configobj }:
+{ lib, buildPythonPackage, isPy3k, fetchFromGitHub, twisted, ldaptor, configobj }:
 
 buildPythonPackage rec {
   pname = "privacyidea-ldap-proxy";
   version = "0.6.1";
+
+  # https://github.com/privacyidea/privacyidea-ldap-proxy/issues/50
+  disabled = isPy3k;
 
   src = fetchFromGitHub {
     owner = "privacyidea";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @lheckemann This completely disables privacyidea-ldap-proxy since that project does not support Python 3 while ldaptor does not support Python 2.