### PR TITLE
nixos/hddtemp: add support for HDD/SSD temperature montoring

### DIFF
--- a/nixos/modules/hardware/sensor/hddtemp.nix
+++ b/nixos/modules/hardware/sensor/hddtemp.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkIf mkOption types;
+
+  cfg = config.hardware.sensor.hddtemp;
+
+  wrapper = pkgs.writeShellScript "hddtemp-wrapper" ''
+    set -eEuo pipefail
+
+    file=/var/lib/hddtemp/hddtemp.db
+
+    drives=(${toString (map (e: ''$(realpath ${lib.escapeShellArg e}) '') cfg.drives)})
+
+    cp ${pkgs.hddtemp}/share/hddtemp/hddtemp.db $file
+    ${lib.concatMapStringsSep "\n" (e: "echo ${lib.escapeShellArg e} >> $file") cfg.dbEntries}
+
+    exec ${pkgs.hddtemp}/bin/hddtemp ${lib.escapeShellArgs cfg.extraArgs} \
+      --daemon \
+      --unit=${cfg.unit} \
+      --file=$file \
+      ''${drives[@]}
+  '';
+
+in
+{
+  meta.maintainers = with lib.maintainers; [ peterhoeg ];
+
+  ###### interface
+
+  options = {
+    hardware.sensor.hddtemp = {
+      enable = mkOption {
+        description = ''
+          Enable this option to support HDD/SSD temperature sensors.
+        '';
+        type = types.bool;
+        default = false;
+      };
+
+      drives = mkOption {
+        description = "List of drives to monitor. If you pass /dev/disk/by-path/* entries the symlinks will be resolved as hddtemp doesn't like names with colons.";
+        type = types.listOf types.str;
+      };
+
+      unit = mkOption {
+        description = "Celcius or Fahrenheit";
+        type = types.enum [ "C" "F" ];
+        default = "C";
+      };
+
+      dbEntries = mkOption {
+        description = "Additional DB entries";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+
+      extraArgs = mkOption {
+        description = "Additional arguments passed to the daemon.";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    systemd.services.hddtemp = {
+      description = "HDD/SSD temperature";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = wrapper;
+        StateDirectory = "hddtemp";
+        PrivateTmp = true;
+        ProtectHome = "tmpfs";
+        ProtectSystem = "strict";
+      };
+    };
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,6 +46,7 @@
   ./hardware/cpu/intel-microcode.nix
   ./hardware/digitalbitbox.nix
   ./hardware/device-tree.nix
+  ./hardware/sensor/hddtemp.nix
   ./hardware/sensor/iio.nix
   ./hardware/keyboard/zsa.nix
   ./hardware/ksm.nix

--- a/pkgs/tools/misc/hddtemp/default.nix
+++ b/pkgs/tools/misc/hddtemp/default.nix
@@ -1,32 +1,38 @@
 { lib, stdenv, fetchurl }:
-
-stdenv.mkDerivation {
-  name = "hddtemp-0.3_beta15";
-
-  db = fetchurl{
+let
+  db = fetchurl {
     url = "mirror://savannah/hddtemp/hddtemp.db";
     sha256 = "1fr6qgns6qv7cr40lic5yqwkkc7yjmmgx8j0z6d93csg3smzhhya";
   };
 
+in
+stdenv.mkDerivation rec {
+  pname = "hddtemp";
+  version = "0.3-beta15";
+
   src = fetchurl {
-    url = "mirror://savannah/hddtemp/hddtemp-0.3-beta15.tar.bz2";
-    sha256 = "0nzgg4nl8zm9023wp4dg007z6x3ir60rwbcapr9ks2al81c431b1";
+    url = "mirror://savannah/hddtemp/hddtemp-${version}.tar.bz2";
+    sha256 = "sha256-YYVBWEBUCT1TvootnoHJcXTzDwCvkcuHAKl+RC1571s=";
   };
 
   # from Gentoo
   patches = [ ./byteswap.patch ./dontwake.patch ./execinfo.patch ./satacmds.patch ];
 
-  configurePhase =
-    ''
-      mkdir -p $out/nix-support
-      cp $db $out/nix-support/hddtemp.db
-      ./configure --prefix=$out --with-db-path=$out/nix-support/hddtemp.db
-    '';
+  configureFlags = [
+    "--with-db-path=${placeholder "out"}/share/${pname}/hddtemp.db"
+  ];
+
+  postInstall = ''
+    install -Dm444 ${db} $out/share/${pname}/hddtemp.db
+  '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Tool for displaying hard disk temperature";
     homepage = "https://savannah.nongnu.org/projects/hddtemp/";
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Basic module for temperature monitoring + some minor `hddtemp` cleanups while at it.

The module does a few things:
1. enables you to add drive database entries
2. resolves drive symlinks which is needed if you want to pass a drive `by-path` as hddtemp chokes on colons
3. because we run this from a wrapper script, we can pass wildcards for the drives which is otherwise not possible directly using `ExecStart`.
3. limits the permissions somewhat

Ideally we lock this down properly with `DynamicUser = true;` but the problem is permissions needed to fetch SMART data which doesn't seem doable with the existing capabilities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
