### PR TITLE
xfig: 3.2.7b1 -> 3.2.8

### DIFF
--- a/pkgs/applications/graphics/xfig/default.nix
+++ b/pkgs/applications/graphics/xfig/default.nix
@@ -1,17 +1,14 @@
 { lib, stdenv, fetchurl, xlibsWrapper, makeWrapper, libXpm
-, libXmu, libXi, libXp, Xaw3d, fig2dev
+, libXmu, libXi, libXp, Xaw3d, libXaw, fig2dev
 }:
 
-let
-  version = "3.2.7a";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "xfig";
-  inherit version;
+  version = "3.2.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/mcj/xfig-${version}.tar.xz";
-    sha256 = "096zgp0bqnxhgxbrv2jjylrjz3pr4da0xxznlk2z7ffxr5pri2fa";
+    sha256 = "1czamqp0xn0j6qjnasa3fjnrzi072v6qknylr6jrs4gwsfw4ybyw";
   };
 
   postPatch = ''
@@ -30,7 +27,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ xlibsWrapper libXpm libXmu libXi libXp Xaw3d ];
+  buildInputs = [ xlibsWrapper libXpm libXmu libXi libXp Xaw3d libXaw ];
 
   meta = with lib; {
     description = "An interactive drawing tool for X11";
@@ -38,6 +35,6 @@ in stdenv.mkDerivation {
       Note that you need to have the <literal>netpbm</literal> tools
       in your path to export bitmaps.
     '';
-    inherit (fig2dev.meta) license homepage platforms;
+    inherit (fig2dev.meta) license homepage platforms maintainers;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
