### PR TITLE
treewide: migrate to -fno-common

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -222,9 +222,6 @@ let
     ++ lib.optionals (langD) [
       "--with-target-system-zlib=yes"
     ]
-    # Make -fcommon default on gcc10
-    # TODO: fix all packages (probably 100+) and remove that
-    ++ lib.optional (version >= "10.1.0") "--with-specs=%{!fno-common:%{!fcommon:-fcommon}}"
   ;
 
 in configureFlags

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -50,18 +50,6 @@ let
       ./purity.patch
       # https://reviews.llvm.org/D51899
       ./gnu-install-dirs.patch
-      # Revert: [Driver] Default to -fno-common for all targets
-      # https://reviews.llvm.org/D75056
-      #
-      # Maintains compatibility with packages that haven't been fixed yet, and
-      # matches gcc10's configuration in nixpkgs.
-      (fetchpatch {
-        revert = true;
-        url = "https://github.com/llvm/llvm-project/commit/0a9fc9233e172601e26381810d093e02ef410f65.diff";
-        stripLen = 1;
-        excludes = [ "docs/*" "test/*" ];
-        sha256 = "0gxgmi0qbm89mq911dahallhi8m6wa9vpklklqmxafx4rplrr8ph";
-      })
       (substituteAll {
         src = ../../clang-11-12-LLVMgold-path.patch;
         libllvmLibdir = "${libllvm.lib}/lib";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

GCC 10 [defaults to `-fno-common`](https://gcc.gnu.org/gcc-10/porting_to.html), a change that broke some packages. To ease the transition when migrating to GCC 10, we [changed the default back](https://github.com/NixOS/nixpkgs/commit/b1b3ca79073ba82b551906fd11cc0ca086f81894) in our build of GCC. This commit undoes that, bringing us closer to upstream and reducing our technical debt. (Clang, which [made the same change](https://reviews.llvm.org/D75056), also cites "performance and code-size benefits"; it's unclear if this is the case for GCC.)

In an effort to reduce the potential breakage from this PR, I've made no effort to patch or upgrade packages broken by this. Instead, for any package that fails to build, I fix it by setting `NIX_CFLAGS_COMPILE = "-fcommon"`, i.e. returning to the status quo. This brings the vast majority of packages onto the new default, and has no risk of introducing new bugs due to incorrect patches. As the rest of the world migrates towards GCC 10, most of these will probably get fixed by upstream, and we can remove the flag; for the rest, we can decide whether to write/find a patch or keep the flag indefinitely.

This PR is not ready to merge at this point. Before doing so, I'd like to try building at least these things:
- [ ] The `configuration.nix` of the laptop I'm testing this on
- [ ] Some (or all) of the configurations in `release.nix`
- [ ] Packages listed as broken (or previously broken) in the [Gentoo](https://bugs.gentoo.org/705764) and [Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=1792464) issues for migrating to GCC 10.

It might also be a good idea to set up a hydra job.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
