### PR TITLE
python3Packages.pyfritzhome: 0.4.2 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/pyfritzhome/default.nix
+++ b/pkgs/development/python-modules/pyfritzhome/default.nix
@@ -1,20 +1,25 @@
-{ lib, buildPythonPackage, fetchPypi, pythonOlder
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
 , requests
-, nose, mock }:
+, nose
+, mock
+}:
 
 buildPythonPackage rec {
   pname = "pyfritzhome";
-  version = "0.4.2";
+  version = "0.6.0";
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-   inherit pname version;
-   sha256 = "0ncyv8svw0fhs01ijjkb1gcinb3jpyjvv9xw1bhnf4ri7b27g6ww";
+  src = fetchFromGitHub {
+    owner = "hthiery";
+    repo = "python-fritzhome";
+    rev = version;
+    sha256 = "1wzys84hxrjcg86fcn7f7i2i6979qwcpny2afk5rvwljh8f7bli5";
   };
 
-  propagatedBuildInputs = [
-    requests
-  ];
+  propagatedBuildInputs = [ requests ];
 
   checkInputs = [
     mock
@@ -24,6 +29,8 @@ buildPythonPackage rec {
   checkPhase = ''
     nosetests --with-coverage
   '';
+
+  pythonImportsCheck = [ "pyfritzhome" ];
 
   meta = with lib; {
     description = "Python Library to access AVM FRITZ!Box homeautomation";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.6.0

Use GitHub as source instead of PyPI as new releases are not available on PyPI.

Commit log: https://github.com/hthiery/python-fritzhome/commits/master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
