### PR TITLE
[20.09] opensmtpd: patches for CVE-2020-35679 and CVE-2020-35680

### DIFF
--- a/pkgs/servers/mail/opensmtpd/CVE-2020-35679.patch
+++ b/pkgs/servers/mail/opensmtpd/CVE-2020-35679.patch
@@ -1,0 +1,41 @@
+From 79a034b4aed29e965f45a13409268290c9910043 Mon Sep 17 00:00:00 2001
+From: martijn <martijn@openbsd.org>
+Date: Wed, 23 Dec 2020 08:12:14 +0000
+Subject: [PATCH] Use regfree after we're done with preg.
+
+From gilles@
+---
+ usr.sbin/smtpd/table.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/smtpd/table.c b/smtpd/table.c
+index b79451caadd..1d82d88b81a 100644
+--- a/smtpd/table.c
++++ b/smtpd/table.c
+@@ -1,4 +1,4 @@
+-/*	$OpenBSD: table.c,v 1.48 2019/01/10 07:40:52 eric Exp $	*/
++/*	$OpenBSD: table.c,v 1.49 2020/12/23 08:12:14 martijn Exp $	*/
+ 
+ /*
+  * Copyright (c) 2013 Eric Faurot <eric@openbsd.org>
+@@ -464,6 +464,7 @@ table_regex_match(const char *string, const char *pattern)
+ {
+ 	regex_t preg;
+ 	int	cflags = REG_EXTENDED|REG_NOSUB;
++	int ret;
+ 
+ 	if (strncmp(pattern, "(?i)", 4) == 0) {
+ 		cflags |= REG_ICASE;
+@@ -473,7 +474,11 @@ table_regex_match(const char *string, const char *pattern)
+ 	if (regcomp(&preg, pattern, cflags) != 0)
+ 		return (0);
+ 
+-	if (regexec(&preg, string, 0, NULL, 0) != 0)
++	ret = regexec(&preg, string, 0, NULL, 0);
++
++	regfree(&preg);
++
++	if (ret != 0)
+ 		return (0);
+ 
+ 	return (1);

--- a/pkgs/servers/mail/opensmtpd/CVE-2020-35680.patch
+++ b/pkgs/servers/mail/opensmtpd/CVE-2020-35680.patch
@@ -1,0 +1,26 @@
+From 6c3220444ed06b5796dedfd53a0f4becd903c0d1 Mon Sep 17 00:00:00 2001
+From: millert <millert@openbsd.org>
+Date: Wed, 23 Dec 2020 20:17:49 +0000
+Subject: [PATCH] smtpd's filter state machine can prematurely release
+ resources leading to a crash.  From gilles@
+
+---
+ usr.sbin/smtpd/lka_filter.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/smtpd/lka_filter.c b/smtpd/lka_filter.c
+index 21b10ce1033..d1194254d8d 100644
+--- a/smtpd/lka_filter.c
++++ b/smtpd/lka_filter.c
+@@ -600,11 +600,6 @@ filter_session_io(struct io *io, int evt, void *arg)
+ 		filter_data(fs->id, line);
+ 
+ 		goto nextline;
+-
+-	case IO_DISCONNECTED:
+-		io_free(fs->io);
+-		fs->io = NULL;
+-		break;
+ 	}
+ }
+ 

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./proc_path.diff # TODO: upstream to OpenSMTPD, see https://github.com/NixOS/nixpkgs/issues/54045
+    ./CVE-2020-35679.patch
+    ./CVE-2020-35680.patch
   ];
 
   # See https://github.com/OpenSMTPD/OpenSMTPD/issues/885 for the `sh bootstrap`


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix CVE-2020-35679 and CVE-2020-35680

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
