### PR TITLE
ocamlPackages_4_12.ocaml: alpha3 -> beta1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.12.nix
+++ b/pkgs/development/compilers/ocaml/4.12.nix
@@ -1,9 +1,9 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "12";
-  patch_version = "0-alpha3";
+  patch_version = "0-beta1";
   src = fetchTarball {
-    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~alpha3.tar.xz";
-    sha256 = "1hqlf9fi5gmvb6r13z5819rg6k813bw9ihgbbji67hhh4q361wlw";
+    url = "http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0~beta1.tar.xz";
+    sha256 = "1rny74mi0knl8byqg2naw1mgvn22c2zihlwvzbkd56j97flqsxsm";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
