### PR TITLE
pythonPackages.dufte: 0.2.9 -> 0.2.12

### DIFF
--- a/pkgs/development/python-modules/dufte/default.nix
+++ b/pkgs/development/python-modules/dufte/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage rec {
   pname = "dufte";
-  version = "0.2.9";
+  version = "0.2.12";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0nkaczipbsm8c14j9svxry2wigmn5iharibb6b8g062sjaph8x17";
+    sha256 = "0ag1d7h1wijkc7v2vpgkbqjlnpiwd4nh8zhxiby0989bpmlp3jr3";
   };
   format = "pyproject";
 
@@ -34,6 +34,10 @@ buildPythonPackage rec {
   '';
   checkInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "dufte" ];
+  pytestFlagsArray = [
+    # we don't have the "exdown" package (yet)
+    "--ignore=test/test_readme.py"
+  ];
 
   meta = with lib; {
     description = "Clean matplotlib plots";


### PR DESCRIPTION
###### Motivation for this change
Bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
