### PR TITLE
libvirt: 6.8.0 -> 7.0.0

### DIFF
--- a/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+++ b/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
@@ -21,7 +21,7 @@ the nix store, but read them from the root filesystem.
  12 files changed, 53 insertions(+), 42 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 2e57a435df..4a72902a63 100644
+index b5164f6..33719f1 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -39,6 +39,8 @@ if host_machine.system() == 'windows'
@@ -48,7 +48,7 @@ index 2e57a435df..4a72902a63 100644
  # sysconfdir as this makes a lot of things break in testing situations
  if prefix == '/usr'
 diff --git a/meson_options.txt b/meson_options.txt
-index 74de064384..0a21eb845e 100644
+index e5d79c2..081cd32 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -1,3 +1,5 @@
@@ -58,7 +58,7 @@ index 74de064384..0a21eb845e 100644
  option('packager', type: 'string', value: '', description: 'Extra packager name')
  option('packager_version', type: 'string', value: '', description: 'Extra packager version')
 diff --git a/src/libxl/meson.build b/src/libxl/meson.build
-index 3bb6cc5f2e..78d7be0ace 100644
+index 3bb6cc5..78d7be0 100644
 --- a/src/libxl/meson.build
 +++ b/src/libxl/meson.build
 @@ -84,8 +84,8 @@ if conf.has('WITH_LIBXL')
@@ -74,7 +74,7 @@ index 3bb6cc5f2e..78d7be0ace 100644
    ]
  endif
 diff --git a/src/locking/meson.build b/src/locking/meson.build
-index 8a28310e40..9da81cc574 100644
+index 8a28310..9da81cc 100644
 --- a/src/locking/meson.build
 +++ b/src/locking/meson.build
 @@ -243,14 +243,14 @@ if conf.has('WITH_LIBVIRTD')
@@ -97,7 +97,7 @@ index 8a28310e40..9da81cc574 100644
    endif
  endif
 diff --git a/src/lxc/meson.build b/src/lxc/meson.build
-index f8e2a8852a..96d6687c5d 100644
+index f8e2a88..96d6687 100644
 --- a/src/lxc/meson.build
 +++ b/src/lxc/meson.build
 @@ -182,8 +182,8 @@ if conf.has('WITH_LXC')
@@ -113,7 +113,7 @@ index f8e2a8852a..96d6687c5d 100644
    ]
  endif
 diff --git a/src/meson.build b/src/meson.build
-index 29c8210ab2..bc960e0b69 100644
+index 7c47821..d33d16a 100644
 --- a/src/meson.build
 +++ b/src/meson.build
 @@ -669,7 +669,7 @@ endforeach
@@ -176,7 +176,7 @@ index 29c8210ab2..bc960e0b69 100644
  
  meson.add_install_script(
 diff --git a/src/network/meson.build b/src/network/meson.build
-index 13dd2c26b2..1be020081f 100644
+index 3ec598c..b02040b 100644
 --- a/src/network/meson.build
 +++ b/src/network/meson.build
 @@ -79,9 +79,9 @@ if conf.has('WITH_NETWORK')
@@ -191,24 +191,14 @@ index 13dd2c26b2..1be020081f 100644
 +    install_prefix + runstatedir / 'libvirt' / 'network',
    ]
  
-   uuidgen_prog = find_program('uuidgen', required: false)
-@@ -98,7 +98,7 @@ if conf.has('WITH_NETWORK')
-       ],
-       capture: true,
-       install: true,
--      install_dir: confdir / 'qemu' / 'networks',
-+      install_dir: install_prefix + confdir / 'qemu' / 'networks',
-     )
-   else
-     configure_file(
-@@ -106,13 +106,13 @@ if conf.has('WITH_NETWORK')
-       output: '@BASENAME@',
-       copy: true,
-       install: true,
--      install_dir: confdir / 'qemu' / 'networks',
-+      install_dir: install_prefix + confdir / 'qemu' / 'networks',
-     )
-   endif
+   configure_file(
+@@ -89,12 +89,12 @@ if conf.has('WITH_NETWORK')
+     output: '@BASENAME@',
+     copy: true,
+     install: true,
+-    install_dir: confdir / 'qemu' / 'networks',
++    install_dir: install_prefix + confdir / 'qemu' / 'networks',
+   )
  
    meson.add_install_script(
      meson_python_prog.path(), python3_prog.path(), meson_install_symlink_prog.path(),
@@ -218,17 +208,17 @@ index 13dd2c26b2..1be020081f 100644
    )
  
 diff --git a/src/nwfilter/xml/meson.build b/src/nwfilter/xml/meson.build
-index 95af75bb15..7fe99076f4 100644
+index 0d96c54..66c92a1 100644
 --- a/src/nwfilter/xml/meson.build
 +++ b/src/nwfilter/xml/meson.build
