### PR TITLE
libusb1: remove assert that breaks udev = null deep override

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -17,12 +17,6 @@
 , xmlto
 }:
 
-assert
-  x11Support ->
-    libX11 != null && libICE != null && libSM != null;
-
-assert enableSystemd -> systemd != null;
-
 stdenv.mkDerivation rec {
   pname = "dbus";
   version = "1.12.20";

--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -3,13 +3,11 @@
 , autoreconfHook
 , pkg-config
 , enableUdev ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
-, udev ? null
+, udev
 , libobjc
 , IOKit
 , withStatic ? false
 }:
-
-assert enableUdev -> udev != null;
 
 stdenv.mkDerivation rec {
   pname = "libusb";

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -9,7 +9,7 @@
 , pam
 , dbus
 , enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
-, systemd ? null
+, systemd
 , acl
 , gmp
 , darwin
@@ -19,8 +19,6 @@
 , libpaper ? null
 , coreutils
 }:
-
-assert enableSystemd -> systemd != null;
 
 ### IMPORTANT: before updating cups, make sure the nixos/tests/printing.nix test
 ### works at least for your platform.


### PR DESCRIPTION
This is another case of #73102

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
