### PR TITLE
alsaLib: fix build under musl-libc

### DIFF
--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, alsa-ucm-conf, alsa-topology-conf }:
+{ lib, stdenv, fetchurl, fetchpatch, alsa-ucm-conf, alsa-topology-conf }:
 
 stdenv.mkDerivation rec {
   pname = "alsa-lib";
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./alsa-plugin-conf-multilib.patch
+    (fetchpatch {
+      # plucked from upstream master, delete in next release
+      name = "fix-dlo.patch";
+      url = "https://github.com/alsa-project/alsa-lib/commit/ad8c8e5503980295dd8e5e54a6285d2d7e32eb1e.patch";
+      sha256 = "QQP4C1dSnJP1MNKt2el7Wn3KmtwtYzvyIHWdrHs+Jw4=";
+    })
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     ./alsa-plugin-conf-multilib.patch
     (fetchpatch {
       # plucked from upstream master, delete in next release
+      # without this patch alsa 1.2.4 fails to compile against musl-libc
+      # due to an overly conservative ifdef gate in a new feature
       name = "fix-dlo.patch";
       url = "https://github.com/alsa-project/alsa-lib/commit/ad8c8e5503980295dd8e5e54a6285d2d7e32eb1e.patch";
       sha256 = "QQP4C1dSnJP1MNKt2el7Wn3KmtwtYzvyIHWdrHs+Jw4=";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Presently, alsaLib doesn't build under musl. Looks like this was an inadvertent breakage from upstream, so pulling the upstream commit in to build under musl. Alpine linux takes the same approach.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
