### PR TITLE
httpdump: init at 20210126-d2e0dea

### DIFF
--- a/pkgs/tools/security/httpdump/default.nix
+++ b/pkgs/tools/security/httpdump/default.nix
@@ -1,0 +1,29 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, libpcap
+}:
+
+buildGoModule rec {
+  pname = "httpdump";
+  version = "20210126-${lib.strings.substring 0 7 rev}";
+  rev = "d2e0deadca5f9ec2544cb252da3c450966d1860e";
+
+  src = fetchFromGitHub {
+    owner = "hsiafan";
+    repo = pname;
+    inherit rev;
+    sha256 = "0yh8kxy1k23lln09b614limwk9y59r7cn5qhbnzc06ga4mxfczv2";
+  };
+
+  vendorSha256 = "0lb1p63lzn1ngj54bar9add7w0azvgcq3azhv9c5glk3ykv9c3iy";
+
+  propagatedBuildInputs = [ libpcap ];
+
+  meta = with lib; {
+    description = "Parse and display HTTP traffic from network device or pcap file";
+    homepage = "https://github.com/hsiafan/httpdump";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5084,6 +5084,8 @@ in
 
   http-getter = callPackage ../applications/networking/flent/http-getter.nix { };
 
+  httpdump = callPackage ../tools/security/httpdump { };
+
   httpie = callPackage ../tools/networking/httpie { };
 
   httping = callPackage ../tools/networking/httping {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Parse and display HTTP traffic from network device or pcap file.

https://github.com/hsiafan/httpdump

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
