### PR TITLE
[20.09] txt2tags: fix broken download URL

### DIFF
--- a/pkgs/tools/text/txt2tags/default.nix
+++ b/pkgs/tools/text/txt2tags/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
   '';
 
   src = fetchurl {
-    url = "http://txt2tags.googlecode.com/files/${pname}-${version}.tgz";
-    sha256 = "0p5hql559pk8v5dlzgm75yrcxwvz4z30f1q590yzng0ghvbnf530";
+    url = "https://github.com/txt2tags/old/raw/master/${pname}-${version}.tgz";
+    sha256 = "601467d7860f3cfb3d48050707c6277ff3ceb22fa7be4f5bd968de540ac5b05c";
   };
 
   meta = {


### PR DESCRIPTION
Google Code is not accessible for some time now.
The txt2tags project has moved to GitHub.


###### Motivation for this change

The download URL is broken.

###### Things done

- Checked which is the current URL for txt2tags-2.6 in https://txt2tags.org/download.html

- Downloaded the `tgz` and run `sha256sum` to get the hash:

    ```console
    $ sha256sum txt2tags-2.6.tgz 
    601467d7860f3cfb3d48050707c6277ff3ceb22fa7be4f5bd968de540ac5b05c  txt2tags-2.6.tgz
    ```