### PR TITLE
ghcjs: fix eval

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
@@ -10,7 +10,7 @@
     , ghcjs-th, haddock-api-ghcjs, hashable, haskell-src-exts
     , haskell-src-meta, http-types, HUnit, lens, lifted-base, mtl
     , network, optparse-applicative, parallel, parsec, process, random
-    , regex-posix, safe, shelly, split, stdenv, stringsearch, syb
+    , regex-posix, safe, shelly, split, lib, stringsearch, syb
     , system-fileio, system-filepath, tar, template-haskell
     , template-haskell-ghcjs, terminfo, test-framework
     , test-framework-hunit, text, time, transformers
@@ -61,7 +61,7 @@
   ghc-api-ghcjs = callPackage
     ({ mkDerivation, alex, array, base, binary, bytestring, containers
     , deepseq, directory, filepath, ghc-boot, ghc-boot-th, ghc-heap
-    , ghci-ghcjs, happy, hpc, process, stdenv, template-haskell-ghcjs
+    , ghci-ghcjs, happy, hpc, process, lib, template-haskell-ghcjs
     , terminfo, time, transformers, unix
     }:
     mkDerivation {
@@ -81,7 +81,7 @@
 
   ghci-ghcjs = callPackage
     ({ mkDerivation, array, base, binary, bytestring, containers
-    , deepseq, filepath, ghc-boot, ghc-boot-th, ghc-heap, stdenv
+    , deepseq, filepath, ghc-boot, ghc-boot-th, ghc-heap, lib
     , template-haskell-ghcjs, transformers, unix
     }:
     mkDerivation {
@@ -98,7 +98,7 @@
 
   ghcjs-th = callPackage
     ({ mkDerivation, base, binary, bytestring, containers, ghc-prim
-    , ghci-ghcjs, stdenv, template-haskell-ghcjs
+    , ghci-ghcjs, lib, template-haskell-ghcjs
     }:
     mkDerivation {
       pname = "ghcjs-th";
@@ -115,7 +115,7 @@
   haddock-api-ghcjs = callPackage
     ({ mkDerivation, array, base, bytestring, Cabal, containers, deepseq
     , directory, filepath, ghc-api-ghcjs, ghc-boot, ghc-paths
-    , haddock-library-ghcjs, hspec, hspec-discover, QuickCheck, stdenv
+    , haddock-library-ghcjs, hspec, hspec-discover, QuickCheck, lib
     , transformers, xhtml
     }:
     mkDerivation {
@@ -142,7 +142,7 @@
   haddock-library-ghcjs = callPackage
     ({ mkDerivation, base, base-compat, bytestring, containers, deepseq
     , directory, filepath, haddock-library, hspec, hspec-discover
-    , optparse-applicative, parsec, QuickCheck, stdenv, text
+    , optparse-applicative, parsec, QuickCheck, lib, text
     , transformers, tree-diff
     }:
     mkDerivation {
@@ -164,7 +164,7 @@
     }) {};
 
   template-haskell-ghcjs = callPackage
-    ({ mkDerivation, base, ghc-boot-th, pretty, stdenv }:
+    ({ mkDerivation, base, ghc-boot-th, pretty, lib }:
     mkDerivation {
       pname = "template-haskell-ghcjs";
       version = "2.14.0.0";

--- a/pkgs/development/compilers/ghcjs-ng/ghcjs-base.nix
+++ b/pkgs/development/compilers/ghcjs-ng/ghcjs-base.nix
@@ -4,6 +4,7 @@
 , quickcheck-unicode, random, scientific, test-framework
 , test-framework-hunit, test-framework-quickcheck2, text, time
 , transformers, unordered-containers, vector
+, lib
 }:
 mkDerivation {
   pname = "ghcjs-base";


### PR DESCRIPTION
This was causing release-cross to fail hydra eval, so it hasn't been
building for the last few days. So note that although ghcjs still
does not build, this fixes eval so the jobset can proceed.

Verified with `hydra-eval-jobs pkgs/top-level/release-cross.nix -I nixpkgs=.`

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
