### PR TITLE
python3Packages.brottsplatskartan: init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/brottsplatskartan/default.nix
+++ b/pkgs/development/python-modules/brottsplatskartan/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python API wrapper for brottsplatskartan.se";
     homepage = "https://github.com/chrillux/brottsplatskartan";
-    license = with licenses; [ gpl2Only ];
+    license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/brottsplatskartan/default.nix
+++ b/pkgs/development/python-modules/brottsplatskartan/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest-cov
+, pytestCheckHook
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "brottsplatskartan";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "chrillux";
+    repo = pname;
+    rev = version;
+    sha256 = "07iwmnchvpw156j23yfccg4c32izbwm8b02bjr1xgmcwzbq21ks9";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [
+    pytest-cov
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "brottsplatskartan" ];
+
+  meta = with lib; {
+    description = "Python API wrapper for brottsplatskartan.se";
+    homepage = "https://github.com/chrillux/brottsplatskartan";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -96,7 +96,7 @@
     "braviatv" = ps: with ps; [ bravia-tv ];
     "broadlink" = ps: with ps; [ broadlink ];
     "brother" = ps: with ps; [ brother ];
-    "brottsplatskartan" = ps: with ps; [ ]; # missing inputs: brottsplatskartan
+    "brottsplatskartan" = ps: with ps; [ brottsplatskartan ];
     "browser" = ps: with ps; [ ];
     "brunt" = ps: with ps; [ ]; # missing inputs: brunt
     "bsblan" = ps: with ps; [ bsblan ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1044,6 +1044,8 @@ in {
 
   brotlipy = callPackage ../development/python-modules/brotlipy { };
 
+  brottsplatskartan = callPackage ../development/python-modules/brottsplatskartan { };
+
   browser-cookie3 = callPackage ../development/python-modules/browser-cookie3 { };
 
   browsermob-proxy = disabledIf isPy3k (callPackage ../development/python-modules/browsermob-proxy { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Python API wrapper for brottsplatskartan.se

https://github.com/chrillux/brottsplatskartan

This is a Home Assistant dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
