### PR TITLE
gobby5: unstable-2018-04-03 -> unstable-2020-12-29

### DIFF
--- a/pkgs/applications/editors/gobby/default.nix
+++ b/pkgs/applications/editors/gobby/default.nix
@@ -5,12 +5,14 @@
 let
   libinf = libinfinity.override { gtkWidgets = true; inherit avahiSupport; };
 in stdenv.mkDerivation {
-  name = "gobby-unstable-2018-04-03";
+  pname = "gobby";
+  version = "unstable-2020-12-29";
+
   src = fetchFromGitHub {
     owner = "gobby";
     repo = "gobby";
-    rev = "ea4df27c9b6b885434797b0071ce198b23f9f63b";
-    sha256 = "0q7lq64yn16lxvj4jphs8y9194h0xppj8k7y9x8b276krraak2az";
+    rev = "49bfd3c3aa82e6fe9b3d59c3455d7eb4b77379fc";
+    sha256 = "1p2f2rid7c0b9gvmywl3r37sxx57wv3r1rxvs1rwihmf9rkqnfxg";
   };
 
   nativeBuildInputs = [ autoconf automake pkg-config intltool itstool yelp-tools wrapGAppsHook ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The gobby project recently addressed a denial of service vector in their application.

I've kindly asked them to do another release tag: https://github.com/gobby/gobby/issues/188
The issue was reported here: https://github.com/gobby/gobby/issues/183
The issue was fixed here: https://github.com/gobby/gobby/pull/184

Fixes: CVE-2020-35450

@jtojnar Any idea why you named this package gobby**5** and not just gobby?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
