### PR TITLE
[20.09] keepassxc: 2.6.2 -> 2.6.3

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -40,13 +40,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "keepassxc";
-  version = "2.6.2";
+  version = "2.6.3";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = version;
-    sha256 = "032dzywvwpclhsl3n1pq2m9gyxqpg0gkci6axbvbs7bn82wznc4h";
+    sha256 = "1jd2mvafyn095crfs2hnfprqiy8yqsvfybwbjq8n0agapnz4bl5h";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang [
@@ -55,11 +55,6 @@ stdenv.mkDerivation rec {
     "-D__BIG_ENDIAN__=${if stdenv.isBigEndian then "1" else "0"}"
   ];
 
-  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace CMakeLists.txt \
-      --replace "/usr/local/bin" "../bin" \
-      --replace "/usr/local/share/man" "../share/man"
-  '';
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 
   patches = [
@@ -83,14 +78,18 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkPhase = ''
+    runHook preCheck
+
     export LC_ALL="en_US.UTF-8"
     export QT_QPA_PLATFORM=offscreen
     export QT_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}"
     # testcli and testgui are flaky - skip them both
     make test ARGS+="-E 'testcli|testgui' --output-on-failure"
+
+    runHook postCheck
   '';
 
-  nativeBuildInputs = [ cmake wrapQtAppsHook qttools ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook qttools pkg-config ];
 
   buildInputs = [
     asciidoctor
@@ -103,7 +102,6 @@ stdenv.mkDerivation rec {
     libgpgerror
     libsodium
     libyubikey
-    pkg-config
     qrencode
     qtbase
     qtsvg
@@ -124,7 +122,7 @@ stdenv.mkDerivation rec {
     description = "Password manager to store your passwords safely and auto-type them into your everyday websites and applications";
     longDescription = "A community fork of KeePassX, which is itself a port of KeePass Password Safe. The goal is to extend and improve KeePassX with new features and bugfixes to provide a feature-rich, fully cross-platform and modern open-source password manager. Accessible via native cross-platform GUI, CLI, and browser integration with the KeePassXC Browser Extension (https://github.com/keepassxreboot/keepassxc-browser).";
     homepage = "https://keepassxc.org/";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jonafato turion ];
     platforms = platforms.linux ++ platforms.darwin;
   };


### PR DESCRIPTION
###### Motivation for this change

(cherry picked from commit ef0419f06b816c21910718c4aec90bab30facb63)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
