### PR TITLE
llvm_{5,6,8..11}: fix missing lib from stdenv.lib -> lib

### DIFF
--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/10/openmp.nix
+++ b/pkgs/development/compilers/llvm/10/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/11/openmp.nix
+++ b/pkgs/development/compilers/llvm/11/openmp.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/11/openmp.nix
+++ b/pkgs/development/compilers/llvm/11/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/5/openmp.nix
+++ b/pkgs/development/compilers/llvm/5/openmp.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/5/openmp.nix
+++ b/pkgs/development/compilers/llvm/5/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/6/openmp.nix
+++ b/pkgs/development/compilers/llvm/6/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/7/openmp.nix
+++ b/pkgs/development/compilers/llvm/7/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/8/openmp.nix
+++ b/pkgs/development/compilers/llvm/8/openmp.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/8/openmp.nix
+++ b/pkgs/development/compilers/llvm/8/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/9/openmp.nix
+++ b/pkgs/development/compilers/llvm/9/openmp.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib, stdenv
 , fetch
 , cmake
 , llvm

--- a/pkgs/development/compilers/llvm/9/openmp.nix
+++ b/pkgs/development/compilers/llvm/9/openmp.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetch
 , cmake
 , llvm


### PR DESCRIPTION
this was a fallout of the stdenv.lib -> lib changes

actually `llvm/7/` was fixed already.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
