### PR TITLE
byrd: init at git-20200312

### DIFF
--- a/pkgs/applications/terminal-emulators/byrd/default.nix
+++ b/pkgs/applications/terminal-emulators/byrd/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, vte, libconfig, glib, pkg-config }:
+
+stdenv.mkDerivation {
+  pname = "byrd";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "Flyken271";
+    repo = "Byrd";
+    rev = "b65b677ea504592e4d3b45c32bb75342e03956f5";
+    sha256 = "1d575bly2ywgp8nmsddr976i5w3nvh23h8lak2n4m2rjmm3n9wxg";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ vte glib libconfig ];
+
+  buildPhase = ''
+    gcc main.c -o byrd $(pkg-config --libs --cflags vte-2.91 libconfig)
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 0755 -t $out/bin byrd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple and easy terminal for Linux written in C";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ anna328p ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -743,6 +743,8 @@ in
 
   archi = callPackage ../tools/misc/archi { };
 
+  byrd = callPackage ../applications/terminal-emulators/byrd {};
+
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };
 
   eterm = callPackage ../applications/terminal-emulators/eterm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

byrd is a simple terminal emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
