### PR TITLE
uboot: add ubootNanoPCT4 for NanoPC-T4

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -192,7 +192,6 @@ in {
       platforms = ["aarch64-linux"];
       license = lib.licenses.unfreeRedistributableFirmware;
     };
-    BL31="${armTrustedFirmwareRK3399}/bl31.elf";
     filesToInstall = ["u-boot.itb" "idbloader.img"];
     postBuild = ''
       ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.img

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -189,11 +189,11 @@ in {
     defconfig = "nanopc-t4-rk3399_defconfig";
 
     extraMeta = {
-      platforms = [ "aarch64-linux" ];
+      platforms = ["aarch64-linux"];
       license = lib.licenses.unfreeRedistributableFirmware;
     };
-    BL31="${armTrustedFirmwareRK3328}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    BL31="${armTrustedFirmwareRK3399}/bl31.elf";
+    filesToInstall = ["u-boot.itb" "idbloader.img"];
     postBuild = ''
       ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.img
       cat ${rkbin}/rk33/rk3399_miniloader_v1.19.bin >> idbloader.img

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, callPackage
 , fetchurl
 , fetchpatch
 , fetchFromGitHub
@@ -180,18 +179,12 @@ in {
   };
 
   ubootNanoPCT4 = buildUBoot rec {
-    # vanilla u-boot does not work with the nanopc-t4
-    # so we use this repo with the required patches applied
-    src = fetchFromGitHub {
-      owner = "tmountain";
-      repo = "u-boot-nanopct4";
-      rev = "23f6f74ec3ba53263ed97ec3cac9979b0ad998bc";
-      sha256 = "07b3gcizkswld796l502bj6ln0hwz7wcm2rp3knpjmmha5llb5dz";
+    rkbin = fetchFromGitHub {
+      owner = "armbian";
+      repo = "rkbin";
+      rev = "3bd0321cae5ef881a6005fb470009ad5a5d1462d";
+      sha256 = "09r4dzxsbs3pff4sh70qnyp30s3rc7pkc46v1m3152s7jqjasp31";
     };
-
-    version = "2020.10";
-    # this provides wrapped rkbin binaries that are patched to work with NixOS
-    rkbin = callPackage "${src}/rkbin" {};
 
     defconfig = "nanopc-t4-rk3399_defconfig";
 
@@ -199,12 +192,11 @@ in {
       platforms = [ "aarch64-linux" ];
       license = lib.licenses.unfreeRedistributableFirmware;
     };
-    filesToInstall = [ "idbloader.bin" "uboot.img" "trust.bin" ];
+    BL31="${armTrustedFirmwareRK3328}/bl31.elf";
+    filesToInstall = [ "u-boot.itb" "idbloader.img"];
     postBuild = ''
-      ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/share/rkbin/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.bin
-      cat ${rkbin}/share/rkbin/rk33/rk3399_miniloader_v1.19.bin >> idbloader.bin
-      ${rkbin}/bin/trust_merger --replace bl31.elf ${rkbin}/share/rkbin/rk33/rk3399_bl31_v1.30.elf trust.ini
-      ${rkbin}/bin/loaderimage --pack --uboot ./u-boot-dtb.bin uboot.img
+      ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.img
+      cat ${rkbin}/rk33/rk3399_miniloader_v1.19.bin >> idbloader.img
     '';
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20010,6 +20010,7 @@ in
     ubootClearfog
     ubootGuruplug
     ubootJetsonTK1
+    ubootNanoPCT4
     ubootNovena
     ubootOdroidC2
     ubootOdroidXU3


### PR DESCRIPTION
###### Motivation for this change

This adds support for the NanoPC-T4 to u-boot. The NanoPC-T4 does [not work with upstream u-boot out of the box](https://lists.denx.de/pipermail/u-boot/2021-January/437950.html) , so I created a custom repo and applied the necessary changes, which I [extracted from the Armbian builder project](https://github.com/tmountain/u-boot-nanopct4/blob/main/README.md).

The repo referenced in my PR is the result of applying [this patch](https://github.com/tmountain/u-boot-nanopct4/blob/main/vendor/patches/v2020.10.patch) to the v2020.10 u-boot release.

The NanoPC-T4 will not boot if you build u-boot against a bl31.elf file. It only works if you produce a standalone trust.bin via the rkbin trust_merger utility. I have not been able to determine why this is, but Armbian ships with a custom trust.ini file with the following section which may play a role:

```
[BL31_OPTION]
SEC=1
PATH=bl31.elf
ADDR=0x10000
```

The trust_merger utility does not work with Nix out of the box, so I created a [separate derivation](https://github.com/tmountain/u-boot-nanopct4/blob/main/rkbin/default.nix) to wrap it and make it run successfully. This resulted in the need to add a reference to callPackage to the uboot derivation.

If you'd prefer that I reformulate the PR to do the actual patching during the build, I can try to accommodate that request with some basic guidance.

###### Things done

* Created a ubootNanoPCT4 attribute which builds working images for the NanoPC-T4.

- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested execution of all binary files (usually in `./result/bin/`)
