### PR TITLE
ocamlPackages.caqti: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1036,6 +1036,12 @@
     githubId = 1015044;
     name = "Brandon Carrell";
   };
+  bcc32 = {
+    email = "me@bcc32.com";
+    github = "bcc32";
+    githubId = 1239097;
+    name = "Aaron Zeng";
+  };
   bcdarwin = {
     email = "bcdarwin@gmail.com";
     github = "bcdarwin";

--- a/pkgs/development/ocaml-modules/caqti/async.nix
+++ b/pkgs/development/ocaml-modules/caqti/async.nix
@@ -1,0 +1,11 @@
+{ lib, buildDunePackage, async_kernel, async_unix, caqti, core_kernel }:
+
+buildDunePackage {
+  pname = "caqti-async";
+  useDune2 = true;
+  inherit (caqti) version src;
+
+  propagatedBuildInputs = [ async_kernel async_unix caqti core_kernel ];
+
+  meta = caqti.meta // { description = "Async support for Caqti"; };
+}

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, buildDunePackage, cppo, logs, ptime, uri }:
+
+buildDunePackage rec {
+  pname = "caqti";
+  version = "1.3.0";
+  useDune2 = true;
+
+  minimumOCamlVersion = "4.04";
+
+  src = fetchFromGitHub {
+    owner = "paurkedal";
+    repo = "ocaml-${pname}";
+    rev = "v${version}";
+    sha256 = "1ksjchfjnh059wvd95my1sv9b0ild0dfaiynbf2xsaz7zg1y4xmw";
+  };
+
+  buildInputs = [ cppo ];
+  propagatedBuildInputs = [ logs ptime uri ];
+
+  meta = {
+    description = "Unified interface to relational database libraries";
+    license = "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception";
+    maintainers = with lib.maintainers; [ bcc32 ];
+    homepage = "https://github.com/paurkedal/ocaml-caqti";
+  };
+}

--- a/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
@@ -1,0 +1,13 @@
+{ lib, buildDunePackage, caqti, mariadb }:
+
+buildDunePackage {
+  pname = "caqti-driver-mariadb";
+  useDune2 = true;
+  inherit (caqti) version src;
+
+  propagatedBuildInputs = [ caqti mariadb ];
+
+  meta = caqti.meta // {
+    description = "MariaDB driver for Caqti using C bindings";
+  };
+}

--- a/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
@@ -1,0 +1,13 @@
+{ lib, buildDunePackage, caqti, postgresql }:
+
+buildDunePackage {
+  pname = "caqti-driver-postgresql";
+  useDune2 = true;
+  inherit (caqti) version src;
+
+  propagatedBuildInputs = [ caqti postgresql ];
+
+  meta = caqti.meta // {
+    description = "PostgreSQL driver for Caqti based on C bindings";
+  };
+}

--- a/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
@@ -1,0 +1,13 @@
+{ lib, buildDunePackage, caqti, ocaml_sqlite3 }:
+
+buildDunePackage {
+  pname = "caqti-driver-sqlite3";
+  useDune2 = true;
+  inherit (caqti) version src;
+
+  propagatedBuildInputs = [ caqti ocaml_sqlite3 ];
+
+  meta = caqti.meta // {
+    description = "Sqlite3 driver for Caqti using C bindings";
+  };
+}

--- a/pkgs/development/ocaml-modules/caqti/dynload.nix
+++ b/pkgs/development/ocaml-modules/caqti/dynload.nix
@@ -1,0 +1,13 @@
+{ lib, buildDunePackage, caqti }:
+
+buildDunePackage {
+  pname = "caqti-dynload";
+  useDune2 = true;
+  inherit (caqti) version src;
+
+  propagatedBuildInputs = [ caqti ];
+
+  meta = caqti.meta // {
+    description = "Dynamic linking of Caqti drivers using findlib.dynload";
+  };
+}

--- a/pkgs/development/ocaml-modules/caqti/lwt.nix
+++ b/pkgs/development/ocaml-modules/caqti/lwt.nix
@@ -1,0 +1,11 @@
+{ lib, buildDunePackage, caqti, logs, lwt }:
+
+buildDunePackage {
+  pname = "caqti-lwt";
+  useDune2 = true;
+  inherit (caqti) version src;
+
+  propagatedBuildInputs = [ caqti logs lwt ];
+
+  meta = caqti.meta // { description = "Lwt support for Caqti"; };
+}

