### PR TITLE
python3Packages.labgrid: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/labgrid/0001-serialdriver-remove-pyserial-version-check.patch
+++ b/pkgs/development/python-modules/labgrid/0001-serialdriver-remove-pyserial-version-check.patch
@@ -1,0 +1,33 @@
+From 75baa1751973378cb96fb204b0a18a74e5caa2d1 Mon Sep 17 00:00:00 2001
+From: Rouven Czerwinski <r.czerwinski@pengutronix.de>
+Date: Wed, 17 Feb 2021 14:03:20 +0100
+Subject: [PATCH] serialdriver: remove pyserial version check
+
+This check isn't required on NixOS, since pyserial within NixOS already
+contains the patches.
+
+Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
+---
+ labgrid/driver/serialdriver.py | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/labgrid/driver/serialdriver.py b/labgrid/driver/serialdriver.py
+index 126f674e..59a92269 100644
+--- a/labgrid/driver/serialdriver.py
++++ b/labgrid/driver/serialdriver.py
+@@ -27,12 +27,6 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
+         bindings = {"port": "SerialPort", }
+     else:
+         bindings = {"port": {"SerialPort", "NetworkSerialPort"}, }
+-    if version.parse(serial.__version__) != version.Version('3.4.0.1'):
+-        message = ("The installed pyserial version does not contain important RFC2217 fixes.\n"
+-                   "You can install the labgrid fork via:\n"
+-                   "pip uninstall pyserial\n"
+-                   "pip install https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial\n")  # pylint: disable=line-too-long
+-        warnings.warn(message)
+ 
+     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
+     timeout = attr.ib(default=3.0, validator=attr.validators.instance_of(float))
+-- 
+2.30.0
+

--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -1,0 +1,78 @@
+{ ansicolors
+, attrs
+, autobahn
+, buildPythonPackage
+, fetchFromGitHub
+, jinja2
+, lib
+, mock
+, pexpect
+, psutil
+, pyserial
+, pytestCheckHook
+, pytest-dependency
+, pytest-mock
+, pyudev
+, pyusb
+, pyyaml
+, requests
+, setuptools-scm
+, xmodem
+}:
+
+buildPythonPackage rec {
+  pname = "labgrid";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "labgrid-project";
+    repo = "labgrid";
+    rev = "v${version}";
+    sha256 = "15298prs2f4wiyn8lf475qicp3y22lcjdcpwp2fmrya642vnr6w5";
+  };
+
+  patches = [
+    ./0001-serialdriver-remove-pyserial-version-check.patch
+  ];
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    ansicolors
+    attrs
+    autobahn
+    jinja2
+    pexpect
+    pyserial
+    pyudev
+    pyusb
+    pyyaml
+    requests
+    xmodem
+  ];
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+  '';
+
+  checkInputs = [
+    mock
+    psutil
+    pytestCheckHook
+    pytest-mock
+    pytest-dependency
+  ];
+
+  disabledTests = [
+    "docker"
+    "sshmanager"
+  ];
+
+  meta = with lib; {
+    description = "Embedded control & testing library";
+    homepage = "https://labgrid.org";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ emantor ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3491,6 +3491,8 @@ in {
 
   labelbox = callPackage ../development/python-modules/labelbox { };
 
+  labgrid = callPackage ../development/python-modules/labgrid { };
+
   lammps-cython = callPackage ../development/python-modules/lammps-cython { mpi = pkgs.mpi; };
 
   langcodes = callPackage ../development/python-modules/langcodes { };


### PR DESCRIPTION
###### Motivation for this change
Labgrid is an embedded control and testing library, this package
packages the minimum to let the client and core-library work.

Labgrid also has a check for a specific pyserial port we maintain in the project.
Not sure how to deal with this and whether packaging the fork for nixos is fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
