### PR TITLE
nixos/step-ca: Adding module for step-ca.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -837,6 +837,7 @@
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
   ./services/security/sshguard.nix
+  ./services/security/step-ca.nix
   ./services/security/tor.nix
   ./services/security/torify.nix
   ./services/security/torsocks.nix

--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -1,0 +1,121 @@
+{ config, lib, pkgs, ... }:
+
+let cfg = config.services.step-ca;
+
+in {
+  options = {
+    services.step-ca = {
+      enable = lib.mkEnableOption "Step CA PKI Server";
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "SmallStep";
+        description = "Name of your CA.";
+      };
+      hostname = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = "Hostname/FQDN of your CA.";
+      };
+      address = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        example = "0.0.0.0";
+        description = "The address the CA will listen at.";
+      };
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8443;
+        description = "Port to listen on.";
+      };
+      passwordFile = lib.mkOption {
+        type = lib.types.path;
+        default = null;
+        example = "/run/keys/smallstep-password";
+        description = "Path to file containing password of your first provisioner.";
+      };
+      provisioner = lib.mkOption {
+        type = lib.types.str;
+        default = "you@smallstep.com";
+        description = "The name of the first provisioner.";
+      };
+      acmeProvisioner = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "acme";
+        description = "Optionally create an acme provider. The resulting acme url is https://{hostname}:{port}/acme/{acmeProvisioner}/directory";
+      };
+      rootFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          The path of an existing PEM file to be used as the root certificate authority.
+          You can generate one using e.g `step certificate create "MyCompany" root-ca.crt root-ca.key --profile root-ca --no-password --insecure` from the `step-cli` package.
+          Only use this for development as the ca key is not protected with a password.
+          It seems like step-ca ignores the passwordFile parameter so you can't use a key with a password.
+          This should probably be reported as a bug. https://github.com/smallstep/cli/issues/220'';
+      };
+      keyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "The path of an existing key file of the root certificate authority.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.step-ca = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = [ pkgs.step-ca pkgs.step-cli ];
+      environment = { STEPPATH = "/var/lib/step-ca"; HOME = "/var/lib/step-ca"; };
+      script = ''
+        if [ ! -f "$STATE_DIRECTORY/ca-is-init" ]; then
+          step ca init \
+            --ssh \
+            --name ${cfg.name} \
+            --dns ${cfg.hostname} \
+            --address ${cfg.address}:${toString cfg.port} \
+            --provisioner ${cfg.provisioner} \
+            --password-file ${cfg.passwordFile} \
+            ${lib.optionalString (cfg.rootFile != null) " --root=${cfg.rootFile} "} \
+            ${lib.optionalString (cfg.keyFile != null) " --key=${cfg.keyFile} "}
+          ${lib.optionalString (cfg.acmeProvisioner != null) "step ca provisioner add ${cfg.acmeProvisioner} --type ACME"}
+          touch $STATE_DIRECTORY/ca-is-init
+        fi
+        step-ca $STEPPATH/config/ca.json --password-file ${cfg.passwordFile}
+      '';
+      serviceConfig = {
+        Type = "simple";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        Restart = "on-failure";
+        StateDirectory = "step-ca";
+
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        NoNewPrivileges = true;
+        ProtectSystem = "full";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID= true;
+        RemoveIPC = true;
+        SystemCallFilter = "~@clock @debug @module @mount @raw-io @reboot @swap @privileged @resources @cpu-emulation @obsolete";
+        SystemCallArchitectures = "native";
+        MemoryDenyWriteExecute = true;
+        DynamicUser = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
First @Church- are you fine with this? I kept you as an author but added myself as a co-author.
@midchildan you also gave feedback on the original pull request. Would you like to give some again? 

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/97225 stalled and there is no local certificate authoritiy which can e.g. be used instead of letsencrypt for local deployments or testing.

###### Things done

> nixos: Adding module for step-ca, set up by default to allow for both regular x.509 certs and SSH certs as well.
Also add a possibility for ACME and implement systemd hardening. Addressed all feedback from the original PR.

Edit: I will fix the EditorStyle complaints tomorrow (and also the TODOs that are easy to fix)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
