### PR TITLE
ryujinx: 1.0.6416 -> 1.0.6448

### DIFF
--- a/pkgs/misc/emulators/ryujinx/default.nix
+++ b/pkgs/misc/emulators/ryujinx/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, makeWrapper, makeDesktopItem, linkFarmFromDrvs
 , dotnet-sdk_5, dotnetPackages, dotnetCorePackages
-, SDL2, libX11, openal
+, SDL2, libX11, ffmpeg, openal, libsoundio
 , gtk3, gobject-introspection, gdk-pixbuf, wrapGAppsHook
 }:
 
@@ -9,17 +9,19 @@ let
     SDL2
     gtk3
     libX11
+    ffmpeg
     openal
+    libsoundio
   ];
 in stdenv.mkDerivation rec {
   pname = "ryujinx";
-  version = "1.0.6416"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
+  version = "1.0.6448"; # Versioning is based off of the official appveyor builds: https://ci.appveyor.com/project/gdkchan/ryujinx
 
   src = fetchFromGitHub {
     owner = "Ryujinx";
     repo = "Ryujinx";
-    rev = "ad491b5570ec428d0d87d56426b03125e2ca5220";
-    sha256 = "0gjrvdh6n26r9kkljiw9xvmvb47vmpwsjxi4iv41ir3nsdigdvsn";
+    rev = "9eb0ab05c6e820e113b3c61cbacd9b085b2819c4";
+    sha256 = "168nm7p6lqswmsya6gf3296ligyjabqmbrdzginkcviii643yslz";
   };
 
   nativeBuildInputs = [ dotnet-sdk_5 dotnetPackages.Nuget makeWrapper wrapGAppsHook gobject-introspection gdk-pixbuf ];
@@ -32,7 +34,10 @@ in stdenv.mkDerivation rec {
     };
   });
 
-  patches = [ ./log.patch ]; # Without this, Ryujinx tries to write logs to the nix store. This patch makes it write to "~/.config/Ryujinx/Logs" on Linux.
+  patches = [
+    ./log.patch # Without this, Ryujinx attempts to write logs to the nix store. This patch makes it write to "~/.config/Ryujinx/Logs" on Linux.
+    ./disable-updater.patch # This disables the auto-updater, which does not work as it attempts to modify the nix store.
+  ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/misc/emulators/ryujinx/disable-updater.patch
+++ b/pkgs/misc/emulators/ryujinx/disable-updater.patch
@@ -1,0 +1,33 @@
+diff --git a/Ryujinx/Program.cs b/Ryujinx/Program.cs
+index 29043bb8..d3973c7c 100644
+--- a/Ryujinx/Program.cs
++++ b/Ryujinx/Program.cs
+@@ -54,9 +54,6 @@ namespace Ryujinx
+                 }
+             }
+
+-            // Delete backup files after updating.
+-            Task.Run(Updater.CleanupUpdate);
+-
+             Toolkit.Init(new ToolkitOptions
+             {
+                 Backend = PlatformBackend.PreferNative
+@@ -146,11 +143,6 @@ namespace Ryujinx
+                 mainWindow.LoadApplication(launchPathArg);
+             }
+
+-            if (ConfigurationState.Instance.CheckUpdatesOnStart.Value && Updater.CanUpdate(false))
+-            {
+-                _ = Updater.BeginParse(mainWindow, false);
+-            }
+-
+             Application.Run();
+         }
+
+@@ -200,4 +192,4 @@ namespace Ryujinx
+             Logger.Shutdown();
+         }
+     }
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
###### Motivation for this change
This adds support for the `soundio` audio backend, and adds support for nvdec video's by supplying the `ffmpeg` dependency.

The reason for removing the auto-updater instead of simply ignoring it, is that by default it shows a popup asking if you want to update which is quite annoying.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
