### PR TITLE
build-fhs-userenv: fixes for mount points

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -80,6 +80,11 @@ let
     if [[ -d ${env}/etc ]]; then
       for i in ${env}/etc/*; do
         path="/''${i##*/}"
+        # NOTE: we're binding /etc/fonts from the host so we don't want to
+        # override it with a path from the FHS environment.
+        if [[ $path == '/fonts' ]]; then
+          continue
+        fi
         ro_mounts+=(--ro-bind "$i" "/etc$path")
       done
     fi

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -24,8 +24,6 @@ let
     "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc"
   ]);
 
-  chrootenv = callPackage ./chrootenv {};
-
   etcBindFlags = let
     files = [
       # NixOS Compatibility

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -35,6 +35,8 @@ let
       "hosts"
       "resolv.conf"
       "nsswitch.conf"
+      # User profiles
+      "profiles"
       # Sudo & Su
       "login.defs"
       "sudoers"

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -89,6 +89,9 @@ let
       ln -s /host/etc/resolv.conf resolv.conf
       ln -s /host/etc/nsswitch.conf nsswitch.conf
 
+      # symlink user profiles
+      ln -s /host/etc/profiles profiles
+
       # symlink sudo and su stuff
       ln -s /host/etc/login.defs login.defs
       ln -s /host/etc/sudoers sudoers


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #110636.

`/etc/profiles` was not being mounted, which meant that any user-installed package would not be available under the FHS environment. This change alone fixes all the issues reported in #110636 since the AppImage environment can now find the browser executable and the correct cursor.

`/etc/fonts` was also broken since we were mounting the host's `/etc/fonts` but it was getting overriden by the default `/etc/fonts` from `fontconfig` that was part of the FHS environment.

I only tested these changes on AppImages and it solved all the issues I reported in #110636.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
