### PR TITLE
vimPlugins.chadtree: init at 2021-01-21

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -65,12 +65,12 @@ let
 
   ale = buildVimPluginFrom2Nix {
     pname = "ale";
-    version = "2021-01-16";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "dense-analysis";
       repo = "ale";
-      rev = "9387ccfbc57f34f9fdc6af85cd0dbddf5ee8c5ae";
-      sha256 = "1p8fxlnwfiaigfrcw8sk832p4msqcl4n45k5qshy625cz9jkysn0";
+      rev = "7e3d2930d8defbcb233b0bc21822cb8e8377bec2";
+      sha256 = "10ddyvbcy1m00sbcxnba3ijwxjcymqzxlk3hs2gb7z5ng85cryyb";
     };
     meta.homepage = "https://github.com/dense-analysis/ale/";
   };
@@ -401,12 +401,12 @@ let
 
   ci_dark = buildVimPluginFrom2Nix {
     pname = "ci_dark";
-    version = "2020-12-25";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "chuling";
       repo = "ci_dark";
-      rev = "9e683226bb2b73f234cd8feb7367514553d23d32";
-      sha256 = "1jdpnljgf7bnqsfiqy7qfjhwcx4727gc9h0mrcn0xcfl19ppa6xs";
+      rev = "ba5e404ded9f5bcfae68a6ad440ba3909eb7baff";
+      sha256 = "1377apvlwq3i755ply54yi7wz96fflwc4w4aash3hjbjmv0r6ff4";
     };
     meta.homepage = "https://github.com/chuling/ci_dark/";
   };
@@ -882,12 +882,12 @@ let
 
   denite-nvim = buildVimPluginFrom2Nix {
     pname = "denite-nvim";
-    version = "2021-01-16";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "denite.nvim";
-      rev = "b7c43e846b404d6068e4905cc1fc22c73e6d333a";
-      sha256 = "00nyw1fnjjkr7zqns05sp00qvbsyyc8a6avr9s0j76hhamrfwkhg";
+      rev = "18f8a297d1f8ddb3f9fea8941888d57194b7e1e9";
+      sha256 = "0a6vlmzpi7i7wpsc49jrh6bk3m7nq562k6k1lb33vfc41dvyz3am";
     };
     meta.homepage = "https://github.com/Shougo/denite.nvim/";
   };
@@ -1342,12 +1342,12 @@ let
 
   fern-vim = buildVimPluginFrom2Nix {
     pname = "fern-vim";
-    version = "2021-01-17";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "lambdalisue";
       repo = "fern.vim";
-      rev = "f057425350c3a01372f071de0b6f1ac597b962d6";
-      sha256 = "10wrk0a9ich10bgky912i22ix3xanxk81clda63fg4nw7c4sqqfs";
+      rev = "4ec2a38578726daed584a161450b1ead05b0c9db";
+      sha256 = "1k0cc39fb57hz9yv9w2bgbhciia91ls9931xqvr4jmvlx9z99b25";
     };
     meta.homepage = "https://github.com/lambdalisue/fern.vim/";
   };
@@ -1451,24 +1451,24 @@ let
 
   fzf-lsp-nvim = buildVimPluginFrom2Nix {
     pname = "fzf-lsp-nvim";
-    version = "2020-12-24";
+    version = "2021-01-19";
     src = fetchFromGitHub {
       owner = "gfanto";
       repo = "fzf-lsp.nvim";
-      rev = "de69b03c9feaa4b574e4a3e053a9a33467848227";
-      sha256 = "09kpcmnvzgsdbwd5nsnkm93khqhncb8bjl67519wjgx39g73pq50";
+      rev = "5b12d8de47608570b404270c00742e3977ed3103";
+      sha256 = "0y23i1gj4y517qs4ff43fi3ivkz4gmidrvcf6n314nwjgzikff6w";
     };
     meta.homepage = "https://github.com/gfanto/fzf-lsp.nvim/";
   };
 
   fzf-vim = buildVimPluginFrom2Nix {
     pname = "fzf-vim";
-    version = "2021-01-17";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "junegunn";
       repo = "fzf.vim";
-      rev = "1fcdee55cc5975d67248b2f8ea5fbac9aa628b7c";
-      sha256 = "0pnpjm17dn28gidjc43dkh5rn5s5rni5l8zjhy72hnix8ws3m1k0";
+      rev = "36de5db9f0af1fb2e788f890d7f28f1f8239bd4b";
+      sha256 = "02wpqvmsdl64f3xni46is8mydy4h9i41b432qa5z0bfc652ax43d";
     };
     meta.homepage = "https://github.com/junegunn/fzf.vim/";
   };
