### PR TITLE
saw-tools: update license

### DIFF
--- a/pkgs/applications/science/logic/saw-tools/default.nix
+++ b/pkgs/applications/science/logic/saw-tools/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Tools for software verification and analysis";
     homepage    = "https://saw.galois.com";
-    license     = lib.licenses.unfreeRedistributable;
+    license     = licenses.bsd3;
     platforms   = lib.platforms.linux;
     maintainers = [ lib.maintainers.thoughtpolice ];
   };

--- a/pkgs/applications/science/logic/saw-tools/default.nix
+++ b/pkgs/applications/science/logic/saw-tools/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Tools for software verification and analysis";
     homepage    = "https://saw.galois.com";
-    license     = licenses.bsd3;
+    license     = lib.licenses.bsd3;
     platforms   = lib.platforms.linux;
     maintainers = [ lib.maintainers.thoughtpolice ];
   };


### PR DESCRIPTION
###### Motivation for this change
When trying to use saw package, I get:

> Package ‘saw-tools-0.1.1-20150731’ in /nix/store/brydnggk5q9dr7d226fnda0yalipk7q7-source/pkgs/applications/science/logic/saw-tools/default.nix:54 has an unfree license (‘unfreeRedistributable’), refusing to evaluate.

However, the project is actually licensed with BSD 3 ([https://github.com/GaloisInc/saw-script/blob/master/LICENSE](https://github.com/GaloisInc/saw-script/blob/master/LICENSE))

###### Things done
Change license of nix expression to reflect actual license of project.