### PR TITLE
tcsh: workaround source moving to old subdirectory after new release

### DIFF
--- a/pkgs/shells/tcsh/default.nix
+++ b/pkgs/shells/tcsh/default.nix
@@ -9,8 +9,11 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     urls = [
       "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/${pname}-${version}.tar.gz"
+      "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/${pname}-${version}.tar.gz"
       "ftp://ftp.astron.com/pub/tcsh/${pname}-${version}.tar.gz"
+      "ftp://ftp.astron.com/pub/tcsh/old/${pname}-${version}.tar.gz"
       "ftp://ftp.funet.fi/pub/unix/shells/tcsh/${pname}-${version}.tar.gz"
+      "ftp://ftp.funet.fi/pub/unix/shells/tcsh/old/${pname}-${version}.tar.gz"
     ];
     sha256 = "sha256-viz9ZT0qDH9QbS3RTBIyS6dJvUhAN75t9Eo5c/UiYrc=";
   };


### PR DESCRIPTION
###### Motivation for this change

Upstream moves the source to an `old` subdirectory when a new version is released. Add this subdirectory to the `urls` so downloading doesn't break when this occurs (as just finished happening to the NixOS 20.09 release).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