@@ -1559,14 +1559,14 @@ let
 
   gitsigns-nvim = buildVimPluginFrom2Nix {
     pname = "gitsigns-nvim";
-    version = "2021-19-01";
+    version = "2021-01-19";
     src = fetchFromGitHub {
       owner = "lewis6991";
       repo = "gitsigns.nvim";
-      rev = "4440a0f716b76132f365f5ef5c7f7cdad4b7c98c";
-      sha256 = "19hyqga7xj3dc7p629gih80c72a04z1my8qav37myz0jq3bllg2v";
+      rev = "59f7091554378794229bccca1faef6cfcc662024";
+      sha256 = "05s2ln800gxw0xk53gf8zsv01hxdznhrqrkprp4iki4k28lay5kd";
     };
-    meta.homepage = "https://github.com/lewis6991/gitsigns.nvim";
+    meta.homepage = "https://github.com/lewis6991/gitsigns.nvim/";
   };
 
   gitv = buildVimPluginFrom2Nix {
@@ -2136,12 +2136,12 @@ let
 
   lightline-ale = buildVimPluginFrom2Nix {
     pname = "lightline-ale";
-    version = "2021-01-16";
+    version = "2021-01-19";
     src = fetchFromGitHub {
       owner = "maximbaz";
       repo = "lightline-ale";
-      rev = "fa5e6bf8bca114c508b1247a94ef95c89c390a57";
-      sha256 = "00a8lpj57mbjqky4anjk5jjm2kz9y2iim2dvv1slvm6wyvd4hkwq";
+      rev = "932ea5b9287b8ddfd7b7f0218bb28de52d013140";
+      sha256 = "1b3xbhd32jk43z8baj1djls294whbq2qls01l90k4ihsq97jplb9";
     };
     meta.homepage = "https://github.com/maximbaz/lightline-ale/";
   };
@@ -2208,12 +2208,12 @@ let
 
   lualine-nvim = buildVimPluginFrom2Nix {
     pname = "lualine-nvim";
-    version = "2021-01-15";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "hoob3rt";
       repo = "lualine.nvim";
-      rev = "10a6087a74b235a7e3a77310a21a563afad3a148";
-      sha256 = "06p776nkm2r1i6hslbcaqqg4adqlmv3car6gi8yd4yv8vwlffraw";
+      rev = "09835e2a1a5404b4ee4b80fb8e3fa84ccbddfec4";
+      sha256 = "0n4b8iyk9pk4ji0sw8lf973z2wg2lfb59yh0ry3hkl9g66vg5nkl";
     };
     meta.homepage = "https://github.com/hoob3rt/lualine.nvim/";
   };
@@ -2342,12 +2342,12 @@ let
     pname = "ncm2-dictionary";
     version = "2018-11-15";
     src = fetchFromGitHub {
-      owner = "yuki-ycino";
+      owner = "yuki-yano";
       repo = "ncm2-dictionary";
       rev = "c93b52ab0cd1a9ebe5711414c3134f4bba9be6af";
       sha256 = "096l8prqm7zb2s27j2cpnydggszicaji7xjlmhrav7dzc51avafy";
     };
-    meta.homepage = "https://github.com/yuki-ycino/ncm2-dictionary/";
+    meta.homepage = "https://github.com/yuki-yano/ncm2-dictionary/";
   };
 
   ncm2-github = buildVimPluginFrom2Nix {
@@ -2568,12 +2568,12 @@ let
 
   neoformat = buildVimPluginFrom2Nix {
     pname = "neoformat";
-    version = "2021-01-16";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "sbdchd";
       repo = "neoformat";
-      rev = "306b74eab85bc84bb790118bfb6a4b01e352f4f0";
-      sha256 = "0nkhj5yamws84w0gwnydgysqbscigfm2yjb9p8yvbfx23y6idijk";
+      rev = "c1d63f047c2fc1dba638a80c24d9b9b44ceb9f50";
+      sha256 = "1q92lxdy8mgiv3ffp2gxsf0acp98hk3yh3lkvsaj6crdwbrq1ss9";
     };
     meta.homepage = "https://github.com/sbdchd/neoformat/";
   };
