### PR TITLE
gdal_2: 2.4.0 -> 2.4.4, fixing CVE-2019-17546

### DIFF
--- a/pkgs/development/libraries/gdal/2.4.nix
+++ b/pkgs/development/libraries/gdal/2.4.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, unzip, libjpeg, libtiff, zlib
+{ lib, stdenv, fetchurl, unzip, libjpeg, libtiff, zlib
 , postgresql, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
 , libiconv, libxml2
@@ -9,21 +9,12 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "gdal";
-  version = "2.4.0";
+  version = "2.4.4";
 
   src = fetchurl {
     url = "https://download.osgeo.org/gdal/${version}/${pname}-${version}.tar.xz";
-    sha256 = "09qgy36z0jc9w05373m4n0vm4j54almdzql6z9p9zr9pdp61syf3";
+    sha256 = "1n6w0m2603q9cldlz0wyscp75ci561dipc36jqbf3mjmylybv0x3";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2019-17545.patch";
-      url = "https://github.com/OSGeo/gdal/commit/8cd2d2eb6327cf782a74dae263ffa6f89f46c93d.patch";
-      stripLen = 1;
-      sha256 = "06h88a659jcqf6ps1m91qy78s6s9krbkwnz28f5qh7032vlp6qpw";
-    })
-  ];
 
   buildInputs = [ unzip libjpeg libtiff libgeotiff libpng proj openssl sqlite
     libspatialite poppler hdf4 qhull giflib expat libxml2 proj ]
@@ -60,19 +51,6 @@ stdenv.mkDerivation rec {
       #ifdef swap\
       #undef swap\
       #endif' ogr/ogrsf_frmts/mysql/ogr_mysql.h
-    # poppler 0.73.0 support
-    patch -lp2 <${
-      fetchpatch {
-        url = "https://github.com/OSGeo/gdal/commit/29f4dfbcac2de718043f862166cd639ab578b552.diff";
-        sha256 = "1h2rsjjrgwqfgqzppmzv5jgjs1dbbg8pvfmay0j9y0618qp3r734";
-      }
-    } || true
-    patch -p2 <${
-      fetchpatch {
-        url = "https://github.com/OSGeo/gdal/commit/19967e682738977e11e1d0336e0178882c39cad2.diff";
-        sha256 = "12yqd77226i6xvzgqmxiac5ghdinixh8k2crg1r2gnhc0xlc3arj";
-      }
-    }
   '';
 
   # - Unset CC and CXX as they confuse libtool.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13687,7 +13687,7 @@ in
 
   gdal_1_11 = callPackage ../development/libraries/gdal/gdal-1_11.nix { };
 
-  gdal_2 = callPackage ../development/libraries/gdal/2.4.0.nix { };
+  gdal_2 = callPackage ../development/libraries/gdal/2.4.nix { };
 
   gdcm = callPackage ../development/libraries/gdcm { };
 


### PR DESCRIPTION
###### Motivation for this change
This addresses CVE-2019-17546 (https://nvd.nist.gov/vuln/detail/CVE-2019-17546), a vulnerability that affects the bundled libtiff in gdal. I don't think we really _use_ the bundled libtiff, but it's probably best to be able to tick this one off the list.

Stable branch being handled with a patch in #111315.

Not tested *full* rebuild on macos because full evaluation seems broken (coq stuff?).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
