### PR TITLE
[staging] pythonPackages.virtualenv: 20.2.1 -> 20.3.1

### DIFF
--- a/pkgs/development/python-modules/freezegun/0.3.nix
+++ b/pkgs/development/python-modules/freezegun/0.3.nix
@@ -11,17 +11,15 @@
 
 buildPythonPackage rec {
   pname = "freezegun";
-  version = "0.3.5";
+  version = "0.3.15";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "02ly89wwn0plcw8clkkzvxaw6zlpm8qyqpm9x2mfw4a0vppb4ngf";
+    sha256 = "e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b";
   };
 
   propagatedBuildInputs = [ dateutil six ];
   checkInputs = [ mock nose pytest ];
-  # contains python3 specific code
-  doCheck = !isPy27;
 
   meta = with lib; {
     description = "FreezeGun: Let your Python tests travel through time";

--- a/pkgs/development/python-modules/freezegun/default.nix
+++ b/pkgs/development/python-modules/freezegun/default.nix
@@ -1,29 +1,23 @@
-{ lib, stdenv
+{ lib
 , buildPythonPackage
 , pythonOlder
 , fetchPypi
-, isPy27
 , dateutil
-, six
-, mock
-, nose
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "freezegun";
-  version = "1.0.0";
+  version = "1.1.0";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cf08e441f913ff5e59b19cc065a8faa9dd1ddc442eaf0375294f344581a0643";
+    sha256 = "177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3";
   };
 
-  propagatedBuildInputs = [ dateutil six ];
-  checkInputs = [ mock nose pytest ];
-  # contains python3 specific code
-  doCheck = !isPy27;
+  propagatedBuildInputs = [ dateutil ];
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "FreezeGun: Let your Python tests travel through time";

--- a/pkgs/development/python-modules/pytest-freezegun/default.nix
+++ b/pkgs/development/python-modules/pytest-freezegun/default.nix
@@ -1,23 +1,30 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, isPy27
+, fetchFromGitHub
 , freezegun
 , pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pytest-freezegun";
   version = "0.4.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949";
+  src = fetchFromGitHub {
+    owner = "ktosiek";
+    repo = "pytest-freezegun";
+    rev = version;
+    sha256 = "10c4pbh03b4s1q8cjd75lr0fvyf9id0zmdk29566qqsmaz28npas";
   };
 
   propagatedBuildInputs = [
     freezegun
     pytest
+  ];
+
+  checkInputs = [
+    pytestCheckHook
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -1,18 +1,25 @@
 { buildPythonPackage
-, fetchPypi
-, lib
-, stdenv
-, pythonOlder
-, isPy27
 , appdirs
 , contextlib2
+, cython
 , distlib
+, fetchPypi
 , filelock
+, fish
+, flaky
 , importlib-metadata
 , importlib-resources
+, isPy27
+, lib
 , pathlib2
+, pytest-freezegun
+, pytest-mock
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
 , setuptools_scm
 , six
+, stdenv
 }:
 
 buildPythonPackage rec {
@@ -47,10 +54,37 @@ buildPythonPackage rec {
     ./0001-Check-base_prefix-and-base_exec_prefix-for-Python-2.patch
   ];
 
-  meta = {
+  checkInputs = [
+    cython
+    fish
+    flaky
+    pytest-freezegun
+    pytest-mock
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # Ignore tests which require network access
+  disabledTestFiles = [
+    "tests/unit/create/test_creator.py"
+    "tests/unit/seed/embed/test_bootstrap_link_via_app_data.py"
+  ];
+
+  disabledTests = [
+    "test_can_build_c_extensions"
+    "test_xonsh" # imports xonsh, which is not in pythonPackages
+  ];
+
+  pythonImportsCheck = [ "virtualenv" ];
+
+  meta = with lib; {
     description = "A tool to create isolated Python environments";
     homepage = "http://www.virtualenv.org";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ goibhniu ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ goibhniu ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/109930 was reverted.

~This pull request is problematic cause it disabled virtualenv on Python 2.7, which is no longer supported by pytest-freezegun. I do not understand how virtualenv manages to run the tests anyway: https://github.com/pypa/virtualenv/blob/20.4.0/setup.cfg#L97.~
Solutions include
* packaging a separate version of pytest-freezegun for Python 2.7 or
* not running virtualenv's tests on Python 2.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
