### PR TITLE
swift: mark as broken and insecure

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -332,5 +332,8 @@ stdenv.mkDerivation {
     platforms = platforms.linux;
     badPlatforms = platforms.i686;
     broken = stdenv.isAarch64; # 2018-09-04, never built on Hydra
+    knownVulnerabilities = [
+      "CVE-2020-9861"
+    ];
   };
 }

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -331,7 +331,7 @@ stdenv.mkDerivation {
     # Swift doesn't support 32bit Linux, unknown on other platforms.
     platforms = platforms.linux;
     badPlatforms = platforms.i686;
-    broken = stdenv.isAarch64; # 2018-09-04, never built on Hydra
+    broken = true; # 2021-01-29
     knownVulnerabilities = [
       "CVE-2020-9861"
     ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/106245

There's two separate commits because on 20.09, it should only be marked as insecure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @vy-let @mroi 