### PR TITLE
[staging-next] cmake: fix build on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/application-services.patch
@@ -14,15 +14,16 @@ diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.c
 index a5ce5d18f4..3d6838ce82 100644
 --- a/Source/cmGlobalXCodeGenerator.cxx
 +++ b/Source/cmGlobalXCodeGenerator.cxx
-@@ -43,11 +43,6 @@
+@@ -43,11 +43,10 @@
  
  struct cmLinkImplementation;
  
--#if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
+ #if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
 -#  define HAVE_APPLICATION_SERVICES
 -#  include <ApplicationServices/ApplicationServices.h>
--#endif
--
++#  include <CoreFoundation/CoreFoundation.h>
+ #endif
+
  #if !defined(CMAKE_BOOTSTRAP)
  #  include "cmXMLParser.h"
  


### PR DESCRIPTION
Fixes missing CoreFoundation declarations since bump to 3.19.3,
e.g. `error: unknown type name 'CFUUIDRef'`

ApplicationServices.h transitively includes CoreFoundation.h, but as we
patch ApplicationServices out of CMake, the CF symbols were not visible.
Previously this was not a concern, as they were not needed until
https://github.com/Kitware/CMake/commit/d250b67722abcfe1bcd22511943f3e032ef1ef3d

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/110569 (cc @FRidh)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
