### PR TITLE
darwin.CF: fix sandboxed build

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -23,9 +23,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ ninja python3 ];
   buildInputs = [ curl libxml2 objc4 ICU ];
 
-  sourceRoot = "source/CoreFoundation";
+  postPatch = ''
+    cd CoreFoundation
 
-  patchPhase = ''
     cp ${sysdir-free-system-directories} Base.subproj/CFSystemDirectories.c
 
     # In order, since I can't comment individual lines:
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
     # Fix sandbox impurities.
     substituteInPlace ../lib/script.py \
       --replace '/bin/cp' cp
+    patchShebangs --build ../configure
 
     # Includes xpc for some initialization routine that they don't define anyway, so no harm here
     substituteInPlace PlugIn.subproj/CFBundlePriv.h \


### PR DESCRIPTION
Had to abandon the use of sourceRoot primarily because it prevents
stdenv from chmod'ing the ../configure into a writable file.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
