### PR TITLE
firewall: move rpfilter to mangle.PREROUTING to fix conntrack

### DIFF
--- a/nixos/modules/services/networking/wg-quick.nix
+++ b/nixos/modules/services/networking/wg-quick.nix
@@ -328,9 +328,6 @@ in {
   config = mkIf (cfg.interfaces != {}) {
     boot.extraModulePackages = optional (versionOlder kernel.kernel.version "5.6") kernel.wireguard;
     environment.systemPackages = [ pkgs.wireguard-tools ];
-    # This is forced to false for now because the default "--validmark" rpfilter we apply on reverse path filtering
-    # breaks the wg-quick routing because wireguard packets leave with a fwmark from wireguard.
-    networking.firewall.checkReversePath = false;
     systemd.services = mapAttrs' generateUnit cfg.interfaces;
 
     # Prevent networkd from clearing the rules set by wg-quick when restarted (e.g. when waking up from suspend).


### PR DESCRIPTION
fix #51258 

make `conntrack` work: `rpfilter` must be in the `mangle` table, after the `conntrack` stage

see [the netfilter flowchart](https://upload.wikimedia.org/wikipedia/commons/3/37/Netfilter-packet-flow.svg): input path, network layer

```
--> raw.prerouting --> conntrack --> mangle.prerouting -->
```

###### Motivation for this change

this patch is needed to make VPN work (wireguard protocol, configured with `wg-quick`, but probably also with openvpn protocol)
otherwise the VPN server is not reachable (response packets are dropped)

workarounds:
* run `ip route add $vpn_server_ip via $local_gateway_ip`, for example `ip route add 1.2.3.4 via 192.168.0.1`. this works, because this explcit route has a higher priority in the `wg-quick` routing config, so the return-path is found correctly
* in `configuration.nix` set `networking.firewall.checkReversePath = false;` to disable `rpfilter` completely (security risk!)

not tested yet, `nixos-rebuild switch` fails to compile (for other reasons than this patch)

thanks to `another` from `#wireguard` at `freenode.net` for finding the bug


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
