### PR TITLE
pythonPackages.hwi: reintroduce dropped dependencies

### DIFF
--- a/pkgs/development/python-modules/hwi/default.nix
+++ b/pkgs/development/python-modules/hwi/default.nix
@@ -2,11 +2,14 @@
 , buildPythonPackage
 , fetchFromGitHub
 , bitbox02
+, btchip
+, ckcc-protocol
 , ecdsa
 , hidapi
 , libusb1
 , mnemonic
 , pyaes
+, trezor
 , pythonAtLeast
 }:
 
@@ -31,11 +34,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     bitbox02
+    btchip
+    ckcc-protocol
     ecdsa
     hidapi
     libusb1
     mnemonic
     pyaes
+    trezor
   ];
 
   # tests require to clone quite a few firmwares


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

partial revert of 863d89b767c4de7d6a87b77a2b13d74177b2f201

@SuperSandro2000 : Any particular reason why you removed these deps earlier? 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
