### PR TITLE
universal-ctags: bump to p5.9.20210124.0 from git tags

### DIFF
--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, perl, pythonPackages, libiconv, jansson }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, perl, python3Packages, libiconv, jansson }:
 
 stdenv.mkDerivation rec {
   pname = "universal-ctags";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "082yq629s2p4fc5kmjhmzx9q9grc32hwfr1x55ydvhi4x68dbx6d";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config pythonPackages.docutils ];
+  nativeBuildInputs = [ autoreconfHook pkg-config python3Packages.docutils ];
   buildInputs = [ jansson ] ++ lib.optional stdenv.isDarwin libiconv;
 
   # to generate makefile.in

--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, perl, pythonPackages, libiconv, jansson }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "universal-ctags";
-  version = "unstable-2019-07-30";
+  version = "5.9.20210124.0";
 
   src = fetchFromGitHub {
     owner = "universal-ctags";
     repo = "ctags";
-    rev = "920e7910146915e5cae367bc9f135ffd8b042042";
-    sha256 = "14n3ix77rkhq6vq6kspmgjrmm0kg0f8cxikyqdq281sbnfq8bajn";
+    rev = "p${version}";
+    sha256 = "082yq629s2p4fc5kmjhmzx9q9grc32hwfr1x55ydvhi4x68dbx6d";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config pythonPackages.docutils ];

--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,17 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, perl, python3Packages, libiconv, jansson }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, coreutils, pkg-config, perl, python3Packages, libiconv, jansson }:
 
 stdenv.mkDerivation rec {
   pname = "universal-ctags";
-  version = "5.9.20210124.0";
+  version = "5.9.20201206.0";
 
   src = fetchFromGitHub {
     owner = "universal-ctags";
     repo = "ctags";
     rev = "p${version}";
-    sha256 = "082yq629s2p4fc5kmjhmzx9q9grc32hwfr1x55ydvhi4x68dbx6d";
+    sha256 = "0w10zjyz46sjm6ypxmq550dkr84hvc4phm4vm9j53jp5s19x5q19";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config python3Packages.docutils ];
+  nativeBuildInputs = [ autoreconfHook coreutils pkg-config python3Packages.docutils ];
   buildInputs = [ jansson ] ++ lib.optional stdenv.isDarwin libiconv;
 
   # to generate makefile.in
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
     # Remove source of non-determinism
     substituteInPlace main/options.c \
       --replace "printf (\"  Compiled: %s, %s\n\", __DATE__, __TIME__);" ""
+
+    substituteInPlace Tmain/utils.sh \
+      --replace /bin/echo ${coreutils}/bin/echo
   '';
 
   postConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Switching to python2 to python3 seems like a reasonable thing to do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).