### PR TITLE
libav: libvpx >= 1.8 drops some formats

### DIFF
--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -43,6 +43,7 @@ let
 
     patches = []
       ++ optional (vpxSupport && hasPrefix "0.8." version) ./vpxenc-0.8.17-libvpx-1.5.patch
+      ++ optional (vpxSupport && hasPrefix "12." version) ./vpx-12.3-libvpx-1.8.patch
       ;
 
     postPatch = ''

--- a/pkgs/development/libraries/libav/vpx-12.3-libvpx-1.8.patch
+++ b/pkgs/development/libraries/libav/vpx-12.3-libvpx-1.8.patch
@@ -1,0 +1,46 @@
+--- libav/libavcodec/libvpx.c.orig	2018-02-12 21:25:59 UTC
++++ libav/libavcodec/libvpx.c
+@@ -25,6 +25,7 @@
+ enum AVPixelFormat ff_vpx_imgfmt_to_pixfmt(vpx_img_fmt_t img)
+ {
+     switch (img) {
++#if VPX_IMAGE_ABI_VERSION < 5
+     case VPX_IMG_FMT_RGB24:     return AV_PIX_FMT_RGB24;
+     case VPX_IMG_FMT_RGB565:    return AV_PIX_FMT_RGB565BE;
+     case VPX_IMG_FMT_RGB555:    return AV_PIX_FMT_RGB555BE;
+@@ -36,10 +37,13 @@ enum AVPixelFormat ff_vpx_imgfmt_to_pixfmt(vpx_img_fmt
+     case VPX_IMG_FMT_ARGB_LE:   return AV_PIX_FMT_BGRA;
+     case VPX_IMG_FMT_RGB565_LE: return AV_PIX_FMT_RGB565LE;
+     case VPX_IMG_FMT_RGB555_LE: return AV_PIX_FMT_RGB555LE;
++#endif
+     case VPX_IMG_FMT_I420:      return AV_PIX_FMT_YUV420P;
+     case VPX_IMG_FMT_I422:      return AV_PIX_FMT_YUV422P;
+     case VPX_IMG_FMT_I444:      return AV_PIX_FMT_YUV444P;
++#if VPX_IMAGE_ABI_VERSION < 5
+     case VPX_IMG_FMT_444A:      return AV_PIX_FMT_YUVA444P;
++#endif
+ #if VPX_IMAGE_ABI_VERSION >= 3
+     case VPX_IMG_FMT_I440:      return AV_PIX_FMT_YUV440P;
+     case VPX_IMG_FMT_I42016:    return AV_PIX_FMT_YUV420P16BE;
+@@ -53,6 +57,7 @@ enum AVPixelFormat ff_vpx_imgfmt_to_pixfmt(vpx_img_fmt
+ vpx_img_fmt_t ff_vpx_pixfmt_to_imgfmt(enum AVPixelFormat pix)
+ {
+     switch (pix) {
++#if VPX_IMAGE_ABI_VERSION < 5
+     case AV_PIX_FMT_RGB24:        return VPX_IMG_FMT_RGB24;
+     case AV_PIX_FMT_RGB565BE:     return VPX_IMG_FMT_RGB565;
+     case AV_PIX_FMT_RGB555BE:     return VPX_IMG_FMT_RGB555;
+@@ -64,10 +69,13 @@ vpx_img_fmt_t ff_vpx_pixfmt_to_imgfmt(enum AVPixelForm
+     case AV_PIX_FMT_BGRA:         return VPX_IMG_FMT_ARGB_LE;
+     case AV_PIX_FMT_RGB565LE:     return VPX_IMG_FMT_RGB565_LE;
+     case AV_PIX_FMT_RGB555LE:     return VPX_IMG_FMT_RGB555_LE;
++#endif
+     case AV_PIX_FMT_YUV420P:      return VPX_IMG_FMT_I420;
+     case AV_PIX_FMT_YUV422P:      return VPX_IMG_FMT_I422;
+     case AV_PIX_FMT_YUV444P:      return VPX_IMG_FMT_I444;
++#if VPX_IMAGE_ABI_VERSION < 5
+     case AV_PIX_FMT_YUVA444P:     return VPX_IMG_FMT_444A;
++#endif
+ #if VPX_IMAGE_ABI_VERSION >= 3
+     case AV_PIX_FMT_YUV440P:      return VPX_IMG_FMT_I440;
+     case AV_PIX_FMT_YUV420P16BE:  return VPX_IMG_FMT_I42016;


### PR DESCRIPTION
###### Motivation for this change

The recent upgrade of libvpx to 1.8/1.9 broke libav_12.
```
nix build nixpkgs.libav_12
```
```
...
  libavcodec/libvpx.c:66:42: error: 'VPX_IMG_FMT_RGB555_LE' undeclared (first use in this function); did you mean 'AV_PIX_FMT_RGB555LE'?
     66 |     case AV_PIX_FMT_RGB555LE:     return VPX_IMG_FMT_RGB555_LE;
        |                                          ^~~~~~~~~~~~~~~~~~~~~
        |                                          AV_PIX_FMT_RGB555LE
  libavcodec/libvpx.c:70:42: error: 'VPX_IMG_FMT_444A' undeclared (first use in this function); did you mean 'VPX_IMG_FMT_I440'?
     70 |     case AV_PIX_FMT_YUVA444P:     return VPX_IMG_FMT_444A;
        |                                          ^~~~~~~~~~~~~~~~
        |                                          VPX_IMG_FMT_I440
  make: *** [Makefile:48: libavcodec/libvpx.o] Error 1
  make: *** Waiting for unfinished jobs....
```

The issue, as can seen above, is that some libvpx has dropped some of its previously supported formats. The effected code just converts VPX image format constants to AV image format constants, and the solution, as found in [this patch here](https://github.com/shirkdog/hardenedbsd-ports/blob/master/multimedia/libav/files/patch-libavcodec_libvpx.c) is to simply `#if` out the conversion lines for the dropped formats when building against the newer libvpx.

This simply results in the case falling through to the [default none format constants](https://gitlab.com/libav/libav/-/blob/release/12/libavcodec/libvpx.c#L49) and follows the existing `#if` statements found in the code for differences in various other versions of libvpx.

This pull request adds the referenced patch for libav_12. It is applied unconditionally to libav_12 as libvpx <= 1.7 (the ones that had the dropped formats) were removed with the libvpx upgrade that causes this issue.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
