### PR TITLE
ec2instanceconnectcli: init at 1.0.2

### DIFF
--- a/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
+++ b/pkgs/tools/virtualization/ec2instanceconnectcli/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, boto3 }:
+
+buildPythonPackage rec {
+  pname = "ec2instanceconnectcli";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-VaCyCnEhSx1I3bNo57p0IXf92+tO1tT7KSUXzO1IyIU=";
+  };
+
+  propagatedBuildInputs = [ boto3 ];
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "ec2instanceconnectcli" ];
+
+  meta = with lib; {
+    description = "Command Line Interface for AWS EC2 Instance Connect";
+    homepage = "https://github.com/aws/aws-ec2-instance-connect-cli";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ yurrriq ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2001,6 +2001,8 @@ in {
 
   easywatch = callPackage ../development/python-modules/easywatch { };
 
+  ec2instanceconnectcli = callPackage ../tools/virtualization/ec2instanceconnectcli { };
+
   eccodes = toPythonModule (pkgs.eccodes.override {
     enablePython = true;
     pythonPackages = self;


### PR DESCRIPTION
###### Motivation for this change

Add [ec2instanceconnectcli](https://pypi.org/project/ec2instanceconnectcli/).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
