### PR TITLE
ZTS: init zfs test suite nixos tests (WIP)

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1003,6 +1003,7 @@ in {
   zammad = handleTest ./zammad.nix {};
   zeronet-conservancy = handleTest ./zeronet-conservancy.nix {};
   zfs = handleTest ./zfs.nix {};
+  zfs-tests = discoverTests (import ./zfs-tests.nix);
   zigbee2mqtt = handleTest ./zigbee2mqtt.nix {};
   zoneminder = handleTest ./zoneminder.nix {};
   zookeeper = handleTest ./zookeeper.nix {};

--- a/nixos/tests/zfs-tests.nix
+++ b/nixos/tests/zfs-tests.nix
@@ -1,0 +1,185 @@
+let
+  # Running all tests takes very long (multiple hours) and doesn't work properly.
+  # We'll just do a quick smoke-test.
+
+  # test run results (no extra text means PASS):
+  # - chattr
+  # - checksum
+  # - deadman
+  # - devices
+  # - fallocate
+  # - snapshot
+  # - tmpfile
+  # - upgrade
+  # - userquota
+  # - zdb
+  # - zfs
+  # - zfs_sysfs
+  # - zpool_add
+  # - zpool_reopen
+  # - compression (4 FAIL)
+  #   - compression/l2arc_compressed_arc
+  #   - compression/l2arc_compressed_arc_disabled
+  #   - compression/l2arc_encrypted
+  #   - compression/l2arc_encrypted_no_compressed_arc
+  # - events (3 FAIL)
+  #   - events/events_001_pos
+  #   - events/events_002_pos
+  #   - events/zed_rc_filter
+  # - exec (1 FAIL)
+  #   - exec/exec_001_pos
+  # - fault (takes very long, doesn't terminate?)
+  # - large_dnode (1 FAIL)
+  #   - features/large_dnode/large_dnode_006_pos
+  # - misc (1 FAIL)
+  #   - cli_user/misc/arc_summary_001_pos
+  # - mmp (14 SKIP)
+  # - rsend (takes very long, errors out with ENOSPC)
+  # - user_namespace (1 FAIL)
+  # - zfs_mount (2 FAIL)
+  #   - cli_root/zfs_mount/zfs_mount_013_pos
+  #   - cli_root/zfs_mount/zfs_multi_mount
+  # - zfs_share (2 FAIL, 13 SKIP)
+  #   - cli_root/zfs_share/setup
+  # - zpool_create (1 FAIL)
+  #   - cli_root/zpool_create/zpool_create_014_neg
+  # - zpool_expand (1 FAIL)
+  #   - cli_root/zpool_expand/zpool_expand_001_pos
+  # - zpool_split (1 SKIP)
+  #   - cli_root/zpool_split/zpool_split_props
+
+  # TODO
+  # - io (broken? fio)
+  # - pool_checkpoint (takes > 15 minutes)
+  # - cache (fio)
+  # - trim (fio)
+  # - l2arc (fio)
+  # - pam (pamtester)
+
+  tests = [
+    # 00:07
+    "chattr"
+    # 01:47
+    "checksum"
+    # 01:00
+    #"deadman" # disabled because it gives an error
+    # 00:04
+    "devices"
+    # 00:02
+    "fallocate"
+    # 01:03
+    "snapshot"
+    # 00:02
+    "tmpfile"
+    # 00:22
+    "upgrade"
+    # 00:58
+    "userquota"
+    # 04:51
+    "zdb"
+    # 00:43
+    "zfs"
+    # 00:04
+    "zfs_sysfs"
+    # 04:54
+    "zpool_add"
+    # 03:06
+    "zpool_reopen"
+  ];
+
+  mkTest = testname: (
+
+    import ./make-test-python.nix ({ lib, pkgs, ... }:
+      let
+        zfsForTesting = pkgs.zfs;
+      in
+      {
+        name = "zfs-tests-${testname}";
+        meta = with lib.maintainers; {
+          maintainers = [ mindavi ];
+        };
+
+        nodes.machine =
+          { lib, pkgs, config, ... }:
+            with lib;
+            {
+              imports = [ ./common/user-account.nix ];
+              # User must be in wheel group, without requiring password entry.
+              users.users.alice = { isNormalUser = true; group = "wheel"; };
+              security.sudo.wheelNeedsPassword = false;
+
+              # The default size of 512 MB was not enough, so bump it to be safe.
+              # E.g. functional/pool_checkpoint/setup uses quite a bit of harddrive space.
+              virtualisation.diskSize = 8192;
+              # ZFS uses quite a bit of RAM.
+              # This seems like a generous enough amount of memory.
+              virtualisation.memorySize = 4096;
+              # TODO(mindavi): Does it help to assign multiple cores?
+              virtualisation.cores = 6;
+
+              # This prevents that grub is rebuild / included in closure.
+              # It doesn't seem to be used anyway, because disabling helps :).
+              boot.loader.grub.enable = false;
+
+              boot.kernelModules = [ "zfs" ];
+              boot.supportedFilesystems = [ "zfs" ];
+              environment.systemPackages = [
+                pkgs.gcc
+                zfsForTesting
+                pkgs.ksh
+                pkgs.util-linux
+                pkgs.coreutils
+                pkgs.sudo
+                pkgs.lvm2
+                pkgs.gawk
+                pkgs.e2fsprogs # mkfs.ext4
+                pkgs.gzip # gzip, gunzip
+                pkgs.procps
+                pkgs.acl # setfacl, getfacl
+                pkgs.python3
+                pkgs.openssl
+                pkgs.bc
+                pkgs.nfs-utils
+                pkgs.dmidecode
+                pkgs.lsscsi
+                pkgs.file
+                pkgs.sysstat # iostat
+                pkgs.pax
+                pkgs.binutils # strings
+                pkgs.parted
+                pkgs.linuxPackages.perf
+                pkgs.samba # net
+                #pkgs.fio # disable because of kernel crashes... / hangs
+                # exportfs -> nfs-utils?
+
+                pkgs.lvm2
+              ];
+              networking.hostId = "abcdef01";
+            };
+
+        testScript = ''
+          start_all()
+          machine.wait_for_unit("multi-user.target")
+          print(machine.succeed("modprobe zfs", "zfs version", "id"))
+
+          machine.succeed(
+              "su - alice -- ${zfsForTesting.zfs_tests}/share/zfs/zfs-tests.sh -T ${testname} >> test-results.log",
+          )
+          # Show the last lines of the test results log.
+          print(machine.execute("tail -n30 test-results.log")[1])
+
+          print(machine.execute("cat test-results.log")[1])
+          print(machine.execute("grep 'Results Summary' -A 8 test-results.log")[1])
+
+          # These tools are still missing:
+          # Missing util(s): devname2devid mmap_libaio fio pamtester quotaon umask wait setenforce
+          print(machine.execute("grep 'Missing util' test-results.log")[1])
+
+          # Test results can be found in /var/tmp/test_results/<DATETIME>
+        '';
+      })
+  );
+  lib = (import ../../. { }).lib;
+in
+lib.genAttrs tests mkTest
+

--- a/nixos/tests/zfs-tests.nix
+++ b/nixos/tests/zfs-tests.nix
@@ -61,10 +61,13 @@ let
     "chattr"
     # 01:47
     "checksum"
+    "compression"
     # 01:00
-    #"deadman" # disabled because it gives an error
+    "deadman"
     # 00:04
     "devices"
+    "events"
+    "exec"
     # 00:02
     "fallocate"
     # 01:03
@@ -83,6 +86,7 @@ let
     "zfs_sysfs"
     # 04:54
     "zpool_add"
+    "zpool_create"
     # 03:06
     "zpool_reopen"
   ];
