### PR TITLE
nheko: build with VoIP support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -23,6 +23,9 @@
 , olm
 , pkg-config
 , nlohmann_json
+, voipSupport ? true
+, gst_all_1
+, libnice
 }:
 
 mkDerivation rec {
@@ -59,11 +62,23 @@ mkDerivation rec {
     qtquickcontrols2
     qtgraphicaleffects
     qtkeychain
-  ] ++ lib.optional stdenv.isDarwin qtmacextras;
+  ] ++ lib.optional stdenv.isDarwin qtmacextras
+    ++ lib.optionals voipSupport (with gst_all_1; [
+      gstreamer
+      gst-plugins-base
+      (gst-plugins-good.override { qt5Support = true; })
+      gst-plugins-bad
+      libnice
+    ]);
 
   cmakeFlags = [
     "-DCOMPILE_QML=ON" # see https://github.com/Nheko-Reborn/nheko/issues/389
   ];
+
+  preFixup = lib.optionalString voipSupport ''
+    # add gstreamer plugins path to the wrapper
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  '';
 
   meta = with lib; {
     description = "Desktop client for the Matrix protocol";

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -156,6 +156,9 @@ stdenv.mkDerivation rec {
   # fails 1 tests with "Unexpected critical/warning: g_object_set_is_valid_property: object class 'GstRtpStorage' has no property named ''"
   doCheck = false;
 
+  # must be explicitely set since 5590e365
+  dontWrapQtApps = true;
+
   meta = with lib; {
     description = "GStreamer Good Plugins";
     homepage = "https://gstreamer.freedesktop.org";


### PR DESCRIPTION
###### Motivation for this change
Making calls (and fix the embedded media player).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**notes:**

1. The media player works but I still can't get calls to work. In particular is not finding any microphone.
I tested with both alsa and pulseaudio on NixOS to no avail. On the other hand, the webcam is working.

2. For a brief moment, after having switched to pulseaudio, it could detect the microphone and I managed to start a call, but nheko crashed as soon as I pressed the bottom green bar.

3. It seems the problem with the audio sources detection can be traced to the gstreamer monitor: running this
  
    nix-shell --pure -p gst_all_1.gst-plugins-base --run 'gst-device-monitor-1.0'

fails with `Failed to start device monitor!`. I would be good if someone else were to confirm this or put the blame on my setup. In theory it should just work and list all the audio and video sources.

cc: @pstn