### PR TITLE
scons: 4.0.1 -> 4.1.0

### DIFF
--- a/pkgs/development/tools/build-managers/scons/common.nix
+++ b/pkgs/development/tools/build-managers/scons/common.nix
@@ -16,10 +16,18 @@ python3Packages.buildPythonApplication rec {
   postPatch = lib.optionalString (lib.versionAtLeast version "4.0.0") ''
     substituteInPlace setup.cfg \
       --replace "build/dist" "dist"
+  '' + lib.optionalString (lib.versionAtLeast version "4.1.0") ''
+    substituteInPlace setup.cfg \
+      --replace "build/doc/man/" ""
   '';
 
   # The release tarballs don't contain any tests (runtest.py and test/*):
   doCheck = lib.versionOlder version "4.0.0";
+
+  postInstall = lib.optionalString (lib.versionAtLeast version "4.1.0") ''
+    mkdir -p "$out/share/man/man1"
+    mv "$out/"*.1 "$out/share/man/man1/"
+  '';
 
   meta = with stdenv.lib; {
     description = "An improved, cross-platform substitute for Make";

--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -12,7 +12,7 @@ in {
     sha256 = "1yzq2gg9zwz9rvfn42v5jzl3g4qf1khhny6zfbi2hib55zvg60bq";
   }).override { python3Packages = python2Packages; };
   scons_latest = mkScons {
-    version = "4.0.1";
-    sha256 = "0z00l9wzaiqyjq0hapbvsjclvcfjjjq04kmxi7ffq966nl2d2bkj";
+    version = "4.1.0";
+    sha256 = "11axk03142ziax6i3wwy9qpqp7r3i7h5jg9y2xzph9i15rv8vlkj";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
134 packages updated:
aj-snapshot alfred aspcud audiality2 bombono btanks cabal2nix calligra carla chaps conky d1x-rebirth-full d2x-rebirth-full dep2nix-unstable digikam digikam direwolf dxx-rebirth dxx-rebirth dxx-rebirth endless-sky faust2jack-unstable faust2jaqt-unstable fceux-unstable ffado ffado fluxus foxtrotgps foxtrotgps gambatte giada git git git-with-svn glob2 godot godot-headless godot-server goxel gpredict gpsd gringo gtklick hammer-e7aa734 hydra jack1 jack2 jackmix jackmix kde-gtk-config kde-gtk-config kde-gtk-config kde-gtk-config kexi klick koboredux koboredux kreport kreport kreport littlegptracker-unstable lprof lsp-plugins ltc-tools luppp lutris lutris lutris-original marble marble marble marble mariadb-galera mixxx mongodb mongodb mongodb mongodb mongodb mooSpace-unstable nix-prefetch-scripts nix-prefetch-svn nix-update-source nova-filters nsis ocaml4.10.0-dune-release opam opam ori patroni perl5.30.3-SVN-Simple perl5.32.0-SVN-Simple pulseeffects python3.7-pysvn python3.7-ydiff python3.8-pysvn python3.8-ydiff python3.9-pysvn python3.9-ydiff qlandkartegt rabbitvcs rapidsvn rhvoice-unstable rmlint scons (4.0.1 → 4.1.0) serf shotcut sonic-pi soundtracker subversion subversion subversion subversion-client svn-all-fast-export svn2git svnfs swift-im swiften Tambura tetraproc the-powder-toy toluapp tuxguitar urjtag vcstool vdrift-git vdrift-git-with-data viking webbrowser webcamoid xboxdrv xsettingsd ydiff zombietrackergps
```

nixpkgs-review results: WIP
Current status: `[1/120/164 built (5 failed)` and all 5 failures are unrelated. The rest should be fine then.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
