### PR TITLE
python3Packages.aioasuswrt: init at 1.3.2

### DIFF
--- a/pkgs/development/python-modules/aioasuswrt/default.nix
+++ b/pkgs/development/python-modules/aioasuswrt/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, asyncssh
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aioasuswrt";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "kennedyshead";
+    repo = pname;
+    rev = "V${version}";
+    sha256 = "0bzl11224vny4p9vhi1n5s9p04kfavdzs9xkq5qimbisz9sg4ysj";
+  };
+
+  patches = [
+    (fetchpatch {
+      # Remove pytest-runner, https://github.com/kennedyshead/aioasuswrt/pull/63
+      url = "https://github.com/kennedyshead/aioasuswrt/pull/63/commits/e7923927648d5d8daccac1716db86db2a45fcb34.patch";
+      sha256 = "09xzs3hjr3133li6b7lr58n090r00kaxi9hx1fms2zn0ai4xwp9d";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov-report html" "" \
+      --replace "--cov-report term-missing" ""
+  '';
+
+  propagatedBuildInputs = [ asyncssh ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "aioasuswrt" ];
+
+  meta = with lib; {
+    description = "Python module for Asuswrt";
+    homepage = "https://github.com/kennedyshead/aioasuswrt";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -52,7 +52,7 @@
     "arwn" = ps: with ps; [ aiohttp-cors paho-mqtt ];
     "asterisk_cdr" = ps: with ps; [ ]; # missing inputs: asterisk_mbox
     "asterisk_mbox" = ps: with ps; [ ]; # missing inputs: asterisk_mbox
-    "asuswrt" = ps: with ps; [ ]; # missing inputs: aioasuswrt
+    "asuswrt" = ps: with ps; [ aioasuswrt ];
     "atag" = ps: with ps; [ ]; # missing inputs: pyatag
     "aten_pe" = ps: with ps; [ atenpdu ];
     "atome" = ps: with ps; [ ]; # missing inputs: pyatome

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -204,9 +204,11 @@ in {
 
   aioambient = callPackage ../development/python-modules/aioambient { };
 
+  ailment = callPackage ../development/python-modules/ailment { };
+
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
-  ailment = callPackage ../development/python-modules/ailment { };
+  aioasuswrt = callPackage ../development/python-modules/aioasuswrt { };
 
   aiocoap = callPackage ../development/python-modules/aiocoap { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for Asuswrt

https://github.com/kennedyshead/aioasuswrt

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
