### PR TITLE
coqPackages.corn: 8.8.1 → 8.12.0

### DIFF
--- a/pkgs/development/coq-modules/corn/default.nix
+++ b/pkgs/development/coq-modules/corn/default.nix
@@ -3,8 +3,14 @@
 with lib; mkCoqDerivation rec {
   pname = "corn";
   inherit version;
-  defaultVersion = if versions.range "8.6" "8.9" coq.coq-version then "8.8.1" else null;
-  release."8.8.1".sha256 = "0gh32j0f18vv5lmf6nb87nr5450w6ai06rhrnvlx2wwi79gv10wp";
+  defaultVersion = switch coq.coq-version [
+    { case = "8.6"; out = "8.8.1"; }
+    { case = (versions.range "8.7" "8.12"); out = "8.12.0"; }
+  ] null;
+  release = {
+    "8.8.1".sha256 = "0gh32j0f18vv5lmf6nb87nr5450w6ai06rhrnvlx2wwi79gv10wp";
+    "8.12.0".sha256 = "0b92vhyzn1j6cs84z2182fn82hxxj0bqq7hk6cs4awwb3vc7dkhi";
+  };
 
   preConfigure = "patchShebangs ./configure.sh";
   configureScript = "./configure.sh";


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.10–8.12.

Ping @Zimmi48 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
