### PR TITLE
vapoursynth: add withPlugins interface

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8331,6 +8331,12 @@
     githubId = 2320433;
     name = "Sam Boosalis";
   };
+  sbruder = {
+    email = "nixos@sbruder.de";
+    github = "sbruder";
+    githubId = 15986681;
+    name = "Simon Bruder";
+  };
   scalavision = {
     email = "scalavision@gmail.com";
     github = "scalavision";

--- a/pkgs/development/libraries/vapoursynth/0001-Call-weak-function-to-allow-adding-preloaded-plugins.patch
+++ b/pkgs/development/libraries/vapoursynth/0001-Call-weak-function-to-allow-adding-preloaded-plugins.patch
@@ -1,0 +1,74 @@
+From 9b05a6f331506afa5aca8865677af83403d2a32d Mon Sep 17 00:00:00 2001
+From: Tadeo Kondrak <me@tadeo.ca>
+Date: Mon, 25 Jan 2021 11:17:44 -0700
+Subject: [PATCH] Call weak function to allow adding preloaded plugins after
+ compile
+
+---
+ src/core/vscore.cpp | 19 +++++++++++++++++++
+ src/core/vscore.h   |  5 +++++
+ 2 files changed, 24 insertions(+)
+
+diff --git a/src/core/vscore.cpp b/src/core/vscore.cpp
+index 2d29844d..35c509ed 100644
+--- a/src/core/vscore.cpp
++++ b/src/core/vscore.cpp
+@@ -1229,6 +1229,20 @@ void VSCore::destroyFilterInstance(VSNode *node) {
+     freeDepth--;
+ }
+ 
++extern "C" {
++void __attribute__((weak)) VSLoadPluginsNix(void (*load)(void *data, const char *path), void *data);
++
++struct VSLoadPluginsNixCallbackData {
++    VSCore *core;
++    const char *filter;
++};
++
++static void VSLoadPluginsNixCallback(void *data, const char *path) {
++    auto callbackData = static_cast<VSLoadPluginsNixCallbackData *>(data);
++    callbackData->core->loadAllPluginsInPath(path, callbackData->filter);
++}
++}
++
+ VSCore::VSCore(int threads) :
+     coreFreed(false),
+     numFilterInstances(1),
+@@ -1351,6 +1365,11 @@ VSCore::VSCore(int threads) :
+     } // If neither exists, an empty string will do.
+ #endif
+ 
++    if (VSLoadPluginsNix != nullptr) {
++        VSLoadPluginsNixCallbackData data{this, filter.c_str()};
++        VSLoadPluginsNix(VSLoadPluginsNixCallback, &data);
++    }
++
+     VSMap *settings = readSettings(configFile);
+     const char *error = vs_internal_vsapi.getError(settings);
+     if (error) {
+diff --git a/src/core/vscore.h b/src/core/vscore.h
+index 74df8a84..3efac811 100644
+--- a/src/core/vscore.h
++++ b/src/core/vscore.h
+@@ -582,6 +582,9 @@ public:
+     VSFunction() : functionData(nullptr), func(nullptr) {}
+ };
+ 
++extern "C" {
++static void VSLoadPluginsNixCallback(void *data, const char *path);
++}
+ 
+ struct VSPlugin {
+ private:
+@@ -683,6 +686,8 @@ public:
+ 
+     explicit VSCore(int threads);
+     void freeCore();
++
++    friend void VSLoadPluginsNixCallback(void *data, const char *path);
+ };
+ 
+ #endif // VSCORE_H
+-- 
+2.30.0
+

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, makeWrapper
+, runCommandCC, runCommand, vapoursynth, writeText, patchelf, buildEnv
 , zimg, libass, python3, libiconv
 , ApplicationServices
 , ocrSupport ?  false, tesseract ? null
@@ -21,6 +22,10 @@ stdenv.mkDerivation rec {
     sha256 = "1krfdzc2x2vxv4nq9kiv1c09hgj525qn120ah91fw2ikq8ldvmx4";
   };
 
