### PR TITLE
lowdown: fix dylib on darwin

### DIFF
--- a/pkgs/tools/typesetting/lowdown/default.nix
+++ b/pkgs/tools/typesetting/lowdown/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, which }:
+{ lib, stdenv, fetchurl, fixDarwinDylibNames, which }:
 
 stdenv.mkDerivation rec {
   pname = "lowdown";
@@ -11,13 +11,19 @@ stdenv.mkDerivation rec {
     sha512 = "18q8i8lh8w127vzw697n0bzv4mchhna1p4s672hjvy39l3ls8rlj5nwq5npr5fry06yil62sjmq4652vw29r8l49wwk5j82a8l2nr7c";
   };
 
-  nativeBuildInputs = [ which ];
+  nativeBuildInputs = [ which ]
+    ++ lib.optionals stdenv.isDarwin [ fixDarwinDylibNames ];
 
   configurePhase = ''
     ./configure PREFIX=''${!outputDev} \
                 BINDIR=''${!outputBin}/bin \
                 LIBDIR=''${!outputLib}/lib \
                 MANDIR=''${!outputMan}/share/man
+  '';
+
+  # Fix lib extension so that fixDarwinDylibNames detects it
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    mv $lib/lib/liblowdown.{so,dylib}
   '';
 
   patches = lib.optional (!stdenv.hostPlatform.isStatic) ./shared.patch;


### PR DESCRIPTION
Lowdown's dynamic library isn't set up properly on darwin, leading to downstream errors such as:

```
dyld: Library not loaded: liblowdown.so
  Referenced from: /nix/store/d3kin0fzkxkpd9i1fk9j338hb51zcf5q-nix-2.4pre20201205_a5d85d0/bin/nix
  Reason: image not found
```
(https://hydra.nixos.org/build/135748474/nixlog/1)

Previously we only built lowdown statically, so this wasn't an issue until https://github.com/NixOS/nixpkgs/pull/97070 (cc @Ericson2314)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