@@ -2616,12 +2616,12 @@ let
 
   neosnippet-snippets = buildVimPluginFrom2Nix {
     pname = "neosnippet-snippets";
-    version = "2021-01-15";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "neosnippet-snippets";
-      rev = "ba35daa1d248b47b3a5202e5d32e3af5affdcd4b";
-      sha256 = "14aq1m9qbmkyzp36qlpgqm8rdpc0338z68hxshwk55i01wdysqfd";
+      rev = "b10b14873fc0fd46a7daab251e83eaad6c17e1e3";
+      sha256 = "1y5bp92dvz356nzl14bcqhdvfwc59ckc45nw0m4lh43q2h0lvdg1";
     };
     meta.homepage = "https://github.com/Shougo/neosnippet-snippets/";
   };
@@ -2712,12 +2712,12 @@ let
 
   nerdtree = buildVimPluginFrom2Nix {
     pname = "nerdtree";
-    version = "2021-01-19";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "preservim";
       repo = "nerdtree";
-      rev = "7099f638edd3eda5cd5687b4e13d342bb7f9949d";
-      sha256 = "1109acmcxwr6kfrw6ganpqwwarsf5l9vd3vxmmafz3c86ha6kkvw";
+      rev = "b134f6518b902c7e0482ae770b804fd47c2d2426";
+      sha256 = "11gq7dcj8v6y1wlnyc6wfsh54qzd5am8lmjjk69jbbjsjzpb59xb";
     };
     meta.homepage = "https://github.com/preservim/nerdtree/";
   };
@@ -2832,12 +2832,12 @@ let
 
   nvim-dap = buildVimPluginFrom2Nix {
     pname = "nvim-dap";
-    version = "2021-01-17";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "mfussenegger";
       repo = "nvim-dap";
-      rev = "570b84cdd58ff8ae00974d827ab259b226809ab2";
-      sha256 = "040y3a1bzpf69ra6a9f0jzdfw9yf694x9zxmby8ba7xil3q69pzr";
+      rev = "0e4ddd517bce79dbc351b89710becf4c711afd84";
+      sha256 = "0dr2cdfwd8dirwqqwwp4iay24p9ssrynq2801mrk5wd7rnv20x7b";
     };
     meta.homepage = "https://github.com/mfussenegger/nvim-dap/";
   };
@@ -2856,12 +2856,12 @@ let
 
   nvim-gdb = buildVimPluginFrom2Nix {
     pname = "nvim-gdb";
-    version = "2021-01-08";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "sakhnik";
       repo = "nvim-gdb";
-      rev = "81930348bbb1398635cc0ecbbc88e3defd8aaa0f";
-      sha256 = "106g7pxa9rwwq45hmsb55b3dy0px2lr5lb25yy8n6jx6a70z9hf7";
+      rev = "50b578efc1514f6ba45e23cdc89d656a51929208";
+      sha256 = "0qcnchf1mnq0bwgkg7las62i4l4hwyisycymcrs0ki9skqdw5swh";
     };
     meta.homepage = "https://github.com/sakhnik/nvim-gdb/";
   };
@@ -2892,7 +2892,7 @@ let
 
   nvim-jdtls = buildVimPluginFrom2Nix {
     pname = "nvim-jdtls";
-    version = "2021-01-19";
+    version = "2021-01-17";
     src = fetchFromGitHub {
       owner = "mfussenegger";
       repo = "nvim-jdtls";
@@ -2904,12 +2904,12 @@ let
 
   nvim-lspconfig = buildVimPluginFrom2Nix {
     pname = "nvim-lspconfig";
-    version = "2021-01-18";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "nvim-lspconfig";
-      rev = "1f88798c0efe9331e83243ce05605fbac0433e9d";
-      sha256 = "042bgy356v7yy4zm76mngp55n53rnqrlclpm4lafjvl788fny7k4";
+      rev = "86b316140a5fdc902e89ff585ce429357ce4d5df";
+      sha256 = "1d0qb4kpdk677m53wl4lpbkmz283b27x34d78bsq7q078l642sg4";
     };
     meta.homepage = "https://github.com/neovim/nvim-lspconfig/";
   };
@@ -2952,24 +2952,24 @@ let
 
   nvim-tree-lua = buildVimPluginFrom2Nix {
     pname = "nvim-tree-lua";
-    version = "2021-01-17";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "kyazdani42";
       repo = "nvim-tree.lua";
-      rev = "bf59dd4a86f13eeb32ac04d7d1fadadd48662647";
-      sha256 = "19kjxdspiylp5ww2h1xnhzd57fhlpzdbkyglg79a86xlsf1r1c7x";
+      rev = "91bd2b53ba605dd66712178454c3ae9800885c0e";
+      sha256 = "16wwfhly3ii855kq7kdrcyvvcdf1zfrsj24yb5r15dzjp104ahrx";
     };
     meta.homepage = "https://github.com/kyazdani42/nvim-tree.lua/";
   };
 
   nvim-treesitter = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter";
