### PR TITLE
pipewire: 0.3.18 -> 0.3.21

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -318,7 +318,8 @@
   ./services/desktops/gsignond.nix
   ./services/desktops/gvfs.nix
   ./services/desktops/malcontent.nix
-  ./services/desktops/pipewire.nix
+  ./services/desktops/pipewire/pipewire.nix
+  ./services/desktops/pipewire/pipewire-media-session.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/chrome-gnome-shell.nix
   ./services/desktops/gnome3/evolution-data-server.nix

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -17,6 +17,58 @@ let
     mkdir -p "$out/lib"
     ln -s "${cfg.package.jack}/lib" "$out/lib/pipewire"
   '';
+
+  # Helpers for generating the pipewire JSON config file
+  mkSPAValueString = v:
+  if builtins.isList v then "[${lib.concatMapStringsSep " " mkSPAValueString v}]"
+  else if lib.types.attrs.check v then
+    "{${lib.concatStringsSep " " (mkSPAKeyValue v)}}"
+  else lib.generators.mkValueStringDefault { } v;
+
+  mkSPAKeyValue = attrs: map (def: def.content) (
+  lib.sortProperties
+    (
+      lib.mapAttrsToList
+        (k: v: lib.mkOrder (v._priority or 1000) "${lib.escape [ "=" ] k} = ${mkSPAValueString (v._content or v)}")
+        attrs
+    )
+  );
+
+  toSPAJSON = attrs: lib.concatStringsSep "\n" (mkSPAKeyValue attrs);
+  originalEtc =
+    let
+      mkEtcFile = n: nameValuePair n { source = "${cfg.package}/etc/${n}"; };
+    in listToAttrs (map mkEtcFile cfg.package.filesInstalledToEtc);
+
+  customEtc = {
+    # If any paths are updated here they must also be updated in the package test.
+    "alsa/conf.d/49-pipewire-modules.conf" = mkIf cfg.alsa.enable {
+      text = ''
+        pcm_type.pipewire {
+          libs.native = ${cfg.package.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;
+          ${optionalString enable32BitAlsaPlugins
+            "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;"}
+        }
+        ctl_type.pipewire {
+          libs.native = ${cfg.package.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;
+          ${optionalString enable32BitAlsaPlugins
+            "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;"}
+        }
+      '';
+    };
+    "alsa/conf.d/50-pipewire.conf" = mkIf cfg.alsa.enable {
+      source = "${cfg.package}/share/alsa/alsa.conf.d/50-pipewire.conf";
+    };
+    "alsa/conf.d/99-pipewire-default.conf" = mkIf cfg.alsa.enable {
+      source = "${cfg.package}/share/alsa/alsa.conf.d/99-pipewire-default.conf";
+    };
+
+    "pipewire/media-session.d/with-alsa" = mkIf cfg.alsa.enable { text = ""; };
+    "pipewire/media-session.d/with-pulseaudio" = mkIf cfg.pulse.enable { text = ""; };
+    "pipewire/media-session.d/with-jack" = mkIf cfg.jack.enable { text = ""; };
+
+    "pipewire/pipewire.conf" = { text = toSPAJSON cfg.config; };
+  };
 in {
 
   meta = {
@@ -46,18 +98,107 @@ in {
         '';
       };
 
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
+      config = mkOption {
+        type = types.attrs;
         description = ''
-          Literal string to append to /etc/pipewire/pipewire.conf.
+          Configuration for the pipewire daemon.
         '';
+        default = {
+          properties = {
+            ## set-prop is used to configure properties in the system
+            #
+            # "library.name.system" = "support/libspa-support";
+            # "context.data-loop.library.name.system" = "support/libspa-support";
+            "link.max-buffers" = 64; # version < 3 clients can't handle more than 16
+            "mem.allow-mlock" = true;
+            "mem.mlock-all" = true;
+            # https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/pipewire/pipewire.h#L93
+            "log.level" = 3; # 5 is trace, which is verbose as hell, default is 2 which is warnings, 4 is debug output, 3 is info
+
+            ## Properties for the DSP configuration
+            #
+            "default.clock.rate" = 48000; # 48000 is probably saner, 96000 has gaps in audio
+            "default.clock.quantum" = 128; # equivalent to buffer size which is correlated to latency
+            "default.clock.min-quantum" = 32; # No audio through bluetooth if 512 isn't allowed, 16 is the absolute minimum
+            "default.clock.max-quantum" = 1024; # qemu seems to use 16384 but 8192 is the absolute maximum
+            # "default.video.width" = 640;
+            # "default.video.height" = 480;
+            # "default.video.rate.num" = 25;
+            # "default.video.rate.denom" = 1;
+          };
+
+          spa-libs = {
+            ## add-spa-lib <factory-name regex> <library-name>
+            #
+            # used to find spa factory names. It maps an spa factory name
+            # regular expression to a library name that should contain
+            # that factory.
+            #
+            "audio.convert*" = "audioconvert/libspa-audioconvert";
+            "api.alsa.*" = "alsa/libspa-alsa";
+            "api.v4l2.*" = "v4l2/libspa-v4l2";
+            "api.libcamera.*" = "libcamera/libspa-libcamera";
+            "api.bluez5.*" = "bluez5/libspa-bluez5";
+            "api.vulkan.*" = "vulkan/libspa-vulkan";
+            "api.jack.*" = "jack/libspa-jack";
+            "support.*" = "support/libspa-support";
+            # "videotestsrc" = "videotestsrc/libspa-videotestsrc";
+            # "audiotestsrc" = "audiotestsrc/libspa-audiotestsrc";
+          };
+
+          modules = {
+            ##  <module-name> = { [args = "<key>=<value> ..."]
+            #                     [flags = ifexists] }
+            #                     [flags = [ifexists]|[nofail]}
+            #
+            # Loads a module with the given parameters.
+            # If ifexists is given, the module is ignoed when it is not found.
+            # If nofail is given, module initialization failures are ignored.
+            #
+            libpipewire-module-rtkit = {
+              args = "\"rt.prio=20 rt.time.soft=200000 rt.time.hard=200000\"";
+              flags = "ifexists|nofail";
+            };
+            libpipewire-module-protocol-native = { _priority = -100; _content = "null"; };
+            libpipewire-module-profiler = "null";
+            libpipewire-module-metadata = "null";
+            libpipewire-module-spa-device-factory = "null";
+            libpipewire-module-spa-node-factory = "null";
+            libpipewire-module-client-node = "null";
+            libpipewire-module-client-device = "null";
+            libpipewire-module-portal = "null";
+            libpipewire-module-access = {
+              args = "\"access.allowed=${builtins.unsafeDiscardStringContext cfg.sessionManager} access.force=flatpak\"";
+            };
+            libpipewire-module-adapter = "null";
+            libpipewire-module-link-factory = "null";
+            libpipewire-module-session-manager = "null";
+          };
+
+          objects = {
+            ## create-object [-nofail] <factory-name> [<key>=<value> ...]
+            #
+            # Creates an object from a PipeWire factory with the given parameters.
+            # If -nofail is given, errors are ignored (and no object is created)
+            #
+          };
+
+
+          exec = {
+            ## exec <program-name>
+            #
+            # Execute the given program. This is usually used to start the
+            # session manager. run the session manager with -h for options
+            #
+            "${builtins.unsafeDiscardStringContext cfg.sessionManager}" = { args = "\"${lib.concatStringsSep " " cfg.sessionManagerArguments}\""; };
+          };
+        };
       };
 
       sessionManager = mkOption {
-        type = types.nullOr types.string;
-        default = null;
-        example = literalExample ''"''${pipewire}/bin/pipewire-media-session"'';
+        type = types.str;
+        default = "${cfg.package}/bin/pipewire-media-session";
+        example = literalExample ''"\$\{pipewire\}/bin/pipewire-media-session"'';
         description = ''
           Path to the pipewire session manager executable.
         '';
@@ -66,9 +207,30 @@ in {
       sessionManagerArguments = mkOption {
         type = types.listOf types.string;
         default = [];
-        example = literalExample ''[ "-p" "bluez5.msbc-support=true" ]'';
+        example = literalExample ''["-p" "bluez5.msbc-support=true"]'';
         description = ''
           Arguments passed to the pipewire session manager.
+        '';
+      };
+
+      sessionManagerEtcFiles = mkOption {
+        type = types.attrs;
+        default = {};
+        example = literalExample ''
+          "pipewire/pipewire.conf" = {
+            # REPLACES THE FULL CONTENTS OF pipewire.conf, only showing a fragment here.
+            exec = {
+              ## exec <program-name>
+              #
+              # Execute the given program. This is usually used to start the
+              # session manager. run the session manager with -h for options
+              #
+              "/run/current-system/sw/bin/pipewire-media-session" = { args = "\"\""; };
+            };
+          };
+        '';
+        description = ''
+          Advanced. Replace or add config files to /etc/
         '';
       };
 
@@ -101,8 +263,6 @@ in {
       }
     ];
 
-    services.pipewire.sessionManager = mkDefault "${cfg.package}/bin/pipewire-media-session";
-
     environment.systemPackages = [ cfg.package ]
                                  ++ lib.optional cfg.jack.enable jack-libs;
 
@@ -116,68 +276,12 @@ in {
     systemd.user.services.pipewire.bindsTo = [ "dbus.service" ];
     services.udev.packages = [ cfg.package ];
 
-    # If any paths are updated here they must also be updated in the package test.
-    environment.etc."alsa/conf.d/49-pipewire-modules.conf" = mkIf cfg.alsa.enable {
-      text = ''
-        pcm_type.pipewire {
-          libs.native = ${cfg.package.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;
-          ${optionalString enable32BitAlsaPlugins
-            "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;"}
-        }
-        ctl_type.pipewire {
-          libs.native = ${cfg.package.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;
-          ${optionalString enable32BitAlsaPlugins
-            "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;"}
-        }
-      '';
-    };
-    environment.etc."alsa/conf.d/50-pipewire.conf" = mkIf cfg.alsa.enable {
-      source = "${cfg.package}/share/alsa/alsa.conf.d/50-pipewire.conf";
-    };
-    environment.etc."alsa/conf.d/99-pipewire-default.conf" = mkIf cfg.alsa.enable {
-      source = "${cfg.package}/share/alsa/alsa.conf.d/99-pipewire-default.conf";
-    };
     environment.sessionVariables.LD_LIBRARY_PATH =
       lib.optional cfg.jack.enable "/run/current-system/sw/lib/pipewire";
 
-    environment.etc."pipewire/pipewire.conf" = {
-      # Adapted from src/daemon/pipewire.conf.in
-      text = ''
-        set-prop link.max-buffers 16 # version < 3 clients can't handle more
+    # https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/464#note_723554
+    systemd.user.services.pipewire.environment."PIPEWIRE_LINK_PASSIVE" = "1";
 
-        add-spa-lib audio.convert* audioconvert/libspa-audioconvert
-        add-spa-lib api.alsa.* alsa/libspa-alsa
-        add-spa-lib api.v4l2.* v4l2/libspa-v4l2
-        add-spa-lib api.libcamera.* libcamera/libspa-libcamera
-        add-spa-lib api.bluez5.* bluez5/libspa-bluez5
-        add-spa-lib api.vulkan.* vulkan/libspa-vulkan
-        add-spa-lib api.jack.* jack/libspa-jack
-        add-spa-lib support.* support/libspa-support
-
-        load-module libpipewire-module-rtkit # rt.prio=20 rt.time.soft=200000 rt.time.hard=200000
-        load-module libpipewire-module-protocol-native
-        load-module libpipewire-module-profiler
-        load-module libpipewire-module-metadata
-        load-module libpipewire-module-spa-device-factory
-        load-module libpipewire-module-spa-node-factory
-        load-module libpipewire-module-client-node
-        load-module libpipewire-module-client-device
-        load-module libpipewire-module-portal
-        load-module libpipewire-module-access
-        load-module libpipewire-module-adapter
-        load-module libpipewire-module-link-factory
-        load-module libpipewire-module-session-manager
-
-        create-object spa-node-factory factory.name=support.node.driver node.name=Dummy priority.driver=8000
-
-        exec ${cfg.sessionManager} ${lib.concatStringsSep " " cfg.sessionManagerArguments}
-
-        ${cfg.extraConfig}
-      '';
-    };
-
-    environment.etc."pipewire/media-session.d/with-alsa" = mkIf cfg.alsa.enable { text = ""; };
-    environment.etc."pipewire/media-session.d/with-pulseaudio" = mkIf cfg.pulse.enable { text = ""; };
-    environment.etc."pipewire/media-session.d/with-jack" = mkIf cfg.jack.enable { text = ""; };
+    environment.etc = originalEtc // customEtc // cfg.sessionManagerEtcFiles;
   };
 }

--- a/nixos/modules/services/desktops/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire.nix
@@ -156,7 +156,12 @@ in {
             # If nofail is given, module initialization failures are ignored.
             #
             libpipewire-module-rtkit = {
-              args = "\"rt.prio=20 rt.time.soft=200000 rt.time.hard=200000\"";
+              args = {
+                rt.prio = 20;
+                rt.time.soft = 200000;
+                rt.time.hard = 200000;
+                nice.level = -11;
+              };
               flags = "ifexists|nofail";
             };
             libpipewire-module-protocol-native = { _priority = -100; _content = "null"; };
@@ -168,7 +173,12 @@ in {
             libpipewire-module-client-device = "null";
             libpipewire-module-portal = "null";
             libpipewire-module-access = {
-              args = "\"access.allowed=${builtins.unsafeDiscardStringContext cfg.sessionManager} access.force=flatpak\"";
+              args.access = {
+                allowed = ["${builtins.unsafeDiscardStringContext cfg.sessionManager}"];
+                rejected = [];
+                restricted = [];
+                force = "flatpak";
+              };
             };
             libpipewire-module-adapter = "null";
             libpipewire-module-link-factory = "null";

--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -1,0 +1,336 @@
+# pipewire example session manager.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pipewire.pwms;
+  enable32BitAlsaPlugins = cfg.alsa.support32Bit
+                           && pkgs.stdenv.isx86_64
+                           && pkgs.pkgsi686Linux.pipewire != null;
+
+  # Helpers for generating the pipewire JSON config file
+  mkSPAValueString = v:
+  if builtins.isList v then "[${lib.concatMapStringsSep " " mkSPAValueString v}]"
+  else if lib.types.attrs.check v then
+    "{${lib.concatStringsSep " " (mkSPAKeyValue v)}}"
+  else lib.generators.mkValueStringDefault { } v;
+
+  mkSPAKeyValue = attrs: map (def: def.content) (
+  lib.sortProperties
+    (
+      lib.mapAttrsToList
+        (k: v: lib.mkOrder (v._priority or 1000) "${lib.escape [ "=" ] k} = ${mkSPAValueString (v._content or v)}")
+        attrs
+    )
+  );
+
+  toSPAJSON = attrs: lib.concatStringsSep "\n" (mkSPAKeyValue attrs);
+in {
+
+  meta = {
+    maintainers = teams.freedesktop.members;
+  };
+
+  ###### interface
+  options = {
+    services.pipewire.pwms = {
+      enable = mkEnableOption "Example pipewire session manager";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.pipewire.mediaSession;
+        example = literalExample "pkgs.pipewire.mediaSession";
+        description = ''
+          The pipewire-media-session derivation to use.
+        '';
+      };
+
+      config = mkOption {
+        type = types.attrs;
+        description = ''
+          Configuration for the media session core.
+        '';
+        default = {
+          # media-session config file
+          properties = {
+            # Properties to configure the session and some
+            # modules
+            #mem.mlock-all = false
+            #context.profile.modules = default,rtkit
+          };
+
+          spa-libs = {
+            # Mapping from factory name to library.
+            "api.bluez5.*" = "bluez5/libspa-bluez5";
+            "api.alsa.*" = "alsa/libspa-alsa";
+            "api.v4l2.*" = "v4l2/libspa-v4l2";
+            "api.libcamera.*" = "libcamera/libspa-libcamera";
+          };
+
+          modules = {
+            # These are the modules that are enabled when a file with
+            # the key name is found in the media-session.d config directory.
+            # the default bundle is always enabled.
+
+            default = [
+              "flatpak"			# manages flatpak access
+              "portal"			# manage portal permissions
+              "v4l2"			# video for linux udev detection
+              #"libcamera"		# libcamera udev detection
+              "suspend-node"		# suspend inactive nodes
+              "policy-node"		# configure and link nodes
+              #"metadata"		# export metadata API
+              #"default-nodes"		# restore default nodes
+              #"default-profile"	# restore default profiles
+              #"default-routes"		# restore default route
+              #"streams-follow-default"	# move streams when default changes
+              #"alsa-seq"		# alsa seq midi support
+              #"alsa-monitor"		# alsa udev detection
+              #"bluez5"			# bluetooth support
+              #"restore-stream"		# restore stream settings
+            ];
+            "with-audio" = [
+              "metadata"
+              "default-nodes"
+              "default-profile"
+              "default-routes"
+              "alsa-seq"
+              "alsa-monitor"
+            ];
+            "with-alsa" = [
+              "with-audio"
+            ];
+            "with-jack" = [
+              "with-audio"
+            ];
+            "with-pulseaudio" = [
+              "with-audio"
+              "bluez5"
+              "restore-stream"
+              "streams-follow-default"
+            ];
+          };
+        };
+      };
+
+      alsaMonitorConfig = mkOption {
+        type = types.attrs;
+        description = ''
+          Configuration for the alsa monitor.
+        '';
+        default = {
+          # alsa-monitor config file
+          properties = {
+            #alsa.jack-device = true
+          };
+
+          rules = [
+          # an array of matches/actions to evaluate
+          {
+            # rules for matching a device or node. It is an array of
+            # properties that all need to match the regexp. If any of the
+            # matches work, the actions are executed for the object.
+            matches = [
+              {
+                # this matches all cards
+                device.name = "~alsa_card.*";
+              }
+            ];
+            actions = {
+              # actions can update properties on the matched object.
+              update-props = {
+                api.alsa.use-acp = true;
+                #api.alsa.use-ucm = true
+                #api.alsa.soft-mixer = false
+                #api.alsa.ignore-dB = false
+                #device.profile-set = "profileset-name"
+                #device.profile = "default profile name"
+                api.acp.auto-profile = false;
+                api.acp.auto-port = false;
+                #device.nick = "My Device"
+              };
+            };
+          }
+          {
+            matches = [
+              {
+                # matches all sinks
+                node.name = "~alsa_input.*";
+              }
+              {
+                # matches all sources
+                node.name = "~alsa_output.*";
+              }
+            ];
+            actions = {
+              update-props = {
+                #node.nick = 			"My Node"
+                #node.nick = 			null
+                #priority.driver = 		100
+                #priority.session = 		100
+                #node.pause-on-idle = 		false
+                #resample.quality = 		4
+                #channelmix.normalize =		false
+                #channelmix.mix-lfe = 		false
+                #audio.channels = 		2
+                #audio.format = 		"S16LE"
+                #audio.rate = 			44100
+                #audio.position = 		"FL,FR"
+                #api.alsa.period-size =         1024
+                #api.alsa.headroom =            0
+                #api.alsa.disable-mmap =        false
+                #api.alsa.disable-batch =       false
+              };
+            };
+          }
+          ];
+        };
+      };
+
+      bluezMonitorConfig = mkOption {
+        type = types.attrs;
+        description = ''
+          Configuration for the bluez5 monitor.
+        '';
+        default = {
+          # bluez-monitor config file
+          properties = {
+            # msbc is not expected to work on all headset + adapter combinations.
+            #bluez5.msbc-support = true
+            #bluez5.sbc-xq-support = true
+
+            # Enabled headset roles (default: [ hsp_hs hfp_ag ]), this
+            # property only applies to native backend. Currently some headsets
+            # (Sony WH-1000XM3) are not working with both hsp_ag and hfp_ag
+            # enabled, disable either hsp_ag or hfp_ag to work around it.
+            #
+            # Supported headset roles: hsp_hs (HSP Headset),
+            #                          hsp_ag (HSP Audio Gateway),
+            #                          hfp_ag (HFP Audio Gateway)
+            #bluez5.headset-roles = [ hsp_hs hsp_ag hfp_ag ]
+
+            # Enabled A2DP codecs (default: all)
+            #bluez5.codecs = [ sbc aac ldac aptx aptx_hd ]
+          };
+
+          rules = [
+          # an array of matches/actions to evaluate
+          {
+            # rules for matching a device or node. It is an array of
+            # properties that all need to match the regexp. If any of the
+            # matches work, the actions are executed for the object.
+            matches = [
+              {
+                # this matches all cards
+                device.name = "~bluez_card.*";
+              }
+            ];
+            actions = {
+              # actions can update properties on the matched object.
+              update-props = {
+                #device.nick = 			"My Device"
+              };
+            };
+          }
+          {
+            matches = [
+              {
+                # matches all sinks
+                node.name = "~bluez_input.*";
+              }
+              {
+                # matches all sources
+                node.name = "~bluez_output.*";
+              }
+            ];
+            actions = {
+              update-props = {
+                #node.nick = 			"My Node"
+                #node.nick = 			null
+                #priority.driver = 		100
+                #priority.session = 		100
+                #node.pause-on-idle = 		false
+                #resample.quality = 		4
+                #channelmix.normalize =		false
+                #channelmix.mix-lfe = 		false
+              };
+            };
+          }
+          ];
+        };
+      };
+
+      v4l2MonitorConfig = mkOption {
+        type = types.attrs;
+        description = ''
+          Configuration for the V4L2 monitor.
+        '';
+        default = {
+          # v4l2-monitor config file
+          properties = {
+          };
+
+          rules = [
+            # an array of matches/actions to evaluate
+            {
+              # rules for matching a device or node. It is an array of
+              # properties that all need to match the regexp. If any of the
+              # matches work, the actions are executed for the object.
+              matches = [
+                {
+                  # this matches all devices
+                  device.name = "~v4l2_device.*";
+                }
+              ];
+              actions = {
+                # actions can update properties on the matched object.
+                update-props = {
+                  #device.nick = 			"My Device"
+                };
+              };
+            }
+            {
+              matches = [
+                {
+                  # matches all sinks
+                  node.name = "~v4l2_input.*";
+                }
+                {
+                  # matches all sources
+                  node.name = "~v4l2_output.*";
+                }
+              ];
+              actions = {
+                update-props = {
+                  #node.nick = 			"My Node"
+                  #node.nick = 			null
+                  #priority.driver = 		100
+                  #priority.session = 		100
+                  #node.pause-on-idle = 		true
+                };
+              };
+            }
+          ];
+        };
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.pipewire.sessionManagerExecutable = "${cfg.package}/bin/pipewire-media-session";
+
+    environment.etc."pipewire/media-session.d/media-session.conf" = { text = toSPAJSON cfg.config; };
+    environment.etc."pipewire/media-session.d/v4l2-monitor.conf" = { text = toSPAJSON cfg.v4l2MonitorConfig; };
+
+    environment.etc."pipewire/media-session.d/with-alsa" = mkIf config.services.pipewire.alsa.enable { text = ""; };
+    environment.etc."pipewire/media-session.d/alsa-monitor.conf" = mkIf config.services.pipewire.alsa.enable { text = toSPAJSON cfg.alsaMonitorConfig; };
+
+    environment.etc."pipewire/media-session.d/with-pulseaudio" = mkIf config.services.pipewire.pulse.enable { text = ""; };
+    environment.etc."pipewire/media-session.d/bluez-monitor.conf" = mkIf config.services.pipewire.pulse.enable { text = toSPAJSON cfg.bluezMonitorConfig; };
+
+    environment.etc."pipewire/media-session.d/with-jack" = mkIf config.services.pipewire.jack.enable { text = ""; };
+  };
+}

--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -4,7 +4,7 @@
 with lib;
 
 let
-  cfg = config.services.pipewire.pwms;
+  cfg = config.services.pipewire.media-session;
   enable32BitAlsaPlugins = cfg.alsa.support32Bit
                            && pkgs.stdenv.isx86_64
                            && pkgs.pkgsi686Linux.pipewire != null;
@@ -34,8 +34,12 @@ in {
 
   ###### interface
   options = {
-    services.pipewire.pwms = {
-      enable = mkEnableOption "Example pipewire session manager";
+    services.pipewire.media-session = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Example pipewire session manager";
+      };
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -56,8 +56,8 @@ in {
           properties = {
             # Properties to configure the session and some
             # modules
-            #mem.mlock-all = false
-            #context.profile.modules = default,rtkit
+            #mem.mlock-all = false;
+            #context.profile.modules = "default,rtkit";
           };
 
           spa-libs = {
@@ -141,14 +141,14 @@ in {
               # actions can update properties on the matched object.
               update-props = {
                 api.alsa.use-acp = true;
-                #api.alsa.use-ucm = true
-                #api.alsa.soft-mixer = false
-                #api.alsa.ignore-dB = false
-                #device.profile-set = "profileset-name"
-                #device.profile = "default profile name"
+                #api.alsa.use-ucm = true;
+                #api.alsa.soft-mixer = false;
+                #api.alsa.ignore-dB = false;
+                #device.profile-set = "profileset-name";
+                #device.profile = "default profile name";
                 api.acp.auto-profile = false;
                 api.acp.auto-port = false;
-                #device.nick = "My Device"
+                #device.nick = "My Device";
               };
             };
           }
@@ -165,22 +165,22 @@ in {
             ];
             actions = {
               update-props = {
-                #node.nick = 			"My Node"
-                #node.nick = 			null
-                #priority.driver = 		100
-                #priority.session = 		100
-                #node.pause-on-idle = 		false
-                #resample.quality = 		4
-                #channelmix.normalize =		false
-                #channelmix.mix-lfe = 		false
-                #audio.channels = 		2
-                #audio.format = 		"S16LE"
-                #audio.rate = 			44100
-                #audio.position = 		"FL,FR"
-                #api.alsa.period-size =         1024
-                #api.alsa.headroom =            0
-                #api.alsa.disable-mmap =        false
-                #api.alsa.disable-batch =       false
+                #node.nick = 			"My Node";
+                #node.nick = 			null;
+                #priority.driver = 		100;
+                #priority.session = 		100;
+                #node.pause-on-idle = 		false;
+                #resample.quality = 		4;
+                #channelmix.normalize =		false;
+                #channelmix.mix-lfe = 		false;
+                #audio.channels = 		2;
+                #audio.format = 		"S16LE";
+                #audio.rate = 			44100;
+                #audio.position = 		"FL,FR";
+                #api.alsa.period-size =         1024;
+                #api.alsa.headroom =            0;
+                #api.alsa.disable-mmap =        false;
+                #api.alsa.disable-batch =       false;
               };
             };
           }
@@ -197,8 +197,8 @@ in {
           # bluez-monitor config file
           properties = {
             # msbc is not expected to work on all headset + adapter combinations.
-            #bluez5.msbc-support = true
-            #bluez5.sbc-xq-support = true
+            #bluez5.msbc-support = true;
+            #bluez5.sbc-xq-support = true;
 
             # Enabled headset roles (default: [ hsp_hs hfp_ag ]), this
             # property only applies to native backend. Currently some headsets
@@ -208,10 +208,10 @@ in {
             # Supported headset roles: hsp_hs (HSP Headset),
             #                          hsp_ag (HSP Audio Gateway),
             #                          hfp_ag (HFP Audio Gateway)
-            #bluez5.headset-roles = [ hsp_hs hsp_ag hfp_ag ]
+            #bluez5.headset-roles = [ "hsp_hs" "hsp_ag" "hfp_ag" ];
 
             # Enabled A2DP codecs (default: all)
-            #bluez5.codecs = [ sbc aac ldac aptx aptx_hd ]
+            #bluez5.codecs = [ "sbc" "aac" "ldac" "aptx" "aptx_hd" ];
           };
 
           rules = [
@@ -229,7 +229,7 @@ in {
             actions = {
               # actions can update properties on the matched object.
               update-props = {
-                #device.nick = 			"My Device"
+                #device.nick = 			"My Device";
               };
             };
           }
@@ -247,13 +247,13 @@ in {
             actions = {
               update-props = {
                 #node.nick = 			"My Node"
-                #node.nick = 			null
-                #priority.driver = 		100
-                #priority.session = 		100
-                #node.pause-on-idle = 		false
-                #resample.quality = 		4
-                #channelmix.normalize =		false
-                #channelmix.mix-lfe = 		false
+                #node.nick = 			null;
+                #priority.driver = 		100;
+                #priority.session = 		100;
+                #node.pause-on-idle = 		false;
+                #resample.quality = 		4;
+                #channelmix.normalize =		false;
+                #channelmix.mix-lfe = 		false;
               };
             };
           }
@@ -286,7 +286,7 @@ in {
               actions = {
                 # actions can update properties on the matched object.
                 update-props = {
-                  #device.nick = 			"My Device"
+                  #device.nick = 			"My Device";
                 };
               };
             }
@@ -303,11 +303,11 @@ in {
               ];
               actions = {
                 update-props = {
-                  #node.nick = 			"My Node"
-                  #node.nick = 			null
-                  #priority.driver = 		100
-                  #priority.session = 		100
-                  #node.pause-on-idle = 		true
+                  #node.nick = 			"My Node";
+                  #node.nick = 			null;
+                  #priority.driver = 		100;
+                  #priority.session = 		100;
+                  #node.pause-on-idle = 		true;
                 };
               };
             }

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -75,22 +75,22 @@ in {
             #
             # "library.name.system" = "support/libspa-support";
             # "context.data-loop.library.name.system" = "support/libspa-support";
-            "link.max-buffers" = 64; # version < 3 clients can't handle more than 16
-            "mem.allow-mlock" = true;
-            "mem.mlock-all" = true;
-            # https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/pipewire/pipewire.h#L93
-            "log.level" = 3; # 5 is trace, which is verbose as hell, default is 2 which is warnings, 4 is debug output, 3 is info
+            "link.max-buffers" = 16; # version < 3 clients can't handle more than 16
+            #"mem.allow-mlock" = false;
+            #"mem.mlock-all" = true;
+            ## https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/pipewire/pipewire.h#L93
+            #"log.level" = 2; # 5 is trace, which is verbose as hell, default is 2 which is warnings, 4 is debug output, 3 is info
 
             ## Properties for the DSP configuration
             #
-            "default.clock.rate" = 48000; # 48000 is probably saner, 96000 has gaps in audio
-            "default.clock.quantum" = 128; # equivalent to buffer size which is correlated to latency
-            "default.clock.min-quantum" = 32; # No audio through bluetooth if 512 isn't allowed, 16 is the absolute minimum
-            "default.clock.max-quantum" = 1024; # qemu seems to use 16384 but 8192 is the absolute maximum
-            # "default.video.width" = 640;
-            # "default.video.height" = 480;
-            # "default.video.rate.num" = 25;
-            # "default.video.rate.denom" = 1;
+            #"default.clock.rate" = 48000;
+            #"default.clock.quantum" = 1024;
+            #"default.clock.min-quantum" = 32;
+            #"default.clock.max-quantum" = 8192;
+            #"default.video.width" = 640;
+            #"default.video.height" = 480;
+            #"default.video.rate.num" = 25;
+            #"default.video.rate.denom" = 1;
           };
 
           spa-libs = {
@@ -123,10 +123,10 @@ in {
             #
             libpipewire-module-rtkit = {
               args = {
-                rt.prio = 20;
-                rt.time.soft = 200000;
-                rt.time.hard = 200000;
-                nice.level = -11;
+                #rt.prio = 20;
+                #rt.time.soft = 200000;
+                #rt.time.hard = 200000;
+                #nice.level = -11;
               };
               flags = "ifexists|nofail";
             };

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -19,13 +19,18 @@
 , libsndfile
 , vulkan-headers
 , vulkan-loader
+, ncurses
 , makeFontsConf
 , callPackage
 , nixosTests
+, python3
+, runCommand
+, withMediaSession ? true
 , gstreamerSupport ? true, gst_all_1 ? null
 , ffmpegSupport ? true, ffmpeg ? null
-, bluezSupport ? true, bluez ? null, sbc ? null, libopenaptx ? null, ldacbt ? null
+, bluezSupport ? true, bluez ? null, sbc ? null, libopenaptx ? null, ldacbt ? null, fdk_aac ? null
 , nativeHspSupport ? true
+, nativeHfpSupport ? true
 , ofonoSupport ? true
 , hsphfpdSupport ? true
 }:
@@ -35,112 +40,151 @@ let
     fontDirectories = [];
   };
 
-  mesonBool = b: if b then "true" else "false";
-in
-stdenv.mkDerivation rec {
-  pname = "pipewire";
-  version = "0.3.18";
-
-  outputs = [
-    "out"
-    "lib"
-    "pulse"
-    "jack"
-    "dev"
-    "doc"
-    "installedTests"
-  ];
-
-  src = fetchFromGitLab {
-    domain = "gitlab.freedesktop.org";
-    owner = "pipewire";
-    repo = "pipewire";
-    rev = version;
-    sha256 = "1yghhgs18yqrnd0b2r75l5n8yng962r1wszbsi01v6i9zib3jc9g";
-  };
-
-  patches = [
-    # Break up a dependency cycle between outputs.
-    ./alsa-profiles-use-libdir.patch
-    # Move installed tests into their own output.
-    ./installed-tests-path.patch
-    # Change the path of the pipewire-pulse binary in the service definition.
-    ./pipewire-pulse-path.patch
-    # Add flag to specify configuration directory (different from the installation directory).
-    ./pipewire-config-dir.patch
-  ];
-
-  nativeBuildInputs = [
-    doxygen
-    graphviz
-    meson
-    ninja
-    pkg-config
-  ];
-
-  buildInputs = [
-    alsaLib
-    dbus
-    glib
-    libjack2
-    libsndfile
-    udev
-    vulkan-headers
-    vulkan-loader
-    valgrind
-    systemd
-  ] ++ lib.optionals gstreamerSupport [ gst_all_1.gst-plugins-base gst_all_1.gstreamer ]
-  ++ lib.optional ffmpegSupport ffmpeg
-  ++ lib.optionals bluezSupport [ bluez libopenaptx ldacbt sbc ];
-
-  mesonFlags = [
-    "-Ddocs=true"
-    "-Dman=false" # we don't have xmltoman
-    "-Dexamples=true" # only needed for `pipewire-media-session`
-    "-Dudevrulesdir=lib/udev/rules.d"
-    "-Dinstalled_tests=true"
-    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
-    "-Dpipewire_pulse_prefix=${placeholder "pulse"}"
-    "-Dlibjack-path=${placeholder "jack"}/lib"
-    "-Dgstreamer=${mesonBool gstreamerSupport}"
-    "-Dffmpeg=${mesonBool ffmpegSupport}"
-    "-Dbluez5=${mesonBool bluezSupport}"
-    "-Dbluez5-backend-native=${mesonBool nativeHspSupport}"
-    "-Dbluez5-backend-ofono=${mesonBool ofonoSupport}"
-    "-Dbluez5-backend-hsphfpd=${mesonBool hsphfpdSupport}"
-    "-Dpipewire_config_dir=/etc/pipewire"
-  ];
-
-  FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
-
-  doCheck = true;
-
-  postInstall = ''
-    moveToOutput "share/systemd/user/pipewire-pulse.*" "$pulse"
-    moveToOutput "lib/systemd/user/pipewire-pulse.*" "$pulse"
-    moveToOutput "bin/pipewire-pulse" "$pulse"
+  runPythonCommand = name: buildCommandPython: runCommand name {
+    nativeBuildInputs = [ python3 ];
+      inherit buildCommandPython;
+  } ''
+    exec python3 -c "$buildCommandPython"
   '';
 
-  passthru.tests = {
-    installedTests = nixosTests.installed-tests.pipewire;
+  mesonBool = b: if b then "true" else "false";
 
-    # This ensures that all the paths used by the NixOS module are found.
-    test-paths = callPackage ./test-paths.nix {
-      paths-out = [
-        "share/alsa/alsa.conf.d/50-pipewire.conf"
+  self = stdenv.mkDerivation rec {
+    pname = "pipewire";
+    version = "0.3.20";
+
+    outputs = [
+      "out"
+      "lib"
+      "pulse"
+      "jack"
+      "dev"
+      "doc"
+      "installedTests"
+    ];
+
+    src = fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      owner = "pipewire";
+      repo = "pipewire";
+      rev = version;
+      sha256 = "1di8b78ldhswrd7km0nm6q58vnzd62rpy2a4p9spqzs48q6iyvff";
+    };
+
+    patches = [
+      # Break up a dependency cycle between outputs.
+      ./alsa-profiles-use-libdir.patch
+      # Move installed tests into their own output.
+      ./installed-tests-path.patch
+      # Change the path of the pipewire-pulse binary in the service definition.
+      ./pipewire-pulse-path.patch
+      # Add flag to specify configuration directory (different from the installation directory).
+      ./pipewire-config-dir.patch
+    ];
+
+    nativeBuildInputs = [
+      doxygen
+      graphviz
+      meson
+      ninja
+      pkg-config
+    ];
+
+    buildInputs = [
+      alsaLib
+      dbus
+      glib
+      libjack2
+      libsndfile
+      ncurses
+      udev
+      vulkan-headers
+      vulkan-loader
+      valgrind
+      systemd
+    ] ++ lib.optionals gstreamerSupport [ gst_all_1.gst-plugins-base gst_all_1.gstreamer ]
+    ++ lib.optional ffmpegSupport ffmpeg
+    ++ lib.optionals bluezSupport [ bluez libopenaptx ldacbt sbc fdk_aac ];
+
+    mesonFlags = [
+      "-Ddocs=true"
+      "-Dman=false" # we don't have xmltoman
+      "-Dexamples=${mesonBool withMediaSession}" # only needed for `pipewire-media-session`
+      "-Dudevrulesdir=lib/udev/rules.d"
+      "-Dinstalled_tests=true"
+      "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+      "-Dpipewire_pulse_prefix=${placeholder "pulse"}"
+      "-Dlibjack-path=${placeholder "jack"}/lib"
+      "-Dgstreamer=${mesonBool gstreamerSupport}"
+      "-Dffmpeg=${mesonBool ffmpegSupport}"
+      "-Dbluez5=${mesonBool bluezSupport}"
+      "-Dbluez5-backend-hsp-native=${mesonBool nativeHspSupport}"
+      "-Dbluez5-backend-hfp-native=${mesonBool nativeHfpSupport}"
+      "-Dbluez5-backend-ofono=${mesonBool ofonoSupport}"
+      "-Dbluez5-backend-hsphfpd=${mesonBool hsphfpdSupport}"
+      "-Dpipewire_config_dir=/etc/pipewire"
+    ];
+
+    FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
+
+    doCheck = true;
+
+    postInstall = ''
+      moveToOutput "share/systemd/user/pipewire-pulse.*" "$pulse"
+      moveToOutput "lib/systemd/user/pipewire-pulse.*" "$pulse"
+      moveToOutput "bin/pipewire-pulse" "$pulse"
+    '';
+
+    passthru = {
+      filesInstalledToEtc = [
+        "pipewire/pipewire.conf"
+      ] ++ lib.optionals withMediaSession [
+        "pipewire/media-session.d/alsa-monitor.conf"
+        "pipewire/media-session.d/bluez-monitor.conf"
+        "pipewire/media-session.d/media-session.conf"
+        "pipewire/media-session.d/v4l2-monitor.conf"
       ];
-      paths-lib = [
-        "lib/alsa-lib/libasound_module_pcm_pipewire.so"
-        "share/alsa-card-profile/mixer"
-      ];
+
+      tests = let
+        listToPy = list: "[${lib.concatMapStringsSep ", " (f: "'${f}'") list}]";
+      in {
+        installedTests = nixosTests.installed-tests.pipewire;
+
+        # This ensures that all the paths used by the NixOS module are found.
+        test-paths = callPackage ./test-paths.nix {
+          paths-out = [
+            "share/alsa/alsa.conf.d/50-pipewire.conf"
+          ];
+          paths-lib = [
+            "lib/alsa-lib/libasound_module_pcm_pipewire.so"
+            "share/alsa-card-profile/mixer"
+          ];
+        };
+
+        passthruMatches = runPythonCommand "fwupd-test-passthru-matches" ''
+          import itertools
+          import configparser
+          import os
+          import pathlib
+          etc = '${self}/etc'
+          package_etc = set(itertools.chain.from_iterable([[os.path.relpath(os.path.join(prefix, file), etc) for file in files] for (prefix, dirs, files) in os.walk(etc)]))
+          passthru_etc = set(${listToPy passthru.filesInstalledToEtc})
+          assert len(package_etc - passthru_etc) == 0, f'pipewire package contains the following paths in /etc that are not listed in passthru.filesInstalledToEtc: {package_etc - passthru_etc}'
+          assert len(passthru_etc - package_etc) == 0, f'pipewire package lists the following paths in passthru.filesInstalledToEtc that are not contained in /etc: {passthru_etc - package_etc}'
+          config = configparser.RawConfigParser()
+          config.read('${self}/etc/fwupd/daemon.conf')
+          pathlib.Path(os.getenv('out')).touch()
+        '';
+      };
+    };
+
+    meta = with lib; {
+      description = "Server and user space API to deal with multimedia pipelines";
+      homepage = "https://pipewire.org/";
+      license = licenses.mit;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ jtojnar ];
     };
   };
 
-  meta = with lib; {
-    description = "Server and user space API to deal with multimedia pipelines";
-    homepage = "https://pipewire.org/";
-    license = licenses.mit;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ jtojnar ];
-  };
-}
+in self

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -51,7 +51,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.20";
+    version = "0.3.21";
 
     outputs = [
       "out"
@@ -68,7 +68,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "1di8b78ldhswrd7km0nm6q58vnzd62rpy2a4p9spqzs48q6iyvff";
+      hash = "sha256:2YJzPTMPIoQQeNja3F53SD4gtpdSlbD/i77hBWiQfuQ=";
     };
 
     patches = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -128,7 +128,7 @@ let
       moveToOutput "bin/pipewire-media-session" "$mediaSession"
     '';
 
-    passthru = {
+    passthru.tests = {
       installedTests = nixosTests.installed-tests.pipewire;
 
       # This ensures that all the paths used by the NixOS module are found.

--- a/pkgs/development/libraries/pipewire/pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/pipewire-pulse-path.patch
@@ -1,19 +1,22 @@
 diff --git a/meson_options.txt b/meson_options.txt
-index 4b9e46b8..9d73ed06 100644
+index 050a4c31..c481e76c 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -147,3 +147,6 @@ option('pw-cat',
+@@ -148,6 +148,9 @@ option('udev',
  option('udevrulesdir',
         type : 'string',
         description : 'Directory for udev rules (defaults to /lib/udev/rules.d)')
 +option('pipewire_pulse_prefix',
 +       type : 'string',
 +       description : 'Install directory for the pipewire-pulse daemon')
+ option('systemd-user-unit-dir',
+        type : 'string',
+        description : 'Directory for user systemd units (defaults to /usr/lib/systemd/user)')
 diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
-index 29fc93d4..f78946f2 100644
+index 46dfbbc8..0d975cec 100644
 --- a/src/daemon/systemd/user/meson.build
 +++ b/src/daemon/systemd/user/meson.build
-@@ -6,7 +6,7 @@ install_data(
+@@ -9,7 +9,7 @@ install_data(
  
  systemd_config = configuration_data()
  systemd_config.set('PW_BINARY', join_paths(pipewire_bindir, 'pipewire'))


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.21
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.20
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.19

###### Things done

Initial attempt at generating config file in the new format using the upstream template as a base. Pulseaudio and jack (patchbays) seem to be working, everything else needs testing.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
