### PR TITLE
tcl-8_6: 8.6.9 -> 8.6.11

### DIFF
--- a/pkgs/development/interpreters/tcl/8.6.nix
+++ b/pkgs/development/interpreters/tcl/8.6.nix
@@ -2,10 +2,10 @@
 
 callPackage ./generic.nix (args // rec {
   release = "8.6";
-  version = "${release}.9";
+  version = "${release}.11";
 
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
-    sha256 = "0kjzj7mkzfnb7ksxanbibibfpciyvsh5ffdlhs0bmfc75kgd435d";
+    sha256 = "0n4211j80mxr6ql0xx52rig8r885rcbminfpjdb2qrw6hmk8c14c";
   };
 })

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 
 # Version specific stuff
 , release, version, src
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     # Don't install tzdata because NixOS already has a more up-to-date copy.
     "--with-tzdata=no"
     "tcl_cv_strtod_unbroken=ok"
-  ] ++ stdenv.lib.optional stdenv.is64bit "--enable-64bit";
+  ] ++ lib.optional stdenv.is64bit "--enable-64bit";
 
   enableParallelBuilding = true;
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     ln -s $out/lib/libtcl${release}${dllExtension} $out/lib/libtcl${dllExtension}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The Tcl scripting language";
     homepage = "https://www.tcl.tk/";
     license = licenses.tcltk;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
