### PR TITLE
convco: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3699,6 +3699,12 @@
     githubId = 362833;
     name = "Hongchang Wu";
   };
+  hoverbear = {
+    email = "operator+nix@hoverbear.org";
+    github = "hoverbear";
+    githubId = 130903;
+    name = "Ana Hobden";
+  };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";

--- a/pkgs/development/tools/convco/default.nix
+++ b/pkgs/development/tools/convco/default.nix
@@ -1,0 +1,26 @@
+{ lib, rustPlatform, fetchFromGitHub, stdenv, openssl, perl, pkg-config, libiconv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "convco";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "convco";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fqq6irbq1aikhhw08gc9kp0vbk2aminfbvwdlm58cvywyq91bn4";
+  };
+
+  cargoSha256 = "073sfv42fbl8rjm3dih1ghs9vq75mjshp66zdzdan2dmmrnw5m9z";
+
+  nativeBuildInputs = [ openssl perl pkg-config ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
+
+  meta = with lib; {
+    description = "A Conventional commit cli";
+    homepage = "https://github.com/convco/convco";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ hoverbear ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10692,6 +10692,10 @@ in
 
   crate2nix = callPackage ../development/tools/rust/crate2nix { };
 
+  convco = callPackage ../development/tools/convco {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   maturin = callPackage ../development/tools/rust/maturin { };
   inherit (rustPackages) rls;
   rustfmt = rustPackages.rustfmt;


### PR DESCRIPTION
###### Motivation for this change

Introduce the `convco` tool from https://github.com/convco/convco.

Example usage, while in a conventional commit respecting git repo like [Mayastor](https://github.com/openebs/Mayastor) or [Junctor](https://github.com/Hoverbear-Consulting/junctor) or [Vector](https://github.com/timberio/vector):

```bash
convco changelog > CHANGELOG.md
convco commit --refactor
convco version
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
