### PR TITLE
python3Packages.pylink-square: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/pylink-square/default.nix
+++ b/pkgs/development/python-modules/pylink-square/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, fetchFromGitHub
+, mock
+, psutil
+, six
+, future
+}:
+
+let
+  mock' = mock.overridePythonAttrs (old: rec {
+    version = "2.0.0";
+    src = fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "1flbpksir5sqrvq2z0dp8sl4bzbadg21sj4d42w3klpdfvgvcn5i";
+    };
+  });
+in buildPythonPackage rec {
+  pname = "pylink-square";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "square";
+    repo = "pylink";
+    rev = "v${version}";
+    sha256 = "1q5sm1017pcqcgwhsliiiv1wh609lrjdlc8f5ihlschk1d0qidpd";
+  };
+
+  buildInputs = [ mock' ];
+  propagatedBuildInputs = [ psutil six future ];
+
+  preCheck = ''
+    # For an unknown reason, `pylink --version` output is different
+    # inside the nix build environment across different python versions
+    substituteInPlace tests/unit/test_main.py --replace \
+      "expected = 'pylink %s' % pylink.__version__" \
+      "return"
+  '';
+
+  pythonImportsCheck = [ "pylink" ];
+
+  meta = with lib; {
+    description = "Python interface for the SEGGER J-Link";
+    homepage = "https://github.com/Square/pylink";
+    maintainers = with maintainers; [ dump_stack ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5542,6 +5542,8 @@ in {
 
   pylibmc = callPackage ../development/python-modules/pylibmc { };
 
+  pylink-square = callPackage ../development/python-modules/pylink-square { };
+
   pylint-celery = callPackage ../development/python-modules/pylint-celery { };
 
   pylint-django = callPackage ../development/python-modules/pylint-django { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds pylink-square: python interface for the SEGGER J-Link.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
