### PR TITLE
gnu-cobol: 2.2 -> 3.1.2

### DIFF
--- a/pkgs/development/compilers/gnu-cobol/default.nix
+++ b/pkgs/development/compilers/gnu-cobol/default.nix
@@ -1,16 +1,13 @@
 { lib, stdenv, fetchurl, gcc, makeWrapper
 , db, gmp, ncurses }:
 
-let
-  version = "2.2";
-in
 stdenv.mkDerivation rec {
   pname = "gnu-cobol";
-  inherit version;
+  version = "3.1.2";
 
   src = fetchurl {
-    url = "https://sourceforge.com/projects/open-cobol/files/gnu-cobol/${version}/gnucobol-${version}.tar.gz";
-    sha256 = "1jrjmdx0swssjh388pp08awhiisbrs2i7gx4lcm4p1k5rpg3hn4j";
+    url = "mirror://sourceforge/gnucobol/${lib.versions.majorMinor version}/gnucobol-${version}.tar.xz";
+    sha256 = "0x15ybfm63g7c9340fc6712h9v59spnbyaz4rf85pmnp3zbhaw2r";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -31,9 +28,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An open-source COBOL compiler";
-    homepage = "https://sourceforge.net/projects/open-cobol/";
-    license = licenses.gpl3;
+    homepage = "https://sourceforge.net/projects/gnucobol/";
+    license = with licenses; [ gpl3Only lgpl3Only ];
     maintainers = with maintainers; [ ericsagnes ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes:
 * CVE-2019-14468
 * CVE-2019-14486
 * CVE-2019-14528
 * CVE-2019-14541
 * CVE-2019-16395
 * CVE-2019-16396

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
