### PR TITLE
zydis: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10496,4 +10496,10 @@
     github = "zupo";
     githubId = 311580;
   };
+  jbcrail = {
+    name = "Joseph Crail";
+    email = "jbcrail@gmail.com";
+    github = "jbcrail";
+    githubId = 6038;
+  };
 }

--- a/pkgs/development/libraries/zydis/default.nix
+++ b/pkgs/development/libraries/zydis/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "zydis";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "zyantific";
+    repo = "zydis";
+    rev = "bfee99f49274a0eec3ffea16ede3a5bda9cda88f";
+    sha256 = "0x2lpc33ynd0zzirdxp2lycvg3545wh1ssgy4qlv81471iwwzv6b";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Fast and lightweight x86/x86-64 disassembler library";
+    license = licenses.mit;
+    maintainers = [ maintainers.jbcrail ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12876,6 +12876,8 @@ in
 
   ytt = callPackage ../development/tools/ytt {};
 
+  zydis = callPackage ../development/libraries/zydis { };
+
   winpdb = callPackage ../development/tools/winpdb { };
 
   grabserial = callPackage ../development/tools/grabserial { };


### PR DESCRIPTION
###### Motivation for this change

Add [zydis](https://github.com/zyantific/zydis).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).