### PR TITLE
crawl: 0.25.1 -> 0.26.0

### DIFF
--- a/pkgs/games/crawl/crawl_purify.patch
+++ b/pkgs/games/crawl/crawl_purify.patch
@@ -1,20 +1,5 @@
-diff --git a/crawl-ref/source/Makefile b/crawl-ref/source/Makefile
---- a/crawl-ref/source/Makefile
-+++ b/crawl-ref/source/Makefile
-@@ -248,9 +248,9 @@ ifeq ($(uname_S),Darwin)
- 	STRIP := strip -x
- 	NEED_APPKIT = YesPlease
- 	LIBNCURSES_IS_UNICODE = Yes
--	NO_PKGCONFIG = Yes
--	BUILD_SQLITE = YesPlease
--	BUILD_ZLIB = YesPlease
-+	#NO_PKGCONFIG = Yes
-+	#BUILD_SQLITE = YesPlease
-+	#BUILD_ZLIB = YesPlease
- 	ifdef TILES
- 		EXTRA_LIBS += -framework AppKit -framework AudioUnit -framework CoreAudio -framework ForceFeedback -framework Carbon -framework IOKit -framework OpenGL -framework AudioToolbox -framework CoreVideo contrib/install/$(ARCH)/lib/libSDL2main.a
- 		BUILD_FREETYPE = YesPlease
 diff --git a/crawl-ref/source/util/find_font b/crawl-ref/source/util/find_font
+index f8b576fd63..b95c21c0a1 100755
 --- a/crawl-ref/source/util/find_font
 +++ b/crawl-ref/source/util/find_font
 @@ -1,6 +1,6 @@
@@ -25,7 +10,7 @@ diff --git a/crawl-ref/source/util/find_font b/crawl-ref/source/util/find_font
  
  name=$1
  [ "$name" ] || { echo "Usage: $0 <fontname.ttf>" >&2; exit 100; }
-@@ -11,6 +11,6 @@
+@@ -11,6 +11,6 @@ name=$1
          for dir in $FONTDIRS; do
              [ -d "$dir" ] && echo "$dir"
          done
@@ -34,6 +19,7 @@ diff --git a/crawl-ref/source/util/find_font b/crawl-ref/source/util/find_font
        | head -n1
  } 2>/dev/null
 diff --git a/crawl-ref/source/windowmanager-sdl.cc b/crawl-ref/source/windowmanager-sdl.cc
+index e29ccff507..9bf01e040a 100644
 --- a/crawl-ref/source/windowmanager-sdl.cc
 +++ b/crawl-ref/source/windowmanager-sdl.cc
 @@ -20,7 +20,7 @@

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   name = "crawl-${version}${lib.optionalString tileMode "-tiles"}";
-  version = "0.25.1";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "crawl";
     repo = "crawl";
     rev = version;
-    sha256 = "0i1cvwzwmcb07ynz1nk2svprfhsgcqmagvj5jfzayvcb1a2ww23b";
+    sha256 = "0g0icmhppb6f5amf5r2ksfylrlipz2cd8gd85pmd05k463nrmwqi";
   };
 
   # Patch hard-coded paths and remove force library builds
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
   fontsPath = lib.optionalString tileMode dejavu_fonts;
 
   makeFlags = [ "prefix=${placeholder "out"}" "FORCE_CC=cc" "FORCE_CXX=c++" "HOSTCXX=c++"
+                "FORCE_PKGCONFIG=y"
                 "SAVEDIR=~/.crawl" "sqlite=${sqlite.dev}"
                 "DATADIR=${placeholder "out"}"
               ] ++ lib.optional tileMode "TILES=y"


### PR DESCRIPTION
###### Motivation for this change
crawl: 0.25.1 -> 0.26.0

FORCE_PKGCONFIG was added upstream in crawl/crawl@61de54256c8, so we
can drop our patch to the Makefile which does the same thing - nice!
Still need the other patches since crawl/crawl#1367 isn't yet fully
merged.

I haven't tested building on MacOS - changing to FORCE_PKGCONFIG will affect the MacOS build, so can someone do that?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
