### PR TITLE
linkchecker: unstable-2020-08-15 -> 10.0.0

### DIFF
--- a/pkgs/tools/networking/linkchecker/default.nix
+++ b/pkgs/tools/networking/linkchecker/default.nix
@@ -4,13 +4,13 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "linkchecker";
-  version = "unstable-2020-08-15";
+  version = "10.0.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "0086c28b3a419faa60562f2713346996062c03c2";
-    sha256 = "0am5id8vqlqn1gb9jri0vjgiq5ffgrjq8yzdk1zc98gn2n0397wl";
+    rev = "v" + version;
+    sha256 = "sha256-gcaamRxGn124LZ8rU+WzjRookU3akDO0ZyzI7/S6kFA=";
   };
 
   nativeBuildInputs = [ gettext ];


### PR DESCRIPTION
###### Motivation for this change

Proper release with py3 support.

Cc @steshaw 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
