### PR TITLE
[20.09] docker: allow overriding package inputs per docker package

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -1,10 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, buildGoPackage
-, makeWrapper, removeReferencesTo, installShellFiles, pkgconfig
-, go-md2man, go, containerd, runc, docker-proxy, tini, libtool
-, sqlite, iproute, lvm2, systemd
-, btrfs-progs, iptables, e2fsprogs, xz, utillinux, xfsprogs, git
-, procps, libseccomp
-}:
+{ lib, callPackage }:
 
 with lib;
 
@@ -14,7 +8,15 @@ rec {
       , runcRev, runcSha256
       , containerdRev, containerdSha256
       , tiniRev, tiniSha256
-    } :
+
+      # package dependencies
+      , stdenv, lib, fetchFromGitHub, fetchpatch, buildGoPackage
+      , makeWrapper, removeReferencesTo, installShellFiles, pkgconfig
+      , go-md2man, go, containerd, runc, docker-proxy, tini, libtool
+      , sqlite, iproute, lvm2, systemd
+      , btrfs-progs, iptables, e2fsprogs, xz, utillinux, xfsprogs, git
+      , procps, libseccomp
+    }:
   let
     docker-runc = runc.overrideAttrs (oldAttrs: {
       name = "docker-runc-${version}";
@@ -197,7 +199,7 @@ rec {
   # Get revisions from
   # https://github.com/docker/docker-ce/tree/${version}/components/engine/hack/dockerfile/install/*
 
-  docker_18_09 = makeOverridable dockerGen rec {
+  docker_18_09 = callPackage dockerGen rec {
     version = "18.09.9";
     rev = "v${version}";
     sha256 = "0wqhjx9qs96q2jd091wffn3cyv2aslqn2cvpdpgljk8yr9s0yg7h";
@@ -209,7 +211,7 @@ rec {
     tiniSha256 = "1h20i3wwlbd8x4jr2gz68hgklh0lb0jj7y5xk1wvr8y58fip1rdn";
   };
 
-  docker_19_03 = makeOverridable dockerGen rec {
+  docker_19_03 = callPackage dockerGen rec {
     version = "19.03.12";
     rev = "v${version}";
     sha256 = "0i5xr8q3yjrz5zsjcq63v4g1mzqpingjr1hbf9amk14484i2wkw7";


### PR DESCRIPTION
Previously we could not override the input packages to docker at all as
that had been shadowed due to the usage of inherit in all-package.nix.

We are now mixing the "variable" variables for the build and the
dependency declarations for the package and using callPackage as if each
of the docker packages would be separate files that we evaluate.

This now enables overriding e.g. iptables for a single verison of
docker which previously was not feasible without importing the
default.nix again (and passing different arguments).

> pkgs.docker.override { iptables = pkgs.iptables-nftables-compat; }

Backport of ed46383416a21ef496c6b52bc89d80f28c2efcad

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
