### PR TITLE
libexosip: 4.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/libraries/exosip/default.nix
+++ b/pkgs/development/libraries/exosip/default.nix
@@ -1,23 +1,16 @@
-{ lib, stdenv, fetchurl, libosip, openssl, pkg-config, fetchpatch }:
+{ lib, stdenv, fetchurl, libosip, openssl, pkg-config }:
 
 stdenv.mkDerivation rec {
  pname = "libexosip2";
- version = "4.1.0";
+ version = "5.2.0";
 
  src = fetchurl {
-    url = "mirror://savannah/exosip/libeXosip2-${version}.tar.gz";
-    sha256 = "17cna8kpc8nk1si419vgr6r42k2lda0rdk50vlxrw8rzg0xp2xrw";
+    url = "mirror://savannah/exosip/${pname}-${version}.tar.gz";
+    sha256 = "09bj7cm6mk8yr68y5a09a625x10ql6an3zi4pj6y1jbkhpgqibp3";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libosip openssl ];
-
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/libe/libexosip2/4.1.0-2.1/debian/patches/openssl110.patch";
-      sha256 = "01q2dax7pwh197mn18r22y38mrsky85mvs9vbkn9fpcilrdayal6";
-    })
-  ];
 
   meta = with lib; {
     license = licenses.gpl2Plus;

--- a/pkgs/servers/sip/sipwitch/default.nix
+++ b/pkgs/servers/sip/sipwitch/default.nix
@@ -23,5 +23,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
+    broken = true; # Require libexosip2 < 5.0.0 which is vulnerable to CVE-2014-10375.
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix CVE-2014-10375.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
