### PR TITLE
unifdef: 2.6 -> 2.12

### DIFF
--- a/pkgs/development/tools/misc/unifdef/default.nix
+++ b/pkgs/development/tools/misc/unifdef/default.nix
@@ -1,31 +1,24 @@
-{ fetchurl, lib, stdenv }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "unifdef-2.6";
+  pname = "unifdef";
+  version = "2.12";
 
   src = fetchurl {
-    url    = "https://github.com/fanf2/unifdef/archive/${name}.tar.gz";
-    sha256 = "1p5wr5ms9w8kijy9h7qs1mz36dlavdj6ngz2bks588w7a20kcqxj";
+    url = "https://dotat.at/prog/unifdef/unifdef-${version}.tar.xz";
+    sha256 = "00647bp3m9n01ck6ilw6r24fk4mivmimamvm4hxp5p6wxh10zkj3";
   };
 
-  postUnpack = ''
-    substituteInPlace $sourceRoot/unifdef.c \
-      --replace '#include "version.h"' ""
-
-    substituteInPlace $sourceRoot/Makefile \
-      --replace "unifdef.c: version.h" "unifdef.c:"
-  '';
-
-  preBuild = ''
-    unset HOME
-    export DESTDIR=$out
-  '';
+  makeFlags = [
+    "prefix=$(out)"
+    "DESTDIR="
+  ];
 
   meta = with lib; {
-    homepage = "http://dotat.at/prog/unifdef/";
+    homepage = "https://dotat.at/prog/unifdef/";
     description = "Selectively remove C preprocessor conditionals";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = [ maintainers.vrthra ];
+    maintainers = with maintainers; [ orivej vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Needed to package cvise (its tests fail with 2.6).

###### Things done

Checked that it does not fail on the old xnu like 2.11 did in https://github.com/NixOS/nixpkgs/pull/16507#issuecomment-229085065

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
