### PR TITLE
legendary-gl: 0.20.1 -> 0.20.6

### DIFF
--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -7,23 +7,27 @@
 
 buildPythonApplication rec {
   pname = "legendary-gl"; # Name in pypi
-  version = "0.20.1";
+  version = "0.20.6";
 
   src = fetchFromGitHub {
     owner = "derrod";
     repo = "legendary";
     rev = version;
-    sha256 = "0kdrhdvh9gxq1zinh5w852f5fjls9902pcrkhkhm2c0vvq7jfass";
+    sha256 = "1v6jbnasz2ilcafs6qyl6na4a8cxy2lgwr0hqsja6d846rfqa8ad";
   };
 
   propagatedBuildInputs = [ requests ];
 
   disabled = pythonOlder "3.8";
 
+  doCheck = false;
+
+  pythonImportsCheck = [ "requests" ];
+
   meta = with lib; {
     description = "A free and open-source Epic Games Launcher alternative";
     homepage = "https://github.com/derrod/legendary";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ wchresta ];
+    maintainers = with maintainers; [ wchresta equirosa ];
   };
 }

--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -20,6 +20,7 @@ buildPythonApplication rec {
 
   disabled = pythonOlder "3.8";
 
+  # no tests
   doCheck = false;
 
   pythonImportsCheck = [ "legendary" ];

--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -22,7 +22,7 @@ buildPythonApplication rec {
 
   doCheck = false;
 
-  pythonImportsCheck = [ "requests" ];
+  pythonImportsCheck = [ "legendary" ];
 
   meta = with lib; {
     description = "A free and open-source Epic Games Launcher alternative";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New versions released with some improvements:
https://github.com/derrod/legendary/releases/tag/0.20.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
