### PR TITLE
unrtf: 0.21.9 -> 0.21.10

### DIFF
--- a/pkgs/tools/text/unrtf/default.nix
+++ b/pkgs/tools/text/unrtf/default.nix
@@ -1,21 +1,13 @@
-{ lib, stdenv, fetchurl, fetchpatch, autoconf, automake, libiconv }:
+{ lib, stdenv, fetchurl, autoconf, automake, libiconv }:
 
 stdenv.mkDerivation rec {
   pname = "unrtf";
-  version = "0.21.9";
+  version = "0.21.10";
 
   src = fetchurl {
-    url = "https://www.gnu.org/software/unrtf/${pname}-${version}.tar.gz";
-    sha256 = "1pcdzf2h1prn393dkvg93v80vh38q0v817xnbwrlwxbdz4k7i8r2";
+    url = "https://ftp.gnu.org/gnu/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1bil6z4niydz9gqm2j861dkxmqnpc8m7hvidsjbzz7x63whj17xl";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2016-10091-0001-convert.c-Use-safe-buffer-size-and-snprintf.patch";
-      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=849705;filename=0001-convert.c-Use-safe-buffer-size-and-snprintf.patch;msg=20";
-      sha256 = "0s0fjvm3zdm9967sijlipfrwjs0h23n2n8fa6f40xxp8y5qq5a0b";
-    })
-  ];
 
   nativeBuildInputs = [ autoconf automake ];
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages built:</summary>
  <ul>
    <li>recoll</li>
    <li>unrtf</li>
  </ul>
</details>