### PR TITLE
Fix kak plugins

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/kak-buffers.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-buffers.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, lib }:
 stdenv.mkDerivation {
   name = "kak-buffers";
   version = "2019-04-03";

--- a/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
@@ -1,4 +1,4 @@
-{ stdenv, git, fetchFromGitHub }:
+{ stdenv, git, fetchFromGitHub, lib }:
 stdenv.mkDerivation {
   name = "kak-powerline";
   version = "2020-08-22";

--- a/pkgs/applications/editors/kakoune/plugins/kak-vertical-selection.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-vertical-selection.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, lib }:
 stdenv.mkDerivation {
   name = "kak-vertical-selection";
   version = "2019-04-11";


### PR DESCRIPTION
###### Motivation for this change

`lib` argument is missing from the derivations of couple of Kakoune plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
