### PR TITLE
spdlog_1: add support for pkgsStatic

### DIFF
--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -17,7 +17,8 @@ let
       buildInputs = [ fmt ];
 
       cmakeFlags = [
-        "-DSPDLOG_BUILD_SHARED=ON"
+        "-DSPDLOG_BUILD_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+        "-DSPDLOG_BUILD_STATIC=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
         "-DSPDLOG_BUILD_EXAMPLE=OFF"
         "-DSPDLOG_BUILD_BENCH=OFF"
         "-DSPDLOG_BUILD_TESTS=ON"


### PR DESCRIPTION
###### Things done

This causes 22 rebuilds according to `nixpkgs-review`:
bear cloudcompare gerbera hal-hardware-analyzer lizardfs mtxclient nheko pdal python3.7-qiskit python3.7-qiskit-aer python3.7-qiskit-aqua python3.7-qiskit-ignis python3.7-tiledb python3.8-qiskit python3.8-qiskit-aer python3.8-qiskit-aqua python3.8-qiskit-ignis python3.8-tiledb spdlog spdlog tiledb waybar

This could be avoided at the cost of a less readable construction of `cmakeFlags` until the next version bump.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
