### PR TITLE
jfrog-cli: init at 1.43.2

### DIFF
--- a/pkgs/development/tools/misc/jfrog-cli/default.nix
+++ b/pkgs/development/tools/misc/jfrog-cli/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "jfrog-cli";
+  version = "1.43.2";
+
+  src = fetchFromGitHub {
+    owner = "jfrog";
+    repo = "jfrog-cli";
+    rev = "v${version}";
+    sha256 = "0gc8a4cpzcpa3mrqzhba4xx0316z030q71bpxlslivxg5xpvgq0v";
+  };
+
+  CGO_ENABLED = 0;
+
+  vendorSha256 = "1imlc8vmhph9gy4c9xyr2czfyh42p9crh37h5axc5939lnn4x9z6";
+
+  # Extracted from build/build.sh.
+  buildFlagsArray = [
+    "-ldflags=-s -w -extldflags '-static'"
+  ];
+
+  # Most of them seem to require network access.
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/jfrog-cli $out/bin/jfrog
+    ln -s $out/bin/jfrog $out/bin/jfrog-cli
+  '';
+
+  meta = with lib; {
+    description = "A client that provides a simple interface that automates access to the JFrog products";
+    homepage = "https://github.com/jfrog/jfrog-cli";
+    license = licenses.asl20;
+    maintainers = [ teams.deshaw.members ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2416,6 +2416,8 @@ in
 
   jellyfin-mpv-shim = python3Packages.callPackage ../applications/video/jellyfin-mpv-shim { };
 
+  jfrog-cli = callPackage ../development/tools/misc/jfrog-cli { };
+
   jotta-cli = callPackage ../applications/misc/jotta-cli { };
 
   jwt-cli = callPackage ../tools/security/jwt-cli {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
