### PR TITLE
darwin.darling: fix build on case-insensitive filesystems

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -31,9 +31,11 @@ appleDerivation {
 
     mkdir -p $out/include/os
 
-    cp ${darling.src}/src/libc/os/activity.h $out/include/os
-    cp ${darling.src}/src/libc/os/log.h $out/include/os
-    cp ${darling.src}/src/duct/include/os/trace.h $out/include/os
+    (cd ${darling.src}/platform-include && (xargs -n1 echo | cpio -pdm --quiet $out/include) <<<"
+      os/activity.h
+      os/log.h
+      os/trace.h
+    ")
 
     cat <<EOF > $out/include/os/availability.h
     #ifndef __OS_AVAILABILITY__

--- a/pkgs/os-specific/darwin/darling/default.nix
+++ b/pkgs/os-specific/darwin/darling/default.nix
@@ -1,19 +1,14 @@
-{stdenv, lib, fetchzip}:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  pname = "darling";
-  name = pname;
+  pname   = "darling";
+  version = "unstable-2020-04-26";
 
-  src = fetchzip {
-    url = "https://github.com/darlinghq/darling/archive/d2cc5fa748003aaa70ad4180fff0a9a85dc65e9b.tar.gz";
-    sha256 = "11b51fw47nl505h63bgx5kqiyhf3glhp1q6jkpb6nqfislnzzkrf";
-    postFetch = ''
-      # Get rid of case conflict
-      mkdir $out
-      cd $out
-      tar -xzf $downloadedFile --strip-components=1
-      rm -r $out/src/libm
-    '';
+  src = fetchFromGitHub {
+    owner   = "darlinghq";
+    repo    = "darling";
+    rev     = "ea5f07d38a0d4667b4fdda42b131250e4b7c7296";
+    sha256  = "1qnp4fpnjf95pzxn51rmwadnj24llb64pb127yr2qkw35apbz00c";
   };
 
   # only packaging sandbox for now


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Use upstream darlinghq/darling@ea5f07d to fix build on case-insensitive filesystems.
Also update headers in Libsystem due to path modified.

Tested darling but not Libsystem.

cc @veprbl @thefloweringash 
fix #91480 #107431

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
