### PR TITLE
cpython: add separateDebugInfo v2

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -445,6 +445,13 @@ in with passthru; stdenv.mkDerivation {
     find $out -name "*.py" | ${pythonForBuildInterpreter} -m compileall -q -f -x "lib2to3" -i -
     find $out -name "*.py" | ${pythonForBuildInterpreter} -O  -m compileall -q -f -x "lib2to3" -i -
     find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
+    '' + ''
+    # *strip* shebang from libpython gdb script - it should be dual-syntax and
+    # interpretable by whatever python the gdb in question is using, which may
+    # not even match the major version of this python. doing this after the
+    # bytecode compilations for the same reason - we don't want bytecode generated.
+    mkdir -p $out/share/gdb
+    sed '/^#!/d' Tools/gdb/libpython.py > $out/share/gdb/libpython.py
   '';
 
   preFixup = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -411,6 +411,11 @@ in with passthru; stdenv.mkDerivation {
     # This allows build Python to import host Python's sysconfigdata
     mkdir -p "$out/${sitePackages}"
     ln -s "$out/lib/${libPrefix}/"_sysconfigdata*.py "$out/${sitePackages}/"
+
+    # debug info can't be separated from a static library and would otherwise be
+    # left in place by a separateDebugInfo build. force its removal here to save
+    # space in output.
+    $STRIP -S $out/lib/${libPrefix}/config-*/libpython*.a || true
     '' + optionalString stripConfig ''
     rm -R $out/bin/python*-config $out/lib/python*/config-*
     '' + optionalString stripIdlelib ''
@@ -464,6 +469,8 @@ in with passthru; stdenv.mkDerivation {
     # These typically end up in shebangs.
     pythonForBuild buildPackages.bash
   ];
+
+  separateDebugInfo = true;
 
   inherit passthru;
 

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -94,12 +94,18 @@ let
 
   # Integration tests involving the package set.
   # All PyPy package builds are broken at the moment
-  integrationTests = lib.optionalAttrs (python.pythonAtLeast "3.7"  && (!python.isPyPy)) rec {
-    # Before the addition of NIX_PYTHONPREFIX mypy was broken with typed packages
-    nix-pythonprefix-mypy = callPackage ./tests/test_nix_pythonprefix {
-      interpreter = python;
-    };
-  };
+  integrationTests = lib.optionalAttrs (!python.isPyPy) (
+    lib.optionalAttrs (python.isPy3k && !stdenv.isDarwin) { # darwin has no split-debug
+      cpython-gdb = callPackage ./tests/test_cpython_gdb {
+        interpreter = python;
+      };
+    } // lib.optionalAttrs (python.pythonAtLeast "3.7") rec {
+      # Before the addition of NIX_PYTHONPREFIX mypy was broken with typed packages
+      nix-pythonprefix-mypy = callPackage ./tests/test_nix_pythonprefix {
+        interpreter = python;
+      };
+    }
+  );
 
   # Tests to ensure overriding works as expected.
   overrideTests = let

--- a/pkgs/development/interpreters/python/tests/test_cpython_gdb/default.nix
+++ b/pkgs/development/interpreters/python/tests/test_cpython_gdb/default.nix
@@ -1,0 +1,22 @@
+{ interpreter, lib, gdb, writeText, runCommand }:
+
+let
+  crashme-py = writeText "crashme.py" ''
+    import ctypes
+
+    def sentinel_foo_bar():
+        ctypes.memset(0, 1, 1)
+
+    sentinel_foo_bar()
+  '';
+in runCommand "python-gdb" {} ''
+  # test that gdb is able to recover the python stack frame of this segfault
+  ${gdb}/bin/gdb -batch -ex 'set debug-file-directory ${interpreter.debug}/lib/debug' \
+    -ex 'source ${interpreter}/share/gdb/libpython.py' \
+    -ex r \
+    -ex py-bt \
+    --args ${interpreter}/bin/python ${crashme-py} | grep 'in sentinel_foo_bar' > /dev/null
+
+  # success.
+  touch $out
+''


### PR DESCRIPTION
###### Motivation for this change
This is my second attempt at #93083 which had to be reverted due to the increased size of `libpython*.a`. This was because separating debug info doesn't work with static libraries and so it just gets left in place. My fairly simple solution here is to just explicitly unconditionally strip it in `postInstall`.

Also I note that this is only for py3, because cpython2 has been split out to a separate derivation. It's similar enough though and I could add this there too if things go well with py3.

Tested on `master` (before I rebased to `staging`) on non-nixos linux, nixos & macos 10.14 (all x86_64). Obviously, I have *not* performed a full rebuild.

Seeing as this is such a core dependency, are there any of the weirder ports that should be tested? I tried to make the `$STRIP -S` command as universal as possible but I guess it _could_ break some more exotic systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
