### PR TITLE
python3Packages.avion: init at 0.10

### DIFF
--- a/pkgs/development/python-modules/avion/default.nix
+++ b/pkgs/development/python-modules/avion/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, bluepy
+, buildPythonPackage
+, csrmesh
+, fetchPypi
+, pycryptodome
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "avion";
+  version = "0.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zgv45086b97ngyqxdp41wxb7hpn9g7alygc21j9y3dib700vzdz";
+  };
+
+  propagatedBuildInputs = [
+    bluepy
+    csrmesh
+    pycryptodome
+    requests
+  ];
+
+  # Project has no test
+  doCheck = false;
+  # bluepy/uuids.json is not found
+  # pythonImportsCheck = [ "avion" ];
+
+  meta = with lib; {
+    description = "Python API for controlling Avi-on Bluetooth dimmers";
+    homepage = "https://github.com/mjg59/python-avion";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/bluepy-devices/default.nix
+++ b/pkgs/development/python-modules/bluepy-devices/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, bluepy
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "bluepy-devices";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    pname = "bluepy_devices";
+    inherit  version;
+    sha256 = "02zzzivxq2vifgs65m2rm8pqlsbzsbc419c032irzvfxjx539mr8";
+  };
+
+  propagatedBuildInputs = [ bluepy ];
+
+  # Project has no test
+  doCheck = false;
+  pythonImportsCheck = [ "bluepy_devices" ];
+
+  meta = with lib; {
+    description = "Python BTLE Device Interface for bluepy";
+    homepage = "https://github.com/bimbar/bluepy_devices";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/csrmesh/default.nix
+++ b/pkgs/development/python-modules/csrmesh/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, bluepy
+, buildPythonPackage
+, fetchPypi
+, pycryptodomex
+}:
+
+buildPythonPackage rec {
+  pname = "csrmesh";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03lzam54ypcfvqvikh3gsrivvlidmz1ifdq15xv8c5i3n5b178ag";
+  };
+
+  propagatedBuildInputs = [
+    bluepy
+    pycryptodomex
+  ];
+
+  # Project has no test
+  doCheck = false;
+  pythonImportsCheck = [ "csrmesh" ];
+
+  meta = with lib; {
+    description = "Python implementation of the CSRMesh bridge protocol";
+    homepage = "https://github.com/nkaminski/csrmesh";
+    license = with licenses; [ lgpl3Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -61,7 +61,7 @@
     "auth" = ps: with ps; [ aiohttp-cors ];
     "automation" = ps: with ps; [ aiohttp-cors ];
     "avea" = ps: with ps; [ avea ];
-    "avion" = ps: with ps; [ ]; # missing inputs: avion
+    "avion" = ps: with ps; [ avion ];
     "awair" = ps: with ps; [ ]; # missing inputs: python_awair
     "aws" = ps: with ps; [ aiobotocore ];
     "axis" = ps: with ps; [ aiohttp-cors axis paho-mqtt ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1489,6 +1489,8 @@ in {
 
   crytic-compile = callPackage ../development/python-modules/crytic-compile { };
 
+  csrmesh  = callPackage ../development/python-modules/csrmesh { };
+
   csscompressor = callPackage ../development/python-modules/csscompressor { };
 
   cssmin = callPackage ../development/python-modules/cssmin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -985,6 +985,8 @@ in {
 
   bluepy = callPackage ../development/python-modules/bluepy { };
 
+  bluepy-devices = callPackage ../development/python-modules/bluepy-devices { };
+
   bme680 = callPackage ../development/python-modules/bme680 { };
 
   bokeh = callPackage ../development/python-modules/bokeh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -547,6 +547,8 @@ in {
 
   avea = callPackage ../development/python-modules/avea { };
 
+  avion = callPackage ../development/python-modules/avion { };
+
   avro3k = callPackage ../development/python-modules/avro3k { };
 
   avro = callPackage ../development/python-modules/avro { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API for controlling Avi-on Bluetooth dimmers.

https://github.com/mjg59/python-avion

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
