### PR TITLE
nixos/tests/chromium: Add ungoogled-chromium and Google Chrome

### DIFF
--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -1,10 +1,14 @@
 { system ? builtins.currentSystem
 , config ? {}
 , pkgs ? import ../.. { inherit system config; }
-, channelMap ? {
-    stable = pkgs.chromium;
-    beta   = pkgs.chromiumBeta;
-    dev    = pkgs.chromiumDev;
+, channelMap ? { # Maps "channels" to packages
+    stable        = pkgs.chromium;
+    beta          = pkgs.chromiumBeta;
+    dev           = pkgs.chromiumDev;
+    ungoogled     = pkgs.ungoogled-chromium;
+    chrome-stable = pkgs.google-chrome;
+    chrome-beta   = pkgs.google-chrome-beta;
+    chrome-dev    = pkgs.google-chrome-dev;
   }
 }:
 
@@ -14,7 +18,7 @@ with pkgs.lib;
 mapAttrs (channel: chromiumPkg: makeTest rec {
   name = "chromium-${channel}";
   meta = {
-    maintainers = with maintainers; [ aszlig ];
+    maintainers = with maintainers; [ aszlig primeos ];
     # https://github.com/NixOS/hydra/issues/591#issuecomment-435125621
     inherit (chromiumPkg.meta) timeout;
   };
@@ -56,6 +60,19 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
     # Run as user alice
     def ru(cmd):
         return "su - ${user} -c " + shlex.quote(cmd)
+
+
+    def get_browser_binary():
+        """Returns the name of the browser binary."""
+        pname = "${getName chromiumPkg.name}"
+        if pname.find("chromium") != -1:
+            return "chromium"  # Same name for all channels and ungoogled-chromium
+        if pname == "google-chrome":
+            return "google-chrome-stable"
+        if pname == "google-chrome-dev":
+            return "google-chrome-unstable"
+        # For google-chrome-beta and as fallback:
+        return pname
 
 
     def create_new_win():
@@ -153,7 +170,14 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
     machine.wait_for_x()
 
     url = "file://${startupHTML}"
-    machine.succeed(ru(f'ulimit -c unlimited; chromium "{url}" & disown'))
+    machine.succeed(ru(f'ulimit -c unlimited; "{get_browser_binary()}" "{url}" & disown'))
+
+    if get_browser_binary().startswith("google-chrome"):
+        # Need to click away the first window:
+        machine.wait_for_text("Make Google Chrome the default browser")
+        machine.screenshot("google_chrome_default_browser_prompt")
+        machine.send_key("ret")
+
     machine.wait_for_text("startup done")
     machine.wait_until_succeeds(
         ru(

--- a/pkgs/applications/networking/browsers/chromium/README.md
+++ b/pkgs/applications/networking/browsers/chromium/README.md
@@ -36,6 +36,21 @@ update `upstream-info.json`. After updates it is important to test at least
 `nixosTests.chromium` (or basic manual testing) and `google-chrome` (which
 reuses `upstream-info.json`).
 
+To run all automated NixOS VM tests for Chromium, ungoogled-chromium,
+and Google Chrome (not recommended, currently 6x tests!):
+```
+nix-build nixos/tests/chromium.nix
+```
+
+A single test can be selected, e.g. to test `ungoogled-chromium` (see
+`channelMap` in `nixos/tests/chromium.nix` for all available options):
+```
+nix-build nixos/tests/chromium.nix -A ungoogled
+```
+(Note: Testing Google Chrome requires `export NIXPKGS_ALLOW_UNFREE=1`.)
+
+For custom builds it's possible to "override" `channelMap`.
+
 ## Backports
 
 All updates are considered security critical and should be ported to the stable


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
