### PR TITLE
[20.09] libgadu: 1.11.2 -> 1.12.2

### DIFF
--- a/pkgs/development/libraries/libgadu/default.nix
+++ b/pkgs/development/libraries/libgadu/default.nix
@@ -1,21 +1,25 @@
-{stdenv, fetchurl, zlib}:
+{ lib, stdenv, fetchFromGitHub, zlib, protobufc, autoreconfHook }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  pname = "libgadu";
+  version = "1.12.2";
 
-  name = "libgadu-1.11.2";
-
-  src = fetchurl {
-    url = "http://toxygen.net/libgadu/files/libgadu-1.11.2.tar.gz";
-    sha256 = "0kifi9blhbimihqw4kaf6wyqhlx8fpp8nq4s6y280ar9p0il2n3z";
+  src = fetchFromGitHub {
+    owner = "wojtekka";
+    repo = pname;
+    rev = version;
+    sha256 = "1s16cripy5w9k12534qb012iwc5m9qcjyrywgsziyn3kl3i0aa8h";
   };
 
   propagatedBuildInputs = [ zlib ];
+  buildInputs = [ protobufc ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = {
     description = "A library to deal with gadu-gadu protocol (most popular polish IM protocol)";
-    homepage = "http://toxygen.net/libgadu/";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.lgpl21;
+    homepage = "https://libgadu.net/index.en.html";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.lgpl21;
   };
 
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2013-4488 and CVE-2014-3775.

(cherry picked from commit 171406507dfedb0791dee815370f5cc63a02d287)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
