### PR TITLE
libxkbcommon: Add a "USE flag" for Wayland support

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -2,6 +2,8 @@
 , xkeyboard_config, libxcb, libxml2
 , python3
 , libX11
+# To enable the "interactive-wayland" subcommand of xkbcli:
+, withWaylandSupport ? false, wayland, wayland-protocols
 }:
 
 stdenv.mkDerivation rec {
@@ -13,18 +15,24 @@ stdenv.mkDerivation rec {
     sha256 = "0lmwglj16anhpaq0h830xsl1ivknv75i4lir9bk88aq73s2jy852";
   };
 
+  patches = [
+    ./fix-cross-compilation.patch
+  ];
+
   outputs = [ "out" "dev" "doc" ];
 
-  nativeBuildInputs = [ meson ninja pkg-config yacc doxygen ];
-  buildInputs = [ xkeyboard_config libxcb libxml2 ];
+  nativeBuildInputs = [ meson ninja pkg-config yacc doxygen ]
+    ++ lib.optional withWaylandSupport wayland;
+  buildInputs = [ xkeyboard_config libxcb libxml2 ]
+    ++ lib.optionals withWaylandSupport [ wayland wayland-protocols ];
   checkInputs = [ python3 ];
 
   mesonFlags = [
     "-Dxkb-config-root=${xkeyboard_config}/etc/X11/xkb"
     "-Dxkb-config-extra-path=/etc/xkb" # default=$sysconfdir/xkb ($out/etc)
     "-Dx-locale-root=${libX11.out}/share/X11/locale"
-    "-Denable-wayland=false"
     "-Denable-xkbregistry=false" # Optional, separate library (TODO: Install into extra output)
+    "-Denable-wayland=${lib.boolToString withWaylandSupport}"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/libxkbcommon/fix-cross-compilation.patch
+++ b/pkgs/development/libraries/libxkbcommon/fix-cross-compilation.patch
@@ -1,0 +1,20 @@
+diff --git a/meson.build b/meson.build
+index 47c436f..536c60b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -440,13 +440,12 @@ if build_tools
+     if get_option('enable-wayland')
+         wayland_client_dep = dependency('wayland-client', version: '>=1.2.0', required: false)
+         wayland_protocols_dep = dependency('wayland-protocols', version: '>=1.12', required: false)
+-        wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
+-        if not wayland_client_dep.found() or not wayland_protocols_dep.found() or not wayland_scanner_dep.found()
++        if not wayland_client_dep.found() or not wayland_protocols_dep.found()
+             error('''The Wayland xkbcli programs require wayland-client >= 1.2.0, wayland-protocols >= 1.7 which were not found.
+ You can disable the Wayland xkbcli programs with -Denable-wayland=false.''')
+         endif
+ 
+-        wayland_scanner = find_program(wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'))
++        wayland_scanner = find_program('wayland-scanner', native: true)
+         wayland_scanner_code_gen = generator(
+             wayland_scanner,
+             output: '@BASENAME@-protocol.c',


### PR DESCRIPTION
This can be used to enable the optional "interactive-wayland" subcommand of xkbcli.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
