### PR TITLE
trousers: 0.3.14 -> 0.3.15

### DIFF
--- a/pkgs/tools/security/trousers/allow-non-tss-config-file-owner.patch
+++ b/pkgs/tools/security/trousers/allow-non-tss-config-file-owner.patch
@@ -7,10 +7,10 @@ diff -ur trousers-0.3.11.2.orig/src/tcsd/tcsd_conf.c trousers-0.3.11.2/src/tcsd/
  
 +#ifndef ALLOW_NON_TSS_CONFIG_FILE
  	/* make sure user/group TSS owns the conf file */
- 	if (pw->pw_uid != stat_buf.st_uid || grp->gr_gid != stat_buf.st_gid) {
+ 	if (stat_buf.st_uid != 0 || grp->gr_gid != stat_buf.st_gid) {
  		LogError("TCSD config file (%s) must be user/group %s/%s", tcsd_config_file,
 @@ -775,6 +776,7 @@
- 		LogError("TCSD config file (%s) must be mode 0600", tcsd_config_file);
+ 		LogError("TCSD config file (%s) must be mode 0640", tcsd_config_file);
  		return TCSERR(TSS_E_INTERNAL_ERROR);
  	}
 +#endif

--- a/pkgs/tools/security/trousers/default.nix
+++ b/pkgs/tools/security/trousers/default.nix
@@ -1,17 +1,15 @@
-{ lib, stdenv, fetchurl, openssl, pkg-config }:
+{ lib, stdenv, fetchurl, openssl, pkg-config, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   pname = "trousers";
-  version = "0.3.14";
+  version = "0.3.15";
 
   src = fetchurl {
     url = "mirror://sourceforge/trousers/trousers/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0iwgsbrbb7nfqgl61x8aailwxm8akxh9gkcwxhsvf50x4qx72l6f";
+    sha256 = "0zy7r9cnr2gvwr2fb1q4fc5xnvx405ymcbrdv7qsqwl3a4zfjnqy";
   };
 
-  sourceRoot = ".";
-
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ openssl ];
 
   patches = [ ./allow-non-tss-config-file-owner.patch ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix CVE-2020-24332, CVE-2020-24330 and CVE-2020-24331.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages marked as broken and skipped:</summary>
  <ul>
    <li>chaps</li>
    <li>gnutls-kdh</li>
    <li>tlspool</li>
  </ul>
</details>
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>opencryptoki</li>
    <li>pond</li>
    <li>simpleTpmPk11</li>
    <li>strongswanTNC</li>
    <li>tboot</li>
    <li>tpm-luks</li>
    <li>tpm-quote-tools</li>
    <li>tpm-tools</li>
    <li>tpmmanager</li>
    <li>trousers</li>
  </ul>
</details>