### PR TITLE
libreswan: 3.32 -> 4.1 [DRAFT for others to pick up]

### DIFF
--- a/pkgs/tools/networking/libreswan/default.nix
+++ b/pkgs/tools/networking/libreswan/default.nix
@@ -15,25 +15,12 @@ assert stdenv.isLinux -> libselinux != null;
 
 stdenv.mkDerivation rec {
   pname = "libreswan";
-  version = "3.32";
+  version = "4.1";
 
   src = fetchurl {
     url = "https://download.libreswan.org/${pname}-${version}.tar.gz";
-    sha256 = "0bj3g6qwd3ir3gk6hdl9npy3k44shf56vcgjahn30qpmx3z5fsr3";
+    sha256 = "0z92v5a5j6lx2ahx8aqjnk28zk6rlmpqaj06hbavxrzdlb1l8r11";
   };
-
-  # These flags were added to compile v3.18. Try to lift them when updating.
-  NIX_CFLAGS_COMPILE = toString [ "-Wno-error=redundant-decls" "-Wno-error=format-nonliteral"
-    # these flags were added to build with gcc7
-    "-Wno-error=implicit-fallthrough"
-    "-Wno-error=format-truncation"
-    "-Wno-error=pointer-compare"
-    "-Wno-error=stringop-truncation"
-    # The following flag allows libreswan v3.32 to work with NSS 3.22, see
-    # https://github.com/libreswan/libreswan/issues/334.
-    # This flag should not be needed for libreswan v3.33 (which is not yet released).
-    "-DNSS_PKCS11_2_0_COMPAT=1"
-  ];
 
   nativeBuildInputs = [ makeWrapper pkg-config ];
   buildInputs = [ bash iproute iptables systemd coreutils gnused gawk gmp unbound bison flex pam libevent
@@ -47,9 +34,7 @@ stdenv.mkDerivation rec {
 
     # Fix systemd unit directory, and prevent the makefile from trying to reload the
     # systemd daemon or create tmpfiles
-    sed -i -e 's|UNITDIR=.*$|UNITDIR=$\{out}/etc/systemd/system/|g' \
-      -e 's|TMPFILESDIR=.*$|TMPFILESDIR=$\{out}/tmpfiles.d/|g' \
-      -e 's|systemctl|true|g' \
+    sed -i -e 's|systemctl|true|g' \
       -e 's|systemd-tmpfiles|true|g' \
       initsystems/systemd/Makefile
 
@@ -64,6 +49,7 @@ stdenv.mkDerivation rec {
   preBuild = "export INC_USRLOCAL=\${out}";
 
   makeFlags = [
+    "UNITDIR=$(out)/etc/systemd/system/" "TMPFILESDIR=$(out)/tmpfiles.d/"
     "INITSYSTEM=systemd"
     (if docs then "all" else "base")
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A new major version of libreswan has been released.

###### Things done

I fixed some of the problems, but not using libreswan myself I lost tuits when encountering the following problem:

```
../OBJ.linux.x86_64/configs/block -> /nix/store/lvpqg6bqgvpm4ngz47wpwx7khlxj4j58-libreswan-4.1/etc/ipsec.d/policies/block
../OBJ.linux.x86_64/configs/portexcludes.conf -> /nix/store/lvpqg6bqgvpm4ngz47wpwx7khlxj4j58-libreswan-4.1/etc/ipsec.d/policies/portexcludes.conf
mkdir: cannot create directory '/etc/pam.d/': Permission denied
install: cannot create regular file '/etc/pam.d/pluto': No such file or directory
make[2]: *** [Makefile:48: local-install-base] Error 1
make[1]: *** [../mk/targets.mk:73: install-base] Error 2
make[1]: Leaving directory '/build/libreswan-4.1/configs'
make: *** [/build/libreswan-4.1/mk/targets.mk:73: recursive-install-base] Error 2
builder for '/nix/store/i0rfjis0dryp57ibyk4z1h02yg5c0hv7-libreswan-4.1.drv' failed with exit code 2
error: build of '/nix/store/i0rfjis0dryp57ibyk4z1h02yg5c0hv7-libreswan-4.1.drv' failed
```

This is probably not too hard to fix, but I don't have the time for that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