+  patches = [
+    ./0001-Call-weak-function-to-allow-adding-preloaded-plugins.patch
+  ];
+
   nativeBuildInputs = [ pkg-config autoreconfHook makeWrapper ];
   buildInputs = [
     zimg libass
@@ -36,12 +41,17 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru = {
+  passthru = rec {
     # If vapoursynth is added to the build inputs of mpv and then
     # used in the wrapping of it, we want to know once inside the
     # wrapper, what python3 version was used to build vapoursynth so
     # the right python3.sitePackages will be used there.
     inherit python3;
+
+    withPlugins = import ./plugin-interface.nix {
+      inherit lib python3 buildEnv writeText runCommandCC stdenv runCommand
+        vapoursynth makeWrapper withPlugins;
+    };
   };
 
   postInstall = ''
@@ -54,7 +64,7 @@ stdenv.mkDerivation rec {
     homepage    = "http://www.vapoursynth.com/";
     license     = licenses.lgpl21;
     platforms   = platforms.x86_64;
-    maintainers = with maintainers; [ rnhmjoj tadeokondrak ];
+    maintainers = with maintainers; [ rnhmjoj sbruder tadeokondrak ];
   };
 
 }

--- a/pkgs/development/libraries/vapoursynth/editor.nix
+++ b/pkgs/development/libraries/vapoursynth/editor.nix
@@ -1,43 +1,59 @@
-{ lib, mkDerivation, fetchFromBitbucket
+{ lib, stdenv, mkDerivation, fetchFromBitbucket, makeWrapper, runCommand
 , python3, vapoursynth
 , qmake, qtbase, qtwebsockets
 }:
 
-mkDerivation rec {
-  pname = "vapoursynth-editor";
-  version = "R19";
+let
+  unwrapped = mkDerivation rec {
+    pname = "vapoursynth-editor";
+    version = "R19";
 
-  src = fetchFromBitbucket {
-    owner = "mystery_keeper";
-    repo = pname;
-    rev = lib.toLower version;
-    sha256 = "1zlaynkkvizf128ln50yvzz3b764f5a0yryp6993s9fkwa7djb6n";
+    src = fetchFromBitbucket {
+      owner = "mystery_keeper";
+      repo = pname;
+      rev = lib.toLower version;
+      sha256 = "1zlaynkkvizf128ln50yvzz3b764f5a0yryp6993s9fkwa7djb6n";
+    };
+
+    nativeBuildInputs = [ qmake ];
+    buildInputs = [ qtbase vapoursynth qtwebsockets ];
+
+    dontWrapQtApps = true;
+
+    preConfigure = "cd pro";
+
+    preFixup = ''
+      cd ../build/release*
+      mkdir -p $out/bin
+      for bin in vsedit{,-job-server{,-watcher}}; do
+          mv $bin $out/bin
+          wrapQtApp $out/bin/$bin
+      done
+    '';
+
+    passthru = { inherit withPlugins; };
+
+    meta = with lib; {
+      description = "Cross-platform editor for VapourSynth scripts";
+      homepage = "https://bitbucket.org/mystery_keeper/vapoursynth-editor";
+      license = licenses.mit;
+      maintainers = with maintainers; [ tadeokondrak ];
+      platforms = platforms.all;
+    };
   };
 
-  nativeBuildInputs = [ qmake ];
-  buildInputs = [ qtbase vapoursynth qtwebsockets ];
-
-  dontWrapQtApps = true;
-
-  preConfigure = "cd pro";
-
-  preFixup = ''
-    cd ../build/release*
+  withPlugins = plugins: let
+    vapoursynthWithPlugins = vapoursynth.withPlugins plugins;
+  in runCommand "${unwrapped.name}-with-plugins" {
+    buildInputs = [ makeWrapper ];
+    passthru = { withPlugins = plugins': withPlugins (plugins ++ plugins'); };
+  } ''
     mkdir -p $out/bin
     for bin in vsedit{,-job-server{,-watcher}}; do
-        mv $bin $out/bin
-
-        wrapQtApp $out/bin/$bin \
-            --prefix PYTHONPATH : ${vapoursynth}/${python3.sitePackages} \
-            --prefix LD_LIBRARY_PATH : ${vapoursynth}/lib
+        makeWrapper ${unwrapped}/bin/$bin $out/bin/$bin \
+            --prefix PYTHONPATH : ${vapoursynthWithPlugins}/${python3.sitePackages} \
+            --prefix LD_LIBRARY_PATH : ${vapoursynthWithPlugins}/lib
     done
   '';
-
-  meta = with lib; {
-    description = "Cross-platform editor for VapourSynth scripts";
-    homepage = "https://bitbucket.org/mystery_keeper/vapoursynth-editor";
-    license = licenses.mit;
-    maintainers = with maintainers; [ tadeokondrak ];
-    platforms = platforms.all;
-  };
-}
+in
+  withPlugins []

--- a/pkgs/development/libraries/vapoursynth/plugin-interface.nix
+++ b/pkgs/development/libraries/vapoursynth/plugin-interface.nix
@@ -1,0 +1,112 @@
+{ lib, python3, buildEnv, writeText, runCommandCC, stdenv, runCommand
+, vapoursynth, makeWrapper, withPlugins }:
+
+plugins: let
+  pythonEnvironment = python3.buildEnv.override {
+    extraLibs = plugins;
+  };
+
+  getRecursivePropagatedBuildInputs = pkgs: lib.flatten
+    (map
+      (pkg: pkg.propagatedBuildInputs ++ (getRecursivePropagatedBuildInputs pkg.propagatedBuildInputs))
+      pkgs);
+
+  deepPlugins = plugins ++ (getRecursivePropagatedBuildInputs plugins);
+
+  pluginsEnv = buildEnv {
+    name = "vapoursynth-plugins-env";
+    pathsToLink = [ "/lib/vapoursynth" ];
+    paths = deepPlugins;
+  };
+
+  pluginLoader = let
+    source = writeText "vapoursynth-nix-plugins.c" ''
+      void VSLoadPluginsNix(void (*load)(void *data, const char *path), void *data) {
+      ${lib.concatMapStringsSep "" (path: "load(data, \"${path}/lib/vapoursynth\");") deepPlugins}
+      }
+    '';
+  in
+  runCommandCC "vapoursynth-plugin-loader" {
+    executable = true;
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  } ''
+    mkdir -p $out/lib
+    $CC -shared -fPIC ${source} -o "$out/lib/libvapoursynth-nix-plugins${ext}"
+  '';
+
+  ext = stdenv.targetPlatform.extensions.sharedLibrary;
+in
+runCommand "${vapoursynth.name}-with-plugins" {
+  nativeBuildInputs = [ makeWrapper ];
+  passthru = {
+    inherit python3;
+    withPlugins = plugins': withPlugins (plugins ++ plugins');
+  };
+} ''
+  mkdir -p \
+    $out/bin \
+    $out/lib/pkgconfig \
+    $out/lib/vapoursynth \
+    $out/${python3.sitePackages}
+
+  for textFile in \
+      lib/pkgconfig/vapoursynth{,-script}.pc \
+      lib/libvapoursynth.la \
+      lib/libvapoursynth-script.la \
+      ${python3.sitePackages}/vapoursynth.la
+  do
+      substitute ${vapoursynth}/$textFile $out/$textFile \
+          --replace "${vapoursynth}" "$out"
+  done
+
+  for binaryPlugin in ${pluginsEnv}/lib/vapoursynth/*; do
+      ln -s $binaryPlugin $out/''${binaryPlugin#"${pluginsEnv}/"}
+  done
+
+  for pythonPlugin in ${pythonEnvironment}/${python3.sitePackages}/*; do
+      ln -s $pythonPlugin $out/''${pythonPlugin#"${pythonEnvironment}/"}
+  done
+
+  for binaryFile in \
+      lib/libvapoursynth${ext} \
+      lib/libvapoursynth-script${ext}.0.0.0
+  do
+    old_rpath=$(patchelf --print-rpath ${vapoursynth}/$binaryFile)
+    new_rpath="$old_rpath:$out/lib"
+    patchelf \
+        --set-rpath "$new_rpath" \
+        --output $out/$binaryFile \
+        ${vapoursynth}/$binaryFile
+    patchelf \
+        --add-needed libvapoursynth-nix-plugins${ext} \
+        $out/$binaryFile
+  done
+
+  for binaryFile in \
+      ${python3.sitePackages}/vapoursynth${ext} \
+      bin/.vspipe-wrapped
+  do
+      old_rpath=$(patchelf --print-rpath ${vapoursynth}/$binaryFile)
+      new_rpath="''${old_rpath//"${vapoursynth}"/"$out"}"
+      patchelf \
+          --set-rpath "$new_rpath" \
+          --output $out/$binaryFile \
+          ${vapoursynth}/$binaryFile
+  done
+
+  ln -s \
+      ${pluginLoader}/lib/libvapoursynth-nix-plugins${ext} \
+      $out/lib/libvapoursynth-nix-plugins${ext}
+  ln -s ${vapoursynth}/include $out/include
+  ln -s ${vapoursynth}/lib/vapoursynth/* $out/lib/vapoursynth
+  ln -s \
+      libvapoursynth-script${ext}.0.0.0 \
+      $out/lib/libvapoursynth-script${ext}
+  ln -s \
+      libvapoursynth-script${ext}.0.0.0 \
+      $out/lib/libvapoursynth-script${ext}.0
+
+  makeWrapper $out/bin/.vspipe-wrapped $out/bin/vspipe \
+      --prefix PYTHONPATH : $out/${python3.sitePackages}
+''


### PR DESCRIPTION
This PR patches vapoursynth to allow specifying the plugin directory in an environment variable. This allows for a `withPlugins` interface to create a vapoursynth environment with the specified plugins.

###### Motivation for this change

Currently, there is no nice way for using vapoursynth with plugins. A workaround exists (https://github.com/NixOS/nixpkgs/pull/58859#issuecomment-479397341), but has its drawbacks (e.g. temporary usage with `nix run` or `nix-shell` does not work, it does not support multiple environments with different plugins etc.).

Since there is no upstream support for specifying a plugin directory other than in the global configuration file, I added the ability to load plugins from the directory specified in `VAPOURSYNTH_PLUGIN_PATH` as a patch. This is probably not the best option for implementing this, but my other idea (resolving the plugin path relative to the shared library at runtime) would require copying (instead of symlinking) the vapoursynth shared library so the plugin path can be found relative to it. That seemed even worse, so I chose the former option.

An example plugin environment can be built from the following expression: `vapoursynth.withPlugins [ vapoursynth-mvtools vapoursynth-editor ]`  
This includes `vapoursynth-editor` as a plugin (even though it isn’t), since that way the plugin path also gets added to the wrapper of `vsedit`.

This also adds the `VAPOURSYNTH_PLUGIN_PATH` environment variable to the mpv wrapper when vapoursynth support is enabled. Example:

```nix
wrapMpv
  (mpv-unwrapped.override {
    vapoursynthSupport = true;
    vapoursynth = vapoursynth.withPlugins [
      vapoursynth-mvtools
    ];
  })
  { }
```

I’m open for suggestions, as I acknowledge that this solution is somewhat of a hack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
