### PR TITLE
darwin.libdispatch: fixing pure approach

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/libdispatch.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/libdispatch.nix
@@ -1,13 +1,33 @@
-{ stdenv, fetchFromGitHub, cmake, apple_sdk_sierra, xnu-new }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, ninja }:
 
 stdenv.mkDerivation rec {
-  name = "swift-corelibs-libdispatch";
+  pname   = "libdispatch";
+  version = "swift-5.3.2"; # not the real version, APPLE refuse to give one. https://github.com/apple/swift-corelibs-foundation/commit/df3ec55fe6c162d590a7653d89ad669c2b9716b1#commitcomment-30442619
+
   src = fetchFromGitHub {
-    owner = "apple";
-    repo = name;
-    rev = "f83b5a498bad8e9ff8916183cf6e8ccf677c346b";
-    sha256 = "1czkyyc9llq2mnqfp19mzcfsxzas0y8zrk0gr5hg60acna6jkz2l";
+    owner  = "apple";
+    repo   = "swift-corelibs-libdispatch";
+    rev    = "${version}-RELEASE";
+    sha256 = "1bb32dqzijaqwz7wx919f7l50pk16smyi5cbc9vf9gr0d9grk8mw";
   };
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ apple_sdk_sierra.sdk xnu-new ];
+
+  # TODO: patches may be in upstream. Check if they can be dropped in next update.
+  patches = [
+    # fix unneeded link BlocksRuntime
+    (fetchpatch {
+      url = "https://github.com/apple/swift-corelibs-libdispatch/pull/555/commits/f32bd924141d3740d4acdb3e3da27be517525cd5.patch";
+      sha256 = "1dg8l87marrqvnz68b6lpyvbb3zyzjiwzcnahddd07z0dqajgp9r";
+    })
+  ];
+
+  cmakeFlags = [
+    "-D INSTALL_PRIVATE_HEADERS=ON"
+  ];
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  meta = with lib; {
+    platforms   = platforms.darwin; # In fact it could build on linux too, but I doubt if anyone wants it.
+    license     = licenses.apsl20;
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix and update the pure libdispatch, but it still blocked by `>=macos(10.14)` (#101229)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
