### PR TITLE
pythonPackages.pytest-timeout: update patch URL

### DIFF
--- a/pkgs/development/python-modules/pytest-timeout/default.nix
+++ b/pkgs/development/python-modules/pytest-timeout/default.nix
@@ -16,7 +16,8 @@ buildPythonPackage rec {
   };
 
   patches = fetchpatch {
-    url = "https://bitbucket.org/pytest-dev/pytest-timeout/commits/36998c891573d8ec1db1acd4f9438cb3cf2aee2e/raw";
+    name = "raw";  # Preserve name from prior URL to prevent rebuilds
+    url = "https://github.com/pytest-dev/pytest-timeout/commit/20c2ba5ef60007b5071acfd62b326cafce0e5493.patch";
     sha256 = "05zc2w7mjgv8rm8i1cbxp7k09vlscmay5iy78jlzgjqkrx3wkf46";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Patch URL is invalid and couldn't find another, so directly included it (I've now seen several patches with sour URLs, why not just include it in the first place and the potential for this pain?).

###### Things done

Add the patch directly.

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
