### PR TITLE
elfio: init at 3.8

### DIFF
--- a/pkgs/development/libraries/elfio/default.nix
+++ b/pkgs/development/libraries/elfio/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "elfio";
+  version = "3.8";
+
+  src = fetchFromGitHub {
+    owner = "serge1";
+    repo = "ELFIO";
+    rev = "Release_${version}";
+    sha256 = "1h6q4nf19wpgzrz0wycl60s200r642jv41k1ffmqncgf92qy4yyv";
+  };
+
+  installPhase = ''
+      mkdir -p $out/include
+      cp -R ./elfio $out/include
+  '';
+
+  meta = with lib; {
+    description = "Small, header-only C++ library that provides a simple interface for reading and generating files in ELF binary format";
+    homepage = "https://serge1.github.io/ELFIO";
+    license = licenses.mit;
+    maintainers = [ teams.deshaw.members ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13662,6 +13662,8 @@ in
 
   elf-header-real = callPackage ../development/libraries/elf-header { };
 
+  elfio = callPackage ../development/libraries/elfio { };
+
   glibc_memusage = callPackage ../development/libraries/glibc {
     withGd = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
