### PR TITLE
pythonPackages.httpcore: 0.12.0 -> 0.12.3

### DIFF
--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -9,18 +9,20 @@
 , pytestcov
 , sniffio
 , uvicorn
+, trustme
+, trio
 }:
 
 buildPythonPackage rec {
   pname = "httpcore";
-  version = "0.12.0";
+  version = "0.12.3";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "0bwxn7m7r7h6k41swxj0jqj3nzi76wqxwbnry6y7d4qfh4m26g2j";
+    sha256 = "09hbjc5wzhrnri5y3idxcq329d7jiaxljc7y6npwv9gh9saln109";
   };
 
   propagatedBuildInputs = [
@@ -34,11 +36,15 @@ buildPythonPackage rec {
     pytestCheckHook
     pytestcov
     uvicorn
+    trustme
+    trio
   ];
 
   pytestFlagsArray = [
     # these tests fail during dns lookups: httpcore.ConnectError: [Errno -2] Name or service not known
+    "--ignore=tests/test_threadsafety.py"
     "--ignore=tests/sync_tests/test_interfaces.py"
+    "--ignore=tests/sync_tests/test_retries.py"
   ];
 
   pythonImportsCheck = [ "httpcore" ];


### PR DESCRIPTION
###### Motivation for this change
Just a bump. Some new tests to disable due to network access.

Not done a **full** rebuild on macos as full evaluations are failing on master right now.

Reverse dependency `python38Packages.fastapi` already failing for me.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
