### PR TITLE
git-big-picture: 1.0.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -1,27 +1,20 @@
-{ fetchFromGitHub, python3Packages, lib, git, graphviz }:
+{ python3Packages, lib, git, graphviz }:
 
 python3Packages.buildPythonApplication rec {
   pname = "git-big-picture";
-  version = "1.0.0";
+  version = "1.1.1";
+  format = "wheel";
 
-  src = fetchFromGitHub {
-    owner = "git-big-picture";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "14yf71iwgk78nw8w0bpijsnnl4vg3bvxsw3vvypxmbrc1nh0bdha";
+  src = python3Packages.fetchPypi {
+    inherit format version;
+    pname = "git_big_picture";  # underscores needed for working download URL
+    python = "py3";  # i.e. no Python 2.7
+    sha256 = "a20a480057ced1585c4c38497d27a5012f12dd29697313f0bb8fa6ddbb5c17d8";
   };
-
-  buildInputs = [ git graphviz ];
-
-  # NOTE: Tests are disabled due to unpackaged test dependency "Scruf".
-  #       When bumping to 1.1.0, please re-enable and use:
-  #checkInputs = [ cram git pytest ];
-  #checkPhase = "pytest test.py";
-  doCheck = false;
 
   postFixup = ''
     wrapProgram $out/bin/git-big-picture \
-      --prefix PATH ":" ${ lib.makeBinPath buildInputs  }
+      --prefix PATH ":" ${ lib.makeBinPath [ git graphviz ]  }
     '';
 
   meta = {


### PR DESCRIPTION
- Migrate from `fetchFromGitHub` to `fetchPypi` to ease SHA256 handling
- Integrate test suite
- Install a man page (as shipped by upstream)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
