### PR TITLE
usbguard: install shell completion

### DIFF
--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , autoreconfHook
+, installShellFiles
 , asciidoc
 , pkg-config
 , libxslt
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
+    installShellFiles
     asciidoc
     pkg-config
     libxslt # xsltproc
@@ -65,6 +67,11 @@ stdenv.mkDerivation rec {
   ++ (lib.optional (libsodium != null) "--with-crypto-library=sodium");
 
   enableParallelBuilding = true;
+
+  postInstall = ''
+    installShellCompletion --bash --name usbguard.bash scripts/bash_completion/usbguard
+    installShellCompletion --zsh --name _usbguard scripts/usbguard-zsh-completion
+  '';
 
   meta = with lib; {
     description = "The USBGuard software framework helps to protect your computer against BadUSB";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Having tabcompletion for commands is nice. Upstream has completion definitions for bash and zsh. Installing them is not hard nor complex.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] I tested tab completion for bash and zsh. They are working.
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s). Test from https://github.com/NixOS/nixpkgs/pull/110389 works.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
