### PR TITLE
libcgroup: 0.41 -> 0.42.2

### DIFF
--- a/pkgs/os-specific/linux/libcgroup/default.nix
+++ b/pkgs/os-specific/linux/libcgroup/default.nix
@@ -1,26 +1,21 @@
-{ lib, stdenv, fetchurl, fetchpatch, pam, bison, flex }:
+{ lib, stdenv, fetchFromGitHub, pam, bison, flex, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "libcgroup";
-  version = "0.41";
+  version = "0.42.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libcg/${pname}-${version}.tar.bz2";
-    sha256 = "0lgvyq37gq84sk30sg18admxaj0j0p5dq3bl6g74a1ppgvf8pqz4";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1h8s70lm6g7r0wj7j3xgj2g3j9fifvsy2pna6w0j3i5hh42qfms4";
   };
 
   buildInputs = [ pam bison flex ];
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2018-14348.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/libcgroup/files/libcgroup-0.41-remove-umask.patch?id=33e9f4c81de754bbf76b893ea1133ed023f2a0e5";
-      sha256 = "1x0x29ld0cgmfwq4qy13s6d5c8sym1frfh1j2q47d8gfw6qaxka5";
-    })
-  ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   postPatch = ''
-    substituteInPlace src/tools/Makefile.in \
+    substituteInPlace src/tools/Makefile.am \
       --replace 'chmod u+s' 'chmod +x'
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Avoiding false positive when checking for security issues (#99797) and update the package...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>afl</li>
    <li>aflplusplus</li>
    <li>libcgroup</li>
  </ul>
</details>