### PR TITLE
intel-gmmlib: 20.3.3 -> 20.4.1

### DIFF
--- a/pkgs/development/libraries/intel-gmmlib/default.nix
+++ b/pkgs/development/libraries/intel-gmmlib/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-gmmlib";
-  version = "20.3.3";
+  version = "20.4.1";
 
   src = fetchFromGitHub {
     owner  = "intel";
     repo   = "gmmlib";
     rev    = "${pname}-${version}";
-    sha256 = "1diq1gqpfv5bawvag6bzwnd3ilhacwmwx3bl67abjvbb0m3jw4lk";
+    sha256 = "0qb0wpinfv8lg1pq1pxkl6v0kd8ax86m8zxzm6zjx91alsch1mi6";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/intel/gmmlib";
     license = licenses.mit;
     description = "Intel Graphics Memory Management Library";
+    longDescription = ''
+      The Intel(R) Graphics Memory Management Library provides device specific
+      and buffer management for the Intel(R) Graphics Compute Runtime for
+      OpenCL(TM) and the Intel(R) Media Driver for VAAPI.
+    '';
     platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ primeos ];
   };
 }


### PR DESCRIPTION
And add myself as maintainer because we need a new one since 76bab4e9a7d
(and I already maintain intel-media-driver which depends on gmmlib).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
