### PR TITLE
zfs: fix zfs legacy mount

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -21,6 +21,12 @@ let
   buildKernel = any (n: n == configFile) [ "kernel" "all" ];
   buildUser = any (n: n == configFile) [ "user" "all" ];
 
+  # remove this patch at the next ZFS release (> 2.0.1)
+  reapplyPathSanitizerPatch = fetchpatch {
+    url = "https://github.com/openzfs/zfs/commit/03f036cbccdd8699f5fe8540ef317595a35bceb8.patch";
+    sha256 = "c157bbb6551a4e720c3faba005e1b72e4692d304c6ff5e0e685691bd47197dca";
+  };
+
   common = { version
     , sha256
     , extraPatches ? []
@@ -190,7 +196,7 @@ in {
 
     sha256 = "0wmw823ildwm9rcfyk22pvzg100yhps3y9hfjlrpspfd1hhkbp0d";
 
-    extraPatches = [ ];
+    extraPatches = [ reapplyPathSanitizerPatch ];
   };
 
   zfsUnstable = common {
@@ -202,6 +208,6 @@ in {
 
     sha256 = "0wmw823ildwm9rcfyk22pvzg100yhps3y9hfjlrpspfd1hhkbp0d";
 
-    extraPatches = [ ];
+    extraPatches = [ reapplyPathSanitizerPatch ];
   };
 }


### PR DESCRIPTION
Closes #110376

See related discussion

###### Things done

Apply the following patch from ZFS upstream: https://github.com/openzfs/zfs/commit/03f036cbccdd8699f5fe8540ef317595a35bceb8

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
