### PR TITLE
nixos/shells-pkgs: added environment.shellPkgs option

### DIFF
--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -36,6 +36,7 @@
  <xi:include href="r.section.xml" />
  <xi:include href="ruby.section.xml" />
  <xi:include href="rust.section.xml" />
+ <xi:include href="shell.section.xml" />
  <xi:include href="texlive.section.xml" />
  <xi:include href="titanium.section.xml" />
  <xi:include href="vim.section.xml" />

--- a/doc/languages-frameworks/shell.section.md
+++ b/doc/languages-frameworks/shell.section.md
@@ -8,4 +8,6 @@ Those need to have extra outputs called `${shell}_${phase}` where:
 * * `loginShellInit` if the code is meant to be included in the login shell initialization.
 * * `promptInit` if the codeis needed to initialize the shell prompt.
 
+Then you need to put the script to be sourced in such output (not a subdirectory).
+
 Then, nixos users can add those packages to their shell initialization by adding them to `environment.shellPkgs` option.

--- a/doc/languages-frameworks/shell.section.md
+++ b/doc/languages-frameworks/shell.section.md
@@ -1,0 +1,11 @@
+# Shell Packages
+Many packages provide some shell script that gives extra functionality if `source`d from the shell.
+Those need to have extra outputs called `${shell}_${phase}` where:
+* shell refers to the specific shell it needs to be included (either bash, fish or zsh).
+* phase refers to when the file will be sourced, this can be one of:
+* * `interactiveShellInit`,if it needs to be included in the interactive shell initialization
+* * `shellInit` if the code needs to be included in the normal shell initiaalization
+* * `loginShellInit` if the code is meant to be included in the login shell initialization.
+* * `promptInit` if the codeis needed to initialize the shell prompt.
+
+Then, nixos users can add those packages to their shell initialization by adding them to `environment.shellPkgs` option.

--- a/nixos/modules/config/shells-pkgs.nix
+++ b/nixos/modules/config/shells-pkgs.nix
@@ -1,43 +1,92 @@
 { config, pkgs, lib, ... }:
 with lib;
 let
-  cfg = config.environment.shellPkgs;
   lsMod = m: with types; listOf submodule m;
-  nvp = attrsets.nameValuePair;
+  inherit (attrsets) nameValuePair mapAttrs;
+  attrFIelds = mapAttrs (n: v: n);
+  inherit (builtins) filter;
   phases = [ "shellInit" "promptInit" "loginShellInit" "interactiveShellInit" ];
   shells = [ "bash" "fish" "zsh" ];
 
-  shModule = sh: phase:
+  sh_phaseModule = sh: phase:
     let
       phase_sh = phase + "_" + sh;
       getPlugin = attrset.attrByPath [ phase_sh ] null;
       plugins = builtins.filter (p: null != (getPlugin p)) cfg;
