### PR TITLE
python3Packages.pytest_xdist: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -2,7 +2,7 @@
 , fonttools
 , lxml, fs # for fonttools extras
 , setuptools_scm
-, pytestCheckHook, pytest_5, pytestcov, pytest_xdist
+, pytestCheckHook, pytestcov, pytest_xdist
 }:
 
 buildPythonPackage rec {
@@ -30,14 +30,14 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ fonttools lxml fs ];
 
   checkInputs = [
-    # Override pytestCheckHook to use pytest v5, because some tests fail on pytest >= v6
-    # https://github.com/adobe-type-tools/psautohint/issues/284#issuecomment-742800965
-    # Override might be able to be removed in future, check package dependency pins (coverage.yml)
-    (pytestCheckHook.override{ pytest = pytest_5; })
+    pytestCheckHook
     pytestcov
     pytest_xdist
   ];
   disabledTests = [
+    # Test that fails on pytest >= v6
+    # https://github.com/adobe-type-tools/psautohint/issues/284#issuecomment-742800965
+    "test_hashmap_old_version"
     # Slow tests, reduces test time from ~5 mins to ~30s
     "test_mmufo"
     "test_flex_ufo"

--- a/pkgs/development/python-modules/pytest-forked/default.nix
+++ b/pkgs/development/python-modules/pytest-forked/default.nix
@@ -2,7 +2,9 @@
 , buildPythonPackage
 , fetchPypi
 , setuptools_scm
+, py
 , pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -14,19 +16,16 @@ buildPythonPackage rec {
     sha256 = "6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca";
   };
 
-  buildInputs = [ pytest setuptools_scm ];
+  nativeBuildInputs = [ setuptools_scm ];
 
-  # Do not function
-  doCheck = false;
+  propagatedBuildInputs = [ py pytest ];
 
-  checkPhase = ''
-    py.test testing
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Run tests in isolated forked subprocesses";
     homepage = "https://github.com/pytest-dev/pytest-forked";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
-
 }

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -1,28 +1,39 @@
-{ lib, fetchPypi, buildPythonPackage, execnet, pytest_6
-, setuptools_scm, pytest-forked, filelock, psutil, six, isPy3k }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, setuptools_scm
+, pytestCheckHook
+, filelock
+, execnet
+, pytest
+, pytest-forked
+, psutil
+}:
 
 buildPythonPackage rec {
   pname = "pytest-xdist";
-  version = "2.1.0";
-  disabled = !isPy3k;
+  version = "2.2.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0wh6pn66nncfs6ay0n863bgyriwsgppn8flx5l7551j1lbqkinc2";
+    sha256 = "1d8edbb1a45e8e1f8e44b1260583107fc23f8bc8da6d18cb331ff61d41258ecf";
   };
 
-  nativeBuildInputs = [ setuptools_scm pytest_6 ];
-  checkInputs = [ pytest_6 filelock ];
-  propagatedBuildInputs = [ execnet pytest-forked psutil six ];
+  nativeBuildInputs = [ setuptools_scm ];
+  checkInputs = [ pytestCheckHook filelock ];
+  propagatedBuildInputs = [ execnet pytest pytest-forked psutil ];
 
-  # pytest6 doesn't allow for new lines
-  # capture_deprecated not compatible with latest pytest6
-  checkPhase = ''
-    # Excluded tests access file system
-    export HOME=$TMPDIR
-    pytest -n $NIX_BUILD_CORES \
-      -k "not (distribution_rsyncdirs_example or rsync or warning_captured_deprecated_in_pytest_6)"
-  '';
+  # access file system
+  disabledTests = [
+    "test_distribution_rsyncdirs_example"
+    "test_rsync_popen_with_path"
+    "test_popen_rsync_subdir"
+    "test_rsync_report"
+    "test_init_rsync_roots"
+    "test_rsyncignore"
+  ];
 
   meta = with lib; {
     description = "py.test xdist plugin for distributed testing and loop-on-failing modes";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
