### PR TITLE
maintainers/teams: add beam team

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2279,6 +2279,12 @@
     githubId = 265220;
     name = "David Leung";
   };
+  DianaOlympos = {
+    email = "DianaOlympos@noreply.github.com";
+    github = "DianaOlympos";
+    githubId = 15774340;
+    name = "Thomas Depierre";
+  };
   dipinhora = {
     email = "dipinhora+github@gmail.com";
     github = "dipinhora";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -29,6 +29,18 @@ with lib.maintainers; {
     scope = "Maintain ACME-related packages and modules.";
   };
 
+  beam = {
+    members = [
+      ankhers
+      Br1ght0ne
+      DianaOlympos
+      gleber
+      happysalada
+      yurrriq
+    ];
+    scope = "Maintain BEAM-related packages and modules.";
+  };
+
   cinnamon = {
     members = [
       mkg20001

--- a/nixos/modules/services/networking/epmd.nix
+++ b/nixos/modules/services/networking/epmd.nix
@@ -53,4 +53,6 @@ in
       };
     };
   };
+
+  meta.maintainers = teams.beam.members;
 }

--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage rec {
     description = "A statically typed language for the Erlang VM";
     homepage = "https://gleam.run/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ Br1ght0ne ];
+    maintainers = teams.beam.members;
   };
 }

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -69,6 +69,6 @@ in
 
       license = licenses.epl10;
       platforms = platforms.unix;
-      maintainers = with maintainers; [ havvy couchemar ankhers Br1ght0ne ];
+      maintainers = teams.beam.members;
     };
   })

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -126,7 +126,7 @@ in stdenv.mkDerivation ({
     '';
 
     platforms = platforms.unix;
-    maintainers = with maintainers; [ sjmackenzie couchemar gleber ];
+    maintainers = teams.beam.members;
     license = licenses.asl20;
   } // meta);
 }

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -87,7 +87,7 @@ buildRebar3 {
     downloadPage = "https://github.com/rvirding/lfe/releases";
 
     license      = licenses.asl20;
-    maintainers  = with maintainers; [ yurrriq ankhers ];
+    maintainers  = teams.beam.members;
     platforms    = platforms.unix;
   };
 }

--- a/pkgs/development/tools/build-managers/rebar/default.nix
+++ b/pkgs/development/tools/build-managers/rebar/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation {
 
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
+    maintainers = lib.teams.beam.members;
   };
 }

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -136,7 +136,7 @@ stdenv.mkDerivation rec {
       '';
 
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ gleber tazjin ];
+    maintainers = lib.teams.beam.members;
     license = lib.licenses.asl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add a beam team to better coordinate maintenance of BEAM-related packages and modules.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
