### PR TITLE
xfce.xfce4-i3-workspaces-plugin: init at 1.4.0

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -126,6 +126,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfce4-hardware-monitor-plugin = callPackage ./panel-plugins/xfce4-hardware-monitor-plugin.nix { };
 
+  xfce4-i3-workspaces-plugin = callPackage ./panel-plugins/xfce4-i3-workspaces-plugin.nix { };
+
   xfce4-namebar-plugin = callPackage ./panel-plugins/xfce4-namebar-plugin.nix { };
 
   xfce4-netload-plugin = callPackage ./panel-plugins/xfce4-netload-plugin { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-i3-workspaces-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-i3-workspaces-plugin.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, intltool, gtk3
+, libxfce4ui, libxfce4util, xfconf, xfce4-dev-tools, xfce4-panel
+, i3ipc-glib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xfce4-i3-workspaces-plugin";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "denesb";
+    repo = "xfce4-i3-workspaces-plugin";
+    rev = version;
+    sha256 = "sha256-+tjxMr0UbE3BLdxBwNr2mZqKSQOOtw69FmN4rk4loyA=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    intltool
+  ];
+
+  buildInputs = [
+    gtk3
+    xfconf
+    libxfce4ui
+    libxfce4util
+    xfce4-dev-tools
+    xfce4-panel
+    i3ipc-glib
+   ];
+
+  preConfigure = ''
+    ./autogen.sh
+    patchShebangs .
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/denesb/xfce4-i3-workspaces-plugin";
+    description = "Workspace switcher plugin for xfce4-panel which can be used for the i3 window manager";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.berbiche ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add "a workspace switcher plugin for xfce4-panel which can be used for the i3 window manager".

https://github.com/denesb/xfce4-i3-workspaces-plugin

Tests were done by integrating this plugin in my xfce panel configuration.
![image](https://user-images.githubusercontent.com/20448408/106095015-09ab1280-6101-11eb-9cc8-83c93da33388.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


/marvin opt-in
/status needs_reviewer
