### PR TITLE
google-compute-config: Reintroduce fetch-ssh-keys

### DIFF
--- a/nixos/modules/virtualisation/fetch-instance-ssh-keys.bash
+++ b/nixos/modules/virtualisation/fetch-instance-ssh-keys.bash
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WGET() {
+    wget --retry-connrefused -t 15 --waitretry=10 --header='Metadata-Flavor: Google' "$@"
+}
+
+# When dealing with cryptographic keys, we want to keep things private.
+umask 077
+mkdir -p /root/.ssh
+
+echo "Fetching authorized keys..."
+WGET -O /tmp/auth_keys http://metadata.google.internal/computeMetadata/v1/instance/attributes/sshKeys
+
+# Read keys one by one, split in case Google decided
+# to append metadata (it does sometimes) and add to
+# authorized_keys if not already present.
+touch /root/.ssh/authorized_keys
+while IFS='' read -r line || [[ -n "$line" ]]; do
+    keyLine=$(echo -n "$line" | cut -d ':' -f2)
+    IFS=' ' read -r -a array <<<"$keyLine"
+    if [[ ${#array[@]} -ge 3 ]]; then
+        echo "${array[@]:0:3}" >>/tmp/new_keys
+        echo "Added ${array[*]:2} to authorized_keys"
+    fi
+done </tmp/auth_keys
+mv /tmp/new_keys /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+
+echo "Fetching host keys..."
+WGET -O /tmp/ssh_host_ed25519_key http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh_host_ed25519_key
+WGET -O /tmp/ssh_host_ed25519_key.pub http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh_host_ed25519_key_pub
+mv -f /tmp/ssh_host_ed25519_key* /etc/ssh/
+chmod 600 /etc/ssh/ssh_host_ed25519_key
+chmod 644 /etc/ssh/ssh_host_ed25519_key.pub

--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -69,6 +69,69 @@ in
   # GC has 1460 MTU
   networking.interfaces.eth0.mtu = 1460;
 
+  systemd.services.fetch-ssh-keys = {
+    description = "Fetch host keys and authorized_keys for root user";
+
+    wantedBy = [ "sshd.service" ];
+    before = [ "sshd.service" ];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+
+    script =
+      let
+        wget = "${pkgs.wget}/bin/wget --retry-connrefused -t 15 --waitretry=10 --header='Metadata-Flavor: Google'";
+        mktemp = "mktemp --tmpdir=/run";
+      in ''
+        # When dealing with cryptographic keys, we want to keep things private.
+        umask 077
+        mkdir -m 0700 -p /root/.ssh
+
+        echo "Obtaining SSH keys..."
+        AUTH_KEYS=$(${mktemp})
+        ${wget} -O $AUTH_KEYS http://metadata.google.internal/computeMetadata/v1/instance/attributes/sshKeys
+        if [ -s $AUTH_KEYS ]; then
+            # Read in key one by one, split in case Google decided
+            # to append metadata (it does sometimes) and add to
+            # authorized_keys if not already present.
+            touch /root/.ssh/authorized_keys
+            NEW_KEYS=$(${mktemp})
+            # Yes this is a nix escape of two single quotes.
+            while IFS=''' read -r line || [[ -n "$line" ]]; do
+                keyLine=$(echo -n "$line" | cut -d ':' -f2)
+                IFS=' ' read -r -a array <<< "$keyLine"
+                if [ ''${#array[@]} -ge 3 ]; then
+                    echo ''${array[@]:0:3} >> $NEW_KEYS
+                    echo "Added ''${array[@]:2} to authorized_keys"
+                fi
+            done < $AUTH_KEYS
+            mv $NEW_KEYS /root/.ssh/authorized_keys
+            chmod 600 /root/.ssh/authorized_keys
+            rm -f $KEY_PUB
+        else
+            echo "Downloading http://metadata.google.internal/computeMetadata/v1/project/attributes/sshKeys failed."
+            false
+        fi
+        rm -f $AUTH_KEYS
+
+        SSH_HOST_KEYS_DIR=$(${mktemp} -d)
+        ${wget} -O $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh_host_ed25519_key
+        ${wget} -O $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key.pub http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh_host_ed25519_key_pub
+        if [ -s $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key -a -s $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key.pub ]; then
+            mv -f $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key* /etc/ssh/
+            chmod 600 /etc/ssh/ssh_host_ed25519_key
+            chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
+        else
+            echo "Setup of ssh host keys from http://metadata.google.internal/computeMetadata/v1/instance/attributes/ failed."
+            false
+        fi
+        rm -rf $SSH_HOST_KEYS_DIR
+      '';
+    serviceConfig.Type = "oneshot";
+    serviceConfig.RemainAfterExit = true;
+    serviceConfig.StandardError = "journal+console";
+    serviceConfig.StandardOutput = "journal+console";
+  };
+
   systemd.services.google-instance-setup = {
     description = "Google Compute Engine Instance Setup";
     after = [ "network-online.target" "network.target" "rsyslog.service" ];


### PR DESCRIPTION
###### Motivation for this change

Reintroduce the `fetch-ssh-keys` service so that GCE images that work with NixOps can once again be built. Also, reformat the code a bit.

The service was removed in 88570538b3b19d60b00bc3905bbaaef17e5a5c94, likely due to a comment saying it should be removed. It is however still needed for NixOps, at least until the plugin is able to handle `google-oslogin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built an image and deployed it with NixOps.

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
