### PR TITLE
nixos/libinput: change mouse device defaults

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -7,6 +7,9 @@ let cfg = config.services.xserver.libinput;
 
     xorgBool = v: if v then "on" else "off";
 
+    # toString prints floats with hardcoded high precision
+    floatToString = f: builtins.toJSON f;
+
     mkConfigForDevice = deviceType: {
       dev = mkOption {
         type = types.nullOr types.str;
@@ -25,7 +28,7 @@ let cfg = config.services.xserver.libinput;
         example = "flat";
         description =
           ''
-            Sets  the pointer acceleration profile to the given profile.
+            Sets the pointer acceleration profile to the given profile.
             Permitted values are adaptive, flat.
             Not all devices support this option or all profiles.
             If a profile is unsupported, the default profile for this is used.
@@ -37,8 +40,8 @@ let cfg = config.services.xserver.libinput;
       };
 
       accelSpeed = mkOption {
-        type = types.nullOr types.str;
-        example = "-0.5";
+        type = types.nullOr types.float;
+        example = literalExample "-0.5";
         default = null;
         description = "Cursor acceleration (how fast speed increases from minSpeed to maxSpeed).";
       };
@@ -200,7 +203,7 @@ let cfg = config.services.xserver.libinput;
         MatchIs${matchIs} "${xorgBool true}"
         ${optionalString (cfg.${deviceType}.dev != null) ''MatchDevicePath "${cfg.${deviceType}.dev}"''}
         Option "AccelProfile" "${cfg.${deviceType}.accelProfile}"
-        ${optionalString (cfg.${deviceType}.accelSpeed != null) ''Option "AccelSpeed" "${cfg.${deviceType}.accelSpeed}"''}
+        ${optionalString (cfg.${deviceType}.accelSpeed != null) ''Option "AccelSpeed" "${floatToString cfg.${deviceType}.accelSpeed}"''}
         ${optionalString (cfg.${deviceType}.buttonMapping != null) ''Option "ButtonMapping" "${cfg.${deviceType}.buttonMapping}"''}
         ${optionalString (cfg.${deviceType}.calibrationMatrix != null) ''Option "CalibrationMatrix" "${cfg.${deviceType}.calibrationMatrix}"''}
         ${optionalString (cfg.${deviceType}.clickMethod != null) ''Option "ClickMethod" "${cfg.${deviceType}.clickMethod}"''}

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -1,5 +1,6 @@
 { config, lib, pkgs, ... }:
 
+with builtins;
 with lib;
 
 let cfg = config.services.xserver.libinput;
@@ -37,6 +38,7 @@ let cfg = config.services.xserver.libinput;
 
       accelSpeed = mkOption {
         type = types.nullOr types.str;
+        example = "-0.5";
         default = null;
         description = "Cursor acceleration (how fast speed increases from minSpeed to maxSpeed).";
       };
@@ -44,6 +46,7 @@ let cfg = config.services.xserver.libinput;
       buttonMapping = mkOption {
         type = types.nullOr types.str;
         default = null;
+        example = "1 6 3 4 5 0 7";
         description =
           ''
             Sets the logical button mapping for this device, see XSetPointerMapping(3). The string  must
@@ -68,6 +71,7 @@ let cfg = config.services.xserver.libinput;
       clickMethod = mkOption {
         type = types.nullOr (types.enum [ "none" "buttonareas" "clickfinger" ]);
         default = null;
+        example = "buttonareas";
         description =
           ''
             Enables a click method. Permitted values are <literal>none</literal>,
@@ -85,7 +89,7 @@ let cfg = config.services.xserver.libinput;
 
       middleEmulation = mkOption {
         type = types.bool;
-        default = true;
+        default = getAttr deviceType { mouse = false; touchpad = true; };
         description =
           ''
             Enables middle button emulation. When enabled, pressing the left and right buttons
@@ -111,8 +115,9 @@ let cfg = config.services.xserver.libinput;
       };
 
       scrollMethod = mkOption {
-        type = types.enum [ "twofinger" "edge" "button" "none" ];
-        default = "twofinger";
+        type = types.nullOr (types.enum [ "twofinger" "edge" "button" "none" ]);
+        default = getAttr deviceType { mouse = null; touchpad = "twofinger"; };
+        visible = getAttr deviceType { mouse = false; touchpad = true; };
         example = "edge";
         description =
           ''
@@ -144,8 +149,9 @@ let cfg = config.services.xserver.libinput;
       };
 
       tapping = mkOption {
-        type = types.bool;
-        default = true;
+        type = types.nullOr types.bool;
+        default = getAttr deviceType { mouse = null; touchpad = true; };
+        visible = getAttr deviceType { mouse = false; touchpad = true; };
         description =
           ''
             Enables or disables tap-to-click behavior.
@@ -153,8 +159,9 @@ let cfg = config.services.xserver.libinput;
       };
 
       tappingDragLock = mkOption {
-        type = types.bool;
-        default = true;
+        type = types.nullOr types.bool;
+        default = getAttr deviceType { mouse = null; touchpad = true; };
+        visible = getAttr deviceType { mouse = false; touchpad = true; };
         description =
           ''
             Enables or disables drag lock during tapping behavior. When enabled, a finger up during tap-
@@ -201,11 +208,11 @@ let cfg = config.services.xserver.libinput;
         Option "MiddleEmulation" "${xorgBool cfg.${deviceType}.middleEmulation}"
         Option "NaturalScrolling" "${xorgBool cfg.${deviceType}.naturalScrolling}"
         ${optionalString (cfg.${deviceType}.scrollButton != null) ''Option "ScrollButton" "${toString cfg.${deviceType}.scrollButton}"''}
-        Option "ScrollMethod" "${cfg.${deviceType}.scrollMethod}"
+        ${optionalString (cfg.${deviceType}.scrollMethod != null) ''Option "ScrollMethod" "${cfg.${deviceType}.scrollMethod}"''}
         Option "HorizontalScrolling" "${xorgBool cfg.${deviceType}.horizontalScrolling}"
         Option "SendEventsMode" "${cfg.${deviceType}.sendEventsMode}"
-        Option "Tapping" "${xorgBool cfg.${deviceType}.tapping}"
-        Option "TappingDragLock" "${xorgBool cfg.${deviceType}.tappingDragLock}"
+        ${optionalString (cfg.${deviceType}.tapping != null) ''Option "Tapping" "${xorgBool cfg.${deviceType}.tapping}"''}
+        ${optionalString (cfg.${deviceType}.tappingDragLock != null) ''Option "TappingDragLock" "${xorgBool cfg.${deviceType}.tappingDragLock}"''}
         Option "DisableWhileTyping" "${xorgBool cfg.${deviceType}.disableWhileTyping}"
         ${cfg.${deviceType}.additionalOptions}
   '';

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -217,6 +217,7 @@ let cfg = config.services.xserver.libinput;
         ${cfg.${deviceType}.additionalOptions}
   '';
 in {
+  meta.maintainers = with maintainers; [ thiagokokada ];
 
   imports =
     (map (option: mkRenamedOptionModule ([ "services" "xserver" "libinput" option ]) [ "services" "xserver" "libinput" "touchpad" option ]) [

--- a/nixos/modules/services/x11/hardware/synaptics.nix
+++ b/nixos/modules/services/x11/hardware/synaptics.nix
@@ -172,34 +172,32 @@ in {
 
     environment.systemPackages = [ pkg ];
 
-    services.xserver.config =
+    services.xserver.inputClassSections = [
       ''
-        # Automatically enable the synaptics driver for all touchpads.
-        Section "InputClass"
-          Identifier "synaptics touchpad catchall"
-          MatchIsTouchpad "on"
-          ${optionalString (cfg.dev != null) ''MatchDevicePath "${cfg.dev}"''}
-          Driver "synaptics"
-          ${optionalString (cfg.minSpeed != null) ''Option "MinSpeed" "${cfg.minSpeed}"''}
-          ${optionalString (cfg.maxSpeed != null) ''Option "MaxSpeed" "${cfg.maxSpeed}"''}
-          ${optionalString (cfg.accelFactor != null) ''Option "AccelFactor" "${cfg.accelFactor}"''}
-          ${optionalString cfg.tapButtons tapConfig}
-          Option "ClickFinger1" "${builtins.elemAt cfg.buttonsMap 0}"
-          Option "ClickFinger2" "${builtins.elemAt cfg.buttonsMap 1}"
-          Option "ClickFinger3" "${builtins.elemAt cfg.buttonsMap 2}"
-          Option "VertTwoFingerScroll" "${if cfg.vertTwoFingerScroll then "1" else "0"}"
-          Option "HorizTwoFingerScroll" "${if cfg.horizTwoFingerScroll then "1" else "0"}"
-          Option "VertEdgeScroll" "${if cfg.vertEdgeScroll then "1" else "0"}"
-          Option "HorizEdgeScroll" "${if cfg.horizEdgeScroll then "1" else "0"}"
-          ${optionalString cfg.palmDetect ''Option "PalmDetect" "1"''}
-          ${optionalString (cfg.palmMinWidth != null) ''Option "PalmMinWidth" "${toString cfg.palmMinWidth}"''}
-          ${optionalString (cfg.palmMinZ != null) ''Option "PalmMinZ" "${toString cfg.palmMinZ}"''}
-          ${optionalString (cfg.scrollDelta != null) ''Option "VertScrollDelta" "${toString cfg.scrollDelta}"''}
-          ${if !cfg.horizontalScroll then ''Option "HorizScrollDelta" "0"''
-            else (optionalString (cfg.scrollDelta != null) ''Option "HorizScrollDelta" "${toString cfg.scrollDelta}"'')}
-          ${cfg.additionalOptions}
-        EndSection
-      '';
+        Identifier "synaptics touchpad catchall"
+        MatchIsTouchpad "on"
+        ${optionalString (cfg.dev != null) ''MatchDevicePath "${cfg.dev}"''}
+        Driver "synaptics"
+        ${optionalString (cfg.minSpeed != null) ''Option "MinSpeed" "${cfg.minSpeed}"''}
+        ${optionalString (cfg.maxSpeed != null) ''Option "MaxSpeed" "${cfg.maxSpeed}"''}
+        ${optionalString (cfg.accelFactor != null) ''Option "AccelFactor" "${cfg.accelFactor}"''}
+        ${optionalString cfg.tapButtons tapConfig}
+        Option "ClickFinger1" "${builtins.elemAt cfg.buttonsMap 0}"
+        Option "ClickFinger2" "${builtins.elemAt cfg.buttonsMap 1}"
+        Option "ClickFinger3" "${builtins.elemAt cfg.buttonsMap 2}"
+        Option "VertTwoFingerScroll" "${if cfg.vertTwoFingerScroll then "1" else "0"}"
+        Option "HorizTwoFingerScroll" "${if cfg.horizTwoFingerScroll then "1" else "0"}"
+        Option "VertEdgeScroll" "${if cfg.vertEdgeScroll then "1" else "0"}"
+        Option "HorizEdgeScroll" "${if cfg.horizEdgeScroll then "1" else "0"}"
+        ${optionalString cfg.palmDetect ''Option "PalmDetect" "1"''}
+        ${optionalString (cfg.palmMinWidth != null) ''Option "PalmMinWidth" "${toString cfg.palmMinWidth}"''}
+        ${optionalString (cfg.palmMinZ != null) ''Option "PalmMinZ" "${toString cfg.palmMinZ}"''}
+        ${optionalString (cfg.scrollDelta != null) ''Option "VertScrollDelta" "${toString cfg.scrollDelta}"''}
+        ${if !cfg.horizontalScroll then ''Option "HorizScrollDelta" "0"''
+          else (optionalString (cfg.scrollDelta != null) ''Option "HorizScrollDelta" "${toString cfg.scrollDelta}"'')}
+        ${cfg.additionalOptions}
+      ''
+    ];
 
     assertions = [
       {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -202,6 +202,7 @@ in
   latestKernel.hardened = handleTest ./hardened.nix { latestKernel = true; };
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   leaps = handleTest ./leaps.nix {};
+  libinput = handleTest ./libinput.nix {};
   lidarr = handleTest ./lidarr.nix {};
   lightdm = handleTest ./lightdm.nix {};
   limesurvey = handleTest ./limesurvey.nix {};

--- a/nixos/tests/libinput.nix
+++ b/nixos/tests/libinput.nix
@@ -1,0 +1,41 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+{
+  name = "libinput";
+  meta.maintainers = with pkgs.lib.maintainers; [ thiagokokada ];
+
+  machine = { ... }:
+    {
+      imports = [
+        ./common/x11.nix
+        ./common/user-account.nix
+      ];
+
+      test-support.displayManager.auto.user = "alice";
+
+      services.xserver.libinput = {
+        enable = true;
+        mouse = {
+          accelProfile = "flat";
+          accelSpeed = "-0.5";
+        };
+      };
+    };
+
+  testScript = ''
+    def expect_xserver_option(option, value):
+        machine.succeed(f"""cat /var/log/X.0.log | grep 'Option "{option}" "{value}"'""")
+
+
+    machine.start()
+    machine.wait_for_x()
+    machine.succeed("cat /var/log/X.0.log | grep libinput")
+
+    expect_xserver_option("AccelProfile", "flat")
+    expect_xserver_option("AccelSpeed", "-0.5")
+    expect_xserver_option("NaturalScrolling", "off")
+    expect_xserver_option("HorizontalScrolling", "on")
+  '';
+})

--- a/nixos/tests/libinput.nix
+++ b/nixos/tests/libinput.nix
@@ -19,7 +19,7 @@ with lib;
         enable = true;
         mouse = {
           accelProfile = "flat";
-          accelSpeed = "-0.5";
+          accelSpeed = -0.5;
         };
       };
     };

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -3,6 +3,7 @@
 , documentationSupport ? false, doxygen ? null, graphviz ? null # Documentation
 , eventGUISupport ? false, cairo ? null, glib ? null, gtk3 ? null # GUI event viewer support
 , testsSupport ? false, check ? null, valgrind ? null, python3 ? null
+, nixosTests
 }:
 
 assert documentationSupport -> doxygen != null && graphviz != null && python3 != null;
@@ -80,6 +81,10 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
+
+  passthru.tests = {
+    libinput-module = nixosTests.libinput;
+  };
 
   meta = {
     description = "Handles input devices in Wayland compositors and provides a generic X.Org input driver";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This commit changes some mouse device defaults that doesn't make sense (generally) for a mouse, like `tapping`/`tappingDragLock` or `middleEmulation` (it works in mouses, but unless you have a mouse with
only 3 buttons it doesn't make much sense to have it enabled). They're now set to false or null depending of the case.

Since those options can still be useful in some exotic cases, instead of disabling those options in mouse, I set them with `visible = false;`. This way, they don't show in manual, but in the case the user needs it can still be set.

Also, I moved `services.xserver.synaptics` config from `services.xserver.config` to `services.xserver.inputClassSections`. The reason is the same as stated here: https://github.com/NixOS/nixpkgs/pull/108909/files#r555458053.

Added some tests for `services.xserver.libinput` module to make sure it will keep working as it should.

Continuation of PR #108909.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
