### PR TITLE
xed-editor: Init at 2.8.4

### DIFF
--- a/pkgs/applications/editors/xed-editor/default.nix
+++ b/pkgs/applications/editors/xed-editor/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, libxml2
+, libpeas
+, glib
+, gtk3
+, gtksourceview4
+, gspell
+, xapps
+, pkg-config
+, meson
+, ninja
+, wrapGAppsHook
+, intltool
+, itstool }:
+
+stdenv.mkDerivation rec {
+  pname = "xed-editor";
+  version = "2.8.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "xed";
+    rev = version;
+    sha256 = "1hqr4157kp110p01jygqnnzj86zxlfiq4b53j345vqpx0f80c340";
+  };
+
+  nativeBuildInputs = [
+    meson
+    cmake
+    pkg-config
+    intltool
+    itstool
+    ninja
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    libxml2
+    glib
+    gtk3
+    gtksourceview4
+    libpeas
+    gspell
+    xapps
+  ];
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if [[ "$($out/bin/xed --version)" == "xed - Version ${version}" ]] ; then
+      echo "${pname} smoke test passed"
+    else
+      echo "${pname} smoke test failed"
+      return 1
+    fi
+  '';
+
+  meta = with lib; {
+    description = "Light weight text editor from Linux Mint";
+    homepage = "https://github.com/linuxmint/xed";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ tu-maurice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25835,6 +25835,10 @@ in
 
   xdotool = callPackage ../tools/X11/xdotool { };
 
+  xed-editor = callPackage ../applications/editors/xed-editor {
+    xapps = cinnamon.xapps;
+  };
+
   xenPackages = recurseIntoAttrs (callPackage ../applications/virtualization/xen/packages.nix {});
 
   xen = xenPackages.xen-vanilla;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #108817

Also requested in #109578 but this issue also requests more packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
