### PR TITLE
[20.09] qutebrowser: 1.13.1 -> 1.14.1

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -30,12 +30,12 @@ let
 
 in mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
-  version = "1.14.0";
+  version = "1.14.1";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "0jip413yvyhdaywz0iadc32aaanjnhbx1d1vwzx3z1xbgc4i9svn";
+    sha256 = "15l7jphy1qjsh6y6kd5mgkxsl6ymm9564g1yypa946jbyrgi8k2m";
   };
 
   # Needs tox

--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -30,12 +30,12 @@ let
 
 in mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
-  version = "1.13.1";
+  version = "1.14.0";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "1n72dvrv4dch4i07lsis76p7g16a039fwx8rk7w8q9f60wgqb5i8";
+    sha256 = "0jip413yvyhdaywz0iadc32aaanjnhbx1d1vwzx3z1xbgc4i9svn";
   };
 
   # Needs tox


### PR DESCRIPTION
###### Motivation for this change
This release includes several fixes for incompatibe changes introduced
by the Qt 5.15.2 update, which was backported to NixOS 20.09.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested compilation of all pkgs that depend on this change (qutebrowser)
- [x] Tested execution of all binary files
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
