### PR TITLE
release-cross: add ppc64le, ppc64le-musl

### DIFF
--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -150,6 +150,9 @@ in
 
   x86_64-musl = mapTestOnCross lib.systems.examples.musl64 linuxCommon;
 
+  ppc64le = mapTestOnCross lib.systems.examples.powernv linuxCommon;
+  ppc64le-musl = mapTestOnCross lib.systems.examples.musl-power linuxCommon;
+
   android64 = mapTestOnCross lib.systems.examples.aarch64-android-prebuilt linuxCommon;
   android32 = mapTestOnCross lib.systems.examples.armv7a-android-prebuilt linuxCommon;
 


### PR DESCRIPTION
Our support for ppc64le is pretty good now.
Let's add these so it's easier to spot and rectify breakage.

The toolchains are already built for their bootstrap tools,
so this shouldn't put much build strain on hydra.

Tested `hydra-eval-jobs pkgs/top-level/release-cross.nix -I nixpkgs=.` locally.

cc @NixOS/exotic-platform-maintainers 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
