### PR TITLE
libgcrypt_1_5: mark as insecure

### DIFF
--- a/pkgs/development/libraries/libgcrypt/1.5.nix
+++ b/pkgs/development/libraries/libgcrypt/1.5.nix
@@ -38,5 +38,16 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
     repositories.git = "git://git.gnupg.org/libgcrypt.git";
+    knownVulnerabilities = [
+      "CVE-2014-3591"
+      "CVE-2015-0837"
+      "CVE-2015-7511"
+      "CVE-2017-0379"
+      "CVE-2017-7526"
+      "CVE-2017-9526"
+      "CVE-2018-0495"
+      "CVE-2018-6829"
+      "CVE-2018-12437"
+    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/90845 and closes https://github.com/NixOS/nixpkgs/issues/106203

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

affects spotify (cc @9999years @samuela @timokau) and staruml (cc @flokli @oxalica)