### PR TITLE
keepass: remove jraygauthier as maintainer

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -111,7 +111,7 @@ with builtins; buildDotnetPackage rec {
   meta = {
     description = "GUI password manager with strong cryptography";
     homepage = "http://www.keepass.info/";
-    maintainers = with lib.maintainers; [ amorsillo obadz jraygauthier ];
+    maintainers = with lib.maintainers; [ amorsillo obadz ];
     platforms = with lib.platforms; all;
     license = lib.licenses.gpl2;
   };


### PR DESCRIPTION
No longer using this package. Much better alternative
exist: keepassxc, pass, gopass, etc.
