### PR TITLE
starboard-octant-plugin: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
+++ b/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "starboard-octant-plugin";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-wMt/I2zpdM7l+YNwHkAA6sVRWUtlGpN+94jqx2Jy4HA=";
+    sha256 = "sha256-R6hnAqFpebZ9PV3KAX052wjjCtW5D9hKfj7DdS+3Ibg=";
   };
 
-  vendorSha256 = "sha256-fhIIqirEEdqn/n8bBtLw07fEGfnpC/8SOLbkhnytyME=";
+  vendorSha256 = "sha256-c5sel3xs4npTENqRQu8d9hUOK1OFQodF3M0ZpUpr1po=";
 
   buildFlagsArray = [ "-ldflags=" "-s" "-w" ];
 

--- a/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
+++ b/pkgs/applications/networking/cluster/octant/plugins/starboard-octant-plugin.nix
@@ -13,6 +13,8 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-fhIIqirEEdqn/n8bBtLw07fEGfnpC/8SOLbkhnytyME=";
 
+  buildFlagsArray = [ "-ldflags=" "-s" "-w" ];
+
   meta = with lib; {
     description = "Octant plugin for viewing Starboard security information";
     longDescription = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Added -s and -w ldflags to minify terragrunt

Before:
40 MB starboard-octant-plugin
After:
36 MB starboard-octant-plugin

Bump starboard to `0.9.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
