### PR TITLE
elmPackages.elm-json: fix darwin build

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -2,7 +2,8 @@
 , haskell, nodejs
 , fetchurl, fetchpatch, makeWrapper, writeScriptBin
   # Rust dependecies
-, rustPlatform, openssl, pkg-config }:
+, rustPlatform, openssl, pkg-config, Security
+}:
 let
   fetchElmDeps = import ./fetchElmDeps.nix { inherit stdenv lib fetchurl; };
 
@@ -96,7 +97,7 @@ let
 
   elmRustPackages =  {
     elm-json = import ./packages/elm-json.nix {
-      inherit rustPlatform fetchurl openssl stdenv pkg-config;
+      inherit lib rustPlatform fetchurl openssl stdenv pkg-config Security;
     } // {
       meta = with lib; {
         description = "Install, upgrade and uninstall Elm dependencies";

--- a/pkgs/development/compilers/elm/packages/elm-json.nix
+++ b/pkgs/development/compilers/elm/packages/elm-json.nix
@@ -1,4 +1,4 @@
-{ rustPlatform, fetchurl, openssl, stdenv, pkg-config }:
+{ lib, rustPlatform, fetchurl, openssl, stdenv, pkg-config, Security }:
 rustPlatform.buildRustPackage rec {
   pname = "elm-json";
   version = "0.2.7";
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   cargoSha256 = "0ylniriq073kpiykamkn9mxdaa6kyiza4pvf7gnfq2h1dvbqa6z7";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9523,7 +9523,9 @@ in
 
   elm2nix = haskell.lib.justStaticExecutables haskellPackages.elm2nix;
 
-  elmPackages = recurseIntoAttrs (callPackage ../development/compilers/elm { });
+  elmPackages = recurseIntoAttrs (callPackage ../development/compilers/elm {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  });
 
   apache-flex-sdk = callPackage ../development/compilers/apache-flex-sdk { };
 


### PR DESCRIPTION
Fix macos build of elm-json

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Can't test this myself. @BrianHicks can you test this on macos?