### PR TITLE
nixos/nginx: add cgit sub-service (v2)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -248,6 +248,12 @@
     githubId = 10677343;
     name = "Eugene";
   };
+  afix-space = {
+    email = "ohm@afix.space";
+    github = "afix-space";
+    githubId = 18408666;
+    name = "Laurent Barattero";
+  };
   aflatter = {
     email = "flatter@fastmail.fm";
     github = "aflatter";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -919,6 +919,7 @@
   ./services/web-servers/mighttpd2.nix
   ./services/web-servers/minio.nix
   ./services/web-servers/molly-brown.nix
+  ./services/web-servers/nginx/cgit.nix
   ./services/web-servers/nginx/default.nix
   ./services/web-servers/nginx/gitweb.nix
   ./services/web-servers/phpfpm/default.nix

--- a/nixos/modules/services/web-servers/nginx/cgit.nix
+++ b/nixos/modules/services/web-servers/nginx/cgit.nix
@@ -1,0 +1,132 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  globalConfig = config;
+  settingsFormat = {
+    type = with lib.types; let
+      value = oneOf [ int str ] // {
+        description = "INI-like atom (int or string)";
+      };
+      values = coercedTo value lib.singleton (listOf value) // {
+        description = value.description + " or a list of them for duplicate keys";
+      };
+    in
+    attrsOf (values);
+    generate = name: values:
+      pkgs.writeText name (lib.generators.toKeyValue { listsAsDuplicateKeys = true; } values);
+  };
+in
+{
+  options.services.nginx.virtualHosts = mkOption {
+    type = types.attrsOf (types.submodule ({ config, ... }:
+      let
+        cfg = config.cgit;
+
+        # These are the global options for this submodule, but for nicer UX they
+        # are inlined into the freeform settings.  Hence they MUST NOT INTERSECT
+        # with any settings from cgitrc!
+        options = {
+          enable = mkEnableOption "cgit";
+
+          location = mkOption {
+            default = "/";
+            type = types.str;
+            description = ''
+              Location to serve cgit on.
+            '';
+          };
+        };
+
+        # Remove the global options for serialization into cgitrc
+        settings = removeAttrs cfg (attrNames options);
+      in
+      {
+        options.cgit = mkOption {
+          type = types.submodule {
+            freeformType = settingsFormat.type;
+            inherit options;
+            config = {
+              css = mkDefault "/cgit.css";
+              logo = mkDefault "/cgit.png";
+              favicon = mkDefault "/favicon.ico";
+            };
+          };
+          default = { };
+          example = literalExample ''
+            {
+              enable = true;
+              virtual-root = "/";
+              source-filter = "''${pkgs.cgit}/lib/cgit/filters/syntax-highlighting.py";
+              about-filter = "''${pkgs.cgit}/lib/cgit/filters/about-formatting.sh";
+              cache-size = 1000;
+              scan-path = "/srv/git";
+              include = [
+                (builtins.toFile "cgitrc-extra-1" '''
+                  # Anything that has to be in a particular order
+                ''')
+                (builtins.toFile "cgitrc-extra-2" '''
+                  # Anything that has to be in a particular order
+                ''')
+              ];
+            }
+          '';
+          description = ''
+            Verbatim contents of the cgit runtime configuration file. Documentation
+            (with cgitrc example file) is available in "man cgitrc". Or online:
+            http://git.zx2c4.com/cgit/tree/cgitrc.5.txt
+          '';
+        };
+
+        config = let
+          location = removeSuffix "/" cfg.location;
+        in mkIf cfg.enable {
+
+          locations."${location}/" = {
+            root = "${pkgs.cgit}/cgit/";
+            tryFiles = "$uri @cgit";
+          };
+          locations."~ ^${location}/(cgit.(css|png)|favicon.ico|robots.txt)$" = {
+            alias = "${pkgs.cgit}/cgit/$1";
+          };
+          locations."@cgit" = {
+            extraConfig = ''
+              include ${pkgs.nginx}/conf/fastcgi_params;
+              fastcgi_param   CGIT_CONFIG     ${settingsFormat.generate "cgitrc" settings};
+              fastcgi_param   SCRIPT_FILENAME ${pkgs.cgit}/cgit/cgit.cgi;
+              fastcgi_param   QUERY_STRING    $args;
+              fastcgi_param   HTTP_HOST       $server_name;
+              fastcgi_pass    unix:${globalConfig.services.fcgiwrap.socketAddress};
+            '' + (
+              if cfg.location == "/"
+              then
+                ''
+                  fastcgi_param   PATH_INFO   $uri;
+                ''
+              else
+                ''
+                  fastcgi_split_path_info  ^(${location}/)(/?.+)$;
+                  fastcgi_param  PATH_INFO  $fastcgi_path_info;
+                ''
+            );
+          };
+        };
+
+      }));
+  };
+
+  config =
+    let
+      vhosts = config.services.nginx.virtualHosts;
+    in
+    mkIf (any (name: vhosts.${name}.cgit.enable) (attrNames vhosts)) {
+      # make the cgitrc manpage available
+      environment.systemPackages = [ pkgs.cgit ];
+
+      services.fcgiwrap.enable = true;
+    };
+
+  meta = {
+    maintainers = with lib.maintainers; [ afix-space hmenke ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -265,6 +265,7 @@ in
   nghttpx = handleTest ./nghttpx.nix {};
   nginx = handleTest ./nginx.nix {};
   nginx-auth = handleTest ./nginx-auth.nix {};
+  nginx-cgit= handleTest ./nginx-cgit.nix {};
   nginx-etag = handleTest ./nginx-etag.nix {};
   nginx-pubhtml = handleTest ./nginx-pubhtml.nix {};
   nginx-sandbox = handleTestOn ["x86_64-linux"] ./nginx-sandbox.nix {};

--- a/nixos/tests/nginx-cgit.nix
+++ b/nixos/tests/nginx-cgit.nix
@@ -1,0 +1,91 @@
+{ ... }: {
+  "http-clone" = import ./make-test-python.nix ({ lib, ... }: {
+    name = "nginx-cgit-http-clone";
+    meta = {
+      maintainers = with lib.maintainers; [ afix-space hmenke ];
+    };
+
+    machine = { pkgs, ... }: {
+
+      environment.systemPackages = [ pkgs.git ];
+
+      services.nginx.enable = true;
+      services.nginx.virtualHosts."localhost" = {
+        cgit = {
+          enable = true;
+          virtual-root = "/";
+          include = [
+            (builtins.toFile "cgitrc-extra-1" ''
+              repo.url=test-repo.git
+              repo.path=/srv/git/test-repo.git
+              repo.desc=the master foo repository
+              repo.owner=fooman@example.com
+            '')
+            (builtins.toFile "cgitrc-extra-2" ''
+              # Allow http transport git clone
+              enable-http-clone=1
+            '')
+          ];
+        };
+      };
+    };
+
+    testScript = ''
+      # Set up a test repository with only a single file that contains the string
+      # "Hello World!".
+      machine.succeed(
+          """
+          git config --global user.name "NixOS Test"
+          git config --global user.email "NixOS Test"
+          git init
+          echo -n "Hello world!" > test.txt
+          git add test.txt
+          git commit -am "Test commit"
+          git init --bare /srv/git/test-repo.git
+          git push /srv/git/test-repo.git master
+          """
+      )
+
+      machine.wait_for_unit("nginx.service")
+
+      # Clone the repo on the client through cgit's http clone interface and
+      # verify that the test file string is correct.
+      text = machine.succeed(
+          """
+          git clone http://127.0.0.1/test-repo.git /tmp/test-repo
+          cat /tmp/test-repo/test.txt
+          """
+      )
+      assert text == "Hello world!", "Defective clone from cgit"
+    '';
+  });
+
+  "location" = import ./make-test-python.nix ({ lib, ... }: {
+    name = "nginx-cgit-location";
+    meta = {
+      maintainers = with lib.maintainers; [ afix-space hmenke ];
+    };
+
+    machine = { pkgs, ... }: {
+
+      environment.systemPackages = [ pkgs.git ];
+
+      services.nginx.enable = true;
+      services.nginx.virtualHosts."localhost" = {
+        cgit = {
+          enable = true;
+          location = "/somewhere/else/";
+        };
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("nginx.service")
+      machine.succeed("curl -fo /dev/null http://127.0.0.1/somewhere/else/cgit.png")
+      machine.succeed("curl -fo /dev/null http://127.0.0.1/somewhere/else/cgit.css")
+      machine.succeed("curl -fo /dev/null http://127.0.0.1/somewhere/else/favicon.ico")
+      machine.succeed("curl -fo /dev/null http://127.0.0.1/somewhere/else/robots.txt")
+    '';
+  });
+
+}


### PR DESCRIPTION
Second version, greatly improved by hmenke.
Especially free form, test, and allows to have several instances of
cgit...

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add cgit sub-service to nginx

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ X] Ensured that relevant documentation is up to date
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
