### PR TITLE
perkeep: unstable-2020-03-23 -> 0.11

### DIFF
--- a/pkgs/applications/misc/perkeep/default.nix
+++ b/pkgs/applications/misc/perkeep/default.nix
@@ -55,6 +55,5 @@ in buildGoModule rec {
     homepage = "https://perkeep.org";
     license = licenses.asl20;
     maintainers = with maintainers; [ cstrahan danderson kalbasit ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/perkeep/default.nix
+++ b/pkgs/applications/misc/perkeep/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchurl, fetchFromGitHub, lib }:
+{ buildGoModule, fetchurl, fetchFromGitHub, lib }:
 
 let
   gouiJS = fetchurl {
@@ -11,41 +11,50 @@ let
     sha256 = "09hd7p0xscqnh612jbrjvh3njmlm4292zd5sbqx2lg0aw688q8p2";
   };
 
-in buildGoPackage rec {
-  name = "perkeep-${version}";
-  version = "unstable-2020-03-23";
+  packages = [
+    "perkeep.org/server/perkeepd"
+    "perkeep.org/cmd/pk"
+    "perkeep.org/cmd/pk-get"
+    "perkeep.org/cmd/pk-put"
+    "perkeep.org/cmd/pk-mount"
+  ];
+
+in buildGoModule rec {
+  pname = "perkeep";
+  version = "0.11";
 
   src = fetchFromGitHub {
     owner = "perkeep";
     repo = "perkeep";
-    rev = "c2e31370ddefd86b6112a5d891100ea3382a4254";
-    sha256 = "0jf02k20ms7h60wglcq6dj3vqi9rlfww7db5iplgwznbij70c1i4";
+    rev = version;
+    sha256 = "07j5gplk4kcrbazyg4m4bwggzlz5gk89h90r14jvfcpms7v5nrll";
   };
 
-  goPackagePath = "perkeep.org";
+  vendorSha256 = "1af9a6r9qfrak0n5xyv9z8n7gn7xw2sdjn4s9bwwidkrdm81iq6b";
+  deleteVendor = true; # Vendor is out of sync with go.mod
 
   buildPhase = ''
-    cd "$NIX_BUILD_TOP/go/src/$goPackagePath"
+    cd "$NIX_BUILD_TOP/source"
 
     # Skip network fetches
-    sed -i '/fetchAllJS/a if true { return nil }' make.go
     cp ${publisherJS} app/publisher/publisher.js
     cp ${gouiJS} server/perkeepd/ui/goui.js
 
-    go run make.go
+    go run make.go -offline=true -targets=${lib.concatStringsSep "," packages}
   '';
 
-  # devcam is only useful when developing perkeep, we should not install it as
-  # part of this derivation.
+  # genfileembed gets built regardless of -targets, to embed static
+  # content into the Perkeep binaries. Remove it in post-install to
+  # avoid polluting paths.
   postInstall = ''
-    rm -f $out/bin/devcam
+    rm -f $out/bin/genfileembed
   '';
 
   meta = with lib; {
     description = "A way of storing, syncing, sharing, modelling and backing up content (née Camlistore)";
     homepage = "https://perkeep.org";
     license = licenses.asl20;
-    maintainers = with maintainers; [ cstrahan kalbasit ];
+    maintainers = with maintainers; [ cstrahan danderson kalbasit ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Signed-off-by: David Anderson <dave@natulte.net>

###### Motivation for this change

New upstream release.

###### Things done

Note I trimmed the produced binaries down a little, to just the client and server tools rather than also include the demo and development binaries.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
