### PR TITLE
bucklespring: init at 2021-01-21

### DIFF
--- a/pkgs/applications/audio/bucklespring/default.nix
+++ b/pkgs/applications/audio/bucklespring/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, legacy ? false
+, libinput
+
+, pkg-config
+, makeWrapper
+
+, openal
+, alure
+, libXtst
+, libX11
+}:
+
+let
+  inherit (lib) optionals;
+in
+stdenv.mkDerivation rec {
+  pname = "bucklespring";
+  version = "unstable-2021-01-21";
+
+  src = fetchFromGitHub {
+    owner = "zevv";
+    repo = pname;
+    rev = "d63100c4561dd7c57efe6440c12fa8d9e9604145";
+    sha256 = "114dib4npb7r1z2zd1fwsx71xbf9r6psxqd7n7590cwz1w3r51mz";
+  };
+
+  nativeBuildInputs = [ pkg-config makeWrapper ];
+
+  buildInputs = [ openal alure ]
+    ++ optionals (legacy) [ libXtst libX11 ]
+    ++ optionals (!legacy) [ libinput ];
+
+  makeFlags = optionals (!legacy) [ "libinput=1" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/wav
+    cp -r $src/wav $out/share/.
+    install -D ./buckle.desktop $out/share/applications/buckle.desktop
+    install -D ./buckle $out/bin/buckle
+    wrapProgram $out/bin/buckle --add-flags "-p $out/share/wav"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Nostalgia bucklespring keyboard sound";
+    longDescription = ''
+      When built with libinput (wayland or bare console),
+      users need to be in the input group to use this:
+      <code>users.users.alice.extraGroups = [ "input" ];</code>
+    '';
+    homepage = "https://github.com/zevv/bucklespring";
+    license = licenses.gpl2Only;
+    platforms  = platforms.unix;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1222,6 +1222,10 @@ in
 
   btrfs-heatmap = callPackage ../tools/filesystems/btrfs-heatmap { };
 
+  bucklespring = bucklespring-x11;
+  bucklespring-libinput = callPackage ../applications/audio/bucklespring { };
+  bucklespring-x11 = callPackage ../applications/audio/bucklespring { legacy = true; };
+
   buildbot = with python3Packages; toPythonApplication buildbot;
   buildbot-ui = with python3Packages; toPythonApplication buildbot-ui;
   buildbot-full = with python3Packages; toPythonApplication buildbot-full;


### PR DESCRIPTION
###### Motivation for this change
clickety clack keyboard's cool

###### Things done
packaged a tool to produce buckling spring keyboard sounds on keyboard events  
added as 2 attributes as it can be built for X11 or to use libinput, with the default being X11 as that's more common  
with libinput it works on wayland and even bare terminals, but requires the user running it to be in the `input` group (this is noted in the longDescription)  
this should maybe be set up via `programs.bucklespring.enable` but i got stuck on getting that to work a few too many times for something this silly

used the latest master commit because the latest release is 4 years old and several features have been added since

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `185854608` for `bucklespring-x11`
  - `187148680` for `bucklespring-libinput`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
