### PR TITLE
python3Packages.cachetools: 4.1.1 -> 4.2.1

### DIFF
--- a/pkgs/development/python-modules/cachetools/default.nix
+++ b/pkgs/development/python-modules/cachetools/default.nix
@@ -1,12 +1,16 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27 }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+}:
 
 buildPythonPackage rec {
   pname = "cachetools";
-  version = "4.1.1";
+  version = "4.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20";
+    sha256 = "sha256-9Gninnqkz/ZNjeSq2VznbejqESWhbGjg2T9lw8Pckuk=";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cachetools/default.nix
+++ b/pkgs/development/python-modules/cachetools/default.nix
@@ -1,21 +1,28 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, isPy27
+, fetchFromGitHub
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "cachetools";
   version = "4.2.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-9Gninnqkz/ZNjeSq2VznbejqESWhbGjg2T9lw8Pckuk=";
+  src = fetchFromGitHub {
+    owner = "tkem";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1b662ph8m2d05d2vi3izgnr6v7h9zfvscfsaaw8nhdmmm15ivfa6";
   };
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "cachetools" ];
 
   meta = with lib; {
     description = "Extensible memoizing collections and decorators";
     homepage = "https://github.com/tkem/cachetools";
-    license = licenses.mit;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1119,16 +1119,7 @@ in {
 
   cachelib = callPackage ../development/python-modules/cachelib { };
 
-  cachetools = let
-    cachetools' = callPackage ../development/python-modules/cachetools { };
-    cachetools_2 = cachetools'.overridePythonAttrs (oldAttrs: rec {
-      version = "3.1.1";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "16m69l6n6y1r1y7cklm92rr7v69ldig2n3lbl3j323w5jz7d78lf";
-      };
-    });
-  in if isPy3k then cachetools' else cachetools_2;
+  cachetools = callPackage ../development/python-modules/cachetools { };
 
   cachy = callPackage ../development/python-modules/cachy { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 4.2.1

Change log: https://github.com/tkem/cachetools/blob/master/CHANGELOG.rst#v421-2021-01-24

This PR also enables the test as GitHub is now used to get the source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
