### PR TITLE
mosquitto: 1.6.12 -> 2.0.10

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -1,16 +1,28 @@
-{ stdenv, lib, fetchFromGitHub, cmake, docbook_xsl, libxslt
-, openssl, libuuid, libwebsockets_3_1, c-ares, libuv
-, systemd ? null, withSystemd ? stdenv.isLinux }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, docbook_xsl
+, libxslt
+, c-ares
+, cjson
+, libuuid
+, libuv
+, libwebsockets_3_1
+, openssl
+, withSystemd ? stdenv.isLinux
+, systemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
-  version = "1.6.12";
+  version = "2.0.10";
 
   src = fetchFromGitHub {
-    owner  = "eclipse";
-    repo   = "mosquitto";
-    rev    = "v${version}";
-    sha256 = "0y9jna2p7wg57vv2g6ls1dj6w89vaw828y9z1wb3vwz1yhvs35s8";
+    owner = "eclipse";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "144vw7b9ja4lci4mplbxs048x9aixd9c3s7rg6wc1k31w099rb12";
   };
 
   postPatch = ''
@@ -19,21 +31,22 @@ stdenv.mkDerivation rec {
         --replace http://docbook.sourceforge.net/release/xsl/current ${docbook_xsl}/share/xml/docbook-xsl
     done
 
-    for f in {lib,lib/cpp,src}/CMakeLists.txt ; do
-      substituteInPlace $f --replace /sbin/ldconfig true
-    done
-
     # the manpages are not generated when using cmake
     pushd man
     make
     popd
   '';
 
-  buildInputs = [
-    openssl libuuid libwebsockets_3_1 c-ares libuv
-  ] ++ lib.optional withSystemd systemd;
-
   nativeBuildInputs = [ cmake docbook_xsl libxslt ];
+
+  buildInputs = [
+    c-ares
+    cjson
+    libuuid
+    libuv
+    libwebsockets_3_1
+    openssl
+  ] ++ lib.optional withSystemd systemd;
 
   cmakeFlags = [
     "-DWITH_THREADING=ON"
@@ -41,7 +54,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional withSystemd "-DWITH_SYSTEMD=ON";
 
   meta = with lib; {
-    description = "An open source MQTT v3.1/3.1.1 broker";
+    description = "An open source MQTT v3.1/3.1.1/5.0 broker";
     homepage = "https://mosquitto.org/";
     license = licenses.epl10;
     maintainers = with maintainers; [ peterhoeg ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* new major 2.x version: https://mosquitto.org/blog/2020/12/version-2-0-0-released/
* see https://mosquitto.org/documentation/migrating-to-2-0/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
