### PR TITLE
gst_all_1: use newScope to create package set

### DIFF
--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,29 +1,27 @@
-{ callPackage, CoreServices }:
+{ lib, newScope, libav, CoreServices }:
 
-rec {
+lib.makeScope newScope (self: with self; {
   gstreamer = callPackage ./core { inherit CoreServices; };
 
   gstreamermm = callPackage ./gstreamermm { };
 
-  gst-plugins-base = callPackage ./base { inherit gstreamer; };
+  gst-plugins-base = callPackage ./base { };
 
-  gst-plugins-good = callPackage ./good { inherit gst-plugins-base; };
+  gst-plugins-good = callPackage ./good { };
 
-  gst-plugins-bad = callPackage ./bad { inherit gst-plugins-base; };
+  gst-plugins-bad = callPackage ./bad { };
 
-  gst-plugins-ugly = callPackage ./ugly { inherit gst-plugins-base; };
+  gst-plugins-ugly = callPackage ./ugly { };
 
-  gst-rtsp-server = callPackage ./rtsp-server { inherit gst-plugins-base gst-plugins-bad; };
+  gst-rtsp-server = callPackage ./rtsp-server { };
 
-  gst-libav = callPackage ./libav { inherit gst-plugins-base; };
+  gst-libav = callPackage ./libav { inherit libav; };
 
-  gst-devtools = callPackage ./devtools { inherit gstreamer gst-plugins-base; };
+  gst-devtools = callPackage ./devtools { };
 
-  gst-editing-services = callPackage ./ges { inherit gst-plugins-base gst-plugins-bad gst-devtools; };
+  gst-editing-services = callPackage ./ges { };
 
-  gst-vaapi = callPackage ./vaapi {
-    inherit gst-plugins-base gstreamer gst-plugins-bad;
-  };
+  gst-vaapi = callPackage ./vaapi { };
 
   # note: gst-python is in ./python/default.nix - called under pythonPackages
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13800,8 +13800,8 @@ in
   gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
 
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
-    callPackage = newScope { libav = pkgs.ffmpeg; };
     inherit (darwin.apple_sdk.frameworks) CoreServices;
+    libav = ffmpeg;
   });
 
   gusb = callPackage ../development/libraries/gusb { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2534,9 +2534,7 @@ in
 
   monetdb = callPackage ../servers/sql/monetdb { };
 
-  monado = callPackage ../applications/graphics/monado {
-    inherit (gst_all_1) gstreamer gst-plugins-base;
-  };
+  monado = gst_all_1.callPackage ../applications/graphics/monado {  };
 
   mons = callPackage ../tools/misc/mons {};
 
@@ -4582,9 +4580,7 @@ in
 
   glxinfo = callPackage ../tools/graphics/glxinfo { };
 
-  gmrender-resurrect = callPackage ../tools/networking/gmrender-resurrect {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav;
-  };
+  gmrender-resurrect = gst_all_1.callPackage ../tools/networking/gmrender-resurrect { };
 
   gmvault = callPackage ../tools/networking/gmvault { };
 
@@ -12919,9 +12915,7 @@ in
     #      apr with db58 on freebsd (nov 2015), for unknown reasons
   };
 
-  aravis = callPackage ../development/libraries/aravis {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad;
-  };
+  aravis = gst_all_1.callPackage ../development/libraries/aravis { };
 
   arb = callPackage ../development/libraries/arb {};
 
@@ -13394,10 +13388,7 @@ in
 
   farbfeld = callPackage ../development/libraries/farbfeld { };
 
-  farstream = callPackage ../development/libraries/farstream {
-    inherit (gst_all_1)
-      gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad
-      gst-libav;
+  farstream = gst_all_1.callPackage ../development/libraries/farstream {
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
@@ -16939,9 +16930,8 @@ in
 
   wcslib = callPackage ../development/libraries/wcslib { };
 
-  webkitgtk = callPackage ../development/libraries/webkitgtk {
+  webkitgtk = gst_all_1.callPackage ../development/libraries/webkitgtk {
     harfbuzz = harfbuzzFull;
-    inherit (gst_all_1) gst-plugins-base gst-plugins-bad;
   };
 
   websocketpp = callPackage ../development/libraries/websocket++ { };
@@ -22110,9 +22100,7 @@ in
 
   xrdp = callPackage ../applications/networking/remote/xrdp { };
 
-  freerdp = callPackage ../applications/networking/remote/freerdp {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good;
-  };
+  freerdp = gst_all_1.callPackage ../applications/networking/remote/freerdp { };
 
   freerdpUnstable = freerdp;
 
@@ -24019,9 +24007,7 @@ in
   pdftk-legacy = lowPrio (callPackage ../tools/typesetting/pdftk/legacy.nix { });
   pdfgrep  = callPackage ../tools/typesetting/pdfgrep { };
 
-  pdfpc = callPackage ../applications/misc/pdfpc {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-libav;
-  };
+  pdfpc = gst_all_1.callPackage ../applications/misc/pdfpc { };
 
   peach = callPackage ../servers/peach { };
 
@@ -25488,9 +25474,8 @@ in
 
   worker = callPackage ../applications/misc/worker { };
 
-  workrave = callPackage ../applications/misc/workrave {
+  workrave = gst_all_1.callPackage ../applications/misc/workrave {
     inherit (python27Packages) cheetah;
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good;
   };
 
   worldengine-cli = python3Packages.worldengine;
@@ -28408,8 +28393,7 @@ in
 
   fuse-emulator = callPackage ../misc/emulators/fuse-emulator {};
 
-  gajim = callPackage ../applications/networking/instant-messengers/gajim {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-libav;
+  gajim = gst_all_1.callPackage ../applications/networking/instant-messengers/gajim {
     gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Overriding `gst_all_1.gstreamer` is a pain, because it is contained in a `rec` set and manually passes itself and other dependencies from the set directly to dependent packages. So in order to propagate a overwritten `gstreamer` to it's dependent packages an overlay like this is required:
```nix
final: prev: {
  gst_all_1 = prev.gst_all_1 // rec {
    gstreamer = prev.gst_all_1.gstreamer.overrideAttrs (old: { ... });

    gst-plugins-base = prev.gst_all_1.gst-plugins-base.override { inherit gstreamer; };

    gst-plugins-good = prev.gst_all_1.gst-plugins-good.override { inherit gst-plugins-base; };

    ...
  };
}
```
This overlay would also miss new packages in the set depending on any of the current packages.

Using `lib.makeScope` would allow to conveniently override any package in the set and ensure it is used in all dependent packages:

```nix
final: prev: {
  gst_all_1 = prev.gst_all_1.overrideScope' (final: prev: {
    gstreamer = prev.gstreamer.overrideAttrs (old: { ... });
  });
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
