### PR TITLE
nomad-driver-podman: init at 0.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/nomad-driver-podman/default.nix
+++ b/pkgs/applications/networking/cluster/nomad-driver-podman/default.nix
@@ -1,0 +1,28 @@
+{ lib , buildGoModule , fetchFromGitHub, procps, podman }:
+
+buildGoModule rec {
+  pname = "nomad-driver-podman";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1a2alapqm7wnkjm9cg0gvi63pkaila9lhsa5razv0vprhg1k84gy";
+  };
+
+  vendorSha256 = "1zs5y0zfi8dd9w371hpmah4iwxahgvaf70biqqdw3c9yp6yw2rwq";
+
+  subPackages = [ "." ];
+
+  # some tests require a running podman service
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://www.github.com/hashicorp/nomad-driver-podman";
+    description = "Podman task driver for Nomad";
+    platforms = platforms.unix;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/applications/networking/cluster/nomad-driver-podman/default.nix
+++ b/pkgs/applications/networking/cluster/nomad-driver-podman/default.nix
@@ -1,4 +1,4 @@
-{ lib , buildGoModule , fetchFromGitHub, procps, podman }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "nomad-driver-podman";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6448,6 +6448,8 @@ in
     nvidiaGpuSupport = config.cudaSupport or false;
   };
 
+  nomad-driver-podman = callPackage ../applications/networking/cluster/nomad-driver-podman { };
+
   notable = callPackage ../applications/misc/notable { };
 
   nvchecker = with python3Packages; toPythonApplication nvchecker;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Initialize the Nomad Podman driver at version 0.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
