### PR TITLE
Update all skaware packages (s6, s6-rc, execline etc)

### DIFF
--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "nsss";
-  version = "0.0.2.2";
-  sha256 = "0am195wabv63n545ykqnch9gs8cs1g5zw35k2ddxb9dnamhxfi9k";
+  version = "0.1.0.0";
+  sha256 = "15rxbwf16wm1la079yr2xn4bccjgd7m8dh6r7bpr6s57cj93i2mq";
 
   description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions.";
 

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "skalibs";
-  version = "2.9.3.0";
-  sha256 = "0i1vg3bh0w3bpj7cv0kzs6q9v2dd8wa2by8h8j39fh1qkl20f6ph";
+  version = "2.10.0.1";
+  sha256 = "1chwjzlh13jbrldk77h3i4qjqv8hjpvvd3papcb8j46mvj7sxysg";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/development/libraries/utmps/default.nix
+++ b/pkgs/development/libraries/utmps/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "utmps";
-  version = "0.0.3.2";
-  sha256 = "0zri5pqnva48bm8za4ic5mx0ymv70y4ga16bjh4i5pscs40sj5dh";
+  version = "0.1.0.0";
+  sha256 = "09p0k2sgxr7jlsbrn66fzvzf9zxvpjp85y79xk10hxjglypszyml";
 
   description = "A secure utmpx and wtmp implementation";
 

--- a/pkgs/os-specific/linux/s6-linux-init/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-init/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, skawarePackages }:
+
+with skawarePackages;
+
+buildPackage {
+  pname = "s6-linux-init";
+  version = "1.0.6.0";
+  sha256 = "0kzif3dqhm7h4h7c6npzdbcy7w756222g8ysw116fgb8j385dr6w";
+
+  description = "A set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
+  platforms = lib.platforms.linux;
+
+  outputs = [ "bin" "dev" "doc" "out" ];
+
+  configureFlags = [
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-include=${execline.dev}/include"
+    "--with-include=${s6.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-lib=${s6.out}/lib"
+    "--with-lib=${execline.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+    "--with-dynlib=${execline.lib}/lib"
+    "--with-dynlib=${s6.out}/lib"
+  ];
+
+  postInstall = ''
+    # remove all s6 executables from build directory
+    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libs6_linux_init.* libhpr.*
+    rm -rf skel
+
+    mv doc $doc/share/doc/s6-linux-init/html
+  '';
+
+}

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-linux-utils";
-  version = "2.5.1.3";
-  sha256 = "0wbv02zxaami88xbj2zg63kspz05bbplswg0c6ncb5g9khf52wa4";
+  version = "2.5.1.4";
+  sha256 = "02gxzc9igid2kf2rvm3v6kc9806mpjmdq7cpanv4cml0ip68vbfq";
 
   description = "A set of minimalistic Linux-specific system utilities";
   platforms = lib.platforms.linux;

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "execline";
-  version = "2.6.1.1";
-  sha256 = "0mmsnai3bkyhng0cxdz6bf7d6b7kbsxs4p39m63215lz6kq0hhrr";
+  version = "2.7.0.0";
+  sha256 = "0kl74yix60msgw8k3shhp9ymm80n91yxxqckixj5qbbhmylpnpqd";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 

--- a/pkgs/tools/misc/execline/execlineb-wrapper.c
+++ b/pkgs/tools/misc/execline/execlineb-wrapper.c
@@ -12,6 +12,7 @@
 #include <skalibs/djbunix.h>
 #include <skalibs/strerr2.h>
 #include <skalibs/env.h>
+#include <skalibs/exec.h>
 
 #define dienomem() strerr_diefu1sys(111, "stralloc_catb")
 
@@ -41,10 +42,10 @@ int main(int argc, char const* argv[], char const *const *envp)
   }
 
   // exec into execlineb and append path_modif to the environment
-  xpathexec_r_name(
+  xmexec_aem(
     EXECLINEB_PATH(),
     argv,
-    envp, env_len(envp),
+    envp,
     path_modif.s, path_modif.len
   );
 }

--- a/pkgs/tools/misc/fdtools/default.nix
+++ b/pkgs/tools/misc/fdtools/default.nix
@@ -13,6 +13,7 @@ in stdenv.mkDerivation {
     inherit sha256;
   };
 
+  patches = [ ./new-skalibs.patch ];
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
   buildInputs = [ skawarePackages.skalibs ];

