### PR TITLE
orchis: init at 2021-01-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3237,6 +3237,12 @@
     githubId = 10528737;
     name = "Severin Fürbringer";
   };
+  fufexan = {
+    email = "fufexan@protonmail.com";
+    github = "fufexan";
+    githubId = 36706276;
+    name = "Fufezan Mihai";
+  };
   funfunctor = {
     email = "eocallaghan@alterapraxis.com";
     name = "Edward O'Callaghan";

--- a/pkgs/data/themes/orchis/default.nix
+++ b/pkgs/data/themes/orchis/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, gtk3, gnome-themes-extra, gtk-engine-murrine
+, accentColor ? "default" }:
+
+stdenv.mkDerivation rec {
+  pname = "orchis";
+  version = "2021-01-22";
+
+  src = fetchFromGitHub {
+    repo = "Orchis-theme";
+    owner = "vinceliuice";
+    rev = version;
+    sha256 = "1m0wilvrscg2xnkp6a90j0iccxd8ywvfpza1345sc6xmml9gvjzc";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  buildInputs = [ gnome-themes-extra ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  preInstall = ''
+    mkdir -p $out/share/themes
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    bash install.sh -d $out/share/themes -t ${accentColor}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Material Design theme for GNOME/GTK based desktop environments.";
+    homepage = "https://github.com/vinceliuice/Orchis-theme";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.fufexan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20482,6 +20482,8 @@ in
 
   orbitron = callPackage ../data/fonts/orbitron { };
 
+  orchis = callPackage ../data/themes/orchis { };
+
   orion = callPackage ../data/themes/orion {};
 
   overpass = callPackage ../data/fonts/overpass { };


### PR DESCRIPTION
[Orchis](https://github.com/vinceliuice/Orchis-theme) is a Material Derign theme for GTK.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
