### PR TITLE
falcon, hdf5-blosc: move cmake to nativeBuildInputs

### DIFF
--- a/pkgs/development/interpreters/falcon/default.nix
+++ b/pkgs/development/interpreters/falcon/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1x3gdcz1gqhi060ngqi0ghryf69v8bn50yrbzfad8bhblvhzzdlf";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ cmake pcre zlib sqlite ];
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ pcre zlib sqlite ];
 
   meta = with stdenv.lib; {
     description = "Programming language with macros and syntax at once";

--- a/pkgs/development/libraries/hdf5-blosc/default.nix
+++ b/pkgs/development/libraries/hdf5-blosc/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "plugin" ];
 
-  buildInputs = [ c-blosc cmake hdf5 ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ c-blosc hdf5 ];
 
   preConfigure = ''
     substituteInPlace CMakeLists.txt --replace 'set(BLOSC_INSTALL_DIR "''${CMAKE_CURRENT_BINARY_DIR}/blosc")' 'set(BLOSC_INSTALL_DIR "${c-blosc}")'


### PR DESCRIPTION
###### Motivation for this change
`cmake` should be in `nativeBuildInputs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