-    version = "2021-01-15";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter";
-      rev = "1c3fb201c65b42a3752b299d31b1fcf40e3c38e4";
-      sha256 = "1q3i1jfmrc7spayyhz85w9gfv69shlz59cbf9zrp1fvnlhys4ds9";
+      rev = "99ecb46592f8e9a3a8b56ff2c4fd18f1eff4a5af";
+      sha256 = "131k1p0qjwvm5d3s1670r9a4s053c7x2yi7n69jlljc6x57b3q9n";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter/";
   };
@@ -3012,12 +3012,12 @@ let
 
   nvim-ts-rainbow = buildVimPluginFrom2Nix {
     pname = "nvim-ts-rainbow";
-    version = "2021-01-16";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "p00f";
       repo = "nvim-ts-rainbow";
-      rev = "6fc6c5691bfc5f1d742c3674400ff7074bf4d6f4";
-      sha256 = "02g977djjmpjag72h38i98kiwqw5qbcqa1kp8g0iayyy8agvkr81";
+      rev = "18c879acbcf9349b131c6d78eba41c489796ec74";
+      sha256 = "1nqw98yhqbm4afr60x6njdfgm0gk2sqv91dcvrvw2jjwa1dzzcc5";
     };
     meta.homepage = "https://github.com/p00f/nvim-ts-rainbow/";
   };
@@ -3196,20 +3196,20 @@ let
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "playground";
-      rev = "4a11cf237a6e505feb747f6097d48bf0195888b3";
-      sha256 = "0d9xm63spsaa580n2nyqiiq2p81ilmm0dwzqg6jhw9c020r5rzg1";
+      rev = "bcd83b5ce698e9ffdd27e64be16f04f0544ca047";
+      sha256 = "0kmyx172v94m3193i3pmim79d6pk9zffbm50lvzpy7n0bi16608i";
     };
     meta.homepage = "https://github.com/nvim-treesitter/playground/";
   };
 
   plenary-nvim = buildVimPluginFrom2Nix {
     pname = "plenary-nvim";
-    version = "2021-01-18";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "nvim-lua";
       repo = "plenary.nvim";
-      rev = "fecbbd23e425db8cc60b85d8298f02935d69940d";
-      sha256 = "0q5hsg2rlzhldr221krvxppspdl04rj5qbiq3nk1a25nf5r24d0z";
+      rev = "d63b5b8d3fe2de5db6748ef8f0d3b397c6910d2d";
+      sha256 = "0nfq9ahg89l5af9yxakr8ywpvpig77pa3wi37kkg67g8yq31zxg0";
     };
     meta.homepage = "https://github.com/nvim-lua/plenary.nvim/";
   };
@@ -3854,12 +3854,12 @@ let
 
   tagbar = buildVimPluginFrom2Nix {
     pname = "tagbar";
-    version = "2021-01-15";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "preservim";
       repo = "tagbar";
-      rev = "59eef1364d8ebb16ceb8dba4274f3926f3c3b7f0";
-      sha256 = "004ss6v677qlizmav2cbmcswc39880c0hazcdrkrzxfdfzrb8byp";
+      rev = "16f3f9b77b0440a14f1400bf3340bc41b781a1d5";
+      sha256 = "08ixhd2axs5p3a3c7f9pawscn811rrc84cpqqip5k78f7ws77yw8";
     };
     meta.homepage = "https://github.com/preservim/tagbar/";
   };
