### PR TITLE
factorio: update all versions to 1.1.19

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -10,12 +10,12 @@
         "version": "1.1.19"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.0.0.tar.xz",
+        "name": "factorio_alpha_x64-1.1.19.tar.xz",
         "needsAuth": true,
-        "sha256": "0zixscff0svpb0yg8nzczp2z4filqqxi1k0z0nrpzn2hhzhf1464",
+        "sha256": "1ip855iaw2pzgijpnp7bazj7qm3zqr2599xzaf7wx8gcdviq1k5r",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.0.0/alpha/linux64",
-        "version": "1.0.0"
+        "url": "https://factorio.com/get-download/1.1.19/alpha/linux64",
+        "version": "1.1.19"
       }
     },
     "demo": {
@@ -28,12 +28,12 @@
         "version": "1.1.19"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.0.0.tar.xz",
+        "name": "factorio_demo_x64-1.1.19.tar.xz",
         "needsAuth": false,
-        "sha256": "0h9cqbp143w47zcl4qg4skns4cngq0k40s5jwbk0wi5asjz8whqn",
+        "sha256": "1p9avwkdqpaw9insji9v711rylqn9kxg0gzd8s7hdrmci3ah0ifr",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.0.0/demo/linux64",
-        "version": "1.0.0"
+        "url": "https://factorio.com/get-download/1.1.19/demo/linux64",
+        "version": "1.1.19"
       }
     },
     "headless": {
@@ -46,12 +46,12 @@
         "version": "1.1.19"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.0.0.tar.xz",
+        "name": "factorio_headless_x64-1.1.19.tar.xz",
         "needsAuth": false,
-        "sha256": "0r0lplns8nxna2viv8qyx9mp4cckdvx6k20w2g2fwnj3jjmf3nc1",
+        "sha256": "0w0ir1dzx39vq1w09ikgw956q1ilq6n0cyi50arjhgcqcg44w1ks",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.0.0/headless/linux64",
-        "version": "1.0.0"
+        "url": "https://factorio.com/get-download/1.1.19/headless/linux64",
+        "version": "1.1.19"
       }
     }
   }

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.16.tar.xz",
+        "name": "factorio_alpha_x64-1.1.19.tar.xz",
         "needsAuth": true,
-        "sha256": "000n19mm7xc1qvc93kakvayjd0j749hv5nrdmsp7vdixcd773vjn",
+        "sha256": "1ip855iaw2pzgijpnp7bazj7qm3zqr2599xzaf7wx8gcdviq1k5r",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.16/alpha/linux64",
-        "version": "1.1.16"
+        "url": "https://factorio.com/get-download/1.1.19/alpha/linux64",
+        "version": "1.1.19"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.0.0.tar.xz",
@@ -20,12 +20,12 @@
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.16.tar.xz",
+        "name": "factorio_demo_x64-1.1.19.tar.xz",
         "needsAuth": false,
-        "sha256": "11nkpx8f3a30i06q7iqds12fiy1q67h64vh72y8x5l4mjg16j1js",
+        "sha256": "1p9avwkdqpaw9insji9v711rylqn9kxg0gzd8s7hdrmci3ah0ifr",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.16/demo/linux64",
-        "version": "1.1.16"
+        "url": "https://factorio.com/get-download/1.1.19/demo/linux64",
+        "version": "1.1.19"
       },
       "stable": {
         "name": "factorio_demo_x64-1.0.0.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.16.tar.xz",
+        "name": "factorio_headless_x64-1.1.19.tar.xz",
         "needsAuth": false,
-        "sha256": "02w92sgw4i3k1zywdg30mkr7nfylynsdn7sz5jzslyp0mkglrixi",
+        "sha256": "0w0ir1dzx39vq1w09ikgw956q1ilq6n0cyi50arjhgcqcg44w1ks",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.16/headless/linux64",
-        "version": "1.1.16"
+        "url": "https://factorio.com/get-download/1.1.19/headless/linux64",
+        "version": "1.1.19"
       },
       "stable": {
         "name": "factorio_headless_x64-1.0.0.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

My client running the stable channel prompted for an update. Their [download page](https://factorio.com/download) also lists 1.1.19 as stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
