### PR TITLE
gdu: 3.0.0 -> 4.2.0

### DIFF
--- a/pkgs/tools/system/gdu/default.nix
+++ b/pkgs/tools/system/gdu/default.nix
@@ -2,22 +2,29 @@
 , stdenv
 , buildGoModule
 , fetchFromGitHub
+, installShellFiles
 }:
 
 buildGoModule rec {
   pname = "gdu";
-  version = "3.0.0";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "dundee";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sfb8bxvdd8r05d0bgfcaw6dpbky7f4fgf0dbly7k7sgl29hkafy";
+    sha256 = "0ppsz7ys08lmg5s7lszqc2zcp2vjm54aai3yr3sb4jf3knbmyg5g";
   };
 
-  vendorSha256 = "0w3k23kly8g9mf8a300xz6bv7g1m2nlp5f112k4viyi9zy6vqbv0";
+  vendorSha256 = "058h71gmgi3n4b697myi5890arzw8fkzmxlm1aiwzyfh3k9iv0wh";
 
   buildFlagsArray = [ "-ldflags=-s -w -X github.com/dundee/gdu/build.Version=${version}" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage gdu.1
+  '';
 
   # tests fail if the version is set
   doCheck = false;


### PR DESCRIPTION
https://github.com/dundee/gdu/releases/tag/v4.0.0
https://github.com/dundee/gdu/releases/tag/v4.1.0
https://github.com/dundee/gdu/releases/tag/v4.2.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
