### PR TITLE
xkcdpass: py2 -> py3, add manpage and run tests

### DIFF
--- a/pkgs/development/python-modules/xkcdpass/default.nix
+++ b/pkgs/development/python-modules/xkcdpass/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
+, pytestCheckHook
+, installShellFiles
 }:
 
 buildPythonPackage rec {
@@ -12,14 +14,21 @@ buildPythonPackage rec {
     sha256 = "0ghsjs5bxl996pap910q9s21nywb26mfpjd92rbfywbnj8f2k2cy";
   };
 
-  # No tests included
-  # https://github.com/redacted/XKCD-password-generator/issues/32
-  doCheck = false;
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "xkcdpass" ];
+
+  postInstall = ''
+    installManPage *.?
+    install -Dm444 -t $out/share/doc/${pname} README*
+  '';
 
   meta = with lib; {
-    homepage = "https://pypi.python.org/pypi/xkcdpass/";
     description = "Generate secure multiword passwords/passphrases, inspired by XKCD";
+    homepage = "https://pypi.python.org/pypi/xkcdpass/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ peterhoeg ];
   };
-
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3783,7 +3783,7 @@ in
 
   wsl-open = callPackage ../tools/misc/wsl-open { };
 
-  xkcdpass = with pythonPackages; toPythonApplication xkcdpass;
+  xkcdpass = with python3Packages; toPythonApplication xkcdpass;
 
   xob = callPackage ../tools/X11/xob { };
 


### PR DESCRIPTION
###### Motivation for this change

Drive-by cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
