### PR TITLE
gst-plugins-good: Add optional qt5Support

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -30,6 +30,7 @@
 , mpg123
 , twolame
 , gtkSupport ? false, gtk3 ? null
+, qt5Support ? false, qt5 ? null
 , raspiCameraSupport ? false, libraspberrypi ? null
 , enableJack ? true, libjack2
 , libXdamage
@@ -102,7 +103,12 @@ stdenv.mkDerivation rec {
   ] ++ optionals gtkSupport [
     # for gtksink
     gtk3
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ optionals qt5Support (with qt5; [
+    qtbase
+    qtdeclarative
+    qtwayland
+    qtx11extras
+  ]) ++ optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Cocoa
   ] ++ optionals stdenv.isLinux [
     libv4l
@@ -118,7 +124,8 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
     "-Ddoc=disabled" # `hotdoc` not packaged in nixpkgs as of writing
-    "-Dqt5=disabled" # not clear as of writing how to correctly pass in the required qt5 deps
+  ] ++ optionals (!qt5Support) [
+    "-Dqt5=disabled"
   ] ++ optionals (!gtkSupport) [
     "-Dgtk3=disabled"
   ] ++ optionals (!enableJack) [

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -138,7 +138,6 @@ stdenv.mkDerivation rec {
     "-Dv4l2-gudev=disabled" # Linux-only
     "-Dv4l2=disabled" # Linux-only
     "-Dximagesrc=disabled" # Linux-only
-    "-Dpulse=disabled" # TODO check if we can keep this enabled
   ] ++ optionals (!raspiCameraSupport) [
     "-Drpicamsrc=disabled"
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

nheko video calling (Drafted in PR #110595) needs qmlgl, so I put a switch into gst-plugins-good to enable it.
I put another switch in for `lreleaseSupport`, because I don't think it's necessary in most cases but I would be happy to see it when I needed it while working on something.

While working on it, I saw that pulse was disabled twice in the same block, so I also fixed that in another commit.

Thanks @rnhmjoj for the help,
ping @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 110608"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