@@ -3913,26 +3913,26 @@ let
   };
 
   telescope-fzy-native-nvim = buildVimPluginFrom2Nix {
-     pname = "telescope-fzy-native-nvim";
-     version = "2021-01-02";
-     src = fetchFromGitHub {
-       owner = "nvim-telescope";
-       repo = "telescope-fzy-native.nvim";
-       rev = "654dffd924b29fb9a9252dcbd63528b1498ac9fb";
-       sha256 = "01x9z3n03qharjw778cxb16gw1dsxzmsxph4xsbfy1avf21c6x9g";
-       fetchSubmodules = true;
-     };
-     meta.homepage = "https://github.com/nvim-telescope/telescope-fzy-native.nvim/";
-   };
+    pname = "telescope-fzy-native-nvim";
+    version = "2020-12-31";
+    src = fetchFromGitHub {
+      owner = "nvim-telescope";
+      repo = "telescope-fzy-native.nvim";
+      rev = "654dffd924b29fb9a9252dcbd63528b1498ac9fb";
+      sha256 = "01x9z3n03qharjw778cxb16gw1dsxzmsxph4xsbfy1avf21c6x9g";
+      fetchSubmodules = true;
+    };
+    meta.homepage = "https://github.com/nvim-telescope/telescope-fzy-native.nvim/";
+  };
 
   telescope-nvim = buildVimPluginFrom2Nix {
     pname = "telescope-nvim";
-    version = "2021-01-18";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "nvim-telescope";
       repo = "telescope.nvim";
-      rev = "7d4d3462e990e2af489eb285aa7041d0b787c560";
-      sha256 = "013m8k7s5d2ix83q1d7x6nqi7s9vn5g221wnbngd41ywbdn61a9a";
+      rev = "a81f316712b26a04ec35eda9c46a641ece635881";
+      sha256 = "0cvh5c86cv5jir0ibf1gn5kwkrmrshapi8al8lqavgsh7ryib4nw";
     };
     meta.homepage = "https://github.com/nvim-telescope/telescope.nvim/";
   };
@@ -5296,12 +5296,12 @@ let
 
   vim-floaterm = buildVimPluginFrom2Nix {
     pname = "vim-floaterm";
-    version = "2021-01-15";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "voldikss";
       repo = "vim-floaterm";
-      rev = "355f1788b4a0878be6f99f4d41bf09d79fa4e80a";
-      sha256 = "0j89h2vyggpgx2vhfd0a3x6nk5yaf898g9ipw5ags66sp13c4fqc";
+      rev = "4cdbad8981ac4e7f8c57de5100561b87adcb7ae3";
+      sha256 = "00nrk5ldrn52fvslg3lrbfi63wngf34hlhfrcd5jsgllp918wpcz";
     };
     meta.homepage = "https://github.com/voldikss/vim-floaterm/";
   };
@@ -5464,12 +5464,12 @@ let
 
   vim-go = buildVimPluginFrom2Nix {
     pname = "vim-go";
-    version = "2021-01-17";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "fatih";
       repo = "vim-go";
-      rev = "3a8e3f6ded412b25fb3c13eecf76d5809fa175e8";
-      sha256 = "0vj6wcvx87kkykmlxjdwnbnfiq8bbqjnki8x3qaiv4gx028m778d";
+      rev = "cf7ff75a3f5f6600474dc1912819fd0ce12e97ee";
+      sha256 = "01i2cffnivj9p8fz5l49z4g0cja5hk8klim7wbn38zm7xmq0cn8f";
     };
     meta.homepage = "https://github.com/fatih/vim-go/";
   };
@@ -6487,12 +6487,12 @@ let
 
   vim-orgmode = buildVimPluginFrom2Nix {
     pname = "vim-orgmode";
-    version = "2020-10-15";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "jceb";
       repo = "vim-orgmode";
-      rev = "b7bce17005cf114b0961d0b5576bf584a2574774";
-      sha256 = "1kpg858qazv465k2w8343hkiz9lzclkcx91vcysip77diandn523";
+      rev = "3aeea0648f485f002cfcaf1b3e6a25ef43a12a66";
+      sha256 = "0jx5vw72p8s5np31g0macwx3iqghfgzvx30akyk5fspfayjivaxl";
     };
     meta.homepage = "https://github.com/jceb/vim-orgmode/";
   };
