### PR TITLE
python3Packages.keystone-engine: init at 0.9.2

### DIFF
--- a/pkgs/development/python-modules/keystone-engine/default.nix
+++ b/pkgs/development/python-modules/keystone-engine/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, keystone }:
+
+buildPythonPackage rec {
+  pname = "keystone-engine";
+  version = "0.9.2";
+
+  src = fetchPypi {
+   inherit pname version;
+   sha256 = "1xahdr6bh3dw5swrc2r8kqa8ljhqlb7k2kxv5mrw5rhcmcnzcyig";
+  };
+
+  preConfigure = ''
+    substituteInPlace setup.py --replace \
+      "libkeystone" "${keystone}/lib/libkeystone"
+  '';
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "keystone" ];
+
+  meta = with lib; {
+    description = "Lightweight multi-platform, multi-architecture assembler framework";
+    homepage = "https://www.keystone-engine.org";
+    maintainers = with maintainers; [ dump_stack ];
+    license = licenses.gpl2Only;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3468,6 +3468,8 @@ in {
 
   keyrings-alt = callPackage ../development/python-modules/keyrings-alt { };
 
+  keystone-engine = callPackage ../development/python-modules/keystone-engine { };
+
   keyutils = callPackage ../development/python-modules/keyutils { inherit (pkgs) keyutils; };
 
   kicad = disabledIf isPy27 (toPythonModule (pkgs.kicad.override { python3 = python; }).src);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Python bindings for keystone library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
