### PR TITLE
spotify: use default libgcrypt / libpng

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24818,8 +24818,6 @@ in
   };
 
   spotify-unwrapped = callPackage ../applications/audio/spotify {
-    libgcrypt = libgcrypt_1_5;
-    libpng = libpng12;
     curl = curl.override {
       sslSupport = false; gnutlsSupport = true;
     };


### PR DESCRIPTION
Instead of overriding `libgcrypt` with the (insecure) `libgcrypt_1_5` and `libpng` with `libpng12`, use the defaults for those two packages.

`spotify` was changed to use `libgcrypt_1_5` instead of `libgcrypt` in commit 165cb05ea5f42866a5b38521a8266f10045d48b2 by @monocell in PR #8157 to address #8156, which found that:

> the current spotify client seems to depend on `libgcrypt.so.11`. Pretending with libgcrypt.so.20 produces an error like:
> ```
> ... libgcrypt.so.11: version `GCRYPT_1.2' not found ...
> ```

Given that the relevant Spotify client is more than 5 years old, I don't think we have to worry about this any more. :)

Built and checked on my NixOS desktop machine because @dotlambda said he wouldn't check proprietary software in #111215.

This commit helps #106203, but doesn't close it because `libgcrypt_1_5` is still used in `staruml`.

###### Motivation for this change

`libgcrypt_1_5` has a heap overflow vulnerability; removing it is blocked on removing it from `spotify` and `staruml`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
