### PR TITLE
xorg.libXt: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1015,11 +1015,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libXt = callPackage ({ stdenv, pkg-config, fetchurl, libICE, xorgproto, libSM, libX11 }: stdenv.mkDerivation {
-    name = "libXt-1.2.0";
+    name = "libXt-1.2.1";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/lib/libXt-1.2.0.tar.bz2";
-      sha256 = "0cbqlyssr8aia88c8i7z59z9d0kp3p2hp6683xhz9ndyv8qza7dk";
+      url = "mirror://xorg/individual/lib/libXt-1.2.1.tar.bz2";
+      sha256 = "0q1x7842r8rcn2m0q4q9f69h4qa097fyizs8brzx5ns62s7w1737";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -202,7 +202,7 @@ mirror://xorg/individual/lib/libXres-1.2.0.tar.bz2
 mirror://xorg/individual/lib/libXScrnSaver-1.2.3.tar.bz2
 mirror://xorg/individual/lib/libxshmfence-1.3.tar.bz2
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libXt-1.2.0.tar.bz2
+mirror://xorg/individual/lib/libXt-1.2.1.tar.bz2
 mirror://xorg/individual/lib/libXtst-1.2.3.tar.bz2
 mirror://xorg/individual/lib/libXv-1.0.11.tar.bz2
 mirror://xorg/individual/lib/libXvMC-1.0.12.tar.bz2


### PR DESCRIPTION
###### Motivation for this change
https://lists.x.org/archives/xorg-announce/2021-January/003070.html


###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).