### PR TITLE
[20.03] chromium,google-chrome: Mark as insecure

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -62,7 +62,6 @@ in rec {
         (onFullSupported "nixos.tests.boot-stage1")
         (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiCdrom")
         (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiUsb")
-        (onSystems ["x86_64-linux"] "nixos.tests.chromium")
         (onFullSupported "nixos.tests.containers-imperative")
         (onFullSupported "nixos.tests.containers-ip")
         (onSystems ["x86_64-linux"] "nixos.tests.docker")

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -91,5 +91,15 @@ mkChromiumDerivation (base: rec {
     hydraPlatforms = if channel == "stable" then ["aarch64-linux" "x86_64-linux"] else [];
     timeout = 172800; # 48 hours
     broken = channel == "dev"; # Requires LLVM 11
+    knownVulnerabilities = [
+      ''
+        This version of Chromium is outdated, has known security issues,
+        and will no longer be updated. Please consider switching to the new
+        stable NixOS channel (20.09) or installing Chromium from an active
+        channel. A list of the missing security fixes can be found here:
+        https://chromereleases.googleblog.com/2021/01/stable-channel-update-for-desktop.html
+        https://chromereleases.googleblog.com/2021/01/stable-channel-update-for-desktop_19.html
+      ''
+    ];
   };
 })

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -152,5 +152,15 @@ in stdenv.mkDerivation {
     license = licenses.unfree;
     maintainers = [ maintainers.msteen ];
     platforms = [ "x86_64-linux" ];
+    knownVulnerabilities = [
+      ''
+        This version of Google Chrome is outdated, has known security issues,
+        and will no longer be updated. Please consider switching to the new
+        stable NixOS channel (20.09) or installing Google Chrome from an active
+        channel. A list of the missing security fixes can be found here:
+        https://chromereleases.googleblog.com/2021/01/stable-channel-update-for-desktop.html
+        https://chromereleases.googleblog.com/2021/01/stable-channel-update-for-desktop_19.html
+      ''
+    ];
   };
 }


### PR DESCRIPTION
Since web browsers are especially security critical we should mark them
as insecure so that users are aware of the risks.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Like #88368 but for NixOS 20.09 (a bit delayed this time because the first Chromium update since 20.09 reached its EOL didn't contain any security fixes and then I forgot about it).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
