### PR TITLE
system/boot: add includeDefaultModules option

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -156,6 +156,16 @@ in
       description = "List of modules that are always loaded by the initrd.";
     };
 
+    boot.initrd.includeDefaultModules = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        This option, if set, adds a collection of default kernel modules
+        to <option>boot.initrd.availableKernelModules</option> and
+        <option>boot.initrd.kernelModules</option>.
+      '';
+    };
+
     system.modulesTree = mkOption {
       type = types.listOf types.path;
       internal = true;
@@ -195,7 +205,8 @@ in
   config = mkMerge
     [ (mkIf config.boot.initrd.enable {
         boot.initrd.availableKernelModules =
-          [ # Note: most of these (especially the SATA/PATA modules)
+          optionals config.boot.initrd.includeDefaultModules ([
+            # Note: most of these (especially the SATA/PATA modules)
             # shouldn't be included by default since nixos-generate-config
             # detects them, but I'm keeping them for now for backwards
             # compatibility.
@@ -235,10 +246,11 @@ in
 
             # x86 RTC needed by the stage 2 init script.
             "rtc_cmos"
-          ];
+          ]);
 
         boot.initrd.kernelModules =
-          [ # For LVM.
+          optionals config.boot.initrd.includeDefaultModules [
+            # For LVM.
             "dm_mod"
           ];
       })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I am trying to build NixOS for Raspberry Pi 3 with `boot.kernelPackages = pkgs.linuxPackages_rpi3` (this is needed to support dt overlays and Python GPIO libraries as the mainline kernel doesn't support these yet).

It turns out that `linuxPackages_rpi3` doesn't come with a lot of kernel modules that are added by NixOS configuration by default (see below for a detailed list of missing modules [1]). This means that the NixOS build fails with the following error:
```
root module: ahci
modprobe: FATAL: Module ahci not found in directory /nix/store/cirrb8rzsqsc91l9mwyglxqik2ia3vzk-linux-5.4.79-1.20201201-modules/lib/modules/5.4.79
```

This change allows us to omit the default modules and add just those that are provided by the platform-specific list of supported kernel modules.

###### Things done

I have built an SD image with this change and verified that it boots on a Raspberry Pi 3B (I was able to ssh into it and run my regular services on it).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


[1] The list of missing modules in the RPi3 kernel:
```
ahci
sata_nv
sata_via
sata_sis
sata_uli
ata_piix
pata_marvell
uhci_hcd
ehci_pci
ohci_pci
xhci_pci
```