### PR TITLE
python3Packages.plugwise: init at 0.8.5

### DIFF
--- a/pkgs/development/python-modules/plugwise/default.nix
+++ b/pkgs/development/python-modules/plugwise/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, async-timeout
+, crcmod
+, defusedxml
+, pyserial
+, pytz
+, python-dateutil
+, semver
+, jsonpickle
+, mypy
+, pytest-aiohttp
+, pytest-asyncio
+, pytest-cov
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "plugwise";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "python-plugwise";
+    rev = version;
+    sha256 = "1gviyy31l1j8z0if2id3m13r43kw4mcgd8921813yfhmf174piq4";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+    crcmod
+    defusedxml
+    pyserial
+    pytz
+    python-dateutil
+    semver
+  ];
+
+  checkInputs = [
+    jsonpickle
+    mypy
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-cov
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "plugwise" ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "Python module for Plugwise Smiles, Stretch and USB stick";
+    longDescription = ''
+      XKNX is an asynchronous Python library for reading and writing KNX/IP
+      packets. It provides support for KNX/IP routing and tunneling devices.
+    '';
+    homepage = "https://github.com/plugwise/python-plugwise";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -621,7 +621,7 @@
     "plaato" = ps: with ps; [ aiohttp-cors ];
     "plant" = ps: with ps; [ sqlalchemy ];
     "plex" = ps: with ps; [ aiohttp-cors plexapi plexauth plexwebsocket pysonos ];
-    "plugwise" = ps: with ps; [ ]; # missing inputs: plugwise
+    "plugwise" = ps: with ps; [ plugwise ];
     "plum_lightpad" = ps: with ps; [ ]; # missing inputs: plumlightpad
     "pocketcasts" = ps: with ps; [ ]; # missing inputs: pycketcasts
     "point" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pypoint

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4876,6 +4876,8 @@ in {
 
   pluginbase = callPackage ../development/python-modules/pluginbase { };
 
+  plugwise = callPackage ../development/python-modules/plugwise { };
+
   plumbum = callPackage ../development/python-modules/plumbum { };
 
   ply = callPackage ../development/python-modules/ply { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for Plugwise Smiles, Stretch and USB stick

https://github.com/plugwise/python-plugwise

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
