### PR TITLE
vmware-horizon-client: 2006 -> 2012

### DIFF
--- a/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/default.nix
@@ -1,24 +1,56 @@
-{ lib, stdenv, buildFHSUserEnv, fetchurl, makeWrapper, makeDesktopItem, libxslt, atk
-, fontconfig, freetype, gdk-pixbuf, glib, gtk2, libudev0-shim, libxml2
-, pango, pixman, libX11, libXext, libXinerama, libXrandr , libXrender
-, libXtst, libXcursor, libXi, libxkbfile , libXScrnSaver, zlib, liberation_ttf
-, libtiff, dbus, at-spi2-atk, harfbuzz, gtk3-x11, libuuid, pcsclite
+{ stdenv
+, lib
+, at-spi2-atk
+, atk
+, buildFHSUserEnv
+, dbus
+, fetchurl
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gsettings-desktop-schemas
+, gtk2
+, gtk3-x11
+, harfbuzz
+, liberation_ttf
+, libjpeg
+, libtiff
+, libudev0-shim
+, libuuid
+, libX11
+, libXcursor
+, libXext
+, libXi
+, libXinerama
+, libxkbfile
+, libxml2
+, libXrandr
+, libXrender
+, libXScrnSaver
+, libxslt
+, libXtst
+, makeDesktopItem
+, makeWrapper
+, pango
+, pcsclite
+, pixman
+, zlib
 }:
-
 let
-  version = "2006";
+  version = "2012";
 
   sysArch =
     if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
     else throw "Unsupported system: ${stdenv.hostPlatform.system}";
-    # The downloaded archive also contains i386 and ARM binaries, but these have not been tested.
+  # The downloaded archive also contains i386 and ARM binaries, but these have not been tested.
 
   vmwareHorizonClientFiles = stdenv.mkDerivation {
     name = "vmwareHorizonClientFiles";
     inherit version;
     src = fetchurl {
-      url = https://download3.vmware.com/software/view/viewclients/CART21FQ2/vmware-view-client-linux-2006-8.0.0-16522670.tar.gz;
-      sha256 = "8c46d49fea42f8c1f7cf32a5f038f5a47d2b304743b1e4f4c68c658621b0e79c";
+      url = "https://download3.vmware.com/software/view/viewclients/CART21FQ4/VMware-Horizon-Client-Linux-2012-8.1.0-17349998.tar.gz";
+      sha256 = "0afda1f3116e75a4e7f89990d8ee60ccea5f3bb8a2360652162fa11c795724ce";
     };
     buildInputs = [ makeWrapper ];
     installPhase = ''
@@ -30,12 +62,16 @@ let
       # when it cannot detect a new enough version already present on the system.
       # The checks are distribution-specific and do not function correctly on NixOS.
       # Deleting the bundled library is the simplest way to force it to use our version.
-      rm -f "$out/lib/vmware/gcc/libstdc++.so.6"
+      rm "$out/lib/vmware/gcc/libstdc++.so.6"
+
+      # This libjpeg library interferes with Chromium, so we will be using ours instead.
+      rm $out/lib/vmware/libjpeg.*
 
       # Force the default GTK theme (Adwaita) because Horizon is prone to
       # UI usability issues when using non-default themes, such as Adwaita-dark.
       makeWrapper "$out/bin/vmware-view" "$out/bin/vmware-view_wrapper" \
           --set GTK_THEME Adwaita \
+          --suffix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
           --suffix LD_LIBRARY_PATH : "$out/lib/vmware/view/crtbora:$out/lib/vmware"
     '';
   };
@@ -46,10 +82,37 @@ let
     runScript = "${vmwareHorizonClientFiles}/bin/vmware-view_wrapper";
 
     targetPkgs = pkgs: [
-      pcsclite dbus vmwareHorizonClientFiles atk fontconfig freetype gdk-pixbuf glib gtk2
-      libudev0-shim libxml2 pango pixman liberation_ttf libX11 libXext libXinerama
-      libXrandr libXrender libXtst libXcursor libXi libxkbfile at-spi2-atk libXScrnSaver
-      zlib libtiff harfbuzz gtk3-x11 libuuid
+      at-spi2-atk
+      atk
+      dbus
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      gtk2
+      gtk3-x11
+      harfbuzz
+      liberation_ttf
+      libjpeg
+      libtiff
+      libudev0-shim
+      libuuid
+      libX11
+      libXcursor
+      libXext
+      libXi
+      libXinerama
+      libxkbfile
+      libxml2
+      libXrandr
+      libXrender
+      libXScrnSaver
+      libXtst
+      pango
+      pcsclite
+      pixman
+      vmwareHorizonClientFiles
+      zlib
     ];
   };
 
@@ -61,14 +124,21 @@ let
     mimeType = "x-scheme-handler/vmware-view";
   };
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   name = "vmware-view";
+
   dontUnpack = true;
+
   installPhase = ''
     mkdir -p $out/bin $out/share/applications
     cp "${desktopItem}"/share/applications/* $out/share/applications/
     ln -s "${vmwareFHSUserEnv}/bin/vmware-view" "$out/bin/"
   '';
+
+  unwrapped = vmwareHorizonClientFiles;
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Allows you to connect to your VMware Horizon virtual desktop";

--- a/pkgs/applications/networking/remote/vmware-horizon-client/update.sh
+++ b/pkgs/applications/networking/remote/vmware-horizon-client/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p curl -p jq -p common-updater-scripts -i bash
+set -e
+
+entryPointURL='https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY'
+
+function getTarballMetaUrl {
+    curl "$entryPointURL" | jq -r '
+        .dlgEditionsLists | .[] | select(.name | contains("Client for Linux")) |
+        .dlgList | .[] | select(.name | contains("tarball version")) |
+        @uri "https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=\(.code)&productId=\(.productId)&rPId=\(.releasePackageId)"
+    '
+}
+
+meta="$( curl "$(getTarballMetaUrl)" | jq ".downloadFiles | .[]" )"
+
+ver="$( echo "$meta" | jq -r .version )"
+url="$( echo "$meta" | jq -r .thirdPartyDownloadUrl )"
+sum="$( echo "$meta" | jq -r .sha256checksum )"
+
+echo
+echo "version: $ver"
+echo "tar url: $url"
+echo " sha256: $sum"
+
+cd "$(dirname "$0")/../../../../.."
+update-source-version vmware-horizon-client.unwrapped "$ver" "$sum" "$url"


### PR DESCRIPTION
###### Motivation for this change
Keep the vmware client up-to-date.

Reformat package source with `nixpkgs-fmt`

Fixed bugs (https://github.com/NixOS/nixpkgs/issues/109312):
- Would not run under minimal window managers. Fixed by explicitly adding gsettings schemas.
- Could not log in using oauth when chromium was set as a default browser. Fixed by removing third party libjpeg.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
