### PR TITLE
kreative-square-fonts: init at unstable-2021-01-29

### DIFF
--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -2,8 +2,6 @@
 
 fetchFromGitHub {
   pname = "kreative-square-fonts";
-  # Upstream does not provide a version.
-  version = "unstable-2021-01-29";
 
   owner = "kreativekorp";
   repo = "open-relay";

--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -3,6 +3,7 @@
 let
   pname = "kreative-square-fonts";
   version = "unstable-2021-01-29";
+in
 fetchFromGitHub {
   name = "${pname}-${version}";
 

--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -17,9 +17,7 @@ fetchFromGitHub {
   sha256 = "15vvbbzv6b3jh7lxg77viycdd7yf3y8lxy54vs3rsrsxwncg0pak";
 
   meta = with lib; {
-    description = ''Kreative Square is a fullwidth scalable monospace font
-    designed specifically to support pseudographics, semigraphics, and private
-    use characters.'';
+    description = "Fullwidth scalable monospace font designed specifically to support pseudographics, semigraphics, and private use characters";
     homepage = "https://www.kreativekorp.com/software/fonts/ksquare.shtml";
     license = licenses.ofl;
     platforms = platforms.all;

--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -1,7 +1,10 @@
 { lib, fetchFromGitHub }:
 
-fetchFromGitHub {
+let
   pname = "kreative-square-fonts";
+  version = "unstable-2021-01-29";
+fetchFromGitHub {
+  name = "${pname}-${version}";
 
   owner = "kreativekorp";
   repo = "open-relay";

--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -1,11 +1,9 @@
 { lib, fetchFromGitHub }:
 
-let
+fetchFromGitHub {
   pname = "kreative-square-fonts";
   # Upstream does not provide a version.
   version = "unstable-2021-01-29";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
   owner = "kreativekorp";
   repo = "open-relay";

--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "kreative-square-fonts";
+  # Upstream does not provide a version.
+  version = "unstable-2021-01-29";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+
+  owner = "kreativekorp";
+  repo = "open-relay";
+  rev = "084f05af3602307499981651eca56851bec01fca";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -Dm444 -t $out/share/fonts/truetype/ KreativeSquare/KreativeSquare.ttf
+    install -Dm444 -t $out/share/fonts/truetype/ KreativeSquare/KreativeSquareSM.ttf
+  '';
+  sha256 = "15vvbbzv6b3jh7lxg77viycdd7yf3y8lxy54vs3rsrsxwncg0pak";
+
+  meta = with lib; {
+    description = ''Kreative Square is a fullwidth scalable monospace font
+    designed specifically to support pseudographics, semigraphics, and private
+    use characters.'';
+    homepage = "https://www.kreativekorp.com/software/fonts/ksquare.shtml";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20345,6 +20345,8 @@ in
 
   koreader = callPackage ../applications/misc/koreader {};
 
+  kreative-square-fonts = callPackage ../data/fonts/kreative-square-fonts { };
+
   lato = callPackage ../data/fonts/lato {};
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};


### PR DESCRIPTION
###### Motivation for this change

This adds the "Kreative Square" font, which is one of a handful of fonts in existence that have a perfect *square* appearance (width == height). There are actually 2 fonts. Below are their upstream descriptions:

- *Kreative Square* is the main variant. Use this one if possible.
- *Kreative Square SM* removes all characters not the same width as basic ASCII (combining characters, double-width characters, fixed-width spaces, etc.) for braindead programs that determine if a font is monospaced from its advance widths and not its PANOSE values (GNOME Terminal does this)."

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've built and installed this package and tested it by actually trying to use it in my Alacritty terminal, which worked.
