### PR TITLE
python3Packages.capstone: aarch64 platform name

### DIFF
--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , buildPythonPackage
-, fetchPypi
-, fetchpatch
-, setuptools
 , capstone
+, fetchpatch
+, fetchPypi
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "capstone";
-  version = stdenv.lib.getVersion capstone;
+  version = lib.getVersion capstone;
 
   src = capstone.src;
   sourceRoot = "${capstone.name}/bindings/python";
@@ -16,6 +17,7 @@ buildPythonPackage rec {
   postPatch = ''
     ln -s ${capstone}/lib/libcapstone${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/
     ln -s ${capstone}/lib/libcapstone.a prebuilt/
+    substituteInPlace setup.py --replace manylinux1 manylinux2014
   '';
 
   propagatedBuildInputs = [ setuptools ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package currently doesn't build on aarch64 without this change.

This change fixes [this build failure](https://hydra.nixos.org/build/134914165).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
