### PR TITLE
treewide: remove implicit use of stdenv.lib

### DIFF
--- a/pkgs/applications/networking/irc/wraith/default.nix
+++ b/pkgs/applications/networking/irc/wraith/default.nix
@@ -1,9 +1,6 @@
-{ stdenv, fetchurl, openssl }:
+{ lib, stdenv, fetchurl, openssl }:
 
-with stdenv;
-with lib;
-
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "wraith";
   version = "1.4.7";
   src = fetchurl {
@@ -25,7 +22,7 @@ mkDerivation rec {
     ln -s wraith $out/bin/hub
   '';
 
-  meta = {
+  meta = with lib; {
     description = "An IRC channel management bot written purely in C/C++";
     longDescription = ''
       Wraith is an IRC channel management bot written purely in C/C++. It has

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -45,7 +45,7 @@ let
   };
   releaseRev = v: "V${v}";
   fetched = import ../../../../build-support/coq/meta-fetch/default.nix
-    { inherit stdenv fetchzip; }
+    { inherit lib stdenv fetchzip; }
     { inherit release releaseRev; location = { owner = "coq"; repo = "coq";}; }
     args.version;
   version = fetched.version;

--- a/pkgs/applications/version-management/cvs-fast-export/default.nix
+++ b/pkgs/applications/version-management/cvs-fast-export/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, makeWrapper, flex, bison,
+{lib, stdenv, fetchurl, makeWrapper, flex, bison,
  asciidoc, docbook_xml_dtd_45, docbook_xsl,
  libxml2, libxslt,
  python3, rcs, cvs, git,

--- a/pkgs/applications/version-management/reposurgeon/default.nix
+++ b/pkgs/applications/version-management/reposurgeon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, python27Packages, git
+{ lib, stdenv, fetchurl, makeWrapper, python27Packages, git
 , docbook_xml_dtd_412, docbook_xsl, asciidoc, xmlto, pypy
 , breezy ? null, cvs ? null, darcs ? null, fossil ? null
 , mercurial ? null, monotone ? null, rcs ? null

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -35,7 +35,7 @@ let
     "extraInstallFlags" "setCOQBIN" "mlPlugin"
     "dropAttrs" "dropDerivationAttrs" "keepAttrs" ] ++ dropAttrs) keepAttrs;
   fetch = import ../coq/meta-fetch/default.nix
-    { inherit stdenv fetchzip; } ({
+    { inherit lib stdenv fetchzip; } ({
       inherit release releaseRev;
       location = { inherit domain owner repo; };
     } // optionalAttrs (args?fetcher) {inherit fetcher;});

--- a/pkgs/build-support/coq/meta-fetch/default.nix
+++ b/pkgs/build-support/coq/meta-fetch/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchzip }@args:
-let lib = import ../extra-lib.nix {inherit (args.stdenv) lib;}; in
+{ lib, stdenv, fetchzip }@args:
+let lib' = lib; in
+let lib = import ../extra-lib.nix {lib = lib';}; in
 with builtins; with lib;
 let
   default-fetcher = {domain ? "github.com", owner ? "", repo, rev, name ? "source", sha256 ? null, ...}@args:

--- a/pkgs/development/compilers/dmd/binary.nix
+++ b/pkgs/development/compilers/dmd/binary.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchurl, curl, tzdata, autoPatchelfHook, fixDarwinDylibNames, glibc
+{ lib, stdenv, fetchurl, curl, tzdata, autoPatchelfHook, fixDarwinDylibNames, glibc
 , version, hashes }:
-with stdenv;
+
 let
+  inherit (stdenv) hostPlatform;
   OS = if hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
   MODEL = toString hostPlatform.parsed.cpu.bits;
-in mkDerivation {
+in stdenv.mkDerivation {
   pname = "dmd-bootstrap";
   inherit version;
 

--- a/pkgs/development/compilers/ldc/binary.nix
+++ b/pkgs/development/compilers/ldc/binary.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchurl, curl, tzdata, autoPatchelfHook, fixDarwinDylibNames, libxml2
+{ lib, stdenv, fetchurl, curl, tzdata, autoPatchelfHook, fixDarwinDylibNames, libxml2
 , version, hashes }:
-with stdenv;
+
 let
-  OS = if hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
+  inherit (stdenv) hostPlatform;
+  OS = if stdenv.hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
   ARCH = toString hostPlatform.parsed.cpu.name;
-in mkDerivation {
+in stdenv.mkDerivation {
   pname = "ldc-bootstrap";
   inherit version;
 

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake
+{ lib, stdenv, fetchFromGitHub, cmake
 , boost, python3, eigen
 , icestorm, trellis
 , llvmPackages
@@ -12,7 +12,7 @@
 let
   boostPython = boost.override { python = python3; enablePython = true; };
 in
-with stdenv; mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "nextpnr";
   version = "2021.01.02";
 

--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchurl, libusb-compat-0_1}:
+{lib, stdenv, fetchurl, libusb-compat-0_1}:
 
-with stdenv; mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "libftdi-0.20";
 
   src = fetchurl {
@@ -14,7 +14,7 @@ with stdenv; mkDerivation rec {
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';
-  configureFlags = lib.optional (!isDarwin) "--with-async-mode";
+  configureFlags = lib.optional (!stdenv.isDarwin) "--with-async-mode";
 
   # allow async mode. from ubuntu. see:
   #   https://bazaar.launchpad.net/~ubuntu-branches/ubuntu/trusty/libftdi/trusty/view/head:/debian/patches/04_async_mode.diff

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -4,7 +4,7 @@
 }:
 with lib;
 let fetched = import ../../../build-support/coq/meta-fetch/default.nix
-  {inherit stdenv fetchzip; } ({
+  {inherit lib stdenv fetchzip; } ({
     release."1.12.0".sha256 = "1agisdnaq9wrw3r73xz14yrq3wx742i6j8i5icjagqk0ypmly2is";
     release."1.11.4".sha256 = "1m0jk9swcs3jcrw5yyw5343v8mgax238cjb03s8gc4wipw1fn9f5";
     releaseRev = v: "v${v}";

--- a/pkgs/misc/emulators/mame/default.nix
+++ b/pkgs/misc/emulators/mame/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, makeWrapper
+{ lib, stdenv, mkDerivation, fetchFromGitHub, makeDesktopItem, makeWrapper
 , python, pkg-config, SDL2, SDL2_ttf, alsaLib, which, qtbase, libXinerama
 , libpcap, CoreAudioKit, ForceFeedback
 , installShellFiles }:
-
-with stdenv;
 
 let
   majorVersion = "0";

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, fetchurl
+{ lib, stdenv, runCommand, fetchurl
 , fetchpatch
 , ensureNewerSourcesHook
 , cmake, pkg-config
@@ -36,7 +36,6 @@
 # We must have one crypto library
 assert cryptopp != null || (nss != null && nspr != null);
 
-with stdenv; with lib;
 let
   shouldUsePkg = pkg: if pkg != null && pkg.meta.available then pkg else null;
 
@@ -76,7 +75,7 @@ let
     none = [ ];
   };
 
-  getMeta = description: {
+  getMeta = description: with lib; {
      homepage = "https://ceph.com/";
      inherit description;
      license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
@@ -148,11 +147,11 @@ in rec {
       boost ceph-python-env libxml2 optYasm optLibatomic_ops optLibs3
       malloc zlib openldap lttng-ust babeltrace gperf gtest cunit
       snappy rocksdb lz4 oathToolkit leveldb libnl libcap_ng rdkafka
-    ] ++ optionals stdenv.isLinux [
+    ] ++ lib.optionals stdenv.isLinux [
       linuxHeaders util-linux libuuid udev keyutils optLibaio optLibxfs optZfs
       # ceph 14
       rdma-core rabbitmq-c
-    ] ++ optionals hasRadosgw [
+    ] ++ lib.optionals hasRadosgw [
       optFcgi optExpat optCurl optFuse optLibedit
     ];
 

--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -1,8 +1,6 @@
-{ stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, kerberos, gcc, libcxx, which, catch2 }:
+{ lib, stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, kerberos, gcc, libcxx, which, catch2 }:
 
 # Common attributes of irods packages
-
-with stdenv;
 
 {
   nativeBuildInputs = [ autoconf automake cmake gnumake help2man texinfo which gcc ];
@@ -35,7 +33,7 @@ with stdenv;
     "
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Integrated Rule-Oriented Data System (iRODS)";
     longDescription = ''
       The Integrated Rule-Oriented Data System (iRODS) is open source data management

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -1,13 +1,11 @@
-{ stdenv, fetchFromGitHub, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which, catch2 }:
-
-with stdenv;
+{ lib, stdenv, fetchFromGitHub, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl , pam, libiodbc, kerberos, gcc, libcxx, which, catch2 }:
 
 let
   avro-cpp=avro-cpp_llvm;
 in
 let
   common = import ./common.nix {
-    inherit stdenv bzip2 zlib autoconf automake cmake gnumake
+    inherit lib stdenv bzip2 zlib autoconf automake cmake gnumake
             help2man texinfo libtool cppzmq libarchive jansson
             zeromq openssl pam libiodbc kerberos gcc libcxx
             boost avro-cpp which catch2;
@@ -83,7 +81,7 @@ in rec {
      '';
 
      cmakeFlags = common.cmakeFlags ++ [
-       "-DCMAKE_INSTALL_PREFIX=${out}"
+       "-DCMAKE_INSTALL_PREFIX=${stdenv.out}"
        "-DIRODS_DIR=${irods}/lib/irods/cmake"
        "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
        "-DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"


### PR DESCRIPTION
###### Motivation for this change
Part of #108938.

This change was performed by commenting out where `lib` is inherited in `pkgs/stdenv/generic/default.nix` and fixing evaluation errors, then dropping the changes made to autogenerated `node-env.nix` files (the generator has been fixed upstream).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
