### PR TITLE
firejail: 0.9.64 -> 0.9.64.2

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -1,24 +1,17 @@
-{lib, stdenv, fetchurl, fetchpatch, which, xdg-dbus-proxy, nixosTests}:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="firejail";
-    version="0.9.64";
-    name="${baseName}-${version}";
-    url="mirror://sourceforge/firejail/firejail/firejail-${version}.tar.xz";
-    sha256="1zgjwy2k57nx0r63fzr15gijah098ig0bll66jd615vc9q3snfz5";
+{ lib, stdenv, fetchFromGitHub, fetchpatch, which, xdg-dbus-proxy, nixosTests }:
+
+stdenv.mkDerivation rec {
+  pname = "firejail";
+  version = "0.9.64.2";
+
+  src = fetchFromGitHub {
+    owner = "netblue30";
+    repo = "firejail";
+    rev = version;
+    sha256 = "1adizsb7pxr101bvvd359hxympnv36rnikp78npdr5dcvwddv3dv";
   };
-  buildInputs = [
-    which
-  ];
-in
-stdenv.mkDerivation {
-  inherit (s) name version;
-  inherit buildInputs;
-  src = fetchurl {
-    inherit (s) url sha256;
-    name = "${s.name}.tar.bz2";
-  };
+
+  buildInputs = [ which ];
 
   patches = [
     # Adds the /nix directory when using an overlay.
@@ -79,12 +72,10 @@ stdenv.mkDerivation {
   passthru.tests = nixosTests.firejail;
 
   meta = {
-    inherit (s) version;
     description = "Namespace-based sandboxing tool for Linux";
-    license = lib.licenses.gpl2Plus ;
-    maintainers = [lib.maintainers.raskin];
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
     homepage = "https://firejail.wordpress.com/";
-    downloadPage = "https://sourceforge.net/projects/firejail/files/firejail/";
   };
 }

--- a/pkgs/os-specific/linux/firejail/default.upstream
+++ b/pkgs/os-specific/linux/firejail/default.upstream
@@ -1,3 +1,0 @@
-url https://sourceforge.net/projects/firejail/files/firejail/
-version_link '[-][0-9.]+[.]tar[.][a-z0-9]+/download$'
-SF_redirect


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [0.9.64.2](https://github.com/netblue30/firejail/releases/tag/0.9.64.2).
- nixfmt/nixpkgs-fmt
- use fetchFromGitHub

@7c6f434c are you okay with moving this to fetchFromGitHub?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
