### PR TITLE
spdlog: propagate fmt

### DIFF
--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -14,7 +14,8 @@ let
       };
 
       nativeBuildInputs = [ cmake ];
-      buildInputs = [ fmt ];
+      # spdlog <1.3 uses a bundled version of fmt
+      propagatedBuildInputs = lib.optional (lib.versionAtLeast version "1.3") fmt;
 
       cmakeFlags = [
         "-DSPDLOG_BUILD_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
@@ -25,7 +26,9 @@ let
         "-DSPDLOG_FMT_EXTERNAL=ON"
       ];
 
-      outputs = [ "out" "doc" ];
+      outputs = [ "out" "doc" ]
+        # spdlog <1.4 is header only, no need to split libraries and headers
+        ++ lib.optional (lib.versionAtLeast version "1.4") "dev";
 
       postInstall = ''
         mkdir -p $out/share/doc/spdlog


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`fmt` is needed by the headers and CMake config script, so it must always be available at build time for dependent packages. To prevent `fmt.dev` from needlessly becoming part of the runtime closure, a `dev` output was added to `spdlog`.

cc @obadz @drewrisinger @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
