### PR TITLE
bundlerEnv: ignore bundler configuration file

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+++ b/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
@@ -34,6 +34,7 @@ paths.each do |path|
 ENV["BUNDLE_GEMFILE"] = #{gemfile.dump}
 ENV.delete 'BUNDLE_PATH'
 ENV['BUNDLE_FROZEN'] = '1'
+ENV['BUNDLE_IGNORE_CONFIG'] = '1'
 
 Gem.paths = { 'GEM_HOME' => #{bundle_path.dump} }
 


### PR DESCRIPTION
Change will make packaged ruby application ignore the user-wide bundle
configuration.

Fix #85989

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The presence of BUNDLE_PATH set via configuration file breaks some packaged ruby application such as solargraph, mailcatcher, metasploit. BUNDLE_PATH should be ignored as shown in #81612 and #81442

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
