### PR TITLE
[20.09] chromium: 87.0.4280.141 -> 88.0.4324.96

### DIFF
--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -1,10 +1,14 @@
 { system ? builtins.currentSystem
 , config ? {}
 , pkgs ? import ../.. { inherit system config; }
-, channelMap ? {
-    stable = pkgs.chromium;
-    beta   = pkgs.chromiumBeta;
-    dev    = pkgs.chromiumDev;
+, channelMap ? { # Maps "channels" to packages
+    stable        = pkgs.chromium;
+    beta          = pkgs.chromiumBeta;
+    dev           = pkgs.chromiumDev;
+    ungoogled     = pkgs.ungoogled-chromium;
+    chrome-stable = pkgs.google-chrome;
+    chrome-beta   = pkgs.google-chrome-beta;
+    chrome-dev    = pkgs.google-chrome-dev;
   }
 }:
 
@@ -14,7 +18,7 @@ with pkgs.lib;
 mapAttrs (channel: chromiumPkg: makeTest rec {
   name = "chromium-${channel}";
   meta = {
-    maintainers = with maintainers; [ aszlig ];
+    maintainers = with maintainers; [ aszlig primeos ];
     # https://github.com/NixOS/hydra/issues/591#issuecomment-435125621
     inherit (chromiumPkg.meta) timeout;
   };
@@ -56,6 +60,19 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
     # Run as user alice
     def ru(cmd):
         return "su - ${user} -c " + shlex.quote(cmd)
+
+
+    def get_browser_binary():
+        """Returns the name of the browser binary."""
+        pname = "${getName chromiumPkg.name}"
+        if pname.find("chromium") != -1:
+            return "chromium"  # Same name for all channels and ungoogled-chromium
+        if pname == "google-chrome":
+            return "google-chrome-stable"
+        if pname == "google-chrome-dev":
+            return "google-chrome-unstable"
+        # For google-chrome-beta and as fallback:
+        return pname
 
 
     def create_new_win():
@@ -153,7 +170,14 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
     machine.wait_for_x()
 
     url = "file://${startupHTML}"
-    machine.succeed(ru(f'ulimit -c unlimited; chromium "{url}" & disown'))
+    machine.succeed(ru(f'ulimit -c unlimited; "{get_browser_binary()}" "{url}" & disown'))
+
+    if get_browser_binary().startswith("google-chrome"):
+        # Need to click away the first window:
+        machine.wait_for_text("Make Google Chrome the default browser")
+        machine.screenshot("google_chrome_default_browser_prompt")
+        machine.send_key("ret")
+
     machine.wait_for_text("startup done")
     machine.wait_until_succeeds(
         ru(

--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -80,7 +80,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
 
     def close_win():
         def try_close(_):
-            machine.execute(
+            status, _ = machine.execute(
                 ru(
                     "${xdo "close-window" ''
                       search --onlyvisible --name "new tab"
@@ -89,13 +89,14 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
                     ''}"
                 )
             )
-            machine.execute(
-                ru(
-                    "${xdo "close-window" ''
-                      key Ctrl+w
-                    ''}"
+            if status == 0:
+                machine.execute(
+                    ru(
+                        "${xdo "close-window" ''
+                          key Ctrl+w
+                        ''}"
+                    )
                 )
-            )
             for _ in range(1, 20):
                 status, out = machine.execute(
                     ru(

--- a/pkgs/applications/networking/browsers/chromium/README.md
+++ b/pkgs/applications/networking/browsers/chromium/README.md
@@ -36,6 +36,21 @@ update `upstream-info.json`. After updates it is important to test at least
 `nixosTests.chromium` (or basic manual testing) and `google-chrome` (which
 reuses `upstream-info.json`).
 
+To run all automated NixOS VM tests for Chromium, ungoogled-chromium,
+and Google Chrome (not recommended, currently 6x tests!):
+```
+nix-build nixos/tests/chromium.nix
+```
+
+A single test can be selected, e.g. to test `ungoogled-chromium` (see
+`channelMap` in `nixos/tests/chromium.nix` for all available options):
+```
+nix-build nixos/tests/chromium.nix -A ungoogled
+```
+(Note: Testing Google Chrome requires `export NIXPKGS_ALLOW_UNFREE=1`.)
+
+For custom builds it's possible to "override" `channelMap`.
+
 ## Backports
 
 All updates are considered security critical and should be ported to the stable

--- a/pkgs/applications/networking/browsers/chromium/update.py
+++ b/pkgs/applications/networking/browsers/chromium/update.py
@@ -102,6 +102,31 @@ def get_latest_ungoogled_chromium_build():
     }
 
 
+def channel_name_to_attr_name(channel_name):
+    """Maps a channel name to the corresponding main Nixpkgs attribute name."""
+    if channel_name == 'stable':
+        return 'chromium'
+    if channel_name == 'beta':
+        return 'chromiumBeta'
+    if channel_name == 'dev':
+        return 'chromiumDev'
+    if channel_name == 'ungoogled-chromium':
+        return 'ungoogled-chromium'
+    print(f'Error: Unexpected channel: {channel_name}', file=sys.stderr)
+    sys.exit(1)
+
+
+def print_updates(channels_old, channels_new):
+    """Print a summary of the updates."""
+    print('Updates:')
+    for channel_name in channels_old:
+        version_old = channels_old[channel_name]["version"]
+        version_new = channels_new[channel_name]["version"]
+        if version_old < version_new:
+            attr_name = channel_name_to_attr_name(channel_name)
+            print(f'- {attr_name}: {version_old} -> {version_new}')
+
+
 channels = {}
 last_channels = load_json(JSON_PATH)
 
@@ -174,3 +199,4 @@ with open(JSON_PATH, 'w') as out:
     sorted_channels = OrderedDict(sorted(channels.items(), key=get_channel_key))
     json.dump(sorted_channels, out, indent=2)
     out.write('\n')
+    print_updates(last_channels, sorted_channels)

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -1,20 +1,20 @@
 {
   "stable": {
-    "version": "87.0.4280.141",
-    "sha256": "0x9k809m36pfirnw2vnr9pk93nxdbgrvna0xf1rs3q91zkbr2x8l",
-    "sha256bin64": "0wq3yi0qyxzcid390w5rh4xjq92fjajvlifjl70g6sqnbk6vgvdp",
+    "version": "88.0.4324.96",
+    "sha256": "17y7x50cx2d3bbz0hna25j8pyqsk0914266mpvrpk5am52xwb5c9",
+    "sha256bin64": "09210781s9y49l6qkbd1v8w52741rmhxz6cc6qsldnqpm5mwlgsc",
     "deps": {
       "gn": {
-        "version": "2020-09-09",
+        "version": "2020-11-05",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "e002e68a48d1c82648eadde2f6aafa20d08c36f2",
-        "sha256": "0x4c7amxwzxs39grqs3dnnz0531mpf1p75niq7zhinyfqm86i4dk"
+        "rev": "53d92014bf94c3893886470a1c7c1289f8818db0",
+        "sha256": "1xcm07qjk6m2czi150fiqqxql067i832adck6zxrishm70c9jbr9"
       }
     },
     "chromedriver": {
-      "version": "87.0.4280.88",
-      "sha256_linux": "1insh1imi25sj4hdkbll5rzwnag8wvfxv4ckshpq8akl8r13p6lj",
-      "sha256_darwin": "048hsqp6575r980m769lzznvxypmfcwn89f1d3ik751ymzmb5r78"
+      "version": "88.0.4324.27",
+      "sha256_linux": "1vx1llg0x6903ggqa345iswd63y9c24184zv784q01zqxqwn0g8p",
+      "sha256_darwin": "0x1s6crfwkcn86w6p8g4vmx5raqlr41pjr4h2dbwppgrc0nx1p14"
     }
   },
   "beta": {

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "89.0.4356.6",
-    "sha256": "1jq0wbaaz07kz2190rq3vl2b5spx3qfda4al9ygkm8man817d2nr",
-    "sha256bin64": "0dgvp2my328s4ah0hmp1hg1c3x21gkrz9mjvbfs54r2pjb7y5sbl",
+    "version": "89.0.4381.6",
+    "sha256": "031w24qf5cn9y30pgh736g67p6c10kwpflhvxa24h0v99gqnah2i",
+    "sha256bin64": "1fssdxllq2ncpy8s7ykbq33456hfjlgj1m5147wbg2c5k36rj78s",
     "deps": {
       "gn": {
-        "version": "2020-11-05",
+        "version": "2020-12-22",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "53d92014bf94c3893886470a1c7c1289f8818db0",
-        "sha256": "1xcm07qjk6m2czi150fiqqxql067i832adck6zxrishm70c9jbr9"
+        "rev": "0d67e272bdb8145f87d238bc0b2cb8bf80ccec90",
+        "sha256": "07mrfl9hbjldbgidwwhr482a0s0ppqzwa5j7v5nbqxj18j55iril"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "88.0.4324.87",
-    "sha256": "0pfrx8b2rmrxx5dfv4kc1ggrgi7kj7gbxrzqzd7rsvjpasyidbxg",
-    "sha256bin64": "07xl02zg5pi89l6dqrbqx2ibl8pm9v6njqfl8p4l2hwsb881hx8g",
+    "version": "88.0.4324.96",
+    "sha256": "17y7x50cx2d3bbz0hna25j8pyqsk0914266mpvrpk5am52xwb5c9",
+    "sha256bin64": "1v7bpidqs8y3k7kzfp52q8xsdc515mnf9arfw9pp5bsp79fl3rik",
     "deps": {
       "gn": {
         "version": "2020-11-05",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -44,9 +44,9 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "87.0.4280.88",
-    "sha256": "1h09g9b2zxad85vd146ymvg3w2kpngpi78yig3dn1vrmhwr4aiiy",
-    "sha256bin64": "0n3fm6wf8zfkv135d50xl8xxrnng3q55vyxkck1da8jyvh18bijb",
+    "version": "87.0.4280.141",
+    "sha256": "0x9k809m36pfirnw2vnr9pk93nxdbgrvna0xf1rs3q91zkbr2x8l",
+    "sha256bin64": "0wq3yi0qyxzcid390w5rh4xjq92fjajvlifjl70g6sqnbk6vgvdp",
     "deps": {
       "gn": {
         "version": "2020-09-09",
@@ -55,8 +55,8 @@
         "sha256": "0x4c7amxwzxs39grqs3dnnz0531mpf1p75niq7zhinyfqm86i4dk"
       },
       "ungoogled-patches": {
-        "rev": "87.0.4280.88-1",
-        "sha256": "0w2137w8hfcgl6f938hqnb4ffp33v5r8vdzxrvs814w7dszkiqgg"
+        "rev": "87.0.4280.141-1",
+        "sha256": "0r09d27jrdz01rcwifchbq7ksh2bac15h8svq18jx426mr56dzla"
       }
     }
   }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "88.0.4324.79",
-    "sha256": "1xmssngzg370gazvqngw5mzhfq476fan5y3sp4ggs8fx5anh6jlz",
-    "sha256bin64": "16m2k4kr92236yvfnl276cy77d5324b7ca3grsw990c0b2kgizq7",
+    "version": "88.0.4324.87",
+    "sha256": "0pfrx8b2rmrxx5dfv4kc1ggrgi7kj7gbxrzqzd7rsvjpasyidbxg",
+    "sha256bin64": "07xl02zg5pi89l6dqrbqx2ibl8pm9v6njqfl8p4l2hwsb881hx8g",
     "deps": {
       "gn": {
         "version": "2020-11-05",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,9 +31,9 @@
     }
   },
   "dev": {
-    "version": "89.0.4381.6",
-    "sha256": "031w24qf5cn9y30pgh736g67p6c10kwpflhvxa24h0v99gqnah2i",
-    "sha256bin64": "1fssdxllq2ncpy8s7ykbq33456hfjlgj1m5147wbg2c5k36rj78s",
+    "version": "89.0.4385.0",
+    "sha256": "0cwfwkaidxi86n80kcn3lxrwz90zp6ra9dib1nd4xnhpgl7vjjjf",
+    "sha256bin64": "1hvrdvmlqc95qb9gn7iihal4h1kzf6jqrhk9xvv45chsvwl79pmd",
     "deps": {
       "gn": {
         "version": "2020-12-22",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -18,9 +18,9 @@
     }
   },
   "beta": {
-    "version": "88.0.4324.50",
-    "sha256": "17v0qp05785xc4whsbw6fmf0x5ccjx2mk6n4qy6z2mx2yjjjfv8q",
-    "sha256bin64": "01cphbd56l7g3cdmrvwynkzrpx9h3v7pz6ac76sxlp6irjzhbnva",
+    "version": "88.0.4324.79",
+    "sha256": "1xmssngzg370gazvqngw5mzhfq476fan5y3sp4ggs8fx5anh6jlz",
+    "sha256bin64": "16m2k4kr92236yvfnl276cy77d5324b7ca3grsw990c0b2kgizq7",
     "deps": {
       "gn": {
         "version": "2020-11-05",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -31,15 +31,15 @@
     }
   },
   "dev": {
-    "version": "89.0.4385.0",
-    "sha256": "0cwfwkaidxi86n80kcn3lxrwz90zp6ra9dib1nd4xnhpgl7vjjjf",
-    "sha256bin64": "1hvrdvmlqc95qb9gn7iihal4h1kzf6jqrhk9xvv45chsvwl79pmd",
+    "version": "89.0.4389.9",
+    "sha256": "12jiy5p1cbrs0gc3kd86walcnh038lzs5gnb9vif45f7kxn3c9pm",
+    "sha256bin64": "1wmidvf5gfm1xkpaj07gsvyk1r8b6jbcv46w5vclydlc1r6wh81s",
     "deps": {
       "gn": {
-        "version": "2020-12-22",
+        "version": "2021-01-07",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "0d67e272bdb8145f87d238bc0b2cb8bf80ccec90",
-        "sha256": "07mrfl9hbjldbgidwwhr482a0s0ppqzwa5j7v5nbqxj18j55iril"
+        "rev": "595e3be7c8381d4eeefce62a63ec12bae9ce5140",
+        "sha256": "08y7cjlgjdbzja5ij31wxc9i191845m01v1hc7y176svk9y0hj1d"
       }
     }
   },


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport of #110010 (and aee78d463e826ea5c144cff9c8e9e8c02a6ea4a0).
cc @Frostman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