-    in {
-      options.environment.shellPkgs = mkOption {
-        type = lsMod {
-          options = nvp phase_sh (mkOption {
-            type = with types; nullOr path;
-            default = null;
-            description = ''
-              Path to a script that will be added to ${sh}.${phase}.
-            '';
-          });
+    in
+      {
+        options = {
+          environment.shellPkgs = mkOption {
+            type = lsMod {
+              options = nameValuePair phase_sh (
+                mkOption {
+                  type = with types; nullOr path;
+                  default = null;
+                  description = ''
+                    Path to a script that will be added to ${sh}.${phase}.
+                  '';
+                }
+              );
+            };
+          };
+          programs."${sh}".shellPkgs = mkOption {
+            type = lsMod {
+              options = nameValuePair phase_sh (
+                mkOption {
+                  type = with types; nullOr path;
+                  default = null;
+                  description = ''
+                    Path to a script that will be added to ${sh}.${phase}.
+                  '';
+                }
+              );
+            };
+          };
         };
-      };
 
-      config.programs = nvp sh (nvp phase (mkMerge (map (p: "source '${getPlugin p}'\n") plugins)));
+        config.programs."${sh}" = mkMerge [
+          {
+            shellPkgs = filter (p: p?"${phase_sh}") config.environment.shellPkgs;
+          }
+        ] ++ (
+          map
+            (p: nameValuePair phase "source ${p."${phase_sh}"}")
+            config.programs."${sh}".shellPkgs
+        );
+      };
+  shModule = sh: let
+    phases_sh = map (phase: phase + "_" + sh) phases;
+  in
+    {
+      imports = map (sh_phaseModule sh) phases;
+      options.programs."${sh}".shellPkgs = mkOption {
+        default = [];
+        description = ''
+          A list of packages that will be added to the various phases of ${sh}.
+        '';
+        type =
+          lsMod { freeformType = with types; oneOf [ package (submodule {}) ]; };
+      };
+      config.assertions = map (
+        p: {
+          assertion =
+            (lists.intersect phases_sh (attrFields config.programs."${sh}".shellPkgs)) != [];
+          message = ''
+            ${toString p} must have at least one of ${strings.concatStringSep " , " phases_sh} attribute
+          '';
+        }
+      );
     };
 
-in {
-  imports = lists.concatMap
-    (f: map f phases)
-    (map shModule shells);
+in
+{
+  imports = map shModule shells;
   options.environment.shellPkgs = mkOption {
-    default = [ ];
+    default = [];
     description = ''
       A list of packages that will be added to the various phases of various shells.
     '';
     type =
-      lsMod { freeformType = with types; oneOf [ package (submodule { }) ]; };
+      lsMod { freeformType = with types; oneOf [ package (submodule {}) ]; };
   };
 }

--- a/nixos/modules/config/shells-pkgs.nix
+++ b/nixos/modules/config/shells-pkgs.nix
@@ -1,0 +1,43 @@
+{ config, pkgs, lib, ... }:
+with lib;
+let
+  cfg = config.environment.shellPkgs;
+  lsMod = m: with types; listOf submodule m;
+  nvp = attrsets.nameValuePair;
+  phases = [ "shellInit" "promptInit" "loginShellInit" "interactiveShellInit" ];
+  shells = [ "bash" "fish" "zsh" ];
+
+  shModule = sh: phase:
+    let
+      phase_sh = phase + "_" + sh;
+      getPlugin = attrset.attrByPath [ phase_sh ] null;
+      plugins = builtins.filter (p: null != (getPlugin p)) cfg;
+    in {
+      options.environment.shellPkgs = mkOption {
+        type = lsMod {
+          options = nvp phase_sh (mkOption {
+            type = with types; nullOr path;
+            default = null;
+            description = ''
+              Path to a script that will be added to ${sh}.${phase}.
+            '';
+          });
+        };
+      };
+
+      config.programs = nvp sh (nvp phase (mkMerge (map (p: "source '${getPlugin p}'\n") plugins)));
+    };
+
+in {
+  imports = lists.concatMap
+    (f: map f phases)
+    (map shModule shells);
+  options.environment.shellPkgs = mkOption {
+    default = [ ];
+    description = ''
+      A list of packages that will be added to the various phases of various shells.
+    '';
+    type =
+      lsMod { freeformType = with types; oneOf [ package (submodule { }) ]; };
+  };
+}

--- a/nixos/modules/config/shells-pkgs.nix
+++ b/nixos/modules/config/shells-pkgs.nix
@@ -1,92 +1,93 @@
 { config, pkgs, lib, ... }:
-with lib;
 let
-  lsMod = m: with types; listOf submodule m;
-  inherit (attrsets) nameValuePair mapAttrs;
-  attrFIelds = mapAttrs (n: v: n);
+  cfg = config.environment.shellPkgs;
+  cfgSh = sh: config.programs."${sh}".shellPkgs;
   inherit (builtins) filter;
-  phases = [ "shellInit" "promptInit" "loginShellInit" "interactiveShellInit" ];
-  shells = [ "bash" "fish" "zsh" ];
+  inherit (lib) types mkOption;
+  lsMod = m: with types; listOf submodule m;
+  shPkgBaseType = lsMod { freeformType = with types; oneOf [ package (submodule { }) ]; };
+  assertOutputsArePresent = outputNames: map (p: {
+    assertion = lib.lists.any (x: (p."${x}" or null) != null) outputNames;
+    message = ''
+      ${p.pname or p.name or (builtins.toJSON p)} must have at least one of ${strings.concatStringSep " , " outputNames} outputs.
+    '';
+  });
 
-  sh_phaseModule = sh: phase:
+
+  modByShAndPhase = sh: phase:
     let
       outputName = phase + "_" + sh;
-      getPlugin = attrset.attrByPath [ outputName ] null;
-      plugins = builtins.filter (p: null != (getPlugin p)) cfg;
-    in
-      {
-        options = {
-          environment.shellPkgs = mkOption {
-            type = lsMod {
-              options = nameValuePair outputName (
-                mkOption {
-                  type = with types; nullOr path;
-                  default = null;
-                  description = ''
-                    Path to a script that will be added to ${sh}.${phase}.
-                  '';
-                }
-              );
-            };
-          };
-          programs."${sh}".shellPkgs = mkOption {
-            type = lsMod {
-              options = nameValuePair outputName (
-                mkOption {
-                  type = with types; nullOr path;
-                  default = null;
-                  description = ''
-                    Path to a script that will be added to ${sh}.${phase}.
-                  '';
-                }
-              );
-            };
+      o.shellPkgs = mkOption {
+        type = lsMod {
+          options."${outputName}" = mkOption {
+            type = with types; nullOr path;
+            default = null;
+            description = ''
+              Path to a script that will be added to programs.${sh}.${phase}.
+            '';
           };
         };
-
-        config.programs."${sh}" = mkMerge [
-          {
-            shellPkgs = filter (p: null != p."${outputName}") config.environment.shellPkgs;
-          }
-        ] ++ (
-          map
-            (p: nameValuePair phase "source ${p."${outputName}"}")
-            config.programs."${sh}".shellPkgs
-        );
       };
-  shModule = sh: let
-    outputNames = map (phase: phase + "_" + sh) phases;
-  in
+      sourced = pkgs.runCommand outputName
+        {
+          files = map (p: p."${outputName}") (cfgSh sh);
+        } "cat $files > $out";
+    in
     {
-      imports = map (sh_phaseModule sh) phases;
+      options = {
+        environment = o;
+        programs."${sh}" = o;
+      };
+      config.environment.shellPkgsOutputs = [ outputName ];
+      config.programs."${sh}" = {
+        shellPkgs = filter (p: null != (p."${outputName}"or null)) cfg;
+        "${phase}" = "source ${sourced}";
+      };
+    };
+
+
+  modByPhasesAndSh = phases: sh:
+    let
+      outputNames = map (phase: phase + "_" + sh) phases;
+    in
+    {
+      imports = map (modByShAndPhase sh) phases;
       options.programs."${sh}".shellPkgs = mkOption {
-        default = [];
+        default = [ ];
         description = ''
           A list of packages that will be added to the various phases of ${sh}.
         '';
-        type =
-          lsMod { freeformType = with types; oneOf [ package (submodule {}) ]; };
+        type = shPkgBaseType // {
+          description = "A list of packages with outputs for the phases of ${sh}.";
+        };
       };
-      config.assertions = map (
-        p: {
-          assertion =
-            (lists.intersect outputNames (filter (f: null != (p."${f}"or null)) (attrFields p))) != [];
-          message = ''
-            ${toString p} must have at least one of ${strings.concatStringSep " , " outputNames} outputs.
-          '';
-        }
-      ) config.programs."${sh}".shellPkgs;
+      config.assertions = assertOutputsArePresent outputNames (cfgSh sh);
     };
 
 in
+
 {
-  imports = map shModule shells;
-  options.environment.shellPkgs = mkOption {
-    default = [];
-    description = ''
-      A list of packages that will be added to the various phases of various shells.
-    '';
-    type =
-      lsMod { freeformType = with types; oneOf [ package (submodule {}) ]; };
+  imports =
+    map (modByPhasesAndSh [ "shellInit" "promptInit" "loginShellInit" "interactiveShellInit" ])
+      [ "bash" "fish" "zsh" ];
+
+  options.environment = {
+    shellPkgs = mkOption {
+      default = [ ];
+      description = ''
+        A list of packages that will be added to the various phases of various shells.
+      '';
+      type = shPkgBaseType // {
+        description = "A list of packages with outputs for the phases of various shells.";
+      };
+    };
+
+    shellPkgsOutputs = mkOption {
+      internal = true;
+      type = with types; listOf string;
+      description = "A list of build outputs taken in consideration for environment.shellPkgs";
+    };
   };
+
+  config.assertions = assertOutputsArePresent config.environment.shellPkgsOutputs cfg;
 }

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -29,6 +29,7 @@
   ./config/qt5.nix
   ./config/resolvconf.nix
   ./config/shells-environment.nix
+  ./config/shells-pkgs.nix
   ./config/swap.nix
   ./config/sysctl.nix
   ./config/system-environment.nix

--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -27,14 +27,17 @@ in
             The default value is `fuck`, but you can use anything else as well.
           '';
         };
+        recursive = mkEnableOption "recursively applying rules untilthe command runs";
+        noConfirm = mkEnableOption "applying rules automatically, without any user confirmation";
+        instantMode = mkEnableOption ''
+          the experimental instant mode, that reduces evaluation times by logging shell output
+          instead of re-running the command itself
+        '';
       };
     };
 
     config = mkIf cfg.enable {
       environment.systemPackages = with pkgs; [ thefuck ];
-
-      programs.bash.interactiveShellInit = bashAndZshInitScript;
-      programs.zsh.interactiveShellInit = mkIf prg.zsh.enable bashAndZshInitScript;
-      programs.fish.interactiveShellInit = mkIf prg.fish.enable fishInitScript;
+      environment.shellPkgs = [(pkgs.thefuck.mkShellPkg cfg)];
     };
   }

--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -27,7 +27,7 @@ in
             The default value is `fuck`, but you can use anything else as well.
           '';
         };
