### PR TITLE
Update Haskell package set to Stackage Nightly 2021-01-29 (plus other fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -815,8 +815,9 @@ self: super: {
   # https://github.com/haskell-hvr/cryptohash-sha512/pull/5#issuecomment-752796913
   cryptohash-sha512 = dontCheck (doJailbreak super.cryptohash-sha512);
 
-  # Depends on tasty < 1.x, which we don't have.
-  cryptohash-sha256 = doJailbreak super.cryptohash-sha256;
+  # https://github.com/haskell-hvr/cryptohash-sha256/issues/11
+  # Jailbreak is necessary to break out of tasty < 1.x dependency.
+  cryptohash-sha256 = markUnbroken (doJailbreak super.cryptohash-sha256);
 
   # Needs tasty-quickcheck ==0.8.*, which we don't have.
   cryptohash-sha1 = doJailbreak super.cryptohash-sha1;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1377,11 +1377,6 @@ self: super: {
   # jailbreaking pandoc-citeproc because it has not bumped upper bound on pandoc
   pandoc-citeproc = doJailbreak super.pandoc-citeproc;
 
-  # 2021-01-17: Tests are broken because of a version mismatch.
-  # See here: https://github.com/jgm/pandoc/issues/7035
-  # This problem is fixed on master. Remove override when this assert fails.
-  pandoc = assert super.pandoc.version == "2.11.3.2"; dontCheck super.pandoc;
-
   # The test suite attempts to read `/etc/resolv.conf`, which doesn't work in the sandbox.
   domain-auth = dontCheck super.domain-auth;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1412,7 +1412,7 @@ self: super: {
   # https://github.com/haskell/haskell-language-server/issues/610
   # https://github.com/haskell/haskell-language-server/issues/611
   haskell-language-server = dontCheck (super.haskell-language-server.override {
-    lsp-test = dontCheck self.lsp-test_0_12_0_0;
+    lsp-test = dontCheck self.lsp-test;
     fourmolu = self.fourmolu_0_3_0_0;
   });
   # 2021-01-20
@@ -1421,12 +1421,10 @@ self: super: {
   apply-refact = super.apply-refact_0_8_2_1;
 
   fourmolu = dontCheck super.fourmolu;
+
   # 1. test requires internet
   # 2. dependency shake-bench hasn't been published yet so we also need unmarkBroken and doDistribute
-  ghcide = doDistribute (unmarkBroken (dontCheck
-  (super.ghcide_0_7_0_0.override {
-    lsp-test = dontCheck self.lsp-test_0_12_0_0;
-  })));
+  ghcide = doDistribute (unmarkBroken (dontCheck (super.ghcide_0_7_0_0.override { lsp-test = dontCheck self.lsp-test; })));
   refinery = doDistribute super.refinery_0_3_0_0;
   data-tree-print = doJailbreak super.data-tree-print;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -64,7 +64,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "0w71kbz127fcli24sxsvd48l5xamwamjwhr18x9alam5cldqkkz1";
+      sha256 = "1m9jfr5b0qwajwwmvcq02263bmnqgcqvpdr06sdwlfz3sxsjfp8r";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1417,7 +1417,7 @@ self: super: {
   # https://github.com/haskell/haskell-language-server/issues/610
   # https://github.com/haskell/haskell-language-server/issues/611
   haskell-language-server = dontCheck (super.haskell-language-server.override {
-    lsp-test = dontCheck self.lsp-test_0_11_0_7;
+    lsp-test = dontCheck self.lsp-test_0_12_0_0;
     fourmolu = self.fourmolu_0_3_0_0;
   });
   # 2021-01-20
@@ -1430,7 +1430,7 @@ self: super: {
   # 2. dependency shake-bench hasn't been published yet so we also need unmarkBroken and doDistribute
   ghcide = doDistribute (unmarkBroken (dontCheck
   (super.ghcide_0_7_0_0.override {
-    lsp-test = dontCheck self.lsp-test_0_11_0_7;
+    lsp-test = dontCheck self.lsp-test_0_12_0_0;
   })));
   refinery = doDistribute super.refinery_0_3_0_0;
   data-tree-print = doJailbreak super.data-tree-print;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -76,7 +76,7 @@ default-package-overrides:
   # haskell-language-server 0.5.0.0 doesn't accept newer versions
   - fourmolu ==0.2.*
   - refinery ==0.2.*
-  # Stackage Nightly 2021-01-20
+  # Stackage Nightly 2021-01-29
   - abstract-deque ==0.3
   - abstract-par ==0.3.3
   - AC-Angle ==1.0
@@ -215,33 +215,33 @@ default-package-overrides:
   - ansi-terminal ==0.10.3
   - ansi-wl-pprint ==0.6.9
   - ANum ==0.2.0.2
+  - ap-normalize ==0.1.0.0
   - apecs ==0.9.2
   - apecs-gloss ==0.2.4
   - apecs-physics ==0.4.5
   - api-field-json-th ==0.1.0.2
   - api-maker ==0.1.0.0
-  - ap-normalize ==0.1.0.0
+  - app-settings ==0.2.0.12
   - appar ==0.1.8
   - appendmap ==0.1.5
   - apply-refact ==0.9.0.0
   - apportionment ==0.0.0.3
   - approximate ==0.3.2
   - approximate-equality ==1.1.0.2
-  - app-settings ==0.2.0.12
   - arbor-lru-cache ==0.1.1.1
   - arbor-postgres ==0.0.5
   - arithmoi ==0.11.0.1
   - array-memoize ==0.6.0
   - arrow-extras ==0.1.0.1
-  - ascii ==1.0.0.2
+  - ascii ==1.0.1.0
   - ascii-case ==1.0.0.2
-  - ascii-char ==1.0.0.2
-  - asciidiagram ==1.3.3.3
+  - ascii-char ==1.0.0.6
   - ascii-group ==1.0.0.2
   - ascii-predicates ==1.0.0.2
   - ascii-progress ==0.3.3.0
-  - ascii-superset ==1.0.0.2
+  - ascii-superset ==1.0.1.0
   - ascii-th ==1.0.0.2
+  - asciidiagram ==1.3.3.3
   - asif ==6.0.4
   - asn1-encoding ==0.9.6
   - asn1-parse ==0.9.5
@@ -269,8 +269,8 @@ default-package-overrides:
   - authenticate ==1.3.5
   - authenticate-oauth ==1.6.0.1
   - auto ==0.4.3.1
-  - autoexporter ==1.1.19
   - auto-update ==0.1.6
+  - autoexporter ==1.1.19
   - avers ==0.0.17.1
   - avro ==0.5.2.0
   - aws-cloudfront-signed-cookies ==0.2.0.6
@@ -278,6 +278,11 @@ default-package-overrides:
   - backtracking ==0.1.0
   - bank-holidays-england ==0.2.0.6
   - barbies ==2.0.2.0
+  - base-compat ==0.11.2
+  - base-compat-batteries ==0.11.2
+  - base-orphans ==0.8.4
+  - base-prelude ==1.4
+  - base-unicode-symbols ==0.2.4.2
   - base16 ==0.3.0.1
   - base16-bytestring ==0.1.1.7
   - base16-lens ==0.1.3.0
@@ -286,17 +291,12 @@ default-package-overrides:
   - base32string ==0.9.1
   - base58-bytestring ==0.1.0
   - base58string ==0.10.0
-  - base64 ==0.4.2.2
+  - base64 ==0.4.2.3
   - base64-bytestring ==1.1.0.0
   - base64-bytestring-type ==1.0.1
   - base64-lens ==0.3.0
   - base64-string ==0.2
-  - base-compat ==0.11.2
-  - base-compat-batteries ==0.11.2
   - basement ==0.0.11
-  - base-orphans ==0.8.4
-  - base-prelude ==1.4
-  - base-unicode-symbols ==0.2.4.2
   - basic-prelude ==0.7.0
   - bazel-runfiles ==0.12
   - bbdb ==0.8
@@ -307,10 +307,10 @@ default-package-overrides:
   - benchpress ==0.2.2.15
   - between ==0.11.0.0
   - bibtex ==0.1.0.6
-  - bifunctors ==5.5.9
+  - bifunctors ==5.5.10
   - bimap ==0.4.0
-  - bimaps ==0.1.0.2
   - bimap-server ==0.1.0.1
+  - bimaps ==0.1.0.2
   - bin ==0.1
   - binary-conduit ==1.3.1
   - binary-ext ==2.0.4
@@ -330,8 +330,8 @@ default-package-overrides:
   - bins ==0.1.2.0
   - bitarray ==0.0.1.1
   - bits ==0.5.2
-  - bitset-word8 ==0.1.1.2
   - bits-extra ==0.0.2.0
+  - bitset-word8 ==0.1.1.2
   - bitvec ==1.0.3.0
   - bitwise-enum ==1.0.0.3
   - blake2 ==0.3.0
@@ -357,12 +357,12 @@ default-package-overrides:
   - boring ==0.1.3
   - both ==0.1.1.1
   - bound ==2.0.2
-  - BoundedChan ==1.0.3.0
   - bounded-queue ==1.0.0
+  - BoundedChan ==1.0.3.0
   - boundingboxes ==0.2.3
   - bower-json ==1.0.0.1
   - boxes ==0.1.5
-  - brick ==0.58.1
+  - brick ==0.59
   - broadcast-chan ==0.2.1.1
   - bsb-http-chunked ==0.0.0.4
   - bson ==0.4.0.1
@@ -376,10 +376,10 @@ default-package-overrides:
   - butcher ==1.3.3.2
   - bv ==0.5
   - bv-little ==1.1.1
-  - byteable ==0.1.1
   - byte-count-reader ==0.10.1.2
-  - bytedump ==1.0
   - byte-order ==0.1.2.0
+  - byteable ==0.1.1
+  - bytedump ==1.0
   - byteorder ==1.0.4
   - bytes ==0.17
   - byteset ==0.1.1.0
@@ -395,6 +395,8 @@ default-package-overrides:
   - bzlib-conduit ==0.3.0.2
   - c14n ==0.1.0.1
   - c2hs ==0.28.7
+  - ca-province-codes ==1.0.0.0
+  - cabal-debian ==5.1
   - cabal-doctest ==1.0.8
   - cabal-file ==0.1.1
   - cabal-flatpak ==0.1.0.2
@@ -405,13 +407,12 @@ default-package-overrides:
   - calendar-recycling ==0.0.0.1
   - call-stack ==0.2.0
   - can-i-haz ==0.3.1.0
-  - ca-province-codes ==1.0.0.0
   - cardano-coin-selection ==1.0.1
   - carray ==0.1.6.8
   - casa-client ==0.0.1
   - casa-types ==0.0.1
-  - cased ==0.1.0.0
   - case-insensitive ==1.2.1.0
+  - cased ==0.1.0.0
   - cases ==0.1.4
   - casing ==0.1.4.1
   - cassava ==0.5.2.0
@@ -435,7 +436,7 @@ default-package-overrides:
   - charsetdetect-ae ==1.1.0.4
   - Chart ==1.9.3
   - chaselev-deque ==0.5.0.5
-  - ChasingBottoms ==1.3.1.9
+  - ChasingBottoms ==1.3.1.10
   - cheapskate ==0.1.1.2
   - cheapskate-highlight ==0.1.0.0
   - cheapskate-lucid ==0.1.0.0
@@ -472,12 +473,12 @@ default-package-overrides:
   - cmark-gfm ==0.2.2
   - cmark-lucid ==0.1.0.0
   - cmdargs ==0.10.20
-  - codec-beam ==0.2.0
-  - codec-rpm ==0.2.2
-  - code-page ==0.2
   - co-log ==0.4.0.1
   - co-log-concurrent ==0.5.0.0
   - co-log-core ==0.2.1.1
+  - code-page ==0.2
+  - codec-beam ==0.2.0
+  - codec-rpm ==0.2.2
   - Color ==0.3.0
   - colorful-monoids ==0.2.1.3
   - colorize-haskell ==1.0.1
@@ -523,8 +524,8 @@ default-package-overrides:
   - conferer-aeson ==1.0.0.0
   - conferer-hspec ==1.0.0.0
   - conferer-warp ==1.0.0.0
-  - ConfigFile ==1.1.4
   - config-ini ==0.2.4.0
+  - ConfigFile ==1.1.4
   - configurator ==0.3.0.0
   - configurator-export ==0.1.0.1
   - configurator-pg ==0.2.5
@@ -532,12 +533,13 @@ default-package-overrides:
   - connection-pool ==0.2.2
   - console-style ==0.0.2.1
   - constraint ==0.1.4.0
-  - constraints ==0.12
   - constraint-tuples ==0.1.2
+  - constraints ==0.12
   - construct ==0.3
   - contravariant ==1.5.3
   - contravariant-extras ==0.3.5.2
   - control-bool ==0.2.1
+  - control-dsl ==0.2.1.3
   - control-monad-free ==0.6.2
   - control-monad-omega ==0.3.2
   - convertible ==1.1.1.0
@@ -560,21 +562,21 @@ default-package-overrides:
   - cron ==0.7.0
   - crypto-api ==0.13.3
   - crypto-cipher-types ==0.0.9
-  - cryptocompare ==0.1.2
   - crypto-enigma ==0.1.1.6
-  - cryptohash ==0.11.9
-  - cryptohash-cryptoapi ==0.1.4
-  - cryptohash-md5 ==0.11.100.1
-  - cryptohash-sha1 ==0.11.100.1
-  - cryptohash-sha256 ==0.11.101.0
-  - cryptonite ==0.27
-  - cryptonite-conduit ==0.2.2
-  - cryptonite-openssl ==0.7
   - crypto-numbers ==0.2.7
   - crypto-pubkey ==0.2.8
   - crypto-pubkey-types ==0.4.3
   - crypto-random ==0.0.9
   - crypto-random-api ==0.2.0
+  - cryptocompare ==0.1.2
+  - cryptohash ==0.11.9
+  - cryptohash-cryptoapi ==0.1.4
+  - cryptohash-md5 ==0.11.100.1
+  - cryptohash-sha1 ==0.11.100.1
+  - cryptohash-sha256 ==0.11.102.0
+  - cryptonite ==0.27
+  - cryptonite-conduit ==0.2.2
+  - cryptonite-openssl ==0.7
   - csp ==1.4.0
   - css-syntax ==0.1.0.0
   - css-text ==0.1.3.0
@@ -611,7 +613,6 @@ default-package-overrides:
   - data-default-instances-dlist ==0.0.1
   - data-default-instances-old-locale ==0.0.1
   - data-diverse ==4.7.0.0
-  - datadog ==0.2.5.0
   - data-dword ==0.3.2
   - data-endian ==0.1.1
   - data-fix ==0.3.0
@@ -630,6 +631,7 @@ default-package-overrides:
   - data-reify ==0.6.3
   - data-serializer ==0.3.4.1
   - data-textual ==0.3.0.3
+  - datadog ==0.2.5.0
   - dataurl ==0.1.0.0
   - DAV ==1.3.4
   - DBFunctor ==0.1.1.1
@@ -648,38 +650,40 @@ default-package-overrides:
   - dense-linear-algebra ==0.1.0.0
   - depq ==0.4.1.0
   - deque ==0.4.3
-  - deriveJsonNoPrefix ==0.1.0.1
   - derive-topdown ==0.0.2.2
+  - deriveJsonNoPrefix ==0.1.0.1
   - deriving-aeson ==0.2.6
   - deriving-compat ==0.5.10
   - derulo ==1.0.9
-  - dhall ==1.37.1
-  - dhall-bash ==1.0.35
-  - dhall-json ==1.7.4
-  - dhall-lsp-server ==1.0.12
-  - dhall-yaml ==1.2.4
+  - dhall ==1.38.0
+  - dhall-bash ==1.0.36
+  - dhall-json ==1.7.5
+  - dhall-lsp-server ==1.0.13
+  - dhall-yaml ==1.2.5
+  - di-core ==1.0.4
+  - di-monad ==1.3.1
   - diagrams-solve ==0.1.2
   - dialogflow-fulfillment ==0.1.1.3
-  - di-core ==1.0.4
   - dictionary-sharing ==0.1.0.0
   - Diff ==0.4.0
   - digest ==0.0.1.2
   - digits ==0.3.1
   - dimensional ==1.3
-  - di-monad ==1.3.1
-  - directory-tree ==0.12.1
   - direct-sqlite ==2.3.26
+  - directory-tree ==0.12.1
   - dirichlet ==0.1.0.2
   - discount ==0.1.1
   - disk-free-space ==0.1.0.1
   - distributed-closure ==0.4.2.0
   - distribution-opensuse ==1.1.1
   - distributive ==0.6.2.1
-  - dl-fedora ==0.7.5
+  - dl-fedora ==0.7.6
   - dlist ==0.8.0.8
   - dlist-instances ==0.1.1.1
   - dlist-nonempty ==0.1.1
   - dns ==4.0.1
+  - do-list ==1.0.1
+  - do-notation ==0.1.0.2
   - dockerfile ==0.2.0
   - doclayout ==0.3
   - doctemplates ==0.9
@@ -688,8 +692,6 @@ default-package-overrides:
   - doctest-exitcode-stdio ==0.0
   - doctest-lib ==0.1
   - doldol ==0.4.1.2
-  - do-list ==1.0.1
-  - do-notation ==0.1.0.2
   - dot ==0.3
   - dotenv ==0.8.0.7
   - dotgen ==0.4.3
@@ -729,10 +731,10 @@ default-package-overrides:
   - elerea ==2.9.0
   - elf ==0.30
   - eliminators ==0.7
-  - elm2nix ==0.2.1
   - elm-bridge ==0.6.1
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
+  - elm2nix ==0.2.1
   - elynx ==0.5.0.1
   - elynx-markov ==0.5.0.1
   - elynx-nexus ==0.5.0.1
@@ -744,16 +746,16 @@ default-package-overrides:
   - enclosed-exceptions ==1.0.3
   - ENIG ==0.0.1.0
   - entropy ==0.4.1.6
+  - enum-subset-generate ==0.1.0.0
   - enummapset ==0.6.0.3
   - enumset ==0.0.5
-  - enum-subset-generate ==0.1.0.0
   - envelope ==0.2.2.0
   - envparse ==0.4.1
   - envy ==2.1.0.0
   - epub-metadata ==4.5
   - eq ==4.2.1
   - equal-files ==0.0.5.3
-  - equational-reasoning ==0.6.0.4
+  - equational-reasoning ==0.7.0.0
   - equivalence ==0.3.5
   - erf ==2.0.0.0
   - error-or ==0.1.2.0
@@ -768,25 +770,25 @@ default-package-overrides:
   - essence-of-live-coding-quickcheck ==0.2.4
   - etc ==0.4.1.0
   - eve ==0.1.9.0
+  - event-list ==0.1.2
   - eventful-core ==0.2.0
   - eventful-test-helpers ==0.2.0
-  - event-list ==0.1.2
   - eventstore ==1.4.1
   - every ==0.0.1
   - exact-combinatorics ==0.2.0.9
   - exact-pi ==0.5.0.1
   - exception-hierarchy ==0.1.0.4
   - exception-mtl ==0.4.0.1
-  - exceptions ==0.10.4
   - exception-transformers ==0.4.0.9
   - exception-via ==0.1.0.0
+  - exceptions ==0.10.4
   - executable-path ==0.0.3.1
   - exit-codes ==1.0.0
   - exomizer ==1.0.0
+  - exp-pairs ==0.2.1.0
   - experimenter ==0.1.0.4
   - expiring-cache-map ==0.0.6.1
   - explicit-exception ==0.1.10
-  - exp-pairs ==0.2.1.0
   - express ==0.1.3
   - extended-reals ==0.2.4.0
   - extensible-effects ==5.0.0.1
@@ -813,10 +815,10 @@ default-package-overrides:
   - fgl ==5.7.0.3
   - file-embed ==0.0.13.0
   - file-embed-lzma ==0
-  - filelock ==0.1.1.5
-  - filemanip ==0.3.6.3
   - file-modules ==0.1.2.4
   - file-path-th ==0.1.0.0
+  - filelock ==0.1.1.5
+  - filemanip ==0.3.6.3
   - filepattern ==0.1.2
   - fileplow ==0.1.0.0
   - filtrable ==0.1.4.0
@@ -846,9 +848,9 @@ default-package-overrides:
   - fn ==0.3.0.2
   - focus ==1.0.2
   - focuslist ==0.1.0.2
-  - foldable1 ==0.1.0.0
   - fold-debounce ==0.2.0.9
   - fold-debounce-conduit ==0.2.0.5
+  - foldable1 ==0.1.0.0
   - foldl ==1.4.10
   - folds ==0.7.5
   - follow-file ==0.0.3
@@ -862,10 +864,10 @@ default-package-overrides:
   - foundation ==0.0.25
   - free ==5.1.5
   - free-categories ==0.2.0.2
+  - free-vl ==0.1.4
   - freenect ==1.2.1
   - freer-simple ==1.2.1.1
   - freetype2 ==0.2.0
-  - free-vl ==0.1.4
   - friendly-time ==0.4.1
   - from-sum ==0.2.3.0
   - frontmatter ==0.1.0.2
@@ -876,13 +878,13 @@ default-package-overrides:
   - funcmp ==1.9
   - function-builder ==0.3.0.1
   - functor-classes-compat ==1
-  - fusion-plugin ==0.2.1
+  - fusion-plugin ==0.2.2
   - fusion-plugin-types ==0.1.0
   - fuzzcheck ==0.1.1
   - fuzzy ==0.1.0.0
   - fuzzy-dates ==0.1.1.2
-  - fuzzyset ==0.2.0
   - fuzzy-time ==0.1.0.0
+  - fuzzyset ==0.2.0
   - gauge ==0.2.5
   - gd ==3000.7.3
   - gdp ==0.0.3.0
@@ -897,8 +899,8 @@ default-package-overrides:
   - generic-lens-core ==2.0.0.0
   - generic-monoid ==0.1.0.1
   - generic-optics ==2.0.0.0
-  - GenericPretty ==1.2.2
   - generic-random ==1.3.0.1
+  - GenericPretty ==1.2.2
   - generics-sop ==0.5.1.0
   - generics-sop-lens ==0.2.0.1
   - geniplate-mirror ==0.7.7
@@ -932,9 +934,6 @@ default-package-overrides:
   - ghc-core ==0.5.6
   - ghc-events ==0.15.1
   - ghc-exactprint ==0.6.3.3
-  - ghcid ==0.8.7
-  - ghci-hexcalc ==0.1.1.0
-  - ghcjs-codemirror ==0.0.0.2
   - ghc-lib ==8.10.3.20201220
   - ghc-lib-parser ==8.10.3.20201220
   - ghc-lib-parser-ex ==8.10.0.17
@@ -948,7 +947,10 @@ default-package-overrides:
   - ghc-typelits-extra ==0.4.2
   - ghc-typelits-knownnat ==0.7.4
   - ghc-typelits-natnormalise ==0.7.3
-  - ghc-typelits-presburger ==0.5.0.0
+  - ghc-typelits-presburger ==0.5.2.0
+  - ghci-hexcalc ==0.1.1.0
+  - ghcid ==0.8.7
+  - ghcjs-codemirror ==0.0.0.2
   - ghost-buster ==0.1.1.0
   - gi-atk ==2.0.22
   - gi-cairo ==1.0.24
@@ -966,9 +968,10 @@ default-package-overrides:
   - gi-gtk ==3.0.36
   - gi-gtk-hs ==0.3.9
   - gi-harfbuzz ==0.0.3
+  - gi-pango ==1.0.23
+  - gi-xlib ==2.0.9
   - ginger ==0.10.1.0
   - gingersnap ==0.3.1.0
-  - gi-pango ==1.0.23
   - githash ==0.1.5.0
   - github ==0.26
   - github-release ==1.3.5
@@ -977,7 +980,6 @@ default-package-overrides:
   - github-webhooks ==0.15.0
   - gitlab-haskell ==0.2.5
   - gitrev ==1.3.1
-  - gi-xlib ==2.0.9
   - gl ==0.9
   - glabrous ==2.0.2
   - GLFW-b ==3.3.0.0
@@ -992,11 +994,11 @@ default-package-overrides:
   - gothic ==0.1.5
   - gpolyline ==0.1.0.1
   - graph-core ==0.3.0.0
+  - graph-wrapper ==0.2.6.0
   - graphite ==0.10.0.1
   - graphql-client ==1.1.0
   - graphs ==0.7.1
   - graphviz ==2999.20.1.0
-  - graph-wrapper ==0.2.6.0
   - gravatar ==0.8.0
   - greskell ==1.2.0.0
   - greskell-core ==0.1.3.5
@@ -1011,7 +1013,7 @@ default-package-overrides:
   - hackage-db ==2.1.0
   - hackage-security ==0.6.0.1
   - haddock-library ==1.9.0
-  - hadolint ==1.19.0
+  - hadolint ==1.20.0
   - hadoop-streaming ==0.2.0.3
   - hakyll-convert ==0.3.0.3
   - half ==0.3.1
@@ -1022,6 +1024,7 @@ default-package-overrides:
   - happstack-server ==7.7.0
   - happy ==1.20.0
   - HasBigDecimal ==0.1.1
+  - hasbolt ==0.1.4.4
   - hashable ==1.3.0.0
   - hashable-time ==0.2.0.2
   - hashids ==1.0.2.4
@@ -1037,6 +1040,7 @@ default-package-overrides:
   - haskell-lsp ==0.22.0.0
   - haskell-lsp-types ==0.22.0.0
   - haskell-names ==0.9.9
+  - haskell-src ==1.0.3.1
   - haskell-src-exts ==1.23.1
   - haskell-src-exts-util ==0.2.5
   - haskell-src-meta ==0.8.5
@@ -1064,7 +1068,7 @@ default-package-overrides:
   - hedgehog-fakedata ==0.0.1.3
   - hedgehog-fn ==1.0
   - hedgehog-quickcheck ==0.1.1
-  - hedis ==0.14.0
+  - hedis ==0.14.1
   - hedn ==0.3.0.2
   - here ==1.2.13
   - heredoc ==0.2.0.0
@@ -1078,9 +1082,9 @@ default-package-overrides:
   - hgeometry ==0.11.0.0
   - hgeometry-combinatorial ==0.11.0.0
   - hgrev ==0.2.6
+  - hi-file-parser ==0.1.0.0
   - hidapi ==0.1.5
   - hie-bios ==0.7.2
-  - hi-file-parser ==0.1.0.0
   - higher-leveldb ==0.6.0.0
   - highlighting-kate ==0.6.4
   - hinfo ==0.0.3.0
@@ -1119,15 +1123,16 @@ default-package-overrides:
   - hpc-lcov ==1.0.1
   - hprotoc ==2.4.17
   - hruby ==0.3.8
-  - hsass ==0.8.0
   - hs-bibutils ==6.10.0.0
+  - hs-functors ==0.1.7.1
+  - hs-GeoIP ==0.3
+  - hs-php-session ==0.0.9.3
+  - hsass ==0.8.0
   - hsc2hs ==0.68.7
   - hscolour ==1.24.4
   - hsdns ==1.8
   - hsebaysdk ==0.4.1.0
   - hsemail ==2.2.1
-  - hs-functors ==0.1.7.1
-  - hs-GeoIP ==0.3
   - hsini ==0.5.1.2
   - hsinstall ==2.6
   - HSlippyMap ==3.0.1
@@ -1154,14 +1159,13 @@ default-package-overrides:
   - hspec-hedgehog ==0.0.1.2
   - hspec-leancheck ==0.0.4
   - hspec-megaparsec ==2.2.0
-  - hspec-meta ==2.6.0
+  - hspec-meta ==2.7.8
   - hspec-need-env ==0.1.0.5
   - hspec-parsec ==0
   - hspec-smallcheck ==0.5.2
   - hspec-tables ==0.0.1
   - hspec-wai ==0.10.1
   - hspec-wai-json ==0.10.1
-  - hs-php-session ==0.0.9.3
   - hsshellscript ==3.4.5
   - HStringTemplate ==0.8.7
   - HSvm ==0.1.1.3.22
@@ -1169,12 +1173,12 @@ default-package-overrides:
   - HsYAML-aeson ==0.2.0.0
   - hsyslog ==5.0.2
   - htaglib ==1.2.0
+  - HTF ==0.14.0.5
   - html ==1.0.1.2
   - html-conduit ==1.3.2.1
   - html-entities ==1.1.4.3
   - html-entity-map ==0.1.0.0
   - htoml ==1.0.0.3
-  - http2 ==2.0.5
   - HTTP ==4000.3.15
   - http-api-data ==0.4.1.1
   - http-client ==0.6.4.1
@@ -1186,13 +1190,14 @@ default-package-overrides:
   - http-date ==0.0.10
   - http-directory ==0.1.8
   - http-download ==0.2.0.0
-  - httpd-shed ==0.4.1.1
   - http-link-header ==1.0.3.1
   - http-media ==0.8.0.0
   - http-query ==0.1.0
   - http-reverse-proxy ==0.6.0
   - http-streams ==0.8.7.2
   - http-types ==0.12.3
+  - http2 ==2.0.5
+  - httpd-shed ==0.4.1.1
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.1.0
   - HUnit-approx ==1.1.1.1
@@ -1205,7 +1210,6 @@ default-package-overrides:
   - hw-conduit-merges ==0.2.1.0
   - hw-diagnostics ==0.0.1.0
   - hw-dsv ==0.4.1.0
-  - hweblib ==0.6.3
   - hw-eliasfano ==0.1.2.0
   - hw-excess ==0.2.3.0
   - hw-fingertree ==0.1.2.0
@@ -1218,7 +1222,7 @@ default-package-overrides:
   - hw-json-simd ==0.1.1.0
   - hw-json-simple-cursor ==0.1.1.0
   - hw-json-standard-cursor ==0.2.3.1
-  - hw-kafka-client ==4.0.1
+  - hw-kafka-client ==4.0.2
   - hw-mquery ==0.2.1.0
   - hw-packed-vector ==0.2.1.0
   - hw-parser ==0.1.1.0
@@ -1230,6 +1234,7 @@ default-package-overrides:
   - hw-string-parse ==0.0.0.4
   - hw-succinct ==0.1.0.1
   - hw-xml ==0.5.1.0
+  - hweblib ==0.6.3
   - hxt ==9.3.1.18
   - hxt-charproperties ==9.4.0.0
   - hxt-css ==0.1.0.3
@@ -1313,26 +1318,26 @@ default-package-overrides:
   - iso3166-country-codes ==0.20140203.8
   - iso639 ==0.1.0.3
   - iso8601-time ==0.1.5
-  - iterable ==3.0
   - it-has ==0.2.0.0
+  - iterable ==3.0
+  - ix-shapable ==0.1.0
   - ixset-typed ==0.5
   - ixset-typed-binary-instance ==0.1.0.2
   - ixset-typed-conversions ==0.1.2.0
   - ixset-typed-hashable-instance ==0.1.0.2
-  - ix-shapable ==0.1.0
   - jack ==0.7.1.4
   - jalaali ==1.0.0.0
   - jira-wiki-markup ==1.3.2
   - jose ==0.8.4
-  - jose-jwt ==0.8.0
+  - jose-jwt ==0.9.0
   - js-chart ==2.9.4.1
   - js-dgtable ==0.5.2
   - js-flot ==0.8.3
   - js-jquery ==3.3.1
   - json-feed ==1.0.11
-  - jsonpath ==0.2.0.0
   - json-rpc ==1.0.3
   - json-rpc-generic ==0.2.1.5
+  - jsonpath ==0.2.0.0
   - JuicyPixels ==3.3.5
   - JuicyPixels-blurhash ==0.1.0.3
   - JuicyPixels-extra ==0.4.1
@@ -1406,14 +1411,14 @@ default-package-overrides:
   - libgit ==0.3.1
   - libgraph ==1.14
   - libjwt-typed ==0.2
-  - libmpd ==0.9.3.0
+  - libmpd ==0.10.0.0
   - liboath-hs ==0.0.1.2
   - libyaml ==0.1.2
   - LibZip ==1.0.1
   - life-sync ==1.1.1.0
+  - lift-generics ==0.2
   - lifted-async ==0.10.1.2
   - lifted-base ==0.2.3.12
-  - lift-generics ==0.2
   - line ==4.0.1
   - linear ==1.21.3
   - linear-circuit ==0.1.0.2
@@ -1422,11 +1427,11 @@ default-package-overrides:
   - linux-namespaces ==0.1.3.0
   - liquid-fixpoint ==0.8.10.2
   - List ==0.6.2
-  - ListLike ==4.7.4
   - list-predicate ==0.1.0.1
-  - listsafe ==0.1.0.1
   - list-singleton ==1.0.0.4
   - list-t ==1.0.4
+  - ListLike ==4.7.4
+  - listsafe ==0.1.0.1
   - ListTree ==0.2.3
   - little-logger ==0.3.1
   - little-rio ==0.2.2
@@ -1459,22 +1464,22 @@ default-package-overrides:
   - machines ==0.7.1
   - magic ==1.1
   - magico ==0.0.2.1
-  - mainland-pretty ==0.7.0.1
   - main-tester ==0.2.0.1
+  - mainland-pretty ==0.7.0.1
   - makefile ==1.1.0.0
   - managed ==1.0.8
   - MapWith ==0.2.0.0
   - markdown ==0.1.17.4
   - markdown-unlit ==0.5.1
   - markov-chain ==0.0.3.4
-  - massiv ==0.5.9.0
-  - massiv-io ==0.4.0.0
+  - massiv ==0.6.0.0
+  - massiv-io ==0.4.1.0
   - massiv-persist ==0.1.0.0
   - massiv-serialise ==0.1.0.0
-  - massiv-test ==0.1.6
-  - mathexpr ==0.3.0.0
+  - massiv-test ==0.1.6.1
   - math-extras ==0.1.1.0
   - math-functions ==0.3.4.1
+  - mathexpr ==0.3.0.0
   - matplotlib ==0.7.5
   - matrices ==0.5.0
   - matrix ==0.3.6.1
@@ -1486,9 +1491,9 @@ default-package-overrides:
   - mbox-utility ==0.0.3.1
   - mcmc ==0.4.0.0
   - mcmc-types ==1.0.3
+  - med-module ==0.1.2.1
   - medea ==1.2.0
   - median-stream ==0.7.0.0
-  - med-module ==0.1.2.1
   - megaparsec ==9.0.1
   - megaparsec-tests ==9.0.1
   - membrain ==0.0.0.2
@@ -1517,16 +1522,16 @@ default-package-overrides:
   - mime-mail ==0.5.0
   - mime-mail-ses ==0.4.3
   - mime-types ==0.1.0.9
+  - min-max-pqueue ==0.1.0.2
   - mini-egison ==1.0.0
   - minimal-configuration ==0.1.4
   - minimorph ==0.3.0.0
   - minio-hs ==1.5.3
   - miniutter ==0.5.1.1
-  - min-max-pqueue ==0.1.0.2
   - mintty ==0.1.2
   - missing-foreign ==0.1.1
   - MissingH ==1.4.3.0
-  - mixed-types-num ==0.4.0.2
+  - mixed-types-num ==0.4.1
   - mltool ==0.2.0.1
   - mmap ==0.5.9
   - mmark ==0.0.7.2
@@ -1534,8 +1539,8 @@ default-package-overrides:
   - mmark-ext ==0.2.1.2
   - mmorph ==1.1.3
   - mnist-idx ==0.1.2.8
-  - mockery ==0.3.5
   - mock-time ==0.1.0
+  - mockery ==0.3.5
   - mod ==0.1.2.1
   - model ==0.5
   - modern-uri ==0.3.3.0
@@ -1545,9 +1550,7 @@ default-package-overrides:
   - monad-control-aligned ==0.0.1.1
   - monad-coroutine ==0.9.0.4
   - monad-extras ==0.6.0
-  - monadic-arrays ==0.2.2
   - monad-journal ==0.8.1
-  - monadlist ==0.0.2
   - monad-logger ==0.3.36
   - monad-logger-json ==0.1.0.0
   - monad-logger-logstash ==0.1.0.0
@@ -1556,26 +1559,28 @@ default-package-overrides:
   - monad-memo ==0.5.3
   - monad-metrics ==0.2.2.0
   - monad-par ==0.3.5
-  - monad-parallel ==0.7.2.3
   - monad-par-extras ==0.3.3
+  - monad-parallel ==0.7.2.3
   - monad-peel ==0.2.1.2
   - monad-primitive ==0.1
   - monad-products ==4.0.1
-  - MonadPrompt ==1.0.0.5
-  - MonadRandom ==0.5.2
   - monad-resumption ==0.1.4.0
   - monad-skeleton ==0.1.5
   - monad-st ==0.2.4.1
-  - monads-tf ==0.1.0.3
   - monad-time ==0.3.1.0
   - monad-unlift ==0.2.0
   - monad-unlift-ref ==0.2.1
+  - monadic-arrays ==0.2.2
+  - monadlist ==0.0.2
+  - MonadPrompt ==1.0.0.5
+  - MonadRandom ==0.5.2
+  - monads-tf ==0.1.0.3
   - mongoDB ==2.7.0.0
-  - monoid-subclasses ==1.0.1
-  - monoid-transformer ==0.0.4
   - mono-traversable ==1.0.15.1
   - mono-traversable-instances ==0.1.1.0
   - mono-traversable-keys ==0.1.0
+  - monoid-subclasses ==1.0.1
+  - monoid-transformer ==0.0.4
   - more-containers ==0.2.2.0
   - morpheus-graphql ==0.16.0
   - morpheus-graphql-client ==0.16.0
@@ -1588,14 +1593,14 @@ default-package-overrides:
   - mpi-hs-cereal ==0.1.0.0
   - mtl-compat ==0.2.2
   - mtl-prelude ==2.0.3.1
-  - multiarg ==0.30.0.10
   - multi-containers ==0.1.1
+  - multiarg ==0.30.0.10
   - multimap ==1.2.1
   - multipart ==0.2.1
   - multiset ==0.3.4.3
   - multistate ==0.8.0.3
-  - murmur3 ==1.0.4
   - murmur-hash ==0.1.0.9
+  - murmur3 ==1.0.4
   - MusicBrainz ==0.4.1
   - mustache ==2.3.1
   - mutable-containers ==0.3.4
@@ -1643,16 +1648,16 @@ default-package-overrides:
   - nicify-lib ==1.0.1
   - NineP ==0.0.2.1
   - nix-paths ==1.0.1
+  - no-value ==1.0.0.0
+  - non-empty ==0.3.2
+  - non-empty-sequence ==0.2.0.4
+  - non-negative ==0.1.2
   - nonce ==1.0.7
   - nondeterminism ==1.4
-  - non-empty ==0.3.2
   - nonempty-containers ==0.3.4.1
-  - nonemptymap ==0.0.6.0
-  - non-empty-sequence ==0.2.0.4
   - nonempty-vector ==0.2.1.0
-  - non-negative ==0.1.2
+  - nonemptymap ==0.0.6.0
   - not-gloss ==0.7.7.0
-  - no-value ==1.0.0.0
   - nowdoc ==0.1.1.0
   - nqe ==0.6.3
   - nri-env-parser ==0.1.0.3
@@ -1668,9 +1673,9 @@ default-package-overrides:
   - nvim-hs ==2.1.0.4
   - nvim-hs-contrib ==2.0.0.0
   - nvim-hs-ghcid ==2.0.0.0
+  - o-clock ==1.2.0.1
   - oauthenticated ==0.2.1.0
   - ObjectName ==1.1.0.1
-  - o-clock ==1.2.0.1
   - odbc ==0.2.2
   - oeis2 ==1.0.4
   - ofx ==0.4.4.0
@@ -1683,9 +1688,9 @@ default-package-overrides:
   - Only ==0.1
   - oo-prototypes ==0.1.0.0
   - opaleye ==0.7.1.0
+  - open-browser ==0.2.1.0
   - OpenAL ==1.7.0.5
   - openapi3 ==3.0.1.0
-  - open-browser ==0.2.1.0
   - openexr-write ==0.1.0.2
   - OpenGL ==3.0.3.0
   - OpenGLRaw ==3.3.4.0
@@ -1749,10 +1754,10 @@ default-package-overrides:
   - pattern-arrows ==0.0.2
   - pava ==0.1.1.0
   - pcg-random ==0.1.3.7
-  - pcre2 ==1.1.4
   - pcre-heavy ==1.0.0.2
   - pcre-light ==0.4.1.0
   - pcre-utils ==0.1.8.1.1
+  - pcre2 ==1.1.4
   - pdfinfo ==1.5.4
   - peano ==0.1.0.1
   - pem ==0.2.4
@@ -1774,8 +1779,8 @@ default-package-overrides:
   - persistent-test ==2.0.3.5
   - persistent-typed-db ==0.1.0.2
   - pg-harness-client ==0.6.0
-  - pgp-wordlist ==0.1.0.3
   - pg-transact ==0.3.1.1
+  - pgp-wordlist ==0.1.0.3
   - phantom-state ==0.2.1.2
   - pid1 ==0.1.2.0
   - pinboard ==0.10.2.0
@@ -1814,6 +1819,7 @@ default-package-overrides:
   - port-utils ==0.2.1.0
   - posix-paths ==0.2.1.6
   - possibly ==1.0.0.0
+  - post-mess-age ==0.2.1.0
   - postgres-options ==0.2.0.0
   - postgresql-binary ==0.12.3.3
   - postgresql-libpq ==0.9.4.3
@@ -1822,28 +1828,27 @@ default-package-overrides:
   - postgresql-simple ==0.6.4
   - postgresql-typed ==0.6.1.2
   - postgrest ==7.0.1
-  - post-mess-age ==0.2.1.0
   - pptable ==0.3.0.0
   - pqueue ==1.4.1.3
   - prairie ==0.0.1.0
   - prefix-units ==0.2.0
   - prelude-compat ==0.0.0.2
   - prelude-safeenum ==0.1.1.2
-  - prettyclass ==1.0.0.0
   - pretty-class ==1.0.1.1
   - pretty-diff ==0.2.0.3
   - pretty-hex ==1.1
+  - pretty-relative-time ==0.2.0.0
+  - pretty-show ==1.10
+  - pretty-simple ==4.0.0.0
+  - pretty-sop ==0.2.0.3
+  - pretty-terminal ==0.1.0.0
+  - prettyclass ==1.0.0.0
   - prettyprinter ==1.7.0
   - prettyprinter-ansi-terminal ==1.1.2
   - prettyprinter-compat-annotated-wl-pprint ==1.1
   - prettyprinter-compat-ansi-wl-pprint ==1.0.1
   - prettyprinter-compat-wl-pprint ==1.0.0.1
   - prettyprinter-convert-ansi-wl-pprint ==1.1.1
-  - pretty-relative-time ==0.2.0.0
-  - pretty-show ==1.10
-  - pretty-simple ==4.0.0.0
-  - pretty-sop ==0.2.0.3
-  - pretty-terminal ==0.1.0.0
   - primes ==0.2.1.0
   - primitive ==0.7.1.0
   - primitive-addr ==0.1.0.2
@@ -1857,14 +1862,20 @@ default-package-overrides:
   - product-profunctors ==0.11.0.1
   - profiterole ==0.1
   - profunctors ==5.5.2
-  - projectroot ==0.2.0.1
   - project-template ==0.2.1.0
+  - projectroot ==0.2.0.1
   - prometheus ==2.2.2
   - prometheus-client ==1.0.1
   - prometheus-wai-middleware ==1.0.1.0
   - promises ==0.3
   - prompt ==0.1.1.2
   - prospect ==0.1.0.0
+  - proto-lens ==0.7.0.0
+  - proto-lens-optparse ==0.1.1.7
+  - proto-lens-protobuf-types ==0.7.0.0
+  - proto-lens-protoc ==0.7.0.0
+  - proto-lens-runtime ==0.7.0.0
+  - proto-lens-setup ==0.4.0.4
   - proto3-wire ==1.1.0
   - protobuf ==0.2.1.3
   - protobuf-simple ==0.1.1.0
@@ -1872,12 +1883,6 @@ default-package-overrides:
   - protocol-buffers-descriptor ==2.4.17
   - protocol-radius ==0.0.1.1
   - protocol-radius-test ==0.1.0.1
-  - proto-lens ==0.7.0.0
-  - proto-lens-optparse ==0.1.1.7
-  - proto-lens-protobuf-types ==0.7.0.0
-  - proto-lens-protoc ==0.7.0.0
-  - proto-lens-runtime ==0.7.0.0
-  - proto-lens-setup ==0.4.0.4
   - protolude ==0.3.0
   - proxied ==0.3.1
   - psqueues ==0.2.7.2
@@ -1886,7 +1891,7 @@ default-package-overrides:
   - pureMD5 ==2.1.3
   - purescript-bridge ==0.14.0.0
   - pushbullet-types ==0.4.1.0
-  - pusher-http-haskell ==2.0.0.2
+  - pusher-http-haskell ==2.0.0.3
   - pvar ==1.0.0.0
   - PyF ==0.9.0.2
   - qchas ==1.1.0.1
@@ -1924,37 +1929,38 @@ default-package-overrides:
   - random-source ==0.3.0.8
   - random-tree ==0.6.0.5
   - range ==0.3.0.2
-  - Ranged-sets ==0.4.0
   - range-set-list ==0.1.3.1
+  - Ranged-sets ==0.4.0
   - rank1dynamic ==0.4.1
   - rank2classes ==1.4.1
   - Rasterific ==0.7.5.3
   - rasterific-svg ==0.3.3.2
-  - ratel ==1.0.12
   - rate-limit ==1.4.2
+  - ratel ==1.0.12
   - ratel-wai ==1.1.3
   - rattle ==0.2
+  - raw-strings-qq ==1.1
   - rawfilepath ==0.2.4
   - rawstring-qm ==0.2.3.0
-  - raw-strings-qq ==1.1
   - rcu ==0.2.4
   - rdf ==0.1.0.4
   - rdtsc ==1.3.0.1
   - re2 ==0.3
-  - readable ==0.3.1
   - read-editor ==0.1.0.2
   - read-env-var ==1.0.0.0
+  - readable ==0.3.1
   - reanimate ==1.1.3.2
   - reanimate-svg ==0.13.0.0
   - rebase ==1.6.1
   - record-dot-preprocessor ==0.2.7
   - record-hasfield ==1.0
-  - records-sop ==0.1.0.3
   - record-wrangler ==0.1.1.0
+  - records-sop ==0.1.0.3
   - recursion-schemes ==5.2.1
   - reducers ==3.12.3
-  - refact ==0.3.0.2
   - ref-fd ==0.4.0.2
+  - ref-tf ==0.4.0.2
+  - refact ==0.3.0.2
   - refined ==0.6.1
   - reflection ==2.1.6
   - reform ==0.2.7.4
@@ -1962,7 +1968,6 @@ default-package-overrides:
   - reform-hamlet ==0.0.5.3
   - reform-happstack ==0.2.5.4
   - RefSerialize ==0.4.0
-  - ref-tf ==0.4.0.2
   - regex ==1.1.0.0
   - regex-applicative ==0.3.4
   - regex-applicative-text ==0.1.0.1
@@ -1987,7 +1992,7 @@ default-package-overrides:
   - replace-attoparsec ==1.4.4.0
   - replace-megaparsec ==1.4.4.0
   - repline ==0.4.0.0
-  - req ==3.8.0
+  - req ==3.9.0
   - req-conduit ==1.0.0
   - rerebase ==1.6.1
   - resistor-cube ==0.0.1.2
@@ -2004,7 +2009,7 @@ default-package-overrides:
   - rhine ==0.7.0
   - rhine-gloss ==0.7.0
   - rigel-viz ==0.2.0.0
-  - rio ==0.1.19.0
+  - rio ==0.1.20.0
   - rio-orphans ==0.1.1.0
   - rio-prettyprint ==0.1.1.0
   - roc-id ==0.1.0.0
@@ -2020,15 +2025,15 @@ default-package-overrides:
   - runmemo ==1.0.0.1
   - rvar ==0.2.0.6
   - safe ==0.3.19
-  - safecopy ==0.10.3.1
   - safe-decimal ==0.2.0.0
   - safe-exceptions ==0.1.7.1
   - safe-foldable ==0.1.0.0
-  - safeio ==0.0.5.0
   - safe-json ==1.1.1.1
   - safe-money ==0.9
-  - SafeSemaphore ==0.10.1
   - safe-tensor ==0.2.1.0
+  - safecopy ==0.10.3.1
+  - safeio ==0.0.5.0
+  - SafeSemaphore ==0.10.1
   - salak ==0.3.6
   - salak-yaml ==0.3.5.3
   - saltine ==0.1.1.1
@@ -2066,14 +2071,14 @@ default-package-overrides:
   - semigroupoid-extras ==5
   - semigroupoids ==5.3.5
   - semigroups ==0.19.1
-  - semirings ==0.6
   - semiring-simple ==1.0.0.1
+  - semirings ==0.6
   - semver ==0.4.0.1
   - sendfile ==0.7.11.1
   - seqalign ==0.2.0.4
   - seqid ==0.6.2
   - seqid-streams ==0.7.2
-  - sequence-formats ==1.5.1.4
+  - sequence-formats ==1.5.2
   - sequenceTools ==1.4.0.5
   - serf ==0.1.1.0
   - serialise ==0.2.3.0
@@ -2113,11 +2118,12 @@ default-package-overrides:
   - shared-memory ==0.2.0.0
   - shell-conduit ==5.0.0
   - shell-escape ==0.2.0
+  - shell-utility ==0.1
   - shellmet ==0.0.3.1
   - shelltestrunner ==1.9
-  - shell-utility ==0.1
   - shelly ==1.9.0
   - shikensu ==0.3.11
+  - shortcut-links ==0.5.1.1
   - should-not-typecheck ==2.1.0
   - show-combinators ==0.2.0.0
   - siggy-chardust ==1.0.0
@@ -2185,16 +2191,16 @@ default-package-overrides:
   - splitmix ==0.1.0.3
   - spoon ==0.3.1
   - spreadsheet ==0.1.3.8
+  - sql-words ==0.1.6.4
   - sqlcli ==0.2.2.0
   - sqlcli-odbc ==0.2.0.1
   - sqlite-simple ==0.4.18.0
-  - sql-words ==0.1.6.4
   - squeal-postgresql ==0.7.0.1
   - squeather ==0.6.0.0
   - srcloc ==0.5.1.2
   - stache ==2.2.0
-  - stackcollapse-ghc ==0.0.1.3
   - stack-templatizer ==0.1.0.2
+  - stackcollapse-ghc ==0.0.1.3
   - stateref ==0.3
   - StateVar ==1.2.1
   - static-text ==0.2.0.6
@@ -2209,8 +2215,8 @@ default-package-overrides:
   - stm-extras ==0.1.0.3
   - stm-hamt ==1.2.0.4
   - stm-lifted ==2.5.0.0
-  - STMonadTrans ==0.4.5
   - stm-split ==0.0.2.1
+  - STMonadTrans ==0.4.5
   - stopwatch ==0.1.0.6
   - storable-complex ==0.2.3.0
   - storable-endian ==0.2.6
@@ -2231,7 +2237,6 @@ default-package-overrides:
   - strict-list ==0.1.5
   - strict-tuple ==0.1.4
   - strict-tuple-lens ==0.1.0.1
-  - stringbuilder ==0.5.1
   - string-class ==0.1.7.0
   - string-combinators ==0.6.0.5
   - string-conv ==0.1.2
@@ -2239,8 +2244,9 @@ default-package-overrides:
   - string-interpolate ==0.3.0.2
   - string-qq ==0.0.4
   - string-random ==0.1.4.0
-  - stringsearch ==0.3.6.6
   - string-transform ==1.1.1
+  - stringbuilder ==0.5.1
+  - stringsearch ==0.3.6.6
   - stripe-concepts ==1.0.2.4
   - stripe-core ==2.6.2
   - stripe-haskell ==2.6.2
@@ -2259,16 +2265,16 @@ default-package-overrides:
   - swagger2 ==2.6
   - sweet-egison ==0.1.1.3
   - swish ==0.10.0.4
-  - syb ==0.7.1
+  - syb ==0.7.2.1
   - symbol ==0.2.4
   - symengine ==0.1.2.0
   - symmetry-operations-symbols ==0.0.2.1
   - sysinfo ==0.1.1
   - system-argv0 ==0.1.1
-  - systemd ==2.3.0
   - system-fileio ==0.3.16.4
   - system-filepath ==0.4.14
   - system-info ==0.5.1
+  - systemd ==2.3.0
   - tabular ==0.2.2.8
   - taffybar ==3.2.3
   - tagchup ==0.4.1.1
@@ -2290,7 +2296,7 @@ default-package-overrides:
   - tasty-expected-failure ==0.12.2
   - tasty-focus ==1.0.1
   - tasty-golden ==2.3.3.2
-  - tasty-hedgehog ==1.0.0.2
+  - tasty-hedgehog ==1.0.1.0
   - tasty-hspec ==1.1.6
   - tasty-hunit ==0.10.0.3
   - tasty-hunit-compat ==0.2.0.1
@@ -2300,6 +2306,7 @@ default-package-overrides:
   - tasty-program ==1.0.5
   - tasty-quickcheck ==0.10.1.2
   - tasty-rerun ==1.1.18
+  - tasty-silver ==3.1.15
   - tasty-smallcheck ==0.8.2
   - tasty-test-reporter ==0.1.1.4
   - tasty-th ==0.1.7
@@ -2313,7 +2320,7 @@ default-package-overrides:
   - temporary-rc ==1.2.0.3
   - temporary-resourcet ==0.1.0.1
   - tensorflow-test ==0.1.0.0
-  - tensors ==0.1.4
+  - tensors ==0.1.5
   - termbox ==0.3.0
   - terminal-progress-bar ==0.4.1
   - terminal-size ==0.3.2.1
@@ -2333,7 +2340,6 @@ default-package-overrides:
   - text-icu ==0.7.0.1
   - text-latin1 ==0.3.1
   - text-ldap ==0.1.1.13
-  - textlocal ==0.1.0.5
   - text-manipulate ==0.2.0.1
   - text-metrics ==0.3.0
   - text-postgresql ==0.0.3.1
@@ -2344,8 +2350,9 @@ default-package-overrides:
   - text-show ==3.9
   - text-show-instances ==3.8.4
   - text-zipper ==0.11
-  - tfp ==1.0.1.1
+  - textlocal ==0.1.0.5
   - tf-random ==0.5
+  - tfp ==1.0.1.1
   - th-abstraction ==0.4.2.0
   - th-bang-compat ==0.0.1.0
   - th-compat ==0.1
@@ -2353,10 +2360,6 @@ default-package-overrides:
   - th-data-compat ==0.1.0.0
   - th-desugar ==1.11
   - th-env ==0.1.0.2
-  - these ==1.1.1.1
-  - these-lens ==1.0.1.1
-  - these-optics ==1.0.1.1
-  - these-skinny ==0.7.4
   - th-expand-syns ==0.4.6.0
   - th-extras ==0.0.0.4
   - th-lift ==0.8.2
@@ -2364,33 +2367,37 @@ default-package-overrides:
   - th-nowq ==0.1.0.5
   - th-orphans ==0.13.11
   - th-printf ==0.7
-  - thread-hierarchy ==0.3.0.2
-  - thread-local-storage ==0.2
-  - threads ==0.5.1.6
-  - thread-supervisor ==0.2.0.0
-  - threepenny-gui ==0.9.0.0
   - th-reify-compat ==0.0.1.5
   - th-reify-many ==0.1.9
-  - throttle-io-stream ==0.2.0.1
-  - through-text ==0.1.0.0
-  - throwable-exceptions ==0.1.0.9
   - th-strict-compat ==0.1.0.1
   - th-test-utils ==1.1.0
   - th-utilities ==0.2.4.1
+  - these ==1.1.1.1
+  - these-lens ==1.0.1.1
+  - these-optics ==1.0.1.1
+  - these-skinny ==0.7.4
+  - thread-hierarchy ==0.3.0.2
+  - thread-local-storage ==0.2
+  - thread-supervisor ==0.2.0.0
+  - threads ==0.5.1.6
+  - threepenny-gui ==0.9.0.0
+  - throttle-io-stream ==0.2.0.1
+  - through-text ==0.1.0.0
+  - throwable-exceptions ==0.1.0.9
   - thyme ==0.3.5.5
   - tidal ==1.6.1
   - tile ==0.3.0.0
   - time-compat ==1.9.5
-  - timeit ==2.0
-  - timelens ==0.2.0.2
   - time-lens ==0.4.0.2
   - time-locale-compat ==0.1.1.5
   - time-locale-vietnamese ==1.0.0.0
   - time-manager ==0.0.0
   - time-parsers ==0.1.2.1
-  - timerep ==2.0.1.0
-  - timer-wheel ==0.3.0
   - time-units ==1.0.0
+  - timeit ==2.0
+  - timelens ==0.2.0.2
+  - timer-wheel ==0.3.0
+  - timerep ==2.0.1.0
   - timezone-olson ==0.2.0
   - timezone-series ==0.1.9
   - tinylog ==0.15.0
@@ -2425,13 +2432,10 @@ default-package-overrides:
   - ttl-hashtables ==1.4.1.0
   - ttrie ==0.1.2.1
   - tuple ==0.3.0.2
-  - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
+  - tuples-homogenous-h98 ==0.1.1.0
   - turtle ==1.5.20
-  - TypeCompose ==0.9.14
-  - typed-process ==0.2.6.0
-  - typed-uuid ==0.0.0.2
   - type-equality ==1
   - type-errors ==0.2.0.0
   - type-errors-pretty ==0.0.1.1
@@ -2445,8 +2449,12 @@ default-package-overrides:
   - type-of-html ==1.6.1.2
   - type-of-html-static ==0.1.0.2
   - type-operators ==0.2.0.0
-  - typerep-map ==0.3.3.0
   - type-spec ==0.4.0.0
+  - typecheck-plugin-nat-simple ==0.1.0.2
+  - TypeCompose ==0.9.14
+  - typed-process ==0.2.6.0
+  - typed-uuid ==0.0.0.2
+  - typerep-map ==0.3.3.0
   - tzdata ==0.2.20201021.0
   - ua-parser ==0.7.5.1
   - uglymemo ==0.1.0.1
@@ -2479,11 +2487,11 @@ default-package-overrides:
   - universe-instances-trans ==1.1
   - universe-reverse-instances ==1.1.1
   - universe-some ==1.2.1
-  - universum ==1.5.0
+  - universum ==1.7.2
   - unix-bytestring ==0.3.7.3
-  - unix-compat ==0.5.2
+  - unix-compat ==0.5.3
   - unix-time ==0.4.7
-  - unliftio ==0.2.13.1
+  - unliftio ==0.2.14
   - unliftio-core ==0.2.0.1
   - unliftio-pool ==0.2.1.1
   - unlit ==0.4.0.0
@@ -2533,7 +2541,7 @@ default-package-overrides:
   - vector-split ==1.0.0.2
   - vector-th-unbox ==0.2.1.7
   - verbosity ==0.4.0.0
-  - versions ==4.0.1
+  - versions ==4.0.2
   - vformat ==0.14.1.0
   - vformat-aeson ==0.1.0.1
   - vformat-time ==0.1.0.0
@@ -2585,18 +2593,18 @@ default-package-overrides:
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
   - witch ==0.0.0.4
-  - witherable-class ==0
-  - within ==0.2.0.1
   - with-location ==0.1.0
   - with-utf8 ==1.0.2.1
+  - witherable-class ==0
+  - within ==0.2.0.1
   - wizards ==1.0.3
   - wl-pprint-annotated ==0.1.0.1
   - wl-pprint-console ==0.1.0.2
   - wl-pprint-text ==1.2.0.1
-  - word24 ==2.0.1
-  - word8 ==0.1.3
   - word-trie ==0.3.0
   - word-wrap ==0.4.1
+  - word24 ==2.0.1
+  - word8 ==0.1.3
   - world-peace ==1.0.2.0
   - wrap ==0.0.0
   - wreq ==0.5.3.2
@@ -2623,7 +2631,6 @@ default-package-overrides:
   - xml-basic ==0.1.3.1
   - xml-conduit ==1.9.0.0
   - xml-conduit-writer ==0.1.1.2
-  - xmlgen ==0.6.2.2
   - xml-hamlet ==0.5.0.1
   - xml-helpers ==1.0.0
   - xml-html-qq ==0.1.0.1
@@ -2633,13 +2640,15 @@ default-package-overrides:
   - xml-to-json ==2.0.1
   - xml-to-json-fast ==2.0.0
   - xml-types ==0.3.8
+  - xmlgen ==0.6.2.2
   - xmonad ==0.15
   - xmonad-contrib ==0.16
-  - xmonad-extras ==0.15.2
+  - xmonad-extras ==0.15.3
   - xss-sanitize ==0.3.6
   - xxhash-ffi ==0.2.0.0
   - yaml ==0.11.5.0
   - yamlparse-applicative ==0.1.0.2
+  - yes-precure5-command ==5.5.3
   - yesod ==1.6.1.0
   - yesod-auth ==1.6.10.1
   - yesod-auth-hashdb ==1.7.1.5
@@ -2657,7 +2666,6 @@ default-package-overrides:
   - yesod-static ==1.6.1.0
   - yesod-test ==1.6.12
   - yesod-websockets ==0.3.0.2
-  - yes-precure5-command ==5.5.3
   - yi-rope ==0.11
   - yjsvg ==0.2.0.1
   - yjtools ==0.9.18
@@ -2672,9 +2680,9 @@ default-package-overrides:
   - zio ==0.1.0.2
   - zip ==1.7.0
   - zip-archive ==0.4.1
+  - zip-stream ==0.2.0.1
   - zipper-extra ==0.1.3.2
   - zippers ==0.3
-  - zip-stream ==0.2.0.1
   - zlib ==0.6.2.2
   - zlib-bindings ==0.1.1.5
   - zlib-lens ==0.1.2.1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3297,6 +3297,7 @@ broken-packages:
   - atomic-primops-foreign
   - atomic-primops-vector
   - atomo
+  - atp
   - atp-haskell
   - ats-pkg
   - ats-setup
@@ -4958,6 +4959,7 @@ broken-packages:
   - envstatus
   - epanet-haskell
   - epass
+  - ephemeral
   - epi-sim
   - epic
   - epoll


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2021-01-29 20:00 +01:00. You can watch this live on Twitch at https://www.twitch.tv/peti343.