### PR TITLE
jiten: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7235,6 +7235,16 @@
     github = "obsidian-systems-maintenance";
     githubId = 80847921;
   };
+  obfusk = {
+    email = "flx@obfusk.net";
+    github = "obfusk";
+    githubId = 1260687;
+    name = "Felix C. Stegerman";
+    keys = [{
+      longkeyid = "rsa4096/0x2F9607F09B360F2D";
+      fingerprint = "D5E4 A51D F8D2 55B9 FAC6  A9BB 2F96 07F0 9B36 0F2D";
+    }];
+  };
   odi = {
     email = "oliver.dunkl@gmail.com";
     github = "odi";

--- a/pkgs/applications/misc/jiten/default.nix
+++ b/pkgs/applications/misc/jiten/default.nix
@@ -1,0 +1,91 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, makeWrapper
+, pcre
+, sqlite
+, nodejs
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "jiten";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "obfusk";
+    repo = "jiten";
+    rev = "v${version}";
+    sha256 = "1lg1n7f4383jdlkbma0q65yl6l159wgh886admcq7l7ap26zpqd2";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pcre sqlite ];
+  propagatedBuildInputs = with python3Packages; [ click flask ];
+  checkInputs = [ nodejs ];
+
+  preBuild = ''
+    export JITEN_VERSION=${version}   # override `git describe`
+    export JITEN_FINAL=yes            # build & package *.sqlite3
+  '';
+
+  postPatch = ''
+    substituteInPlace Makefile                  --replace /bin/bash "$(command -v bash)"
+    substituteInPlace jiten/res/jmdict/Makefile --replace /bin/bash "$(command -v bash)"
+  '';
+
+  checkPhase = "make test";
+
+  postInstall = ''
+    # requires pywebview
+    rm $out/bin/jiten-gui
+  '';
+
+  meta = with lib; {
+    description = "Japanese android/cli/web dictionary based on jmdict/kanjidic";
+    longDescription = ''
+      Jiten is a Japanese dictionary based on JMDict/Kanjidic
+
+      Fine-grained search using regexes (regular expressions)
+      • simple searches don't require knowledge of regexes
+      • quick reference available in the web interface and android app
+
+      JMDict multilingual japanese dictionary
+      • kanji, readings (romaji optional), meanings & more
+      • meanings in english, dutch, german, french and/or spanish
+      • pitch accent (from Wadoku)
+      • browse by frequency/jlpt
+
+      Kanji dictionary
+      • readings (romaji optional), meanings (english), jmdict entries, radicals & more
+      • search using SKIP codes
+      • search by radical
+      • browse by frequency/level/jlpt
+
+      Example sentences (from Tatoeba)
+      • with english, dutch, german, french and/or spanish translation
+      • some with audio
+
+      Stroke order
+      • input a word or sentence and see how it's written
+
+      Web interface
+      • available online at https://jiten.obfusk.dev
+      • light/dark mode
+      • search history (stored locally)
+      • tooltips to quickly see meanings and readings for kanji and words
+      • use long press for tooltips on mobile
+      • converts romaji to hiragana and between hiragana and katakana
+      • can be run on your own computer
+
+      Command-line interface
+    '';
+    homepage = "https://github.com/obfusk/jiten";
+    license = with licenses; [
+      agpl3Plus               # code
+      cc-by-sa-30             # jmdict/kanjidic
+      unfreeRedistributable   # pitch data from wadoku is non-commercial :(
+    ];
+    maintainers = [ maintainers.obfusk ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2665,6 +2665,8 @@ in
 
   jellyfin-mpv-shim = python3Packages.callPackage ../applications/video/jellyfin-mpv-shim { };
 
+  jiten = callPackage ../applications/misc/jiten { };
+
   jotta-cli = callPackage ../applications/misc/jotta-cli { };
 
   joycond = callPackage ../os-specific/linux/joycond { };


### PR DESCRIPTION
###### Motivation for this change

I'm the developer of [Jiten Japanese Dictionary](https://github.com/obfusk/jiten). A NixOS user wanted to install it, so I made a nix expression. Since having it in nixpkgs would be even better, I'm making this PR :)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`~~
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [ ] ~~Determined the impact on package closure size (by running `nix path-info -S` before and after)~~
- [ ] ~~Ensured that relevant documentation is up to date~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
