### PR TITLE
zz: install modules shipped with compiler

### DIFF
--- a/pkgs/development/compilers/zz/default.nix
+++ b/pkgs/development/compilers/zz/default.nix
@@ -5,7 +5,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.1";
 
   src = fetchFromGitHub {
-    owner = "aep";
+    owner = "zetzit";
     repo = "zz";
     rev = version;
     sha256 = "0kqrfm2r9wn0p2c3lcprsy03p9qhrwjs990va8qi59jp704l84ad";
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "🍺🐙 ZetZ a zymbolic verifier and tranzpiler to bare metal C";
-    homepage = "https://github.com/aep/zz";
+    homepage = "https://github.com/zetzit/zz";
     license = licenses.mit;
     maintainers = [ maintainers.marsam ];
   };

--- a/pkgs/development/compilers/zz/default.nix
+++ b/pkgs/development/compilers/zz/default.nix
@@ -15,8 +15,18 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0yllcqxyyhwr9h0z8q84l0ms8x6jrqhpg79ik4xng6h5yf4ab0pq";
 
+  postPatch = ''
+    # remove search path entry which would reference /build
+    sed -i '/env!("CARGO_MANIFEST_DIR")/d' src/lib.rs
+  '';
+
   postInstall = ''
-    wrapProgram $out/bin/zz --prefix PATH ":" "${lib.getBin z3}/bin"
+    mkdir -p "$out/share/zz"
+    cp -r modules "$out/share/zz/"
+
+    wrapProgram $out/bin/zz \
+      --prefix PATH ":" "${lib.getBin z3}/bin" \
+      --suffix ZZ_MODULE_PATHS ":" "$out/share/zz/modules"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


Previously zz wouldn't be able to compile anything using standard
modules like `mem` or `log` out of the box.

To fix this we copy the modules directory included in the source to
`$out/share/zz/modules` and add an entry to `ZZ_MODULE_PATHS` in the wrapper
around zz.

We also remove a search path entry which used to reference `/build`
because it used `CARGO_MANIFEST_DIR` at build time. The default search
path now includes:

* `/nix/store/modules`
* `$out/share/zz/modules`
* `$(pwd)/modules`

Patching out `/nix/store/modules` would be kind of cumbersome as it is a
multi-line entry, but it probably does no harm and fine to leave in.

An issue arising by this PR might be that the added search path entry
may take priority over an user specified location even though we use
`--suffix`. This is because zz internally uses a `HashSet` which has no
guaranteed iteration order. This may lead to unexpected behavior for
users wo previously provided custom versions of the standard modules via
`ZZ_MODULE_PATHS`. However, this is an issue in upstream issue as well
where `ZZ_MODULE_PATHS` may or may not take priority over the compiled in
search path, so this issue should probably be resolved upstream (I'll
file a report or PR).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
