### PR TITLE
python3Packages.canmatrix: 0.9.1 -> 0.9.3

### DIFF
--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -13,7 +13,7 @@
 , xlrd
 , XlsxWriter
 , pyyaml
-, pytest
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -48,14 +48,11 @@ buildPythonPackage rec {
       --replace "version = versioneer.get_version()" "version = \"${version}\""
   '';
 
-  checkInputs = [
-    pytest
-  ];
-
+  checkInputs = [ pytestCheckHook ];
   # long_envvar_name_imports requires stable key value pair ordering
-  checkPhase = ''
-    pytest -s src/canmatrix -k 'not long_envvar_name_imports'
-  '';
+  pytestFlagsArray = [ "-s src/canmatrix" ];
+  disabledTests = [ "long_envvar_name_imports" ];
+  pythonImportsCheck = [ "canmatrix" ];
 
   meta = with lib; {
     homepage = "https://github.com/ebroecker/canmatrix";

--- a/pkgs/development/python-modules/canmatrix/default.nix
+++ b/pkgs/development/python-modules/canmatrix/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "canmatrix";
-  version = "0.9.1";
+  version = "0.9.3";
 
   # uses fetchFromGitHub as PyPi release misses test/ dir
   src = fetchFromGitHub {
     owner = "ebroecker";
     repo = pname;
     rev = version;
-    sha256 = "129lcchq45h8wqjvvn0rwpbmih4m0igass2cx7a21z94li97hcia";
+    sha256 = "sha256-9FupG1VmROgsxYhsafQYPPqG0xEOAYYK8QDOIBNzE0Y=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/canopen/default.nix
+++ b/pkgs/development/python-modules/canopen/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pythonImportsCheck = [ "canopen" ];
+
   meta = with lib; {
     homepage = "https://github.com/christiansandberg/canopen/";
     description = "CANopen stack implementation";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.9.3

Commit log: https://github.com/ebroecker/canmatrix/commits/development

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
