### PR TITLE
sord: 0.16.4 -> unstable-2021-01-12

### DIFF
--- a/pkgs/development/libraries/sord/default.nix
+++ b/pkgs/development/libraries/sord/default.nix
@@ -1,12 +1,16 @@
-{ lib, stdenv, fetchurl, pkg-config, python3, serd, pcre, wafHook }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, python3, serd, pcre, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "sord";
-  version = "0.16.4";
+  version = "unstable-2021-01-12";
 
-  src = fetchurl {
-    url = "https://download.drobilla.net/${pname}-${version}.tar.bz2";
-    sha256 = "1mwh4qvp9q4vgrgg5bz9sgjhxscncrylf2b06h0q55ddwzs9hndi";
+  # Commit picked in mitigation of #109729
+  src = fetchFromGitHub {
+    owner = "drobilla";
+    repo = pname;
+    rev = "d2efdb2d026216449599350b55c2c85c0d3efb89";
+    sha256 = "hHTwK+K6cj9MGO77a1IXiUZtEbXZ08cLGkYZ5eMOIVA=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ pkg-config python3 wafHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix segfault.
Continuation of https://github.com/NixOS/nixpkgs/pull/110538
Getting source from master for now until release version is out.

Also apparently fetchFromGitLab doesn't fetch submodules? 
And i'm not sure what should i put as a version if this is a commit from a master branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
