### PR TITLE
lammps: stable_22Aug2018 -> stable_29Oct2020

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -12,14 +12,14 @@ let packages = [
 in
 stdenv.mkDerivation rec {
   # LAMMPS has weird versioning converted to ISO 8601 format
-  version = "stable_22Aug2018";
+  version = "stable_29Oct2020";
   pname = "lammps";
 
   src = fetchFromGitHub {
     owner = "lammps";
     repo = "lammps";
     rev = version;
-    sha256 = "1dlifm9wm1jcw2zwal3fnzzl41ng08c7v48w6hx2mz84zljg1nsj";
+    sha256 = "1rmi9r5wj2z49wg43xyhqn9sm37n95cyli3g7vrqk3ww35mmh21q";
   };
 
   passthru = {

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -59,8 +59,8 @@ stdenv.mkDerivation rec {
       funding from the DOE. It is an open-source code, distributed freely
       under the terms of the GNU Public License (GPL).
       '';
-    homepage = "http://lammps.sandia.gov";
-    license = licenses.gpl2;
+    homepage = "https://lammps.sandia.gov";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update from an old 2018 version. Supersedes and closes https://github.com/NixOS/nixpkgs/pull/80614

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
