### PR TITLE
nixos/uwsgi: set up the default runtime directory 

### DIFF
--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -209,6 +209,7 @@ in {
         KillSignal = "SIGQUIT";
         AmbientCapabilities = cfg.capabilities;
         CapabilityBoundingSet = cfg.capabilities;
+        RuntimeDirectory = mkIf (cfg.runDir == "/run/uwsgi") "uwsgi";
       };
     };
 

--- a/nixos/tests/searx.nix
+++ b/nixos/tests/searx.nix
@@ -81,8 +81,9 @@ import ./make-test-python.nix ({ pkgs, ...} :
           base.wait_for_unit("searx-init")
           base.wait_for_file("/run/searx/settings.yml")
           output = base.succeed(
-              "${pkgs.yq-go}/bin/yq r /run/searx/settings.yml"
-              " 'engines.(name==startpage).shortcut'"
+              "${pkgs.yq-go}/bin/yq eval"
+              " '.engines[] | select(.name==\"startpage\") | .shortcut'"
+              " /run/searx/settings.yml"
           ).strip()
           assert output == "start", "Settings not merged"
 


### PR DESCRIPTION
###### Motivation for this change
Fix issue #110691

###### Things done

- [x] Tested via
  - [x] `nixosTests.uwsgi`
  - [x] `nixosTests.searx`
  - [x] `nixosTests.ihatemoney`
  - [x] running this command and checking the directory with `stat`:

        nix-build -E '(import ./nixos { configuration = { config, pkgs, ... }: { 
            services.uwsgi = {
            enable = true;
            plugins = [ "python3" ];
            instance = {
              type = "emperor";
              vassals = {
                foobar = {
                  type = "normal";
                  socket = "${config.services.uwsgi.runDir}/foobar.sock";
                };
              };
            };
          };
          users.users.root.password = "";
          }; }).vm'

- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
