### PR TITLE
python3Packages.bash_kernel: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/development/python-modules/bash_kernel/default.nix
+++ b/pkgs/development/python-modules/bash_kernel/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "bash_kernel";
-  version = "0.7.1";
+  version = "0.7.2";
   format = "flit";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1s2kc7m52kq28b4j1q3456g5ani6nmq4n0rpbqi3yvh7ks0rby19";
+    sha256 = "0w0nbr3iqqsgpk83rgd0f5b02462bkyj2n0h6i9dwyc1vpnq9350";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Fixes #108503

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).