### PR TITLE
gnunet: 0.14.0 -> 0.14.1; gnunet-gtk 0.13.1 -> 0.14.0

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnunet";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/${pname}-${version}.tar.gz";
-    sha256 = "sha256-2u9gO9Mu0dM1yixcaqOnZcDfGcp69dc5CH5tkl6vRas=";
+    sha256 = "1hhqv994akymf4s593mc1wpsjy6hccd0zbdim3qmc1y3f32hacja";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/applications/networking/p2p/gnunet/gtk.nix
+++ b/pkgs/applications/networking/p2p/gnunet/gtk.nix
@@ -5,6 +5,7 @@
 , gtk3
 , libextractor
 , libgcrypt
+, libsodium
 , libxml2
 , pkg-config
 , wrapGAppsHook
@@ -12,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnunet-gtk";
-  version = "0.13.1";
+  version = "0.14.0";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/${pname}-${version}.tar.gz";
-    sha256 = "1zdzgq16h77w6ybwg3lqjsjr965np6iqvncqvkbj07glqd4wss0j";
+    sha256 = "18rc7mb45y17d5nrlpf2p4ixp7ir67gcgjf4hlj4r95ic5zi54wa";
   };
 
   nativeBuildInputs= [
@@ -31,15 +32,16 @@ stdenv.mkDerivation rec {
     gtk3
     libextractor
     libgcrypt
+    libsodium
     libxml2
   ];
+
+  configureFlags = [ "--with-gnunet=${gnunet}" ];
 
   patchPhase = "patchShebangs pixmaps/icon-theme-installer";
 
   meta = gnunet.meta // {
     description = "GNUnet GTK User Interface";
     homepage = "https://git.gnunet.org/gnunet-gtk.git";
-    # configure: error: compiling gnunet-gtk requires GNUnet core headers
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Otherwise `gnunet-setup` will not pick up plugins. See:
https://git.gnunet.org/gnunet-gtk.git/tree/README?id=5034ca084258d6653b2986b00167c736a9cd93ed#n19

Fixes https://github.com/NixOS/nixpkgs/issues/115112

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
