### PR TITLE
pythonPackages.prometheus-flask-exporter: init at 0.18.1

### DIFF
--- a/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
+++ b/pkgs/development/python-modules/prometheus-flask-exporter/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flask
+, prometheus_client
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "prometheus-flask-exporter";
+  version = "0.18.1";
+
+  src = fetchFromGitHub {
+    owner = "rycus86";
+    repo = "prometheus_flask_exporter";
+    rev = version;
+    sha256 = "1dwisp681w0f6zf0000rxd3ksdb48zb9mr38qfdqk2ir24y8w370";
+  };
+
+  propagatedBuildInputs = [ flask prometheus_client ];
+
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "tests/" ];
+
+  meta = with lib; {
+    description = "Prometheus exporter for Flask applications";
+    homepage = "https://github.com/rycus86/prometheus_flask_exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lbpdt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4721,6 +4721,8 @@ in {
 
   prometheus_client = callPackage ../development/python-modules/prometheus_client { };
 
+  prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };
+
   promise = callPackage ../development/python-modules/promise { };
 
   prompt_toolkit = let


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package allows a python Flask application to easily expose Prometheus metrics.

It is not a standalone exporter but is meant to be used as a library, so I didn't add a Prometheus exporter for NixOS under `nixos/modules/services/monitoring/prometheus/exporters/`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
