### PR TITLE
re2: fix for pkgsStatic

### DIFF
--- a/pkgs/development/libraries/re2/default.nix
+++ b/pkgs/development/libraries/re2/default.nix
@@ -17,9 +17,13 @@ stdenv.mkDerivation {
     substituteInPlace Makefile  --replace "SED_INPLACE=sed -i '''" "SED_INPLACE=sed -i"
   '';
 
+  buildFlags = if stdenv.hostPlatform.isStatic then [ "static" ] else null;
+
   preCheck = "patchShebangs runtests";
   doCheck = true;
   checkTarget = "test";
+
+  installTargets = if stdenv.hostPlatform.isStatic then [ "static-install" ] else null;
 
   doInstallCheck = true;
   installCheckTarget = "testinstall";

--- a/pkgs/development/libraries/re2/default.nix
+++ b/pkgs/development/libraries/re2/default.nix
@@ -17,13 +17,13 @@ stdenv.mkDerivation {
     substituteInPlace Makefile  --replace "SED_INPLACE=sed -i '''" "SED_INPLACE=sed -i"
   '';
 
-  buildFlags = if stdenv.hostPlatform.isStatic then [ "static" ] else null;
+  buildFlags = lib.optionals stdenv.hostPlatform.isStatic [ "static" ];
 
   preCheck = "patchShebangs runtests";
   doCheck = true;
   checkTarget = "test";
 
-  installTargets = if stdenv.hostPlatform.isStatic then [ "static-install" ] else null;
+  installTargets = lib.optionals stdenv.hostPlatform.isStatic [ "static-install" ];
 
   doInstallCheck = true;
   installCheckTarget = "testinstall";


### PR DESCRIPTION
Not using `lib.optional` to avoid changing the `.drv` hash.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
