### PR TITLE
zsh-prezto: install to right place

### DIFF
--- a/pkgs/shells/zsh/zsh-prezto/default.nix
+++ b/pkgs/shells/zsh/zsh-prezto/default.nix
@@ -12,26 +12,20 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildPhase = ''
-    sed -i '/\''${ZDOTDIR:\-\$HOME}\/.zpreztorc" ]]/i\
-    if [[ -s "/etc/zpreztorc" ]]; then\
-      source "/etc/zpreztorc"\
-    fi' init.zsh
-    sed -i -e "s|\''${ZDOTDIR:\-\$HOME}/.zprezto/|$out/|g" init.zsh
-    for i in runcoms/*; do
-      sed -i -e "s|\''${ZDOTDIR:\-\$HOME}/.zprezto/|$out/|g" $i
-    done
-  '';
-
   installPhase = ''
-    mkdir -p $out
-    cp ./* $out/ -R
+    mkdir -p $out/share/zsh-prezto
+    cp -R ./ $out/share/zsh-prezto
   '';
 
   passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
-    description = "Prezto is the configuration framework for Zsh; it enriches the command line interface environment with sane defaults, aliases, functions, auto completion, and prompt themes";
+    description = "The configuration framework for Zsh";
+    longDescription = ''
+      Prezto is the configuration framework for Zsh; it enriches
+      the command line interface environment with sane defaults,
+      aliases, functions, auto completion, and prompt themes.
+    '';
     homepage = "https://github.com/sorin-ionescu/prezto";
     license = licenses.mit;
     maintainers = with maintainers; [ holymonson ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

zsh-prezto was installing files directly in $out, we move it to $out/share like other zsh configuration framework.
And drop no-longer-needed buildPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
