### PR TITLE
nixos/fish: Fix foreign-env function path

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -24,7 +24,7 @@ let
     "source /etc/fish/${file}.fish"
   else
     ''
-      set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish-foreign-env/functions $fish_function_path
+      set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d $fish_function_path
       fenv source /etc/fish/foreign-env/${file} > /dev/null
       set -e fish_function_path[1]
     '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix the broken `foreign-env` path in the `sourceEnv` function of `fish.nix`. Without the fix I get errors like these:
```
/etc/fish/config.fish (line 6): 
fenv source /etc/fish/foreign-env/shellInit > /dev/null
^
from sourcing file /etc/fish/config.fish
	called on line 39 of file /nix/store/j6k8pvb73n68landa81c173fx45qn4q5-fish-3.1.2/etc/fish/config.fish
from sourcing file /nix/store/j6k8pvb73n68landa81c173fx45qn4q5-fish-3.1.2/etc/fish/config.fish
	called during startup
/etc/fish/config.fish (line 40): 
fenv source /etc/fish/foreign-env/interactiveShellInit > /dev/null
^
from sourcing file /etc/fish/config.fish
	called on line 39 of file /nix/store/j6k8pvb73n68landa81c173fx45qn4q5-fish-3.1.2/etc/fish/config.fish
from sourcing file /nix/store/j6k8pvb73n68landa81c173fx45qn4q5-fish-3.1.2/etc/fish/config.fish
	called during startup
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
