### PR TITLE
python3Packages.pygdbmi: 0.9.0.2 -> 0.10.0.0, gdbgui: 0.13.2.1 -> 0.14.0.2

### DIFF
--- a/pkgs/development/python-modules/pygdbmi/default.nix
+++ b/pkgs/development/python-modules/pygdbmi/default.nix
@@ -7,15 +7,13 @@
 
 buildPythonPackage rec {
   pname = "pygdbmi";
-  version = "0.9.0.2";
+  version = "0.10.0.0";
 
   src = fetchFromGitHub {
-    #inherit pname version;
-    #inherit pname version;
     owner = "cs01";
     repo = "pygdbmi";
     rev = version;
-    sha256 = "01isx7912dbalmc3xsafk1a1n6bzzfrjn2363djcq0v57rqii53d";
+    sha256 = "0a6b3zyxwdcb671c6lrwxm8fhvsbjh0m8hf1r18m9dha86laimjr";
   };
 
   checkInputs = [ gdb ];

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -3,6 +3,10 @@
 , fetchPypi
 , gdb
 , flask
+, six
+, bidict
+, python-engineio
+, python-socketio
 , flask-socketio
 , flask-compress
 , pygdbmi
@@ -12,14 +16,48 @@
 , eventlet
 , }:
 
+let
+  # gdbgui only works with the latest previous major version of flask-socketio,
+  # which depends itself on the latest previous major versions of dependencies.
+  python-engineio' = python-engineio.overridePythonAttrs (old: rec {
+    version = "3.14.2";
+    src = fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "119halljynqsgswlhlh750qv56js1p7j52sc0nbwxh8450zmbd7a";
+    };
+    propagatedBuildInputs = [ six ];
+    doCheck = false;
+  });
+  python-socketio' = python-socketio.overridePythonAttrs (old: rec {
+    version = "4.6.1";
+    src = fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "047syhrrxh327p0fnab0d1zy25zijnj3gs1qg3kjpsy1jaj5l7yd";
+    };
+    propagatedBuildInputs = [ bidict python-engineio' ];
+    doCheck = false;
+  });
+  flask-socketio' = flask-socketio.overridePythonAttrs (old: rec {
+    version = "4.3.2";
+    src = fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "0s2xs9kv9cbwy8bcxszhdwlcb9ldv0fj33lwilf5vypj0wsin01p";
+    };
+    propagatedBuildInputs = [ flask python-socketio' ];
+    doCheck = false;
+  });
+in
 buildPythonApplication rec {
   pname = "gdbgui";
-  version = "0.13.2.1";
+  version = "0.14.0.2";
 
   buildInputs = [ gdb ];
   propagatedBuildInputs = [
     flask
-    flask-socketio
+    flask-socketio'
     flask-compress
     pygdbmi
     pygments
@@ -30,13 +68,14 @@ buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0zn5wi47m8pn4amx574ryyhqvhynipxzyxbx0878ap6g36vh6l1h";
+    sha256 = "1v6wwsncgnhlg5c7gsmzcp52hfblfnz5kf5pk4d0zybflsxak02d";
   };
 
   postPatch = ''
     echo ${version} > gdbgui/VERSION.txt
     # remove upper version bound
     sed -ie 's!, <.*"!"!' setup.py
+    sed -i 's/greenlet==/greenlet>=/' setup.py
   '';
 
   postInstall = ''
@@ -52,6 +91,6 @@ buildPythonApplication rec {
     homepage = "https://www.gdbgui.com/";
     license = licenses.gpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ yrashk ];
+    maintainers = with maintainers; [ yrashk dump_stack ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Bump pygdbmi to the latest version, and gdbgui which is depends on it.

Note: gdbgui was broken on the unstable branch, so there is also a fix of dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
