### PR TITLE
icr: 0.8.0 -> unstable-2020-10-05

### DIFF
--- a/pkgs/development/tools/icr/default.nix
+++ b/pkgs/development/tools/icr/default.nix
@@ -1,15 +1,26 @@
-{ stdenv, lib, fetchFromGitHub, crystal, shards, makeWrapper, pkg-config, which
-, openssl, readline, libyaml, zlib }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, crystal
+, shards
+, makeWrapper
+, pkg-config
+, which
+, openssl
+, readline
+, libyaml
+, zlib
+}:
 
 crystal.buildCrystalPackage rec {
   pname = "icr";
-  version = "0.8.0";
+  version = "unstable-2020-10-06";
 
   src = fetchFromGitHub {
     owner = "crystal-community";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1bz2bhs6csyg2rhrlknlvaiilq3vq8plxjh1hdxmbrfi3n6c7k5a";
+    repo = "icr";
+    rev = "8c57cd7c1fdf8088cb05c1587bd6c40d244a8a80";
+    sha256 = "sha256-b0w6oG2npNgdi2ZowMlJy0iUxQWqb9+DiruQl7Ztb0E=";
   };
 
   shardsFile = ./shards.nix;


### PR DESCRIPTION
###### Motivation for this change

`icr` doesn't compile with a recent crystal without this.

Cc @NixOS/crystal-lang 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
