### PR TITLE
babelfish: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/shells/fish/babelfish.nix
+++ b/pkgs/shells/fish/babelfish.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, buildGoModule, fetchFromGitHub }:
 buildGoModule rec {
   pname = "babelfish";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "bouk";
     repo = "babelfish";
     rev = "v${version}";
-    sha256 = "A5FUnER25FDkL/K7RCqudZI6Xd5wg9B8aLbYUw6+7BA=";
+    sha256 = "1sr6y79igyfc9ia33nyrjjm4my1jrpcw27iks37kygh93npsb3r1";
   };
 
-  vendorSha256 = "T70gnmmR4yBwY2ZCiIR35LIbFYSnTRvwTGLwyDgoXnY=";
+  vendorSha256 = "0xjy50wciw329kq1nkd7hhaipcp4fy28hhk6cdq21qwid6g21gag";
 
   meta = with lib; {
     description = "Translate bash scripts to fish";


### PR DESCRIPTION
###### Motivation for this change

Packaging a new version that fixes a bug critical to https://github.com/NixOS/nixpkgs/pull/108947

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
