### PR TITLE
grpc-tools: init at 1.10.0

### DIFF
--- a/pkgs/development/tools/misc/grpc-tools/default.nix
+++ b/pkgs/development/tools/misc/grpc-tools/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, cmake
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "grpc-tools";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "grpc";
+    repo = "grpc-node";
+    rev = "3a094f01711942f79abd8a536c45a91b574d626f"; # version 1.10.0 was not tagged
+    sha256 = "1a7l91kxc3g7mqfqvhc3nb7zy0n21ifs5ck0qqg09qh3f44q04xm";
+    fetchSubmodules = true;
+  };
+
+  sourceRoot = "source/packages/grpc-tools";
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin grpc_node_plugin
+    install -Dm755 -t $out/bin deps/protobuf/protoc
+  '';
+
+  meta = with lib; {
+    description = "Distribution of protoc and the gRPC Node protoc plugin for ease of installation with npm";
+    longDescription = ''
+      This package distributes the Protocol Buffers compiler protoc along with
+      the plugin for generating client and service objects for use with the Node
+      gRPC libraries.
+    '';
+    homepage = "https://github.com/grpc/grpc-node/tree/master/packages/grpc-tools";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.nzhang-zh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4789,6 +4789,8 @@ in
 
   grpcui = callPackage ../tools/networking/grpcui { };
 
+  grpc-tools = callPackage ../development/tools/misc/grpc-tools { };
+
   grub = pkgsi686Linux.callPackage ../tools/misc/grub ({
     stdenv = overrideCC stdenv buildPackages.pkgsi686Linux.gcc6;
   } // (config.grub or {}));


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #93173

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
