### PR TITLE
javacc: init at 7.0.10

### DIFF
--- a/pkgs/development/tools/parsing/javacc/default.nix
+++ b/pkgs/development/tools/parsing/javacc/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, ant, jdk }:
+
+stdenv.mkDerivation rec {
+  pname = "javacc";
+  version = "7.0.10";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "120jva4sw1kylkwgqf869zxddss01mcn1nmimx9vmd4xaadz7cf2";
+  };
+
+  nativeBuildInputs = [ ant jdk ];
+
+  buildPhase = ''
+    ant jar
+  '';
+
+  installPhase = ''
+    mkdir -p $out/target
+    mv scripts $out/bin
+    mv target/javacc.jar $out/target/
+  '';
+
+  meta = with lib; {
+    homepage = "https://javacc.github.io/javacc";
+    description = "A parser generator for building parsers from grammars";
+    license = licenses.bsd2;
+    maintainers = [ teams.deshaw.members ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12212,6 +12212,10 @@ in
 
   jam = callPackage ../development/tools/build-managers/jam { };
 
+  javacc = callPackage ../development/tools/parsing/javacc {
+    jdk = jdk8;
+  };
+
   jbake = callPackage ../development/tools/jbake { };
 
   jbang = callPackage ../development/tools/jbang { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