@@ -7207,12 +7207,12 @@ let
 
   vim-snippets = buildVimPluginFrom2Nix {
     pname = "vim-snippets";
-    version = "2021-01-17";
+    version = "2021-01-20";
     src = fetchFromGitHub {
       owner = "honza";
       repo = "vim-snippets";
-      rev = "673390c68328d8d067439127f15923a8ebc9efd8";
-      sha256 = "1mvsm0q6nzsp31ndh5yrr3bbgysn4fmcfzlg0rjbh18y159fcfqv";
+      rev = "d6f2d5728002456fac0075c2442695d25167f8d9";
+      sha256 = "007jb9xmq5cz1lc79s8x1idknjfbzmikss0wmrfjqq5dbkibvv9s";
     };
     meta.homepage = "https://github.com/honza/vim-snippets/";
   };
@@ -8157,12 +8157,12 @@ let
 
   yats-vim = buildVimPluginFrom2Nix {
     pname = "yats-vim";
-    version = "2021-01-10";
+    version = "2021-01-21";
     src = fetchFromGitHub {
       owner = "HerringtonDarkholme";
       repo = "yats.vim";
-      rev = "ac6057f57e0d96ee744635e35cacf2f2d3037d95";
-      sha256 = "037vmmnhir217ais2bnl6lskbpdh2wfmjq6qmjvrdp2ylwscm81d";
+      rev = "6104b30b32732e367266f06ecf6e817df32ac1b9";
+      sha256 = "0r8asbc387mmdiignr862gz4xd590c6rhp3ff78v7z7rn94dnamd";
       fetchSubmodules = true;
     };
     meta.homepage = "https://github.com/HerringtonDarkholme/yats.vim/";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -375,6 +375,18 @@ let
     meta.homepage = "https://github.com/tyru/caw.vim/";
   };
 
