### PR TITLE
lua: Add more symlinks to lua.pc

### DIFF
--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -83,7 +83,9 @@ self = stdenv.mkDerivation rec {
     Libs: -L$out/lib -llua -lm
     Cflags: -I$out/include
     EOF
+    ln -s "$out/lib/pkgconfig/lua.pc" "$out/lib/pkgconfig/lua-${luaversion}.pc"
     ln -s "$out/lib/pkgconfig/lua.pc" "$out/lib/pkgconfig/lua${luaversion}.pc"
+    ln -s "$out/lib/pkgconfig/lua.pc" "$out/lib/pkgconfig/lua${lib.replaceStrings [ "." ] [ "" ] luaversion}.pc"
   '';
 
   passthru = rec {


### PR DESCRIPTION
###### Motivation for this change

This is essentially a continuation of #42473. Some packages expect `lua53.pc` to exist, but Nixpkgs currently only has `lua.pc` and `lua5.3.pc`. This creates a symlink to lua.pc for every name of the file used by Arch.

For a version of Lua (for example, 5.4) there are now:
- lib/pkgconfig/lua.pc
- lib/pkgconfig/lua-5.4.pc
- lib/pkgconfig/lua5.4.pc
- lib/pkgconfig/lua54.pc

Compare the names used by [Arch](https://archlinux.org/packages/extra/x86_64/lua/files/) and [Debian](https://packages.debian.org/sid/amd64/liblua5.4-dev/filelist).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
