### PR TITLE
nixos/tests/chromium: Simplify the logic

### DIFF
--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -51,7 +51,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
   testScript = let
     xdo = name: text: let
       xdoScript = pkgs.writeText "${name}.xdo" text;
-    in "${pkgs.xdotool}/bin/xdotool '${xdoScript}'";
+    in "${pkgs.xdotool}/bin/xdotool ${xdoScript}";
   in ''
     import shlex
     from contextlib import contextmanager, _GeneratorContextManager
@@ -76,96 +76,59 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
 
 
     def create_new_win():
+        """Creates a new Chromium window."""
         with machine.nested("Creating a new Chromium window"):
-            status, _ = machine.execute(
+            machine.wait_until_succeeds(
                 ru(
-                    "${xdo "new-window" ''
+                    "${xdo "create_new_win-select_main_window" ''
                       search --onlyvisible --name "startup done"
                       windowfocus --sync
                       windowactivate --sync
                     ''}"
                 )
             )
-            if status == 0:
-                machine.execute(
-                    ru(
-                        "${xdo "new-window" ''
-                          key Ctrl+n
-                        ''}"
-                    )
-                )
-
-
-    def close_win():
-        def try_close(_):
-            status, _ = machine.execute(
+            machine.send_key("ctrl-n")
+            # Wait until the new window appears:
+            machine.wait_until_succeeds(
                 ru(
-                    "${xdo "close-window" ''
-                      search --onlyvisible --name "new tab"
+                    "${xdo "create_new_win-wait_for_window" ''
+                      search --onlyvisible --name "New Tab"
                       windowfocus --sync
                       windowactivate --sync
                     ''}"
                 )
             )
-            if status == 0:
-                machine.execute(
-                    ru(
-                        "${xdo "close-window" ''
-                          key Ctrl+w
-                        ''}"
-                    )
-                )
-            for _ in range(1, 20):
-                status, _ = machine.execute(
-                    ru(
-                        "${xdo "wait-for-close" ''
-                          search --onlyvisible --name "new tab"
-                        ''}"
-                    )
-                )
-                if status != 0:
-                    return True
-                machine.sleep(1)
-                return False
-
-        retry(try_close)
 
 
-    def wait_for_new_win():
-        ret = False
-        with machine.nested("Waiting for new Chromium window to appear"):
-            for _ in range(1, 20):
-                status, _ = machine.execute(
-                    ru(
-                        "${xdo "wait-for-window" ''
-                          search --onlyvisible --name "new tab"
-                          windowfocus --sync
-                          windowactivate --sync
-                        ''}"
-                    )
-                )
-                if status == 0:
-                    ret = True
-                    machine.sleep(10)
-                    break
-                machine.sleep(1)
-        return ret
-
-
-    def create_and_wait_for_new_win():
-        for _ in range(1, 3):
-            create_new_win()
-            if wait_for_new_win():
-                return True
-        assert False, "new window did not appear within 60 seconds"
+    def close_new_tab_win():
+        """Closes the Chromium window with the title "New Tab"."""
+        machine.wait_until_succeeds(
+            ru(
+                "${xdo "close_new_tab_win-select_main_window" ''
+                  search --onlyvisible --name "New Tab"
+                  windowfocus --sync
+                  windowactivate --sync
+                ''}"
+            )
+        )
+        machine.send_key("ctrl-w")
+        # Wait until the closed window disappears:
+        machine.wait_until_fails(
+            ru(
+                "${xdo "close_new_tab_win-wait_for_close" ''
+                  search --onlyvisible --name "New Tab"
+                ''}"
+            )
+        )
 
 
     @contextmanager
     def test_new_win(description):
-        create_and_wait_for_new_win()
+        create_new_win()
         with machine.nested(description):
             yield
-        close_win()
+        # Close the newly created window:
+        machine.send_key("ctrl-w")
 
 
     machine.wait_for_x()
@@ -192,9 +155,11 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
         )
     )
 
-    create_and_wait_for_new_win()
+    create_new_win()
+    # Optional: Wait for the new tab page to fully load before taking the screenshot:
+    machine.wait_for_text("Web Store")
     machine.screenshot("empty_windows")
-    close_win()
+    close_new_tab_win()
 
     machine.screenshot("startup_done")
 
@@ -202,7 +167,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
         machine.succeed(
             ru(
                 "${xdo "type-url" ''
-                  search --sync --onlyvisible --name "new tab"
+                  search --sync --onlyvisible --name "New Tab"
                   windowfocus --sync
                   type --delay 1000 "chrome://sandbox"
                 ''}"
@@ -212,7 +177,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
         machine.succeed(
             ru(
                 "${xdo "submit-url" ''
-                  search --sync --onlyvisible --name "new tab"
+                  search --sync --onlyvisible --name "New Tab"
                   windowfocus --sync
                   key --delay 1000 Return
                 ''}"
@@ -224,7 +189,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
         machine.succeed(
             ru(
                 "${xdo "find-window" ''
-                  search --sync --onlyvisible --name "sandbox status"
+                  search --sync --onlyvisible --name "Sandbox Status"
                   windowfocus --sync
                 ''}"
             )
@@ -258,7 +223,7 @@ mapAttrs (channel: chromiumPkg: makeTest rec {
         machine.succeed(
             ru(
                 "${xdo "find-window-after-copy" ''
-                  search --onlyvisible --name "sandbox status"
+                  search --onlyvisible --name "Sandbox Status"
                 ''}"
             )
         )


### PR DESCRIPTION
- Improve the documentation (Python docstrings for functions and more
  meaningful xdotool script names).
- Make more use of the existing methods (e.g. wait_until_succeeds(), and
  send_key())
  - Note: This increases timeouts from 60 seconds to (currently)
    15 minutes but the defaults from test-driver.py should be fine.

This should make it simpler to read the code, understand the test
output, and drop the custom xdotool scripts in the future.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
