### PR TITLE
libpgf: 6.14.12 -> 7.21.2

### DIFF
--- a/pkgs/development/libraries/libpgf/default.nix
+++ b/pkgs/development/libraries/libpgf/default.nix
@@ -1,24 +1,20 @@
-{ lib, stdenv, fetchurl, autoconf, automake, libtool, dos2unix }:
+{ lib, stdenv, fetchzip, autoreconfHook }:
 
-with lib;
-
-let
-  version = "6.14.12";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "libpgf";
-  inherit version;
+  version = "7.21.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libpgf/libpgf-src-${version}.tar.gz";
-    sha256 = "1ssqjbh6l5jc04f67n47m9bqcigl46c6lgyabyi6cabnh1frk9dx";
+  src = fetchzip {
+    url = "mirror://sourceforge/${pname}/${pname}/${version}/${pname}.zip";
+    sha256 = "0l1j5b1d02jn27miggihlppx656i0pc70cn6x89j1rpj33zn0g9r";
   };
 
-  buildInputs = [ autoconf automake libtool dos2unix ];
+  nativeBuildInputs = [ autoreconfHook ];
 
-  preConfigure = "dos2unix configure.ac; sh autogen.sh";
-
-# configureFlags = optional static "--enable-static --disable-shared";
+  autoreconfPhase = ''
+    mv README.txt README
+    sh autogen.sh
+  '';
 
   meta = {
     homepage = "https://www.libpgf.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2015-6673.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>libpgf</li>
    <li>pgf_graphics</li>
  </ul>
</details>