@@ -151,6 +155,7 @@ let
                 pkgs.samba # net
                 #pkgs.fio # disable because of kernel crashes... / hangs
                 # exportfs -> nfs-utils?
+                pkgs.tree
 
                 pkgs.lvm2
               ];
@@ -162,7 +167,7 @@ let
           machine.wait_for_unit("multi-user.target")
           print(machine.succeed("modprobe zfs", "zfs version", "id"))
 
-          machine.succeed(
+          machine.execute(
               "su - alice -- ${zfsForTesting.zfs_tests}/share/zfs/zfs-tests.sh -T ${testname} >> test-results.log",
           )
           # Show the last lines of the test results log.
@@ -175,7 +180,10 @@ let
           # Missing util(s): devname2devid mmap_libaio fio pamtester quotaon umask wait setenforce
           print(machine.execute("grep 'Missing util' test-results.log")[1])
 
+          print(machine.succeed("tree /var/tmp/test_results/"))
+          print(machine.succeed("cat /var/tmp/test_results/current/**"))
           # Test results can be found in /var/tmp/test_results/<DATETIME>
+          machine.succeed("grep 'Percent passed.*100' test-results.log")
         '';
       })
   );


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/108649

Using the official test suite is nice. Currently some random tests are enabled, the hardest part of this whole story seems to be: which tests should be enabled?

Note that running the 'sanity' tests already takes over 40 minutes, which is unacceptable. @adisbladis and me had a quick chat over on IRC (https://logs.nix.samueldr.com/nixos/2021-01-10, search for Mindavi and adisbladis), and we determined that ~10 mins is a good amount of time to shoot for (this is quite arbitrary, and based on the fact that ZFS is a fundamental part of the system).

There are some things I'd like feedback on:

- Do we want to combine the zfs.nix and this one (zfs-tests.nix currently)? 
- Is there a way to conditionally not remove the test suite files? I've commented out the line and tried some things with a variable as function argument, but couldn't figure out how to combine `override` and `overrideAttrs` (they're both needed).
- Is it acceptable that ZFS is rebuilt? This is currently done because the build scripts are changed (due to changes required to the test scripts).

All the currently enabled tests are passing, but (as can be seen in the test script) some of the tests fail. I'm not sure why, and the failing tests may be contributing to the long sanity test time as well.

This one in particular seems to be a culprit:

```
file_wait_event exceeded 120.289 seconds
ERROR: file_wait_event /var/tmp/zed/zed.debug.log sysevent.fs.zfs.scrub_start exited 1
```

It can be seen multiple times in a failure log.

I think the first step for this should be that we decide on where to put this and how to handle the ZFS conditional building / inclusion of the test suite. After this is merged, it's possible to look into what tests are best to run. This set will at least do _something_ in the good direction. If you have suggestions, please let me know. I don't want to be bikeshedding about which ones to run exactly now though. I'll trust any good advice on this, as long as the runtime stays acceptable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@adisbladis 
@Atemu

Attached is a test log of some of the failing tests, with the data of the logfiles that the ZTS generates included.

[zfs-tests-failing-tests-dump.txt](https://github.com/NixOS/nixpkgs/files/5875502/zfs-tests-failing-tests-dump.txt)

