### PR TITLE
arrow-cpp: 2.0.0 -> 3.0.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, fetchFromGitHub, fetchpatch, fixDarwinDylibNames
 , autoconf, boost, brotli, cmake, flatbuffers, gflags, glog, gtest, lz4
-, perl, python3, rapidjson, snappy, thrift, utf8proc, which, zlib, zstd
+, perl, python3, rapidjson, re2, snappy, thrift, utf8proc, which, zlib, zstd
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
@@ -8,25 +8,25 @@ let
   arrow-testing = fetchFromGitHub {
     owner = "apache";
     repo = "arrow-testing";
-    rev = "860376d4e586a3ac34ec93089889da624ead6c2a";
-    sha256 = "16k3lz4ji4y3qcjhr765q14jwwlac8iqscwndwd8ll3zr0vy69b0";
+    rev = "d6c4deb22c4b4e9e3247a2f291046e3c671ad235";
+    sha256 = "0cwhnqijam632zp07j98i8ym967wz6kd35fim1msv88x2rhqky1i";
   };
 
   parquet-testing = fetchFromGitHub {
     owner = "apache";
     repo = "parquet-testing";
-    rev = "d914f9d289488c7db1759d7a88a4a1b8f062c7dd";
-    sha256 = "0xj3ynck2wv6l70xnmvs13bz1jycqjrl5k4lwhhwgag338048als";
+    rev = "e31fe1a02c9e9f271e4bfb8002d403c52f1ef8eb";
+    sha256 = "02f51dvx8w5mw0bx3hn70hkn55mn1m65kzdps1ifvga9hghpy0sh";
   };
 
 in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "2.0.0";
+  version = "3.0.0";
 
   src = fetchurl {
     url =
       "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "1ghzqw0rx4rxa2d7i76y3szisv0bd9cl7vzadbc41cvvhk6440xy";
+    sha256 = "0yp2b02wrc3s50zd56fmpz4nhhbihp0zw329v4zizaipwlxwrhkk";
   };
   sourceRoot = "apache-arrow-${version}/cpp";
 
@@ -67,6 +67,7 @@ in stdenv.mkDerivation rec {
     gtest
     lz4
     rapidjson
+    re2
     snappy
     thrift
     utf8proc
@@ -115,6 +116,15 @@ in stdenv.mkDerivation rec {
     if doInstallCheck then "${arrow-testing}/data" else null;
   PARQUET_TEST_DATA =
     if doInstallCheck then "${parquet-testing}/data" else null;
+  GTEST_FILTER =
+    if doInstallCheck then let
+      # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11398
+      filteredTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+        "TestFilterKernelWithNumeric/3.CompareArrayAndFilterRandomNumeric"
+        "TestFilterKernelWithNumeric/7.CompareArrayAndFilterRandomNumeric"
+        "TestCompareKernel.PrimitiveRandomTests"
+      ];
+    in "-${builtins.concatStringsSep ":" filteredTests}" else null;
   installCheckInputs = [ perl which ];
   installCheckPhase =
   let

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -34,6 +34,13 @@ buildPythonPackage rec {
     export PYARROW_PARALLEL=$NIX_BUILD_CORES
   '';
 
+  # Deselect a single test because pyarrow prints a 2-line error message where
+  # only a single line is expected. The additional line of output comes from
+  # the glog library which is an optional dependency of arrow-cpp that is
+  # enabled in nixpkgs.
+  # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11393
+  pytestFlagsArray = [ "--deselect=pyarrow/tests/test_memory.py::test_env_var" ];
+
   dontUseSetuptoolsCheck = true;
   preCheck = ''
     mv pyarrow/tests tests


### PR DESCRIPTION
###### Motivation for this change
https://arrow.apache.org/release/3.0.0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
