### PR TITLE
pcsc-safenet: init at 10.0.37-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9834,6 +9834,12 @@
     githubId = 43315;
     name = "William Roe";
   };
+  wldhx = {
+    email = "wldhx+nixpkgs@wldhx.me";
+    github = "wldhx";
+    githubId = 15619766;
+    name = "wldhx";
+  };
   wmertens = {
     email = "Wout.Mertens@gmail.com";
     github = "wmertens";

--- a/pkgs/tools/security/pcsc-safenet/default.nix
+++ b/pkgs/tools/security/pcsc-safenet/default.nix
@@ -1,0 +1,96 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, gtk2
+, openssl
+, pcsclite
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pcsc-safenet";
+  version = "10.0.37-0";
+
+  # https://aur.archlinux.org/packages/sac-core/
+  src = fetchurl {
+    url = "https://storage.spidlas.cz/public/soft/safenet/SafenetAuthenticationClient-core-${version}_amd64.deb";
+    sha256 = "1r9739bhal7ramj1rpawaqvik45xbs1c756l1da96din638gzy5l";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  buildInputs = [
+    gtk2
+    openssl
+    pcsclite
+  ];
+
+  runtimeDependencies = [
+    openssl
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  installPhase = ''
+    # Set up for pcsc drivers
+    mkdir -p pcsc/drivers
+    mv usr/share/eToken/drivers/* pcsc/drivers/
+    rm -r usr/share/eToken/drivers
+
+    # Move binaries out
+    mv usr/bin bin
+
+    # Move UI to bin
+    mv usr/share/SAC/SACUIProcess bin/
+    rm -r usr/share/SAC
+
+    mkdir $out
+    cp -r {bin,etc,lib,pcsc,usr,var} $out/
+
+    cd "$out/lib/"
+    ln -sf libeToken.so.10.0.37 libeTPkcs11.so
+    ln -sf libeToken.so.10.0.37 libeToken.so.10.0
+    ln -sf libeToken.so.10.0.37 libeToken.so.10
+    ln -sf libeToken.so.10.0.37 libeToken.so
+    ln -sf libcardosTokenEngine.so.10.0.37 libcardosTokenEngine.so.10.0
+    ln -sf libcardosTokenEngine.so.10.0.37 libcardosTokenEngine.so.10
+    ln -sf libcardosTokenEngine.so.10.0.37 libcardosTokenEngine.so
+
+    cd $out/pcsc/drivers/aks-ifdh.bundle/Contents/Linux/
+    ln -sf libAksIfdh.so.10.0 libAksIfdh.so
+    ln -sf libAksIfdh.so.10.0 libAksIfdh.so.10
+
+    ln -sf ${openssl.out}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
+  '';
+
+  dontAutoPatchelf = true;
+
+  # Patch DYN shared libraries (autoPatchElfHook only patches EXEC | INTERP).
+  postFixup = ''
+    autoPatchelf "$out"
+
+    runtime_rpath="${lib.makeLibraryPath runtimeDependencies}"
+
+    for mod in $(find "$out" -type f -name '*.so.*'); do
+      mod_rpath="$(patchelf --print-rpath "$mod")"
+      patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
+    done;
+  '';
+
+  meta = with lib; {
+    homepage = "https://safenet.gemalto.com/multi-factor-authentication/security-applications/authentication-client-token-management";
+    description = "Safenet Authentication Client";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ wldhx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6891,6 +6891,8 @@ in
 
   pcsc-cyberjack = callPackage ../tools/security/pcsc-cyberjack { };
 
+  pcsc-safenet = callPackage ../tools/security/pcsc-safenet { };
+
   pcsc-scm-scl011 = callPackage ../tools/security/pcsc-scm-scl011 { };
   ifdnfc = callPackage ../tools/security/ifdnfc { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A new take on #77786. Pcsc support for Aladdin / e5100 tokens, works for me with 0529:0620.

Closes #77786

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