-        recursive = mkEnableOption "recursively applying rules untilthe command runs";
+        recursive = mkEnableOption "recursively applying rules until the command runs";
         noConfirm = mkEnableOption "applying rules automatically, without any user confirmation";
         instantMode = mkEnableOption ''
           the experimental instant mode, that reduces evaluation times by logging shell output

--- a/pkgs/applications/misc/navi/default.nix
+++ b/pkgs/applications/misc/navi/default.nix
@@ -20,13 +20,18 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     wrapProgram $out/bin/navi \
       --prefix PATH : "$out/bin" \
-      --prefix PATH : ${lib.makeBinPath([ wget ] ++ lib.optionals withFzf [ fzf ])}
+      --prefix PATH : ${lib.makeBinPath([ wget ] ++ lib.optionals withFzf [ fzf ])} \
+      --prefix PATH : ${lib.makeBinPath [ fzf wget ]}
+    ${lib.concatMapStrings (sh:"$out/bin/navi widget ${sh} > $interactiveShellInit_${sh};") shells}
   '';
+
+  shells = [ "bash" "fish" "zsh" ];
+  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}") shells);
 
   checkFlags = [
     # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
     "--skip=test_parse_variable_line"
-   ];
+  ];
 
   meta = with lib; {
     description = "An interactive cheatsheet tool for the command-line and application launchers";

--- a/pkgs/shells/zsh/fzf-zsh/default.nix
+++ b/pkgs/shells/zsh/fzf-zsh/default.nix
@@ -24,8 +24,11 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
+  outputs = [ "out" "interactiveShellInit_zsh"];
+
   installPhase = ''
     install -Dm0644 fzf-zsh.plugin.zsh $out/share/zsh/plugins/fzf-zsh/fzf-zsh.plugin.zsh
+    install -Dm0644 fzf-zsh.plugin.zsh $interactiveShellInit_zsh
   '';
 
   meta = with lib; {

--- a/pkgs/shells/zsh/zsh-bd/default.nix
+++ b/pkgs/shells/zsh/zsh-bd/default.nix
@@ -14,11 +14,14 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   dontBuild = true;
 
+  outputs = [ "out" "interactiveShellInit_zsh" ];
+
   installPhase = ''
     mkdir -p $out/share/zsh-bd
     cp {.,$out/share/zsh-bd}/bd.zsh
     cd $out/share/zsh-bd
     ln -s bd{,.plugin}.zsh
+    cp bd.plugin.zsh $interactiveShellInit_zsh
   '';
 
   meta = {

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, substituteAll, pkgs, bash }:
 
 # To make use of this derivation, use
-# `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/powerlevel10k.zsh-theme";`
+# `environment.shellPkgs =[pkgs.powerlevel10k];`
 
 let
   # match gitstatus version with given `gitstatus_version`:
@@ -38,11 +38,15 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "promptInit_zsh" ];
+
   installPhase = ''
     install -D powerlevel10k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
     install -D config/* --target-directory=$out/share/zsh-powerlevel10k/config
     install -D internal/* --target-directory=$out/share/zsh-powerlevel10k/internal
     cp -R gitstatus $out/share/zsh-powerlevel10k/gitstatus
+
+    cp $out/share/zsh-powerlevel10k/powerlevel10k.zsh-theme $promptInit_zsh
   '';
 
   meta = {

--- a/pkgs/tools/misc/atuin/default.nix
+++ b/pkgs/tools/misc/atuin/default.nix
@@ -25,12 +25,14 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security SystemConfiguration ];
 
+  outputs = [ "out" ] ++ (map (sh: "interactiveShellInit_${sh}") shells);
+  shells = [ "bash" "zsh" "fish" ];
   postInstall = ''
     installShellCompletion --cmd atuin \
-      --bash <($out/bin/atuin gen-completions -s bash) \
-      --fish <($out/bin/atuin gen-completions -s fish) \
-      --zsh <($out/bin/atuin gen-completions -s zsh)
-  '';
+      ${lib.concatMapStrings (sh: " --${sh} <$($out/bin/autin gen-completions -s ${sh})")}
+  '' + lib.concatMapStrings
+    (sh: "$out/bin/atuin init ${sh} > $interactiveShellInit_${sh};")
+    shells;
 
   meta = with lib; {
     description = "Replacement for a shell history which records additional commands context with optional encrypted synchronization between machines";

--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -21,7 +21,11 @@ stdenv.mkDerivation rec {
     install -Dt "$out/share/bash-completion/completions/" -m444 "$out/share/autojump/autojump.bash"
     install -Dt "$out/share/fish/vendor_conf.d/" -m444 "$out/share/autojump/autojump.fish"
     install -Dt "$out/share/zsh/site-functions/" -m444 "$out/share/autojump/autojump.zsh"
+    ${lib.concatMapStrings (sh:"install -m444 $out/share/autojump/autojump.${sh} $interactiveShellInit_${sh};") shells}
   '';
+
+  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}")shells);
+  shells = [ "bash" "fish" "zsh" ];
 
   meta = with lib; {
     description = "A `cd' command that learns";

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
         ${lib.concatMapStrings
     (
         sh: ''
-          $out/bin/direnv hook ${sh} > $${sh}_interactiveShellInit
+          $out/bin/direnv hook ${sh} > ''$${sh}_interactiveShellInit
         ''
       )
     shells}

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
     make BASH_PATH=$BASH_PATH
   '';
 
-  outputs = [ "out" ] ++ map (sh: "${sh}_interactiveShellInit");
+  outputs = [ "out" ] ++ map (sh: "interactiveShellInit_${sh}");
   shells = [ "bash" "fish" "zsh" ];
 
   installPhase = ''
@@ -30,7 +30,7 @@ buildGoModule rec {
         ${lib.concatMapStrings
     (
         sh: ''
-          $out/bin/direnv hook ${sh} > ''$${sh}_interactiveShellInit
+          $out/bin/direnv hook ${sh} > ''$interactiveShellInit_${sh}
         ''
       )
     shells}

--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchFromGitHub, buildGoModule, bash, fish, zsh }:
-
 buildGoModule rec {
   pname = "direnv";
   version = "2.31.0";
@@ -16,15 +15,25 @@ buildGoModule rec {
   # we have no bash at the moment for windows
   BASH_PATH =
     lib.optionalString (!stdenv.hostPlatform.isWindows)
-    "${bash}/bin/bash";
+      "${bash}/bin/bash";
 
   # replace the build phase to use the GNUMakefile instead
   buildPhase = ''
     make BASH_PATH=$BASH_PATH
   '';
 
+  outputs = [ "out" ] ++ map (sh: "${sh}_interactiveShellInit");
+  shells = [ "bash" "fish" "zsh" ];
+
   installPhase = ''
-    make install PREFIX=$out
+        make install PREFIX=$out
+        ${lib.concatMapStrings
+    (
+        sh: ''
+          $out/bin/direnv hook ${sh} > $${sh}_interactiveShellInit
+        ''
+      )
+    shells}
   '';
 
   checkInputs = [ fish zsh ];

--- a/pkgs/tools/misc/mcfly/default.nix
+++ b/pkgs/tools/misc/mcfly/default.nix
@@ -18,6 +18,9 @@ rustPlatform.buildRustPackage rec {
   '';
 
   cargoSha256 = "sha256-2SKgzVJdtzH9poHx/NJba6+lj/C0PBcEgI/2ITO18Bk=";
+  shells = [ "bash" "fish" "zsh" ];
+  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}") shells);
+  postInstall = lib.concatMapStrings (sh:"$out/bin/mcfly init ${sh} > $interactiveShellInit_${sh};") shells;
 
   meta = with lib; {
     homepage = "https://github.com/cantino/mcfly";

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -13,6 +13,10 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
+  shells = ["bash" "fish" "zsh"];
+  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}") shells);
+  postInstall = lib.concatMapStrings (sh:"$out/bin/pazi init ${sh} > $interactiveShellInit_${sh};") shells;
+
   cargoSha256 = "1iamlp5519h8mmgd4964cvyp7mmnqdg2d3qj5v7yzilyp4nz15jc";
 
   meta = with lib; {

--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -9,7 +9,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0yvjzmz2vqc63l8911jflqf5aww7wxsav2yal5wg9ci9hzq6dl7j";
   };
 
-  outputs = [ "out" "vim" ];
+  shells = [ "bash" "fish" "zsh" ];
+  outputs = [ "out" "vim" ] ++ (map (sh:"interactiveShellInit_${sh}") shells);
 
   cargoSha256 = "1jk2vcm2z6r1xd6md98jzpcy7kdwp5p2fzxvvaz9qscyfnx28x17";
 
@@ -30,6 +31,21 @@ rustPlatform.buildRustPackage rec {
     echo $out/share/skim
     SCRIPT
     chmod +x $out/bin/sk-share
+
+    (
+      echo 'if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then'
+      cat $out/share/skim/{completion,key-bindings}.bash
+      echo fi
+    ) > $interactiveShellInit_bash
+    (
+      echo 'if [[ $options[zle] = on ]]; then'
+      cat $out/share/skim/{completion,key-bindings}.zsh
+      echo fi
+    ) > $interactiveShellInit_zsh
+    (
+      cat $out/share/skim/key-bindings.fish
+      echo skim_key_bindings
+    ) > $interactiveShellInit_fish
   '';
 
   # https://github.com/lotabout/skim/issues/440

--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
       echo 'if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then'
       $out/bin/starship init ${sh}
       echo fi
-    ) > $interactiveShellInit_${sh}
+    ) > $promptInit_${sh}
 
   '') shells;
 

--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = if stdenv.isDarwin then [ "battery" ] else [ "default" ];
 
   shells = ["bash" "fish" "zsh"];
-  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}") shells);
+  outputs = ["out"] ++ (map (sh:"promptInit_${sh}") shells);
   postInstall = lib.concatMapStrings (sh: ''
   
     STARSHIP_CACHE=$TMPDIR $out/bin/starship completions ${sh} > starship.${sh}

--- a/pkgs/tools/misc/z-lua/default.nix
+++ b/pkgs/tools/misc/z-lua/default.nix
@@ -24,9 +24,13 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/z.lua --set LUA_CPATH "${lua52Packages.luafilesystem}/lib/lua/5.2/lfs.so" --set _ZL_USE_LFS 1;
     # Create symlink for backwards compatibility. See: https://github.com/NixOS/nixpkgs/pull/96081
     ln -s $out/bin/z.lua $out/bin/z
+    ${lib.concatMapStrings (sh:"$out/bin/z --init ${sh} > $interactiveShellInit_${sh};") shells}
 
     runHook postInstall
   '';
+
+  shells = ["bash" "fish" "zsh"];
+  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}"));
 
   meta = with lib; {
     homepage = "https://github.com/skywind3000/z.lua";

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
       --bash contrib/completions/zoxide.bash \
       --fish contrib/completions/zoxide.fish \
       --zsh contrib/completions/_zoxide
-    ${lib.concatMapStrings (sh:"$out/bin/zoxide init ${sh} > $interactiveShellInit_${sh};")}
+    ${lib.concatMapStrings (sh:"$out/bin/zoxide init ${sh} > $interactiveShellInit_${sh};") shells}
   '';
   shells = ["bash" "fish" "zsh"];
   outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}") shells);

--- a/pkgs/tools/misc/zoxide/default.nix
+++ b/pkgs/tools/misc/zoxide/default.nix
@@ -36,7 +36,10 @@ rustPlatform.buildRustPackage rec {
       --bash contrib/completions/zoxide.bash \
       --fish contrib/completions/zoxide.fish \
       --zsh contrib/completions/_zoxide
+    ${lib.concatMapStrings (sh:"$out/bin/zoxide init ${sh} > $interactiveShellInit_${sh};")}
   '';
+  shells = ["bash" "fish" "zsh"];
+  outputs = ["out"] ++ (map (sh:"interactiveShellInit_${sh}") shells);
 
   meta = with lib; {
     description = "A fast cd command that learns your habits";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Nowadays nixpkgs contains several packages containing snippets to be added to shells initializations, however those snippets are often in disparate places and need to read the package before knowing the specific path to be sourced.

This option allow for a programmatic addition of shell snippets, as simply as `environment.sessionPackages`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
