### PR TITLE
python3{9,10}: add tzdata to config

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -8,6 +8,7 @@
 , openssl
 , readline
 , sqlite
+, tzdata
 , tcl ? null, tk ? null, tix ? null, libX11 ? null, xorgproto ? null, x11Support ? false
 , bluez ? null, bluezSupport ? false
 , zlib
@@ -246,6 +247,9 @@ in with passthru; stdenv.mkDerivation {
     "--without-ensurepip"
     "--with-system-expat"
     "--with-system-ffi"
+  ] ++ optionals (tzdata != null && pythonAtLeast "3.9" ) [
+    # https://docs.python.org/3/library/zoneinfo.html#zoneinfo-data-compile-time-config
+    "--with-tzpath=${tzdata}/share/zoneinfo"
   ] ++ optionals enableOptimizations [
     "--enable-optimizations"
   ] ++ optionals (pythonOlder "3.7") [

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -197,6 +197,7 @@ in {
     ncurses = null;
     gdbm = null;
     sqlite = null;
+    tzdata = null;
     configd = null;
     stripConfig = true;
     stripIdlelib = true;


### PR DESCRIPTION
##### Motivation for this change
As mentioned here: https://github.com/HypothesisWorks/hypothesis/issues/2767#issuecomment-766084036 doing 
 something like `python3.10 -c 'import zoneinfo; zoneinfo.ZoneInfo("UTC")` will fail. This is my attempt to add a default tzdata reference. Unfortunately it still doesn't work

cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
