### PR TITLE
python3Packages.hass-nabucasa: 0.39.0 -> 0.41.0

### DIFF
--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -1,6 +1,17 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, acme, aiohttp, snitun, attrs, pycognito, warrant
-, pytest-aiohttp, asynctest, atomicwrites, pytest }:
+{ lib
+, acme
+, aiohttp
+, asynctest
+, atomicwrites
+, attrs
+, buildPythonPackage
+, fetchFromGitHub
+, pycognito
+, pytest-aiohttp
+, pytestCheckHook
+, snitun
+, warrant
+}:
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
@@ -15,19 +26,25 @@ buildPythonPackage rec {
 
   postPatch = ''
     sed -i 's/"acme.*"/"acme"/' setup.py
-    sed -i 's/"attrs.*"/"attrs"/' setup.py
-    sed -i 's/"cryptography.*"/"cryptography"/' setup.py
   '';
 
   propagatedBuildInputs = [
-    acme aiohttp atomicwrites snitun attrs warrant pycognito
+    acme
+    aiohttp
+    atomicwrites
+    attrs
+    pycognito
+    snitun
+    warrant
   ];
 
-  checkInputs = [ pytest pytest-aiohttp asynctest ];
+  checkInputs = [
+    asynctest
+    pytest-aiohttp
+    pytestCheckHook
+  ];
 
-  checkPhase = ''
-    pytest tests/
-  '';
+  pythonImportsCheck = [ "hass_nabucasa" ];
 
   meta = with lib; {
     homepage = "https://github.com/NabuCasa/hass-nabucasa";

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.39.0";
+  version = "0.41.0";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "1bsvwxddpp4dsq3k2320qrx5x9lscqzffzz1zj6fbwgc4741f01w";
+    sha256 = "sha256-ewWw3PyJGRHP23J6WBBWs9YGl4vTb9/j/soZ6n5wbLM=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pycognito/default.nix
+++ b/pkgs/development/python-modules/pycognito/default.nix
@@ -6,6 +6,7 @@
 , envs
 , python-jose
 , requests
+, pytestCheckHook
 , mock
 , isPy27
 }:
@@ -16,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pvizeli";
-    repo = "pycognito";
+    repo = pname;
     rev = version;
     sha256 = "sha256-RJeHPCTuaLN+zB0N0FGt4qrTI6++1ks5iBn64Cx0Psc=";
   };
@@ -35,7 +36,13 @@ buildPythonPackage rec {
 
   disabled = isPy27;
 
-  checkInputs = [ mock ];
+  checkInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests.py" ];
+  pythonImportsCheck = [ "pycognito" ];
 
   meta = with lib; {
     description = "Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support";

--- a/pkgs/development/python-modules/pycognito/default.nix
+++ b/pkgs/development/python-modules/pycognito/default.nix
@@ -1,14 +1,14 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, cryptography
 , boto3
+, buildPythonPackage
+, cryptography
 , envs
+, fetchFromGitHub
+, isPy27
+, mock
+, pytestCheckHook
 , python-jose
 , requests
-, pytestCheckHook
-, mock
-, isPy27
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/pycognito/default.nix
+++ b/pkgs/development/python-modules/pycognito/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "pycognito";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "pvizeli";
     repo = "pycognito";
     rev = version;
-    sha256 = "HLzPrRon+ipcUZlD1l4nYSwSbdDLwOALy4ejGunjK0w=";
+    sha256 = "sha256-RJeHPCTuaLN+zB0N0FGt4qrTI6++1ks5iBn64Cx0Psc=";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.41.0

Requires also an update of `pycognito`. Use for both modules now `pytestCheckHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
