### PR TITLE
plover: add dev-with-plugins

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -1,7 +1,24 @@
-{ lib, stdenv, fetchurl, python27Packages, python36Packages, wmctrl,
-  qtbase, mkDerivationWith }:
+{ lib, stdenv, fetchurl, fetchFromGitHub, python27Packages, python36Packages, wmctrl, qtbase, mkDerivationWith }:
 
-{
+let
+  requests-futures = with python36Packages; buildPythonPackage rec {
+    pname = "requests-futures";
+    version = "1.0.0";
+
+    src = fetchFromGitHub {
+      owner = "ross";
+      repo = "requests-futures";
+      rev = "d5cbf487c010dd84c4e030e279d48e7179e35335";
+      sha256 = "1f7r3wjs7kg3dzg7zszxxpaax45ps9phclyvvzxi5y86d3shgwdm";
+    };
+
+    # tests try to access network
+    doCheck = false;
+
+    propagatedBuildInputs = [ requests ];
+  };
+in rec {
+
   stable = with python27Packages; buildPythonPackage rec {
     pname = "plover";
     version = "3.1.1";
@@ -52,4 +69,45 @@
       makeWrapperArgs+=("''${qtWrapperArgs[@]}")
     '';
   };
+
+  plugins-manager = with python36Packages; buildPythonPackage rec {
+    pname = "plover-plugins-manager";
+    version = "0.5.16";
+
+    meta = with lib; {
+      description = "OpenSteno Plover stenography software plugin manager";
+      maintainers = with maintainers; [ tckmn ];
+      license     = licenses.gpl2;
+    };
+
+    src = fetchFromGitHub {
+      owner = "benoit-pierre";
+      repo = "plover_plugins_manager";
+      rev = "7f697da4a97cf92eeb639742a115a89887155c90";
+      sha256 = "152c02anzzvk2a5mgsnlmc1bc48lhgqf58rw2z6ir1x5carpzm91";
+    };
+
+    # apply nix sys.path wrapper to plugin manager's python call
+    postPatch = "patch -p1 <${./plugins-manager.patch}";
+
+    # tests try to instantiate a virtualenv and lack permission
+    doCheck = false;
+
+    propagatedBuildInputs = [ pip pkginfo dev pygments readme_renderer requests requests-cache requests-futures setuptools wheel ];
+  };
+
+  dev-with-plugins = dev.overrideAttrs (old: {
+    name = "plover-with-plugins-${old.version}";
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [ plugins-manager ];
+
+    # we have to remove the old plover from PYTHONPATH; otherwise python thinks
+    # it's already installed and refuses to install it again
+    preInstall = ''
+      export PYTHONPATH="$(sed 's![^:]*-${old.name}-[^:]*:!!g' <<<"$PYTHONPATH")"
+    '';
+
+    # the plugin manager installs plugins as local python packages
+    permitUserSite = true;
+  });
+
 }

--- a/pkgs/applications/misc/plover/plugins-manager.patch
+++ b/pkgs/applications/misc/plover/plugins-manager.patch
@@ -1,0 +1,22 @@
+diff --git a/plover_plugins_manager/__main__.py b/plover_plugins_manager/__main__.py
+index f121bcc..43a3257 100644
+--- a/plover_plugins_manager/__main__.py
++++ b/plover_plugins_manager/__main__.py
+@@ -41,16 +41,7 @@ def pip(args, stdin=None, stdout=None, stderr=None, **kwargs):
+            'plover_plugins_manager.pip_wrapper',
+            '--disable-pip-version-check']
+     env = dict(os.environ)
+-    # Make sure user plugins are handled
+-    # even if user site is not enabled.
+-    if not site.ENABLE_USER_SITE:
+-        pypath = env.get('PYTHONPATH')
+-        if pypath is None:
+-            pypath = []
+-        else:
+-            pypath = pypath.split(os.pathsep)
+-        pypath.insert(0, site.USER_SITE)
+-        env['PYTHONPATH'] = os.pathsep.join(pypath)
++    env['PYTHONPATH'] = os.pathsep.join(sys.path + [site.USER_SITE])
+     command = args.pop(0)
+     if command == 'check':
+         cmd.append('check')


### PR DESCRIPTION
###### Motivation for this change

This adds plover.dev-with-plugins, which is plover.dev with the added
plover-plugins-manager dependency (which causes the plugin manager to
appear in the Plover interface).

Fixes #89341 in the first way; the second way is morally better but more
difficult to do.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
