### PR TITLE
tt-rss: 2019-01-29 -> 2021-01-29

### DIFF
--- a/pkgs/servers/tt-rss/default.nix
+++ b/pkgs/servers/tt-rss/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tt-rss";
-  version = "2019-01-29";
-  rev = "c7c9c5fb0ab6b3d4ea3078865670d6c1dfe2ecac";
+  version = "2021-01-29";
+  rev = "6d8f2221b82b6a31becbeed8baf5e05ad9e053fe";
 
   src = fetchurl {
-    url = "https://git.tt-rss.org/git/tt-rss/archive/${rev}.tar.gz";
-    sha256 = "0k184zqrfscv17gnl106q4yzhqmxb0g1dn1wkdkrclc3qcrviyp6";
+    url = "https://git.tt-rss.org/fox/tt-rss/archive/${rev}.tar.gz";
+    sha256 = "124c62hck631xlq5aa1miz9rbg711ygk7z1yx92m5dfcy630l7x5";
   };
 
   installPhase = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[tt-rss](https://tt-rss.org/) does not tag specific releases, master branch is considered the stable production ready output.
This PR bump the revision to match most recent commit on master at the time.

###### Things done

- [x] Tested a deployment using the NixOS module

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @globin @zohl 