### PR TITLE
ijq: init at 0.2.3

### DIFF
--- a/pkgs/development/tools/ijq/default.nix
+++ b/pkgs/development/tools/ijq/default.nix
@@ -1,0 +1,28 @@
+{ buildGoModule, fetchgit, lib, jq, makeWrapper }:
+
+buildGoModule rec {
+  pname = "ijq";
+  version = "0.2.3";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~gpanders/ijq";
+    rev = "v${version}";
+    sha256 = "14n54jh5387jf97zhc7aidn7w60zp5624xbvq4jdbsh96apg3bk1";
+  };
+
+  vendorSha256 = "0xbni6lk6y3ig7pj2234fv7ra6b8qv0k8m3bvh59wwans8xpihzb";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/ijq" \
+      --prefix PATH : "${lib.makeBinPath [ jq ]}"
+  '';
+
+  meta = with lib; {
+    description = "Interactive wrapper for jq";
+    homepage = "https://git.sr.ht/~gpanders/ijq";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ justinas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5166,6 +5166,8 @@ in
     packages = config.ihaskell.packages or (self: []);
   };
 
+  ijq = callPackage ../development/tools/ijq { };
+
   iruby = callPackage ../applications/editors/jupyter-kernels/iruby { };
 
   ike-scan = callPackage ../tools/security/ike-scan { };


### PR DESCRIPTION
###### Motivation for this change

[ijq](https://git.sr.ht/~gpanders/ijq) provides an interactive TUI for writing [jq](https://stedolan.github.io/jq/) expressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
