### PR TITLE
stdenv/darwin: set NIX_COREFOUNDATION_RPATH via hook

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation-setup-hook.sh
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation-setup-hook.sh
@@ -1,0 +1,8 @@
+useCoreFoundationFramework () {
+  # Avoid overriding value set by the impure CF
+  if [ -z "${NIX_COREFOUNDATION_RPATH+x}" ]; then
+    export NIX_COREFOUNDATION_RPATH=@out@/Library/Frameworks
+  fi
+}
+
+addEnvHooks "$hostOffset" useCoreFoundationFramework

--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, ninja, python3, curl, libxml2, objc4, ICU
+, withRpathHook ? true }:
 
 let
   # 10.12 adds a new sysdir.h that our version of CF in the main derivation depends on, but
@@ -10,7 +11,7 @@ let
   };
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   name = "swift-corefoundation";
 
   src = fetchFromGitHub {
@@ -111,4 +112,6 @@ stdenv.mkDerivation {
       ln -s Versions/Current/$i $base/$i
     done
   '';
-}
+} // lib.optionalAttrs withRpathHook {
+  setupHook = ./corefoundation-setup-hook.sh;
+})


### PR DESCRIPTION
This will unset the variable in the cross stdenv where CF is taken out
of extraBuildInputs. This is useful for cross compilation to linux
where setting RPATH on glibc will break it in runtime.

The hook needs to be turned off during the bootstrapping to prevent
unwanted references between the stages.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes darwin -> gnu64 cross compilation

Closes: #103517

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Gaelan