### PR TITLE
haskellPackages.glicko: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5617,7 +5617,6 @@ broken-packages:
   - GLFW-OGL
   - GLFW-task
   - gli
-  - glicko
   - glider-nlp
   - GLMatrix
   - glob-posix


### PR DESCRIPTION
I'm the author of the package and fixed the dependencies upstream, now builds correctly and can be unmarked as broken.

Tested with current unstable (4eccd6f73).
```
nix-shell -p 'haskellPackages.ghcWithPackages (pkgs: [pkgs.glicko])' -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/4eccd6f731627ba5ad9915bcf600c9329a34ca78.tar.gz
```