### PR TITLE
keybase,keybase-gui,kbfs: 5.5.2 -> 5.6.1

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -6,7 +6,7 @@
 
 buildGoPackage rec {
   pname = "keybase";
-  version = "5.5.2";
+  version = "5.6.1";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/kbnm" "go/keybase" ];
@@ -17,7 +17,7 @@ buildGoPackage rec {
     owner = "keybase";
     repo = "client";
     rev = "v${version}";
-    sha256 = "01k50mank6cdc7q3yd8m7xi8vmyklsqlmz7hw17a35lqcsjzy9zj";
+    sha256 = "12b0jdwhnvxb51x3pq0g0f23grv9yjbxmpsz36n8ab3j0fvmfg0g";
   };
 
   patches = [

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -4,17 +4,17 @@
 , runtimeShell, gsettings-desktop-schemas }:
 
 let
-  versionSuffix = "20201016183637.d4ebf7d999";
+  versionSuffix = "20210125164223.f3b21527b9";
 in
 
 stdenv.mkDerivation rec {
   pname = "keybase-gui";
-  version = "5.5.2"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "5.6.1"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
 
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "0qwbqnc6dhfnx3gdwl1lyhdsbclaxpkv3zr3dmxfx1242s64v0c1";
+    sha256 = "12ckfd02j0f3p3pdlwc640f61z1wzblf2414h6fkf5vzd289h35p";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
keybase,keybase-gui,kbfs: 5.5.2 -> 5.6.1
###### Motivation for this change
New version of Keybase released today: https://github.com/keybase/client/releases/tag/v5.6.1

###### Things done
I tested this by creating an overlay in my own configuration.nix file and rebuilding. Everything builds and runs as expected

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