-@@ -19,4 +19,4 @@ nwfilter_xml_files = [
+@@ -25,4 +25,4 @@ nwfilter_xml_files = [
    'qemu-announce-self.xml',
  ]
  
 -install_data(nwfilter_xml_files, install_dir: sysconfdir / 'libvirt' / 'nwfilter')
 +install_data(nwfilter_xml_files, install_dir: install_prefix + sysconfdir / 'libvirt' / 'nwfilter')
 diff --git a/src/qemu/meson.build b/src/qemu/meson.build
-index 4e599d1e69..ba558d78f8 100644
+index 90640b0..8802cec 100644
 --- a/src/qemu/meson.build
 +++ b/src/qemu/meson.build
 @@ -171,12 +171,12 @@ if conf.has('WITH_QEMU')
@@ -252,7 +242,7 @@ index 4e599d1e69..ba558d78f8 100644
    ]
  endif
 diff --git a/src/remote/meson.build b/src/remote/meson.build
-index 9ad2f6ab1c..429a15b326 100644
+index 9ad2f6a..429a15b 100644
 --- a/src/remote/meson.build
 +++ b/src/remote/meson.build
 @@ -245,7 +245,7 @@ if conf.has('WITH_REMOTE')
@@ -283,7 +273,7 @@ index 9ad2f6ab1c..429a15b326 100644
    )
  endif
 diff --git a/src/security/apparmor/meson.build b/src/security/apparmor/meson.build
-index af43780211..e2d6c812f8 100644
+index af43780..e2d6c81 100644
 --- a/src/security/apparmor/meson.build
 +++ b/src/security/apparmor/meson.build
 @@ -17,22 +17,22 @@ foreach name : apparmor_gen_profiles
@@ -314,7 +304,7 @@ index af43780211..e2d6c812f8 100644
    rename: 'usr.lib.libvirt.virt-aa-helper',
  )
 diff --git a/tools/meson.build b/tools/meson.build
-index b8c6802f0a..dacd0ff1ce 100644
+index b8c6802..dacd0ff 100644
 --- a/tools/meson.build
 +++ b/tools/meson.build
 @@ -115,7 +115,7 @@ if conf.has('WITH_LOGIN_SHELL')
@@ -334,7 +324,3 @@ index b8c6802f0a..dacd0ff1ce 100644
 +    install_dir: install_prefix + sysconfdir / 'sysconfig',
      rename: 'libvirt-guests',
    )
- 
--- 
-2.29.2
-

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -31,19 +31,19 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "libvirt";
-  version = "6.8.0";
+  version = "7.0.0";
 
   src =
     if buildFromTarball then
       fetchurl {
         url = "https://libvirt.org/sources/${pname}-${version}.tar.xz";
-        sha256 = "0hhk2r0dnm9zmfwmnsnmnacm4pik6z60llp22axx7kcpqxv98nv5";
+        sha256 = "12fxkpy7j2qhfxypw9jg3bzdd9xx6vf6x96iy5kjihh89n236f6a";
       }
     else
       fetchgit {
         url = "https://gitlab.com/libvirt/libvirt.git";
         rev = "v${version}";
-        sha256 = "sha256-BQZPdmDE0g7xWd6QOHMKosP2HgVpIjsfgfohA9VxEHs=";
+        sha256 = "0xg9d410008mny73r2cp5ipghqpk0gz9gy7j32vcfk691dq75b3c";
         fetchSubmodules = true;
       };
 

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -111,7 +111,6 @@ in stdenv.mkDerivation rec {
     "-Ddriver_esx=enabled"
     "-Ddriver_remote=enabled"
     "-Dpolkit=enabled"
-    "-Ddbus=enabled"
     (opt "storage_iscsi" enableIscsi)
   ] ++ optionals stdenv.isLinux [
     (opt "storage_zfs" (zfs != null))
@@ -119,8 +118,6 @@ in stdenv.mkDerivation rec {
     "-Dapparmor=enabled"
     "-Dsecdriver_apparmor=enabled"
     "-Dnumad=enabled"
-    "-Dmacvtap=enabled"
-    "-Dvirtualport=enabled"
     "-Dstorage_disk=enabled"
     (opt "storage_rbd" enableCeph)
   ] ++ optionals stdenv.isDarwin [

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "6.8.0";
+  version = "7.0.0";
 
   src = assert version == libvirt.version; fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     rev = "v${version}";
-    sha256 = "sha256-A3eRfzQAfubyPefDlq5bAiFJ/G90D2JKdJO2Em0wE00=";
+    sha256 = "0vdvpqiypxis8wny7q39qps050zi13l66pnpa47040q6bar0d4xw";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19257,10 +19257,10 @@ let
 
   SysVirt = buildPerlModule rec {
     pname = "Sys-Virt";
-    version = "6.3.0";
+    version = "7.0.0";
    src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANBERR/Sys-Virt-v6.3.0.tar.gz";
-      sha256 = "6333fe3c554322fec5a3e1890b08a4ea4f39b0fbb506b3592688a5785a488f39";
+      url = "mirror://cpan/authors/id/D/DA/DANBERR/Sys-Virt-v7.0.0.tar.gz";
+      sha256 = "1w3div7p86kz9mmcdzmap7fi8hxvzs4nfglks044ihgi5la14r1y";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ pkgs.libvirt CPANChanges TestPod TestPodCoverage XMLXPath ];


### PR DESCRIPTION
###### Motivation for this change
Update libvirt to version `7.0.0`. Removed unknow mesonFlags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
