### PR TITLE
libxc: 4.3.4 -> 5.1.0

### DIFF
--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -1,32 +1,39 @@
-{ lib, stdenv, fetchurl, gfortran, perl }:
+{ lib, stdenv, fetchFromGitLab, cmake, gfortran, perl }:
 
 let
-  version = "4.3.4";
+  version = "5.1.0";
 
 in stdenv.mkDerivation {
   pname = "libxc";
   inherit version;
-  src = fetchurl {
-    url = "http://www.tddft.org/programs/octopus/down.php?file=libxc/${version}/libxc-${version}.tar.gz";
-    sha256 = "0dw356dfwn2bwjdfwwi4h0kimm69aql2f4yk9f2kk4q7qpfkgvm8";
+
+  src = fetchFromGitLab {
+    owner = "libxc";
+    repo = "libxc";
+    rev = version;
+    sha256 = "0qbxh0lfx4cab1fk1qfnx72g4yvs376zqrq74jn224vy32nam2x7";
   };
 
   buildInputs = [ gfortran ];
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ perl cmake ];
 
   preConfigure = ''
     patchShebangs ./
   '';
 
-  configureFlags = [ "--enable-shared" ];
+  cmakeFlags = [ "-DENABLE_FORTRAN=ON" "-DBUILD_SHARED_LIBS=ON" ];
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$(pwd)
+  '';
 
   doCheck = true;
   enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Library of exchange-correlation functionals for density-functional theory";
-    homepage = "https://octopus-code.org/wiki/Libxc";
-    license = licenses.lgpl3;
+    homepage = "https://www.tddft.org/programs/Libxc/";
+    license = licenses.mpl20;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ markuskowa ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update to next major version.
https://gitlab.com/libxc/libxc/-/blob/master/ChangeLog.md

###### Things done
* update
* fix homepage + license
* switch to Gltlab sources
* switch to cmake

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
