### PR TITLE
toolbox: init at 0.0.99

### DIFF
--- a/pkgs/applications/virtualization/toolbox/default.nix
+++ b/pkgs/applications/virtualization/toolbox/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, go-md2man
+, installShellFiles
+, fetchpatch
+, glibc
+}:
+
+buildGoModule rec {
+  pname = "toolbox";
+  version = "0.0.99";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "toolbox";
+    rev = version;
+    sha256 = "CKjndWXDLxQ5epco/+TwRFxftbeMhYp/7NOWglF6EL8=";
+  };
+
+  modRoot = "src";
+
+  patches = [
+    ./toolbox_glibc.patch
+    (fetchpatch {
+      url = "https://github.com/containers/toolbox/commit/14cacc4ea6dc8fc51cb1e6bffa221e2dbcb61a0b.patch";
+      sha256 = "DFakCVBj/RgKU5pem3KxKgjorl8FNlHApR56wxWpkpA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/containers/toolbox/commit/a0f34e65c0c6b25b9300ed5f511403a29943a06a.patch";
+      sha256 = "9PZ7pDKlvkpEBQMyfR089nkDvRNRQ4Xzcij3ku1cdqE=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/cmd/create.go --subst-var-by glibc ${glibc}
+  '';
+
+  vendorSha256 = "06s97kpbw40571jjp96jpld1qxb2frd4akcrwwxi1minvs24lb5p";
+
+  buildFlagsArray = [
+    "-ldflags=-X github.com/containers/toolbox/pkg/version.currentVersion=${version}"
+  ];
+
+  nativeBuildInputs = [
+    go-md2man
+    installShellFiles
+  ];
+
+  preConfigure = ''
+    substituteInPlace src/cmd/create.go \
+      --replace '"/etc/profile.d/toolbox.sh"}' '"${placeholder "out"}/share/profile.d/toolbox.sh"}'
+  '';
+
+   postInstall = ''
+     cd ..
+     for d in doc/*.md; do
+       go-md2man -in $d -out ''${d%.md}
+     done
+     installManPage doc/*.[1-9]
+     installShellCompletion --bash completion/bash/toolbox
+     install profile.d/toolbox.sh -Dt $out/share/profile.d
+ '';
+
+  meta = with lib; {
+    description = "Unprivileged development environment";
+    homepage = "https://github.com/containers/toolbox";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mjlbach ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/toolbox/toolbox_glibc.patch
+++ b/pkgs/applications/virtualization/toolbox/toolbox_glibc.patch
@@ -1,0 +1,21 @@
+diff --git a/src/cmd/create.go b/src/cmd/create.go
+index 74e90b1..113ef80 100644
+--- a/src/cmd/create.go
++++ b/src/cmd/create.go
+@@ -207,6 +207,8 @@ func createContainer(container, image, release string, showCommandToEnter bool)
+ 	toolboxPathEnvArg := "TOOLBOX_PATH=" + toolboxPath
+ 	toolboxPathMountArg := toolboxPath + ":/usr/bin/toolbox:ro"
+ 
++	glibcMountArg := "@glibc@:@glibc@:ro"
++
+ 	var runtimeDirectory string
+ 	var xdgRuntimeDirEnv []string
+ 
+@@ -423,6 +425,7 @@ func createContainer(container, image, release string, showCommandToEnter bool)
+ 		"--volume", toolboxPathMountArg,
+ 		"--volume", usrMountArg,
+ 		"--volume", runtimeDirectoryMountArg,
++		"--volume", glibcMountArg,
+ 	}...)
+ 
+ 	createArgs = append(createArgs, avahiSocketMount...)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7056,6 +7056,8 @@ in
 
   podiff = callPackage ../tools/text/podiff { };
 
+  toolbox = callPackage ../applications/virtualization/toolbox { };
+
   podman = if stdenv.isDarwin then
     callPackage ../applications/virtualization/podman { }
   else


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Closes #96115: Toolbox is a container tool, that gives an "escape" hatch for immutable systems like nix (and Silverblue).

~Pending upstream patches: https://github.com/containers/toolbox/pull/675 https://github.com/containers/toolbox/pull/676~ Edit: have been merged!

I also need to not hardcode the glibc nix store path.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
