### PR TITLE
nixos/nomad: fix data_dir-default-not-propagating bug

### DIFF
--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -114,6 +114,7 @@ in
       } // (optionalAttrs cfg.enableDocker {
         SupplementaryGroups = "docker"; # space-separated string
       });
+
       unitConfig = {
         StartLimitIntervalSec = 10;
         StartLimitBurst = 3;

--- a/nixos/modules/services/networking/nomad.nix
+++ b/nixos/modules/services/networking/nomad.nix
@@ -51,10 +51,7 @@ in
 
       settings = mkOption {
         type = format.type;
-        default = {
-          # Agrees with `StateDirectory = "nomad"` set below.
-          data_dir = "/var/lib/nomad";
-        };
+        default = {};
         description = ''
           Configuration for Nomad. See the <link xlink:href="https://www.nomadproject.io/docs/configuration">documentation</link>
           for supported values.
@@ -77,6 +74,11 @@ in
 
   ##### implementation
   config = mkIf cfg.enable {
+    services.nomad.settings = {
+      # Agrees with `StateDirectory = "nomad"` set below.
+      data_dir = mkDefault "/var/lib/nomad";
+    };
+
     environment = {
       etc."nomad.json".source = format.generate "nomad.json" cfg.settings;
       systemPackages = [ cfg.package ];


### PR DESCRIPTION
- nixos/nomad: add newline
- nixos/nomad: move data_dir default setting to allow propagation of default

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The value of `data_dir` in the `nomad` module was only
set to its default if `settings` was not overridden at all.

This PR fixes the issue so that you can override `settings`
without having to specify the default value of `data_dir`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
