### PR TITLE
treewide: stdenv.lib -> lib

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
   * Not start with the package name.
   * Not have a period at the end.
 * `meta.license` must be set and fit the upstream license.
-  * If there is no upstream license, `meta.license` should default to `stdenv.lib.licenses.unfree`.
+  * If there is no upstream license, `meta.license` should default to `lib.licenses.unfree`.
 * `meta.maintainers` must be set.
 
 See the nixpkgs manual for more details on [standard meta-attributes](https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes) and on how to [submit changes to nixpkgs](https://nixos.org/nixpkgs/manual/#chap-submitting-changes).

--- a/nixos/tests/usbguard.nix
+++ b/nixos/tests/usbguard.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "usbguard";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ tnias ];
   };
 

--- a/pkgs/applications/graphics/hdr-plus/default.nix
+++ b/pkgs/applications/graphics/hdr-plus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch
+{ lib, stdenv, fetchFromGitHub, fetchpatch
 , cmake, halide
 , libpng, libjpeg, libtiff, libraw
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Burst photography pipeline based on Google's HDR+";
     homepage = "https://www.timothybrooks.com/tech/hdr-plus/";
     license = licenses.mit;

--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -38,10 +38,10 @@ in mkDerivation rec {
   passthru.updateScript = writeScript "${pname}-updater" ''
     #!${stdenv.shell}
     set -eu -o pipefail
-    PATH=${stdenv.lib.makeBinPath [curl pup common-updater-scripts]}:$PATH
+    PATH=${lib.makeBinPath [curl pup common-updater-scripts]}:$PATH
     latestVersion="$(curl -sS https://www.rescuetime.com/release-notes/linux | pup '.release:first-of-type h2 strong text{}' | tr -d '\n')"
 
-    for platform in ${stdenv.lib.concatStringsSep " " meta.platforms}; do
+    for platform in ${lib.concatStringsSep " " meta.platforms}; do
       # The script will not perform an update when the version attribute is up to date from previous platform run
       # We need to clear it before each run
       update-source-version ${pname} 0 $(yes 0 | head -64 | tr -d "\n") --system=$platform

--- a/pkgs/applications/radio/klog/default.nix
+++ b/pkgs/applications/radio/klog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, hamlib, pkg-config, qt5, qtbase, qttools, qtserialport, qtcharts, qmake, wrapQtAppsHook }:
+{ lib, stdenv, fetchurl, hamlib, pkg-config, qt5, qtbase, qttools, qtserialport, qtcharts, qmake, wrapQtAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "klog";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [ "KLog.pro" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A multiplatform free hamradio logger";
     longDescription = ''
       KLog provides QSO management, useful QSL management DX-Cluster client, DXCC management,

--- a/pkgs/applications/science/biology/migrate/default.nix
+++ b/pkgs/applications/science/biology/migrate/default.nix
@@ -1,4 +1,4 @@
-{ gccStdenv, fetchurl, zlib, mpi }:
+{ lib, gccStdenv, fetchurl, zlib, mpi }:
 
 gccStdenv.mkDerivation rec {
   version = "3.7.2";
@@ -14,7 +14,7 @@ gccStdenv.mkDerivation rec {
   buildFlags = [ "thread" "mpis" ];
   preInstall = "mkdir -p $out/man/man1";
 
-  meta = with gccStdenv.lib; {
+  meta = with lib; {
     description = "Estimates population size, migration, population splitting parameters using genetic/genomic data";
     homepage = "https://peterbeerli.com/migrate-html5/index.html";
     license = licenses.mit;

--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -132,7 +132,7 @@ Description: BLAS C implementation
 Cflags: -I$dev/include
 Libs: -L$out/lib -lcblas
 EOF
-'' + stdenv.lib.optionalString (blasImplementation == "mkl") ''
+'' + lib.optionalString (blasImplementation == "mkl") ''
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
   ln -s $out/lib/libblas${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -98,7 +98,7 @@ Description: LAPACK C implementation
 Cflags: -I$dev/include
 Libs: -L$out/lib -llapacke
 EOF
-'' + stdenv.lib.optionalString (lapackImplementation == "mkl") ''
+'' + lib.optionalString (lapackImplementation == "mkl") ''
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
   ln -s $out/lib/liblapack${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , bash
 , binutils-unwrapped
 , coreutils
@@ -15,7 +16,7 @@ rec {
     src = ./appimage-exec.sh;
     isExecutable = true;
     dir = "bin";
-    path = with pkgs; stdenv.lib.makeBinPath [
+    path = lib.makeBinPath [
       bash
       binutils-unwrapped
       coreutils

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -94,7 +94,7 @@ rec {
       inherit imageDigest;
       imageName = finalImageName;
       imageTag = finalImageTag;
-      impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
       outputHashMode = "flat";
       outputHashAlgo = "sha256";
       outputHash = sha256;

--- a/pkgs/build-support/docker/nix-prefetch-docker.nix
+++ b/pkgs/build-support/docker/nix-prefetch-docker.nix
@@ -1,6 +1,4 @@
-{ stdenv, makeWrapper, nix, skopeo, jq }:
-
-with stdenv.lib;
+{ lib, stdenv, makeWrapper, nix, skopeo, jq }:
 
 stdenv.mkDerivation {
   name = "nix-prefetch-docker";
@@ -12,13 +10,13 @@ stdenv.mkDerivation {
   installPhase = ''
     install -vD ${./nix-prefetch-docker} $out/bin/$name;
     wrapProgram $out/bin/$name \
-      --prefix PATH : ${makeBinPath [ nix skopeo jq ]} \
+      --prefix PATH : ${lib.makeBinPath [ nix skopeo jq ]} \
       --set HOME /homeless-shelter
   '';
 
   preferLocalBuild = true;
 
-  meta = {
+  meta = with lib; {
     description = "Script used to obtain source hashes for dockerTools.pullImage";
     maintainers = with maintainers; [ offline ];
     platforms = platforms.unix;

--- a/pkgs/build-support/dotnetenv/build-solution.nix
+++ b/pkgs/build-support/dotnetenv/build-solution.nix
@@ -1,4 +1,4 @@
-{stdenv, dotnetfx}:
+{ lib, stdenv, dotnetfx }:
 { name
 , src
 , baseDir ? "."
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '';
 
   preBuild = ''
-    ${stdenv.lib.optionalString modifyPublicMain ''
+    ${lib.optionalString modifyPublicMain ''
       sed -i -e "s|static void Main|public static void Main|" ${mainClassFile}
     ''}
     ${preBuild}

--- a/pkgs/build-support/dotnetenv/default.nix
+++ b/pkgs/build-support/dotnetenv/default.nix
@@ -1,9 +1,9 @@
-{stdenv, dotnetfx}:
+{ lib, stdenv, dotnetfx }:
 
 let dotnetenv =
 {
   buildSolution = import ./build-solution.nix {
-    inherit stdenv;
+    inherit lib stdenv;
     dotnetfx = dotnetfx.pkg;
   };
 

--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -1,6 +1,6 @@
 # Adaptation of the MIT-licensed work on `sbt2nix` done by Charles O'Farrell
 
-{ fetchurl, stdenv }:
+{ lib, fetchurl, stdenv }:
 let
   defaultRepos = [
     "https://repo1.maven.org/maven2"
@@ -36,21 +36,20 @@ assert (url == "") || (urls == []);
 # if repos is empty, then url or urls must be specified.
 assert (repos != []) || (url != "") || (urls != []);
 
-
 let
   name_ =
-    with stdenv.lib; concatStrings [
-      (replaceChars ["."] ["_"] groupId) "_"
-      (replaceChars ["."] ["_"] artifactId) "-"
+    lib.concatStrings [
+      (lib.replaceChars ["."] ["_"] groupId) "_"
+      (lib.replaceChars ["."] ["_"] artifactId) "-"
       version
     ];
   mkJarUrl = repoUrl:
-    with stdenv.lib; concatStringsSep "/" [
-      (removeSuffix "/" repoUrl)
-      (replaceChars ["."] ["/"] groupId)
+    lib.concatStringsSep "/" [
+      (lib.removeSuffix "/" repoUrl)
+      (lib.replaceChars ["."] ["/"] groupId)
       artifactId
       version
-      "${artifactId}-${version}${optionalString (!isNull classifier) "-${classifier}"}.jar"
+      "${artifactId}-${version}${lib.optionalString (!isNull classifier) "-${classifier}"}.jar"
     ];
   urls_ =
     if url != "" then [url]

--- a/pkgs/build-support/icon-conv-tools/default.nix
+++ b/pkgs/build-support/icon-conv-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, icoutils }:
+{ lib, stdenv, icoutils }:
 
 stdenv.mkDerivation {
   name = "icon-conv-tools-0.0.0";
@@ -23,9 +23,9 @@ stdenv.mkDerivation {
   dontPatchELF = true;
   dontStrip = true;
 
-  meta = {
+  meta = with lib; {
     description = "Tools for icon conversion specific to nix package manager";
-    maintainers = with stdenv.lib.maintainers; [ jraygauthier ];
-    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with maintainers; [ jraygauthier ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation {
     )
   '';
 
-  meta = {
-    platforms = stdenv.lib.platforms.unix;
+  meta = with lib; {
+    platforms = platforms.unix;
     description = "An LD_PRELOAD library to intercept and rewrite the paths in glibc calls";
     longDescription = ''
       libredirect is an LD_PRELOAD library to intercept and rewrite the paths in

--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeText, ocaml, findlib, ocamlbuild, camlp4 }:
+{ lib, stdenv, writeText, ocaml, findlib, ocamlbuild, camlp4 }:
 
 { name, version, buildInputs ? [],
   createFindlibDestdir ?  true,
@@ -14,7 +14,7 @@ let
   };
 in
   assert minimumSupportedOcamlVersion != null ->
-          stdenv.lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
+          lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
 
 stdenv.mkDerivation (args // {
   name = "ocaml-${name}-${version}";

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,11 +1,11 @@
-{ stdenv, ocaml, findlib, dune, dune_2 }:
+{ lib, stdenv, ocaml, findlib, dune, dune_2 }:
 
 { pname, version, buildInputs ? [], enableParallelBuilding ? true, ... }@args:
 
 let Dune = if args.useDune2 or false then dune_2 else dune; in
 
 if args ? minimumOCamlVersion &&
-   ! stdenv.lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+   ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,4 +1,4 @@
-{ stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild }:
+{ lib, stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild }:
 
 { pname, version, buildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
   minimumOCamlVersion ? null,
@@ -8,7 +8,7 @@
 }@args:
 
 if args ? minimumOCamlVersion &&
-   ! stdenv.lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+   ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion
 then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -2,6 +2,7 @@
 # PKG_CONFIG_PATH_FOR_BUILD work properly.
 
 { stdenvNoCC
+, lib
 , buildPackages
 , pkg-config
 , baseBinName ? "pkg-config"
@@ -19,7 +20,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
+  targetPrefix = lib.optionalString (targetPlatform != hostPlatform)
                                         (targetPlatform.config + "-");
 
   # See description in cc-wrapper.
@@ -119,7 +120,7 @@ stdenv.mkDerivation {
     let pkg-config_ = if pkg-config != null then pkg-config else {}; in
     (if pkg-config_ ? meta then removeAttrs pkg-config.meta ["priority"] else {}) //
     { description =
-        stdenv.lib.attrByPath ["meta" "description"] "pkg-config" pkg-config_
+        lib.attrByPath ["meta" "description"] "pkg-config" pkg-config_
         + " (wrapper script)";
       priority = 10;
   };

--- a/pkgs/build-support/plugins.nix
+++ b/pkgs/build-support/plugins.nix
@@ -1,4 +1,4 @@
-{ stdenv }:
+{ lib, stdenv }:
 # helper functions for packaging programs with plugin systems
 {
 
@@ -13,7 +13,7 @@
   diffPlugins = expectedPlugins: foundPluginsFilePath: ''
      # sort both lists first
      plugins_expected=$(mktemp)
-     (${stdenv.lib.concatMapStrings (s: "echo \"${s}\";") expectedPlugins}) \
+     (${lib.concatMapStrings (s: "echo \"${s}\";") expectedPlugins}) \
        | sort -u > "$plugins_expected"
      plugins_found=$(mktemp)
      sort -u "${foundPluginsFilePath}" > "$plugins_found"

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -2,6 +2,7 @@
 # that contains a Debian-like (i.e. dpkg-based) OS.
 
 { name ? "debian-build"
+, lib
 , diskImage
 , src, stdenv, vmTools, checkinstall
 , fsTranslation ? false
@@ -10,8 +11,6 @@
 , # Features required by this package.
   debRequires ? []
 , ... } @ args:
-
-with stdenv.lib;
 
 vmTools.runInLinuxImage (stdenv.mkDerivation (
 
@@ -59,8 +58,8 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
       export PAGER=cat
       ${checkinstall}/sbin/checkinstall --nodoc -y -D \
         --fstrans=${if fsTranslation then "yes" else "no"} \
-        --requires="${concatStringsSep "," debRequires}" \
-        --provides="${concatStringsSep "," debProvides}" \
+        --requires="${lib.concatStringsSep "," debRequires}" \
+        --provides="${lib.concatStringsSep "," debProvides}" \
         ${if (src ? version) then "--pkgversion=$(echo ${src.version} | tr _ -)"
                              else "--pkgversion=0.0.0"} \
         ''${debMaintainer:+--maintainer="'$debMaintainer'"} \

--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ lib, pkgs }:
 
 with pkgs;
 
@@ -23,7 +23,7 @@ rec {
     } // args);
 
   nixBuild = args: import ./nix-build.nix (
-    { inherit stdenv;
+    { inherit lib stdenv;
     } // args);
 
   coverageAnalysis = args: nixBuild (
@@ -46,7 +46,7 @@ rec {
     } // args);
 
   debBuild = args: import ./debian-build.nix (
-    { inherit stdenv vmTools checkinstall;
+    { inherit lib stdenv vmTools checkinstall;
     } // args);
 
   aggregate =
@@ -94,7 +94,7 @@ rec {
 
       phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
-      patchPhase = stdenv.lib.optionalString isNixOS ''
+      patchPhase = lib.optionalString isNixOS ''
         touch .update-on-nixos-rebuild
       '';
 

--- a/pkgs/build-support/release/nix-build.nix
+++ b/pkgs/build-support/release/nix-build.nix
@@ -12,7 +12,7 @@
 , doCoverityAnalysis ? false
 , lcovFilter ? []
 , lcovExtraTraceFiles ? []
-, src, stdenv
+, src, lib, stdenv
 , name ? if doCoverageAnalysis then "nix-coverage" else "nix-build"
 , failureHook ? null
 , prePhases ? []
@@ -69,7 +69,7 @@ stdenv.mkDerivation (
         fi
       '';
 
-    failureHook = (stdenv.lib.optionalString (failureHook != null) failureHook) +
+    failureHook = (lib.optionalString (failureHook != null) failureHook) +
     ''
       if test -n "$succeedOnFailure"; then
           if test -n "$keepBuildDirectory"; then
@@ -136,10 +136,10 @@ stdenv.mkDerivation (
 
     buildInputs =
       buildInputs ++
-      (stdenv.lib.optional doCoverageAnalysis args.makeGCOVReport) ++
-      (stdenv.lib.optional doClangAnalysis args.clang-analyzer) ++
-      (stdenv.lib.optional doCoverityAnalysis args.cov-build) ++
-      (stdenv.lib.optional doCoverityAnalysis args.xz);
+      (lib.optional doCoverageAnalysis args.makeGCOVReport) ++
+      (lib.optional doClangAnalysis args.clang-analyzer) ++
+      (lib.optional doCoverityAnalysis args.cov-build) ++
+      (lib.optional doCoverityAnalysis args.xz);
 
     lcovFilter = ["/nix/store/*"] ++ lcovFilter;
 

--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkg-config, curl, darwin, libiconv, libgit2, libssh2,
+{ lib, stdenv, pkg-config, curl, darwin, libiconv, libgit2, libssh2,
   openssl, sqlite, zlib, dbus, dbus-glib, gdk-pixbuf, cairo, python3,
   libsodium, postgresql, gmp, foundationdb, capnproto, nettle, clang,
   llvmPackages, ... }:
@@ -17,7 +17,7 @@ in
 
   cargo = attrs: {
     buildInputs = [ openssl zlib curl ]
-      ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
+      ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
   };
 
   libz-sys = attrs: {
@@ -149,7 +149,7 @@ in
   };
 
   serde_derive = attrs: {
-    buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+    buildInputs = lib.optional stdenv.isDarwin Security;
   };
 
   thrussh-libsodium = attrs: {

--- a/pkgs/build-support/rust/fetchCargoTarball.nix
+++ b/pkgs/build-support/rust/fetchCargoTarball.nix
@@ -1,4 +1,4 @@
-{ stdenv, cacert, git, cargo, python3 }:
+{ lib, stdenv, cacert, git, cargo, python3 }:
 let cargo-vendor-normalise = stdenv.mkDerivation {
   name = "cargo-vendor-normalise";
   src = ./cargo-vendor-normalise.py;
@@ -80,7 +80,7 @@ in stdenv.mkDerivation ({
 
   inherit (hash_) outputHashAlgo outputHash;
 
-  impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 } // (builtins.removeAttrs args [
   "name" "sha256" "cargoUpdateHook"
 ]))

--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -1,4 +1,5 @@
 { runCommand
+, lib
 , stdenv
 , storeDir ? builtins.storeDir
 , writeScript
@@ -64,7 +65,7 @@ rec {
             mkdir proc sys dev
 
             # Run root script
-            ${stdenv.lib.optionalString (runAsRoot != null) ''
+            ${lib.optionalString (runAsRoot != null) ''
               mkdir -p ./${storeDir}
               mount --rbind ${storeDir} ./${storeDir}
               unshare -imnpuf --mount-proc chroot ./ ${runAsRootFile}

--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -1,6 +1,5 @@
-{ stdenv, cleanPackaging, fetchurl }:
-let lib = stdenv.lib;
-in {
+{ lib, stdenv, cleanPackaging, fetchurl }:
+{
   # : string
   pname
   # : string
@@ -98,7 +97,7 @@ in stdenv.mkDerivation {
   meta = {
     homepage = "https://skarnet.org/software/${pname}/";
     inherit description platforms;
-    license = stdenv.lib.licenses.isc;
+    license = lib.licenses.isc;
     maintainers = with lib.maintainers;
       [ pmahoney Profpatsch ] ++ maintainers;
   };

--- a/pkgs/build-support/skaware/clean-packaging.nix
+++ b/pkgs/build-support/skaware/clean-packaging.nix
@@ -3,10 +3,10 @@
 # files were either discarded or moved to outputs.
 # This ensures nothing is forgotten and new files
 # are correctly handled on update.
-{ stdenv, file, writeScript }:
+{ lib, stdenv, file, writeScript }:
 
 let
-  globWith = stdenv.lib.concatMapStringsSep "\n";
+  globWith = lib.concatMapStringsSep "\n";
   rmNoise = noiseGlobs: globWith (f:
     ''rm -rf ${f}'') noiseGlobs;
   mvDoc = docGlobs: globWith

--- a/pkgs/build-support/substitute-files/substitute-all-files.nix
+++ b/pkgs/build-support/substitute-files/substitute-all-files.nix
@@ -1,10 +1,10 @@
-{ stdenv }:
+{ lib, stdenv }:
 
 args:
 
 stdenv.mkDerivation ({
   name = if args ? name then args.name else baseNameOf (toString args.src);
-  builder = with stdenv.lib; builtins.toFile "builder.sh" ''
+  builder = builtins.toFile "builder.sh" ''
     source $stdenv/setup
     set -o pipefail
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation ({
     args=
 
     pushd "$src"
-    echo -ne "${concatStringsSep "\\0" args.files}" | xargs -0 -n1 -I {} -- find {} -type f -print0 | while read -d "" line; do
+    echo -ne "${lib.concatStringsSep "\\0" args.files}" | xargs -0 -n1 -I {} -- find {} -type f -print0 | while read -d "" line; do
       mkdir -p "$out/$(dirname "$line")"
       substituteAll "$line" "$out/$line"
     done

--- a/pkgs/build-support/templaterpm/default.nix
+++ b/pkgs/build-support/templaterpm/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Create templates of nix expressions from RPM .spec files";
     maintainers = with maintainers; [ tstrobel ];
-    platforms = with stdenv.lib.platforms; unix;
+    platforms = platforms.unix;
     hydraPlatforms = [];
   };
 }

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1,4 +1,5 @@
-{ pkgs
+{ lib
+, pkgs
 , kernel ? pkgs.linux
 , img ? pkgs.stdenv.hostPlatform.linux-kernel.target
 , storeDir ? builtins.storeDir
@@ -572,7 +573,7 @@ rec {
       buildCommand = ''
         ${createRootFS}
 
-        PATH=$PATH:${stdenv.lib.makeBinPath [ dpkg dpkg glibc lzma ]}
+        PATH=$PATH:${lib.makeBinPath [ dpkg dpkg glibc lzma ]}
 
         # Unpack the .debs.  We do this to prevent pre-install scripts
         # (which have lots of circular dependencies) from barfing.

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -196,7 +196,7 @@ let
 
 in runCommand "test-writers" {
   passthru = { inherit writeTest bin simple; };
-  meta.platforms = stdenv.lib.platforms.all;
+  meta.platforms = lib.platforms.all;
 } ''
   ${lib.concatMapStringsSep "\n" (test: writeTest "success" "${test}/bin/test_writers") (lib.attrValues bin)}
   ${lib.concatMapStringsSep "\n" (test: writeTest "success" test) (lib.attrValues simple)}

--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, coreutils, gnused, gnugrep, diffutils, nix, git, jq }:
+{ lib, stdenv, makeWrapper, coreutils, gnused, gnugrep, diffutils, nix, git, jq }:
 
 stdenv.mkDerivation {
   name = "common-updater-scripts";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     cp ${./scripts}/* $out/bin
 
     for f in $out/bin/*; do
-      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnused gnugrep nix diffutils git jq ]}
+      wrapProgram $f --prefix PATH : ${lib.makeBinPath [ coreutils gnused gnugrep nix diffutils git jq ]}
     done
   '';
 }

--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -35,7 +35,7 @@ let
     buildPhase = ''
       export GRADLE_USER_HOME=$(mktemp -d)
       # https://github.com/gradle/gradle/issues/4426
-      ${stdenv.lib.optionalString stdenv.isDarwin "export TERM=dumb"}
+      ${lib.optionalString stdenv.isDarwin "export TERM=dumb"}
       gradle --no-daemon desktop:release
     '';
     # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
@@ -57,7 +57,7 @@ in stdenv.mkDerivation rec {
   buildPhase = ''
     export GRADLE_USER_HOME=$(mktemp -d)
     # https://github.com/gradle/gradle/issues/4426
-    ${stdenv.lib.optionalString stdenv.isDarwin "export TERM=dumb"}
+    ${lib.optionalString stdenv.isDarwin "export TERM=dumb"}
     # point to offline repo
     sed -ie "s#repositories {#repositories { maven { url '${deps}' };#g" build.gradle
     gradle --offline --no-daemon desktop:release

--- a/pkgs/os-specific/linux/statifier/default.nix
+++ b/pkgs/os-specific/linux/statifier/default.nix
@@ -1,4 +1,4 @@
-{ multiStdenv, fetchurl }:
+{ lib, multiStdenv, fetchurl }:
 
 let version = "1.7.4"; in
 multiStdenv.mkDerivation {
@@ -16,7 +16,7 @@ multiStdenv.mkDerivation {
     sed -e s@/bin/bash@"${multiStdenv.shell}"@g -i src/*.sh
   '';
 
-  meta = with multiStdenv.lib; {
+  meta = with lib; {
     description = "Tool for creating static Linux binaries";
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/servers/fiche/default.nix
+++ b/pkgs/servers/fiche/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "fiche";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Command line pastebin for sharing terminal output";
     longDescription = ''
       Fiche is a command line pastebin server for sharing terminal output.

--- a/pkgs/servers/foundationdb/vsmake.nix
+++ b/pkgs/servers/foundationdb/vsmake.nix
@@ -139,7 +139,7 @@ let
 
         outputs = [ "out" "lib" "dev" "pythonsrc" ];
 
-        meta = with gcc6Stdenv.lib; {
+        meta = with lib; {
           description = "Open source, distributed, transactional key-value store";
           homepage    = "https://www.foundationdb.org";
           license     = licenses.asl20;

--- a/pkgs/servers/http/envoy/default.nix
+++ b/pkgs/servers/http/envoy/default.nix
@@ -1,4 +1,5 @@
-{ buildBazelPackage
+{ lib
+, buildBazelPackage
 , fetchFromGitHub
 , stdenv
 , cmake
@@ -109,7 +110,7 @@ buildBazelPackage rec {
     "--cxxopt=-Wno-uninitialized"
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://envoyproxy.io";
     description = "Cloud-native edge and service proxy";
     license = licenses.asl20;

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, glibc }:
-with stdenv.lib;
+{ lib, stdenv, glibc }:
+
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
   sanitizersWorking = !stdenv.hostPlatform.isMusl && (
-    (stdenv.cc.isClang && versionAtLeast (getVersion stdenv.cc.name) "5.0.0")
+    (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc.name) "5.0.0")
     || (stdenv.cc.isGNU && stdenv.isLinux)
   );
-  staticLibc = optionalString (stdenv.hostPlatform.libc == "glibc") "-L ${glibc.static}/lib";
+  staticLibc = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "-L ${glibc.static}/lib";
 in stdenv.mkDerivation {
   name = "cc-wrapper-test";
 
@@ -23,7 +23,7 @@ in stdenv.mkDerivation {
     $CXX -o cxx-check ${./cxx-main.cc}
     ./cxx-check
 
-    ${optionalString (stdenv.isDarwin && stdenv.cc.isClang) ''
+    ${lib.optionalString (stdenv.isDarwin && stdenv.cc.isClang) ''
       printf "checking whether compiler can build with CoreFoundation.framework... " >&2
       mkdir -p foo/lib
       $CC -framework CoreFoundation -o core-foundation-check ${./core-foundation-main.c}
@@ -31,12 +31,12 @@ in stdenv.mkDerivation {
     ''}
 
 
-    ${optionalString (!stdenv.isDarwin) ''
+    ${lib.optionalString (!stdenv.isDarwin) ''
       printf "checking whether compiler builds valid static C binaries... " >&2
       $CC ${staticLibc} -static -o cc-static ${./cc-main.c}
       ./cc-static
       # our glibc does not have pie enabled yet.
-      ${optionalString (stdenv.hostPlatform.isMusl && stdenv.cc.isGNU) ''
+      ${lib.optionalString (stdenv.hostPlatform.isMusl && stdenv.cc.isGNU) ''
         printf "checking whether compiler builds valid static pie C binaries... " >&2
         $CC ${staticLibc} -static-pie -o cc-static-pie ${./cc-main.c}
         ./cc-static-pie
@@ -52,7 +52,7 @@ in stdenv.mkDerivation {
     printf "checking whether compiler uses NIX_LDFLAGS... " >&2
     mkdir -p foo/lib
     $CC -shared \
-      ${optionalString stdenv.isDarwin "-Wl,-install_name,@rpath/libfoo.dylib"} \
+      ${lib.optionalString stdenv.isDarwin "-Wl,-install_name,@rpath/libfoo.dylib"} \
       -DVALUE=42 \
       -o foo/lib/libfoo${stdenv.hostPlatform.extensions.sharedLibrary} \
       ${./foo.c}
@@ -68,7 +68,7 @@ in stdenv.mkDerivation {
     $CXX -I std-include -nostdinc++ -o nostdinc-main++ ${./nostdinc-main.c}
     ./nostdinc-main++
 
-    ${optionalString sanitizersWorking ''
+    ${lib.optionalString sanitizersWorking ''
       printf "checking whether sanitizers are fully functional... ">&2
       $CC -o sanitizers -fsanitize=address,undefined ${./sanitizers.c}
       ./sanitizers
@@ -77,5 +77,5 @@ in stdenv.mkDerivation {
     touch $out
   '';
 
-  meta.platforms = platforms.all;
+  meta.platforms = lib.platforms.all;
 }

--- a/pkgs/test/cc-wrapper/multilib.nix
+++ b/pkgs/test/cc-wrapper/multilib.nix
@@ -1,4 +1,4 @@
-{ stdenv }:
+{ lib, stdenv }:
 
 stdenv.mkDerivation {
   name = "cc-multilib-test";
@@ -33,5 +33,5 @@ stdenv.mkDerivation {
     touch $out
   '';
 
-  meta.platforms = stdenv.lib.platforms.x86_64;
+  meta.platforms = lib.platforms.x86_64;
 }

--- a/pkgs/test/install-shell-files/default.nix
+++ b/pkgs/test/install-shell-files/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, runCommandLocal, recurseIntoAttrs, installShellFiles }:
+{ lib, stdenv, runCommandLocal, recurseIntoAttrs, installShellFiles }:
 
 let
   runTest = name: env: buildCommand:
     runCommandLocal "install-shell-files--${name}" ({
       nativeBuildInputs = [ installShellFiles ];
-      meta.platforms = stdenv.lib.platforms.all;
+      meta.platforms = lib.platforms.all;
     } // env) buildCommand;
 in
 

--- a/pkgs/test/ld-library-path/default.nix
+++ b/pkgs/test/ld-library-path/default.nix
@@ -1,4 +1,4 @@
-{ stdenv }:
+{ lib, stdenv }:
 
 # This tests that libraries listed in LD_LIBRARY_PATH take precedence over those listed in RPATH.
 
@@ -84,5 +84,5 @@ in stdenv.mkDerivation {
     touch $out
   '';
 
-  meta.platforms = stdenv.lib.platforms.linux;
+  meta.platforms = lib.platforms.linux;
 }

--- a/pkgs/test/patch-shebangs/default.nix
+++ b/pkgs/test/patch-shebangs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand }:
+{ lib, stdenv, runCommand }:
 
 let
   bad-shebang = stdenv.mkDerivation {
@@ -13,7 +13,7 @@ let
   };
 in runCommand "patch-shebangs-test" {
   passthru = { inherit bad-shebang; };
-  meta.platforms = stdenv.lib.platforms.all;
+  meta.platforms = lib.platforms.all;
 } ''
   printf "checking whether patchShebangs works properly... ">&2
   if ! grep -q '^#!/bin/sh' ${bad-shebang}/bin/test; then

--- a/pkgs/test/stdenv-inputs/default.nix
+++ b/pkgs/test/stdenv-inputs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv }:
+{ lib, stdenv }:
 
 let
   foo = stdenv.mkDerivation {
@@ -12,7 +12,7 @@ let
       chmod +x $out/bin/foo
       cp ${./foo.c} $out/include/foo.h
       $CC -shared \
-        ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/libfoo.dylib"} \
+        ${lib.optionalString stdenv.isDarwin "-Wl,-install_name,$out/lib/libfoo.dylib"} \
         -o $out/lib/libfoo${stdenv.hostPlatform.extensions.sharedLibrary} \
         ${./foo.c}
     '';
@@ -30,7 +30,7 @@ let
       chmod +x $out/bin/bar
       cp ${./bar.c} $dev/include/bar.h
       $CC -shared \
-        ${stdenv.lib.optionalString stdenv.isDarwin "-Wl,-install_name,$dev/lib/libbar.dylib"} \
+        ${lib.optionalString stdenv.isDarwin "-Wl,-install_name,$dev/lib/libbar.dylib"} \
         -o $dev/lib/libbar${stdenv.hostPlatform.extensions.sharedLibrary} \
         ${./bar.c}
     '';
@@ -64,5 +64,5 @@ stdenv.mkDerivation {
     touch $out
   '';
 
-  meta.platforms = stdenv.lib.platforms.all;
+  meta.platforms = lib.platforms.all;
 }

--- a/pkgs/tools/graphics/metapixel/default.nix
+++ b/pkgs/tools/graphics/metapixel/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libpng, libjpeg, giflib, perl, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, libpng, libjpeg, giflib, perl, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "metapixel";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cp metapixel-sizesort $out/bin/metapixel-sizesort
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/schani/metapixel";
     description = "Tool for generating photomosaics";
     license = licenses.gpl2Only;

--- a/pkgs/tools/networking/lxi-tools/default.nix
+++ b/pkgs/tools/networking/lxi-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub
 , autoreconfHook, pkg-config
 , liblxi, readline, lua
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ liblxi readline lua ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Tool for communicating with LXI compatible instruments";
     longDescription = ''
       lxi-tools is a collection of open source software tools

--- a/pkgs/tools/text/source-highlight/default.nix
+++ b/pkgs/tools/text/source-highlight/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   # source-highlight uses it's own binary to generate documentation.
   # During cross-compilation, that binary was built for the target
   # platform architecture, so it can't run on the build host.
-  patchPhase = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  patchPhase = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     substituteInPlace Makefile.in --replace "src doc tests" "src tests"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Part of #108938
* EditorConfig fails, because this needs a change in `pkgs/build-support/dotnetenv/build-solution.nix` which would cause a rebuild
* 0 rebuilds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
