### PR TITLE
go-audit: init at 1.0.0

### DIFF
--- a/pkgs/tools/system/go-audit/default.nix
+++ b/pkgs/tools/system/go-audit/default.nix
@@ -1,0 +1,29 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "go-audit";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "slackhq";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02iwjzaz2ks0zmwijaijwzc3gn9mhn7xpx369ylgaz68arlapfjg";
+  };
+
+  vendorSha256 = "11kb7xm82s0d8d06b2jknwn3dfh4i0a1dv0740y47vk62sf6f05i";
+
+  # Tests need network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An alternative to the auditd daemon";
+    homepage = "https://github.com/slackhq/go-audit";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1347,6 +1347,8 @@ in
 
   asc-key-to-qr-code-gif = callPackage ../tools/security/asc-key-to-qr-code-gif { };
 
+  go-audit = callPackage ../tools/system/go-audit { };
+
   gopass = callPackage ../tools/security/gopass { };
 
   gospider = callPackage ../tools/security/gospider { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
go-audit is an alternative to the auditd daemon.

https://github.com/slackhq/go-audit

Fixes #110554

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
