### PR TITLE
pythonPackages.pytest-check: 0.3.9 -> 1.0.1, staticjinja: 0.4.0 -> 1.0.3

### DIFF
--- a/pkgs/development/python-modules/pytest-check/default.nix
+++ b/pkgs/development/python-modules/pytest-check/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "pytest-check";
-  version = "0.3.9";
+  version = "1.0.1";
 
   src = fetchPypi {
     pname = "pytest_check";
     inherit version;
-    sha256 = "0asrrz0fgk6wqffsz1ffd6z9xyw314fwh5bwjzcq75w8w1g4ass9";
+    sha256 = "1i01i5ab06ic11na13gcacrlcs2ab6rmaii0yz0x06z5ynnljn6s";
   };
 
   propagatedBuildInputs = [ pytest ];

--- a/pkgs/development/python-modules/staticjinja/default.nix
+++ b/pkgs/development/python-modules/staticjinja/default.nix
@@ -6,12 +6,16 @@
 , easywatch
 , jinja2
 , pytestCheckHook
+, pytest-check
+, fetchPypi
 , markdown
+, sphinx
+, sphinx_rtd_theme
 }:
 
 buildPythonPackage rec {
   pname = "staticjinja";
-  version = "0.4.0";
+  version = "1.0.3";
 
   disabled = isPy27; # 0.4.0 drops python2 support
 
@@ -21,7 +25,7 @@ buildPythonPackage rec {
     owner = "staticjinja";
     repo = pname;
     rev = version;
-    sha256 = "0pysk8pzmcg1nfxz8m4i6bvww71w2zg6xp33zgg5vrf8yd2dfx9i";
+    sha256 = "12rpv5gv64i5j4w98wm1444xnnmarcn3pg783j3fkkzc58lk5wwj";
   };
 
   propagatedBuildInputs = [
@@ -32,13 +36,18 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
+    pytest-check
     markdown
+    sphinx_rtd_theme
+    sphinx
   ];
 
-  # Import paths differ by a "build/lib" subdirectory, but the files are
-  # the same, so we ignore import mismatches.
   preCheck = ''
+    # Import paths differ by a "build/lib" subdirectory, but the files are
+    # the same, so we ignore import mismatches.
     export PY_IGNORE_IMPORTMISMATCH=1
+    # The tests need to find and call the installed staticjinja executable
+    export PATH="$PATH:$out/bin";
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
