### PR TITLE
llvmPackages_rocm.clang: add isClang and llvm passthru

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/clang.nix
+++ b/pkgs/development/compilers/llvm/rocm/clang.nix
@@ -56,6 +56,11 @@ stdenv.mkDerivation rec {
     echo "$VCSVersion" > lib/Basic/VCSVersion.inc
   '';
 
+  passthru = {
+    isClang = true;
+    inherit llvm;
+  };
+
   meta = with lib; {
     description = "ROCm fork of the clang C/C++/Objective-C/Objective-C++ LLVM compiler frontend";
     homepage = "https://llvm.org/";


### PR DESCRIPTION
Matches generic clang compilers, and fixes isClang inspection, which
071030840252273acf05c9902458d4db5bdd71ab depends on for the `--gcc-toolchain` flag to be set up properly.


###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/110834

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
