### PR TITLE
parallel: add disableNagMessage

### DIFF
--- a/pkgs/tools/misc/parallel/wrapper.nix
+++ b/pkgs/tools/misc/parallel/wrapper.nix
@@ -1,13 +1,10 @@
-{ parallel, makeWrapper , runCommand
-, perlPackages
-, extraPerlPackages ?
-    with perlPackages; [ DBI DBDPg DBDSQLite DBDCSV TextCSV ]
-}:
+{ lib, runCommand, makeWrapper, parallel, perlPackages
+, extraPerlPackages ? with perlPackages; [ DBI DBDPg DBDSQLite DBDCSV TextCSV ]
+, willCite ? false }:
 
-runCommand "parallel-full" {
-  nativeBuildInputs = [ makeWrapper ];
-  } ''
-      mkdir -p $out/bin
-      makeWrapper ${parallel}/bin/parallel $out/bin/parallel \
-        --set PERL5LIB "${perlPackages.makeFullPerlPath extraPerlPackages}"
-  ''
+runCommand "parallel-full" { nativeBuildInputs = [ makeWrapper ]; } ''
+  mkdir -p $out/bin
+  makeWrapper ${parallel}/bin/parallel $out/bin/parallel \
+    --set PERL5LIB "${perlPackages.makeFullPerlPath extraPerlPackages}" \
+    ${lib.optionalString willCite "--add-flags --will-cite"}
+''


### PR DESCRIPTION
## Motivation for this change
Concern about the nag screen as well as GPL issues.

See https://github.com/NixOS/nixpkgs/issues/110584
Let's break the problem down into it's components.

###### Nag
This is a usability concern for some people and for some automation.

###### GPLv3
I don't think Nixpkgs should get into the habit of "fixing" the potential license issue by patching this out completely. My personal opinion is that it is a bit non-standard, but is technically okay. Regardless, the Nix-community is not a compliance organization, nor is in a good position to enforce this. The author and the GNU organization seems to claim there is no conflict. I recommend this be brought up with them directly. Packaging systems hiding the potential issue from users by default also seems odd.

###### Things done
adds an option for Nix users to disable the citation request by adding a `--will-cite` to the wrapped parallel call.

###### Potential issues
- some users may want this without the extra wrapping (this would mean a patch)
- some may want to disable the nag, but also not use the extra perl pacakges (this would mean they can set extraPerlPackages to `[]`)

###### Checklist
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
