### PR TITLE
dduper: init at 0.04

### DIFF
--- a/pkgs/tools/filesystems/btrfs-progs/default.nix
+++ b/pkgs/tools/filesystems/btrfs-progs/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, pkg-config, attr, acl, zlib, libuuid, e2fsprogs, lzo
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt, zstd, python3
+, patches ? []
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,8 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = lib.optional stdenv.hostPlatform.isMusl "--disable-backtrace";
+
+  inherit patches;
 
   meta = with lib; {
     description = "Utilities for the btrfs filesystem";

--- a/pkgs/tools/filesystems/dduper/default.nix
+++ b/pkgs/tools/filesystems/dduper/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchFromGitHub, python3Packages, btrfs-progs }:
+
+let
+  our-btrfs-progs = btrfs-progs.override {
+    patches = [ patch ];
+  };
+
+  version = "0.04";
+
+  src = fetchFromGitHub {
+    owner = "Lakshmipathi";
+    repo = "dduper";
+    rev = "v${version}";
+    sha256 = "09ncdawxkffldadqhfblqlkdl05q2qmywxyg6p61fv3dr2f2v5wm";
+  };
+
+  patch = stdenv.mkDerivation {
+    name = "btrfs-csum.patch";
+
+    inherit src;
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase = ''
+      cp patch/btrfs-progs-v5.6.1/0001-Print-csum-for-a-given-file-on-stdout.patch $out
+    '';
+  };
+in
+python3Packages.buildPythonPackage rec {
+  pname = "dduper";
+
+  inherit src version;
+
+  buildInputs = [ our-btrfs-progs ];
+
+  pythonPath = [ python3Packages.python
+    python3Packages.numpy
+    python3Packages.ptable ];
+
+  prePatch = ''
+    sed -i 's,/usr/sbin/btrfs\.static,'${our-btrfs-progs}/bin/btrfs, dduper
+  '';
+
+  doCheck = false;
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+
+  buildPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp dduper $out/bin
+
+    wrapPythonPrograms
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Block-level out-of-band BTRFS dedupe tool";
+    homepage = "https://github.com/Lakshmipathi/dduper";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/filesystems/dduper/default.nix
+++ b/pkgs/tools/filesystems/dduper/default.nix
@@ -44,8 +44,7 @@ python3Packages.buildPythonPackage rec {
   doCheck = false;
   dontUseSetuptoolsBuild = true;
   dontUsePipInstall = true;
-
-  buildPhase = ":";
+  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2118,6 +2118,8 @@ in
 
   duperemove = callPackage ../tools/filesystems/duperemove { };
 
+  dduper = callPackage ../tools/filesystems/dduper { };
+
   dvc = callPackage ../applications/version-management/dvc { };
 
   dvc-with-remotes = callPackage ../applications/version-management/dvc {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add dduper package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
