### PR TITLE
yuzu-mainline: 482 -> 517 && yuzu-ea: init at 1377

### DIFF
--- a/pkgs/misc/emulators/yuzu/base.nix
+++ b/pkgs/misc/emulators/yuzu/base.nix
@@ -1,0 +1,66 @@
+{ pname, version, src, branch
+, stdenv, fetchFromGitHub, wrapQtAppsHook
+, cmake, pkgconfig
+, libpulseaudio, libjack2, alsaLib, sndio, ecasound
+, vulkan-loader, vulkan-headers
+, qtbase, qtwebengine, qttools
+, nlohmann_json, rapidjson
+, zlib, zstd, libzip, lz4
+, glslang
+, boost173
+, catch2
+, fmt
+, SDL2
+, udev
+, libusb1
+, ffmpeg
+}:
+
+stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  buildInputs = [
+    libpulseaudio libjack2 alsaLib sndio ecasound
+    vulkan-loader vulkan-headers
+    qtbase qtwebengine qttools
+    nlohmann_json rapidjson
+    zlib zstd libzip lz4
+    glslang
+    boost173
+    catch2
+    fmt
+    SDL2
+    udev
+    libusb1
+    ffmpeg
+  ];
+
+  cmakeFlags = [ "-DENABLE_QT_TRANSLATION=ON" "-DYUZU_USE_QT_WEB_ENGINE=ON" "-DUSE_DISCORD_PRESENCE=ON" ];
+
+  # Trick the configure system. This prevents a check for submodule directories.
+  preConfigure = "rm -f .gitmodules";
+
+  # Fix vulkan detection
+  postFixup = ''
+    wrapProgram $out/bin/yuzu --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+    wrapProgram $out/bin/yuzu-cmd --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://yuzu-emu.org";
+    description = "The ${branch} branch of an experimental Nintendo Switch emulator written in C++";
+    longDescription = ''
+      An experimental Nintendo Switch emulator written in C++.
+      Using the mainline branch is recommanded for general usage.
+      Using the early-access branch is recommanded if you would like to try out experimental features, with a cost of stability.
+    '';
+    license = with licenses; [
+      gpl2Plus
+      # Icons
+      cc-by-nd-30 cc0
+    ];
+    maintainers = with maintainers; [ ivar joshuafern ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/misc/emulators/yuzu/base.nix
+++ b/pkgs/misc/emulators/yuzu/base.nix
@@ -1,6 +1,6 @@
-{ pname, version, src, branch
-, stdenv, fetchFromGitHub, wrapQtAppsHook
-, cmake, pkgconfig
+{ pname, version, src, branchName
+, stdenv, lib, fetchFromGitHub, wrapQtAppsHook
+, cmake, pkg-config
 , libpulseaudio, libjack2, alsaLib, sndio, ecasound
 , vulkan-loader, vulkan-headers
 , qtbase, qtwebengine, qttools
@@ -19,7 +19,7 @@
 stdenv.mkDerivation rec {
   inherit pname version src;
 
-  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
   buildInputs = [
     libpulseaudio libjack2 alsaLib sndio ecasound
     vulkan-loader vulkan-headers
@@ -36,10 +36,16 @@ stdenv.mkDerivation rec {
     ffmpeg
   ];
 
-  cmakeFlags = [ "-DENABLE_QT_TRANSLATION=ON" "-DYUZU_USE_QT_WEB_ENGINE=ON" "-DUSE_DISCORD_PRESENCE=ON" ];
+  cmakeFlags = [
+    "-DENABLE_QT_TRANSLATION=ON"
+    "-DYUZU_USE_QT_WEB_ENGINE=ON"
+    "-DUSE_DISCORD_PRESENCE=ON"
+  ];
 
   # Trick the configure system. This prevents a check for submodule directories.
-  preConfigure = "rm -f .gitmodules";
+  preConfigure = ''
+    rm -f .gitmodules
+  '';
 
   # Fix vulkan detection
   postFixup = ''
@@ -47,9 +53,9 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/yuzu-cmd --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://yuzu-emu.org";
-    description = "The ${branch} branch of an experimental Nintendo Switch emulator written in C++";
+    description = "The ${branchName} branch of an experimental Nintendo Switch emulator written in C++";
     longDescription = ''
       An experimental Nintendo Switch emulator written in C++.
       Using the mainline branch is recommanded for general usage.

--- a/pkgs/misc/emulators/yuzu/default.nix
+++ b/pkgs/misc/emulators/yuzu/default.nix
@@ -1,17 +1,28 @@
-{ branch ? "mainline", pkgs }:
+{ branch ? "mainline", libsForQt5, fetchFromGitHub }:
 let
-  inherit (pkgs) libsForQt5 fetchFromGitHub;
+  inherit libsForQt5 fetchFromGitHub;
 in {
   mainline = libsForQt5.callPackage ./base.nix rec {
     pname = "yuzu-mainline";
     version = "517";
-    branch = branch;
+    branchName = branch;
     src = fetchFromGitHub {
       owner = "yuzu-emu";
       repo = "yuzu-mainline";
       rev = "mainline-0-${version}";
       sha256 = "0i73yl2ycs8p9cqn25rw35cll0l6l68605f1mc1qvf4zy82jggbb";
       fetchSubmodules = true;
+    };
+  };
+  early-access = libsForQt5.callPackage ./base.nix rec {
+    pname = "yuzu-ea";
+    version = "1377";
+    branchName = branch;
+    src = fetchFromGitHub {
+      owner = "pineappleEA";
+      repo = "pineapple-src";
+      rev = "EA-${version}";
+      sha256 = "0jjddmcqbkns5iqjwqh51hpjviw5j12n49jwfq7xwrsns6vbpqkf";
     };
   };
 }.${branch}

--- a/pkgs/misc/emulators/yuzu/default.nix
+++ b/pkgs/misc/emulators/yuzu/default.nix
@@ -1,47 +1,17 @@
-{ lib, stdenv, fetchFromGitHub
-, cmake, pkg-config, wrapQtAppsHook
-, boost173, catch2, fmt, lz4, nlohmann_json, rapidjson, zlib, zstd, SDL2
-, udev, libusb1, libzip, qtbase, qtwebengine, qttools, ffmpeg
-, libpulseaudio, libjack2, alsaLib, sndio, ecasound
-, useVulkan ? true, vulkan-loader, vulkan-headers
-}:
-
-stdenv.mkDerivation rec {
-  pname = "yuzu";
-  version = "482";
-
-  src = fetchFromGitHub {
-    owner = "yuzu-emu";
-    repo = "yuzu-mainline"; # They use a separate repo for mainline “branch”
-    rev = "mainline-0-${version}";
-    sha256 = "1bhkdbhj1dv33qv0np26gzsw65p4z88whjmd6bc7mh2b5lvrjwxm";
-    fetchSubmodules = true;
+{ branch ? "mainline", pkgs }:
+let
+  inherit (pkgs) libsForQt5 fetchFromGitHub;
+in {
+  mainline = libsForQt5.callPackage ./base.nix rec {
+    pname = "yuzu-mainline";
+    version = "517";
+    branch = branch;
+    src = fetchFromGitHub {
+      owner = "yuzu-emu";
+      repo = "yuzu-mainline";
+      rev = "mainline-0-${version}";
+      sha256 = "0i73yl2ycs8p9cqn25rw35cll0l6l68605f1mc1qvf4zy82jggbb";
+      fetchSubmodules = true;
+    };
   };
-
-  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
-  buildInputs = [ qtbase qtwebengine qttools boost173 catch2 fmt lz4 nlohmann_json rapidjson zlib zstd SDL2 udev libusb1 libpulseaudio alsaLib sndio ecasound libjack2 libzip ffmpeg ]
-    ++ lib.optionals useVulkan [ vulkan-loader vulkan-headers ];
-  cmakeFlags = [ "-DENABLE_QT_TRANSLATION=ON" "-DYUZU_USE_QT_WEB_ENGINE=ON" "-DUSE_DISCORD_PRESENCE=ON" ]
-    ++ lib.optionals (!useVulkan) [ "-DENABLE_VULKAN=No" ];
-
-  # Trick the configure system. This prevents a check for submodule directories.
-  preConfigure = "rm .gitmodules";
-
-  # Fix vulkan detection
-  postFixup = lib.optionals useVulkan ''
-    wrapProgram $out/bin/yuzu --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
-    wrapProgram $out/bin/yuzu-cmd --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
-  '';
-
-  meta = with lib; {
-    homepage = "https://yuzu-emu.org";
-    description = "An experimental Nintendo Switch emulator written in C++";
-    license = with licenses; [
-      gpl2Plus
-      # Icons
-      cc-by-nd-30 cc0
-    ];
-    maintainers = with maintainers; [ ivar joshuafern ];
-    platforms = platforms.linux;
-  };
-}
+}.${branch}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -736,6 +736,7 @@ mapAliases ({
   xv = xxv; # added 2020-02-22
   youtubeDL = youtube-dl;  # added 2014-10-26
   ytop = throw "ytop has been abandoned by upstream. Consider switching to bottom instead";
+  yuzu = yuzu-mainline; # added 2021-01-25
   zdfmediathk = mediathekview; # added 2019-01-19
   gnome_user_docs = gnome-user-docs; # added 2019-11-20
   # spidermonkey is not ABI upwards-ompatible, so only allow this for nix-shell

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29411,8 +29411,9 @@ in
 
   yaxg = callPackage ../tools/graphics/yaxg {};
 
-  yuzu = libsForQt5.callPackage ../misc/emulators/yuzu {
-    stdenv = gcc10Stdenv;
+  yuzu-mainline = import ../misc/emulators/yuzu {
+    branch = "mainline";
+    inherit pkgs;
   };
 
   zap = callPackage ../tools/networking/zap { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29413,7 +29413,11 @@ in
 
   yuzu-mainline = import ../misc/emulators/yuzu {
     branch = "mainline";
-    inherit pkgs;
+    inherit (pkgs) libsForQt5 fetchFromGitHub;
+  };
+  yuzu-ea = import ../misc/emulators/yuzu {
+    branch = "early-access";
+    inherit (pkgs) libsForQt5 fetchFromGitHub;
   };
 
   zap = callPackage ../tools/networking/zap { };


### PR DESCRIPTION
###### Motivation for this change
This updates the `yuzu-mainline` package, and adds the early-access branch. I've made adding different branches simpler in the process.

This supersedes  #99656 as this builds from source and is on the latest version as of writing this.

@aanderse you might find this interesting :) 

@SuperSandro2000 @jonringer you both reviewed the previous pineapple PR, so i thought you might be interested in reviewing this one as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
