### PR TITLE
 python3Packages.amcrest: init at 1.7.2

### DIFF
--- a/pkgs/development/python-modules/amcrest/default.nix
+++ b/pkgs/development/python-modules/amcrest/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, argcomplete
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, requests
+, responses
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "amcrest";
+  version = "1.7.2";
+
+  src = fetchFromGitHub {
+    owner = "tchellomello";
+    repo = "python-amcrest";
+    rev = version;
+    sha256 = "06gbrshf6vqvq3k813d1w37k2kmps0g6msa4lp2f9xvzw3iczshy";
+  };
+
+  propagatedBuildInputs = [
+    argcomplete
+    requests
+    urllib3
+  ];
+
+  checkInputs = [
+    mock
+    pytestCheckHook
+    responses
+  ];
+
+  pythonImportsCheck = [ "amcrest" ];
+
+  meta = with lib; {
+    description = "Python module for Amcrest and Dahua Cameras";
+    homepage = "https://github.com/tchellomello/python-amcrest";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -27,7 +27,7 @@
     "amazon_polly" = ps: with ps; [ boto3 ];
     "ambiclimate" = ps: with ps; [ aiohttp-cors ambiclimate ];
     "ambient_station" = ps: with ps; [ ]; # missing inputs: aioambient
-    "amcrest" = ps: with ps; [ ha-ffmpeg ]; # missing inputs: amcrest
+    "amcrest" = ps: with ps; [ amcrest ha-ffmpeg ];
     "ampio" = ps: with ps; [ ]; # missing inputs: asmog
     "android_ip_webcam" = ps: with ps; [ ]; # missing inputs: pydroid-ipcam
     "androidtv" = ps: with ps; [ adb-shell androidtv pure-python-adb ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -318,6 +318,8 @@ in {
 
   ambiclimate = callPackage ../development/python-modules/ambiclimate { };
 
+  amcrest = callPackage ../development/python-modules/amcrest { };
+
   amply = callPackage ../development/python-modules/amply { };
 
   amqp = callPackage ../development/python-modules/amqp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for Amcrest and Dahua Cameras.

https://github.com/tchellomello/python-amcrest

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
