### PR TITLE
armagetronad: 0.2.8.3.5 -> 0.2.9.1.0

### DIFF
--- a/pkgs/games/armagetronad/default.nix
+++ b/pkgs/games/armagetronad/default.nix
@@ -1,30 +1,42 @@
-{ lib, stdenv, fetchurl, SDL, libxml2, SDL_image, libjpeg, libpng, libGLU, libGL, zlib }:
+{ lib, stdenv, fetchurl
+, pkg-config, SDL, libxml2, SDL_image, libjpeg, libpng, libGLU, libGL, zlib
+, dedicatedServer ? false }:
 
 let
-  versionMajor = "0.2.8";
-  versionMinor = "3.5";
+  versionMajor = "0.2.9";
+  versionMinor = "1.0";
   version = "${versionMajor}.${versionMinor}";
 in
-
 stdenv.mkDerivation {
-  pname = "armagetron";
+  pname = if dedicatedServer then "armagetronad-dedicated" else "armagetronad";
   inherit version;
   src = fetchurl {
-    url = "https://launchpad.net/armagetronad/${versionMajor}/${versionMajor}.${versionMinor}/+download/armagetronad-${version}.src.tar.bz2";
-    sha256 = "1vyja7mzivs3pacxb7kznndsgqhq4p0f7x2zg55dckvzqwprdhqx";
+    url = "https://launchpad.net/armagetronad/${versionMajor}/${version}/+download/armagetronad-${version}.tbz";
+    sha256 = "sha256-WbbHwBzj+MylQ34z+XSmN1KVQaEapPUsGlwXSZ4m9qE";
   };
-
-  NIX_LDFLAGS = "-lSDL_image";
 
   enableParallelBuilding = true;
 
-  configureFlags = [ "--disable-etc" ];
-  buildInputs = [ SDL SDL_image libxml2 libjpeg libpng libGLU libGL zlib ];
+  configureFlags = [
+    "--enable-memmanager"
+    "--enable-automakedefaults"
+    "--disable-useradd"
+    "--disable-initscripts"
+    "--disable-etc"
+    "--disable-uninstall"
+    "--disable-sysinstall"
+  ] ++ lib.optional dedicatedServer "--enable-dedicated";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libxml2 zlib ]
+    ++ lib.optionals (!dedicatedServer) [ SDL SDL_image libxml2 libjpeg libpng libGLU libGL ];
 
   meta = with lib; {
     homepage = "http://armagetronad.org";
-    description = "An multiplayer networked arcade racing game in 3D similar to Tron";
-    license = licenses.gpl2;
+    description = "A multiplayer networked arcade racing game in 3D similar to Tron";
+    maintainers = with maintainers; [ numinit ];
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26248,6 +26248,8 @@ in
 
   armagetronad = callPackage ../games/armagetronad { };
 
+  armagetronad-dedicated = callPackage ../games/armagetronad { dedicatedServer = true; };
+
   arena = callPackage ../games/arena {};
 
   arx-libertatis = libsForQt5.callPackage ../games/arx-libertatis { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updating armagetronad to latest and adding dedicated server with different compile flags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
