### PR TITLE
boundary: init at 0.1.4

### DIFF
--- a/pkgs/tools/networking/boundary/default.nix
+++ b/pkgs/tools/networking/boundary/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, fetchzip }:
+
+let
+  inherit (stdenv.hostPlatform) system;
+  suffix = {
+    x86_64-linux = "linux_amd64";
+    aarch64-linux = "linux_arm64";
+    x86_64-darwin = "darwin_amd64";
+  }."${system}" or (throw "Unsupported system: ${system}");
+  fetchsrc = version: sha256: fetchzip {
+      url = "https://releases.hashicorp.com/boundary/${version}/boundary_${version}_${suffix}.zip";
+      sha256 = sha256."${system}";
+    };
+in
+stdenv.mkDerivation rec {
+  pname = "boundary";
+  version = "0.1.4";
+
+  src = fetchsrc version {
+    x86_64-linux = "sha256-+YGXSyaGhfNk+T5P7wCqsNEYwpV/Oet7kOM8OPC1A6I=";
+    aarch64-linux = "sha256-tikxRBF2Y+urv7S1EUu2d60twZWox1pI96yYX357r8o=";
+    x86_64-darwin = "sha256-N+6iiybnWZkruhUe9TRcGaq5xES/iHzlEVGcghT4EUc=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -D boundary $out/bin/boundary
+  '';
+
+  dontPatchELF = true;
+  dontPatchShebangs = true;
+
+  meta = with lib; {
+    homepage = "https://boundaryproject.io/";
+    changelog = "https://github.com/hashicorp/boundary/blob/v${version}/CHANGELOG.md";
+    description = "Enables identity-based access management for dynamic infrastructure";
+    longDescription = ''
+      Boundary provides a secure way to access hosts and critical systems
+      without having to manage credentials or expose your network, and is
+      entirely open source.
+
+      Boundary is designed to be straightforward to understand, highly scalable,
+      and resilient. It can run in clouds, on-prem, secure enclaves and more,
+      and does not require an agent to be installed on every end host.
+    '';
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ jk ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/tools/networking/boundary/update.sh
+++ b/pkgs/tools/networking/boundary/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk nix-prefetch
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/default.nix"
+if [ ! -f "$NIX_DRV" ]; then
+  echo "ERROR: cannot find default.nix in $ROOT"
+  exit 1
+fi
+
+fetch_arch() {
+  VER="$1"; ARCH="$2"
+  URL="https://releases.hashicorp.com/boundary/${VER}/boundary_${VER}_${ARCH}.zip"
+  nix-prefetch "{ stdenv, fetchzip }:
+stdenv.mkDerivation rec {
+  pname = \"boundary\"; version = \"${VER}\";
+  src = fetchzip { url = \"$URL\"; };
+}
+"
+}
+
+replace_sha() {
+  sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+}
+
+# https://releases.hashicorp.com/boundary/0.1.4/boundary_0.1.4_linux_amd64.zip
+BOUNDARY_VER=$(curl -Ls -w "%{url_effective}" -o /dev/null https://github.com/hashicorp/boundary/releases/latest | awk -F'/' '{print $NF}' | sed 's/v//')
+
+BOUNDARY_LINUX_X64_SHA256=$(fetch_arch "$BOUNDARY_VER" "linux_amd64")
+BOUNDARY_DARWIN_X64_SHA256=$(fetch_arch "$BOUNDARY_VER" "darwin_amd64")
+BOUNDARY_LINUX_AARCH64_SHA256=$(fetch_arch "$BOUNDARY_VER" "linux_arm64")
+
+sed -i "s/version = \".*\"/version = \"$BOUNDARY_VER\"/" "$NIX_DRV"
+
+replace_sha "x86_64-linux" "$BOUNDARY_LINUX_X64_SHA256"
+replace_sha "x86_64-darwin" "$BOUNDARY_DARWIN_X64_SHA256"
+replace_sha "aarch64-linux" "$BOUNDARY_LINUX_AARCH64_SHA256"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1033,6 +1033,8 @@ in
 
   boxes = callPackage ../tools/text/boxes { };
 
+  boundary = callPackage ../tools/networking/boundary { };
+
   chamber = callPackage ../tools/admin/chamber {  };
 
   charm = callPackage ../applications/misc/charm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

~Draft until some questions are answered on the HashiCorp Discuss~ Desktop electron edition is still in-progress :+1: 

Init boundary at `0.1.4`

https://boundaryproject.io
https://github.com/hashicorp/boundary
(UI https://github.com/hashicorp/boundary-ui)

Ran the dev server, haven't tried ssh-ing using it as my nixos config is a bit broken so I can't easily change firewall rules.

I tried building from source but it's one of those JS/Node built UI + Go deals and it'll only get more complicated once its released with the CLI + the desktop electron version.
The influxdb2 derivation helped but it's still in progress.

It is *possible* to build the CLI without the UI bundle but I'm 99% sure that's an unintended usecase :sweat_smile:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS (x86_64)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
