### PR TITLE
python3Packages.geojson-client: init at 0.5

### DIFF
--- a/pkgs/development/python-modules/geojson-client/default.nix
+++ b/pkgs/development/python-modules/geojson-client/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, geojson
+, haversine
+, pytz
+, requests
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "geojson-client";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "exxamalte";
+    repo = "python-geojson-client";
+    rev = "v${version}";
+    sha256 = "1cc6ymbn45dv7xdl1r8bbizlmsdbxjmsfza442yxmmm19nxnnqjv";
+  };
+
+  propagatedBuildInputs = [
+    geojson
+    haversine
+    pytz
+    requests
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "geojson_client" ];
+
+  meta = with lib; {
+    description = "Python module for convenient access to GeoJSON feeds";
+    homepage = "https://github.com/exxamalte/python-geojson-client";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/haversine/default.nix
+++ b/pkgs/development/python-modules/haversine/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "haversine";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mapado";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1c3yf9162b2b7l1lsw3ffd1linnc542qvljpgwxp6y5arrmljqnv";
+  };
+
+  checkInputs = [
+    numpy
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "haversine" ];
+
+  meta = with lib; {
+    description = "Python module the distance between 2 points on earth";
+    homepage = "https://github.com/mapado/haversine";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -292,7 +292,7 @@
     "generic" = ps: with ps; [ ];
     "generic_thermostat" = ps: with ps; [ ];
     "geniushub" = ps: with ps; [ ]; # missing inputs: geniushub-client
-    "geo_json_events" = ps: with ps; [ ]; # missing inputs: geojson_client
+    "geo_json_events" = ps: with ps; [ geojson-client ];
     "geo_location" = ps: with ps; [ ];
     "geo_rss_events" = ps: with ps; [ ]; # missing inputs: georss_generic_client
     "geofency" = ps: with ps; [ aiohttp-cors ];
@@ -885,7 +885,7 @@
     "uptime" = ps: with ps; [ ];
     "uptimerobot" = ps: with ps; [ ]; # missing inputs: pyuptimerobot
     "uscis" = ps: with ps; [ ]; # missing inputs: uscisstatus
-    "usgs_earthquakes_feed" = ps: with ps; [ ]; # missing inputs: geojson_client
+    "usgs_earthquakes_feed" = ps: with ps; [ geojson-client ];
     "utility_meter" = ps: with ps; [ ];
     "uvc" = ps: with ps; [ uvcclient ];
     "vacuum" = ps: with ps; [ ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2859,6 +2859,8 @@ in {
 
   hatasmota = callPackage ../development/python-modules/hatasmota { };
 
+  haversine = callPackage ../development/python-modules/haversine { };
+
   hawkauthlib = callPackage ../development/python-modules/hawkauthlib { };
 
   hbmqtt = callPackage ../development/python-modules/hbmqtt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2502,6 +2502,8 @@ in {
 
   geojson = callPackage ../development/python-modules/geojson { };
 
+  geojson-client = callPackage ../development/python-modules/geojson-client { };
+
   geopandas = callPackage ../development/python-modules/geopandas { };
 
   geopy = if isPy3k then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python module for convenient access to GeoJSON feeds.

https://github.com/exxamalte/python-geojson-client

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
