### PR TITLE
lib/modules: Set submodule type for renamed option sets

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -895,7 +895,7 @@ rec {
       fromOpt = getAttrFromPath from options;
       toOf = attrByPath to
         (abort "Renaming error: option `${showOption to}' does not exist.");
-      toType = let opt = attrByPath to {} options; in opt.type or null;
+      toType = let opt = attrByPath to {} options; in opt.type or (types.submodule {});
     in
     {
       options = setAttrByPath from (mkOption {


### PR DESCRIPTION
For renames like

```
mkAliasOptionModule [ "services" "compton" ] [ "services" "picom" ]
```

where the target is an option set (like services.picom) instead of a single option (like services.picom.enable), previously the renamed option type was unset, leading to it being `types.unspecified`.

This changes it to be `types.submodule {}` instead, which makes more sense.

- [x] Built the NixOS manual successfully and verified that `services.compton` shows `submodule` as its type

Discovered in https://github.com/NixOS/nixpkgs/issues/76184
Ping @dasJ