### PR TITLE
pythonPackages.cached-property: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/development/python-modules/cached-property/default.nix
+++ b/pkgs/development/python-modules/cached-property/default.nix
@@ -1,28 +1,25 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-, pytest
+, fetchPypi
+, pytestCheckHook
 , freezegun
 }:
 
 buildPythonPackage rec {
   pname = "cached-property";
-  version = "1.5.1";
+  version = "1.5.2";
 
-  # conftest.py is missing in PyPI tarball
-  src = fetchFromGitHub {
-    owner = "pydanny";
-    repo = pname;
-    rev = version;
-    sha256 = "0xh0pwmiikx0il9nnfyf034ydmlw6992s0d209agd9j5d3s2k5q6";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130";
   };
 
-  checkInputs = [ pytest freezegun ];
+  checkInputs = [ pytestCheckHook freezegun ];
 
-  # https://github.com/pydanny/cached-property/issues/131
-  checkPhase = ''
-    py.test -k "not test_threads_ttl_expiry"
-  '';
+  disabledTests = [
+    # https://github.com/pydanny/cached-property/issues/131
+    "test_threads_ttl_expiry"
+  ];
 
   meta = {
     description = "A decorator for caching properties in classes";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
