### PR TITLE
remctl: init at 3.17

### DIFF
--- a/pkgs/by-name/re/remctl/package.nix
+++ b/pkgs/by-name/re/remctl/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  autoreconfHook,
+  libevent,
+  krb5,
+  openssl,
+  perl,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "remctl";
+  version = "3.18";
+
+  src = fetchgit {
+    url = "git://git.eyrie.org/kerberos/remctl.git";
+    rev = "release/${finalAttrs.version}";
+    sha256 = "sha256-4KzNhFswNTwcXrDBAfRyr502zwRQ3FACV8gDfBm7M0A";
+  };
+
+  # Fix references to /usr/bin/perl in tests and
+  # disable acl/localgroup test that does not work in sandbox.
+  postPatch = ''
+    patchShebangs tests
+    sed -i '\,server/acl/localgroup,d' tests/TESTS
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [
+    krb5
+    libevent
+    openssl
+  ];
+
+  # Invokes pod2man to create man pages required by Makefile.
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  makeFlags = [
+    "LD=$(CC)"
+    "REMCTL_PERL_FLAGS='--prefix=$(out)'"
+    "REMCTL_PYTHON_INSTALL='--prefix=$(out)'"
+  ];
+
+  checkTarget = "check-local";
+
+  meta = with lib; {
+    description = "Remote execution tool";
+    homepage = "https://www.eyrie.org/~eagle/software/remctl";
+    mainProgram = "remctl";
+    license = licenses.mit;
+    maintainers = teams.deshaw.members;
+  };
+})

--- a/pkgs/development/perl-modules/NetRemctl/default.nix
+++ b/pkgs/development/perl-modules/NetRemctl/default.nix
@@ -1,0 +1,20 @@
+{
+  buildPerlModule,
+  remctl,
+  TestPod,
+}:
+
+buildPerlModule {
+  pname = "NetRemctl";
+
+  inherit (remctl) meta src version;
+
+  postPatch = ''
+    cp -R tests/tap/perl/Test perl/t/lib
+    cd perl
+  '';
+
+  buildInputs = [ remctl ];
+
+  checkInputs = [ TestPod ];
+}

--- a/pkgs/development/python-modules/remctl/default.nix
+++ b/pkgs/development/python-modules/remctl/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  remctl-c, # remctl from pkgs, not from pythonPackages
+  typing,
+}:
+
+buildPythonPackage {
+  inherit (remctl-c)
+    meta
+    pname
+    src
+    version
+    ;
+  setSourceRoot = "sourceRoot=$(echo */python)";
+
+  buildInputs = [ remctl-c ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.5") [ typing ];
+}

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19100,6 +19100,8 @@ with self; {
     };
   };
 
+  NetRemctl = callPackage ../development/perl-modules/NetRemctl { };
+
   NetServer = buildPerlPackage {
     pname = "Net-Server";
     version = "2.014";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13542,6 +13542,10 @@ self: super: with self; {
 
   remarshal = callPackage ../development/python-modules/remarshal { };
 
+  remctl = callPackage ../development/python-modules/remctl {
+    remctl-c = pkgs.remctl;
+  };
+
   remi = callPackage ../development/python-modules/remi { };
 
   remote-pdb = callPackage ../development/python-modules/remote-pdb { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
