### PR TITLE
go-minimock: include version in build flags

### DIFF
--- a/pkgs/development/tools/go-minimock/default.nix
+++ b/pkgs/development/tools/go-minimock/default.nix
@@ -11,6 +11,10 @@ buildGoModule rec {
     sha256 = "0r0krbwvx5w1z0yv2qqi92irbsfhkvwvaigy350cvcz9gmcppj4h";
   };
 
+  buildFlagsArray = [
+    "-ldflags=-s -w -X main.version=${version}"
+  ];
+
   vendorSha256 = "1macwm6hybjinwnx62v146yxydcn5k5r587nxwkf4ffy76s2m3jc";
 
   doCheck = true;


### PR DESCRIPTION
minimock includes the version in the mocks it generates so not having it
set properly annoys co-workers.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
