### PR TITLE
batman-adv: 2020.4 -> 2021.0 

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.open-mesh.org/projects/batman-adv/wiki/Wiki";
     description = "B.A.T.M.A.N. routing protocol in a linux kernel module for layer 2";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ fpletz ];
+    maintainers = with lib.maintainers; [ fpletz hexa ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,9 +1,9 @@
 {
-  version = "2020.4";
+  version = "2021.0";
 
   sha256 = {
-    batman-adv = "1cxr0zmn9nzisawkrfk0gzd9fx0pg6261c889kz47hwp4f545v6d";
-    alfred = "1ay69nifzghpbvy11fdca5cllkn852h6rg045lci4vzgqf7b2bd2";
-    batctl = "05rrpfbpdhxn5zgdps849qls2ifis6a94cjryb60d4y1nc2n0d7w";
+    batman-adv = "1898y0m8sgca0dmhyfkpmx2g6qc0b1xvh5nm7cvnhwl9h2jrp62s";
+    alfred = "0jr4wbz81ijd03ssfxb9mqlj3zbx2k495lsl0np262hyla6w0qm0";
+    batctl = "1r01a8zxivq4slwc81dgg9qknqsli8qw17csfj95321gjpqqpv4w";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release.

https://git.open-mesh.org/batman-adv.git/commit/fbb853ec870380fe76283d9fbe8ba106739fa260

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
