### PR TITLE
python3Packages.pebble: init at 4.6.0

### DIFF
--- a/pkgs/development/python-modules/pebble/default.nix
+++ b/pkgs/development/python-modules/pebble/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, isPy27, fetchPypi, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "pebble";
+  version = "4.6.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    pname = "Pebble";
+    inherit version;
+    sha256 = "0a595f7mrf89xlck9b2x83bqybc9zd9jxkl0sa5cf19vax18rg8h";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "API to manage threads and processes within an application";
+    homepage = "https://github.com/noxdafox/pebble";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4749,6 +4749,8 @@ in {
 
   pdoc3 = callPackage ../development/python-modules/pdoc3 { };
 
+  pebble = callPackage ../development/python-modules/pebble { };
+
   pecan = callPackage ../development/python-modules/pecan { };
 
   peewee = callPackage ../development/python-modules/peewee { };


### PR DESCRIPTION
###### Motivation for this change

Needed to package cvise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
