### PR TITLE
Enable PPC64 (big-endian)

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -24,6 +24,7 @@ let
 
     "x86_64-redox"
 
+    "powerpc64-linux"
     "powerpc64le-linux"
 
     "riscv32-linux" "riscv64-linux"
@@ -72,7 +73,7 @@ in {
   darwin        = filterDoubles predicates.isDarwin;
   freebsd       = filterDoubles predicates.isFreeBSD;
   # Should be better, but MinGW is unclear.
-  gnu           = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; });
+  gnu           = filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnu; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.elfv1; }) ++ filterDoubles (matchAttrs { kernel = parse.kernels.linux; abi = parse.abis.elfv2; });
   illumos       = filterDoubles predicates.isSunOS;
   linux         = filterDoubles predicates.isLinux;
   netbsd        = filterDoubles predicates.isNetBSD;
@@ -85,5 +86,5 @@ in {
 
   embedded      = filterDoubles predicates.isNone;
 
-  mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux" "powerpc64le-linux"];
+  mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux" "powerpc64-linux" "powerpc64le-linux"];
 }

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -21,6 +21,19 @@ rec {
     config = "powerpc64le-unknown-linux-musl";
   };
 
+  ppc64-elfv1 = {
+    config = "powerpc64-unknown-linux-elfv1";
+  };
+  ppc64-elfv2 = {
+    config = "powerpc64-unknown-linux-elfv2";
+  };
+  ppc64 = ppc64-elfv2; # default to modern elfv2
+
+  ppc64-musl = {
+    config = "powerpc64-unknown-linux-musl";
+    gcc = { abi = "elfv2"; }; # for gcc configuration
+  };
+
   sheevaplug = {
     config = "armv5tel-unknown-linux-gnueabi";
   } // platforms.sheevaplug;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -337,9 +337,17 @@ rec {
             The "gnu" ABI is ambiguous on 32-bit ARM. Use "gnueabi" or "gnueabihf" instead.
           '';
         }
+        { assertion = platform: platform.system != "powerpc64-linux";
+          message = ''
+            The "gnu" ABI is ambiguous on big-endian 64-bit PPC. Use "elfv1" or "elfv2" instead.
+          '';
+        }
       ];
     };
     gnuabi64     = { abi = "64"; };
+
+    elfv1        = { abi = "elfv1"; };
+    elfv2        = { abi = "elfv2"; };
 
     musleabi     = { float = "soft"; };
     musleabihf   = { float = "hard"; };
@@ -444,6 +452,7 @@ rec {
             if lib.versionAtLeast (parsed.cpu.version or "0") "6"
             then abis.gnueabihf
             else abis.gnueabi
+          else if cpu == "powerpc64" then abis.elfv2
           else abis.gnu
         else                     abis.unknown;
     };

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -28,7 +28,7 @@ with lib.systems.doubles; lib.runTests {
   testredox = mseteq redox [ "x86_64-redox" ];
   testgnu = mseteq gnu (linux /* ++ kfreebsd ++ ... */);
   testillumos = mseteq illumos [ "x86_64-solaris" ];
-  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64le-linux" ];
+  testlinux = mseteq linux [ "aarch64-linux" "armv5tel-linux" "armv6l-linux" "armv7a-linux" "armv7l-linux" "i686-linux" "mipsel-linux" "riscv32-linux" "riscv64-linux" "x86_64-linux" "powerpc64-linux" "powerpc64le-linux" ];
   testnetbsd = mseteq netbsd [ "i686-netbsd" "x86_64-netbsd" ];
   testopenbsd = mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ];
   testwindows = mseteq windows [ "i686-cygwin" "x86_64-cygwin" "i686-windows" "x86_64-windows" ];

--- a/pkgs/development/compilers/gcc/common/platform-flags.nix
+++ b/pkgs/development/compilers/gcc/common/platform-flags.nix
@@ -11,6 +11,6 @@ in lib.concatLists [
   (lib.optional (p ? float) "--with-float=${p.float}")
   (lib.optional (p ? mode) "--with-mode=${p.mode}")
   (lib.optional
-    (let tp = targetPlatform; in tp.isPower && tp.libc == "glibc" && tp.is64bit && tp.isLittleEndian)
+    (let tp = targetPlatform; in tp.isPower && tp.libc == "glibc" && tp.is64bit)
     "--with-long-double-128")
 ]

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -54,6 +54,7 @@ in
     aarch64-linux = stagesLinux;
     mipsel-linux = stagesLinux;
     powerpc-linux = /* stagesLinux */ stagesNative;
+    powerpc64-linux = stagesLinux;
     powerpc64le-linux = stagesLinux;
     x86_64-darwin = stagesDarwin;
     x86_64-solaris = stagesNix;

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -17,6 +17,8 @@ in lib.mapAttrs (n: make) (with lib.systems.examples; {
   armv6l-musl  = muslpi;
   aarch64-musl = aarch64-multiplatform-musl;
   riscv64 = riscv64;
+  powerpc64 = ppc64;
+  powerpc64-musl = ppc64-musl;
   powerpc64le = powernv;
   powerpc64le-musl = musl-power;
 })

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -19,7 +19,8 @@ in with pkgs; rec {
   tarMinimal = gnutar.override { acl = null; };
 
   busyboxMinimal = busybox.override {
-    useMusl = !stdenv.targetPlatform.isRiscV;
+    useMusl = with stdenv.targetPlatform; !isRiscV &&
+                (system == "powerpc64-linux" -> parsed.abi.name != "elfv1");
     enableStatic = true;
     enableMinimal = true;
     extraConfig = ''


### PR DESCRIPTION
PPC64 supports two ABIs: ELF v1 and v2.

ELFv1 is historically what GCC and most packages expect, but this is
changing because musl outright does not work with ELFv1. So any distro
which uses musl must use ELFv2. Many other platforms are moving to ELFv2
too, such as FreeBSD (as of v13) and Gentoo (as of late 2020).

Since we use musl extensively, let's default to ELFv2.

Nix gives us the power to specify this declaratively for the entire
system, so ELFv1 is not dropped entirely. It can be specified explicitly
in the target config, e.g. "powerpc64-unknown-linux-elfv1". Otherwise the
default is "powerpc64-unknown-linux-elfv2". For musl,
"powerpc64-unknown-linux-musl" must use elfv2 internally to function.

cc @CrystalGamma 
cc @NixOS/exotic-platform-maintainers 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