--- a/pkgs/development/ocaml-modules/caqti/type-calendar.nix
+++ b/pkgs/development/ocaml-modules/caqti/type-calendar.nix
@@ -1,0 +1,14 @@
+{ lib, buildDunePackage, calendar, caqti }:
+
+buildDunePackage {
+  pname = "caqti-type-calendar";
+  version = "1.2.0";
+  useDune2 = true;
+  inherit (caqti) src;
+
+  propagatedBuildInputs = [ calendar caqti ];
+
+  meta = caqti.meta // {
+    description = "Date and time field types using the calendar library";
+  };
+}

--- a/pkgs/development/ocaml-modules/mariadb/default.nix
+++ b/pkgs/development/ocaml-modules/mariadb/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, buildOasisPackage
+, ctypes, mariadb, libmysqlclient }:
+
+buildOasisPackage rec {
+  pname = "mariadb";
+  version = "1.1.4";
+
+  minimumOCamlVersion = "4.07.0";
+
+  src = fetchFromGitHub {
+    owner = "andrenth";
+    repo = "ocaml-mariadb";
+    rev = version;
+    sha256 = "1rxqvxr6sv4x2hsi05qm9jz0asaq969m71db4ckl672rcql1kwbr";
+  };
+
+  buildInputs = [ mariadb libmysqlclient ];
+  propagatedBuildInputs = [ ctypes ];
+
+  meta = {
+    description = "OCaml bindings for MariaDB";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcc32 ];
+    homepage = "https://github.com/andrenth/ocaml-mariadb";
+  };
+}

--- a/pkgs/development/ocaml-modules/postgresql/default.nix
+++ b/pkgs/development/ocaml-modules/postgresql/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildDunePackage, postgresql }:
+
+buildDunePackage rec {
+  pname = "postgresql";
+  version = "4.6.3";
+
+  minimumOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "mmottl";
+    repo = "postgresql-ocaml";
+    rev = version;
+    sha256 = "0fd96qqwkwjhv6pawk4wivwncszkif0sq05f0g5gd28jzwrsvpqr";
+  };
+
+  buildInputs = [ postgresql ];
+
+  meta = {
+    description = "Bindings to the PostgreSQL library";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ bcc32 ];
+    homepage = "https://mmottl.github.io/postgresql-ocaml";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -128,6 +128,22 @@ let
 
     cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
+    caqti = callPackage ../development/ocaml-modules/caqti { };
+
+    caqti-async = callPackage ../development/ocaml-modules/caqti/async.nix { };
+
+    caqti-driver-mariadb = callPackage ../development/ocaml-modules/caqti/driver-mariadb.nix { };
+
+    caqti-driver-postgresql = callPackage ../development/ocaml-modules/caqti/driver-postgresql.nix { };
+
+    caqti-driver-sqlite3 = callPackage ../development/ocaml-modules/caqti/driver-sqlite3.nix { };
+
+    caqti-dynload = callPackage ../development/ocaml-modules/caqti/dynload.nix { };
+
+    caqti-lwt = callPackage ../development/ocaml-modules/caqti/lwt.nix { };
+
+    caqti-type-calendar = callPackage ../development/ocaml-modules/caqti/type-calendar.nix { };
+
     cfstream = callPackage ../development/ocaml-modules/cfstream { };
 
     charInfo_width = callPackage ../development/ocaml-modules/charInfo_width { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -751,6 +751,10 @@ let
 
     pgocaml_ppx = callPackage ../development/ocaml-modules/pgocaml/ppx.nix {};
 
+    postgresql = callPackage ../development/ocaml-modules/postgresql {
+      inherit (pkgs) postgresql;
+    };
+
     ocaml-r = callPackage ../development/ocaml-modules/ocaml-r { };
 
     ocaml-sat-solvers = callPackage ../development/ocaml-modules/ocaml-sat-solvers { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -725,6 +725,10 @@ let
 
     ocaml-lsp = callPackage ../development/ocaml-modules/ocaml-lsp { };
 
+    mariadb = callPackage ../development/ocaml-modules/mariadb {
+      inherit (pkgs) mariadb;
+    };
+
     ocaml-migrate-parsetree = ocaml-migrate-parsetree-1-8;
 
     ocaml-migrate-parsetree-1-8 = callPackage ../development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

Package the OCaml caqti library, a library for monadic cooperative-threaded access to various relational databases.  I added myself as maintainer, although I don't have much experience maintaining such packages.  If the relevant OCaml package reviewers would be willing/prefer to maintain these packages, I'm happy to accommodate.

I also tested these packages by building some personal projects that depend on caqti (https://github.com/bcc32/watch-later), so I can validate that at least `caqti-async`+`caqti-driver-sqlite3` works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