--- a/pkgs/tools/misc/fdtools/new-skalibs.patch
+++ b/pkgs/tools/misc/fdtools/new-skalibs.patch
@@ -1,0 +1,223 @@
+diff -Naur misc/fdtools-2020.05.04/src/check_exit_exec.c misc-new/fdtools-2020.05.04/src/check_exit_exec.c
+--- misc/fdtools-2020.05.04/src/check_exit_exec.c	2015-03-16 04:55:56.000000000 +0100
++++ misc-new/fdtools-2020.05.04/src/check_exit_exec.c	2021-01-22 10:50:25.529955213 +0100
+@@ -2,6 +2,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ 
++#include <skalibs/exec.h>
+ #include <skalibs/stddjb.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/diewarn.h"
+@@ -14,7 +15,7 @@
+ 
+   if (str_equal(arg, ":")) {
+     ++argv;
+-    pathexec0((char const**)argv);
++    mexec0((char const**)argv);
+     DIE1(exec, argv[0]);
+   }
+ }
+diff -Naur misc/fdtools-2020.05.04/src/grabconsole.c misc-new/fdtools-2020.05.04/src/grabconsole.c
+--- misc/fdtools-2020.05.04/src/grabconsole.c	2020-04-24 06:01:22.000000000 +0200
++++ misc-new/fdtools-2020.05.04/src/grabconsole.c	2021-01-22 10:43:27.887754936 +0100
+@@ -4,6 +4,7 @@
+ #include <errno.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/types.h"
+@@ -26,6 +27,6 @@
+   if (fd_grabconsole(fd)!=0) DIE0(tioccons);
+ 
+   argv+=2;
+-  pathexec0((char const**)argv);
++  mexec0((char const**)argv);
+   DIE1(exec, argv[0]);
+ }
+diff -Naur misc/fdtools-2020.05.04/src/pipecycle.c misc-new/fdtools-2020.05.04/src/pipecycle.c
+--- misc/fdtools-2020.05.04/src/pipecycle.c	2015-03-16 04:55:56.000000000 +0100
++++ misc-new/fdtools-2020.05.04/src/pipecycle.c	2021-01-22 10:47:58.033220790 +0100
+@@ -4,6 +4,7 @@
+ #include <unistd.h>
+ #include <signal.h>
+ 
++#include <skalibs/exec.h>
+ #include <skalibs/stddjb.h>
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/types.h"
+@@ -56,7 +57,7 @@
+       if (fd_shuffle(2, current, wanted)!=0) DIE0(dup);
+     }
+     read(start[0], &j, 1);
+-    pathexec(args);
++    mexec(args);
+     DIE1(exec, args[0]);
+   }
+ 
+diff -Naur misc/fdtools-2020.05.04/src/recvfd.c misc-new/fdtools-2020.05.04/src/recvfd.c
+--- misc/fdtools-2020.05.04/src/recvfd.c	2020-04-28 09:35:05.000000000 +0200
++++ misc-new/fdtools-2020.05.04/src/recvfd.c	2021-01-22 10:47:14.180994779 +0100
+@@ -7,6 +7,7 @@
+ #include <limits.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/types.h"
+ #include "fdtools.h"
+@@ -69,9 +70,9 @@
+       named_fd=duped;
+     }
+     buf[int_fmt(buf, named_fd)]='\0';
+-    if (pathexec_env(argv[i]+1, buf)==0) DIE0(alloc);
++    if (env_mexec(argv[i]+1, buf)==0) DIE0(alloc);
+   }
+   argv+=nfds+1;
+-  pathexec0((char const**)argv);
++  mexec0((char const**)argv);
+   DIE1(exec, argv[0]);
+ }
+diff -Naur misc/fdtools-2020.05.04/src/sendfd.c misc-new/fdtools-2020.05.04/src/sendfd.c
+--- misc/fdtools-2020.05.04/src/sendfd.c	2015-03-16 06:48:39.000000000 +0100
++++ misc-new/fdtools-2020.05.04/src/sendfd.c	2021-01-22 10:43:07.207634214 +0100
+@@ -7,6 +7,7 @@
+ #include <limits.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/types.h"
+ #include "fdtools.h"
+@@ -40,6 +41,6 @@
+   argv+=nfds;
+   if (*argv==NULL) _exit(0);
+   ++argv;
+-  pathexec0((char const**)argv);
++  mexec0((char const**)argv);
+   DIE1(exec, argv[0]);
+ }
+diff -Naur misc/fdtools-2020.05.04/src/setstate.c misc-new/fdtools-2020.05.04/src/setstate.c
+--- misc/fdtools-2020.05.04/src/setstate.c	2020-05-04 10:04:21.000000000 +0200
++++ misc-new/fdtools-2020.05.04/src/setstate.c	2021-01-22 10:45:05.084304318 +0100
+@@ -8,6 +8,7 @@
+ #include <errno.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/intattr.h"
+ #include "prjlibs-c/diewarn.h"
+@@ -167,6 +168,6 @@
+   }
+ 
+   argv+=2;
+-  pathexec_run(argv[0], (char const**)argv, (char const**)environ);
++  mexec_ae(argv[0], (char const**)argv, (char const**)environ);
+   DIE1(exec, argv[0]);
+ }
+diff -Naur misc/fdtools-2020.05.04/src/statfile.c misc-new/fdtools-2020.05.04/src/statfile.c
+--- misc/fdtools-2020.05.04/src/statfile.c	2015-03-22 00:33:44.000000000 +0100
++++ misc-new/fdtools-2020.05.04/src/statfile.c	2021-01-22 10:48:23.673351183 +0100
+@@ -6,6 +6,7 @@
+ #include <errno.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/warn.h"
+@@ -15,7 +16,7 @@
+ char const* PROG="statfile";
+ 
+ static void set(char const* const var, char const* const val) {
+-  if (pathexec_env(var, val)==0) DIE0(alloc);
++  if (env_mexec(var, val)==0) DIE0(alloc);
+ }
+ 
+ static void set64n(char const* const var, time_t t, unsigned int nsec) {
+@@ -178,6 +179,6 @@
+   }
+ 
+   argv+=3;
+-  pathexec((char const**)argv);
++  mexec((char const**)argv);
+   DIE1(exec, argv[0]);
+ }
+diff -Naur misc/fdtools-2020.05.04/src/vc-get-linux.c misc-new/fdtools-2020.05.04/src/vc-get-linux.c
+--- misc/fdtools-2020.05.04/src/vc-get-linux.c	2020-04-28 07:04:49.000000000 +0200
++++ misc-new/fdtools-2020.05.04/src/vc-get-linux.c	2021-01-22 10:47:34.649100757 +0100
+@@ -10,6 +10,7 @@
+ #include <sys/sysmacros.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/types.h"
+@@ -38,7 +39,7 @@
+       errno=0;
+       if (ioctl(fd, VT_OPENQRY, &vtnum)<0 || vtnum==-1) DIE0(vt_qry);
+       bufnum[ulong_fmt(bufnum, vtnum)]='\0';
+-      if (pathexec_env("TTY", buf)==0) DIE0(alloc);
++      if (env_mexec("TTY", buf)==0) DIE0(alloc);
+     }
+     fd_close(fd);
+ 
+@@ -50,12 +51,12 @@
+       if (fstat(fd, &statbuf)!=0) DIE1(stat, buf);
+       buf[ulong_fmt(buf, minor(statbuf.st_rdev))]='\0';
+     }
+-    if (pathexec_env("VCNUM", buf)==0) DIE0(alloc);
++    if (env_mexec("VCNUM", buf)==0) DIE0(alloc);
+ 
+     buf[ulong_fmt(buf, fd)]='\0';
+-    if (pathexec_env("VCFD", buf)==0) DIE0(alloc);
++    if (env_mexec("VCFD", buf)==0) DIE0(alloc);
+   }
+ 
+-  pathexec((char const**)argv+2);
++  mexec((char const**)argv+2);
+   DIE1(exec, argv[2]);
+ }
+diff -Naur misc/fdtools-2020.05.04/src/vc-lock-linux.c misc-new/fdtools-2020.05.04/src/vc-lock-linux.c
+--- misc/fdtools-2020.05.04/src/vc-lock-linux.c	2015-03-20 05:59:42.000000000 +0100
++++ misc-new/fdtools-2020.05.04/src/vc-lock-linux.c	2021-01-22 10:48:36.857417751 +0100
+@@ -8,6 +8,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/vt.h>
+ 
++#include <skalibs/exec.h>
+ #include <skalibs/stddjb.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/diewarn.h"
+@@ -79,7 +80,7 @@
+       WARN0(fork);
+     } else if (pid==0) {
+       sigprocmask(SIG_SETMASK, &old_set, NULLP);
+-      pathexec((char const**)argv);
++      mexec((char const**)argv);
+       DIE1(exec, *argv);
+     } else {
+       int status;
+diff -Naur misc/fdtools-2020.05.04/src/vc-switch-linux.c misc-new/fdtools-2020.05.04/src/vc-switch-linux.c
+--- misc/fdtools-2020.05.04/src/vc-switch-linux.c	2020-04-28 07:14:04.000000000 +0200
++++ misc-new/fdtools-2020.05.04/src/vc-switch-linux.c	2021-01-22 10:42:41.259480648 +0100
+@@ -10,6 +10,7 @@
+ #include <sys/sysmacros.h>
+ 
+ #include <skalibs/stddjb.h>
++#include <skalibs/exec.h>
+ #include "prjlibs-c/constants.h"
+ #include "prjlibs-c/diewarn.h"
+ #include "prjlibs-c/types.h"
+@@ -36,6 +37,6 @@
+   if (ioctl(fd, VT_ACTIVATE, ttyno)<0) DIE0(vt_act);
+   if (!scan) fd_close(fd);
+ 
+-  pathexec0((char const**)argv+3);
++  mexec0((char const**)argv+3);
+   DIE1(exec, argv[3]);
+ }

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -7,8 +7,8 @@ let
 
 in buildPackage {
   pname = pname;
-  version = "2.2.3.0";
-  sha256 = "063zwifigg2b3wsixdcz4h9yvr6fkqssvx0iyfsprjfmm1yapfi9";
+  version = "2.2.3.1";
+  sha256 = "1ks1ch5v3p2z8y8wp5fmzzgjrqn2l5sj1sgfp8vv6wy8psd8mrj3";
 
   description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-dns";
-  version = "2.3.2.0";
-  sha256 = "09hyb1xv9glqq0yy7wy8hiwvlr78kwv552pags8ancgamag15di7";
+  version = "2.3.5.0";
+  sha256 = "0h5p5dbkkdadahrp4pqhc3x9ds758i6djy49k5zrn7mm5k4722wz";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -20,8 +20,8 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 buildPackage {
   pname = "s6-networking";
-  version = "2.3.1.2";
-  sha256 = "1029bgwfmv903y5ji93j75m7p2jgchdxya1khxzb42q2z7yxnlyr";
+  version = "2.4.0.0";
+  sha256 = "1yqykwfl5jnkxgr6skfj5kzd896pknij0hi5m7lj0r18jpfs5zgq";
 
   description = "A suite of small networking utilities for Unix systems";
 
@@ -59,7 +59,7 @@ buildPackage {
     # remove all s6 executables from build directory
     rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
     rm minidentd
-    rm libs6net.* libstls.*
+    rm libs6net.* libstls.* libs6tls.*
 
     mv doc $doc/share/doc/s6-networking/html
   '';

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6-rc";
-  version = "0.5.2.0";
-  sha256 = "1qpygkajalaziszhwfv5rr6hc27q05z8dayyv7im06z6vndimchs";
+  version = "0.5.2.1";
+  sha256 = "02pszbi440wagx2qp8aqj9mv5wm2qisw9lkq7mbnbnxxw9azlhi8";
 
   description = "A service manager for s6-based systems";
   platforms = lib.platforms.linux;

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -4,8 +4,8 @@ with skawarePackages;
 
 buildPackage {
   pname = "s6";
-  version = "2.9.2.0";
-  sha256 = "1pfxx50shncg2s47ic4kp02jh1cxfjq75j3mnxjagyzzz0mbfg9n";
+  version = "2.10.0.0";
+  sha256 = "0xzqrd0m3wjklmw1w3gjw5dcdxnhgvxv2r5wd6m2ismw2jprr9k0";
 
   description = "skarnet.org's small & secure supervision software suite";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7542,6 +7542,8 @@ in
 
   s6-dns = skawarePackages.s6-dns;
 
+  s6-linux-init = skawarePackages.s6-linux-init;
+
   s6-linux-utils = skawarePackages.s6-linux-utils;
 
   s6-networking = skawarePackages.s6-networking;
@@ -16460,6 +16462,7 @@ in
 
     s6 = callPackage ../tools/system/s6 { };
     s6-dns = callPackage ../tools/networking/s6-dns { };
+    s6-linux-init = callPackage ../os-specific/linux/s6-linux-init { };
     s6-linux-utils = callPackage ../os-specific/linux/s6-linux-utils { };
     s6-networking = callPackage ../tools/networking/s6-networking { };
     s6-portable-utils = callPackage ../tools/misc/s6-portable-utils { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This pull request updates all [skaware software packages](https://skarnet.org/software), most notably: the `s6` supervising system, the underlying libraries and related tools.

I have successfully tested this against my work in progress branch of the very experimental [nix-processmgmt](https://github.com/svanderburg/nix-processmgmt) framework that adds `s6-rc` support: https://github.com/svanderburg/nix-processmgmt/tree/s6-rc

In addition to updating all the packages to their latest versions, I have also packaged `s6-linux-init` that depends on newer versions of `execline` and `skalibs`.

I have commit access to Nixpkgs, but since I'm still a relative newbie to `s6`, I'd like the community to take a look at this update first, just to be sure that I don't break anything important.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
