### PR TITLE
nomachine-client: 6.12.3 -> 7.0.211

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "6.12";
-  versionMinor = "3";
-  versionBuild_x86_64 = "7";
-  versionBuild_i686 = "8";
+  versionMajor = "7.0";
+  versionMinor = "211";
+  versionBuild_x86_64 = "4";
+  versionBuild_i686 = "4";
 in
   stdenv.mkDerivation rec {
     pname = "nomachine-client";
@@ -13,23 +13,18 @@ in
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
-          urls = [
-            "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz"
-            "https://web.archive.org/web/https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz"
-          ];
-          sha256 = "1dqsqwxbd77g6gc0hvjmmg4flm3vwwv5y98m8d9wxyybp37vkmgd";
+          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
+          sha256 = "06habqsl5gp13sym519r3qp188qwqqfw8p48wcs4zj3kcri6fjz0";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
-          urls = [
-            "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz"
-            "https://web.archive.org/web/https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz"
-          ];
-          sha256 = "1q14hxjy66s5cpq19rshscsm679csb6p16c5p2agh5zd64cr4am6";
+          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
+          sha256 = "1y4lr95mwilwr7gqsxqvygq4w3dcp4cjh8m06wdi3avwdzrjkgj9";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";
 
+    # nxusb-legacy is only needed for kernel versions < 3
     postUnpack = ''
       mv $(find . -type f -name nxclient.tar.gz) .
       mv $(find . -type f -name nxplayer.tar.gz) .
@@ -37,6 +32,8 @@ in
       tar xf nxclient.tar.gz
       tar xf nxplayer.tar.gz
       rm $(find . -maxdepth 1 -type f)
+      rm -r NX/share/src/nxusb-legacy
+      rm NX/bin/nxusbd-legacy NX/lib/libnxusb-legacy.so
     '';
 
     nativeBuildInputs = [ file makeWrapper autoPatchelfHook ];
@@ -85,8 +82,8 @@ in
       description = "NoMachine remote desktop client (nxplayer)";
       homepage = "https://www.nomachine.com/";
       license = {
-        fullName = "NoMachine 6 End-User License Agreement";
-        url = "https://www.nomachine.com/licensing-6";
+        fullName = "NoMachine 7 End-User License Agreement";
+        url = "https://www.nomachine.com/licensing-7";
         free = false;
       };
       maintainers = with maintainers; [ talyz ];


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).