### PR TITLE
Revert "webkitgtk: enable WPE_RENDERER"

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -51,8 +51,6 @@
 , xdg-dbus-proxy
 , substituteAll
 , glib
-, libwpe
-, libwpe-fdo
 }:
 
 assert enableGeoLocation -> geoclue2 != null;
@@ -122,8 +120,6 @@ stdenv.mkDerivation rec {
     libsecret
     libtasn1
     libwebp
-    libwpe
-    libwpe-fdo
     libxkbcommon
     libxml2
     libxslt
@@ -158,6 +154,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_INTROSPECTION=ON"
     "-DPORT=GTK"
     "-DUSE_LIBHYPHEN=OFF"
+    "-DUSE_WPE_RENDERER=OFF"
   ] ++ optionals stdenv.isDarwin [
     "-DENABLE_GRAPHICS_CONTEXT_3D=OFF"
     "-DENABLE_GTKDOC=OFF"


### PR DESCRIPTION
This reverts commit 132f7e6cfed4eaefe2aac9c867e5549b8e37591c.

This commit broke evolution & epiphany webkitgtk in some cases. See https://github.com/NixOS/nixpkgs/issues/110468. Unclear exactly what broke, but best to revert to be safe.