### PR TITLE
obs-gstreamer: init at 0.2.1

### DIFF
--- a/pkgs/applications/video/obs-studio/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/obs-gstreamer.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gst_all_1
+, pkg-config
+, meson
+, ninja
+, obs-studio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-gstreamer";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "fzwoch";
+    repo = "obs-gstreamer";
+    rev = "v${version}";
+    sha256 = "1fdpwr8br8x9cnrhr3j4f0l81df26n3bj2ibi3cg96rl86054nid";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = [ gst_all_1.gstreamermm obs-studio ];
+
+  # obs-studio expects the shared object to be located in bin/32bit or bin/64bit
+  # https://github.com/obsproject/obs-studio/blob/d60c736cb0ec0491013293c8a483d3a6573165cb/libobs/obs-nix.c#L48
+  postInstall = let
+    pluginPath = {
+      i686-linux = "bin/32bit";
+      x86_64-linux = "bin/64bit";
+    }.${stdenv.targetPlatform.system} or (throw "Unsupported system: ${stdenv.targetPlatform.system}");
+  in ''
+    mkdir -p $out/share/obs/obs-plugins/obs-gstreamer/${pluginPath}
+    ln -s $out/lib/obs-plugins/obs-gstreamer.so $out/share/obs/obs-plugins/obs-gstreamer/${pluginPath}
+  '';
+
+  meta = with lib; {
+    description = "An OBS Studio source, encoder and video filter plugin to use GStreamer elements/pipelines in OBS Studio";
+    homepage = "https://github.com/fswoch/obs-gstreamer";
+    maintainers = with maintainers; [ ahuzik ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23884,6 +23884,8 @@ in
 
   obs-wlrobs = callPackage ../applications/video/obs-studio/wlrobs.nix { };
 
+  obs-gstreamer = callPackage ../applications/video/obs-studio/obs-gstreamer.nix { };
+
   obs-move-transition = callPackage ../applications/video/obs-studio/obs-move-transition.nix { };
 
   obs-v4l2sink = libsForQt5.callPackage ../applications/video/obs-studio/v4l2sink.nix { };


### PR DESCRIPTION
###### Motivation for this change

This package adds obs-gstreamer plugin, that allows using gstreamer pipelines in OBS Studio

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
