### PR TITLE
darwin.CoreFoundation: update to swift newest version

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -431,7 +431,7 @@ self: super: builtins.intersectAttrs super {
       ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
                             (with pkgs.darwin.apple_sdk.frameworks;
                              [ AGL Cocoa OpenGL IOKit Kernel CoreVideo
-                               pkgs.darwin.CF ]);
+                               pkgs.darwin.CoreFoundation ]);
   });
   OpenCL = overrideCabal super.OpenCL (drv: {
     librarySystemDepends =

--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -83,7 +83,7 @@ in stdenv.mkDerivation rec {
     cp -a ChangeLog examples LICENSE.BSD README.md third-party.txt $out/share/doc/phantomjs
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     install_name_tool -change \
-        ${darwin.CF}/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation \
+        ${darwin.CoreFoundation}/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation \
         /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation \
       -change \
         ${darwin.configd}/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration \

--- a/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
@@ -1,8 +1,8 @@
 linkSystemCoreFoundationFramework() {
   NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks${NIX_CFLAGS_COMPILE:+ }${NIX_CFLAGS_COMPILE-}"
-  # gross! many symbols (such as _OBJC_CLASS_$_NSArray) are defined in system CF, but not
+  # gross! many symbols (such as _OBJC_CLASS_$_NSArray) are defined in system CoreFoundation, but not
   # in the opensource release
-  # if the package needs private headers, we assume they also want to link with system CF
+  # if the package needs private headers, we assume they also want to link with system CoreFoundation
   NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 }
 

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -172,7 +172,7 @@ let
 
     propagatedBuildInputs = builtins.attrValues deps;
 
-    # don't use pure CF for dylibs that depend on frameworks
+    # don't use pure CoreFoundation for dylibs that depend on frameworks
     setupHook = ./framework-setup-hook.sh;
 
     # Not going to be more specific than this for now

--- a/pkgs/os-specific/darwin/apple-sdk/framework-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk/framework-setup-hook.sh
@@ -1,10 +1,10 @@
 # On macOS, frameworks are linked to the system CoreFoundation but
-# dynamic libraries built with nix use a pure version of CF this
+# dynamic libraries built with nix use a pure version of CoreFoundation this
 # causes segfaults for binaries that depend on it at runtime.  This
 # can be solved in two ways.
-# 1. Rewrite references to the pure CF using this setup hook, this
+# 1. Rewrite references to the pure CoreFoundation using this setup hook, this
 # works for the simple case but this can still cause problems if other
-# dependencies (eg. python) use the pure CF.
+# dependencies (eg. python) use the pure CoreFoundation.
 # 2. Create a wrapper for the binary that sets DYLD_FRAMEWORK_PATH to
 # /System/Library/Frameworks.  This will make everything load the
 # system's CoreFoundation framework while still keeping the

--- a/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
@@ -6,7 +6,7 @@ appleDerivation {
   installPhase = ''
     mkdir -p $out/include/dispatch $out/include/os
 
-    # Move these headers so CF can find <os/voucher_private.h>
+    # Move these headers so CoreFoundation can find <os/voucher_private.h>
     mv private/voucher*.h  $out/include/os
     cp -r private/*.h  $out/include/dispatch
 

--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
@@ -1,5 +1,5 @@
 { stdenv, appleDerivation, lib
-, Librpcsvc, apple_sdk, pam, CF, openbsm }:
+, Librpcsvc, apple_sdk, pam, CoreFoundation, openbsm }:
 
 appleDerivation {
   # xcbuild fails with:
@@ -7,7 +7,7 @@ appleDerivation {
   # see issue facebook/xcbuild#188
   # buildInputs = [ xcbuild ];
 
-  buildInputs = [ Librpcsvc apple_sdk.frameworks.OpenDirectory pam CF
+  buildInputs = [ Librpcsvc apple_sdk.frameworks.OpenDirectory pam CoreFoundation
                   apple_sdk.frameworks.IOKit openbsm ];
   # NIX_CFLAGS_COMPILE = lib.optionalString hostPlatform.isi686 "-D__i386__"
   #                    + lib.optionalString hostPlatform.isx86_64 "-D__x86_64__"

--- a/pkgs/os-specific/darwin/swift-corelibs/foundation/default.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/foundation/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU }:
 
 let
-  # 10.12 adds a new sysdir.h that our version of CF in the main derivation depends on, but
+  # 10.12 adds a new sysdir.h that our version of CoreFoundation in the main derivation depends on, but
   # isn't available publicly, so instead we grab an older version of the same file that did
   # not use sysdir.h, but provided the same functionality. Luckily it's simple :) hack hack
   sysdir-free-system-directories = fetchurl {

--- a/pkgs/os-specific/darwin/usr-include/default.nix
+++ b/pkgs/os-specific/darwin/usr-include/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation {
   name = "darwin-usr-include";
-  buildInputs = [ darwin.CF stdenv.libc ];
+  buildInputs = [ darwin.CoreFoundation stdenv.libc ];
   buildCommand = ''
     mkdir -p $out
     cd $out
     ln -sf ${stdenv.libc}/include/* .
     mkdir CoreFoundation
-    ln -sf ${darwin.CF}/Library/Frameworks/CoreFoundation.framework/Headers/* CoreFoundation
+    ln -sf ${darwin.CoreFoundation}/Library/Frameworks/CoreFoundation.framework/Headers/* CoreFoundation
   '';
 
   meta.platforms = lib.platforms.darwin;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -344,7 +344,7 @@ in rec {
       darwin = super.darwin // {
         inherit (darwin)
           binutils dyld Libsystem xnu configd ICU libdispatch libclosure
-          launchd CF darwin-stubs;
+          launchd CoreFoundation darwin-stubs;
       };
     };
   in with prevStage; stageFun 2 prevStage {
@@ -353,7 +353,7 @@ in rec {
     '';
 
     extraNativeBuildInputs = [ pkgs.xz ];
-    extraBuildInputs = [ pkgs.darwin.CF ];
+    extraBuildInputs = [ pkgs.darwin.CoreFoundation ];
     libcxx = pkgs.libcxx;
 
     allowedRequisites =
@@ -363,7 +363,7 @@ in rec {
         llvmPackages_7.clang-unwrapped zlib libxml2.out curl.out openssl.out
         libssh2.out nghttp2.lib libkrb5 coreutils gnugrep pcre.out gmp libiconv
       ]) ++
-      (with pkgs.darwin; [ dyld Libsystem CF ICU locale ]);
+      (with pkgs.darwin; [ dyld Libsystem CoreFoundation ICU locale ]);
 
     overrides = persistent;
   };
@@ -400,7 +400,7 @@ in rec {
     # and instead goes by $PATH, which happens to contain bootstrapTools. So it goes and
     # patches our shebangs back to point at bootstrapTools. This makes sure bash comes first.
     extraNativeBuildInputs = with pkgs; [ xz ];
-    extraBuildInputs = [ pkgs.darwin.CF pkgs.bash ];
+    extraBuildInputs = [ pkgs.darwin.CoreFoundation pkgs.bash ];
     libcxx = pkgs.libcxx;
 
     extraPreHook = ''
@@ -449,7 +449,7 @@ in rec {
       darwin = super.darwin // rec {
         inherit (darwin) dyld Libsystem libiconv locale darwin-stubs;
 
-        CF = super.darwin.CF.override {
+        CoreFoundation = super.darwin.CoreFoundation.override {
           inherit libxml2;
           python3 = prevStage.python3;
         };
@@ -458,7 +458,7 @@ in rec {
   in with prevStage; stageFun 4 prevStage {
     shell = "${pkgs.bash}/bin/bash";
     extraNativeBuildInputs = with pkgs; [ xz ];
-    extraBuildInputs = [ pkgs.darwin.CF pkgs.bash ];
+    extraBuildInputs = [ pkgs.darwin.CoreFoundation pkgs.bash ];
     libcxx = pkgs.libcxx;
 
     extraPreHook = ''
@@ -504,7 +504,7 @@ in rec {
     targetPlatform = localSystem;
 
     preHook = commonPreHook + ''
-      export NIX_COREFOUNDATION_RPATH=${pkgs.darwin.CF}/Library/Frameworks
+      export NIX_COREFOUNDATION_RPATH=${pkgs.darwin.CoreFoundation}/Library/Frameworks
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
 
@@ -519,7 +519,7 @@ in rec {
     };
 
     extraNativeBuildInputs = [];
-    extraBuildInputs = [ pkgs.darwin.CF ];
+    extraBuildInputs = [ pkgs.darwin.CoreFoundation ];
 
     extraAttrs = {
       libc = pkgs.darwin.Libsystem;
@@ -537,7 +537,7 @@ in rec {
       curl.out openssl.out libssh2.out nghttp2.lib libkrb5
       cc.expand-response-params libxml2.out
     ]) ++ (with pkgs.darwin; [
-      dyld Libsystem CF cctools ICU libiconv locale libtapi
+      dyld Libsystem CoreFoundation cctools ICU libiconv locale libtapi
     ]);
 
     overrides = lib.composeExtensions persistent (self: super: {
@@ -546,7 +546,7 @@ in rec {
       inherit cc;
 
       darwin = super.darwin // {
-        inherit (prevStage.darwin) CF darwin-stubs;
+        inherit (prevStage.darwin) CoreFoundation darwin-stubs;
         xnu = super.darwin.xnu.override { inherit (prevStage) python3; };
       };
     });

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -451,7 +451,6 @@ in rec {
 
         CoreFoundation = super.darwin.CoreFoundation.override {
           inherit libxml2;
-          python3 = prevStage.python3;
         };
       };
     };

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -99,7 +99,7 @@ in rec {
 
       cp -d ${darwin.libtapi}/lib/libtapi* $out/lib
 
-      cp -rd ${pkgs.darwin.CF}/Library $out
+      cp -rd ${pkgs.darwin.CoreFoundation}/Library $out
 
       chmod -R u+w $out
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -98,7 +98,7 @@ let
       setup = setupScript;
 
       # We pretty much never need rpaths on Darwin, since all library path references
-      # are absolute unless we go out of our way to make them relative (like with CF)
+      # are absolute unless we go out of our way to make them relative (like with CoreFoundation)
       # TODO: This really wants to be in stdenv/darwin but we don't have hostPlatform
       # there (yet?) so it goes here until then.
       preHook = preHook+ lib.optionalString buildPlatform.isDarwin ''

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "1n7xy657ii0sa42zx6944v2m4v9qrh6sqgmw17l3nch3y43sxlyh";
   };
 
-  # avoid retaining reference to CF during stdenv bootstrap
+  # avoid retaining reference to CoreFoundation during stdenv bootstrap
   configureFlags = lib.optionals stdenv.isDarwin [
     "gt_cv_func_CFPreferencesCopyAppValue=no"
     "gt_cv_func_CFLocaleCopyCurrent=no"

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -83,7 +83,7 @@ in
 
   CoreSymbolication = callPackage ../os-specific/darwin/CoreSymbolication { };
 
-  CoreFoundation = callPackage ../os-specific/darwin/swift-corelibs/foundation { inherit (darwin) objc4 ICU; };
+  CoreFoundation = callPackage ../os-specific/darwin/swift-corelibs/foundation { inherit (darwin) ICU; };
 
   # As the name says, this is broken, but I don't want to lose it since it's a direction we want to go in
   # libdispatch-broken = callPackage ../os-specific/darwin/swift-corelibs/libdispatch.nix { inherit (darwin) apple_sdk_sierra xnu; };

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -83,7 +83,7 @@ in
 
   CoreSymbolication = callPackage ../os-specific/darwin/CoreSymbolication { };
 
-  CF = callPackage ../os-specific/darwin/swift-corelibs/corefoundation.nix { inherit (darwin) objc4 ICU; };
+  CoreFoundation = callPackage ../os-specific/darwin/swift-corelibs/foundation { inherit (darwin) objc4 ICU; };
 
   # As the name says, this is broken, but I don't want to lose it since it's a direction we want to go in
   # libdispatch-broken = callPackage ../os-specific/darwin/swift-corelibs/libdispatch.nix { inherit (darwin) apple_sdk_sierra xnu; };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -21,7 +21,7 @@ self: super: let
   # but more portable than Nix store binaries.
   makeStaticDarwin = stdenv_: let stdenv = stdenv_.override {
     # extraBuildInputs are dropped in cross.nix, but darwin still needs them
-    extraBuildInputs = [ self.buildPackages.darwin.CF ];
+    extraBuildInputs = [ self.buildPackages.darwin.CoreFoundation ];
   }; in stdenv // {
     mkDerivation = args: stdenv.mkDerivation (args // {
       NIX_CFLAGS_LINK = toString (args.NIX_CFLAGS_LINK or "")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR is almost done, but it needs libdispatch update to macos-10.13 or above to provide `DISPATCH_APPLY_AUTO`. (#101229)
Also, it may need a newer ICU. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
