### PR TITLE
python3Packages.wasabi: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/wasabi/default.nix
+++ b/pkgs/development/python-modules/wasabi/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "wasabi";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "75fec6db6193c8615d7f398ae4aa2c4ad294e6e3e81c6a6dbbbd3864ee2223c3";
+    sha256 = "6e5228a51f5550844ef5080e74759e7ecb6e344241989d018686ba968f0b4f5a";
   };
 
   checkInputs = [ pytestCheckHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog:
https://github.com/ines/wasabi/releases/tag/v0.8.1

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>python37Packages.textacy</li>
    <li>python38Packages.textacy</li>
    <li>python39Packages.textacy</li>
  </ul>
</details>
<details>
  <summary>9 packages built:</summary>
  <ul>
    <li>python37Packages.spacy</li>
    <li>python37Packages.thinc</li>
    <li>python37Packages.wasabi</li>
    <li>python38Packages.spacy</li>
    <li>python38Packages.thinc</li>
    <li>python38Packages.wasabi</li>
    <li>python39Packages.spacy</li>
    <li>python39Packages.thinc</li>
    <li>python39Packages.wasabi</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
