### PR TITLE
elfutils: 0.180 -> 0.182, fix building under musl

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,47 +1,95 @@
-{ lib, stdenv, fetchurl, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs, argp-standalone }:
+{ lib, stdenv, fetchurl, fetchpatch, pkg-config, autoreconfHook, musl-fts
+, musl-obstack, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
+, argp-standalone }:
 
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
   pname = "elfutils";
-  version = "0.180";
+  version = "0.182";
 
   src = fetchurl {
     url = "https://sourceware.org/elfutils/ftp/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "17an1f67bfzxin482nbcxdl5qvywm27i9kypjyx8ilarbkivc9xq";
+    sha256 = "7MQGkU7fM18Lf8CE6+bEYMTW1Rdb/dZojBx42RRriFg=";
   };
 
-  patches = [ ./debug-info-from-env.patch ];
+  patches = [
+    ./debug-info-from-env.patch
+    ./musl-cdefs_h.patch
+    (fetchpatch {
+      name = "fix-aarch64_fregs.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/fix-aarch64_fregs.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "zvncoRkQx3AwPx52ehjA2vcFroF+yDC2MQR5uS6DATs=";
+    })
+    (fetchpatch {
+      name = "musl-asm-ptrace-h.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-asm-ptrace-h.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "8D1wPcdgAkE/TNBOgsHaeTZYhd9l+9TrZg8d5C7kG6k=";
+    })
+    (fetchpatch {
+      name = "musl-fts-obstack.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-fts-obstack.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "3lbC0UtscTIJgT7kOXnnjWrpPAVt2PYMbW+uJK6K350=";
+    })
+    (fetchpatch {
+      name = "musl-macros.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-macros.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "tp6O1TRsTAMsFe8vw3LMENT/vAu6OmyA8+pzgThHeA8=";
+    })
+    (fetchpatch {
+      name = "musl-qsort_r.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-qsort_r.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "FPWCkdtFT3zw8aNnz0Jz5Vmu8B/mRfNgfhbM/ej7d8M=";
+    })
+    (fetchpatch {
+      name = "musl-strerror_r.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strerror_r.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "QF6YwWkcT12dZHKzfqFgxy/1fkIllo0AAosbV0sM5PU=";
+    })
+    (fetchpatch {
+      name = "musl-strndupa.patch";
+      url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strndupa.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
+      sha256 = "sha256-7daehJj1t0wPtQzTv+/Rpuqqs5Ng/EYnZzrcf2o/Lb0=";
+    })
+  ] ++ lib.optional stdenv.hostPlatform.isMusl [ ./musl-error_h.patch ];
 
   hardeningDisable = [ "format" ];
 
   # We need bzip2 in NativeInputs because otherwise we can't unpack the src,
   # as the host-bzip2 will be in the path.
-  nativeBuildInputs = [ m4 bison flex gettext bzip2 ];
+  nativeBuildInputs = [ m4 bison flex gettext bzip2 ]
+    ++ lib.optional stdenv.hostPlatform.isMusl [ pkg-config autoreconfHook ];
   buildInputs = [ zlib bzip2 xz ]
-    ++ lib.optional stdenv.hostPlatform.isMusl argp-standalone;
+    ++ lib.optional stdenv.hostPlatform.isMusl [
+    argp-standalone
+    musl-fts
+    musl-obstack
+  ];
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
-    NIX_CFLAGS_COMPILE+=" -fgnu89-inline"
+    NIX_CFLAGS_COMPILE+=" -Wno-null-dereference"
   '';
 
-  configureFlags =
-    [ "--program-prefix=eu-" # prevent collisions with binutils
-      "--enable-deterministic-archives"
-      "--disable-debuginfod"
-    ];
+  configureFlags = [
+    "--program-prefix=eu-" # prevent collisions with binutils
+    "--enable-deterministic-archives"
+    "--disable-libdebuginfod"
+    "--disable-debuginfod"
+  ];
 
   enableParallelBuilding = true;
 
   doCheck = false; # fails 3 out of 174 tests
   doInstallCheck = false; # fails 70 out of 174 tests
 
