### PR TITLE
[20.03] curl: update CVE patch hashes for extra digits added to index line

### DIFF
--- a/pkgs/tools/networking/curl/CVE-2020-8169.patch
+++ b/pkgs/tools/networking/curl/CVE-2020-8169.patch
@@ -1,0 +1,134 @@
+From 600a8cded447cd7118ed50142c576567c0cf5158 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 14 May 2020 14:37:12 +0200
+Subject: [PATCH] url: make the updated credentials URL-encoded in the URL
+
+Found-by: Gregory Jefferis
+Reported-by: Jeroen Ooms
+Added test 1168 to verify. Bug spotted when doing a redirect.
+Bug: https://github.com/jeroen/curl/issues/224
+Closes #5400
+---
+ lib/url.c               |  6 ++--
+ tests/data/Makefile.inc |  1 +
+ tests/data/test1168     | 78 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 83 insertions(+), 2 deletions(-)
+ create mode 100644 tests/data/test1168
+
+diff --git a/lib/url.c b/lib/url.c
+index f250f2ff20a..9b8b2bdde64 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -2788,12 +2788,14 @@ static CURLcode override_login(struct Curl_easy *data,
+ 
+   /* for updated strings, we update them in the URL */
+   if(user_changed) {
+-    uc = curl_url_set(data->state.uh, CURLUPART_USER, *userp, 0);
++    uc = curl_url_set(data->state.uh, CURLUPART_USER, *userp,
++                      CURLU_URLENCODE);
+     if(uc)
+       return Curl_uc_to_curlcode(uc);
+   }
+   if(passwd_changed) {
+-    uc = curl_url_set(data->state.uh, CURLUPART_PASSWORD, *passwdp, 0);
++    uc = curl_url_set(data->state.uh, CURLUPART_PASSWORD, *passwdp,
++                      CURLU_URLENCODE);
+     if(uc)
+       return Curl_uc_to_curlcode(uc);
+   }
+diff --git a/tests/data/Makefile.inc b/tests/data/Makefile.inc
+index 004a90b2360..bb6bf0f2fd0 100644
+--- a/tests/data/Makefile.inc
++++ b/tests/data/Makefile.inc
+@@ -136,6 +136,7 @@ test1136 test1137 test1138 test1139 test1140 test1141 test1142 test1143 \
+ test1144 test1145 test1146 test1147 test1148 test1149 test1150 test1151 \
+ test1152 test1153 test1154 test1155 test1156 test1157 test1158 test1159 \
+ test1160 test1161 test1162 test1163 test1164 test1165 test1166 test1167 \
++test1168 \
+ \
+ test1170 test1171 test1172 test1173 test1174 test1175 test1176 test1177 \
+ \
+diff --git a/tests/data/test1168 b/tests/data/test1168
+new file mode 100644
+index 00000000000..283e91e0197
+--- /dev/null
++++ b/tests/data/test1168
+@@ -0,0 +1,78 @@
++<testcase>
++<info>
++<keywords>
++HTTP
++HTTP GET
++followlocation
++</keywords>
++</info>
++# Server-side
++<reply>
++<data>
++HTTP/1.1 301 This is a weirdo text message swsclose
++Date: Thu, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Location: /data/11680002.txt
++Connection: close
++
++This server reply is for testing a simple Location: following
++
++</data>
++<data2>
++HTTP/1.1 200 Followed here fine swsclose
++Date: Thu, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Content-Length: 52
++
++If this is received, the location following worked
++
++</data2>
++<datacheck>
++HTTP/1.1 301 This is a weirdo text message swsclose
++Date: Thu, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Location: /data/11680002.txt
++Connection: close
++
++HTTP/1.1 200 Followed here fine swsclose
++Date: Thu, 09 Nov 2010 14:49:00 GMT
++Server: test-server/fake
++Content-Length: 52
++
++If this is received, the location following worked
++
++</datacheck>
++</reply>
++
++# Client-side
++<client>
++<server>
++http
++</server>
++ <name>
++HTTP redirect with credentials using # in user and password
++ </name>
++ <command>
++http://%HOSTIP:%HTTPPORT/want/1168 -L -u "catmai#d:#DZaRJYrixKE*gFY"
++</command>
++</client>
++
++# Verify data after the test has been "shot"
++<verify>
++<strip>
++^User-Agent:.*
++</strip>
++<protocol>
++GET /want/1168 HTTP/1.1
++Host: %HOSTIP:%HTTPPORT
++Authorization: Basic Y2F0bWFpI2Q6I0RaYVJKWXJpeEtFKmdGWQ==
++Accept: */*
++
++GET /data/11680002.txt HTTP/1.1
++Host: %HOSTIP:%HTTPPORT
++Authorization: Basic Y2F0bWFpI2Q6I0RaYVJKWXJpeEtFKmdGWQ==
++Accept: */*
++
++</protocol>
++</verify>
++</testcase>

--- a/pkgs/tools/networking/curl/CVE-2020-8177.patch
+++ b/pkgs/tools/networking/curl/CVE-2020-8177.patch
@@ -1,0 +1,62 @@
+From 8236aba58542c5f89f1d41ca09d84579efb05e22 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Sun, 31 May 2020 23:09:59 +0200
+Subject: [PATCH] tool_getparam: -i is not OK if -J is used
+
+Reported-by: sn on hackerone
+Bug: https://curl.haxx.se/docs/CVE-2020-8177.html
+---
+ src/tool_cb_hdr.c   | 22 ++++------------------
+ src/tool_getparam.c |  5 +++++
+ 2 files changed, 9 insertions(+), 18 deletions(-)
+
+diff --git a/src/tool_cb_hdr.c b/src/tool_cb_hdr.c
+index 3b102388866..b80707fde57 100644
+--- a/src/tool_cb_hdr.c
++++ b/src/tool_cb_hdr.c
+@@ -186,25 +186,11 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
+       filename = parse_filename(p, len);
+       if(filename) {
+         if(outs->stream) {
+-          int rc;
+-          /* already opened and possibly written to */
+-          if(outs->fopened)
+-            fclose(outs->stream);
+-          outs->stream = NULL;
+-
+-          /* rename the initial file name to the new file name */
+-          rc = rename(outs->filename, filename);
+-          if(rc != 0) {
+-            warnf(per->config->global, "Failed to rename %s -> %s: %s\n",
+-                  outs->filename, filename, strerror(errno));
+-          }
+-          if(outs->alloc_filename)
+-            Curl_safefree(outs->filename);
+-          if(rc != 0) {
+-            free(filename);
+-            return failure;
+-          }
++          /* indication of problem, get out! */
++          free(filename);
++          return failure;
+         }
++
+         outs->is_cd_filename = TRUE;
+         outs->s_isreg = TRUE;
+         outs->fopened = FALSE;
+diff --git a/src/tool_getparam.c b/src/tool_getparam.c
+index 0cd11c47986..1ab3983f4ac 100644
+--- a/src/tool_getparam.c
++++ b/src/tool_getparam.c
+@@ -1817,6 +1817,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
+       }
+       break;
+     case 'i':
++      if(config->content_disposition) {
++        warnf(global,
++              "--include and --remote-header-name cannot be combined.\n");
++        return PARAM_BAD_USE;
++      }
+       config->show_headers = toggle; /* show the headers as well in the
+                                         general output stream */
+       break;

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -41,18 +41,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     # remove these two patches for cURL >= 7.71.0
-    (fetchurl {
-      # https://www.openwall.com/lists/oss-security/2020/06/24/1
-      name = "CVE-2020-8169.patch";
-      url = "https://github.com/curl/curl/commit/600a8cded447cd.patch";
-      sha256 = "10qdh995mgaxza3va7r7gl1xkyfidbhk09i5srm9h59ml4fqm36r";
-    })
-    (fetchurl {
-      # https://www.openwall.com/lists/oss-security/2020/06/24/2
-      name = "CVE-2020-8177.patch";
-      url = "https://github.com/curl/curl/commit/8236aba58542c5f.patch";
-      sha256 = "08zwizkbwy2blcqza4681099cd13z3ww2lq5ypnf2c5zsysnv48a";
-    })
+    # https://www.openwall.com/lists/oss-security/2020/06/24/1
+    # https://www.openwall.com/lists/oss-security/2020/06/24/2
+    ./CVE-2020-8169.patch
+    ./CVE-2020-8177.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change

The fetched CVE patches for curl changed so the hashes no longer agree.

###### Things done

I diffed the old and new versions. It seems github just added extra digits to the index lines. For example
```
diff -U2 /nix/store/4psjdyqqf4wb4cv8ijds35cpqnmyjd5p-CVE-2020-8169.patch /nix/store/rsx49gzgb1fgylyh8cggnd92nx0hl9gw-CVE-2020-8169.patch
```
```
--- /nix/store/4psjdyqqf4wb4cv8ijds35cpqnmyjd5p-CVE-2020-8169.patch	1969-12-31 19:00:01.000000000 -0500
+++ /nix/store/rsx49gzgb1fgylyh8cggnd92nx0hl9gw-CVE-2020-8169.patch	1969-12-31 19:00:01.000000000 -0500
@@ -17,5 +17,5 @@
 
 diff --git a/lib/url.c b/lib/url.c
-index f250f2ff20a..9b8b2bdde64 100644
+index f250f2ff20a3..9b8b2bdde640 100644
 --- a/lib/url.c
 +++ b/lib/url.c
@@ -38,5 +38,5 @@
    }
 diff --git a/tests/data/Makefile.inc b/tests/data/Makefile.inc
-index 004a90b2360..bb6bf0f2fd0 100644
+index 004a90b23608..bb6bf0f2fd06 100644
 --- a/tests/data/Makefile.inc
 +++ b/tests/data/Makefile.inc
@@ -51,5 +51,5 @@
 diff --git a/tests/data/test1168 b/tests/data/test1168
 new file mode 100644
-index 00000000000..283e91e0197
+index 000000000000..283e91e01974
 --- /dev/null
 +++ b/tests/data/test1168
```
so I just updated the hashes to match the new versions.

If this causes some sort of mass rebuild, perhaps a better solution would be to just add the old ones directly to nixpkgs to avoid having to changes any hashes. If you would prefer that, let me know and I will change it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
