### PR TITLE
obs-move-transition: 2.0.2 -> 2.3.0

### DIFF
--- a/pkgs/applications/video/obs-studio/obs-move-transition.nix
+++ b/pkgs/applications/video/obs-studio/obs-move-transition.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-move-transition";
-  version = "2.0.2";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "exeldro";
     repo = "obs-move-transition";
     rev = version;
-    sha256 = "0kr868lxlanq0y98f2hb70y92ac2nla8khsj879kjf3z6dqdpd66";
+    sha256 = "0cl6z3cvdjmbisvfcy281pcg6rhxmyfs31rwv7q4x39352rcs1nw";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     substituteInPlace move-source-filter.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
     substituteInPlace move-value-filter.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
     substituteInPlace move-transition.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
+    substituteInPlace audio-move.c --replace '<../UI/obs-frontend-api/obs-frontend-api.h>' '<obs-frontend-api.h>'
   '';
 
   # obs-studio expects the shared object to be located in bin/32bit or bin/64bit

--- a/pkgs/applications/video/obs-studio/rename-obs-move-transition-cmake.patch
+++ b/pkgs/applications/video/obs-studio/rename-obs-move-transition-cmake.patch
@@ -7,7 +7,7 @@ index d116619..a1366ce 100644
 +	cmake_policy(SET CMP0048 NEW)
 +endif (POLICY CMP0048)
 +
- project(move-transition VERSION 2.0.2)
+ project(move-transition VERSION 2.3.0)
  set(PROJECT_FULL_NAME "Move Transition")
  
 +include(FindLibobs.cmake)
@@ -17,9 +17,9 @@ index d116619..a1366ce 100644
 +	"${LIBOBS_INCLUDE_DIR}/../plugins/obs-transitions"
 +	"${LIBOBS_INCLUDE_DIR}/../UI/obs-frontend-api")
 +
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version.h)
+
  set(move-transition_HEADERS
- 	move-transition.h
- 	easing.h)
 @@ -34,4 +45,10 @@ target_link_libraries(move-transition
  	libobs)
  


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A new version of this package was released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
