### PR TITLE
Fix NixOS cross compilation: Revert "[nix-update-cpan] perlPackages.HTTPDaemon: 6.01 -> 6.12"

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9703,12 +9703,11 @@ let
 
   HTTPDaemon = buildPerlPackage {
     pname = "HTTP-Daemon";
-    version = "6.12";
+    version = "6.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Daemon-6.12.tar.gz";
-      sha256 = "19hz9r6f1p406fk1pqyd99h96ipxsmknh4fh1xw0qrrq1k8vwiyz";
+      url = "mirror://cpan/authors/id/G/GA/GAAS/HTTP-Daemon-6.01.tar.gz";
+      sha256 = "1hmd2isrkilf0q0nkxms1q64kikjmcw9imbvrjgky6kh89vqdza3";
     };
-    buildInputs = [ CPANMetaCheck ModuleBuildTiny TestNeeds ];
     propagatedBuildInputs = [ HTTPMessage ];
     meta = {
       description = "A simple http server class";


### PR DESCRIPTION
The recent perl modules bump triggered #66741 more globally and [broke NixOS cross-compilation](https://github.com/NixOS/nixpkgs/issues/66741#issuecomment-763277042). Reverting the HTTPDaemon bump seems to fix NixOS compilation, but doesn't address the underlying cause.

Since I'm no expert in Perl and the original issue hasn't been fixed in over a year and a half I'm proposing a revert until the issue can be resolved.