### PR TITLE
spglib: init at 1.16.0

### DIFF
--- a/pkgs/development/libraries/spglib/default.nix
+++ b/pkgs/development/libraries/spglib/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, cmake } :
+
+stdenv.mkDerivation rec {
+  pname = "spglib";
+  version = "1.16.0";
+
+  src = fetchFromGitHub {
+    owner = "atztogo";
+    repo = "spglib";
+    rev = "v${version}";
+    sha256 = "1kzc956m1pnazhz52vspqridlw72wd8x5l3dsilpdxl491aa2nws";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  checkTarget = "check";
+  doCheck = true;
+
+  meta = with lib; {
+    description = "C library for finding and handling crystal symmetries";
+    homepage = "https://atztogo.github.io/spglib/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7854,6 +7854,8 @@ in
 
   soapui = callPackage ../applications/networking/soapui { };
 
+  spglib = callPackage ../development/libraries/spglib { };
+
   ssh-askpass-fullscreen = callPackage ../tools/networking/ssh-askpass-fullscreen { };
 
   sshguard = callPackage ../tools/security/sshguard {};


### PR DESCRIPTION
###### Motivation for this change
Small C library for finding and handling crystal symmetries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
