### PR TITLE
qt515.qtwebengine: update darwin patches

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -84,7 +84,10 @@ let
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qtwebengine = [ ]
-      ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
+      ++ optionals stdenv.isDarwin [
+        ./qtwebengine-darwin-no-platform-check.patch
+        ./qtwebengine-mac-dont-set-dsymutil-path.patch
+      ];
     qtwebkit = [
       (fetchpatch {
         name = "qtwebkit-bison-3.7-build.patch";

--- a/pkgs/development/libraries/qt-5/5.15/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebengine-darwin-no-platform-check.patch
@@ -1,27 +1,31 @@
-diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
---- a/mkspecs/features/platform.prf
-+++ b/mkspecs/features/platform.prf
-@@ -40,8 +40,6 @@ defineTest(isPlatformSupported) {
-   } else:osx {
-     # FIXME: Try to get it back down to 8.2 for building on OS X 10.11
-     !isMinXcodeVersion(8, 3, 3) {
--      skipBuild("Using Xcode version $$QMAKE_XCODE_VERSION, but at least version 8.3.3 is required to build Qt WebEngine.")
--      return(false)
+diff a/configure.pri b/configure.pri
+--- a/configure.pri
++++ b/configure.pri
+@@ -439,8 +439,6 @@ defineTest(qtwebengine_isWindowsPlatformSupported) {
+ 
+ defineTest(qtwebengine_isMacOsPlatformSupported) {
+     !qtwebengine_isMinXcodeVersion(10, 0, 0) {
+-        qtwebengine_platformError("requires at least version 10.0.0, but using Xcode version $${QMAKE_XCODE_VERSION}.")
+-        return(false)
      }
      !clang|intel_icc {
-         skipBuild("Qt WebEngine on macOS requires Clang.")
-@@ -54,8 +52,6 @@ defineTest(isPlatformSupported) {
-       return(false)
+         qtwebengine_platformError("requires Clang.")
+@@ -449,12 +447,6 @@ defineTest(qtwebengine_isMacOsPlatformSupported) {
+     # We require macOS 10.13 (darwin version 17.0.0) or newer.
+     darwin_major_version = $$section(QMAKE_HOST.version, ., 0, 0)
+     lessThan(darwin_major_version, 17) {
+-        qtwebengine_platformError("requires macOS version 10.13 or newer.")
+-        return(false)
+-    }
+-    !qtwebengine_isMinOSXSDKVersion(10, 13): {
+-        qtwebengine_platformError("requires a macOS SDK version of 10.13 or newer. Current version is $${WEBENGINE_OSX_SDK_PRODUCT_VERSION}.")
+-        return(false)
      }
-     !isMinOSXSDKVersion(10, 12): {
--      skipBuild("Building Qt WebEngine requires a macOS SDK version of 10.12 or newer. Current version is $${WEBENGINE_OSX_SDK_PRODUCT_VERSION}.")
--      return(false)
-     }
-   } else {
-     skipBuild("Unknown platform. Qt WebEngine only supports Linux, Windows, and macOS.")
-diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
---- a/src/core/config/mac_osx.pri
-+++ b/src/core/config/mac_osx.pri
+     return(true)
+ }
+diff a/src/buildtools/config/mac_osx.pri b/src/buildtools/config/mac_osx.pri
+--- a/src/buildtools/config/mac_osx.pri
++++ b/src/buildtools/config/mac_osx.pri
 @@ -5,8 +5,6 @@ load(functions)
  # otherwise query for it.
  QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
@@ -29,5 +33,5 @@ diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
 -     QMAKE_MAC_SDK_VERSION = $$system("/usr/bin/xcodebuild -sdk $${QMAKE_MAC_SDK} -version SDKVersion 2>/dev/null")
 -     isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
  }
-
- QMAKE_CLANG_DIR = "/usr"
+ 
+ # chromium/build/mac/find_sdk.py expects the SDK version (mac_sdk_min) in Major.Minor format.

--- a/pkgs/development/libraries/qt-5/5.15/qtwebengine-mac-dont-set-dsymutil-path.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebengine-mac-dont-set-dsymutil-path.patch
@@ -1,0 +1,12 @@
+diff a/src/3rdparty/chromium/build/toolchain/mac/BUILD.gn b/src/3rdparty/chromium/build/toolchain/mac/BUILD.gn
+--- a/src/3rdparty/chromium/build/toolchain/mac/BUILD.gn
++++ b/src/3rdparty/chromium/build/toolchain/mac/BUILD.gn
+@@ -184,8 +184,6 @@ template("mac_toolchain") {
+     # If dSYMs are enabled, this flag will be added to the link tools.
+     if (_enable_dsyms) {
+       dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
+-      dsym_switch += "-Wcrl,dsymutilpath," +
+-                     "${prefix}dsymutil" + " "
+ 
+       dsym_output_dir =
+           "{{root_out_dir}}/{{target_output_name}}{{output_extension}}.dSYM"

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -16,6 +16,7 @@
 , cups, darwin, openbsm, runCommand, xcbuild, writeScriptBin
 , ffmpeg_3 ? null
 , lib, stdenv, fetchpatch
+, qtCompatVersion
 }:
 
 with stdenv.lib;
@@ -66,21 +67,31 @@ qtModule {
       sed -i -e '/libpci_loader.*Load/s!"\(libpci\.so\)!"${pciutils}/lib/\1!' \
         src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
     ''
-    + optionalString stdenv.isDarwin (''
+    + optionalString stdenv.isDarwin (
+    (if (lib.versionAtLeast qtCompatVersion "5.14") then ''
+      substituteInPlace src/buildtools/config/mac_osx.pri \
+        --replace 'QMAKE_CLANG_DIR = "/usr"' 'QMAKE_CLANG_DIR = "${stdenv.cc}"'
+    '' else ''
       substituteInPlace src/core/config/mac_osx.pri \
         --replace 'QMAKE_CLANG_DIR = "/usr"' 'QMAKE_CLANG_DIR = "${stdenv.cc}"'
-    ''
+    '')
      # Following is required to prevent a build error:
      # ninja: error: '/nix/store/z8z04p0ph48w22rqzx7ql67gy8cyvidi-SDKs/MacOSX10.12.sdk/usr/include/mach/exc.defs', needed by 'gen/third_party/crashpad/crashpad/util/mach/excUser.c', missing and no known rule to make it
     + ''
       substituteInPlace src/3rdparty/chromium/third_party/crashpad/crashpad/util/BUILD.gn \
         --replace '$sysroot/usr' "${darwin.xnu}"
     ''
-    + ''
     # Apple has some secret stuff they don't share with OpenBSM
+    + (if (lib.versionAtLeast qtCompatVersion "5.14") then ''
+    substituteInPlace src/3rdparty/chromium/base/mac/mach_port_rendezvous.cc \
+      --replace "audit_token_to_pid(request.trailer.msgh_audit)" "request.trailer.msgh_audit.val[5]"
+    substituteInPlace src/3rdparty/chromium/third_party/crashpad/crashpad/util/mach/mach_message.cc \
+      --replace "audit_token_to_pid(audit_trailer->msgh_audit)" "audit_trailer->msgh_audit.val[5]"
+    '' else ''
     substituteInPlace src/3rdparty/chromium/base/mac/mach_port_broker.mm \
       --replace "audit_token_to_pid(msg.trailer.msgh_audit)" "msg.trailer.msgh_audit.val[5]"
-
+    '')
+    + ''
     substituteInPlace src/3rdparty/chromium/sandbox/mac/BUILD.gn \
       --replace 'libs = [ "sandbox" ]' 'libs = [ "/usr/lib/libsandbox.1.dylib" ]'
     '');


### PR DESCRIPTION
A working build seems to further requre SDK 10.14+ and working that
around is not trivial.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Record useful progress towards fixing the `qt515.qtwebengine` on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
