### PR TITLE
WIP Adding Yugabyte DB.

### DIFF
--- a/pkgs/development/libraries/cds/default.nix
+++ b/pkgs/development/libraries/cds/default.nix
@@ -1,0 +1,26 @@
+{
+  cmake,
+  fetchurl,
+  lib,
+  stdenv,
+}:
+stdenv.mkDerivation rec {
+  pname = "cds";
+  version = "2.3.3";
+
+  src = fetchurl {
+    url = "https://github.com/khizmax/libcds/archive/v${version}.tar.gz";
+    sha256 = "1273wk370nqpq5yg9xvf90icnb6yc1rb5gghnb1a6qvbrl73i47h";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    homepage = "http://libcds.sourceforge.net/";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ kevincox ];
+    description = "CDS is a C++ template library of lock-free and fine-grained algorithms.";
+  };
+}

--- a/pkgs/development/libraries/crcutil/default.nix
+++ b/pkgs/development/libraries/crcutil/default.nix
@@ -1,0 +1,41 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  which,
+  autoconf,
+  automake,
+  libtool,
+}:
+stdenv.mkDerivation rec {
+  pname = "crcutil";
+  version = "8678969f02c4679fa40abaa9c5d7afadec50ed84";
+
+  src = fetchFromGitHub {
+    owner = "cloudera";
+    repo = "crcutil";
+    rev = version;
+    hash = "sha256:1890pksyszwxhpy9n1wh5bmrakbgrhsf7piwzgkj0206b58a2k73";
+  };
+
+  nativeBuildInputs = [
+    which
+    autoconf
+    automake
+    libtool
+  ];
+
+  NIX_CFLAGS_COMPILE = "-mcrc32";
+
+  preConfigurePhases = "autogen";
+  autogen = ''
+    bash ./autogen.sh
+  '';
+
+  meta = {
+    homepage = "https://github.com/cloudera/crcutil";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kevincox ];
+    description = "High performance CRC implementation.";
+  };
+}

--- a/pkgs/development/libraries/crypt_blowfish/default.nix
+++ b/pkgs/development/libraries/crypt_blowfish/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "crypt_blowfish";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://www.openwall.com/crypt/crypt_blowfish-${version}.tar.gz";
+    hash = "sha256:1zbjip7aiim33r4022qh6r4nd9850fxfky5phbcfhvwrlvy03yl3";
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib
+    ar cr $out/lib/libcrypt_blowfish.a *.o
+
+    mkdir -p $out/include
+    cp *.h $out/include
+  '';
+
+  meta = with lib; {
+    description = "Implementation of bcrypt, provided via the crypt(3) and a reentrant interface";
+    homepage = "https://www.openwall.com/crypt/";
+    license = lib.licenses.publicDomain; # There is also a fallback license available.
+    platforms = platforms.unix;
+    maintainers = [ maintainers.kevincox ];
+  };
+}

--- a/pkgs/development/libraries/squeasel/default.nix
+++ b/pkgs/development/libraries/squeasel/default.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  openssl,
+  sqlite,
+  wolfssl,
+}:
+stdenv.mkDerivation rec {
+  pname = "squeasel";
+  version = "d83cf6d9af0e2c98c16467a6a035ae0d7ca21cb1";
+
+  src = fetchFromGitHub {
+    owner = "cloudera";
+    repo = "squeasel";
+    rev = version;
+    hash = "sha256:0b5vx5z2xl3whyrw5155w3z9lgm8ij992xcaghbwv2hjwhd0wwvb";
+  };
+
+  buildInputs = [
+    openssl
+    sqlite
+    wolfssl
+  ];
+
+  buildPhase = ''
+    make squeasel.o
+    ar cr libsqueasel.a squeasel.o
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/
+    mv libsqueasel.a $out/lib
+  '';
+
+  meta = {
+    homepage = "https://github.com/cloudera/squeasel";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kevincox ];
+    description = "Easy to use, powerful, embeddable web server";
+  };
+}

