### PR TITLE
molden: fix outdated URLs

### DIFF
--- a/pkgs/applications/science/chemistry/molden/default.nix
+++ b/pkgs/applications/science/chemistry/molden/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   pname = "molden";
 
   src = fetchurl {
-    url = "ftp://ftp.cmbi.ru.nl/pub/molgraph/molden/molden${version}.tar.gz";
+    url = "ftp://ftp.cmbi.umcn.nl/pub/molgraph/molden/molden${version}.tar.gz";
     sha256 = "02qi16pz2wffn3cc47dpjqhfafzwfmb79waw4nnhfyir8a4h3cq1";
   };
 
@@ -31,10 +31,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
      description = "Display and manipulate molecular structures";
-     homepage = "http://www.cmbi.ru.nl/molden/";
+     homepage = "http://www3.cmbi.umcn.nl/molden/";
      license = {
        fullName = "Free for academic/non-profit use";
-       url = "http://www.cmbi.ru.nl/molden/CopyRight.html";
+       url = "http://www3.cmbi.umcn.nl/molden/CopyRight.html";
        free = false;
      };
      platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Fix outdated URLs and unbreak build. Needs back port to 20.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
