### PR TITLE
linuxPackages.oci-seccomp-bpf-hook: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/os-specific/linux/oci-seccomp-bpf-hook/default.nix
+++ b/pkgs/os-specific/linux/oci-seccomp-bpf-hook/default.nix
@@ -10,15 +10,14 @@
 
 buildGoModule rec {
   pname = "oci-seccomp-bpf-hook";
-  version = "1.2.0";
+  version = "1.2.1";
   src = fetchFromGitHub {
     owner = "containers";
     repo = "oci-seccomp-bpf-hook";
     rev = "v${version}";
-    sha256 = "143x4daixzhhhpli1l14r7dr7dn3q42w8dddr16jzhhwighsirqw";
+    sha256 = "0zbrpv6j4gd4l36zl2dljazdm85qlqwchf0xvmnaywcj8c8b49xw";
   };
   vendorSha256 = null;
-  doCheck = false;
 
   outputs = [ "out" "man" ];
   nativeBuildInputs = [
@@ -30,6 +29,10 @@ buildGoModule rec {
     bcc
     libseccomp
   ];
+
+  checkPhase = ''
+    go test -v ./...
+  '';
 
   buildPhase = ''
     make


### PR DESCRIPTION
###### Motivation for this change
Update to the latest release.

cc @NixOS/podman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
