### PR TITLE
pythonPackages.django_silk: 4.0.1 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -1,7 +1,9 @@
 { lib
 , buildPythonPackage
 , python
+, pythonAtLeast
 , fetchFromGitHub
+, fetchpatch
 , django
 , pygments
 , simplejson
@@ -23,15 +25,23 @@
 
 buildPythonPackage rec {
   pname = "django-silk";
-  version = "4.0.1";
+  version = "4.1.0";
 
   # pypi tarball doesn't include test project
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "django-silk";
     rev = version;
-    sha256 = "0yy9rzxvwlp2xvnw76r9hnqajlp417snam92xpb6ay0hxwslwqyb";
+    sha256 = "1km3hmx1sir0c5gqr2p1h2938slhxp2hzf10cb80q98mas8spjkn";
   };
+
+  patches = lib.optional (pythonAtLeast "3.9") (fetchpatch {
+    # should be able to remove after 4.1.1
+    name = "python-3.9-support.patch";
+    url = "https://github.com/jazzband/django-silk/commit/134089e4cad7bd3b76fb0f70c423082cb7d2b34a.patch";
+    sha256 = "09c1xd9y33h3ibiv5w9af9d79c909rgc1g5sxpd4y232h5id3c8r";
+  });
+
   # "test_time_taken" tests aren't suitable for reproducible execution, but django's
   # test runner doesn't have an easy way to ignore tests - so instead prevent it from picking
   # them up as tests


### PR DESCRIPTION

###### Motivation for this change
A bump and fix for python 3.9 while we're here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
