### PR TITLE
python3Packages.panflute: init at 2.0.5

### DIFF
--- a/pkgs/development/python-modules/panflute/default.nix
+++ b/pkgs/development/python-modules/panflute/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchPypi
+, click
+, pyyaml
+, buildPythonPackage
+, isPy3k
+}:
+
+buildPythonPackage rec{
+  version = "2.0.5";
+  pname = "panflute";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ssmqcyr91f0gpl49lz6a9jkl17l06h6qcik24rlmva28ii6aszz";
+  };
+
+  propagatedBuildInputs = [ click pyyaml ];
+
+  meta = with lib; {
+    description = "A Pythonic alternative to John MacFarlane's pandocfilters, with extra helper functions";
+    homepage = "http://scorreia.com/software/panflute";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4638,6 +4638,8 @@ in {
 
   panel = callPackage ../development/python-modules/panel { };
 
+  panflute = callPackage ../development/python-modules/panflute { };
+
   papermill = callPackage ../development/python-modules/papermill { };
 
   paperspace = callPackage ../development/python-modules/paperspace { };


### PR DESCRIPTION
###### Motivation for this change

Panflute is an alternative to pandocfilters, I was very surprised to find it was not included yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