+  chadtree = buildVimPluginFrom2Nix {
+    pname = "chadtree";
+    version = "2021-01-21";
+    src = fetchFromGitHub {
+      owner = "ms-jpq";
+      repo = "chadtree";
+      rev = "a351625c4029fb15b14eebe46016c9a6b1bc7d26";
+      sha256 = "0jmnsr1k9v7zpxkbd6h9i4cizbkm99vyr4366wdjiikbn29jx6pr";
+    };
+    meta.homepage = "https://github.com/ms-jpq/chadtree/";
+  };
+
   changeColorScheme-vim = buildVimPluginFrom2Nix {
     pname = "changeColorScheme-vim";
     version = "2010-10-18";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -275,7 +275,7 @@ leanprover/lean.vim
 ledger/vim-ledger
 lepture/vim-jinja
 lervag/vimtex
-lewis6991/gitsigns.nvim
+lewis6991/gitsigns.nvim@main
 lfilho/cosco.vim
 lifepillar/vim-mucomplete
 lighttiger2505/deoplete-vim-lsp

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -353,6 +353,7 @@ mopp/sky-color-clock.vim
 morhetz/gruvbox
 motus/pig.vim
 mpickering/hlint-refactor-vim
+ms-jpq/chadtree@chad
 mtikekar/vim-bsv
 nanotech/jellybeans.vim
 natebosch/vim-lsc

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -680,6 +680,6 @@ Xuyuanp/nerdtree-git-plugin
 ycm-core/YouCompleteMe
 Yggdroot/indentLine
 Yilin-Yang/vim-markbar
-yuki-ycino/ncm2-dictionary
+yuki-yano/ncm2-dictionary
 zah/nim.vim
 ziglang/zig.vim


### PR DESCRIPTION
###### Motivation for this change

Add a [fairly popular Neovim plugin](https://github.com/ms-jpq/chadtree)

###### Things done

~Will run `nix-review`~

Output:

```
$ nix-env -f /Users/yuuki/.cache/nixpkgs-review/pr-110364/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package added:
vimPlugins.chadtree (init at 2021-01-21)

33 packages updated:
spacevim vimPlugins.ale (2021-01-16 → 2021-01-20) vimPlugins.ci_dark (2020-12-25 → 2021-01-20) vimPlugins.denite-nvim (2021-01-16 → 2021-01-21) vimPlugins.denite (2021-01-16 → 2021-01-21) vimPlugins.fern-vim (2021-01-17 → 2021-01-20) vimPlugins.fzf-lsp-nvim (2020-12-24 → 2021-01-19) vimPlugins.fzf-vim (2021-01-17 → 2021-01-20) vimPlugins.gitsigns-nvim (2021-19-01 → 2021-01-19) vimPlugins.lightline-ale (2021-01-16 → 2021-01-19) vimPlugins.lualine-nvim (2021-01-15 → 2021-01-20) vimPlugins.neoformat (2021-01-16 → 2021-01-20) vimPlugins.neosnippet-snippets (2021-01-15 → 2021-01-20) vimPlugins.The_NERD_tree (2021-01-19 → 2021-01-20) vimPlugins.nerdtree (2021-01-19 → 2021-01-20) vimPlugins.nvim-dap (2021-01-17 → 2021-01-20) vimPlugins.nvim-gdb (2021-01-08 → 2021-01-20) vimPlugins.nvim-jdtls (2021-01-19 → 2021-01-17) vimPlugins.nvim-lspconfig (2021-01-18 → 2021-01-21) vimPlugins.nvim-tree-lua (2021-01-17 → 2021-01-20) vimPlugins.nvim-treesitter (2021-01-15 → 2021-01-21) vimPlugins.nvim-ts-rainbow (2021-01-16 → 2021-01-21) vimplugin-playground vimPlugins.plenary-nvim (2021-01-18 → 2021-01-21) vimPlugins.tagbar (2021-01-15 → 2021-01-21) vimPlugins.Tagbar (2021-01-15 → 2021-01-21) vimPlugins.telescope-fzy-native-nvim (2021-01-02 → 2020-12-31) vimPlugins.telescope-nvim (2021-01-18 → 2021-01-20) vimPlugins.vim-floaterm (2021-01-15 → 2021-01-21) vimPlugins.vim-go (2021-01-17 → 2021-01-20) vimPlugins.vim-orgmode (2020-10-15 → 2021-01-20) vimPlugins.vim-snippets (2021-01-17 → 2021-01-20) vimPlugins.yats-vim (2021-01-10 → 2021-01-21)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /Users/yuuki/.cache/nixpkgs-review/pr-110364/build.nix
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
getting attributes of path '/usr/lib/libSystem.B.dylib: No such file or directory
(use '--show-trace' to show detailed location information)

Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/110364

30 packages failed to build:
spacevim vimPlugins.Tagbar vimPlugins.nerdtree vimPlugins.ale vimPlugins.ci_dark vimPlugins.denite vimPlugins.fern-vim vimPlugins.fzf-lsp-nvim vimPlugins.fzf-vim vimPlugins.gitsigns-nvim vimPlugins.lightline-ale vimPlugins.lualine-nvim vimPlugins.neoformat vimPlugins.neosnippet-snippets vimPlugins.nvim-dap vimPlugins.nvim-gdb vimPlugins.nvim-jdtls vimPlugins.nvim-lspconfig vimPlugins.nvim-tree-lua vimPlugins.nvim-treesitter vimPlugins.nvim-ts-rainbow vimPlugins.playground vimPlugins.plenary-nvim vimPlugins.telescope-fzy-native-nvim vimPlugins.telescope-nvim vimPlugins.vim-floaterm vimPlugins.vim-go vimPlugins.vim-orgmode vimPlugins.vim-snippets vimPlugins.yats-vim

1 package built:
vimPlugins.chadtree

error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/mkig36ixq3kjlxhwrnhrdphnyzqmz3rr-spacevim-1.5.0.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/1hwr21l5cqq23gw5smh7xdfw2gw0djfk-vimplugin-tagbar-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/p9k95vf5rvlh87w8f9jn4359sbyfkrk4-vimplugin-nerdtree-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/0zmhgf3cshid9l8miw61n6ryr6q8d6qc-vimplugin-ale-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/1ch0a71nw2lvi6wqzydd19s2fqn5k8cs-vimplugin-ci_dark-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/6nriw3fp7k2qgp4wsnjrxy6m6ifnvh46-vimplugin-denite-nvim-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/blvimmn9bj8rlzdfc923bkh9rab3xd4b-vimplugin-fern-vim-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/65zx7f9q2kaynw3pxk8wzhjv9b4k4bi0-vimplugin-fzf-lsp-nvim-2021-01-19.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/6ri74qy1jdj378837jxrk4vb8w3n70v0-vimplugin-fzf-vim-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/zjw7fjp1z7nps51hz3hs6jxj98lw4dri-vimplugin-gitsigns-nvim-2021-01-19.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/33863750yy5dx225zxyh78yxcjh4fdag-vimplugin-lightline-ale-2021-01-19.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/x1336ddyr2y3vrzc6753v87zj0qfd1hi-vimplugin-lualine-nvim-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/xhcvp8ry8918gg1qzn2px6318wv11a3k-vimplugin-neoformat-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/m3c43kina7rzgvpkj7spq8mr19nywszb-vimplugin-neosnippet-snippets-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/s32v9xgniw2ym33p9vx78i3zg7zmq5v8-vimplugin-nvim-dap-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/klb4pbkcb120vsy2b3nrjanhj76q4jsp-vimplugin-nvim-gdb-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/dp4dhg4xjyfklw9g15xh6cybyzdgkcbk-vimplugin-nvim-jdtls-2021-01-17.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/4r4qah57hymidk0xcflbkzamyryqycnj-vimplugin-nvim-lspconfig-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/6njsmclncqjkccsxgpqcmgrxh7j421ax-vimplugin-nvim-tree-lua-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/ww0sdrzr5x25yxs1p6km203vgvazh1lq-vimplugin-nvim-treesitter-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/838yjr96jccgn0lbcawxpm85dw7q4abp-vimplugin-nvim-ts-rainbow-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/yqpjf72vfi83j0nz13lxpkxq0z9lnmy3-vimplugin-playground-2021-01-19.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/m3pml562kkn9xs4647zxrjafnks3zblj-vimplugin-plenary-nvim-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/wy8mv1srv4ccwjyy3rafdqqzi4s89p1v-vimplugin-telescope-fzy-native-nvim-2020-12-31.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/rq3vlfshc91hhcpk9fdkrrvq8dclmx8x-vimplugin-telescope-nvim-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/n62mwgd52lpasy7hq8232di74q2sl3lc-vimplugin-vim-floaterm-2021-01-21.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/qgbdnkmilsr555ri8imd3y5lj3vi0hwd-vimplugin-vim-go-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/b1fadh2mxw0r5yvcs6w4g66kmgrb27mg-vimplugin-vim-orgmode-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/hn43fs1785j8nkwnzbp3vwh1mnj4aa38-vimplugin-vim-snippets-2021-01-20.drv' is not available
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ nix
build log of '/nix/store/qvpmwnipqk6qapg7m7p239la99icv48r-vimplugin-yats-vim-2021-01-21.drv' is not available
$ nix-shell /Users/yuuki/.cache/nixpkgs-review/pr-110364/shell.nix
these 6 paths will be fetched (1.46 MiB download, 7.85 MiB unpacked):
  /nix/store/860hfijyay9fhihyi3yx1cnks7xv03xg-bash-interactive-4.4-p23-info
  /nix/store/8bai73gdad4bh4h1aj0h8254f9xnx641-bash-interactive-4.4-p23
  /nix/store/c000j0qk9xn7443n856kf5aim0n3fvdq-bash-interactive-4.4-p23-dev
  /nix/store/i2bsfy53lhdk7khyqpqm2lir9zhbq3z8-bash-interactive-4.4-p23-man
  /nix/store/m7vjr697nngmz760cvxpdanr1741zwwv-bash-interactive-4.4-p23-doc
  /nix/store/qx392yyigjmj6rzn8d5v70pb7v1fvnv7-readline-7.0p5
copying path '/nix/store/m7vjr697nngmz760cvxpdanr1741zwwv-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/860hfijyay9fhihyi3yx1cnks7xv03xg-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/i2bsfy53lhdk7khyqpqm2lir9zhbq3z8-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/qx392yyigjmj6rzn8d5v70pb7v1fvnv7-readline-7.0p5' from 'https://cache.nixos.org'...
copying path '/nix/store/8bai73gdad4bh4h1aj0h8254f9xnx641-bash-interactive-4.4-p23' from 'https://cache.nixos.org'...
copying path '/nix/store/c000j0qk9xn7443n856kf5aim0n3fvdq-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...

```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
