### PR TITLE
python3Packages.adafruit* and python3Packages.binho-host-adapter: init at 0.1.6

### DIFF
--- a/pkgs/development/python-modules/adafruit-platformdetect/default.nix
+++ b/pkgs/development/python-modules/adafruit-platformdetect/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "Adafruit-PlatformDetect";
+  version = "2.27.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rnmy74rjjcyni5sr8h1djffpj7wngn2wqckl5vknp2smaihp34l";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  # Project has not published tests yet
+  doCheck = false;
+  pythonImportsCheck = [ "adafruit_platformdetect" ];
+
+  meta = with lib; {
+    description = "Platform detection for use by Adafruit libraries";
+    homepage = "https://github.com/adafruit/Adafruit_Python_PlatformDetect";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/adafruit-pureio/default.nix
+++ b/pkgs/development/python-modules/adafruit-pureio/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "Adafruit-PureIO";
+  version = "1.1.8";
+
+  src = fetchPypi {
+    pname = "Adafruit_PureIO";
+    inherit version;
+    sha256 = "1mfa6sfz7qwgajz3lqw0s69ivvwbwvblwkjzbrwdrxjbma4jaw66";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  # Physical SMBus is not present
+  doCheck = false;
+  pythonImportsCheck = [ "Adafruit_PureIO" ];
+
+  meta = with lib; {
+    description = "Python interface to Linux IO including I2C and SPI";
+    homepage = "https://github.com/adafruit/Adafruit_Python_PureIO";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/binho-host-adapter/default.nix
+++ b/pkgs/development/python-modules/binho-host-adapter/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyserial
+}:
+
+buildPythonPackage rec {
+  pname = "binho-host-adapter";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mp8xa1qwaww2k5g2nqg7mcivzsbfw2ny1l9yjsi73109slafv8y";
+  };
+
+  propagatedBuildInputs = [ pyserial ];
+
+  # Project has no tests
+  doCheck = false;
+  pythonImportsCheck = [ "binhoHostAdapter" ];
+
+  meta = with lib; {
+    description = "Python library for Binho Multi-Protocol USB Host Adapters";
+    homepage = "https://github.com/adafruit/Adafruit_Python_PlatformDetect";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -162,6 +162,8 @@ in {
 
   actdiag = callPackage ../development/python-modules/actdiag { };
 
+  adafruit-platformdetect = callPackage ../development/python-modules/adafruit-platformdetect { };
+
   adal = callPackage ../development/python-modules/adal { };
 
   adb-homeassistant = callPackage ../development/python-modules/adb-homeassistant { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -164,6 +164,8 @@ in {
 
   adafruit-platformdetect = callPackage ../development/python-modules/adafruit-platformdetect { };
 
+  adafruit-pureio = callPackage ../development/python-modules/adafruit-pureio { };
+
   adal = callPackage ../development/python-modules/adal { };
 
   adb-homeassistant = callPackage ../development/python-modules/adb-homeassistant { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -913,6 +913,8 @@ in {
 
   binaryornot = callPackage ../development/python-modules/binaryornot { };
 
+  binho-host-adapter = callPackage ../development/python-modules/binho-host-adapter { };
+
   binwalk = callPackage ../development/python-modules/binwalk {
     pyqtgraph = null;
     matplotlib = null;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
All three are dependencies for other Adafruit Python modules and perhaps for CircuitPython. 

Those are dependencies of dependencies which are used by Home Assistant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
