### PR TITLE
gzdoom: 4.4.2 -> 4.5.0

### DIFF
--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -6,12 +6,12 @@ let
   zmusic-src = fetchFromGitHub {
     owner = "coelckers";
     repo = "zmusic";
-    rev = "2d0ea861174f9e2031400ab29f5bcc8425521cc6";
-    sha256 = "1ac7lhbzwfr0fsyv7n70hvb8imzngxn1qyanmv9j26j0h90hhl8a";
+    rev = "bff02053bea30bd789e45f60b90db3ffc69c8cc8";
+    sha256 = "0vpr79gpdbhslg5qxyd1qxlv5akgli26skm1vb94yd8v69ymdcy2";
   };
   zmusic = stdenv.mkDerivation {
     pname = "zmusic";
-    version = "1.1.0";
+    version = "1.1.3";
 
     src = zmusic-src;
 
@@ -28,13 +28,13 @@ let
 
   gzdoom = stdenv.mkDerivation rec {
     pname = "gzdoom";
-    version = "4.4.2";
+    version = "4.5.0";
 
     src = fetchFromGitHub {
       owner = "coelckers";
       repo = "gzdoom";
       rev = "g${version}";
-      sha256 = "1xkkmbsdv64wyb9r2fv5mwyqw0bjryk528jghdrh47pndmjs9a38";
+      sha256 = "0kmqnyhdi5psi7zwrx9j3pz0cplypsvhg4cr8w2jbawh6jb71sk9";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
Also updates the zmusic dependency to 1.1.3.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
