### PR TITLE
pikopixel: 1.0-b9e -> 1.0-b10

### DIFF
--- a/pkgs/applications/graphics/pikopixel/default.nix
+++ b/pkgs/applications/graphics/pikopixel/default.nix
@@ -11,11 +11,11 @@ let
 
 in gnustep'.gsmakeDerivation rec {
   pname = "pikopixel";
-  version = "1.0-b9e";
+  version = "1.0-b10";
 
   src = fetchurl {
     url = "http://twilightedge.com/downloads/PikoPixel.Sources.${version}.tar.gz";
-    sha256 = "1gmgb5ch7s6fwvg85l6pl6fsx0maqwd8yvg7sz3r9lj32g2pz5wn";
+    sha256 = "1b27npgsan2nx1p581b9q2krx4506yyd6s34r4sf1r9x9adshm77";
   };
 
   sourceRoot = "PikoPixel.Sources.${version}/PikoPixel";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
