### PR TITLE
stdenv: warn about use of inherited lib

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2103.xml
+++ b/nixos/doc/manual/release-notes/rl-2103.xml
@@ -479,6 +479,14 @@ self: super:
   <itemizedlist>
    <listitem>
     <para>
+     <literal>stdenv.lib</literal> has been deprecated and will break
+     eval in 21.11.  Please use <literal>pkgs.lib</literal> instead.
+     See <link xlink:href="https://github.com/NixOS/nixpkgs/issues/108938">#108938</link>
+     for details.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The Mailman NixOS module (<literal>services.mailman</literal>) has a new
      option <xref linkend="opt-services.mailman.enablePostfix" />, defaulting
      to true, that controls integration with Postfix.

--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -16,15 +16,15 @@ stdenv.mkDerivation rec {
   };
 
   patchPhase = "patchShebangs .";
-  preBuild = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     make CC=${buildPackages.stdenv.cc}/bin/cc find_sizes
     mv find_sizes find_sizes_build
     make clean
 
     substituteInPlace Makefile --replace "./find_sizes" "./find_sizes_build"
-    substituteInPlace Makefile --replace "ar cr" "${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar cr"
-    substituteInPlace Makefile --replace "ranlib" "${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
-    substituteInPlace Makefile --replace "STRIP=strip" "STRIP=${stdenv.lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
+    substituteInPlace Makefile --replace "ar cr" "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar cr"
+    substituteInPlace Makefile --replace "ranlib" "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
+    substituteInPlace Makefile --replace "STRIP=strip" "STRIP=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
   '';
   nativeBuildInputs = [ perl zlib ];
 #  buildInputs = [ zlib ];

--- a/pkgs/development/tools/rust/cargo-valgrind/default.nix
+++ b/pkgs/development/tools/rust/cargo-valgrind/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
 , nix-update-script
@@ -30,10 +31,10 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram $out/bin/cargo-valgrind --prefix PATH : ${stdenv.lib.makeBinPath [ valgrind ]}
+    wrapProgram $out/bin/cargo-valgrind --prefix PATH : ${lib.makeBinPath [ valgrind ]}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = ''Cargo subcommand "valgrind": runs valgrind and collects its output in a helpful manner'';
     homepage = "https://github.com/jfrimmel/cargo-valgrind";
     license = with licenses; [ asl20 /* or */ mit ];

--- a/pkgs/servers/pleroma-otp/default.nix
+++ b/pkgs/servers/pleroma-otp/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, stdenv
 , autoPatchelfHook
 , fetchurl
 , file
@@ -60,11 +61,11 @@ stdenv.mkDerivation {
     pleroma = nixosTests.pleroma;
   };
 
-  meta = {
+  meta = with lib; {
     description = "ActivityPub microblogging server";
     homepage = https://git.pleroma.social/pleroma/pleroma;
-    license = stdenv.lib.licenses.agpl3;
-    maintainers = with stdenv.lib.maintainers; [ ninjatrappeur ];
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ ninjatrappeur ];
     platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -152,9 +152,12 @@ let
         inherit lib config stdenv;
       }) mkDerivation;
 
-      # For convenience, bring in the library functions in lib/ so
-      # packages don't have to do that themselves.
-      inherit lib;
+      # Slated for deprecation in 21.11
+      lib = builtins.trace ( "Warning: `stdenv.lib` is deprecated "
+                           + "and will be removed in the next release. "
+                           + "Please use `pkgs.lib` instead. "
+                           + "For more information see https://github.com/NixOS/nixpkgs/issues/108938")
+                           lib;
 
       inherit fetchurlBoot;
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -153,11 +153,11 @@ let
       }) mkDerivation;
 
       # Slated for deprecation in 21.11
-      lib = builtins.trace ( "Warning: `stdenv.lib` is deprecated "
-                           + "and will be removed in the next release. "
-                           + "Please use `pkgs.lib` instead. "
-                           + "For more information see https://github.com/NixOS/nixpkgs/issues/108938")
-                           lib;
+      lib = builtins.trace
+        ( "Warning: `stdenv.lib` is deprecated and will be removed in the next release."
+         + " Please use `pkgs.lib` instead."
+         + " For more information see https://github.com/NixOS/nixpkgs/issues/108938")
+        lib;
 
       inherit fetchurlBoot;
 


### PR DESCRIPTION
###### Motivation for this change
Closes #108938
- Remove re-introduced stdenv.lib instances
- ~~Removed lib from stdenv (doing this to check ofborg eval)~~
- warn about use of inherited lib

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
