### PR TITLE
mpich: 3.2.2 -> 3.4.1

### DIFF
--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -1,24 +1,52 @@
-{ lib, stdenv, fetchurl, perl, gfortran
-,  openssh, hwloc
+{ stdenv, lib, fetchurl, perl, gfortran
+, openssh, hwloc, autoconf, automake, libtool
+# device options are ch3 or ch4
+, device ? "ch4"
+# backend option are libfabric or ucx
+, ch4backend ? "libfabric"
+, ucx, libfabric
+# Process manager to build
+, withPm ? "hydra:gforker"
 } :
+
+assert (ch4backend == "ucx" || ch4backend == "libfabric");
 
 stdenv.mkDerivation  rec {
   pname = "mpich";
-  version = "3.3.2";
+  version = "3.4.1";
 
   src = fetchurl {
     url = "https://www.mpich.org/static/downloads/${version}/mpich-${version}.tar.gz";
-    sha256 = "1farz5zfx4cd0c3a0wb9pgfypzw0xxql1j1294z1sxslga1ziyjb";
+    sha256 = "09wpfw9lsrc84vcmfw94razd4xv4znx4mmg7rqmljvgg0jc96dl8";
   };
+
+  patches = [
+    # Reverts an upstream change that causes json-c test to fail
+    ./jsonc-test.patch
+  ];
+
+  # Required for the json-c patch
+  nativeBuildInputs = [ autoconf automake libtool ];
+
+  # Update configure after patch
+  postPatch = ''
+    cd modules/json-c
+    ./autogen.sh
+    cd ../..
+  '';
+
 
   configureFlags = [
     "--enable-shared"
     "--enable-sharedlib"
+    "--with-pm=${withPm}"
   ];
 
   enableParallelBuilding = true;
 
-  buildInputs = [ perl gfortran openssh hwloc ];
+  buildInputs = [ perl gfortran openssh hwloc ]
+    ++ lib.optional (ch4backend == "ucx") ucx
+    ++ lib.optional (ch4backend == "libfabric") libfabric;
 
   doCheck = true;
 
@@ -27,14 +55,7 @@ stdenv.mkDerivation  rec {
     sed -i 's:CC="gcc":CC=${stdenv.cc}/bin/gcc:' $out/bin/mpicc
     sed -i 's:CXX="g++":CXX=${stdenv.cc}/bin/g++:' $out/bin/mpicxx
     sed -i 's:FC="gfortran":FC=${gfortran}/bin/gfortran:' $out/bin/mpifort
-  ''
-  + lib.optionalString (!stdenv.isDarwin) ''
-    # /tmp/nix-build... ends up in the RPATH, fix it manually
-    for entry in $out/bin/mpichversion $out/bin/mpivars; do
-      echo "fix rpath: $entry"
-      patchelf --set-rpath "$out/lib" $entry
-    done
-    '';
+  '';
 
   meta = with lib; {
     description = "Implementation of the Message Passing Interface (MPI) standard";

--- a/pkgs/development/libraries/mpich/jsonc-test.patch
+++ b/pkgs/development/libraries/mpich/jsonc-test.patch
@@ -1,0 +1,62 @@
+--- b/modules/json-c/configure.ac
++++ a/modules/json-c/configure.ac
+@@ -75,7 +75,7 @@
+ AC_FUNC_VPRINTF
+ AC_FUNC_MEMCMP
+ AC_CHECK_FUNCS([realloc])
++AC_CHECK_FUNCS(strcasecmp strdup strerror snprintf vsnprintf vasprintf open strncasecmp setlocale)
+-AC_CHECK_FUNCS(strcasecmp strdup strerror snprintf vsnprintf open strncasecmp setlocale)
+ AC_CHECK_DECLS([INFINITY], [], [], [[#include <math.h>]])
+ AC_CHECK_DECLS([nan], [], [], [[#include <math.h>]])
+ AC_CHECK_DECLS([isnan], [], [], [[#include <math.h>]])
+--- b/modules/json-c/json_pointer.c
++++ a/modules/json-c/json_pointer.c
+@@ -208,7 +208,7 @@
+ 	}
+
+ 	va_start(args, path_fmt);
++	rc = vasprintf(&path_copy, path_fmt, args);
+-	rc = json_vasprintf(&path_copy, path_fmt, args);
+ 	va_end(args);
+
+ 	if (rc < 0)
+@@ -287,7 +287,7 @@
+
+ 	/* pass a working copy to the recursive call */
+ 	va_start(args, path_fmt);
++	rc = vasprintf(&path_copy, path_fmt, args);
+-	rc = json_vasprintf(&path_copy, path_fmt, args);
+ 	va_end(args);
+
+ 	if (rc < 0)
+--- b/modules/json-c/printbuf.c
++++ a/modules/json-c/printbuf.c
+@@ -129,7 +129,7 @@
+      would have been written - this code handles both cases. */
+   if(size == -1 || size > 127) {
+     va_start(ap, msg);
++    if((size = vasprintf(&t, msg, ap)) < 0) { va_end(ap); return -1; }
+-    if((size = json_vasprintf(&t, msg, ap)) < 0) { va_end(ap); return -1; }
+     va_end(ap);
+     printbuf_memappend(p, t, size);
+     free(t);
+--- b/modules/json-c/vasprintf_compat.h
++++ a/modules/json-c/vasprintf_compat.h
+@@ -8,8 +8,9 @@
+
+ #include "snprintf_compat.h"
+
++#if !defined(HAVE_VASPRINTF)
+ /* CAW: compliant version of vasprintf */
++static int vasprintf(char **buf, const char *fmt, va_list ap)
+-static int json_vasprintf(char **buf, const char *fmt, va_list ap)
+ {
+ #ifndef WIN32
+ 	static char _T_emptybuffer = '\0';
+@@ -40,5 +41,6 @@
+
+ 	return chars;
+ }
++#endif /* !HAVE_VASPRINTF */
+
+ #endif /* __vasprintf_compat_h */


### PR DESCRIPTION
###### Motivation for this change
https://raw.githubusercontent.com/pmodels/mpich/v3.4.1/RELEASE_NOTES
https://raw.githubusercontent.com/pmodels/mpich/v3.4.1/CHANGES

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
