### PR TITLE
firefox-bin: 84.0.2 -> 85.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,965 +1,965 @@
 {
-  version = "84.0.2";
+  version = "85.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ach/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ach/firefox-85.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "00ad2b1cf208c43fef463979c39a6e1f272d360b4b539e3255aa9f17bbc115be";
+      sha256 = "af7632d2ec4772c1532745b44509ea429681fc41295e8cd577bded16aa56920a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/af/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/af/firefox-85.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "fa9b27a4e23dbad3bc87ba275df4cc87f44bfe13f009268f4ea70ff31ec6e847";
+      sha256 = "9254217dadb1fbdc58d8f2cb565a43cf22a48a9621dd9b25c274b266dfaa4a94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/an/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/an/firefox-85.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "074206329118376889a1a8f414617c821e9fbbc35a8f9b8d38f3dcd1622280cc";
+      sha256 = "e92e9b30f6646ec58a8a963b4017883058058e52bb392ac81eceb6cfaccc5f98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ar/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ar/firefox-85.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "8871b4c191aed7f5923f4dd64254a41e03780c66f4179c3a54768758c2f99f5e";
+      sha256 = "29d207b37c8b8832183256c5434da76bb41b8c893c728678877b6551b40f8d82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ast/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ast/firefox-85.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "a2a143d21d9381410896ac90fd359a086859183fb5e8f18a71157be4263ae481";
+      sha256 = "aa68b7807a1cdaa0c780c0da2afcaa5b28946ead2c6f5ea5adfab798f9d223b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/az/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/az/firefox-85.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "f8493138759fbf0d2e9f13c3510c51b1b343fc2e10eef9b96d083a35e9a57a26";
+      sha256 = "c193052c8ee725d6c909c4f84099d1f72de71ac59318f8fb7f959322ea78e315";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/be/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/be/firefox-85.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "a943d5f372ab63cef96d351f52d248cd2b575756b8a53c9d17b88035c8022bad";
+      sha256 = "54bb585bfbc3b910ac95dbce7b1507b210a871bece19df250bd871fdd4354e18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/bg/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/bg/firefox-85.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d3c12c9a43ae9728fffbcf016a03bcf1411fb891e8bb84a58b9f3cb5adfb9a68";
+      sha256 = "3199a6111d85e00c63314f842adc8277d54bfbb457172bfa03f59fc186d0213e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/bn/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/bn/firefox-85.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "95c19322009f9f8be9f2e11d0baa530111db13fe65d93e93d97f8953e8653741";
+      sha256 = "c9767a236edb36585348d7d69668074ff8b7bf0ce8bf9461660fa3f5002b5700";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/br/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/br/firefox-85.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "20178f91bbb29ab3994db94fcb0929a15754395a6c5c1a2a5f292a3e0fe97ff6";
+      sha256 = "4f5cc23bb984de4703f0861c06d51621851149cf7f140439f4e628b760f7e6b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/bs/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/bs/firefox-85.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "c61a7cf7cc981175a2041534dc90548be21973c7b520a6e4f3da45e7d8f5b509";
+      sha256 = "fd09d9c54505ed70a94a861bac653c89b1401f3dd8bcfade90a0b43517e0bb12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ca-valencia/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ca-valencia/firefox-85.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a52c5fdc41d360a660330ecc055ebd2206a7ada996af17bf76d97e5a82dc552d";
+      sha256 = "3b16d75fcd1f5cb38df9a3bada0dd59c050f57d4b19988d413dfa910a07a21d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ca/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ca/firefox-85.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1d827df4ff4ae8eecf1cbb888c8f011ab0320c05a878da0b24e8e0b4abfb1a59";
+      sha256 = "e3736de71272be8fb64762f48175d8f3c5efa001f5ef683327a706bacdbfe412";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/cak/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/cak/firefox-85.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "dfff83803ed04547aa8c8c9b12ee2fda7388017e8e17bab3d2d1244026779b8d";
+      sha256 = "a75a176b989383367b973b683a0755a283350aad43e2b9f8825561a3fefd9bd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/cs/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/cs/firefox-85.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "601b791c8829653f4eabb08c5d66fba83acddd001b1ccfe2f1f3b615808c9928";
+      sha256 = "40060c9664c9518692601215e86047f05e9dc1d7a51454b4e2097f6dddab5be4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/cy/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/cy/firefox-85.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "aa14be4f6e6adebfd11e334a305355ed4cf199d3d578c7648b6f42fe73275b3d";
+      sha256 = "a015e8b04695fbbc19f98361ea1965cb5901ecf285ed2a56f073b8ff0abe98fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/da/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/da/firefox-85.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "dcc37cc52c473b77f9944eae767cc218330bad1d4753e3da7ae9bc1d59b6ea5f";
+      sha256 = "976e53318750b552292d899f4534541cfd02d64c18f3f1f283ee6b5eba10f220";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/de/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/de/firefox-85.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "5d7332a8b02c84afdca3fa0876087312dc8abfb4307cfd12896aa9671b6dc855";
+      sha256 = "2951b14baacc84b9627b714a80dede18897a3f9696b50ce06c48131888b31322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/dsb/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/dsb/firefox-85.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "a79e0512916e0258d73815fc32c343a908c2bf684a3ee55f6603ed2bff204261";
+      sha256 = "7b878a3be6798bc19b06242696a61ea78536a1b39851f9a1d41797192d7313ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/el/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/el/firefox-85.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "fcf89299094d3757c8cec828ea43befc02cc258d3640f7474fc24dac63bcbafa";
+      sha256 = "86948d6656659180cc279401106ba7aa420e817b6cc2f633c5f9dde5f2753b33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/en-CA/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/en-CA/firefox-85.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "7849e70478c410500f0e49cf3372e7b3395a8668e2df13641450db2e23485f0b";
+      sha256 = "cebc4e8e9320d0141e2a81b4e54177103f6bcf69685055e3ee1bdf59b2188efd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/en-GB/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/en-GB/firefox-85.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6533bd93be6777db55a0787447b97d0cf32d770ab79dbb0a4689e528c277e807";
+      sha256 = "377b3afe2fbf6dc6d953658fe086347b795a25131eb9374465fe0b7089d22d04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/en-US/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/en-US/firefox-85.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "4d987bc87b56dfd2518e162401496c247750ca0a18d8c9072c9ad1ecbd67cbb9";
+      sha256 = "addf2e4094d4b1f4d4445165a1f52fbd2198cde5fc9c213aef1145bfe8fffef2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/eo/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/eo/firefox-85.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "88bcb8ff61ad19d3a9975b8a8e302b2b4f37303c04e02770e5eaa6a99dc8a1eb";
+      sha256 = "0393c54f640bba1d73c5a8f7f128d6c3d28b633432f72ec9fadc5305c6a394ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-AR/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-AR/firefox-85.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "44469a62926e451499b3f813034001dcd9228c80a05d9d69431b9918fdc6b99b";
+      sha256 = "700a5c7c906514dba573c72ebd92fd2809351382b870362a9e73d295ad68ee7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-CL/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-CL/firefox-85.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "81e42f8acedd167a1f69d500fca94752a5453e096b471d07e86adcd99e29b40e";
+      sha256 = "dc76f5b7690326a51ef2606bc19946c329ed3a4174cbcffe9193ec7281c03d83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-ES/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-ES/firefox-85.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "4b47dcf3b595b5c0011a8f8f56f938991cd68576cf4655e04e43ebec14e1256f";
+      sha256 = "57e60cf15b7562d5766c3bffe511b43f50b9ee00c484344d7997b1dd74e6000e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/es-MX/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/es-MX/firefox-85.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c54dcd581d45d273b8b6138393a662b4618e8bd181f625cda6d23ca6b9baf358";
+      sha256 = "77531203ff37345f9849b61f0c163c573c5ac5091e5d0e07037681609e0cac8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/et/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/et/firefox-85.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "2fa06a0e49fc69719acd018148a400c9fbfb3ad68ad13183b1c26971337474b3";
+      sha256 = "a68e6825149007d042fc9f1fb359c18c8cf09da6bee0ef3d9f2a619bb2985b61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/eu/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/eu/firefox-85.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "9171ab64137fa21b4ee50598d244af0760898c6553ae060252109314b997fcf0";
+      sha256 = "7a94fa17efff869247b65eaf1c8731c536fedfc46edaaffba27d0367033a54f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fa/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fa/firefox-85.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "3b16e8290e15999a29a9ac92d8294ac212e4e9e4c96fe2ebba09ca43dc66edbe";
+      sha256 = "732417908adb7da3a9a06ad9022d3f487f6650445b93c406d6bd03482a622401";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ff/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ff/firefox-85.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "1124cd9611e9ccbfe1255afaf8cf3591b0f61d0d2e63c4cae877209b8c591ba9";
+      sha256 = "defe2f208ba27521850ec1fd8abe73c181004ddd66bc15d45a2d01c8908fee97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fi/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fi/firefox-85.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "e3afa4a74b325d52b6cca0436b36d7d5c0d4e2e50755da28aeb587411f705e8f";
+      sha256 = "247ad848a34946c93129012de65da3153401b3a1dbd41d132d03904657b8ff87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fr/firefox-85.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c5470bf4a8a71985bb356c0e56b516108ee6abd6437815bfaf6e3c2f5fe09e46";
+      sha256 = "ac56118839123c10899e043fde74051b4dca211832c2ca4abffc42062773648b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/fy-NL/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/fy-NL/firefox-85.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "4608593cde1c810cfd1301f87fe348b5172d92863416b5b135e2adf8b41a5106";
+      sha256 = "aff1bdd3559698eb253e6339088a1818490bc11fcec08560fed9732705d8f12d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ga-IE/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ga-IE/firefox-85.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "64101b561b5adc391c79347b870784d18f9b8457ea8523b5cd8448aa6f9ea80e";
+      sha256 = "b3aaaa9b45865d0be2fabaee45ec8ef481cc92afd93976058441c3c801f71761";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gd/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gd/firefox-85.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "1048d1f82dc14c4da5954b3e8da2b0cddfe2ec31e9cd520a60202655771f260e";
+      sha256 = "979140c1d5db3ee847af64eb86e97a657f7665cc85e0754d4f580229a81a6a56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gl/firefox-85.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "bfd82fb48bd4e403f60acc217c48f42e2ad967f9810ad632e112354acdf6f459";
+      sha256 = "8953815137c2f40fbf490ce41f09c9f1c44114cf0640478e22e16ad67397f99e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gn/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gn/firefox-85.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "bf4d24303ee087df005cf04bb1511ebed5635c0b6a27154d292d00240ac35ac4";
+      sha256 = "5b8887274069e3c14ba4911cf64e01103ca2b2092f7819d535932ef09a486656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/gu-IN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/gu-IN/firefox-85.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "3669c53042edf83d37ad4e7ab7486f9ac3c2535811fd21fce45188b153b3eb66";
+      sha256 = "f18ac181d0b5dedfc107ace1b257475d7ff75e15f069db183bd445e91ff066fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/he/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/he/firefox-85.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "cf83947396daac7bf4c53d97a58df2fc856056833a3547ca19289fb0b0f4b895";
+      sha256 = "b1b4b4bba5379e6aea2052dce060a857d545abedb75beeb09132c83d89315772";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hi-IN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hi-IN/firefox-85.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "f497cd8173fe2f4b4e14921805004ce81b5e8f63f70b3a135a9be787ad34693d";
+      sha256 = "9fa023800ee3db1485a18ba33ce6e4b004123434da4b7e177e9413cd9dc72293";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hr/firefox-85.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "6e2eb6ede94ff51ab5d2c57744c16738bba50beb5cb4140d42ae1085d6a186ec";
+      sha256 = "5dd335bb622a37629874680a132b4199dddfc341ed6cab7c34cc8bc6fef8fd33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hsb/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hsb/firefox-85.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "99fad7bdc3db88dd5fc2d6244f37716938f2fa44904ffabfe44a25840b390716";
+      sha256 = "f89219c755fe8aaf1309c6b83feffaf6630816882563286e324a90ca62394a5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hu/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hu/firefox-85.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bd94dbefb12821ca1e0232dff9804ee7e1caf5fdd3a5823268f757b70f467930";
+      sha256 = "8bff8576e76bc01e57838ec7751a8cf17d99e0c9dc153e91061ace650d8c058c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/hy-AM/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/hy-AM/firefox-85.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "b9497158d7cce081fd9f6c4c0eab0871ae00eee7745b59544f63026b48757c83";
+      sha256 = "adab4ab3ce22632836266963323a75a81db9e653614b9b639a6f61eeb10543a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ia/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ia/firefox-85.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "cd4f2462e64989151e4962cd89f8d3e97f295505bf1c447db6549f898ec6a38b";
+      sha256 = "8b4acfb5654eb694b50155cfa41e02e19316cb47e552fc6537339156bb5cbfca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/id/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/id/firefox-85.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "0c0b086fc304ed4ab1f23b659999cb303b9016962d26f0509b73009a9c651ae8";
+      sha256 = "e848c3877e0453d4ab9b6ccf6078fb919c4d15b1f0f20c1a975654c5e6182530";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/is/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/is/firefox-85.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a7482f969ad5e537c1d8084cab54eb03b12860df4c084a7aaf51409577af6b49";
+      sha256 = "00036a6977a932b547ee5b97f5c830456cb19393cda45c190ee5237e796a76e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/it/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/it/firefox-85.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "2139dd8f281de5ef79c3a3671eaeb0704db0dcff286df6da44351fcc5d102864";
+      sha256 = "81dc17afe61ed833494cca7687a1bea1f6a5a3d93571ae0522e481ba2c9e73aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ja/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ja/firefox-85.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "818b66e1e9ff60f30bceb6b44acd2c704de5f64016de7bea45a4110118341314";
+      sha256 = "2f0a652d51740c9adc760a8843433a52226327600fc7e9e87b603e97c0541547";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ka/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ka/firefox-85.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "805d101b7977061af0d5e3b99a8980b972aa4c8eb6ae9914d10c527a58a6aaed";
+      sha256 = "8f01dcfe02fd71d3c3d564ab111b34e4f2d5c58981233c5698c87bf449144015";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/kab/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/kab/firefox-85.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "34a75868f2e8da1fb87235b29b2b1fa7d28b55dea8351a472cc1d752c1b084dc";
+      sha256 = "1163788f9d943533b124a57fb3e3fc1aae56793f929e5ac2d3f17b1826e3d353";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/kk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/kk/firefox-85.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "a8c40b1ebac7d0375232518f35b854600f35e52dd6b0123e86a70cb0f3386406";
+      sha256 = "f91eae3b5afcff6c49548c6d5d5d5b0fc0dd6a9500b87baaf00e0cee96efe22f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/km/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/km/firefox-85.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "3ccc2a85edec4f90c39d23ba74474e27326ed18fd020847d567ed93406ca9678";
+      sha256 = "2ab5040f15ceea952a7fb6d737eed93b23e1423e2298c31a5d7486c81ecab9af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/kn/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/kn/firefox-85.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "634c0ba151f9334f4991c2f118b96de45d8a4fe359a08c3cb001f3b813d89198";
+      sha256 = "c141f0e1c95c0630aecda5f929ea3720f3620ad9f30f95e4e371865c2d0eb96b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ko/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ko/firefox-85.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "d085163b35684903418648648dca8ad078e1a89f611775ab4b01fb60aa4d1b2b";
+      sha256 = "8e87b7f748f2fddb3edf5f12fcd8238bf8f05b403c707471878ef540f8fa2a40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/lij/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/lij/firefox-85.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "b676b6f955441df571541b52b6534ad12caf5df45d16dd374b3cda19d58e990c";
+      sha256 = "99e4be7139c456c7a7da8d1ba1b845d381995241940b9e9f3db81892cb51231b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/lt/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/lt/firefox-85.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "eb5499c40bfc805599e51f490d1bd860c6c46512f927a47af3f9ae5bdb9e3fbc";
+      sha256 = "acfc0ce0b56a15d2b5a7492807b9b70b801712b420a72d5b2e73a6e5021cce71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/lv/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/lv/firefox-85.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "935e736c0d46254d8429d87eb2a72e46c9c70c92ebdb1fd1077798e538af770f";
+      sha256 = "c8bab5353b01987b6e3ee434ec5460cb54d56183662fa9c7f3017ae018be575d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/mk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/mk/firefox-85.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "310fcae105829fd03ede31c32e1f078c69d1bed7880469976159968de1f7ccfb";
+      sha256 = "7ba1d47b8923862ff2228faeaf86a1277dd48f45ffa83230f3b9b22b1860febc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/mr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/mr/firefox-85.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "acd8be31fba57a9ced68960c1dd28c9e91a88433b0b885bd3f8e2656a639e3bc";
+      sha256 = "acbc9dd00e31437bee02f9d3548af926ca021f128239f67ff5399e533923e2d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ms/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ms/firefox-85.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "71a6a63883123b19e70c0bb1e6251550fa4b5035792c7b767d47839428d4e0a9";
+      sha256 = "6293173ccfcd0475b6ee0baffb54d4b43776710b3c4ea97ef1437a8919aebc1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/my/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/my/firefox-85.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "121264d0508aa26f9d6e89620bb1821d07763c28d5085b5cf7d0ce90704bf983";
+      sha256 = "c4e075996c9a6c13e2631bd85d6f5b3015400dfa40116479e5a17c939d538cf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/nb-NO/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/nb-NO/firefox-85.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "9b930c9e5e92c01ae89c7388d6a168d83b4e95f945381f1301a6137795f4e017";
+      sha256 = "94d8f6ea965080e0b28d797c0c73813164216541bb6c008adffa523722a2727d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ne-NP/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ne-NP/firefox-85.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "99994740252ec76e9728950d307762acec5ab6555d4b5921d89a083447bd7e70";
+      sha256 = "129ab6f7276d180c3adacfe970c4c870953481790b451f8dc98134c914daddd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/nl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/nl/firefox-85.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "cbe751edd3b72a8cd823b9cf548ce77e3a148bceac4861853d1374e79c2cf694";
+      sha256 = "0f7efdcd52cf5c214da536261e539b45d8da3ad37543b6296feb92186053a59f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/nn-NO/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/nn-NO/firefox-85.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f63c3f08d01d8963d8ec6047b69efec9f36a92d822a8ae966cc2a7d66f33f93e";
+      sha256 = "2e42e0a8eb2dc2fcd217aacd7c0aa7eac5e673bad0d66f0555f7bb51ffb895fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/oc/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/oc/firefox-85.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "675090877a1cb5841ddb98c5ba8ebaba9d4ad2d4de9d17c7e9559ba6a8b2e1ec";
+      sha256 = "d4fabdd18ca199f6081093fe4c88191885ae0c19fc36fe574f546b26b5d2eacf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pa-IN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pa-IN/firefox-85.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "6fd35af9216a1099c246f9e12161384d6a5d1d24e846d3aabe5bef3a55b215b8";
+      sha256 = "88ddf2bc486d13217edd3d325247dae774ba60d509481d7a6900e06ae30f70d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pl/firefox-85.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "54cae52178e21f0f2beabe1120746962141cbf79fb5dc6eef11ae1f2705e9e4d";
+      sha256 = "9e6336fe8745e21674270a95bce7d24508c9585955c58ad74f631e1fa73c56f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pt-BR/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pt-BR/firefox-85.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "f1dc18aea91440dfe5e34b332c2e2b2b0241d7af1c1a8f2a979eead34db64480";
+      sha256 = "68573084e4a826978bfae5c1c8cbfecba2fd578d0c6a07affebc2ba19f1d97e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/pt-PT/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/pt-PT/firefox-85.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "c2159af01743f1004e3dba0b99a2670155ae3e695f0fd0208b367f910bcba642";
+      sha256 = "6b6bcca14f08cb8fe07282a3b24797417ea73a60300cdf76c64ffda4bfb051c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/rm/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/rm/firefox-85.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "211813cb32c9f2b0880c7116dc935929570c81937d3446aef506da3705172099";
+      sha256 = "331c0cd9510564ade274c209514dc5ec3647e3ea37da6b630a7cefb8c445332c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ro/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ro/firefox-85.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "a2144bde6023d4b8468128c52015849e6a8f77c0c10d4851a9255f6204a98a77";
+      sha256 = "52df2b116aaac13590076b86216b904def287e18828f040980cae01e8ae67b1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ru/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ru/firefox-85.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "098748cde08f1d362a8eed6432353a1edabc84579abb30aca983772c5b6ac36e";
+      sha256 = "2fbcd36492688e21dc4e8fb1faf1ea67ecd745f3b7f58b0950786120c9043cf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/si/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/si/firefox-85.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "41707b3e3b7dbaaea510c58ba503fe22de84963fe1979b2e4c7e00cdf1ded01a";
+      sha256 = "2a4ab4bf9fee148931d09bae59ec1f049c09aafdcfee3c6a083adb3d2b1e42ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sk/firefox-85.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4ba12f304145102db13feaca98f84bae5e06609c721967e1b69d68643a94c1db";
+      sha256 = "4ba12a5d49a2ee0f5c41f63cab08b7c161f3546ca9195339e22d463879e7f45b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sl/firefox-85.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "2dfafc7ca5fdf0a03a8301f1daacc397fc49f3fae18f6ac6454b4110c5bdd65f";
+      sha256 = "6f1f6379a9706d2af9c7797d8c1c86700f3e9ff7cd72fa35c3d602e6622de47e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/son/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/son/firefox-85.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "13139fb6bb47472c2ce47dd535bdeea6fa90521681c2a8e8ea963bebecbdd54f";
+      sha256 = "b9292626bad35a50dcb81d34db417417b031a6ef9a215e26d5e1ee9456e244cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sq/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sq/firefox-85.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "9710315181f78df3673b71fef597b9498c0a860b167ab4b9c4e68df9c500a6be";
+      sha256 = "077dbbaa904712782252e8f8a01b78237d51cbbeeda0e455ad5f2569f9a394d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sr/firefox-85.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "bbd69589dc5a1fe7b3a0f74c0d8e20cb4cf6b7ed771faf7c161c96301736e89c";
+      sha256 = "c537ab1e63530a82cf5c181d98895b580705e3418f598ab3f98fa67cd9a83f10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/sv-SE/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/sv-SE/firefox-85.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "a5769159d0c7bc89865ffe1e2fd6b88675afdbda29752ebdaae986f0ace7d3f4";
+      sha256 = "42e36cc411666fad716a60643eae0be0301783fda10cb07943c8b6df293430dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ta/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ta/firefox-85.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "836aef11ef967ee8c74b9c4221525c31427ee509b798952b59a43a6c7c2169f8";
+      sha256 = "b77e5c448f6a1bde09da07c3b20339f54214d89b4394123809e7bec668d65abb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/te/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/te/firefox-85.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a8e091052e0f606ad8b29b344d65cd86ee45a2b349c99e462f96cc36c08c18e8";
+      sha256 = "8c700eb9c7a9057e4639c39643430667ed9099a37d2214c8ffc5d349e5b0fe79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/th/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/th/firefox-85.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "17679aff5806314398ffd9568be11157f41b0820313394f7c59c8bc69af8cff2";
+      sha256 = "3a467b98fb435e80bb913c56291803a79a05a42c73576be49b014394a29002f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/tl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/tl/firefox-85.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "7fd68265f2d1187dab49480004355d241fbe628cf9bce7a613ed5e048df9223d";
+      sha256 = "599214c5dd5eb28d6ea3b7e2db8795ce4923284c721b15a85bcbdbe74b416c5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/tr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/tr/firefox-85.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "0eeb30611cd3da04ef0c3439e59a3c2c46f2d38b566795691f8992041507550a";
+      sha256 = "1192f241df3a8691d0e895737c03a790f47a731a6335d2ee2fd1e1310b3d0cc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/trs/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/trs/firefox-85.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "31ed82b3b45c9f9e6a84fb57b32c23468f42d4072b04437db5dd62f1d541ea80";
+      sha256 = "f68c08305ec3d1396826e3310ac88b5b07beb71beebcbfaebf3ac81c543bc47e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/uk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/uk/firefox-85.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "bee267b4822a44edfcacd11bc6aa83ed2957dce95789926ea3cf3d714fd99542";
+      sha256 = "4705551ac9a02b450f5e81b05a08912b7b26bdba99b9e9095461aa9c70aeed36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/ur/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/ur/firefox-85.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "1da5fbc3e3b77a102d00bd1db146944640b9e8c5a9c7c5222a3570281846d1b5";
+      sha256 = "ec84dd4c7a4e338a21ccf8f09c1dfb14a9e34e3240a55b92901cc5e6a89bb135";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/uz/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/uz/firefox-85.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "11b92211b88db216ee17537c27d86511f827a7435bbe3cc0ea39d0c015c55c0a";
+      sha256 = "d7a5b1c95cd9c8bc20cff8add8a2fa9c9c909b3845cbdc6f593f2686f9f27a40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/vi/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/vi/firefox-85.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "29e1f625c9862cb13b5f6238ba2f72200b864abf66ff44af11ca991c67a742d5";
+      sha256 = "a3c1a719317c9fc73371132dfc0349dce50db061c4f96d32585bb26d0aecc7c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/xh/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/xh/firefox-85.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "6e859ba83b1fcc2930db6ac53ddc5f36ec2bc325b034337c33a2e5b531f905d8";
+      sha256 = "cacdaf5b7044a7e951fd67c4ff25ed41f2fe05a6cf2f4ff5b9d8d9fb0cf211ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/zh-CN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/zh-CN/firefox-85.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "afa32b9e1560aff7c7a6dd9d3c627690ee70c20ea5748f1754cc8ebdffeccb15";
+      sha256 = "888569bd9bf58a58ffd5effdc4f0c58ac53354cec5d2792f0d88cfb30efff4bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-x86_64/zh-TW/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-x86_64/zh-TW/firefox-85.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "5f0ec2ca348b788590ec4eb552d34c204612895145521eb53a3b1dd73c34eafc";
+      sha256 = "71e1fc336cfda1401b4d96ed185423486480a5ad4d267d3c94336470fa4a8bce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ach/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ach/firefox-85.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "f003b9197505256cefcc96a07a3314ee9438a5024048d9815691d5f149233e67";
+      sha256 = "efcfa1aaac69712596c7f5ecbaf359c69980eb0b4d8c99857085f3a4564d5026";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/af/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/af/firefox-85.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "67b9eecc70db21a150ad45682be637e3c6187cd8b0ca3fab9c20e12517372925";
+      sha256 = "b5e1eb9041fdda259a3db87d784e6b633a18f18c46038361d4a6d2a8aeadcda3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/an/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/an/firefox-85.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "08fe11419370ed3e8a47819f22bed8f5cc4cadd3296dd69304a4fb5f5a7a5dd1";
+      sha256 = "35ecf29bbb2e65feb372c83d2bf6b1c28b6edd57873eaec3090ed0200121043a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ar/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ar/firefox-85.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "fb85564a9037ee9168dfb14ed9f743affa5cd7829e2f2637f75184713db93712";
+      sha256 = "ef86ed77ac7de83e4e068970f57843ab801f89f180837015f1ea4e3ea11f3b6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ast/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ast/firefox-85.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "89c659c314dfe2674ce65a37793c151db5c127452e786f77772c1db7b0fc1aa8";
+      sha256 = "6b58d2d132944a5106b73f47bdffbd606df63173f817bbdb32c4d3b2354030a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/az/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/az/firefox-85.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "9062c6fcd28afd070baff45df8320aab43e61e7d6343945bd1304a2b8fcf78ce";
+      sha256 = "1ee85155d8d45fe003bea0d8ff9d5a1c40c4d52102e125b4bc1ad608b5383c39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/be/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/be/firefox-85.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "0043bb412b2ad9c4bd5f60199f8e3c3e1d81b8bd35d687c909ea65cf0a1eaedd";
+      sha256 = "e6f30798e101d73b0e359a63a35b044ea51df964f1e22a9c894f1b572cb99653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/bg/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/bg/firefox-85.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "97ebda162b20aefad89ea918896a1d0a2b7546a67b577000f4ddb6cb93bc5a32";
+      sha256 = "e3bbc6ca6c77fdb56dac6c8ad0c45d425485ef279c115651bb4824f6d52a14f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/bn/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/bn/firefox-85.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "705b8e97ca21e14343f16c39ac5a081d866f7b422be154eb55cc4ebe728ef9a3";
+      sha256 = "583762c0fb01f6ee1165eb98122940fc42286e6f8678679466a2b79051a45fd3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/br/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/br/firefox-85.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "8a61f457be78003ba212b9921a657428d117bdc978e1f62eb4ba2b2cfd553b13";
+      sha256 = "abef23deaac27bea07d0586f78578b34407765c05cdeaa9bd4d4ea0b552bafbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/bs/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/bs/firefox-85.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "074a4153395b6397ffa5b2a74bb22b456e15357a760003a4dfc2c5974e8efa1f";
+      sha256 = "8f4385e1a8db5567d499a046a169d8a77c585a61734ee7257063a98d722cd278";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ca-valencia/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ca-valencia/firefox-85.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "87109dec410e6f57199743666d46e81a42fe6364cb55742e24391d922bd8c0dd";
+      sha256 = "eca948e8e2020cf401ac4dcaefda2aaf967336122e1927418a80d9a854e2e52c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ca/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ca/firefox-85.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "7ab7be9dd01b25f119de9a432b1487a506d5b8306b7c516614feb9a559de6cdc";
+      sha256 = "c46250371ac43baaed265e74998e0bc44fdf01c4308f1bae8e34896e75004096";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/cak/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/cak/firefox-85.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "e5518707de8deffc05024f76248711b59037f994a1b6883e65243a01a82076c7";
+      sha256 = "64dace82a39b131fad3509b2865a6cb22c5044a88838187f975a9c3bbb5cff2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/cs/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/cs/firefox-85.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "682add587e420149a34cdba03a0b91a7190a33753bb40972836c8e12110ea356";
+      sha256 = "799c10e7f4068f4122637f4e8ae992f4da892b8f4ae17e47e2b93ff9f61f236c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/cy/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/cy/firefox-85.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "396764a821b7333aae3dfa6924e5246ac6aeb613470e5098ff542aa5d7dca65d";
+      sha256 = "9075bde46721937fc83f891a3f3162969e61c8ae6aa0904b6d597fd5c2872e81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/da/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/da/firefox-85.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "28aa6f2f3ae2fd19b5b6d149c1bf735ae55c56ff3bee0646bef98dcdfcbf3dff";
+      sha256 = "d1bc56c35db77e1ed7c3b206ca7906834edd41e8d37f5fb467fa75eab22b1c6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/de/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/de/firefox-85.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "eefb48753ea89ebbd27e7357a22ae7246086093d7054b684ed8f2ed1dbd66835";
+      sha256 = "8430827afb4a748890d1b114d3363898ff6a882b2a17165a10abe8ef385ec83f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/dsb/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/dsb/firefox-85.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "65c947541d4c6125b292b6e5ac61486bb434b56a824e304c343464d4a8ac4021";
+      sha256 = "e6985031027fc9d4e5d8ab0899daadd93a5333a668b116b632181ed34006ae64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/el/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/el/firefox-85.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "86d20281cd16436acc0c015b2a72775ab3beaf1f52348181131c210448dd9ccd";
+      sha256 = "4e5bb6be18e963006f30a1478194b6613ff922e9dd3939ed7df5e2d79df5c630";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/en-CA/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/en-CA/firefox-85.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "d71c02929a7e4b08bfe1d83eaa577755d7dd1074f2328c428bea73c1bdd82920";
+      sha256 = "b172f0368b07b6f908035e7d41a95ee8abd9c21cfe77923d902ec53517716a6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/en-GB/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/en-GB/firefox-85.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "5ef6635f57a34fab6dcc54462b621721063ab354798d8924e8621895fc3ed4ac";
+      sha256 = "3e64db811fa3cf989dff5b043b9ffc3349f119ce27185fcade110e57ccb66056";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/en-US/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/en-US/firefox-85.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "7008acb0a5112d22b02f75fa8b46ecdb46dc2cb0ab691791595f2ac45187d6e5";
+      sha256 = "e6269d7b11bd0e2d918e45059d201a2ae329da6ae69d33648de1e8ed885c65fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/eo/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/eo/firefox-85.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "e9dadf0b2b655bbcee8557805ee1b93cfef911c9c1a60d63b31afc84f06f9021";
+      sha256 = "fa1e60db4ff414b96c7813545a5b67730f312cbd85bbf079aa4c03eed5dc0920";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-AR/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-AR/firefox-85.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "3ca485c3eda6a0d2cf348d2870fa708ad374dc0fc830696484e0c2ff5ef3c967";
+      sha256 = "f65977cf029a0075e2214708719a6af4b8e41d39bbf59b1ad998a5fca460c717";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-CL/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-CL/firefox-85.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "e69f6b048f42ff8eac54176d5b3c85cd31ce02794f22bce2a09fd262d62789a1";
+      sha256 = "94cf0ad46c52685c03c385ca80e159e5ddf229f31c8ef764defa50dfb5e59857";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-ES/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-ES/firefox-85.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1cf1ea30406e16564fabd54b339ebd2111498eecbf25ec93c7401e2143e1d456";
+      sha256 = "6603132e1660a50ab3f0347a22b52b9480f4bac21f67f958fb0f112205f3dd3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/es-MX/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/es-MX/firefox-85.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "94a8ea4e1fb63470a46a83678f71698b151ebf9c57794a086a8982d29edc0706";
+      sha256 = "325cefd6f0920207fdcb11674a4b5a3f8d71a4b65e64c11f7ab3681a7a1ffb08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/et/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/et/firefox-85.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "b4fde31f58defe8b35d4c9325f1485093bfb155c73f6d3c02fa3cdcbc8393105";
+      sha256 = "9e997aac788ad9c5d249a2e1cce5f3a968fb5564c67e585f842d576aad5b710f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/eu/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/eu/firefox-85.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "d84a2bdc2f55b57c612abbb0208ef4b7683ef7d696739e9b1a36238daf61ab9f";
+      sha256 = "c677e6c0e86ce007fd0027132891b0baeefb172dfe19b8a3b6c0a1fdb09413a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fa/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fa/firefox-85.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "054e6269745c8ae120daab489a9157618956bf2ecbc309bc64b7fb2f73400766";
+      sha256 = "4961d99cfa342ff1148f751a7ecb480439f2850247e4b4815023ae767cb92c55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ff/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ff/firefox-85.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "1ebef6026207141e0d3d37533ecff2b22a4e936e27a58939fbaa72d723078049";
+      sha256 = "751d7fb2485d00f1653397cbab88e0131b959cb9fe94a2c74687b05967a0efe1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fi/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fi/firefox-85.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "9a8609ae113b392d3bcee30ae48c1e8b4ce6a1fc180c7f936c52934fa1911429";
+      sha256 = "98244bbd2d914c14b66a2f1b58312fed6ad09d69a8c6e36c6a28b9d6f5b93bd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fr/firefox-85.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "afcc5075d8455d32360d5045125290c8b843e48f4b774ab48d5c2f49e1cd9fe2";
+      sha256 = "c90054aa48353ecd2e7d8bec810e98b8706bc837216bd2237010c50d73890de1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/fy-NL/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/fy-NL/firefox-85.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "232dd4a17ff87945b1ea11183fea8711c572e31d34898d15b378a54697c720b9";
+      sha256 = "343559198dbea2cd4f4d66c83fb8c0f44fede93843d43421c9a7e5925a7f834c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ga-IE/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ga-IE/firefox-85.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "c68e57472d6837074bb8180063ce6eebf0396b187aa3d47ee9bccf1cd1529459";
+      sha256 = "44a19acee4c0a8e03604de46c19c28f54f9ecc8bbf8f32f2e7b3922c11659df9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gd/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gd/firefox-85.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ed6ab375a3e487ee3c6f2d4017f8bde6c3ff29978a8b2f125b58e3ca2472ce38";
+      sha256 = "bad179771be3cb0fd0ed4dfb287f16df65a06b78b3741853f474184f534f1ec2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gl/firefox-85.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "28993fb518753a241abb2e6a22583f8a318bfeeca4e0eca76bedfb2aa0a01e07";
+      sha256 = "58732e181252d40d59e3acfaaa1da9533e659fa4d3c43f70c03801fe793c7280";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gn/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gn/firefox-85.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "370637503e0fa36b937f32867bd68a300fe1bd8d99188ab86ad9392ab5b8a8b6";
+      sha256 = "645d6840fa76e286bf107c526de0762c5074ef3b52bae49ee5f02307c52d02f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/gu-IN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/gu-IN/firefox-85.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "1fc77e276cf34424e3c7522af9bfb5d3dd43e33357ce01b696655c2a91a8f2a0";
+      sha256 = "f61f6b052a687807022b72629a22a6b53890487add36634d09e2860d92d6733e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/he/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/he/firefox-85.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "b1ffe2fcfd55fff2b696dd40d3292ad9cf2cde1179bd8c9c7103df9c902b276e";
+      sha256 = "5b96a1b4298737182a7c7c99ea43eb7b6558593f9f7b18df4a0217101dc183e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hi-IN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hi-IN/firefox-85.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "d13f74a4a45e7a20a1ec3354dce98f33bef647d6153aed2539cf567a6eb3fcfc";
+      sha256 = "e4c393235aaa9d80d678ea2f69092462815705647022fb2635a00174e597eb60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hr/firefox-85.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f0a288dc290d2665948e3536b7b52b799461bf060be38b957aff7cd52aac02ff";
+      sha256 = "3722f05edf8f9fd5adf782291be51b708e7f08943b2f03351b36df00a1ef0d1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hsb/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hsb/firefox-85.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e395166b3039027e56eb6d2d7f97b121c1bd947cd6266829b949b221cbb2cb74";
+      sha256 = "e79dc707afdd246540e886522890d6ae2f53c38054c8902303d9bdd03df02359";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hu/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hu/firefox-85.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "666b47226545e9e8f45ff09e3428d6317fbe67a197e13ada814b6a4f72544a98";
+      sha256 = "415edcbfa2cf3bd0cb1278799914ccd683af51b8e380039c4aaba118e66047af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/hy-AM/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/hy-AM/firefox-85.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "779111633101f8b7da4c84d3d085ab1e8e3502d255316d17eca653b0481d0885";
+      sha256 = "4561cf20fea47b11a330be2bc3b517c1c53b4577f250b531225c53f321df7382";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ia/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ia/firefox-85.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "e27ac7b8e8d2f3c4f453563d2d2efd3005b12be1696de453182a53a3de490ab1";
+      sha256 = "97b44d0e08f79ad55aafe2384b523d24e0147d414b95ff81834feb59c6b07695";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/id/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/id/firefox-85.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "86dcf72326ea283bcfd612cbec0ea095be72fe16d446a317a31c886d91f5b452";
+      sha256 = "2b501c2b43fc54f1ba5a89f8b0d19f8d25626584d1bcc108e16e2287f11449a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/is/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/is/firefox-85.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "17305f92a16967d941df34a59706f90b94b8c671d01e8aab768fbfd473a81f78";
+      sha256 = "2cc3d7b82be2bad7ab6dc5659bf7a4c8ce4d882964588a2a767e78a34d832b27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/it/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/it/firefox-85.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "4b2804d9c52c4f9202e867f2540523cc45675b5d34e46a8d59b044c88a840f5e";
+      sha256 = "68b3f63b6e561f038894d6503b4fba8177e3fc025a189b68e2da11f8bef11c2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ja/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ja/firefox-85.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "6a8bc7abc0c320a31d7fac4e457bd46a3fe7379f795e8cb2f36b2de70bf048f3";
+      sha256 = "0023494cb7a5485b1d492c2b9f1eb40a9fed06db0de6a2bcc76b54c4c8b44b5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ka/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ka/firefox-85.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "de6b6be1696d20148cb94cfacaee0fe5ec128550de006a6f64723885d47a1352";
+      sha256 = "a6489db173bbf47f76379afd09c75912d2bc4b8fdd8023d654df9d5f257378ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/kab/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/kab/firefox-85.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "a898355c71d00c72aedb87901184f69d0598fabc4827c9070ebb900a48dbf152";
+      sha256 = "3b060b719b8bf0993786b05753467534e10986304b3251f572603be5aaeec2eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/kk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/kk/firefox-85.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "1945b3526a8f52cc7cbaa30e344333c43c7d228d557a249fa4f41a8bb91eb4b1";
+      sha256 = "7c1139dad1b300c8450357356e6c317159b5d702db30747c1ff7aec31f33f82b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/km/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/km/firefox-85.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "3e033fae06700495784b4eaa911309d250d3e55a94139a65f44248975c414980";
+      sha256 = "f9dbec23d5110b389fea294cdecad03772f2471952e9ea01bc9d0462f7541ca5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/kn/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/kn/firefox-85.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "b70553b460d0604bff55ea29657e74b1133995ae93bb958b6b20af366cce2eeb";
+      sha256 = "7521548f755d51ed47e9596d58223f699fd4494bd5af8fffc1c59018f20be8bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ko/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ko/firefox-85.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "0ed0d1a0219ef92c0de45578c3674da0ba0e8fd9ed2e00afc01b05d53ea28112";
+      sha256 = "bed7a64af30ad21413516c201498fbc335125768ebea48cc895e724e6208d566";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/lij/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/lij/firefox-85.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "5fa837001b3bc5d9138ed14e22720933f28fedef63a7dd473976348448cebb30";
+      sha256 = "426c432ae9727806af45667948a1f1aed7196a245441054da590931f98b5e96a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/lt/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/lt/firefox-85.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "b54990d4737b71dfa235d20ee2f87367b72f0a1245585135a9918d2755b3d1cb";
+      sha256 = "badafabd22ea7934cc2099677c9890cca609c56f3b16a863fa2c977f1e86a9c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/lv/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/lv/firefox-85.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "06ece913374b567ea10cd9377485d0793a12a151e9e3ba08e3c5433a5e772151";
+      sha256 = "7caf8f81efa55b69cd51fb5f75652c6d9aeacb2711d9bdbc29fa80dcfeda74df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/mk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/mk/firefox-85.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "dc69547cdf414f783017ebb8931dd24ad1b899f19bac20bca4d21ebe91963a0c";
+      sha256 = "ef22239e208acfc9b0a57dd06781c09dea1afd0303a091cf075c021a5c85003a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/mr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/mr/firefox-85.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "f503a40041ba0f4e44791f8d2e38c41f25698fd970457fd8cafd92d2d3e64102";
+      sha256 = "99d2c32ea14feec74db39d1eabc0c914a8681bc216aa76cd970473fbc06e5dee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ms/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ms/firefox-85.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "07491c18e9fe0d7f97b24c8bcf571ede2c4effda58ceacb0395fb7ce9eae1eb7";
+      sha256 = "43011dbbc33615a67088619053a2579098e2afaed43b09268e5117290f100101";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/my/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/my/firefox-85.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "19d57112de4c6429e915568ae317c3bef2ef6d58d0c57d5a07be0cb2f1bc11d0";
+      sha256 = "d78bb48ec1b01787037d575da259b724db2bfffb0cad1700801ac7696eeacc55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/nb-NO/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/nb-NO/firefox-85.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "72e6576c3a725675c2514d39b3ea4497590410037aca696c5f3f3dd5109b3c09";
+      sha256 = "64f55d03bcdd9132b40cad1a5265cd81e2945022056141272dc0fca22aee2a71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ne-NP/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ne-NP/firefox-85.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "fb624e1ea63aca7f481024c40e7b5a47e504ea545169566f86e7ca24e36e7582";
+      sha256 = "b3d7c64b087ccd67b56dbb0f9554dd3db6481fd59ec7f46db1a03dfea129c372";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/nl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/nl/firefox-85.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "a1aab7534d0dde0c61c48bf0f33fb336c12b5d8c644e41188dad7c138531bbf7";
+      sha256 = "f2c83282acb30108f4bb381eecc30d61758d1e2279abfb772050b3ed8827b8fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/nn-NO/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/nn-NO/firefox-85.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "d1c645cd0b65f8b48b0497b1a16b25a2e11d8de70bb3e37baf6f05c5750525cb";
+      sha256 = "534dbf0d58c85fe21ad9998a703ac4df5a0b7d124c80eaca0b72fe42b97628f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/oc/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/oc/firefox-85.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "f110c97c8e464ace6026ddb3da15c13177455bcba067a54d4c531329a4cdfdab";
+      sha256 = "c3eaa5dbee8ee90d735c5e6db3c397011837385d4ac4d46ba3693d3aebd03e1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pa-IN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pa-IN/firefox-85.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "4931270889eb97b55b3bea7177e778422045bfcebc25e4bc05019ffbde438c78";
+      sha256 = "66c640b7bfb626b8d851af9f3170356adb3436fe1adbce76961df586fcdac051";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pl/firefox-85.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "c0438fb22ef1c610afc16bfd689d1843d6099e91e6b8a30b03a2f692b609eb4a";
+      sha256 = "64d5f25fc15cad09c103fd243d0767aa4d0a6e10940e9229e9fbf5e5354f14b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pt-BR/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pt-BR/firefox-85.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "df61ec134c161d0f44ad0805bda8d1baa37d21c618c4f4d165e40996d7ba5956";
+      sha256 = "8cbd4c44af5da9fff2baedddfda640661dc3c3e0a2541985a12b0a42a76bbece";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/pt-PT/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/pt-PT/firefox-85.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "a09341dc8284b77fa3bd1c7d5fbc377a93cd21109e1330b0a2260613df3c4e5e";
+      sha256 = "5fde2c95eafa41bd9c8da90fbc6408eee8fe8187d18ebc2b9e04a19e662eb7a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/rm/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/rm/firefox-85.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "19016551888f5104227e3cfed6c66b7ca11e11a31d9c007c3d00f6821126fd03";
+      sha256 = "1f2b1d0c9695b7a8796670baefe35e95d91a4060137c01739e00033a2c50aae3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ro/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ro/firefox-85.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "d5cacf3a2c3cf9c3c6fe182005c038094fb6b8ae58ea169123e6289f7a2c5457";
+      sha256 = "77fad9b28166ba65d8514f76f43f4686345ac7ce7cd8e08bb5575da1b042bba4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ru/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ru/firefox-85.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "8907175fd858dc243dafd4216b3602f154ce824a2388b714cee9352322781f39";
+      sha256 = "58b4896bf014197734a9d8fcd03e526be422858aa0ac109282f0dcd543bb8697";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/si/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/si/firefox-85.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "19be977d9110dddb944e0ca713aa986fb3c005a4f39bde23a4a0b907cb7d39df";
+      sha256 = "8aee64af130801e33df0d2aa91ed0b1d1328e39963320a418fd04a3bb0a0ec89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sk/firefox-85.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "2a7a5dfacaa016ae6d2dbb52d0803a8a27f74061a6bf71fcbac5fe2e10834374";
+      sha256 = "2f7813dc98211b3cf8fd0d2d233e2c7dca7f94e85fb2a70df9c69aa6bd5add5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sl/firefox-85.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "61c65884ba57fa5fd37919a390b8af4cb0d7abf31ead557f2967049c35a4bc72";
+      sha256 = "75564047dfa2bc5e4c0dd1d1dd1f15e1c59e96c203470731db143ae424cd8c2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/son/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/son/firefox-85.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "be825ca5923ec9aa37417d4d4842bd82ee4271ec201bb317e0b58f654fe8a7c1";
+      sha256 = "3684681de408a4cd02fdb81c559bdb15252dc56c0376a94ee512d7cc49e67190";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sq/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sq/firefox-85.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "c7ab49257d5e44bb96e8f39bb586e51a100b899fb6e595a86bf41ebc25b55021";
+      sha256 = "573e998a49756843d14f063d4e3aea23f7844076d8ed3b5a0409d0c3758d7a17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sr/firefox-85.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "b22e12526457dfaaf976eb94262965c3bd46edf4a99380a430d75b2324ad654a";
+      sha256 = "9289ae5e5270553dfc11dd6a7b9db6e6afa106919daedf085494c96f79cd0c52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/sv-SE/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/sv-SE/firefox-85.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "5e024fc41d9287480ab09ea45d46e9dc358be53adce325826d9820b6cf3ab8ae";
+      sha256 = "4b97dd3f617774925a140edcde97b5e0864405401222f46bcc59d02537168ff9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ta/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ta/firefox-85.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "529afecbbdfa2f934d755f80c7a0bc9d4bac5053cc0c6421c1687ab16e5b1f02";
+      sha256 = "80273dacecd26e0dbf1dcc39858f05c5ef0415972851166c0761f553e832e071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/te/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/te/firefox-85.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "d90b59759a4f24f9142250f6fe5853fa0e6afdc30bff7e735fc5b70a3b76f555";
+      sha256 = "e074997f616b1b356f40dab47f25e13e8b9b143bfaf932a0a281eec8675b71dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/th/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/th/firefox-85.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "023f86d83e23371bbbe68bb586a08e81a58cec027a44c0ddeb217ea1343b5cd5";
+      sha256 = "e28ae199709c1ab1d580f8bd83b7ef8cf56750f17b4c30bcd188b088a61d8ba7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/tl/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/tl/firefox-85.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "2fd3a1f80900f16eac1de89c8a7a4f93cafef144a24d9c261b09549a3b659448";
+      sha256 = "c8b5161094d3fbed51d4dc033804ce5c2e77f9d96172076edced695ba76922c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/tr/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/tr/firefox-85.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "1144aa3437ae67c6921ddeeceb59dad5767d1d59c7932fa0da460c64a4f5577f";
+      sha256 = "a5178b392fdf8b36292548c9a98e22b879eb19e0f6d237192b376b7df92ee219";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/trs/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/trs/firefox-85.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "1f3e1d5fec2b4d9b11c3c0ded1a68aa7e36d13fae472ce782fd820d4fd32a7c6";
+      sha256 = "38554c05e9122c71ea0910892e6c455c4402ead97c6f00d309391544ca208697";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/uk/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/uk/firefox-85.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "165dfdd03c178af49d3f3139a0c9032431f92cf91e79d6842b5e0b006c73490c";
+      sha256 = "d6b2fe56aae2b6f4543072f0968c357ab893d89b92ff6c053cc709df75a51aa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/ur/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/ur/firefox-85.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "6a91871a99188c0bc6a956d92382c800543d95a4d917e64d3295d9b1fe8971e6";
+      sha256 = "fcd15754df86493bc627e8fd65f0237a7a10e6e5e5843715bd31445e4b99f2dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/uz/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/uz/firefox-85.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "ade7a34f46893e3367384b414322895f5cd9ce0d341b7a7ddeb191fcc7679e5a";
+      sha256 = "2a9cfc082a01c6af057627f4d028b67e0f0b72f913994ac208cea6ccfcd7e41a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/vi/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/vi/firefox-85.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "aca136daf5a8d71b55e479a37a1d42569ee6c9086ac96bf98587948eb23c5f59";
+      sha256 = "b32b7b8ff09a0642d4636a1d6477ba3b14c0a47ef93407078998818e7fc23145";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/xh/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/xh/firefox-85.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "6993f823fd76b8974334b37ebe9c683d43fd2524ea1c485ef0c53db993db15ef";
+      sha256 = "5a95cd2dbb58f739b58eb8ba5d829d1e7f4e7be405cc6659857432a5c10c8d21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/zh-CN/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/zh-CN/firefox-85.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b179fb98b0eb374e28574a4eb61f86df8765ee5bac033e93ad6c3e71d010e7cc";
+      sha256 = "e5f93c089a0de95e3e430ed7ad3b028ee7a427072ebb3a035451b5724ee248d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/84.0.2/linux-i686/zh-TW/firefox-84.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/85.0/linux-i686/zh-TW/firefox-85.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0c51a4e5afa22fac0c98e2e960168fb5625a29d2d9e1565ecd08080d83e72d73";
+      sha256 = "348b26495fca92805814ee355962741154654d9babe5959ed4f41065123a50d2";
     }
     ];
 }


### PR DESCRIPTION
###### Motivation for this change

Firefox 85.0 was released a few days ago.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
