### PR TITLE
gradle: 6.7 -> 6.8.1

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -51,15 +51,15 @@ rec {
     };
   };
 
-  gradle_latest = gradle_6_7;
+  gradle_latest = gradle_6_8;
 
-  gradle_6_7 = gradleGen rec {
-    name = "gradle-6.7";
-    nativeVersion = "0.22-milestone-8";
+  gradle_6_8 = gradleGen rec {
+    name = "gradle-6.8.1";
+    nativeVersion = "0.22-milestone-9";
 
     src = fetchurl {
       url = "https://services.gradle.org/distributions/${name}-bin.zip";
-      sha256 = "1i6zm55wzy13wvvmf3804b0rs47yrqqablf4gpf374ls05cpgmca";
+      sha256 = "1zfn7400k39qbiidd5zxay6v5f5xz8x4g7rrf04p71bkmws1lngx";
     };
   };
 

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -88,7 +88,7 @@ let
   '';
 
   # The default one still uses jdk8 (#89731)
-  gradle_6 = (gradleGen.override (old: { java = jdk; })).gradle_6_7;
+  gradle_6 = (gradleGen.override (old: { java = jdk; })).gradle_6_8;
 
   # fake build to pre-download deps into fixed-output derivation
   deps = stdenv.mkDerivation {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12203,7 +12203,7 @@ in
   gradle_4_10 = res.gradleGen.gradle_4_10;
   gradle_4 = gradle_4_10;
   gradle_5 = res.gradleGen.gradle_5_6;
-  gradle_6 = res.gradleGen.gradle_6_7;
+  gradle_6 = res.gradleGen.gradle_6_8;
 
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New Gradle release(s). Previous version packaged was 6.7, this MR packages 6.8.1, versions 6.7.1 and 6.8 have been released in the meantime. Notes:

  * https://docs.gradle.org/6.8.1/release-notes.html (released on 2021-01-22)
  * https://docs.gradle.org/6.8/release-notes.html (released on 2021-01-08)
  * https://docs.gradle.org/6.7.1/release-notes.html (released on 2020-11-16)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Mentioning some people that are likely to review/merge, hope that's okay:

 * @p-h because you did the previous upgrade from 6.6 to 6.7 in #101762.
 * @Ma27 because you merged the previous upgrade from 6.6 to 6.7 in #101762.
 * @alyssais because you merged the upgrade from 6.5 to 6.6 in #95322
 * @petabyteboy because you are listed as maintainer for `mindustry`, which referenced `gradle_6_7` explicitly. I changed this reference to `gradle_6_8`, which should be reasonably safe.

Let's keep Gradle fresh :)