### PR TITLE
[20.09] Revert: cryptopp: 8.2.0 -> 8.4.0

### DIFF
--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -1,15 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, }:
+{ stdenv, fetchFromGitHub, nasm, which }:
 
+with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "crypto++";
-  version = "8.4.0";
-  underscoredVersion = lib.strings.replaceStrings ["."] ["_"] version;
+  version = "8.2.0";
+  underscoredVersion = strings.replaceStrings ["."] ["_"] version;
 
   src = fetchFromGitHub {
     owner = "weidai11";
     repo = "cryptopp";
     rev = "CRYPTOPP_${underscoredVersion}";
-    sha256 = "1gwn8yh1mh41hkh6sgnhb9c3ygrdazd7645msl20i0zdvcp7f5w3";
+    sha256 = "01zrrzjn14yhkb9fzzl57vmh7ig9a6n6fka45f8za0gf7jpcq3mj";
   };
 
   postPatch = ''
@@ -18,6 +19,9 @@ stdenv.mkDerivation rec {
         --replace "ARFLAGS = -static -o" "ARFLAGS = -cru"
   '';
 
+  nativeBuildInputs = optionals stdenv.hostPlatform.isx86 [ nasm which ];
+
+  preBuild = optionalString stdenv.hostPlatform.isx86 "${stdenv.shell} rdrand-nasm.sh";
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
   buildFlags = [ "shared" "libcryptopp.pc" ];
   enableParallelBuilding = true;
@@ -27,17 +31,17 @@ stdenv.mkDerivation rec {
   preInstall = "rm libcryptopp.a"; # built for checks but we don't install static lib into the nix store
   installTargets = [ "install-lib" ];
   installFlags = [ "LDCONF=true" ];
-  postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${lib.versions.majorMinor version}
-    ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${lib.versions.major version}
+  postInstall = optionalString (!stdenv.hostPlatform.isDarwin) ''
+    ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${versions.majorMinor version}
+    ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${versions.major version}
   '';
 
   meta = {
     description = "Crypto++, a free C++ class library of cryptographic schemes";
     homepage = "https://cryptopp.com/";
     changelog = "https://raw.githubusercontent.com/weidai11/cryptopp/CRYPTOPP_${underscoredVersion}/History.txt";
-    license = with lib.licenses; [ boost publicDomain ];
-    platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ c0bw3b ];
+    license = with licenses; [ boost publicDomain ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ c0bw3b ];
   };
 }

--- a/pkgs/development/python-modules/pycryptopp/default.nix
+++ b/pkgs/development/python-modules/pycryptopp/default.nix
@@ -34,8 +34,6 @@ buildPythonPackage rec {
 
   buildInputs = [ setuptoolsDarcs darcsver pkgs.cryptopp ];
 
-  doCheck = false;
-
   meta = with stdenv.lib; {
     homepage = "https://tahoe-lafs.org/trac/pycryptopp";
     description = "Python wrappers for the Crypto++ library";


### PR DESCRIPTION
###### Motivation for this change

Revert https://github.com/NixOS/nixpkgs/pull/110795.

Reading the [release notes](https://github.com/weidai11/cryptopp/releases) of cryptopp, it looks like 8.4.0 actually reintroduces CVE-2019-14318.

Only 8.3.0 does have the fix, [but it seems to make things worse](https://github.com/weidai11/cryptopp/issues/994#issuecomment-752389621).

So I guess it'd make sense to revert this PR? It doesn't have a security benefit and it breaks packages: At least `cryfs` and it breaks the tests of `python2Packages.pycryptopp`.

See also my comment on the [original PR](https://github.com/NixOS/nixpkgs/pull/110555#issuecomment-768277887).

@c0bw3b @dotlambda @LeSuisse 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
