### PR TITLE
stdenv/generic: throw when using stdenv.lib and disallowing aliases

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -153,11 +153,11 @@ let
       }) mkDerivation;
 
       # Slated for deprecation in 21.11
-      lib = builtins.trace
+      lib = if config.allowAlises then builtins.trace
         ( "Warning: `stdenv.lib` is deprecated and will be removed in the next release."
          + " Please use `pkgs.lib` instead."
          + " For more information see https://github.com/NixOS/nixpkgs/issues/108938")
-        lib;
+        lib else throw "`stdenv.lib` is a deprecated alias for `pkgs.lib`";
 
       inherit fetchurlBoot;
 


### PR DESCRIPTION
###### Motivation for this change
As requested by @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
