### PR TITLE
nixos/test/dnscrypt-wrapper: fix test

### DIFF
--- a/nixos/tests/dnscrypt-wrapper/default.nix
+++ b/nixos/tests/dnscrypt-wrapper/default.nix
@@ -31,6 +31,7 @@ import ../make-test-python.nix ({ pkgs, ... }: {
 
     client = { lib, ... }:
       { services.dnscrypt-proxy2.enable = true;
+        services.dnscrypt-proxy2.upstreamDefaults = false;
         services.dnscrypt-proxy2.settings = {
           server_names = [ "server" ];
           static.server.stamp = "sdns://AQAAAAAAAAAAEDE5Mi4xNjguMS4xOjUzNTMgFEHYOv0SCKSuqR5CDYa7-58cCBuXO2_5uTSVU9wNQF0WMi5kbnNjcnlwdC1jZXJ0LnNlcnZlcg";


### PR DESCRIPTION
###### Motivation for this change

The test was broken by the inclusion of the default dnscrypt-proxy
configuration in e4c49db6.


###### Things done

- [x] Tested via `nixosTests.dnscrypt-wrapper`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @waynr @Atemu 