### PR TITLE
home-assistant: 2021.1.4 -> 2021.1.5 (and more)

### DIFF
--- a/pkgs/development/python-modules/asgi-csrf/default.nix
+++ b/pkgs/development/python-modules/asgi-csrf/default.nix
@@ -1,8 +1,17 @@
-{ lib, stdenv, buildPythonPackage, isPy27, fetchFromGitHub, itsdangerous, python-multipart
-, pytestCheckHook, starlette, httpx, pytest-asyncio }:
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, itsdangerous
+, python-multipart
+, pytestCheckHook
+, starlette
+, httpx
+, pytest-asyncio
+}:
 
 buildPythonPackage rec {
-  version = "0.7.1";
+  version = "0.8";
   pname = "asgi-csrf";
   disabled = isPy27;
 
@@ -11,7 +20,7 @@ buildPythonPackage rec {
     owner = "simonw";
     repo = pname;
     rev = version;
-    sha256 = "1hhqrb9r46y6i3d3w6hc9zm6yyikdyd2k5pcbyw0r9fl959yi4hf";
+    sha256 = "sha256-0I/p9SjVVZhJQeR7s1R3tooP9XMNLPlcxl0dBSzsVaw=";
   };
 
   propagatedBuildInputs = [
@@ -26,10 +35,7 @@ buildPythonPackage rec {
     starlette
   ];
 
-  # tests fail while importing a private module from httpx
-  #  E   ModuleNotFoundError: No module named 'httpx._content_streams'
-  # https://github.com/simonw/asgi-csrf/issues/18
-  doCheck = false;
+  doCheck = false; # asgi-lifespan missing
 
   pythonImportsCheck = [ "asgi_csrf" ];
 

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -12,20 +12,20 @@
 
 buildPythonPackage rec {
   pname = "pyatmo";
-  version = "4.2.1";
+  version = "4.2.2";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "jabesq";
-    repo = "netatmo-api-python";
+    repo = "pyatmo";
     rev = "v${version}";
-    sha256 = "12lmjhqjn71a358nkpzl3dwgiwmmz4lcv9f0qf69ngznpiirk28m";
+    sha256 = "sha256-3IxDDLa8KMHVkHAeTmdNVRPc5aKzF3VwL2kKnG8Fp7I=";
   };
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "oauthlib~=3.1.0" "oauthlib" \
-      --replace "requests~=2.23.0" "requests"
+      --replace "oauthlib~=3.1" "oauthlib" \
+      --replace "requests~=2.24" "requests"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pybotvac/default.nix
+++ b/pkgs/development/python-modules/pybotvac/default.nix
@@ -1,18 +1,33 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, requests }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, requests_oauthlib
+, voluptuous
+}:
 
 buildPythonPackage rec {
   pname = "pybotvac";
-  version = "0.0.18";
+  version = "0.0.20";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e983c9ffc0734c2e5a7c2adf5d0d0dfe399d94157c590ef70fad765f882c341f";
+    sha256 = "sha256-1NnTSO4vO3Ryt4vYD5ZTQGr241GqA2KsGRBVowSTCzM=";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [
+    requests
+    requests_oauthlib
+    voluptuous
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pybotvac" ];
 
   meta = with lib; {
-    description = "Python package for controlling Neato pybotvac Connected vacuum robot";
+    description = "Python module for interacting with Neato Botvac Connected vacuum robots";
     homepage = "https://github.com/stianaske/pybotvac";
     license = licenses.mit;
     maintainers = with maintainers; [ elseym ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2021.1.4";
+  version = "2021.1.5";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -57,7 +57,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2021.1.4";
+  hassVersion = "2021.1.5";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -76,7 +76,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    sha256 = "03aa7kd216rnp8h80nv002ahafiy0031lxk1bkwcirrznphcw7sj";
+    sha256 = "sha256-xi5rHZlhwgEHll3TFlRu7D963tdcQNMmWcoXVjEFLXo=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/home-assistant/core/releases/tag/2021.1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
