### PR TITLE
Add VS Code extensions

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -328,6 +328,18 @@ let
         };
       };
 
+      hookyqr.beautify = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "beautify";
+          publisher = "HookyQR";
+          version = "1.5.0";
+          sha256 = "1c0kfavdwgwham92xrh0gnyxkrl9qlkpv39l1yhrldn8vd10fj5i";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       ibm.output-colorizer = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "output-colorizer";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -612,6 +612,18 @@ let
         };
       };
 
+      spywhere.guides = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "guides";
+          publisher = "spywhere";
+          version = "0.9.3";
+          sha256 = "1kvsj085w1xax6fg0kvsj1cizqh86i0pkzpwi0sbfvmcq21i6ghn";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       streetsidesoftware.code-spell-checker = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "code-spell-checker";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -369,6 +369,18 @@ let
         };
       };
 
+      jock.svg = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "svg";
+          publisher = "jock";
+          version = "1.4.4";
+          sha256 = "0kn2ic7pgbd4rbvzpsxfwyiwxa1iy92l0h3jsppxc8gk8xbqm2nc";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       jpoissonnier.vscode-styled-components = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-styled-components";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -292,6 +292,18 @@ let
         };
       };
 
+      gruntfuggly.todo-tree = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "todo-tree";
+          publisher = "Gruntfuggly";
+          version = "0.0.196";
+          sha256 = "1l4f290018f2p76q6hn2b2injps6wz65as7dm537wrsvsivyg2qz";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       haskell.haskell = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "haskell";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -612,6 +612,18 @@ let
         };
       };
 
+      streetsidesoftware.code-spell-checker = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "code-spell-checker";
+          publisher = "streetsidesoftware";
+          version = "1.10.2";
+          sha256 = "1ll046rf5dyc7294nbxqk5ya56g2bzqnmxyciqpz2w5x7j75rjib";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       tamasfe.even-better-toml = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "even-better-toml";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -473,6 +473,18 @@ let
         };
       };
 
+      rubymaniac.vscode-paste-and-indent = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-paste-and-indent";
+          publisher = "Rubymaniac";
+          version = "0.0.8";
+          sha256 = "0fqwcvwq37ndms6vky8jjv0zliy6fpfkh8d9raq8hkinfxq6klgl";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       matklad.rust-analyzer = callPackage ./rust-analyzer {};
 
       ocamllabs.ocaml-platform = buildVscodeMarketplaceExtension {

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -128,6 +128,18 @@ let
         };
       };
 
+      davidanson.vscode-markdownlint = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-markdownlint";
+          publisher = "DavidAnson";
+          version = "0.38.0";
+          sha256 = "0d6hbsjrx1j8wrmfnvdwsa7sci1brplgxwkmy6sp74va7zxfjnqv";
+        };
+        meta = with lib; {
+          license = licenses.mit;
+        };
+      };
+
       dhall.dhall-lang = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "dhall-lang";


### PR DESCRIPTION
###### Motivation for this change

Add support for a couple of missing VS Code extensions:
- https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint
- https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree
- https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify
- https://marketplace.visualstudio.com/items?itemName=Rubymaniac.vscode-paste-and-indent
- https://marketplace.visualstudio.com/items?itemName=jock.svg
- https://marketplace.visualstudio.com/items?itemName=spywhere.guides
- https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
