### PR TITLE
parachute: init at 0.9.1

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/kwin/scripts/parachute.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/kwin/scripts/parachute.nix
@@ -1,0 +1,37 @@
+{ lib, mkDerivation, fetchFromGitHub
+, kcoreaddons, kwindowsystem, plasma-framework, systemsettings }:
+
+mkDerivation rec {
+  pname = "parachute";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "tcorreabr";
+    repo = "parachute";
+    rev = "v${version}";
+    sha256 = "QIWb1zIGfkS+Bef7LK+JA6XpwGUW+79XZY47j75nlCE=";
+  };
+
+  buildInputs = [
+    kcoreaddons kwindowsystem plasma-framework systemsettings
+  ];
+
+  dontBuild = true;
+
+  # 1. --global still installs to $HOME/.local/share so we use --packageroot
+  # 2. plasmapkg2 doesn't copy metadata.desktop into place, so we do that manually
+  installPhase = ''
+    runHook preInstall
+    plasmapkg2 --type kwinscript --install ${src} --packageroot $out/share/kwin/scripts
+    install -Dm644 ${src}/metadata.desktop $out/share/kservices5/Parachute.desktop
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Look at your windows and desktops from above.";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mjlbach ];
+    inherit (src.meta) homepage;
+    inherit (kwindowsystem.meta) platforms;
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -146,6 +146,7 @@ let
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };
+        parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };
       };
 
     };


### PR DESCRIPTION
###### Motivation for this change
Parachute is a kwin extension that provides a gnome activites like overview with krunner based app launching and window selection.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
