### PR TITLE
nikto: init at 2.2.0

### DIFF
--- a/pkgs/tools/networking/nikto/NIKTODIR-nix-wrapper-fix.patch
+++ b/pkgs/tools/networking/nikto/NIKTODIR-nix-wrapper-fix.patch
@@ -1,0 +1,26 @@
+diff --color -ur a/program/nikto.pl b/program/nikto.pl
+--- a/program/nikto.pl	2021-01-30 12:05:54.915072538 +0100
++++ b/program/nikto.pl	2021-01-30 12:36:42.877729231 +0100
+@@ -223,7 +223,8 @@
+     # Guess Nikto current directory
+     my $NIKTODIR = abs_path($0);
+     chomp($NIKTODIR);
+-    $NIKTODIR =~ s#[\\/]nikto.pl$##;
++    $NIKTODIR =~ s#[\\/]bin[\\/]\.nikto-wrapped$##;
++
+ 
+     # Guess user's home directory -- to support Windows
+     foreach my $var (split(/ /, "HOME USERPROFILE")) {
+@@ -231,10 +232,10 @@
+     }
+ 
+     # Read the conf files in order (previous values are over-written with each, if multiple found)
+-    push(@CF,"$NIKTODIR/nikto.conf.default");
++    push(@CF,"$NIKTODIR/etc/nikto.conf.default");
+     push(@CF,"/etc/nikto.conf");
+     push(@CF,"$home/nikto.conf");
+-    push(@CF,"$NIKTODIR/nikto.conf");
++    push(@CF,"$NIKTODIR/etc/nikto.conf");
+     push(@CF,"nikto.conf");
+     push(@CF,"$VARIABLES{'configfile'}");
+ 

--- a/pkgs/tools/networking/nikto/default.nix
+++ b/pkgs/tools/networking/nikto/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, perlPackages
+, makeWrapper
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nikto";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sullo";
+    repo = "nikto";
+    rev = "c83d0461edd75c02677dea53da2896644f35ecab";
+    sha256 = "0vwq2zdxir67cn78ls11qf1smd54nppy266v7ajm5rqdc47q7fy2";
+  };
+
+  # Nikto searches its configuration file based on its current path
+  # This fixes the current path regex for the wrapped executable.
+  patches = [ ./NIKTODIR-nix-wrapper-fix.patch ];
+
+  postPatch = ''
+    # EXECDIR needs to be changed to the path where we copy the programs stuff
+    # Forcing SSLeay is needed for SSL support (the auto mode doesn't seem to work otherwise)
+    substituteInPlace program/nikto.conf.default \
+      --replace "# EXECDIR=/opt/nikto" "EXECDIR=$out/share" \
+      --replace "LW_SSL_ENGINE=auto" "LW_SSL_ENGINE=SSLeay"
+  '';
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  propagatedBuildInputs = [ perlPackages.NetSSLeay ];
+
+  buildInputs = [
+    perlPackages.perl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share"
+    cp -a program/* "$out/share"
+    install -Dm 755 "program/nikto.pl" "$out/bin/nikto"
+    install -Dm 644 program/nikto.conf.default "$out/etc/nikto.conf"
+    installManPage documentation/nikto.1
+    install -Dm 644 program/docs/nikto_manual.html "$out/share/doc/${pname}/manual.html"
+    install -Dm 644 README.md "$out/share/doc/${pname}/README"
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/nikto \
+      --prefix PERL5LIB : $PERL5LIB
+  '';
+
+  meta = with lib; {
+    description = "Web server scanner";
+    license = licenses.gpl2Plus;
+    homepage = "https://cirt.net/Nikto2";
+    maintainers = with maintainers; [ shamilton ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15834,6 +15834,8 @@ in
 
   nika-fonts = callPackage ../data/fonts/nika-fonts { };
 
+  nikto = callPackage ../tools/networking/nikto { };
+
   nlohmann_json = callPackage ../development/libraries/nlohmann_json { };
 
   nntp-proxy = callPackage ../applications/networking/nntp-proxy { };


### PR DESCRIPTION
###### Motivation for this change
I started to work on pentesting skills and nikto is a good tool to have.

###### Things done
Packaged nikto to 2.2.0 unofficial release (it's the latest commit of the 2.2.0 branch).

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
