### PR TITLE
vkBasalt: init at 0.3.2.4

### DIFF
--- a/pkgs/tools/graphics/vkBasalt/default.nix
+++ b/pkgs/tools/graphics/vkBasalt/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, glslang
+, meson
+, ninja
+, pkg-config
+, libX11
+, spirv-headers
+, vulkan-headers
+, vkBasalt32
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vkBasalt";
+  version = "0.3.2.4";
+
+  src = fetchFromGitHub {
+    owner = "DadSchoorse";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01iplj6dlw2vl35hyci5m5yp8jmzcwng6c3jk3wn97jpv6m3hjqz";
+  };
+
+  nativeBuildInputs = [ glslang meson ninja pkg-config ];
+  buildInputs = [ libX11 spirv-headers vulkan-headers ];
+  mesonFlags = [ "-Dappend_libdir_vkbasalt=true" ];
+
+  # Include 32bit layer in 64bit build
+  postInstall = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") ''
+    ln -s ${vkBasalt32}/share/vulkan/implicit_layer.d/vkBasalt.json \
+      "$out/share/vulkan/implicit_layer.d/vkBasalt32.json"
+  '';
+
+  meta = with lib; {
+    description = "A Vulkan post processing layer for Linux";
+    homepage = "https://github.com/DadSchoorse/vkBasalt";
+    license = licenses.zlib;
+    maintainers = with maintainers; [ metadark ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8602,6 +8602,10 @@ in
 
   vix = callPackage ../tools/misc/vix { };
 
+  vkBasalt = callPackage ../tools/graphics/vkBasalt {
+    vkBasalt32 = pkgsi686Linux.vkBasalt;
+  };
+
   vnc2flv = callPackage ../tools/video/vnc2flv {};
 
   vncrec = callPackage ../tools/video/vncrec { };


### PR DESCRIPTION
###### Motivation for this change
Closes #84684

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  No binary files, tested through use of Vulkan games
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Examples
#### The Legend of Zelda: Breath of the Wild with [Glitch](https://github.com/crosire/reshade-shaders/blob/891aca49c57c7e2178c16f27e7aa812c58a4998f/Shaders/Glitch.fx) shader:
![glitch](https://user-images.githubusercontent.com/382041/105929164-fde22200-6014-11eb-8ada-88e8b38e2f34.png)

#### Phasmophobia with [FilmGrain](https://github.com/crosire/reshade-shaders/blob/891aca49c57c7e2178c16f27e7aa812c58a4998f/Shaders/FilmGrain.fx), [Sepia](https://github.com/crosire/reshade-shaders/blob/891aca49c57c7e2178c16f27e7aa812c58a4998f/Shaders/Sepia.fx) & [Vignette](https://github.com/crosire/reshade-shaders/blob/891aca49c57c7e2178c16f27e7aa812c58a4998f/Shaders/Vignette.fx) shaders:
![phasmophobia-small](https://user-images.githubusercontent.com/382041/105929385-7517b600-6015-11eb-9ee3-9d5b2aa79fcf.png)
