### PR TITLE
py-sonic: 0.7.7 -> 0.7.8

### DIFF
--- a/pkgs/development/python-modules/py-sonic/default.nix
+++ b/pkgs/development/python-modules/py-sonic/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "py-sonic";
-  version = "0.7.7";
+  version = "0.7.8";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4cea42a2b0dc2ed0fd8568d6bf0509cfa2675a8b1c347ce9364a00881ebc0272";
+    sha256 = "1nfpiry1jlgcyxcs5zamyfxwdvdiwg4yw0v8jysfc74hm362rg7d";
   };
 
   # package has no tests


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update package to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