--- a/pkgs/servers/sql/yugabyte/default.nix
+++ b/pkgs/servers/sql/yugabyte/default.nix
@@ -1,0 +1,117 @@
+{
+  boost165,
+  cds,
+  cmake,
+  crcutil,
+  crypt_blowfish,
+  curl,
+  fetchFromGitHub,
+  glog,
+  gmock,
+  gperftools,
+  hiredis,
+  lib,
+  libbacktrace,
+  libev,
+  libunwind,
+  libuuid,
+  lz4,
+  nettools,
+  openssl,
+  protobuf,
+  python3,
+  snappy,
+  squeasel,
+  stdenv,
+  which,
+  zlib,
+}: let
+in stdenv.mkDerivation rec {
+  pname = "yugabyte";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "yugabyte";
+    repo = "yugabyte-db";
+    rev = "v${version}";
+    sha256 = "06zdqqgwa9nqmfp466zq4r3gdf545wlkz7nppv9af5vlpi2504mz";
+    fetchSubmodules = true;
+  };
+
+  # YugabyteDB has a very custom and weird build process. It really wants to run by a script and download all of its dependencies. We don't want that so a lot of this is just poking the build scripts in funny ways because the upstream devs didn't want to do anything the standard way.
+
+  nativeBuildInputs = [
+    cmake
+    nettools
+    protobuf
+    python3
+    which
+  ];
+  buildInputs = [
+    (lz4.override { enableStatic = true; })
+    (boost165.override {
+      enableMultiThreaded = true;
+      enableSingleThreaded = true;
+      enableStatic = true;
+    })
+    cds
+    crcutil
+    crypt_blowfish
+    curl
+    glog
+    gmock
+    gperftools
+    hiredis
+    libbacktrace
+    libev
+    libunwind
+    libuuid
+    openssl
+    snappy
+    squeasel
+    zlib
+  ];
+
+  # Their build scripts *really* want the libs to be in the thirdparty dir.
+  YB_THIRDPARTY_DIR = "/nix/store";
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=release"
+    # "-DYB_NO_REBUILD_THIRDPARTY=1"
+    "-DCMAKE_FIND_DEBUG_MODE=1"
+  ];
+
+  # It is very picky what directory you build it in.
+  dontUseCmakeBuildDir = true;
+  cmakeDir = "../..";
+  preConfigurePhases = "makeBuildDir";
+  makeBuildDir = ''
+    mkdir -p build/release-gcc-dynamic
+    cd build/release-gcc-dynamic
+  '';
+
+  # YugabyteDB uses some compiler wrappers that do a lot of work. It seems infeasible to avoid them so we do some tricks to use them.
+  patchPhase = ''
+    patchShebangs build-support/validate_build_root.py
+
+    patchShebangs build-support/compiler-wrappers/compiler-wrapper.sh
+    cmakeFlags="-DCMAKE_C_COMPILER=$(realpath build-support/compiler-wrappers)/cc $cmakeFlags"
+    cmakeFlags="-DCMAKE_CXX_COMPILER=$(realpath build-support/compiler-wrappers)/c++ $cmakeFlags"
+  '';
+
+  # nativeBuildInputs = lib.optionals icuEnabled [ pkg-config ];
+
+  separateDebugInfo = true;
+
+  passthru = {
+    # tests.postgresql = nixosTests.postgresql-wal-receiver.${thisAttr};
+  };
+
+  meta = with lib; {
+    homepage    = "https://www.postgresql.org";
+    description = "A powerful, open source object-relational database system";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ kevincox ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1184,6 +1184,8 @@ in
 
   crcpp = callPackage ../development/libraries/crcpp { };
 
+  crypt_blowfish = callPackage ../development/libraries/crypt_blowfish { };
+
   cudd = callPackage ../development/libraries/cudd { };
 
   cue = callPackage ../development/tools/cue { };
@@ -10768,6 +10770,8 @@ in
 
   crate2nix = callPackage ../development/tools/rust/crate2nix { };
 
+  crcutil = callPackage ../development/libraries/crcutil { };
+
   convco = callPackage ../development/tools/convco {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
@@ -10840,6 +10844,8 @@ in
   };
 
   squeak = callPackage ../development/compilers/squeak { };
+
+  squeasel = callPackage ../development/libraries/squeasel { };
 
   squirrel-sql = callPackage ../development/tools/database/squirrel-sql {
     drivers = [ mssql_jdbc mysql_jdbc postgresql_jdbc ];
@@ -29782,9 +29788,13 @@ in
 
   cagebreak = callPackage ../applications/window-managers/cagebreak/default.nix {};
 
+  cds = callPackage ../development/libraries/cds {};
+
   psftools = callPackage ../os-specific/linux/psftools {};
 
   lc3tools = callPackage ../development/tools/lc3tools {};
+
+  yugabyte = callPackage ../servers/sql/yugabyte {};
 
   zktree = callPackage ../applications/misc/zktree {};
 }


### PR DESCRIPTION
I couldn't get it to build but am pushing the WIP.


Other (incompletely) packaged things for people searching:

pkgs/development/libraries/cds/default.nix            |  26 +++++++++++++++
 pkgs/development/libraries/crcutil/default.nix        |  41 +++++++++++++++++++++++
 pkgs/development/libraries/crypt_blowfish/default.nix |  31 +++++++++++++++++
 pkgs/development/libraries/squeasel/default.nix       |  42 +++++++++++++++++++++++
 pkgs/servers/sql/yugabyte/default.nix                 | 117 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 pkgs/top-level/all-packages.nix

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
