### PR TITLE
ocamlPackages.mirage-crypto*: 0.8.8 -> 0.8.10

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -4,11 +4,11 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.8.8";
+  version = "0.8.10";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-v${version}.tbz";
-    sha256 = "19czylfyakckfzzcbqgv9ygl243wix7ak8zkbdcb9hcl2k2shswb";
+    sha256 = "8a5976fe7837491d2fbd1917b77524776f70ae590e9f55cf757cc8951b5481fc";
   };
 
   useDune2 = true;

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ lib, fetchurl, buildDunePackage, fetchpatch
 , alcotest, cstruct-unix
 , asn1-combinators, domain-name, fmt, gmap, rresult, mirage-crypto, mirage-crypto-pk
 , logs, base64
@@ -14,6 +14,14 @@ buildDunePackage rec {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-v${version}.tbz";
     sha256 = "1b4lcphmlyjhdgqi0brakgjp3diwmrj1y9hx87svi5xklw3zik22";
   };
+
+  patches = [
+    # fix tests for mirage-crypto >= 0.8.9, can be removed at next release
+    (fetchpatch {
+      url = "https://github.com/mirleft/ocaml-x509/commit/ba1fdd4432950293e663416a0c454c8c04a71c0f.patch";
+      sha256 = "1rbjf7408772ns3ypk2hyw9v17iy1kcx84plr1rqc56iwk9zzxmr";
+    })
+  ];
 
   useDune2 = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bugfix releases:

* <https://github.com/mirage/mirage-crypto/releases/tag/v0.8.9>
* <https://github.com/mirage/mirage-crypto/releases/tag/v0.8.10>
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
