### PR TITLE
aws-sdk-cpp: fix cross compilation, configure for curl with http2

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -38,7 +38,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
   ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "-DENABLE_TESTING=OFF"
-    "-DCURL_HAS_H2=0"
+    "-DCURL_HAS_H2=1"
+    "-DCURL_HAS_TLS_PROXY=1"
   ] ++ lib.optional (apis != ["*"])
     "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
 


### PR DESCRIPTION
###### Motivation for this change

This should fix cross compiling aws-sdk-cpp, in particular `pkgsCross.armv7l-hf-multiplatform.aws-sdk-cpp`.

Issue reported in https://github.com/NixOS/nixpkgs/pull/107623#issuecomment-764520198

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @flokli