### PR TITLE
open-isns: 0.99 -> 0.100

### DIFF
--- a/pkgs/os-specific/linux/open-iscsi/default.nix
+++ b/pkgs/os-specific/linux/open-iscsi/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, automake, autoconf, libtool, gettext
-, util-linux, openisns, openssl, kmod, perl, systemd, pkgconf
+, util-linux, open-isns, openssl, kmod, perl, systemd, pkgconf
 }:
 
 stdenv.mkDerivation rec {
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "2.1.3";
 
   nativeBuildInputs = [ autoconf automake gettext libtool perl pkgconf ];
-  buildInputs = [ kmod openisns.lib openssl systemd util-linux ];
+  buildInputs = [ kmod open-isns.lib openssl systemd util-linux ];
 
   src = fetchFromGitHub {
     owner = "open-iscsi";

--- a/pkgs/os-specific/linux/open-isns/default.nix
+++ b/pkgs/os-specific/linux/open-isns/default.nix
@@ -1,15 +1,28 @@
-{ lib, stdenv, openssl, fetchFromGitHub }:
+{ lib, stdenv, openssl, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "open-isns";
-  version = "0.99";
+  version = "0.100";
 
   src = fetchFromGitHub {
-    owner = "gonzoleeman";
+    owner = "open-iscsi";
     repo = "open-isns";
     rev = "v${version}";
-    sha256 = "0m294aiv80rkihacw5094093pc0kd5bkbxqgs6i32jsglxy33hvf";
+    sha256 = "0d0dz965azsisvfl5wpp1b7m0q0fmaz5r7x5dfybkry551sbcydr";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "deprecated-sighold-sigrelease";
+      url = "https://github.com/open-iscsi/open-isns/commit/e7dac76ce61039fefa58985c955afccb60dabe87.patch";
+      sha256 = "15v106xn3ns7z4nlpby7kkm55rm9qncsmy2iqc4ifli0h67g34id";
+    })
+    (fetchpatch {
+      name = "warn_unused_result";
+      url = "https://github.com/open-iscsi/open-isns/commit/4c39cb09735a494099fba0474d25ff26800de952.patch";
+      sha256 = "1jlydrh9rgkky698jv0mp2wbbizn90q5wjbay086l0h6iqp8ibc3";
+    })
+  ];
 
   propagatedBuildInputs = [ openssl ];
   outputs = [ "out" "lib" ];
@@ -20,10 +33,11 @@ stdenv.mkDerivation rec {
   installFlags = [ "etcdir=$(out)/etc" "vardir=$(out)/var/lib/isns" ];
   installTargets = [ "install" "install_hdrs" "install_lib" ];
 
-  meta = {
+  meta = with lib; {
     description = "iSNS server and client for Linux";
-    license = lib.licenses.lgpl21;
-    homepage = "https://github.com/gonzoleeman/open-isns";
-    platforms = lib.platforms.linux;
+    license = licenses.lgpl21Only;
+    homepage = "https://github.com/open-iscsi/open-isns";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.markuskowa ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -412,6 +412,7 @@ mapAliases ({
   oblogout = throw "oblogout has been removed from nixpkgs, as it's archived upstream."; # added 2019-12-10
   opencl-icd = ocl-icd; # added 2017-01-20
   openexr_ctl = ctl; # added 2018-04-25
+  openisns = open-isns; # added 2020-01-28
   openjpeg_1 = throw "openjpeg_1 has been removed, use openjpeg_2 instead"; # added 2021-01-24
   openjpeg_2 = openjpeg; # added 2021-01-25
   opensans-ttf = open-sans; # added 2018-12-04

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18849,7 +18849,7 @@ in
 
   openiscsi = callPackage ../os-specific/linux/open-iscsi { };
 
-  openisns = callPackage ../os-specific/linux/open-isns { };
+  open-isns = callPackage ../os-specific/linux/open-isns { };
 
   osx-cpu-temp = callPackage ../os-specific/darwin/osx-cpu-temp {
     inherit (pkgs.darwin.apple_sdk.frameworks) IOKit;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/open-iscsi/open-isns/blob/v0.100/ChangeLog

###### Things done
* Update + add upstream patches
* Update Github repo source and homepage
* add maintainer
* Fix attribute to match official name
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change.
 Tested with out of tree test: https://github.com/markuskowa/nix-system/blob/master/tests/isns.nix
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