-  meta = {
+  meta = with lib; {
     homepage = "https://sourceware.org/elfutils/";
     description = "A set of utilities to handle ELF objects";
-    platforms = lib.platforms.linux;
-    license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.eelco ];
+    platforms = platforms.linux;
+    # licenses are GPL2 or LGPL3+ for libraries, GPL3+ for bins,
+    # but since this package isn't split that way, all three are listed.
+    license = with licenses; [ gpl2Only lgpl3Plus gpl3Plus ];
+    maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/development/tools/misc/elfutils/musl-cdefs_h.patch
+++ b/pkgs/development/tools/misc/elfutils/musl-cdefs_h.patch
@@ -1,0 +1,15 @@
+# avoids a warning about including an internal header when
+# compiling with musl-libc
+diff -crb --new-file a/lib/fixedsizehash.h b/lib/fixedsizehash.h
+*** a/lib/fixedsizehash.h	2020-06-11 11:37:46.000000000 -0400
+--- b/lib/fixedsizehash.h	2021-01-21 05:52:59.000000000 -0500
+***************
+*** 30,36 ****
+  #include <errno.h>
+  #include <stdlib.h>
+  #include <string.h>
+- #include <sys/cdefs.h>
+  
+  #include <system.h>
+  
+--- 30,35 ----

--- a/pkgs/development/tools/misc/elfutils/musl-error_h.patch
+++ b/pkgs/development/tools/misc/elfutils/musl-error_h.patch
@@ -1,0 +1,66 @@
+diff -crb --new-file a/lib/error.h b/lib/error.h
+*** a/lib/error.h	1969-12-31 19:00:00.000000000 -0500
+--- b/lib/error.h	2021-01-21 04:38:25.000000000 -0500
+***************
+*** 0 ****
+--- 1,27 ----
++ #ifndef _ERROR_H_
++ #define _ERROR_H_
++ 
++ #include <stdarg.h>
++ #include <stdio.h>
++ #include <stdlib.h>
++ #include <string.h>
++ #include <errno.h>
++ 
++ static unsigned int error_message_count = 0;
++ 
++ static inline void error(int status, int errnum, const char* format, ...)
++ {
++ 	va_list ap;
++ 	fprintf(stderr, "%s: ", program_invocation_name);
++ 	va_start(ap, format);
++ 	vfprintf(stderr, format, ap);
++ 	va_end(ap);
++ 	if (errnum)
++ 		fprintf(stderr, ": %s", strerror(errnum));
++ 	fprintf(stderr, "\n");
++ 	error_message_count++;
++ 	if (status)
++ 		exit(status);
++ }
++ 
++ #endif	/* _ERROR_H_ */
+diff -crb --new-file a/src/error.h b/src/error.h
+*** a/src/error.h	1969-12-31 19:00:00.000000000 -0500
+--- b/src/error.h	2021-01-21 04:38:29.000000000 -0500
+***************
+*** 0 ****
+--- 1,27 ----
++ #ifndef _ERROR_H_
++ #define _ERROR_H_
++ 
++ #include <stdarg.h>
++ #include <stdio.h>
++ #include <stdlib.h>
++ #include <string.h>
++ #include <errno.h>
++ 
++ static unsigned int error_message_count = 0;
++ 
++ static inline void error(int status, int errnum, const char* format, ...)
++ {
++ 	va_list ap;
++ 	fprintf(stderr, "%s: ", program_invocation_name);
++ 	va_start(ap, format);
++ 	vfprintf(stderr, format, ap);
++ 	va_end(ap);
++ 	if (errnum)
++ 		fprintf(stderr, ": %s", strerror(errnum));
++ 	fprintf(stderr, "\n");
++ 	error_message_count++;
++ 	if (status)
++ 		exit(status);
++ }
++ 
++ #endif	/* _ERROR_H_ */

--- a/pkgs/os-specific/linux/musl-fts/default.nix
+++ b/pkgs/os-specific/linux/musl-fts/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "musl-fts";
+  version = "1.2.7";
+
+  src = fetchFromGitHub {
+    owner = "void-linux";
+    repo = "musl-fts";
+    rev = "v${version}";
+    sha256 = "Azw5qrz6OKDcpYydE6jXzVxSM5A8oYWAztrHr+O/DOE=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/void-linux/musl-fts";
+    description = "An implementation of fts(3) for musl-libc";
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.pjjw ];
+  };
+}

--- a/pkgs/os-specific/linux/musl-obstack/default.nix
+++ b/pkgs/os-specific/linux/musl-obstack/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "musl-obstack";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "void-linux";
+    repo = "musl-obstack";
+    rev = "v${version}";
+    sha256 = "v0RTnrqAmJfOeGsJFc04lqFR8QZhYiLyvy8oRYiuC80=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/void-linux/musl-obstack";
+    description =
+      "An extraction of the obstack functions and macros from GNU libiberty for use with musl-libc";
+    platforms = platforms.linux;
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.pjjw ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19489,6 +19489,8 @@ in
 
   musl = callPackage ../os-specific/linux/musl { };
 
+  musl-fts = callPackage ../os-specific/linux/musl-fts { };
+
   nushell = callPackage ../shells/nushell {
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19490,6 +19490,7 @@ in
   musl = callPackage ../os-specific/linux/musl { };
 
   musl-fts = callPackage ../os-specific/linux/musl-fts { };
+  musl-obstack = callPackage ../os-specific/linux/musl-obstack { };
 
   nushell = callPackage ../shells/nushell {
     inherit (darwin.apple_sdk.frameworks) AppKit Security;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Trying to restore runctionality to a good amount of pkgsMusl- have copied the approach Alpine uses to get elfutils working in nixpkgs. Had to add two additional packages that are there essentially just for musl packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
