### PR TITLE
mtxclient: Remove unneeded dependencies, add myself as maintainer.

### DIFF
--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -5,8 +5,6 @@
 , pkg-config
 , boost17x
 , openssl
-, zlib
-, libsodium
 , olm
 , spdlog
 , nlohmann_json
@@ -42,8 +40,6 @@ stdenv.mkDerivation rec {
     spdlog
     boost17x
     openssl
-    zlib
-    libsodium
     olm
   ];
 
@@ -51,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "Client API library for Matrix, built on top of Boost.Asio";
     homepage = "https://github.com/Nheko-Reborn/mtxclient";
     license = licenses.mit;
-    maintainers = with maintainers; [ fpletz ];
+    maintainers = with maintainers; [ fpletz pstn ];
     platforms = platforms.all;
     # Should be fixable if a higher clang version is used, see:
     # https://github.com/NixOS/nixpkgs/pull/85922#issuecomment-619287177


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
mtxclient dropped dependencies on [zlib](https://github.com/Nheko-Reborn/mtxclient/commit/1018c0822b80cdfc5d6b589fe94d1fd759113ef6) and [libsodium](https://github.com/Nheko-Reborn/mtxclient/commit/5baba997091ea5f3fc8879b7eea4a811b6dc2afe). They should be removed from the package.

I verified that they are not referenced by CMakeLists.txt any more, so the actual build isn't changed at all. On top of that nheko is currently the only depending package made by the same developers, so no weird edge cases should happen.
On top of that I'm currently using nheko with these changes without any issues.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
