### PR TITLE
[staging] perl532: 5.32.0 -> 5.32.1, perl-cross: 4c55233 -> 1.3.5

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -168,11 +168,11 @@ let
       priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     };
   } // optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
-    crossVersion = "4c55233ae95a6aef4d93291fe8ad12709b11e575"; # Jan 21, 2021
+    crossVersion = "1.3.5"; # Jan 24, 2021
 
     perl-cross-src = fetchurl {
       url = "https://github.com/arsv/perl-cross/archive/${crossVersion}.tar.gz";
-      sha256 = "04bxn43ir7b4c2bb1z1l71l93hrysjv00h879nm70m99q6vxq2hc";
+      sha256 = "1sa2f8s1hc604g5y98w6m6y5q43s9jiyrpnp4b34zkfx1qs3w6l4";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc makeWrapper ];
@@ -200,8 +200,8 @@ in {
   perl532 = common {
     perl = pkgs.perl532;
     buildPerl = buildPackages.perl532;
-    version = "5.32.0";
-    sha256 = "1d6001cjnpxfv79000bx00vmv2nvdz7wrnyas451j908y7hirszg";
+    version = "5.32.1";
+    sha256 = "0b7brakq9xs4vavhg391as50nbhzryc7fy5i65r81bnq3j897dh3";
   };
 
   # the latest Devel version


### PR DESCRIPTION
###### Motivation for this change

https://metacpan.org/changes/release/SHAY/perl-5.32.1 

dependencies:
perl-cross: https://github.com/arsv/perl-cross/commit/4c55233ae95a6aef4d93291fe8ad12709b11e575 -> [1.3.5](https://github.com/arsv/perl-cross/tree/1.3.5)

Build:
- [X] linux x64
- [X] pkgCross aarch64
- [X] darwin x64 (big sur)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
