### PR TITLE
wimboot: fix builds under binutils 2.34+

### DIFF
--- a/pkgs/tools/misc/wimboot/default.nix
+++ b/pkgs/tools/misc/wimboot/default.nix
@@ -14,11 +14,16 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-address-of-packed-member"; # Fails on gcc9
 
   patches = [
-    # Fix for newer binutils
+    # Fixes for newer binutils
+    # Add R_X86_64_PLT32 as known reloc target
     (fetchpatch {
-      url =
-        "https://github.com/ipxe/wimboot/commit/91be50c17d4d9f463109d5baafd70f9fdadd86db.patch";
+      url = "https://github.com/ipxe/wimboot/commit/91be50c17d4d9f463109d5baafd70f9fdadd86db.patch";
       sha256 = "113448n49hmk8nz1dxbhxiciwl281zwalvb8z5p9xfnjvibj8274";
+    })
+    # Fix building with binutils 2.34 (bfd_get_section_* removed in favour of bfd_section_*)
+    (fetchpatch {
+      url = "https://github.com/ipxe/wimboot/commit/2f97e681703d30b33a4d5032a8025ab8b9f2de75.patch";
+      sha256 = "0476mp74jaq3k099b654al6yi2yhgn37d9biz0wv3ln2q1gy94yf";
     })
   ];
 
@@ -40,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://ipxe.org/wimboot";
     description = "Windows Imaging Format bootloader";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ das_j ajs124 ];
     platforms = platforms.x86; # Fails on aarch64
   };


### PR DESCRIPTION
###### Motivation for this change

Fix builds under binutils 2.34+. Also updates license to gpl2Plus (https://github.com/ipxe/wimboot/blob/master/src/die.c#L6-L7).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
