### PR TITLE
[staging] python310Packages: fix package set

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "5.30.0";
+  version = "6.0.2";
   pname = "hypothesis";
 
   # Use github tarballs that includes tests
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "hypothesis-python-${version}";
-    sha256 = "0fmc4jfaksr285fjhp18ibj2rr8cxmbd0pwx370r5wf8jnhm6jb3";
+    sha256 = "1iy3v03jfafm7w5r6hp6izzg7lw3i144nvvq113ais52rm6xhn96";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
@@ -33,6 +33,7 @@ buildPythonPackage rec {
   inherit doCheck;
 
   checkPhase = ''
+    HOME=$TMPDIR
     rm tox.ini # This file changes how py.test runs and breaks it
     py.test tests/cover
   '';

--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "packaging";
-  version = "20.7";
+  version = "20.8";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "Ba87uF0yA3fbKBzyVKsFDhp+vL9UEGhamkB+GKH4EjY=";
+    sha256 = "sha256-eFmBhacAikcNZFJqgFnemqpEkjjygPyetrE7psQQkJM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "20.3";
+  version = "20.3.3";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    sha256 = "e/2/0MrGY3myELmvuTAbNfXCBuT8kmvz9qTwITdDtQU=";
+    sha256 = "sha256-fIhPhTVSJ2SLB5W2YCpR1kTpQAeqXM67IpjUdoCGIyk=";
     name = "${pname}-${version}-source";
   };
 

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -13,7 +13,7 @@
 
 let
   pname = "setuptools";
-  version = "50.3.1";
+  version = "51.3.3";
 
   # Create an sdist of setuptools
   sdist = stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ let
       owner = "pypa";
       repo = pname;
       rev = "v${version}";
-      sha256 = "Z4KHB3Pv4wZPou/Vbp1DFDgDp47OTDfVChGP55GtIJE=";
+      sha256 = "012hcxhs7cb1z6nf0rh3mv03ablrha1l3w8l7kklz1hipqlw7sbs";
       name = "${pname}-${version}-source";
     };
 

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -18,12 +18,12 @@
 
 buildPythonPackage rec {
   pname = "trio";
-  version = "0.17.0";
+  version = "0.18.0";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zcxirpdvvl54pbfkgw7vz984879xwvdygqfpggnam24is2zjp78";
+    sha256 = "sha256-h6Zq5h8n/lAMkCSSapukgsB+Hg9WOAtwomTRnENboHY=";
   };
 
   checkInputs = [ astor pytestCheckHook pyopenssl trustme jedi pylint yapf ];

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -34,6 +34,8 @@ buildPythonPackage rec {
     "getprotobyname"
     "waitpid"
     "static_tool_sees_all_symbols"
+    # stderr is being captured
+    "test_fallback_when_no_hook_claims_it"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "wheel";
-  version = "0.35.1";
+  version = "0.36.2";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    sha256 = "uS+9a47ZopI0yGlEnJi421WyzS//8BxUvH25hX4BBL8=";
+    sha256 = "sha256-8lK2UvqBIxUYm6IOuT+Jk71wYbEEjvI7typS3749N9g=";
     name = "${pname}-${version}-source";
   };
 


### PR DESCRIPTION
###### Motivation for this change
This should be enough to allow python310 wheels to build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
