### PR TITLE
Agda don't install Everything module

### DIFF
--- a/nixos/tests/agda.nix
+++ b/nixos/tests/agda.nix
@@ -23,6 +23,13 @@ in
   };
 
   testScript = ''
+    assert (
+        "${pkgs.agdaPackages.lib.interfaceFile "Everything.agda"}" == "Everything.agdai"
+    ), "wrong interface file for Everything.agda"
+    assert (
+        "${pkgs.agdaPackages.lib.interfaceFile "tmp/Everything.agda.md"}" == "tmp/Everything.agdai"
+    ), "wrong interface file for tmp/Everything.agda.md"
+
     # Minimal script that typechecks
     machine.succeed("touch TestEmpty.agda")
     machine.succeed("agda TestEmpty.agda")

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -70,7 +70,7 @@ let
         installPhase = if installPhase != null then installPhase else ''
           runHook preInstall
           mkdir -p $out
-          find \( ${concatMapStringsSep " -or " (p: "-name '*.${p}'") (extensions ++ extraExtensions)} \) -exec cp -p --parents -t "$out" {} +
+          find -not \( -path ${everythingFile} -or -path ${lib.interfaceFile everythingFile} \) -and \( ${concatMapStringsSep " -or " (p: "-name '*.${p}'") (extensions ++ extraExtensions)} \) -exec cp -p --parents -t "$out" {} +
           runHook postInstall
         '';
       };

--- a/pkgs/build-support/agda/lib.nix
+++ b/pkgs/build-support/agda/lib.nix
@@ -1,0 +1,10 @@
+{ lib }:
+{
+  /* Returns the Agda interface file to a given Agda file.
+  *
+  * Examples:
+  * interfaceFile "Everything.agda" == "Everything.agdai"
+  * interfaceFile "src/Everything.lagda.tex" == "src/Everything.agdai"
+  */
+  interfaceFile = agdaFile: lib.head (builtins.match ''(.*\.)l?agda(\.(md|org|rst|tex))?'' agdaFile) + "agdai";
+}

--- a/pkgs/development/libraries/agda/standard-library/default.nix
+++ b/pkgs/development/libraries/agda/standard-library/default.nix
@@ -14,6 +14,9 @@ mkDerivation rec {
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];
   preConfigure = ''
     runhaskell GenerateEverything.hs
+    # We will only build/consider Everything.agda, in particular we don't want Everything*.agda
+    # do be copied to the store.
+    rm EverythingSafe.agda EverythingSafeGuardedness.agda EverythingSafeSizedTypes.agda
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -11,6 +11,8 @@ let
   in {
     inherit mkDerivation;
 
+    lib = lib.extend (final: prev: import ../build-support/agda/lib.nix { lib = prev; });
+
     agda = withPackages [] // { inherit withPackages; };
 
     standard-library = callPackage ../development/libraries/agda/standard-library {


### PR DESCRIPTION
###### Motivation for this change
agdaPackages.mkDerivation: don't install Everything module

The Everthing module is not part of a library and should therefore
not be copied to the nix store.

This is particularly bad, if the Everything module is defined in
an agda library included directory, e.g. consider an agda-lib with

````
include: .
````

and Everything.agda in the project root (.), in which case the
Everything module would become part of the library.
If multiple such projects are in the dependency tree, the Everything
module becomes ambiguous and the build would fail.

###### Things done
Exclude Everything.agda etc. from `find` in `installPhase`.

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Ensured that relevant documentation is up to date