### PR TITLE
poly2tri-c: move away from untrusted repo to one that is owned by its Nixpkgs maintainer

### DIFF
--- a/pkgs/development/libraries/poly2tri-c/default.nix
+++ b/pkgs/development/libraries/poly2tri-c/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchFromGitHub
+, fetchFromGitLab
 , autoreconfHook
 , pkg-config
 , glib
@@ -11,9 +11,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "out" "dev" ];
 
-  src = fetchFromGitHub {
-    owner = "Mattey40";
-    repo = "poly2tri-c";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jtojnar";
+    repo = pname;
     rev = "p2tc-${version}";
     sha256 = "158vm3wqfxs22b74kqc4prlvjny38qqm3kz5wrgasmx0qciwh0g8";
   };


### PR DESCRIPTION

###### Motivation for this change

poly2tri-c hasn't been under development for a long time. Using unrelated Google code exports on Github is suboptimal but not easy to avoid. But as @jtojnar, the maintainer of the package also owns a fork on gitlab.gnome.org, I'd vouch to use this as source.

See also:
https://gitlab.gnome.org/GNOME/gegl/-/issues/214#note_1002908
https://github.com/NixOS/nixpkgs/pull/109812


###### Things done

I tested that the src hash still matches and doesn't need to be altered.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
