### PR TITLE
gobgp: init at 2.23.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3657,6 +3657,12 @@
     githubId = 3656888;
     name = "hhm";
   };
+  higebu = {
+    name = "Yuya Kusakabe";
+    email = "yuya.kusakabe@gmail.com";
+    github = "higebu";
+    githubId = 733288;
+  };
   hinton = {
     email = "t@larkery.com";
     name = "Tom Hinton";

--- a/pkgs/tools/networking/gobgp/default.nix
+++ b/pkgs/tools/networking/gobgp/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "gobgp";
+  version = "2.23.0";
+
+  src = fetchFromGitHub {
+    owner = "osrg";
+    repo = "gobgp";
+    rev = "v${version}";
+    sha256 = "0r7w1c3rh0wnsrhdpzr2fp1aqdqafrb42f2hra6xwwspr092ixq0";
+  };
+
+  vendorSha256 = "0dmd4r6x76jn8pyvp47x4llzc2wij5m9lchgyaagcb5sfdgbns9x";
+
+  postConfigure = ''
+    export CGO_ENABLED=0
+  '';
+
+  buildFlagsArray = ''
+    -ldflags=
+    -s -w -extldflags '-static'
+  '';
+
+  subPackages = [ "cmd/gobgp" ];
+
+  meta = with lib; {
+    description = "A CLI tool for GoBGP";
+    homepage = "https://osrg.github.io/gobgp/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ higebu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -728,6 +728,8 @@ in
 
   albert = libsForQt5.callPackage ../applications/misc/albert {};
 
+  gobgp = callPackage ../tools/networking/gobgp { };
+
   metapixel = callPackage ../tools/graphics/metapixel { };
 
   ### APPLICATIONS/TERMINAL-EMULATORS


### PR DESCRIPTION
###### Motivation for this change

A CLI tool for GoBGP. GoBGP is an open source BGP implementation. https://github.com/osrg/gobgp
I will create a gobgpd package as a next step.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    - 15MB
    ```console
    $ nix path-info -S $(which gobgp)
    /nix/store/mbmrqik607diwsdls8i78fn8j4pjjsbr-gobgp-2.23.0           15041048
    ```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
