### PR TITLE
capnproto-java: init at 0.1.5

### DIFF
--- a/pkgs/development/tools/capnproto-java/default.nix
+++ b/pkgs/development/tools/capnproto-java/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, capnproto, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "capnproto-java";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "capnproto";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256:1512x70xa6mlg9dmr84r8xbf0jzysjal51ivhhh2ppl97yiqjgls";
+  };
+
+  patches = [
+    # Add make install rule
+    (fetchpatch {
+      url = "https://github.com/capnproto/capnproto-java/commit/e96448d3f5737db25e55cd268652712b69db5cc0.diff";
+      sha256 = "0f3vyap1zsxy675900pzg5ngh7bf9icllm1w04q64g8i91sdzljl";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ capnproto ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "Cap'n Proto codegen plugin for Java";
+    longDescription = "Only includes compiler plugin, the Java runtime/library that the generated code will link to must be built separately with Maven.";
+    homepage = "https://dwrensha.github.io/capnproto-java/index.html";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13150,6 +13150,8 @@ in
 
   capnproto = callPackage ../development/libraries/capnproto { };
 
+  capnproto-java = callPackage ../development/tools/capnproto-java { };
+
   captive-browser = callPackage ../applications/networking/browsers/captive-browser { };
 
   ndn-cxx = callPackage ../development/libraries/ndn-cxx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is an official plugin for [capnproto](https://capnproto.org/) that developers can use to write Java libraries and applications using its serialization protocol. Note that the output of this derivation will not include the Java runtime code necessary to execute the generated code. That may be added as a separate derivation in the future under `development/libraries`: however that is currently an open question.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
