### PR TITLE
vimPlugins.minimap-vim: init at 2021-01-04

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2302,6 +2302,18 @@ let
     meta.homepage = "https://github.com/vim-scripts/mayansmoke/";
   };
 
+  minimap-vim = buildVimPluginFrom2Nix {
+    pname = "minimap-vim";
+    version = "2021-01-04";
+    src = fetchFromGitHub {
+      owner = "wfxr";
+      repo = "minimap.vim";
+      rev = "3e9ba8aae59441ed82b50b186f608e03aecb4f0e";
+      sha256 = "1z264hr0vbsdc0ffaiflzq952xv4h1g55i08dnlifvpizhqbalv6";
+    };
+    meta.homepage = "https://github.com/wfxr/minimap.vim/";
+  };
+
   mkdx = buildVimPluginFrom2Nix {
     pname = "mkdx";
     version = "2021-01-28";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -14,7 +14,8 @@
 , buildVimPluginFrom2Nix
 , nodePackages
 , dasht
-, sqlite, code-minimap
+, sqlite
+, code-minimap
 
 # deoplete-khard dependency
 , khard

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -246,10 +246,10 @@ self: super: {
 
   minimap-vim = super.minimap-vim.overrideAttrs(old: {
     preFixup = ''
-      substituteInPlace $out/share/vim-plugins/minimap-vim/plugin/minimap.vim --replace "code-minimap" \
-      "${code-minimap}/bin/code-minimap"
-      substituteInPlace $out/share/vim-plugins/minimap-vim/bin/minimap_generator.sh --replace "code-minimap" \
-      "${code-minimap}/bin/code-minimap"
+      substituteInPlace $out/share/vim-plugins/minimap-vim/plugin/minimap.vim \
+        --replace "code-minimap" "${code-minimap}/bin/code-minimap"
+      substituteInPlace $out/share/vim-plugins/minimap-vim/bin/minimap_generator.sh \
+        --replace "code-minimap" "${code-minimap}/bin/code-minimap"
     '';
   });
 

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -14,7 +14,7 @@
 , buildVimPluginFrom2Nix
 , nodePackages
 , dasht
-, sqlite
+, sqlite, code-minimap
 
 # deoplete-khard dependency
 , khard
@@ -241,6 +241,15 @@ self: super: {
 
   vim-gist = super.vim-gist.overrideAttrs(old: {
     dependencies = with super; [ webapi-vim ];
+  });
+
+  minimap-vim = super.minimap-vim.overrideAttrs(old: {
+    preFixup = ''
+      substituteInPlace $out/share/vim-plugins/minimap-vim/plugin/minimap.vim --replace "code-minimap" \
+      "${code-minimap}/bin/code-minimap"
+      substituteInPlace $out/share/vim-plugins/minimap-vim/bin/minimap_generator.sh --replace "code-minimap" \
+      "${code-minimap}/bin/code-minimap"
+    '';
   });
 
   meson = buildVimPluginFrom2Nix {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -677,6 +677,7 @@ wbthomason/packer.nvim
 weirongxu/coc-explorer
 wellle/targets.vim
 wellle/tmux-complete.vim
+wfxr/minimap.vim
 whonore/Coqtail
 will133/vim-dirdiff
 wincent/command-t


### PR DESCRIPTION
adds a minimap in vim, quite cool IMO

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
