### PR TITLE
firefox: 84.0.2 -> 85.0; firefox-esr: 78.6.1esr -> 78.7.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -131,28 +131,13 @@ buildStdenv.mkDerivation ({
       sha256 = "135n9brliqy42lj3nqgb9d9if7x6x9nvvn0z4anbyf89bikixw48";
     })
 
-  # there are two flavors of pipewire support
-  # The patches for the ESR release and the patches for the current stable
-  # release.
-  # Until firefox upstream stabilizes pipewire support we will have to continue
-  # tracking multiple versions here.
+  # This patch adds pipewire support for the ESR release
   ++ lib.optional (pipewireSupport && lib.versionOlder ffversion "83")
     (fetchpatch {
       # https://src.fedoraproject.org/rpms/firefox/blob/master/f/firefox-pipewire-0-3.patch
       url = "https://src.fedoraproject.org/rpms/firefox/raw/e99b683a352cf5b2c9ff198756859bae408b5d9d/f/firefox-pipewire-0-3.patch";
       sha256 = "0qc62di5823r7ly2lxkclzj9rhg2z7ms81igz44nv0fzv3dszdab";
     })
-    ++
-    # This picks pipewire patches from fedora that are part of https://bugzilla.mozilla.org/show_bug.cgi?id=1672944
-    lib.optionals (pipewireSupport && lib.versionAtLeast ffversion "83") (let
-      fedora_revision = "d6756537dd8cf4d9816dc63ada66ea026e0fd128";
-      mkPWPatch = spec: fetchpatch {
-        inherit (spec) name sha256;
-        url = "https://src.fedoraproject.org/rpms/firefox/raw/${fedora_revision}/f/${spec.name}";
-      };
-    in map mkPWPatch [
-        { name = "pw6.patch"; sha256 = "12lhx9wjpw0ahbfmw07wsx76bb223mr453q9cg8cq951vyskch3s"; }
-    ])
 
   ++ patches;
 

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    ffversion = "84.0.2";
+    ffversion = "85.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "2cxybnrcr0n75hnw18rrymw1jsd5crqfgnpk10hywbmnkdc72fx5sk51cg890pzwfiagicxfxsacnm3f6g8135k0wsz4294xjjwkm1z";
+      sha512 = "17bx4782ix3nrjnc6y29bz86lkpc2fzapqraa67xi65m46qrn0cs9hwdjyl48rdc44j5972gilpmd217kfxf4wxrfc2vcxadgk75158";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -31,10 +31,10 @@ rec {
 
   firefox-esr-78 = common rec {
     pname = "firefox-esr";
-    ffversion = "78.6.1esr";
+    ffversion = "78.7.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3kq9vb0a8qblqk995xqhghw5d694mr1cjd5alkkwxbdjhpc1mck0ayn40xjph0znga6qdcq8l366p0by8ifbsdhv0x39ng8nvx9jvdf";
+      sha512 = "0606prndxfv9nvrpcnagwky04j4jhn1139gr72a0rydfagznsaqwy13gpzdf58ifycdln63052kchlh2dslz5m8hifp215ydcppv8xg";
     };
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

https://www.mozilla.org/en-US/firefox/85.0/releasenotes/

###### Things done

- [x] Ran the nixos test for stable and esr
- [x] Tested on x86_64-linux Wayland with Pipewire
- [x] Tested on x86_64-linux X11
- [ ] Tested on aarch64

cc @ajs124 @taku0 @vcunat 

