### PR TITLE
rauc: init at 1.5

### DIFF
--- a/pkgs/tools/misc/rauc/default.nix
+++ b/pkgs/tools/misc/rauc/default.nix
@@ -1,0 +1,50 @@
+{ autoreconfHook
+, curl
+, dbus
+, fetchFromGitHub
+, glib
+, json-glib
+, lib
+, nix-update-script
+, openssl
+, pkg-config
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rauc";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10v9nllfw5y53797p00hk6645zkaa6cacsim1rh6y2jngnqfkmw0";
+  };
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = pname;
+    };
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  buildInputs = [ curl dbus glib json-glib openssl ];
+
+  configureFlags = [
+    "--with-dbusinterfacesdir=${placeholder "out"}/share/dbus-1/interfaces"
+    "--with-dbuspolicydir=${placeholder "out"}/share/dbus-1/systemd.d"
+    "--with-dbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"
+  ];
+
+  meta = with lib; {
+    description = "Safe and secure software updates for embedded Linux";
+    homepage = "https://rauc.io";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ emantor ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28888,6 +28888,8 @@ in
 
   rargs = callPackage ../tools/misc/rargs { };
 
+  rauc = callPackage ../tools/misc/rauc { };
+
   redprl = callPackage ../applications/science/logic/redprl { };
 
   renderizer = pkgs.callPackage ../development/tools/renderizer {};


### PR DESCRIPTION
###### Motivation for this change
The Robust Auto Update Controller is an update program for embedded
systems. Primarily useful in NixOS for working with bundles.


###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
