### PR TITLE
concurrentqueue: init at 1.0.2.

### DIFF
--- a/pkgs/development/libraries/concurrentqueue/default.nix
+++ b/pkgs/development/libraries/concurrentqueue/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "concurrentqueue";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "cameron314";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wj5i2yvdapbmpjmn0pyk2c9v03194zckxa6n5g9havqlsby78gs";
+  };
+
+  # The makefile uses relative paths so setting makefile or makeFlags doesn't work.
+  preBuild = ''
+    cd build
+  '';
+
+  #_FORTIFY_SOURCE requires compiling with optimization (-O)
+  NIX_CFLAGS_COMPILE = "-O";
+
+  checkPhase = ''
+    bin/unittests
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{lib,include}
+    cp bin/libtbb.a $out/lib
+    cp ../*.h $out/include
+  '';
+
+  meta = with lib; {
+    description =
+      "A fast multi-producer, multi-consumer lock-free concurrent queue for C++11";
+    homepage = "https://github.com/cameron314/concurrentqueue";
+    license = licenses.bsd3;
+    maintainers = [ teams.deshaw.members ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1880,6 +1880,8 @@ in
 
   compactor = callPackage ../applications/networking/compactor { };
 
+  concurrentqueue = callPackage ../development/libraries/concurrentqueue { };
+
   consul = callPackage ../servers/consul { };
 
   consul-alerts = callPackage ../servers/monitoring/consul-alerts { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
