### PR TITLE
glibc: Add an environment variable for specifying an NSS search path

### DIFF
--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -52,7 +52,7 @@ in
 
         wantedBy = [ "nss-lookup.target" "nss-user-lookup.target" ];
 
-        environment = { LD_LIBRARY_PATH = nssModulesPath; };
+        environment = { NIX_GLIBC_NSS_PATH = nssModulesPath; };
 
         restartTriggers = [
           config.environment.etc.hosts.source

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -119,6 +119,8 @@ stdenv.mkDerivation ({
       })
 
       ./fix-x64-abi.patch
+
+      ./nss-path.patch
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
     ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -62,6 +62,12 @@ callPackage ./common.nix { inherit stdenv; } {
         ])
       ]);
 
+    preHook =
+      ''
+        outName=$(basename $out)
+        NIX_CFLAGS_COMPILE+=" -DDEFAULT_NSS_PATH=\"${dirOf builtins.storeDir}/run/glibc-nss-path/''${outName:0:32}:${dirOf builtins.storeDir}/run/glibc-nss-path\"";
+      '';
+
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for
     # any program we run, because the gcc will have been placed at a new
     # store path than that determined when built (as a source for the

--- a/pkgs/development/libraries/glibc/nss-path.patch
+++ b/pkgs/development/libraries/glibc/nss-path.patch
@@ -1,0 +1,50 @@
+diff -ru -x '*~' glibc-2.32-orig/nss/nsswitch.c glibc-2.32/nss/nsswitch.c
+--- glibc-2.32-orig/nss/nsswitch.c	2020-08-05 04:17:00.000000000 +0200
++++ glibc-2.32/nss/nsswitch.c	2021-01-29 19:40:50.730883061 +0100
+@@ -349,6 +349,35 @@
+ 		__nss_shlib_revision);
+ 
+       ni->library->lib_handle = __libc_dlopen (shlib_name);
++
++      if (ni->library->lib_handle == NULL)
++	{
++	  const char *nss_path = __libc_secure_getenv ("NIX_GLIBC_NSS_PATH");
++	  if (!nss_path)
++	    nss_path = DEFAULT_NSS_PATH;
++
++	  const char *pos = nss_path;
++
++	  while (*pos)
++	    {
++	      const char *end = __strchrnul(pos, ':');
++	      if (pos != end)
++		{
++		  char shlib_path[1024];
++		  size_t shlib_pathlen = (end - pos) + 1 + strlen (shlib_name) + 1;
++		  if (shlib_pathlen < sizeof(shlib_path))
++		    {
++		      __stpcpy (__stpcpy (__stpncpy (shlib_path, pos, end - pos), "/"), shlib_name);
++		      ni->library->lib_handle = __libc_dlopen (shlib_path);
++		      if (ni->library->lib_handle != NULL)
++			break;
++		    }
++		  if (!*end) break;
++		  pos = end + 1;
++		}
++	    }
++	}
++
+       if (ni->library->lib_handle == NULL)
+ 	{
+ 	  /* Failed to load the library.  */
+diff -ru -x '*~' glibc-2.32-orig/sysdeps/generic/unsecvars.h glibc-2.32/sysdeps/generic/unsecvars.h
+--- glibc-2.32-orig/sysdeps/generic/unsecvars.h	2020-08-05 04:17:00.000000000 +0200
++++ glibc-2.32/sysdeps/generic/unsecvars.h	2021-01-29 15:38:37.067684060 +0100
+@@ -27,6 +27,7 @@
+   "LOCPATH\0"								      \
+   "MALLOC_TRACE\0"							      \
+   "NIS_PATH\0"								      \
++  "NIX_GLIBC_NSS_PATH\0"						      \
+   "NLSPATH\0"								      \
+   "RESOLV_HOST_CONF\0"							      \
+   "RES_OPTIONS\0"							      \


### PR DESCRIPTION
With this, you can set `$NIX_GLIBC_NSS_PATH` to a colon-separated list of directories in which glibc will look for NSS modules. In environments where nscd cannot be used, this allows dealing with non-standard NSS modules in a less sledgehammer-y way than setting `$LD_LIBRARY_PATH` (which affects everything, and in particular could cause ABI incompatibilities).

The default value is

  `/nix/run/glibc-nss-path/${out-hash}:/nix/run/glibc-nss-path`

where `out-hash` is the hash part of `glibc.out` (e.g. `/nix/run/glibc-nss-path/0cjq75a1cgwd7ccxsp9warzjax1kr7ag`). Thus,
`glibc` will look for an NSS module named `libnss_mymachines.so.2` at

  `/nix/run/glibc-nss-path/0cjq75a1cgwd7ccxsp9warzjax1kr7ag/libnss_mymachines.so.2`

and

  `/nix/run/glibc-nss-path/libnss_mymachines.so.2`

These are tried *after* the default search locations (i.e. `$LD_LIBRARY_PATH` and `glibc.out/lib`) so they don't override any current behaviour.

The use of `/nix/run` rather than `/run` is because the user may have write access to `/nix` but not to `/run`. On NixOS, it's intended than `/nix/run` is a symlink / bind-mount to `/run`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This does for NSS modules what `/run/opengl-driver` does for our OpenGL support. In particular it's intended for non-NixOS, non-nscd environments that require non-standard NSS modules.

Maybe instead of `NIX_GLIBC_NSS_PATH` we could use a generic environment variable as suggested in https://gist.github.com/Infinisil/3366e7dfc9a01f6eeb25b5cb475cc585 (and then look for `out-hash/nss` and `nss` relative to the directories in that variable).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
