### PR TITLE
hhexen: init at 1.6.3

### DIFF
--- a/pkgs/games/hhexen/default.nix
+++ b/pkgs/games/hhexen/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     install -Dm755 hhexen-gl -t $out/bin
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Linux port of Raven Game's Hexen";
     homepage = "http://hhexen.sourceforge.net/hhexen.html";
     license = licenses.gpl2Plus;

--- a/pkgs/games/hhexen/default.nix
+++ b/pkgs/games/hhexen/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, SDL, stdenv }:
+{ lib, fetchurl, SDL, stdenv }:
 
 stdenv.mkDerivation rec {
   name = "hhexen";

--- a/pkgs/games/hhexen/default.nix
+++ b/pkgs/games/hhexen/default.nix
@@ -1,0 +1,22 @@
+{ fetchurl, SDL, stdenv }:
+
+stdenv.mkDerivation rec {
+  name = "hhexen";
+  version = "1.6.3";
+  src = fetchurl {
+    url = "mirror://sourceforge/hhexen/hhexen-${version}-src.tgz";
+    sha256 = "1jwccqawbdn0rjn5p59j21rjy460jdhps7zwn2z0gq9biggw325b";
+  };
+
+  buildInputs = [ SDL ];
+  installPhase = ''
+    install -Dm755 hhexen-gl -t $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Linux port of Raven Game's Hexen";
+    homepage = "http://hhexen.sourceforge.net/hhexen.html";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ djanatyn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27185,6 +27185,8 @@ in
 
   gnome-tour = callPackage ../desktops/gnome-3/core/gnome-tour { };
 
+  hhexen = callPackage ../games/hhexen { };
+
   hsetroot = callPackage ../tools/X11/hsetroot { };
 
   imwheel = callPackage ../tools/X11/imwheel { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`hhexen` is a modern engine for playing Hexen:
> [Hacked Hexen] based on K.Robillard's Linux Hexen engine, is finally being finished after Dan left it in limbo for a while. New stuff includes midi, screenshots, bug-fixes, transparent maps, and extensive C fixes allowing for OS and CPU portability.

It offers a substantial visual upgrade over some existing Hexen engines in nixpkgs.

`chocolate-hexen`:
![chocolate-hexen screenshot](https://gateway.pinata.cloud/ipfs/QmeiWHPEkjVXa5jakacBzdTpWRvWFfm6ys4Q5avQsz5PQo)

`hhexen`:
![hhexen screenshot](https://gateway.pinata.cloud/ipfs/QmQJQdDVrgFMPwv1sKfQV8Fy8VN8BfLViw48592fYuvmeD)

This is a different engine from than the one mentioned in https://github.com/NixOS/nixpkgs/pull/75468.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
