### PR TITLE
libsmartcols: Add gtk-doc to fix build.

### DIFF
--- a/pkgs/development/libraries/libsmartcols/default.nix
+++ b/pkgs/development/libraries/libsmartcols/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, python3 }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, python3, gtk-doc}:
 
 stdenv.mkDerivation rec {
   name = "libsmartcols";
   version = "v2.36.1";
 
-  nativeBuildInputs = [ autoreconfHook pkg-config python3 ];
+  nativeBuildInputs = [ autoreconfHook pkg-config python3 gtk-doc ];
 
   src = fetchFromGitHub {
     owner = "karelzak";


### PR DESCRIPTION
###### Motivation for this change

This is a bit odd. I created this package and I am not quite sure how that built before his change.
At the moment, it errors out complaining that gtkdocize can't be found:

```
autoreconf: running: gtkdocize --copy
Can't exec "gtkdocize": No such file or directory at /nix/store/63fda1bzb5wzza9y3wr21d1gn83g2nhf-autoconf-2.70/share/autoconf/Autom4te/FileUtils.pm line 293.
```


I tried to disable doc generation, but that's a bit of a mess and adding the dependency is easier.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
