### PR TITLE
loadlibrary: stdenv_32bit.lib -> lib, nodePackages: stdenv.lib -> lib

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -17,7 +17,7 @@ let
       buildInputs = [ pkgs.makeWrapper ];
       postInstall = ''
         for prog in bower2nix fetch-bower; do
-          wrapProgram "$out/bin/$prog" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.git pkgs.nix ]}
+          wrapProgram "$out/bin/$prog" --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.git pkgs.nix ]}
         done
       '';
     };
@@ -91,7 +91,7 @@ let
     makam =  super.makam.override {
       buildInputs = [ pkgs.nodejs pkgs.makeWrapper ];
       postFixup = ''
-        wrapProgram "$out/bin/makam" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.nodejs ]}
+        wrapProgram "$out/bin/makam" --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs ]}
         ${
           if stdenv.isLinux
             then "patchelf --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 \"$out/lib/node_modules/makam/makam-bin-linux64\""
@@ -138,7 +138,7 @@ let
     node2nix = super.node2nix.override {
       buildInputs = [ pkgs.makeWrapper ];
       postInstall = ''
-        wrapProgram "$out/bin/node2nix" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.nix ]}
+        wrapProgram "$out/bin/node2nix" --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nix ]}
       '';
     };
 
@@ -168,7 +168,7 @@ let
       '';
 
       postInstall = let
-        pnpmLibPath = stdenv.lib.makeBinPath [
+        pnpmLibPath = pkgs.lib.makeBinPath [
           nodejs.passthru.python
           nodejs
         ];
@@ -185,7 +185,7 @@ let
 
       nativeBuildInputs = [ pkgs.makeWrapper ];
       postInstall =  ''
-        wrapProgram "$out/bin/pulp" --suffix PATH : ${stdenv.lib.makeBinPath [
+        wrapProgram "$out/bin/pulp" --suffix PATH : ${pkgs.lib.makeBinPath [
           pkgs.purescript
         ]}
       '';
@@ -220,7 +220,7 @@ let
       nativeBuildInputs = [ pkgs.makeWrapper ];
       postInstall = ''
         wrapProgram "$out/bin/typescript-language-server" \
-          --prefix PATH : ${stdenv.lib.makeBinPath [ self.typescript ]}
+          --prefix PATH : ${pkgs.lib.makeBinPath [ self.typescript ]}
       '';
     };
 

--- a/pkgs/tools/misc/loadlibrary/default.nix
+++ b/pkgs/tools/misc/loadlibrary/default.nix
@@ -5,7 +5,7 @@
 
 stdenv_32bit.mkDerivation rec {
   name = "loadlibrary-${version}";
-  version = "20170525-${stdenv_32bit.lib.strings.substring 0 7 rev}";
+  version = "20170525-${lib.strings.substring 0 7 rev}";
   rev = "721b084c088d779075405b7f20c77c2578e2a961";
   src = fetchFromGitHub {
     inherit rev;


### PR DESCRIPTION
###### Motivation for this change
Part of #108938.

Last remaining occurence of `"[sS]tdenv[a-zA-Z0-9_'-]*\.lib\b"` not in an autogenerated file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
