### PR TITLE
treewide: remove more occurences of stdenv.lib

### DIFF
--- a/nixos/tests/vault-postgresql.nix
+++ b/nixos/tests/vault-postgresql.nix
@@ -8,7 +8,7 @@
 import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "vault-postgresql";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ lnl7 roberth ];
   };
   machine = { lib, pkgs, ... }: {

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -1,6 +1,6 @@
-{stdenvNoCC, git, git-lfs, cacert}: let
+{lib, stdenvNoCC, git, git-lfs, cacert}: let
   urlToName = url: rev: let
-    inherit (stdenvNoCC.lib) removeSuffix splitString last;
+    inherit (lib) removeSuffix splitString last;
     base = last (splitString ":" (baseNameOf (removeSuffix "/" url)));
 
     matched = builtins.match "(.*).git" base;
@@ -56,7 +56,7 @@ stdenvNoCC.mkDerivation {
   fetcher = ./nix-prefetch-git;  # This must be a string to ensure it's called with bash.
 
   nativeBuildInputs = [ git ]
-    ++ stdenvNoCC.lib.optionals fetchLFS [ git-lfs ];
+    ++ lib.optionals fetchLFS [ git-lfs ];
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
@@ -66,7 +66,7 @@ stdenvNoCC.mkDerivation {
 
   GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars ++ [
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
     "GIT_PROXY_COMMAND" "SOCKS_SERVER"
   ];
 

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, mercurial }:
+{ lib, stdenvNoCC, mercurial }:
 { name ? null
 , url
 , rev ? null
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation {
   builder = ./builder.sh;
   nativeBuildInputs = [mercurial];
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
   subrepoClause = if fetchSubrepos then "S" else "";
 

--- a/pkgs/build-support/fetchmtn/default.nix
+++ b/pkgs/build-support/fetchmtn/default.nix
@@ -1,5 +1,5 @@
 # You can specify some extra mirrors and a cache DB via options
-{stdenvNoCC, monotone, defaultDBMirrors ? [], cacheDB ? "./mtn-checkout.db"}:
+{lib, stdenvNoCC, monotone, defaultDBMirrors ? [], cacheDB ? "./mtn-checkout.db"}:
 # dbs is a list of strings
 # each is an url for sync
 
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation {
   dbs = defaultDBMirrors ++ dbs;
   inherit branch cacheDB name selector;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
 }
 

--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, gitRepo, cacert, copyPathsToStore }:
+{ lib, stdenvNoCC, gitRepo, cacert, copyPathsToStore }:
 
 { name, manifest, rev ? "HEAD", sha256
 # Optional parameters:
@@ -9,7 +9,7 @@
 assert repoRepoRev != "" -> repoRepoURL != "";
 assert createMirror -> !useArchive;
 
-with stdenvNoCC.lib;
+with lib;
 
 let
   extraRepoInitFlags = [

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, runCommand, awscli }:
+{ lib, stdenvNoCC, runCommand, awscli }:
 
 { s3url
 , name ? builtins.baseNameOf s3url
@@ -16,7 +16,7 @@ let
     AWS_SESSION_TOKEN = session_token;
   };
 
-  credentialAttrs = stdenvNoCC.lib.optionalAttrs (credentials != null) (mkCredentials credentials);
+  credentialAttrs = lib.optionalAttrs (credentials != null) (mkCredentials credentials);
 in runCommand name ({
   nativeBuildInputs = [ awscli ];
 

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, buildPackages
+{ lib, stdenvNoCC, buildPackages
 , subversion, glibcLocales, sshSupport ? true, openssh ? null
 }:
 
@@ -10,7 +10,7 @@
 assert sshSupport -> openssh != null;
 
 let
-  repoName = with stdenvNoCC.lib;
+  repoName = with lib;
     let
       fst = head;
       snd = l: head (tail l);
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation {
   name = name_;
   builder = ./builder.sh;
   nativeBuildInputs = [ subversion glibcLocales ]
-    ++ stdenvNoCC.lib.optional sshSupport openssh;
+    ++ lib.optional sshSupport openssh;
 
   SVN_SSH = if sshSupport then "${buildPackages.openssh}/bin/ssh" else null;
 
@@ -49,6 +49,6 @@ stdenvNoCC.mkDerivation {
 
   inherit url rev ignoreExternals ignoreKeywords;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
   inherit preferLocalBuild;
 }

--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -83,7 +83,7 @@ in stdenvNoCC.mkDerivation rec {
   builder = ./make-initrd.sh;
 
   nativeBuildInputs = [ perl cpio ]
-    ++ stdenvNoCC.lib.optional makeUInitrd ubootTools;
+    ++ lib.optional makeUInitrd ubootTools;
 
   compress = "${_compressorExecutable} ${lib.escapeShellArgs _compressorArgsReal}";
 

--- a/pkgs/build-support/templaterpm/nix-template-rpm.py
+++ b/pkgs/build-support/templaterpm/nix-template-rpm.py
@@ -229,26 +229,26 @@ class SPECTemplate(object):
 
   @property
   def meta(self):
-    out = '  meta = {\n'
+    out = '  meta = with lib; {\n'
     out += '    homepage = ' + self.spec.sourceHeader['url'] + ';\n'
     out += '    description = "' + self.spec.sourceHeader['summary'] + '";\n'
-    out += '    license = stdenv.lib.licenses.' + self.spec.sourceHeader['license'] + ';\n'
+    out += '    license = lib.licenses.' + self.spec.sourceHeader['license'] + ';\n'
     out += '    platforms = [ "i686-linux" "x86_64-linux" ];\n'
-    out += '    maintainers = with stdenv.lib.maintainers; [ ' + self.maintainer + ' ];\n'
+    out += '    maintainers = with lib.maintainers; [ ' + self.maintainer + ' ];\n'
     out += '  };\n'
     out += '}\n'
     return out
 
 
   def __str__(self):
-    head = '{stdenv, fetchurl, ' + ', '.join(self.getBuildInputs("ALL")) + '}:\n\n'
+    head = '{lib, stdenv, fetchurl, ' + ', '.join(self.getBuildInputs("ALL")) + '}:\n\n'
     head += 'stdenv.mkDerivation {\n'
     body = [ self.name, self.src, self.patch, self.buildInputs, self.configure, self.build, self.ocamlExtra, self.install, self.meta ]
     return head + '\n'.join(body)
 
 
   def getTemplate(self):
-    head = '{stdenv, buildRoot, fetchurl, ' + ', '.join(self.getBuildInputs("ALL")) + '}:\n\n'
+    head = '{lib, stdenv, buildRoot, fetchurl, ' + ', '.join(self.getBuildInputs("ALL")) + '}:\n\n'
     head += 'let\n'
     head += '  buildRootInput = (import "${buildRoot}/usr/share/buildroot/buildRootInput.nix") { fetchurl=fetchurl; buildRoot=buildRoot; };\n'
     head += 'in\n\n'

--- a/pkgs/development/compilers/chicken/4/fetchegg/default.nix
+++ b/pkgs/development/compilers/chicken/4/fetchegg/default.nix
@@ -1,7 +1,7 @@
 # Fetches a chicken egg from henrietta using `chicken-install -r'
 # See: http://wiki.call-cc.org/chicken-projects/egg-index-4.html
 
-{ stdenvNoCC, chicken }:
+{ lib, stdenvNoCC, chicken }:
 { name, version, md5 ? "", sha256 ? "" }:
 
 if md5 != "" then
@@ -20,6 +20,6 @@ stdenvNoCC.mkDerivation {
 
   eggName = name;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }
 

--- a/pkgs/development/compilers/chicken/5/fetchegg/default.nix
+++ b/pkgs/development/compilers/chicken/5/fetchegg/default.nix
@@ -1,7 +1,7 @@
 # Fetches a chicken egg from henrietta using `chicken-install -r'
 # See: http://wiki.call-cc.org/chicken-projects/egg-index-5.html
 
-{ stdenvNoCC, chicken }:
+{ lib, stdenvNoCC, chicken }:
 { name, version, md5 ? "", sha256 ? "" }:
 
 if md5 != "" then
@@ -20,6 +20,6 @@ stdenvNoCC.mkDerivation {
 
   eggName = name;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }
 

--- a/pkgs/development/compilers/open-watcom-bin/default.nix
+++ b/pkgs/development/compilers/open-watcom-bin/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchurl, qemu, expect, writeScript, writeScriptBin, ncurses, bash, coreutils }:
+{ lib, stdenvNoCC, fetchurl, qemu, expect, writeScript, writeScriptBin, ncurses, bash, coreutils }:
 
 let
 
@@ -112,7 +112,7 @@ stdenvNoCC.mkDerivation rec {
     done
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "A C/C++ Compiler (binary distribution)";
     homepage = "http://www.openwatcom.org/";
     license = licenses.watcom;

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoLibs, buildPackages
+{ lib, stdenvNoLibs, buildPackages
 , gcc, glibc
 , libiberty
 }:
@@ -128,7 +128,7 @@ stdenvNoLibs.mkDerivation rec {
     "--disable-vtable-verify"
 
     "--with-system-zlib"
-  ] ++ stdenvNoLibs.lib.optional (stdenvNoLibs.hostPlatform.libc == "glibc")
+  ] ++ lib.optional (stdenvNoLibs.hostPlatform.libc == "glibc")
        "--with-glibc-version=${glibc.version}";
 
   configurePlatforms = [ "build" "host" ];

--- a/pkgs/development/libraries/relibc/default.nix
+++ b/pkgs/development/libraries/relibc/default.nix
@@ -1,7 +1,7 @@
-{ stdenvNoCC, buildPackages, makeRustPlatform }:
+{ lib, stdenvNoCC, buildPackages, makeRustPlatform }:
 
 let
-  rpath = stdenvNoCC.lib.makeLibraryPath [
+  rpath = lib.makeLibraryPath [
     buildPackages.stdenv.cc.libc
     "$out"
   ];
@@ -30,7 +30,7 @@ let
           "{}" \;
     '';
 
-    meta.platforms = with stdenvNoCC.lib; platforms.redox ++ platforms.linux;
+    meta.platforms = with lib; platforms.redox ++ platforms.linux;
   };
 
   redoxRustPlatform = buildPackages.makeRustPlatform {
@@ -68,7 +68,7 @@ redoxRustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1fzz7ba3ga57x1cbdrcfrdwwjr70nh4skrpxp4j2gak2c3scj6rz";
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     homepage = "https://gitlab.redox-os.org/redox-os/relibc";
     description = "C Library in Rust for Redox and Linux";
     license = licenses.mit;

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , callPackage
 , stdenvNoCC
 , fetchurl
@@ -135,7 +136,7 @@ in stdenvNoCC.mkDerivation {
     ln -s $out/lib/libmkl_rt${shlibExt} $out/lib/libcblas${shlibExt}
     ln -s $out/lib/libmkl_rt${shlibExt} $out/lib/liblapack${shlibExt}
     ln -s $out/lib/libmkl_rt${shlibExt} $out/lib/liblapacke${shlibExt}
-  '' + stdenvNoCC.lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+  '' + lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
     ln -s $out/lib/libmkl_rt${shlibExt} $out/lib/libblas${shlibExt}".3"
     ln -s $out/lib/libmkl_rt${shlibExt} $out/lib/libcblas${shlibExt}".3"
     ln -s $out/lib/libmkl_rt${shlibExt} $out/lib/liblapack${shlibExt}".3"
@@ -145,7 +146,7 @@ in stdenvNoCC.mkDerivation {
   # fixDarwinDylibName fails for libmkl_cdft_core.dylib because the
   # larger updated load commands do not fit. Use install_name_tool
   # explicitly and ignore the error.
-  postFixup = stdenvNoCC.lib.optionalString stdenvNoCC.isDarwin ''
+  postFixup = lib.optionalString stdenvNoCC.isDarwin ''
     for f in $out/lib/*.dylib; do
       install_name_tool -id $out/lib/$(basename $f) $f || true
     done
@@ -160,7 +161,7 @@ in stdenvNoCC.mkDerivation {
 
   passthru.tests.pkg-config = callPackage ./test { };
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "Intel Math Kernel Library";
     longDescription = ''
       Intel Math Kernel Library (Intel MKL) optimizes code with minimal effort

--- a/pkgs/development/lisp-modules/asdf/2.26.nix
+++ b/pkgs/development/lisp-modules/asdf/2.26.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, texinfo, texLive, perl}:
+{lib, stdenv, fetchurl, texinfo, texLive, perl}:
 let
   s = # Generated upstream information
   rec {
@@ -31,11 +31,11 @@ stdenv.mkDerivation {
     cp -r doc/* "$out"/share/doc/asdf/
     ln -s  "$out"/lib/common-lisp/{asdf/uiop,uiop}
   '';
-  meta = {
+  meta = with lib; {
     inherit (s) version;
     description = "Standard software-system definition library for Common Lisp";
-    license = stdenv.lib.licenses.mit ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;
+    maintainers = [maintainers.raskin];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/lisp-modules/asdf/3.1.nix
+++ b/pkgs/development/lisp-modules/asdf/3.1.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, texinfo, texLive, perl}:
+{lib, stdenv, fetchurl, texinfo, texLive, perl}:
 let
   s = # Generated upstream information
   rec {
@@ -30,11 +30,11 @@ stdenv.mkDerivation {
     cp -r doc/* "$out"/share/doc/asdf/
     ln -s  "$out"/lib/common-lisp/{asdf/uiop,uiop}
   '';
-  meta = {
+  meta = with lib; {
     inherit (s) version;
     description = "Standard software-system definition library for Common Lisp";
-    license = stdenv.lib.licenses.mit ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.mit ;
+    maintainers = [maintainers.raskin];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/lisp-modules/asdf/default.nix
+++ b/pkgs/development/lisp-modules/asdf/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, texinfo, texLive, perl}:
+{lib, stdenv, fetchurl, texinfo, texLive, perl}:
 let
   s = # Generated upstream information
   rec {
@@ -31,11 +31,11 @@ stdenv.mkDerivation {
     cp -r doc/* "$out"/share/doc/asdf/
     ln -s  "$out"/lib/common-lisp/{asdf/uiop,uiop}
   '';
-  meta = {
+  meta = with lib; {
     inherit (s) version;
     description = "Standard software-system definition library for Common Lisp";
-    license = stdenv.lib.licenses.mit ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.mit ;
+    maintainers = [maintainers.raskin];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/lisp-modules/clwrapper/default.nix
+++ b/pkgs/development/lisp-modules/clwrapper/default.nix
@@ -1,4 +1,4 @@
-{stdenv, asdf, which, bash, lisp ? null}:
+{lib, stdenv, asdf, which, bash, lisp ? null}:
 stdenv.mkDerivation {
   name = "cl-wrapper-script";
 
@@ -52,6 +52,6 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Script used to wrap Common Lisp implementations";
-    maintainers = [stdenv.lib.maintainers.raskin];
+    maintainers = [lib.maintainers.raskin];
   };
 }

--- a/pkgs/development/lisp-modules/define-package.nix
+++ b/pkgs/development/lisp-modules/define-package.nix
@@ -1,4 +1,4 @@
-args @ {stdenv, clwrapper, baseName, packageName ? baseName
+args @ {lib, stdenv, clwrapper, baseName, packageName ? baseName
   , parasites ? []
   , buildSystems ? ([packageName] ++ parasites)
   , version ? "latest"
@@ -89,7 +89,7 @@ basePackage = {
     env -i \
     NIX_LISP="$NIX_LISP" \
     NIX_LISP_PRELAUNCH_HOOK='nix_lisp_run_single_form "(progn
-          ${stdenv.lib.concatMapStrings (system: ''
+          ${lib.concatMapStrings (system: ''
             (asdf:compile-system :${system})
             (asdf:load-system :${system})
             (asdf:operate (quote asdf::compile-bundle-op) :${system})

--- a/pkgs/development/lisp-modules/lisp-packages.nix
+++ b/pkgs/development/lisp-modules/lisp-packages.nix
@@ -1,6 +1,6 @@
-{stdenv, clwrapper, pkgs, sbcl, coreutils, nix, asdf}:
+{lib, stdenv, clwrapper, pkgs, sbcl, coreutils, nix, asdf}:
 let lispPackages = rec {
-  inherit pkgs clwrapper stdenv;
+  inherit lib pkgs clwrapper stdenv;
   nixLib = pkgs.lib;
   callPackage = nixLib.callPackageWith lispPackages;
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, pkgs, clwrapper}:
+{lib, stdenv, fetchurl, pkgs, clwrapper}:
 let quicklisp-to-nix-packages = rec {
-  inherit stdenv fetchurl clwrapper pkgs quicklisp-to-nix-packages;
+  inherit lib stdenv fetchurl clwrapper pkgs quicklisp-to-nix-packages;
 
   callPackage = pkgs.lib.callPackageWith quicklisp-to-nix-packages;
   buildLispPackage = callPackage ./define-package.nix;

--- a/pkgs/development/misc/msp430/gcc-support.nix
+++ b/pkgs/development/misc/msp430/gcc-support.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   mspgccVersion = "6_1_1_0";
@@ -19,7 +19,7 @@ in stdenvNoCC.mkDerivation rec {
     touch $out/lib/lib
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = ''
       Development headers and linker scripts for TI MSP430 microcontrollers
     '';

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -110,7 +110,7 @@ rec {
   */
   replaceMaintainersField = stdenv: pkgs: maintainers: stdenv //
     { mkDerivation = args:
-        stdenv.lib.recursiveUpdate
+        pkgs.lib.recursiveUpdate
           (stdenv.mkDerivation args)
           { meta.maintainers = maintainers; };
     };

--- a/pkgs/tools/security/proxmark3/proxmark3-rrg.nix
+++ b/pkgs/tools/security/proxmark3/proxmark3-rrg.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, pkg-config, gcc-arm-embedded, bluez5
+{ lib, stdenv, mkDerivation, fetchFromGitHub, pkg-config, gcc-arm-embedded, bluez5
 , readline
 
 , hardwarePlatform ? "PM3RDV4"
@@ -29,7 +29,7 @@ mkDerivation rec {
     install -Dt $out/firmware bootrom/obj/bootrom.elf armsrc/obj/fullimage.elf
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Client for proxmark3, powerful general purpose RFID tool";
     homepage = "https://rfidresearchgroup.com/";
     license = licenses.gpl2Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25236,7 +25236,7 @@ in
   }).overrideAttrs (oldAttrs: rec {
     pname = "vim-darwin";
     meta = {
-      platforms = stdenv.lib.platforms.darwin;
+      platforms = lib.platforms.darwin;
     };
   });
 


### PR DESCRIPTION
###### Motivation for this change
Part of #108938

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
