### PR TITLE
scenebuilder: init at 15.0.1 + scenic-view: init at 11.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9994,6 +9994,12 @@
     githubId = 78392041;
     name = "Winter";
   };
+  wirew0rm = {
+    email = "alex@wirew0rm.de";
+    github = "wirew0rm";
+    githubId = 1202371;
+    name = "Alexander Krimm";
+  };
   wishfort36 = {
     email = "42300264+wishfort36@users.noreply.github.com";
     github = "wishfort36";

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -1,0 +1,116 @@
+{ lib, stdenv, fetchFromGitHub, jdk, gradleGen, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper, glib, wrapGAppsHook }:
+let
+  # The default one still uses jdk8 (#89731)
+  gradle = (gradleGen.override (old: { java = jdk; })).gradle_latest;
+
+  pname = "scenebuilder";
+  version = "15.0.1";
+
+  src = fetchFromGitHub {
+    owner = "gluonhq";
+    repo = pname;
+    rev = version;
+    sha256 = "0dqlpfgr9qpmk62zsnhzw4q6n0swjqy00294q0kb4djp3jn47iz4";
+  };
+
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps";
+    inherit src;
+
+    nativeBuildInputs = [ jdk perl gradle ];
+
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon build -x test
+    '';
+
+    # Mavenize dependency paths
+    # e.g. org.codehaus.groovy/groovy/2.4.0/{hash}/groovy-2.4.0.jar -> org/codehaus/groovy/groovy/2.4.0/groovy-2.4.0.jar
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0n93kb8pajlbidvdrsf3hwcwqzvgdm6dnly7wvk3vpargx6k7y1r";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "Scene Builder";
+    exec = "scenebuilder";
+    icon = "scenebuilder";
+    comment = "A visual, drag'n'drop, layout tool for designing JavaFX application user interfaces.";
+    desktopName = pname;
+    mimeType = "application/java;application/java-vm;application/java-archive";
+    categories = "Development";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname src version;
+
+  nativeBuildInputs = [ jdk gradle makeWrapper glib wrapGAppsHook ];
+
+  dontWrapGApps = true; # prevent double wrapping
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle -PVERSION=${version} --offline --no-daemon --info --init-script ${gradleInit} build -x test
+
+    runHook postBuild
+    '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/{${pname},icons/hicolor/128x128/apps}
+    cp app/build/libs/SceneBuilder-${version}-all.jar $out/share/${pname}/${pname}.jar
+    cp app/build/resources/main/com/oracle/javafx/scenebuilder/app/SB_Logo.png $out/share/icons/hicolor/128x128/apps/scenebuilder.png
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${jdk}/bin/java $out/bin/${pname} --add-flags "-jar $out/share/${pname}/${pname}.jar" "''${gappsWrapperArgs[@]}"
+    '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "A visual, drag'n'drop, layout tool for designing JavaFX application user interfaces.";
+    homepage = "https://gluonhq.com/products/scene-builder/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ wirew0rm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/scenic-view/default.nix
+++ b/pkgs/development/tools/scenic-view/default.nix
@@ -1,0 +1,113 @@
+{ lib, stdenv, fetchFromGitHub, jdk, gradleGen, makeDesktopItem, copyDesktopItems, perl, writeText, runtimeShell, makeWrapper }:
+let
+  # The default one still uses jdk8 (#89731)
+  gradle = (gradleGen.override (old: { java = jdk; })).gradle_latest;
+
+  pname = "scenic-view";
+  version = "11.0.2";
+
+  src = fetchFromGitHub {
+    owner = "JonathanGiles";
+    repo = pname;
+    rev = version;
+    sha256 = "1idfh9hxqs4fchr6gvhblhvjqk4mpl4rnpi84vn1l3yb700z7dwy";
+  };
+
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps";
+    inherit src;
+
+    nativeBuildInputs = [ jdk perl gradle ];
+
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon build
+    '';
+
+    # Mavenize dependency paths
+    # e.g. org.codehaus.groovy/groovy/2.4.0/{hash}/groovy-2.4.0.jar -> org/codehaus/groovy/groovy/2.4.0/groovy-2.4.0.jar
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    outputHashAlgo =  "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0d6qs0wg2nfxyq85q46a8dcdqknz9pypb2qmvc8k2w8vcdac1y7n";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    desktopName = pname;
+    exec = pname;
+    comment = "JavaFx application to visualize and modify the scenegraph of running JavaFx applications.";
+    mimeType = "application/java;application/java-vm;application/java-archive";
+    categories = "Development";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+  nativeBuildInputs = [ jdk gradle makeWrapper ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --offline --no-daemon --info --init-script ${gradleInit} build
+
+    runHook postBuild
+    '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/${pname}
+    cp build/libs/scenicview.jar $out/share/${pname}/${pname}.jar
+    makeWrapper ${jdk}/bin/java $out/bin/${pname} --add-flags "-jar $out/share/${pname}/${pname}.jar"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "JavaFx application to visualize and modify the scenegraph of running JavaFx applications.";
+    longDescription = ''
+      A JavaFX application designed to make it simple to understand the current state of your application scenegraph
+      and to also easily manipulate properties of the scenegraph without having to keep editing your code.
+      This lets you find bugs and get things pixel perfect without having to do the compile-check-compile dance.
+    '';
+    homepage = "https://github.com/JonathanGiles/scenic-view/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ wirew0rm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12737,6 +12737,8 @@ in
 
   schemaspy = callPackage ../development/tools/database/schemaspy { };
 
+  scenebuilder = callPackage ../development/tools/scenebuilder { };
+
   shncpd = callPackage ../tools/networking/shncpd { };
 
   sigrok-cli = callPackage ../development/tools/sigrok-cli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12739,6 +12739,8 @@ in
 
   scenebuilder = callPackage ../development/tools/scenebuilder { };
 
+  scenic-view = callPackage ../development/tools/scenic-view { };
+
   shncpd = callPackage ../tools/networking/shncpd { };
 
   sigrok-cli = callPackage ../development/tools/sigrok-cli { };


### PR DESCRIPTION
###### Motivation for this change
Add packages for [scenebuilder](https://gluonhq.com//products/scene-builder/) and [scenic-view](https://github.com/JonathanGiles/scenic-view/). Having a packaged version of scenebuilder is useful becaue it can be configured in eclipse, injellij Idea and other Java IDEs to design JavaFx UIs.
I also added scenic-view, because it is a very helpful tool for JavaFx UI design and also because the derivations are quite simillar so I think it is easier to review them together.

fixes: #90243
replaces: #51564

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
