### PR TITLE
Fix ar command path in GHC

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.1.nix
+++ b/pkgs/development/compilers/ghc/8.10.1.nix
@@ -117,6 +117,12 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
   ];
 

--- a/pkgs/development/compilers/ghc/8.10.1.nix
+++ b/pkgs/development/compilers/ghc/8.10.1.nix
@@ -116,6 +116,10 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
+  patches = [
+    ./respect-ar-path.patch
+  ];
+
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.

--- a/pkgs/development/compilers/ghc/8.10.2.nix
+++ b/pkgs/development/compilers/ghc/8.10.2.nix
@@ -107,9 +107,16 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
-  # https://gitlab.haskell.org/ghc/ghc/-/issues/18549
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
+
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/18549
     ./issue-18549.patch
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release

--- a/pkgs/development/compilers/ghc/8.10.2.nix
+++ b/pkgs/development/compilers/ghc/8.10.2.nix
@@ -109,6 +109,7 @@ stdenv.mkDerivation (rec {
 
   # https://gitlab.haskell.org/ghc/ghc/-/issues/18549
   patches = [
+    ./respect-ar-path.patch
     ./issue-18549.patch
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release

--- a/pkgs/development/compilers/ghc/8.10.3.nix
+++ b/pkgs/development/compilers/ghc/8.10.3.nix
@@ -107,7 +107,9 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
-  patches = stdenv.lib.optionals stdenv.isDarwin [
+  patches = [
+    ./respect-ar-path.patch
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release
     (fetchpatch {
       url = "https://gitlab.haskell.org/ghc/ghc/-/commit/97d0b0a367e4c6a52a17c3299439ac7de129da24.patch";

--- a/pkgs/development/compilers/ghc/8.10.3.nix
+++ b/pkgs/development/compilers/ghc/8.10.3.nix
@@ -108,6 +108,12 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     # Make Block.h compile with c++ compilers. Remove with the next release

--- a/pkgs/development/compilers/ghc/8.6.5.nix
+++ b/pkgs/development/compilers/ghc/8.6.5.nix
@@ -110,7 +110,14 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
+
     (fetchpatch { # https://phabricator.haskell.org/D5123
      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/13ff0b7ced097286e0d7b054f050871effe07f86.diff";
      name = "D5123.diff";

--- a/pkgs/development/compilers/ghc/8.6.5.nix
+++ b/pkgs/development/compilers/ghc/8.6.5.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    ./respect-ar-path.patch
     (fetchpatch { # https://phabricator.haskell.org/D5123
      url = "https://gitlab.haskell.org/ghc/ghc/-/commit/13ff0b7ced097286e0d7b054f050871effe07f86.diff";
      name = "D5123.diff";

--- a/pkgs/development/compilers/ghc/8.8.2.nix
+++ b/pkgs/development/compilers/ghc/8.8.2.nix
@@ -111,6 +111,10 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
+  patches = [
+    ./respect-ar-path.patch
+  ];
+
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.

--- a/pkgs/development/compilers/ghc/8.8.2.nix
+++ b/pkgs/development/compilers/ghc/8.8.2.nix
@@ -112,6 +112,12 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
   ];
 

--- a/pkgs/development/compilers/ghc/8.8.3.nix
+++ b/pkgs/development/compilers/ghc/8.8.3.nix
@@ -117,6 +117,12 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
   ];
 

--- a/pkgs/development/compilers/ghc/8.8.3.nix
+++ b/pkgs/development/compilers/ghc/8.8.3.nix
@@ -116,6 +116,10 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
+  patches = [
+    ./respect-ar-path.patch
+  ];
+
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -117,6 +117,12 @@ stdenv.mkDerivation (rec {
   outputs = [ "out" "doc" ];
 
   patches = [
+    # See upstream patch at
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4885. Since we build
+    # from source distributions, the auto-generated configure script needs to be
+    # patched as well, therefore we use an in-tree patch instead of pulling the
+    # upstream patch. Don't forget to check backport status of the upstream patch
+    # when adding new GHC releases in nixpkgs.
     ./respect-ar-path.patch
   ];
 

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -116,6 +116,10 @@ stdenv.mkDerivation (rec {
 
   outputs = [ "out" "doc" ];
 
+  patches = [
+    ./respect-ar-path.patch
+  ];
+
   postPatch = "patchShebangs .";
 
   # GHC is a bit confused on its cross terminology.

--- a/pkgs/development/compilers/ghc/respect-ar-path.patch
+++ b/pkgs/development/compilers/ghc/respect-ar-path.patch
@@ -1,0 +1,25 @@
+diff -urd a/aclocal.m4 b/aclocal.m4
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1199,7 +1199,8 @@
+ # thinks that target == host so it never checks the unqualified
+ # tools for Windows. See #14274.
+ AC_DEFUN([FP_PROG_AR],
+-[if test -z "$fp_prog_ar"; then
++[AC_SUBST(fp_prog_ar,$AR)
++if test -z "$fp_prog_ar"; then
+   if test "$HostOS" = "mingw32"
+   then
+     AC_PATH_PROG([fp_prog_ar], [ar])
+diff -urd a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -10744,6 +10744,8 @@
+ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
+ 
+ 
++fp_prog_ar=$AR
++
+ if test -z "$fp_prog_ar"; then
+   if test "$HostOS" = "mingw32"
+   then


### PR DESCRIPTION
Previously, the "ar command" in the global config of GHC in nixpkgs is
simply "ar" instead of a proper absolute path in the nix store. This
will result in an "ar: command not found" error when using GHC and cabal
in a pure nix shell. This commit adds the patch and applies to all
pre-9.0 versions.

See output of ghc --info for "ar command" value.

The original patch comes from haskell.nix, see [here](https://github.com/input-output-hk/haskell.nix/blob/master/overlays/patches/ghc/respect-ar-path.patch). Hopefully this will be fixed in upstream 9.x releases.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
