### PR TITLE
zz: 0.1 -> unstable-2021-01-26

### DIFF
--- a/pkgs/development/compilers/zz/default.nix
+++ b/pkgs/development/compilers/zz/default.nix
@@ -2,18 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zz";
-  version = "0.1";
+  version = "unstable-2021-01-26";
 
+  # commit chosen by using the latest build from http://bin.zetz.it/
   src = fetchFromGitHub {
     owner = "aep";
     repo = "zz";
-    rev = version;
-    sha256 = "0kqrfm2r9wn0p2c3lcprsy03p9qhrwjs990va8qi59jp704l84ad";
+    rev = "0b5c52674e9adf795fbfb051d4dceef3126e669f";
+    sha256 = "0bb77ll1g5i6a04ybpgx6lqsb74xs4v4nyqm9j4j6x24407h8l89";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  cargoSha256 = "0yllcqxyyhwr9h0z8q84l0ms8x6jrqhpg79ik4xng6h5yf4ab0pq";
+  cargoSha256 = "1lf4k3n89w2797c1yrj1dp97y8a8d5hnixr1nwa2qcq1sxmm5rcg";
 
   postInstall = ''
     wrapProgram $out/bin/zz --prefix PATH ":" "${lib.getBin z3}/bin"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade to an unstable version, since upstream seems to rely on "use the latest build" generally and things are changing fast to the point where the documentation is no longer accurate for 0.1 (as in example programs don't compile).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
