### PR TITLE
enlightenment.terminology: 1.8.1 -> 1.9.0

### DIFF
--- a/pkgs/desktops/enlightenment/terminology/default.nix
+++ b/pkgs/desktops/enlightenment/terminology/default.nix
@@ -1,18 +1,19 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, efl, pcre, mesa }:
+{ lib, stdenv, fetchurl, meson, ninja, pkg-config, python3, efl, pcre, mesa }:
 
 stdenv.mkDerivation rec {
   pname = "terminology";
-  version = "1.8.1";
+  version = "1.9.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1fxqjf7g30ix4qxi6366rrax27s3maxq43z2vakwnhz4mp49m9h4";
+    sha256 = "0v74858yvrrfy0l2pq7yn6izvqhpkb9gw2jpd3a3khjwv8kw6frz";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    python3
   ];
 
   buildInputs = [
@@ -24,6 +25,10 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-D edje-cc=${efl}/bin/edje_cc"
   ];
+
+  postPatch = ''
+    patchShebangs data/colorschemes/*.py
+  '';
 
   meta = {
     description = "Powerful terminal emulator based on EFL";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [1.9.0](https://www.enlightenment.org/news/2021-01-18-terminology-1.9.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
