### PR TITLE
python3Packages.wasmer: make cargoHash invariant to the Python version

### DIFF
--- a/pkgs/development/python-modules/wasmer/default.nix
+++ b/pkgs/development/python-modules/wasmer/default.nix
@@ -11,7 +11,7 @@ let
   version = "1.0.0-beta1";
 
   wheel = rustPlatform.buildRustPackage rec {
-    name = "${pname}-${version}-py${python.version}";
+    inherit pname version;
 
     src = fetchFromGitHub {
       owner = "wasmerio";
@@ -20,7 +20,7 @@ let
       sha256 = "0302lcfjlw7nz18nf86z6swhhpp1qnpwcsm2fj4avl22rsv0h78j";
     };
 
-    cargoSha256 = "0d83dniijjq8rc4fcwj6ja5x4hxh187afnqfd8c9fzb8nx909a0v";
+    cargoHash = "sha256-Rq5m9Lu6kePvohfhODLMOpGPFtCh0woTsQY2TufoiNQ=";
 
     nativeBuildInputs = [ maturin python ];
 
@@ -50,8 +50,6 @@ let
 in
 buildPythonPackage rec {
   inherit pname version;
-  # we can only support one python version because the cargo hash changes with the python version
-  disabled = !isPy38;
 
   format = "wheel";
   src = wheel;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The package name used the Python version. Since the name is used in
the Cargo vendor directory, the Cargo vendor hash depended on the
Python version. Remove the Python version from the name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
