### PR TITLE
libwebsockets: enable 4.1.x series

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -53,4 +53,9 @@ rec {
     version = "4.0.21";
     sha256 = "01k05x4711ngin598jr9dag4ml3m7hi6pkgr4dsb02ryh1kc6146";
   };
+
+  libwebsockets_4_1 = generic {
+    version = "4.1.6";
+    sha256 = "0x56v4hsx92vm1zibfmnqb5g3v23kzciffn3fjlsc3sly2pknhsg";
+  };
 }

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -32,7 +32,9 @@ let
         throughput in both directions.
       '';
       homepage = "https://libwebsockets.org/";
-      license = licenses.lgpl21;
+      # Relicensed from LGPLv2.1+ to MIT with 4.0. Licensing situation
+      # is tricky, see https://github.com/warmcat/libwebsockets/blob/main/LICENSE
+      license = with licenses; [ mit publicDomain bsd3 asl20 ];
       platforms = platforms.all;
     };
   };

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -50,7 +50,7 @@ rec {
   };
 
   libwebsockets_4_0 = generic {
-    version = "4.0.1";
-    sha256 = "1pf7km0w5q7dqlwcwqizdpfqgg10prfq8g2c093f5nghwsfv8mmf";
+    version = "4.0.21";
+    sha256 = "01k05x4711ngin598jr9dag4ml3m7hi6pkgr4dsb02ryh1kc6146";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5954,7 +5954,8 @@ in
   inherit (callPackages ../development/libraries/libwebsockets { })
     libwebsockets_3_1
     libwebsockets_3_2
-    libwebsockets_4_0;
+    libwebsockets_4_0
+    libwebsockets_4_1;
   libwebsockets = libwebsockets_3_2;
 
   licensee = callPackage ../tools/package-management/licensee { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Update 4.0.x series to 4.0.21
- Clarification of the licensing
- Enable the 4.1.x series (Release notes: https://github.com/warmcat/libwebsockets#v410-and-v41-stable-are-released)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
