### PR TITLE
ser2net, gensio: bump to 4.3.2 and 2.2.3

### DIFF
--- a/pkgs/development/libraries/gensio/default.nix
+++ b/pkgs/development/libraries/gensio/default.nix
@@ -1,6 +1,5 @@
 { autoreconfHook
 , fetchFromGitHub
-, fetchpatch
 , lib
 , nix-update-script
 , pkg-config
@@ -9,22 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gensio";
-  version = "2.2.1";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "cminyard";
     repo = pname;
     rev = "v${version}";
-    sha256 = "083khzvyvcgi9j99hbaswglivm9s6dly6spjvisvyacavaybgwgb";
+    sha256 = "sha256-jWKm64RvVkeA/Zvy8VIAXMykuqv2FEzsduN2zcPm4ME=";
   };
-
-  patches =  [
-    # Fix compilation without openipmi, can be dropped for the next release.
-    (fetchpatch {
-      url = "https://github.com/cminyard/gensio/commit/12f6203e6f7aa42172177d7b0870777b605af8d9.patch";
-      sha256 = "19dr4iacccc4il3asdxkag6cj2yc4bxd8p451syfxdm6289rwxic";
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/servers/ser2net/default.nix
+++ b/pkgs/servers/ser2net/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ser2net";
-  version = "4.3.0";
+  version = "4.3.2";
 
   src = fetchFromGitHub {
     owner = "cminyard";
     repo = pname;
     rev = "v${version}";
-    sha256 = "13zhds3zav03f1snc4bb1j07i2x606bmnqm17yx37frib2hjs4nx";
+    sha256 = "sha256-fA4rtFZ2lhGAwY3KUl/Jk8gjueI761J1QRdivMtbqX4=";
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Upstream updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
