### PR TITLE
treewide: remove inherited stdenv.lib

### DIFF
--- a/pkgs/applications/editors/vim/macvim-configurable.nix
+++ b/pkgs/applications/editors/vim/macvim-configurable.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, vimUtils, buildEnv, makeWrapper }:
+{ lib, stdenv, callPackage, vimUtils, buildEnv, makeWrapper }:
 
 let
   macvim = callPackage ./macvim.nix { inherit stdenv; };
@@ -12,7 +12,6 @@ let
     # sourcing of the user's vimrc. Use `customRC = "source $HOME/.vim/vimrc"`
     # if you want to preserve that behavior.
     configure = let
-      inherit (stdenv) lib;
       doConfig = config: let
         vimrcConfig = config // {
           # always source the bundled system vimrc

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchFromGitHub, flex, bison, pkg-config, zlib, libtiff, libpng, fftw
+{ lib, stdenv, fetchFromGitHub, flex, bison, pkg-config, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg_3, makeWrapper, wxGTK30, netcdf, blas
 , proj, gdal, geos, sqlite, postgresql, libmysqlclient, python2Packages, libLAS, proj-datumgrid
 }:
-
-let inherit (stdenv) lib; in
 
 stdenv.mkDerivation rec {
   name = "grass";

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -125,7 +125,7 @@ python3.pkgs.buildPythonApplication {
   '';
 
   passthru.updateScript = import ./update.nix {
-    inherit (stdenv) lib;
+    inherit lib;
     inherit
       writeScript
       common-updater-scripts

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -20,7 +20,6 @@
 }:
 
 let
-    inherit (stdenv) lib;
     buildClient = monolithic || client;
     buildCore = monolithic || enableDaemon;
 in

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, makeWrapper, autoPatchelfHook, wrapGAppsHook, which, more
+{ lib, stdenv, requireFile, makeWrapper, autoPatchelfHook, wrapGAppsHook, which, more
 , file, atk, alsaLib, cairo, fontconfig, gdk-pixbuf, glib, gnome3, gtk2-x11, gtk3
 , heimdal, krb5, libsoup, libvorbis, speex, openssl, zlib, xorg, pango, gtk2
 , gnome2, nss, nspr, gtk_engines, freetype, dconf, libpng12, libxml2
@@ -11,8 +11,6 @@
 }:
 
 let
-  inherit (stdenv) lib;
-
   openssl' = symlinkJoin {
     name = "openssl-backwards-compat";
     nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -13,7 +13,8 @@
 , csdp ? null
 , version, coq-version ? null,
 }@args:
-let lib = import ../../../../build-support/coq/extra-lib.nix {inherit (stdenv) lib;}; in
+let lib' = lib; in
+let lib = import ../../../../build-support/coq/extra-lib.nix {lib = lib';}; in
 with builtins; with lib;
 let
   release = {

--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -91,7 +91,7 @@ let
     # NOTE: this may take a while since it has to update all packages in
     # nixpkgs.nodePackages
     passthru.updateScript = import ./update.nix {
-      inherit (stdenv) lib;
+      inherit lib;
       inherit (src.meta) homepage;
       inherit
         pname

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -245,7 +245,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -271,7 +271,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -284,7 +284,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -303,7 +303,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -255,7 +255,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -240,7 +240,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit lib stdenv crossStageStatic libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -259,7 +259,7 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic langD libcCross threadsCross;
+      inherit lib stdenv crossStageStatic langD libcCross threadsCross;
     })
     EXTRA_FLAGS_FOR_TARGET
     EXTRA_LDFLAGS_FOR_TARGET

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -39,8 +39,7 @@ assert langJava -> lib.versionOlder version "7";
 
 let
   inherit (stdenv)
-    buildPlatform hostPlatform targetPlatform
-    lib;
+    buildPlatform hostPlatform targetPlatform;
 
   crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
   crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -1,7 +1,7 @@
-{ stdenv, crossStageStatic, langD ? false, libcCross, threadsCross }:
+{ lib, stdenv, crossStageStatic, langD ? false, libcCross, threadsCross }:
 
 let
-  inherit (stdenv) lib hostPlatform targetPlatform;
+  inherit (stdenv) hostPlatform targetPlatform;
 in
 
 {

--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch
+{ lib, stdenv, fetchurl, fetchpatch
 , autoreconfHook, libgpgerror, gnupg, pkg-config, glib, pth, libassuan
 , file, which, ncurses
 , texinfo
@@ -8,7 +8,6 @@
 }:
 
 let
-  inherit (stdenv) lib;
   inherit (stdenv.hostPlatform) system;
 in
 

--- a/pkgs/development/libraries/libsnark/default.nix
+++ b/pkgs/development/libraries/libsnark/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkg-config, openssl, boost, gmp, procps }:
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, openssl, boost, gmp, procps }:
 
 let
   rev = "9e6b19ff15bc19fba5da1707ba18e7f160e5ed07";
-  inherit (stdenv) lib;
 in stdenv.mkDerivation rec {
   name = "libsnark-pre${version}";
   version = lib.substring 0 8 rev;

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -124,7 +124,7 @@ let
       # to avoid cyclic dependencies between Qt modules.
       mkDerivation =
         import ../mkDerivation.nix
-        { inherit (stdenv) lib; inherit debug; wrapQtAppsHook = null; }
+        { inherit lib; inherit debug; wrapQtAppsHook = null; }
         stdenvActual.mkDerivation;
     }
     { inherit self srcs patches; };

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -123,12 +123,12 @@ let
     import ../qtModule.nix
     {
       inherit perl;
-      inherit (stdenv) lib;
+      inherit lib;
       # Use a variant of mkDerivation that does not include wrapQtApplications
       # to avoid cyclic dependencies between Qt modules.
       mkDerivation =
         import ../mkDerivation.nix
-        { inherit (stdenv) lib; inherit debug; wrapQtAppsHook = null; }
+        { inherit lib; inherit debug; wrapQtAppsHook = null; }
         stdenvActual.mkDerivation;
     }
     { inherit self srcs patches; };
@@ -140,7 +140,7 @@ let
 
       mkDerivationWith =
         import ../mkDerivation.nix
-        { inherit (stdenv) lib; inherit debug; inherit (self) wrapQtAppsHook; };
+        { inherit lib; inherit debug; inherit (self) wrapQtAppsHook; };
 
       mkDerivation = mkDerivationWith stdenvActual.mkDerivation;
 

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -103,12 +103,12 @@ let
     import ../qtModule.nix
     {
       inherit perl;
-      inherit (stdenv) lib;
+      inherit lib;
       # Use a variant of mkDerivation that does not include wrapQtApplications
       # to avoid cyclic dependencies between Qt modules.
       mkDerivation =
         import ../mkDerivation.nix
-        { inherit (stdenv) lib; inherit debug; wrapQtAppsHook = null; }
+        { inherit lib; inherit debug; wrapQtAppsHook = null; }
         stdenvActual.mkDerivation;
     }
     { inherit self srcs patches; };
@@ -120,7 +120,7 @@ let
 
       mkDerivationWith =
         import ../mkDerivation.nix
-        { inherit (stdenv) lib; inherit debug; inherit (self) wrapQtAppsHook; };
+        { inherit lib; inherit debug; inherit (self) wrapQtAppsHook; };
 
       mkDerivation = mkDerivationWith stdenvActual.mkDerivation;
 

--- a/pkgs/development/tools/profiling/systemtap/default.nix
+++ b/pkgs/development/tools/profiling/systemtap/default.nix
@@ -1,4 +1,4 @@
-{ fetchgit, pkg-config, gettext, runCommand, makeWrapper
+{ lib, fetchgit, pkg-config, gettext, runCommand, makeWrapper
 , elfutils, kernel, gnumake, python2, python2Packages
 }:
 
@@ -10,7 +10,6 @@ let
   version = "4.1";
 
   inherit (kernel) stdenv;
-  inherit (stdenv) lib;
 
   ## stap binaries
   stapBuild = stdenv.mkDerivation {

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -132,7 +132,7 @@ in
 
     passthru.updateScript = import ./update.nix {
       inherit writeScript coreutils gnugrep jq curl common-updater-scripts gnupg nix runtimeShell;
-      inherit (stdenv) lib;
+      inherit lib;
       inherit majorVersion;
     };
 

--- a/pkgs/games/ue4/default.nix
+++ b/pkgs/games/ue4/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, writeScript, fetchurl, requireFile, unzip, clang, mono, which,
+{ lib, stdenv, writeScript, fetchurl, requireFile, unzip, clang, mono, which,
   xorg, xdg-user-dirs }:
 
 let
-  inherit (stdenv) lib;
   deps = import ./cdn-deps.nix { inherit fetchurl; };
   linkDeps = writeScript "link-deps.sh" (lib.concatMapStringsSep "\n" (hash:
     let prefix = lib.concatStrings (lib.take 2 (lib.stringToCharacters hash));

--- a/pkgs/servers/monitoring/prometheus/smokeping-prober.nix
+++ b/pkgs/servers/monitoring/prometheus/smokeping-prober.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, buildGoModule, fetchFromGitHub, nixosTests }:
 
 let
-  inherit (stdenv) lib;
   baseVersion = "0.3.1";
   commit = "9ba85274dcc21bf8132cbe3b3dccfcb4aab57d9f";
 in

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,5 +1,5 @@
 { abiCompat ? null,
-  stdenv, makeWrapper, fetchurl, fetchpatch, fetchFromGitLab, buildPackages,
+  lib, stdenv, makeWrapper, fetchurl, fetchpatch, fetchFromGitLab, buildPackages,
   automake, autoconf, gettext, libiconv, libtool, intltool,
   freetype, tradcpp, fontconfig, meson, ninja, ed, fontforge,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm,
@@ -9,7 +9,7 @@
 }:
 
 let
-  inherit (stdenv) lib isDarwin;
+  inherit (stdenv) isDarwin;
   inherit (lib) overrideDerivation;
 
   malloc0ReturnsNullCrossFlag = lib.optional

--- a/pkgs/tools/graphics/wdisplays/default.nix
+++ b/pkgs/tools/graphics/wdisplays/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkg-config, gtk3, epoxy, wayland, wrapGAppsHook
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, gtk3, epoxy, wayland, wrapGAppsHook
 , fetchpatch
 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  meta = let inherit (stdenv) lib; in {
+  meta = with lib; {
     description = "A graphical application for configuring displays in Wayland compositors";
     homepage = "https://github.com/cyclopsian/wdisplays";
     maintainers = with lib.maintainers; [ lheckemann ma27 ];

--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -3,7 +3,6 @@
 , gettext, vim, bc, screen }:
 
 let
-  inherit (stdenv) lib;
   pythonEnv = python3.withPackages (ps: with ps; [ snack ]);
 in
 stdenv.mkDerivation rec {

--- a/pkgs/tools/misc/staruml/default.nix
+++ b/pkgs/tools/misc/staruml/default.nix
@@ -4,7 +4,6 @@
 , libXdamage, expat }:
 
 let
-  inherit (stdenv) lib;
   LD_LIBRARY_PATH = lib.makeLibraryPath
     [ glib gtk2 gdk-pixbuf alsaLib nss nspr GConf cups libgcrypt dbus libXdamage expat ];
 in

--- a/pkgs/tools/misc/yubikey-manager-qt/default.nix
+++ b/pkgs/tools/misc/yubikey-manager-qt/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , fetchurl
 , wrapQtAppsHook
 , pcsclite
@@ -15,8 +16,6 @@
 , yubikey-manager
 , yubikey-personalization
 }:
-
-let inherit (stdenv) lib; in
 
 stdenv.mkDerivation rec {
   pname = "yubikey-manager-qt";

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, skawarePackages
+{ lib, stdenv, skawarePackages
 
 # Whether to build the TLS/SSL tools and what library to use
 # acceptable values: "libressl", false
@@ -8,7 +8,6 @@
 
 with skawarePackages;
 let
-  inherit (stdenv) lib;
   sslSupportEnabled = sslSupport != false;
   sslLibs = {
     libressl = libressl;

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
   passthru = {
     tests.tor = nixosTests.tor;
     updateScript = import ./update.nix {
-      inherit (stdenv) lib;
+      inherit lib;
       inherit
         writeScript
         common-updater-scripts


### PR DESCRIPTION
###### Motivation for this change
Part of #108938.

This was done manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
