### PR TITLE
prometheus-nextcloud-exporter: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
@@ -2,26 +2,16 @@
 
 buildGoModule rec {
   pname = "prometheus-nextcloud-exporter";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "xperimental";
     repo = "nextcloud-exporter";
     rev = "v${version}";
-    sha256 = "1nmw1hkxgdp7nibrn1gz0lry0666rcc55s3kkfx64ykw6bnl0l34";
+    sha256 = "0kq0ka2gjlibl7vhk3s4z15ja5ai7cmwl144gj4dyhylp2xzr72a";
   };
 
-  patches = [
-    # fixes failing test, remove with next update
-    # see https://github.com/xperimental/nextcloud-exporter/pull/25
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/xperimental/nextcloud-exporter/pull/25.patch";
-      sha256 = "03jvqlqbs5g6ijncx6vxkgwq646yrjlrm0lk2q5vhfjrgrkv0alv";
-      includes = [ "internal/config/config_test.go" ];
-    })
-  ];
-
-  vendorSha256 = "0xdjphki0p03n6g5b4mm2x0rgm902rnbvq8r6p4r45k3mv8cggmf";
+  vendorSha256 = "0qs3p4jl8p0323bklrrhxzql7652pm6a1hj9ch9xyfhkwsx87l4d";
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) nextcloud; };
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/xperimental/nextcloud-exporter/releases/tag/v0.4.0
https://github.com/xperimental/nextcloud-exporter/compare/v0.3.0...v0.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).