### PR TITLE
twemoji-color-font: use prebuilt ttf, 12.0.1 -> 13.0.1

### DIFF
--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "twemoji-color-font";
-  version = "12.0.1";
+  version = "13.0.1";
 
   # We fetch the prebuilt font because building it takes 1.5 hours on hydra.
   # Relevant issue: https://github.com/NixOS/nixpkgs/issues/97871
   src = fetchurl {
     url = "https://github.com/eosrei/twemoji-color-font/releases/download/v${version}/TwitterColorEmoji-SVGinOT-Linux-${version}.tar.gz";
-    sha256 = "1kdy2k7b1k7sjp2l8g10lp2v000iwk8i3wcwgkhqfbwrrj7dg1kq";
+    sha256 = "1mn2cb6a3v0q8i81s9a8bk49nbwxq91n6ki7827i7rhjkncb0mbn";
   };
 
   dontBuild = true;

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -1,37 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, inkscape, imagemagick, potrace, svgo, scfbuild }:
+{ lib
+, stdenv
+, fetchurl
+}:
 
 stdenv.mkDerivation rec {
   pname = "twemoji-color-font";
   version = "12.0.1";
-  src = fetchFromGitHub {
-    owner = "eosrei";
-    repo = "twemoji-color-font";
-    rev = "v${version}";
-    sha256 = "00pbgqpkq21wl8fs0q1xp49xb10m48b9sz8cdc58flkd2vqfssw2";
+
+  # We fetch the prebuilt font because building it takes 1.5 hours on hydra.
+  # Relevant issue: https://github.com/NixOS/nixpkgs/issues/97871
+  src = fetchurl {
+    url = "https://github.com/eosrei/twemoji-color-font/releases/download/v${version}/TwitterColorEmoji-SVGinOT-Linux-${version}.tar.gz";
+    sha256 = "1kdy2k7b1k7sjp2l8g10lp2v000iwk8i3wcwgkhqfbwrrj7dg1kq";
   };
 
-  patches = [
-    # Fix build with Inkscape 1.0
-    # https://github.com/eosrei/twemoji-color-font/pull/82
-    (fetchpatch {
-      url = "https://github.com/eosrei/twemoji-color-font/commit/208ad63c2ceb38c528b5237abeb2b85ceedc1d37.patch";
-      sha256 = "TV8I++BEnVUQg7FNbnrEQ/MLV9n3drmspqjmDZgTGFI=";
-      postFetch = ''
-        substituteInPlace $out \
-          --replace "inkscape --without-gui" "inkscape --export-png"
-      '';
-    })
-  ];
-
-  nativeBuildInputs = [ inkscape imagemagick potrace svgo scfbuild ];
-  # silence inkscape errors about non-writable home
-  preBuild = "export HOME=\"$NIX_BUILD_ROOT\"";
-  makeFlags = [ "SCFBUILD=${scfbuild}/bin/scfbuild" ];
-  enableParallelBuilding = true;
+  dontBuild = true;
 
   installPhase = ''
-    install -Dm755 build/TwitterColorEmoji-SVGinOT.ttf $out/share/fonts/truetype/TwitterColorEmoji-SVGinOT.ttf
-    install -Dm644 linux/fontconfig/56-twemoji-color.conf $out/etc/fonts/conf.d/56-twemoji-color.conf
+    install -Dm755 TwitterColorEmoji-SVGinOT.ttf $out/share/fonts/truetype/TwitterColorEmoji-SVGinOT.ttf
+    install -Dm644 fontconfig/56-twemoji-color.conf $out/etc/fonts/conf.d/56-twemoji-color.conf
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20676,9 +20676,7 @@ in
 
   ttf-tw-moe = callPackage ../data/fonts/ttf-tw-moe { };
 
-  twemoji-color-font = callPackage ../data/fonts/twemoji-color-font {
-    inherit (nodePackages) svgo;
-  };
+  twemoji-color-font = callPackage ../data/fonts/twemoji-color-font { };
 
   twitter-color-emoji = callPackage ../data/fonts/twitter-color-emoji { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #97871

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
