### PR TITLE
weechatScripts.weechat-matrix: fix PYTHONPATH

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix/default.nix
@@ -70,6 +70,10 @@ in buildPythonPackage {
   '';
 
   dontPatchShebangs = true;
+  postFixup = ''
+    addToSearchPath program_PYTHONPATH $out/${python.sitePackages}
+    patchPythonScript $out/share/matrix.py
+  '';
 
   meta = with lib; {
     description = "A Python plugin for Weechat that lets Weechat communicate over the Matrix protocol";


### PR DESCRIPTION
matrix.py tries to import its dependencies, and its own code from
$out/${python.sitePackages}, and neither of these worked because
nothing was telling Python where to load that stuff from.

Using patchPythonScript made it so matrix.py could find its
dependencies, but it still wasn't able to find its own code, so that
had to be added to program_PYTHONPATH beforehand so patchPythonScript
would include it as well.

Fixes: https://github.com/NixOS/nixpkgs/issues/89499

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
