### PR TITLE
mednaffe: small fixup

### DIFF
--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -1,7 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, autoreconfHook, pkg-config, wrapGAppsHook
-, gtk2 ? null, gtk3 ? null, mednafen }:
-
-with lib;
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, mednafen
+, gtk2 ? null
+, gtk3 ? null
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "mednaffe";
@@ -14,13 +20,20 @@ stdenv.mkDerivation rec {
     sha256 = "15qk3a3l1phr8bap2ayh3c0vyvw2jwhny1iz1ajq2adyjpm9fhr7";
   };
 
-  nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config wrapGAppsHook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config wrapGAppsHook ];
   buildInputs = [ gtk2 gtk3 mednafen ];
 
-  configureFlags = [ (enableFeature (gtk3 != null) "gtk3") ];
-  postInstall = "wrapProgram $out/bin/mednaffe --set PATH ${mednafen}/bin";
+  configureFlags = [ (lib.enableFeature (gtk3 != null) "gtk3") ];
 
-  meta = {
+  dontWrapGApps = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/mednaffe \
+      --prefix PATH ':' "${mednafen}/bin" \
+      "''${gappsWrapperArgs[@]}"
+   '';
+
+  meta = with lib; {
     description = "GTK-based frontend for mednafen emulator";
     homepage = "https://github.com/AmatCoder/mednaffe";
     license = licenses.gpl3Plus;


### PR DESCRIPTION
A fixup to the ubiquitous problem of "GTK variables not found". Now the app
doesn't segfault when opening a window.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
