### PR TITLE
aws-mfa: init at 0.0.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8633,6 +8633,12 @@
     githubId = 36899624;
     name = "squalus";
   };
+  srapenne = {
+    email = "solene@perso.pw";
+    github = "rapenne-s";
+    githubId = 248016;
+    name = "Solène Rapenne";
+  };
   srghma = {
     email = "srghma@gmail.com";
     github = "srghma";

--- a/pkgs/tools/admin/aws-mfa/default.nix
+++ b/pkgs/tools/admin/aws-mfa/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, pkgs
+, boto3
+}:
+
+buildPythonApplication rec {
+  pname = "aws-mfa";
+  version = "0.0.12";
+
+  src = fetchFromGitHub {
+    owner = "broamski";
+    repo = "aws-mfa";
+    rev = version;
+    sha256 = "1blcpa13zgyac3v8inc7fh9szxq2avdllx6w5ancfmyh5spc66ay";
+  };
+
+  propagatedBuildInputs = [
+    boto3
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "awsmfa"
+  ];
+
+  meta = with lib; {
+    description = "Manage AWS MFA Security Credentials";
+    homepage = "https://github.com/broamski/aws-mfa";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.srapenne ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -989,6 +989,8 @@ in
 
   aws-google-auth = python3Packages.callPackage ../tools/admin/aws-google-auth { };
 
+  aws-mfa = python3Packages.callPackage ../tools/admin/aws-mfa { };
+
   aws-nuke = callPackage ../tools/admin/aws-nuke { };
 
   aws-okta = callPackage ../tools/security/aws-okta { };


### PR DESCRIPTION
###### Motivation for this change

this adds aws-mfa, a tool to allow MFA with awscli.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
