### PR TITLE
release-cross: remove android

### DIFF
--- a/pkgs/development/mobile/androidenv/deploy-androidpackage.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackage.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation ({
     packageBaseDir=$out/libexec/android-sdk/${package.path}
     mkdir -p $packageBaseDir
     cd $packageBaseDir
-    cp -a $sourceRoot/* .
+    cp -av $sourceRoot/* .
     ${patchInstructions}
   '';
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -153,9 +153,6 @@ in
   ppc64le = mapTestOnCross lib.systems.examples.powernv linuxCommon;
   ppc64le-musl = mapTestOnCross lib.systems.examples.musl-power linuxCommon;
 
-  android64 = mapTestOnCross lib.systems.examples.aarch64-android-prebuilt linuxCommon;
-  android32 = mapTestOnCross lib.systems.examples.armv7a-android-prebuilt linuxCommon;
-
   wasi32 = mapTestOnCross lib.systems.examples.wasi32 wasiCommon;
 
   msp430 = mapTestOnCross lib.systems.examples.msp430 embedded;


### PR DESCRIPTION
AFAIK these have never succeeded, because the ndk-bundle is too large
for hydra to store. Perhaps it is best to disable this - even if we
bumped the size limit, it would take up a lot of space.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
