### PR TITLE
arm-embedded: make gcc multi-lib (arm32 + thumb)

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -127,6 +127,9 @@ rec {
   arm-embedded = {
     config = "arm-none-eabi";
     libc = "newlib";
+    gcc = {
+      enableMultilib = true;
+    };
   };
   armhf-embedded = {
     config = "arm-none-eabihf";

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -21,7 +21,7 @@
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , gnatboot ? null
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -26,7 +26,7 @@
 , libXrender ? null, xorgproto ? null
 , libXrandr ? null, libXi ? null
 , x11Support ? langJava
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -26,7 +26,7 @@
 , libXrender ? null, xorgproto ? null
 , libXrandr ? null, libXi ? null
 , x11Support ? langJava
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -29,7 +29,7 @@
 , libXrender ? null, xorgproto ? null
 , libXrandr ? null, libXi ? null
 , x11Support ? langJava
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -19,7 +19,7 @@
 , libelf                      # optional, for link-time optimizations (LTO)
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -19,7 +19,7 @@
 , libelf                      # optional, for link-time optimizations (LTO)
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -22,7 +22,7 @@
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , gnatboot ? null
-, enableMultilib ? false
+, enableMultilib ? stdenv.targetPlatform.gcc.enableMultilib or false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -140,7 +140,7 @@ let
     ]
 
     ++ (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
+      then ["--enable-multilib" "--disable-libquadmath" "--with-multilib-list=rmprofile" ]
       else ["--disable-multilib"])
     ++ lib.optional (!enableShared) "--disable-shared"
     ++ [

--- a/pkgs/development/compilers/gcc/common/platform-flags.nix
+++ b/pkgs/development/compilers/gcc/common/platform-flags.nix
@@ -8,7 +8,7 @@ in lib.concatLists [
   (lib.optional (p ? cpu) "--with-cpu=${p.cpu}")
   (lib.optional (p ? abi) "--with-abi=${p.abi}")
   (lib.optional (p ? fpu) "--with-fpu=${p.fpu}")
-  (lib.optional (p ? float) "--with-float=${p.float}")
+  (lib.optional (!targetPlatform.gcc.enableMultilib or false && (p ? float)) "--with-float=${p.float}") # --with-multilib-list conflicts with --with-float
   (lib.optional (p ? mode) "--with-mode=${p.mode}")
   (lib.optional
     (let tp = targetPlatform; in tp.isPower && tp.libc == "glibc" && tp.is64bit && tp.isLittleEndian)


### PR DESCRIPTION
###### Motivation for this change
gcc lacked a thumb version of `crtbegin.o`
newlib lacked a thumb version of everything

###### Things done
tested the resulting binaries with the expr&commands in https://gist.github.com/cleverca22/9cb66a1182fba1d660bf1b970437fb7b
confirmed that its no longer leaking arm32 opcodes into an elf binary meant for a thumb-only cpu
###### todo:
get the newlib multilib build properly into the linker search path, i need to manually add a `-L` flag for it currently (see the above gist)
i suspect this change will also break x86 32+64bit multilib

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

