### PR TITLE
linux-rt_5_4: 5.4.84-rt47 -> 5.4.93-rt51

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.4.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "5.4.84-rt47"; # updated by ./update-rt.sh
+  version = "5.4.93-rt51"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -14,14 +14,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "058mhczv6whjwxn7jjh1c6n5zrqjdnvbl2mp7jkfrg6frpvgr189";
+    sha256 = "08nmwd13z10866pc16fqbj41krnvk6hxkl4nmhdkpk346r04jx6k";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "0nccxf9l9ycvb782f48zrbl59vi674qq7yjyaks97440pgyd1jg0";
+      sha256 = "1ffipbnzv8rnmawjlglm667jq67asdr1mwrfhsmwkvlmivm9k4x1";
     };
   }; in [ rt-patch ] ++ lib.remove rt-patch kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/update-rt.sh
+++ b/pkgs/os-specific/linux/kernel/update-rt.sh
@@ -36,7 +36,8 @@ file-version() {
 latest-rt-version() {
     branch="$1" # e.g. 5.4
     curl -sL "$mirror/projects/rt/$branch/sha256sums.asc" |
-        sed -ne '/.patch.xz/ { s/.*patch-\(.*\).patch.xz/\1/; p; q }'
+        sed -ne '/.patch.xz/ { s/.*patch-\(.*\).patch.xz/\1/p}' |
+        tail -n 1
 }
 
 update-if-needed() {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update Linux kernel with RT patches from version 5.4.84 to 5.4.93.
Compiles and runs without any issues on my machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
