### PR TITLE
factorio-headless-experimental, factorio-experimental: 1.1.12 -> 1.1.16

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.12.tar.xz",
+        "name": "factorio_alpha_x64-1.1.16.tar.xz",
         "needsAuth": true,
-        "sha256": "1b6rccm3vvvgs1sky0nrm001hsrzahrd8hc0pgldgyk0i6g5bmss",
+        "sha256": "000n19mm7xc1qvc93kakvayjd0j749hv5nrdmsp7vdixcd773vjn",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.12/alpha/linux64",
-        "version": "1.1.12"
+        "url": "https://factorio.com/get-download/1.1.16/alpha/linux64",
+        "version": "1.1.16"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.0.0.tar.xz",
@@ -20,12 +20,12 @@
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.12.tar.xz",
+        "name": "factorio_demo_x64-1.1.16.tar.xz",
         "needsAuth": false,
-        "sha256": "037lipqxgfxycjsjffgd6rnx3xv62r40fmkyarcclww3yi596zrw",
+        "sha256": "11nkpx8f3a30i06q7iqds12fiy1q67h64vh72y8x5l4mjg16j1js",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.12/demo/linux64",
-        "version": "1.1.12"
+        "url": "https://factorio.com/get-download/1.1.16/demo/linux64",
+        "version": "1.1.16"
       },
       "stable": {
         "name": "factorio_demo_x64-1.0.0.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.12.tar.xz",
+        "name": "factorio_headless_x64-1.1.16.tar.xz",
         "needsAuth": false,
-        "sha256": "0chgv7ymsiz4rrjmp04ckdhk2yzgi4ly7rwl0nv2fswajhl7ngmf",
+        "sha256": "02w92sgw4i3k1zywdg30mkr7nfylynsdn7sz5jzslyp0mkglrixi",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.12/headless/linux64",
-        "version": "1.1.12"
+        "url": "https://factorio.com/get-download/1.1.16/headless/linux64",
+        "version": "1.1.16"
       },
       "stable": {
         "name": "factorio_headless_x64-1.0.0.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* 1.1.16: https://forums.factorio.com/94925
* 1.1.15: https://forums.factorio.com/94883
* 1.1.14: https://forums.factorio.com/94832
* 1.1.13: https://forums.factorio.com/94772


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
