### PR TITLE
python3Packages.bsblan: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/bsblan/default.nix
+++ b/pkgs/development/python-modules/bsblan/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, aresponses
+, coverage
+, mypy
+, pytest-asyncio
+, pytest-cov
+, pytest-mock
+, aiohttp
+, attrs
+, cattrs
+, yarl
+}:
+
+buildPythonPackage rec {
+  pname = "bsblan";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "liudger";
+    repo = "python-bsblan";
+    rev = "v.${version}";
+    sha256 = "0vyg9vsrs34jahlav83qp2djv81p3ks31qz4qh46zdij2nx7l1fv";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    attrs
+    cattrs
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    coverage
+    mypy
+    pytest-asyncio
+    pytest-cov
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "bsblan" ];
+
+  meta = with lib; {
+    description = "Python client for BSB-Lan";
+    homepage = "https://github.com/liudger/python-bsblan";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/cattrs/default.nix
+++ b/pkgs/development/python-modules/cattrs/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, attrs
+, buildPythonPackage
+, fetchFromGitHub
+, hypothesis
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cattrs";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "Tinche";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "083d5mi6x7qcl26wlvwwn7gsp5chxlxkh4rp3a41w8cfwwr3h6l8";
+  };
+
+  propagatedBuildInputs = [ attrs ];
+
+  checkInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "cattr" ];
+
+  meta = with lib; {
+    description = "Python custom class converters for attrs";
+    homepage = "https://github.com/Tinche/cattrs";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -99,7 +99,7 @@
     "brottsplatskartan" = ps: with ps; [ ]; # missing inputs: brottsplatskartan
     "browser" = ps: with ps; [ ];
     "brunt" = ps: with ps; [ ]; # missing inputs: brunt
-    "bsblan" = ps: with ps; [ ]; # missing inputs: bsblan
+    "bsblan" = ps: with ps; [ bsblan ];
     "bt_home_hub_5" = ps: with ps; [ ]; # missing inputs: bthomehub5-devicelist
     "bt_smarthub" = ps: with ps; [ ]; # missing inputs: btsmarthub_devicelist
     "buienradar" = ps: with ps; [ ]; # missing inputs: buienradar

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1046,6 +1046,8 @@ in {
 
   bsdiff4 = callPackage ../development/python-modules/bsdiff4 { };
 
+  bsblan = callPackage ../development/python-modules/bsblan { };
+
   btchip = callPackage ../development/python-modules/btchip { };
 
   bt_proximity = callPackage ../development/python-modules/bt-proximity { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1161,6 +1161,8 @@ in {
 
   catboost = callPackage ../development/python-modules/catboost { };
 
+  cattrs = callPackage ../development/python-modules/cattrs { };
+
   cbeams = callPackage ../misc/cbeams { };
 
   cbor2 = callPackage ../development/python-modules/cbor2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python client for BSB-Lan.

https://github.com/liudger/python-bsblan

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
