### PR TITLE
code-server: 3.6.0 -> 3.8.0

### DIFF
--- a/pkgs/servers/code-server/darwin-fsevents.patch
+++ b/pkgs/servers/code-server/darwin-fsevents.patch
@@ -1,0 +1,11 @@
+--- ./lib/vscode/node_modules/fsevents/install.js
++++ ./lib/vscode/node_modules/fsevents/install.js
+@@ -1,7 +1,3 @@
+ if (process.platform === 'darwin') {
+-  var spawn = require('child_process').spawn;
+-  var args = ['install', '--fallback-to-build'];
+-  var options = {stdio: 'inherit'};
+-  var child = spawn(require.resolve('node-pre-gyp/bin/node-pre-gyp'), args, options);
+-  child.on('close', process.exit);
++  process.stdout.write('fsevents disabled on Darwin by Nix build script\n')
+ }

--- a/pkgs/servers/code-server/playwright.patch
+++ b/pkgs/servers/code-server/playwright.patch
@@ -1,0 +1,10 @@
+--- ./lib/vscode/node_modules/playwright/install.js
++++ ./lib/vscode/node_modules/playwright/install.js
+@@ -14,6 +14,4 @@
+  * limitations under the License.
+  */
+ 
+-const { installBrowsersWithProgressBar } = require('./lib/install/installer');
+-
+-installBrowsersWithProgressBar(__dirname);
++process.stdout.write('Browser install disabled by Nix build script\n');

--- a/pkgs/servers/code-server/remove-cloud-agent-download.patch
+++ b/pkgs/servers/code-server/remove-cloud-agent-download.patch
@@ -1,0 +1,16 @@
+--- ./ci/build/npm-postinstall.sh
++++ ./ci/build/npm-postinstall.sh
+@@ -24,13 +24,6 @@ main() {
+     ;;
+   esac
+ 
+-  OS="$(uname | tr '[:upper:]' '[:lower:]')"
+-  if curl -fsSL "https://storage.googleapis.com/coder-cloud-releases/agent/latest/$OS/cloud-agent" -o ./lib/coder-cloud-agent; then
+-    chmod +x ./lib/coder-cloud-agent
+-  else
+-    echo "Failed to download cloud agent; --link will not work"
+-  fi
+-
+   if ! vscode_yarn; then
+     echo "You may not have the required dependencies to build the native modules."
+     echo "Please see https://github.com/cdr/code-server/blob/master/doc/npm.md"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25371,7 +25371,10 @@ in
 
   vscodium = callPackage ../applications/editors/vscode/vscodium.nix { };
 
-  code-server = callPackage ../servers/code-server { };
+  code-server = callPackage ../servers/code-server {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Security;
+    inherit (darwin) cctools;
+  };
 
   vue = callPackage ../applications/misc/vue { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updates code-server to 3.8.0.

3.8.0 removes the need to run VSCode patches and fetch submodules, which simplifies the script a bit.

I added support for Darwin, tested on macOS 10.15.7 -- It required patching the install scripts of a few packages that aren't needed at runtime. I used `patch` for this rather than `sed` because it seemed easier to review the changes, but let me know if one or the other is preferred and I can switch it out if necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
