### PR TITLE
pythonPackages.jupyter-server-proxy: init at 1.5.4

### DIFF
--- a/pkgs/development/python-modules/jupyter-server-proxy/default.nix
+++ b/pkgs/development/python-modules/jupyter-server-proxy/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, notebook
+, simpervisor
+, aiohttp
+, pytest
+, pytest-asyncio
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "jupyter-server-proxy";
+  version = "1.5.3";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "jupyterhub";
+    repo = "jupyter-server-proxy";
+    rev = "v${version}";
+    sha256 = "140mlzcnhadxrnhfwf7glx9cgzrcsbs1gmcsks62a8dpdns89spd";
+  };
+
+  propagatedBuildInputs = [
+    notebook
+    simpervisor
+    aiohttp
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-asyncio
+  ];
+
+  # tests require network
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Jupyter server extension to supervise and proxy web services";
+    homepage = https://github.com/jupyterhub/jupyter-server-proxy;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/simpervisor/default.nix
+++ b/pkgs/development/python-modules/simpervisor/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytest-asyncio
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "simpervisor";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "yuvipanda";
+    repo = "simpervisor";
+    rev = "v${version}";
+    sha256 = "1brsisx7saf4ic0dih1n5y7rbdbwn1ywv9pl32bch3061r46prvv";
+  };
+
+  checkInputs = [
+    pytest
+    pytest-asyncio
+    aiohttp
+  ];
+
+  checkPhase = ''
+    pytest --ignore tests/test_ready.py
+  '';
+
+  meta = with lib; {
+    description = "Simple async process supervisor";
+    homepage = https://github.com/yuvipanda/simpervisor;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7099,6 +7099,8 @@ in {
 
   simanneal = callPackage ../development/python-modules/simanneal { };
 
+  simpervisor = callPackage ../development/python-modules/simpervisor { };
+
   simpleai = callPackage ../development/python-modules/simpleai { };
 
   simpleaudio = callPackage ../development/python-modules/simpleaudio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3384,6 +3384,8 @@ in {
 
   jupyter-c-kernel = callPackage ../development/python-modules/jupyter-c-kernel { };
 
+  jupyter-server-proxy = callPackage ../development/python-modules/jupyter-server-proxy { };
+
   jupyter_client = if isPy3k then
     callPackage ../development/python-modules/jupyter_client { }
   else


### PR DESCRIPTION


###### Motivation for this change

Needed for jupyterhub / jupyterlab deployments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
