### PR TITLE
chiaki: 2.0.1 -> 2.1.0 (+ licensing fix)

### DIFF
--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -18,13 +18,13 @@
 
 mkDerivation rec {
   pname = "chiaki";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchgit {
     url = "https://git.sr.ht/~thestr4ng3r/chiaki";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0l532i9j6wmzbxqx7fg69kgfd1zy1r1wlw6f756vpxpgswivi892";
+    sha256 = "1hgh2j71rch53cnpm3f195gpfgrb4hd0yqa810k3ikar8zl4h7sd";
   };
 
   nativeBuildInputs = [

--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -57,7 +57,7 @@ mkDerivation rec {
   meta = with lib; {
     homepage = "https://git.sr.ht/~thestr4ng3r/chiaki";
     description = "Free and Open Source PlayStation Remote Play Client";
-    license = licenses.gpl3Plus;
+    license = licenses.agpl3Only;
     maintainers = with maintainers; [ delroth ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release, and I noticed while checking old changelogs that we missed a relicensing during the 2.0 version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
