### PR TITLE
m4acut: Init at 0.1.2

### DIFF
--- a/pkgs/applications/audio/m4acut/default.nix
+++ b/pkgs/applications/audio/m4acut/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, autoreconfHook, fetchFromGitHub, l-smash }:
+stdenv.mkDerivation rec {
+  pname = "m4acut";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "nu774";
+    repo = "m4acut";
+    rev = "v${version}";
+    sha256 = "1hzf9f1fzmlpnxjaxhs2w22wzb28vd87ycaddnix1mmhvh3nvzkd";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ l-smash ];
+
+  meta = with lib; {
+    description = "Losslessly & gaplessly cut m4a (AAC in MP4) files.";
+    homepage = "https://github.com/nu774/m4acut";
+    license = with licenses; [ bsdOriginal zlib ];
+    maintainers = [ maintainers.chkno ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/audio/m4acut/default.nix
+++ b/pkgs/applications/audio/m4acut/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, autoreconfHook, fetchFromGitHub, l-smash }:
+
 stdenv.mkDerivation rec {
   pname = "m4acut";
   version = "0.1.2";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23216,6 +23216,8 @@ in
 
   lyx = libsForQt5.callPackage ../applications/misc/lyx { };
 
+  m4acut = callPackage ../applications/audio/m4acut { };
+
   mac = callPackage ../development/libraries/mac { };
 
   macdylibbundler = callPackage ../development/tools/misc/macdylibbundler { inherit (darwin) cctools; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Make m4acut available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    0 → 39,646,096
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
