### PR TITLE
lib/generators: fix toPretty throwing on (partially applied) builtins

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -236,12 +236,17 @@ rec {
         + libStr.concatMapStringsSep introSpace (go (indent + "  ")) v
         + outroSpace + "]"
     else if isFunction v then
-      let fna = lib.functionArgs v;
+      # functionArgs throws in case of (partially applied) builtins
+      # on nix before commit b2748c6e99239ff6803ba0da76c362790c8be192
+      # which includes current nix stable
+      # TODO remove tryEval workaround when the issue is resolved on nix stable
+      let fna = builtins.tryEval (lib.functionArgs v);
           showFnas = concatStringsSep ", " (libAttr.mapAttrsToList
                        (name: hasDefVal: if hasDefVal then name + "?" else name)
-                       fna);
-      in if fna == {}    then "<function>"
-                         else "<function, args: {${showFnas}}>"
+                       fna.value);
+      in if !fna.success || fna.value == {}
+         then "<function>"
+         else "<function, args: {${showFnas}}>"
     else if isAttrs    v then
       # apply pretty values if allowed
       if attrNames v == [ "__pretty" "val" ] && allowPrettyValues


### PR DESCRIPTION
###### Motivation for this change

An high level example case of the issue occuring can be found below:

```
nix-repl> lib.generators.toPretty {} (lib.concatStringsSep "\n")
error: 'functionArgs' requires a function, at /home/lukas/src/nix/nixpkgs/lib/trivial.nix:334:42

However this does not happen on other partially applied functions:

nix-repl> lib.generators.toPretty {} (lib.concatMapStringsSep "\n")
"<function>"
```

The issue, as it turns out is that while builtins are functions,
`builtins.functionArgs` throws if is passed a builtin or a partially
applied builtin:

```
nix-repl> lib.generators.toPretty {} builtins.toString
error: 'functionArgs' requires a function, at /home/lukas/src/nix/nixpkgs/lib/trivial.nix:334:42

nix-repl> lib.generators.toPretty {} (builtins.foldl' (a: b: a + b))
error: 'functionArgs' requires a function, at /home/lukas/src/nix/nixpkgs/lib/trivial.nix:334:42
```

~~I'm pretty sure this qualifies as a nix bug and should be filed
accordingly,~~ Edit: seems like this has been resolved in `nixUnstable` and
only the latest stable version of nix is affected.

We can work around this in lib.generators.toPretty by
using `tryEval` and falling back to {} which `functionArgs` _should_ return
for builtins.

The nix behavior is inconsistent to say the least:

```
nix-repl> builtins.functionArgs builtins.functionArgs
error: 'functionArgs' requires a function, at (string):1:1

nix-repl> builtins.typeOf builtins.functionArgs
"lambda"

builtins.functionArgs (a: 1 + a)
{ }

nix-repl> builtins.typeOf (a: 1 + a)
"lambda"
```
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
