### PR TITLE
test-driver: Run ptpython REPL at global scope

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -900,6 +900,7 @@ def run_tests() -> None:
                 traceback.print_exc()
                 sys.exit(1)
     else:
+        # Don't use locals(); see https://github.com/NixOS/nixpkgs/pull/111486.
         ptpython.repl.embed(globals())
 
     # TODO: Collect coverage data

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -885,7 +885,7 @@ def join_all() -> None:
 
 
 def test_script() -> None:
-    exec(os.environ["testScript"])
+    exec(os.environ["testScript"], globals())
 
 
 def run_tests() -> None:
@@ -900,7 +900,7 @@ def run_tests() -> None:
                 traceback.print_exc()
                 sys.exit(1)
     else:
-        ptpython.repl.embed(locals(), globals())
+        ptpython.repl.embed(globals())
 
     # TODO: Collect coverage data
 


### PR DESCRIPTION
###### Motivation for this change

This is a workaround for prompt-toolkit/ptpython#279, which was making it impossible to run the installer test interactively:

```pytb
>>> start_all()
…
>>> test_script()
…
machine # [  382.137683] reboot: Power down
(7.06 seconds)
(8.23 seconds)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/lbn2xnibdcvpgkpbrkdh2vlf1ap6930v-nixos-test-driver/bin/.nixos-test-driver-wrapped", line 888, in test_script
    exec(os.environ["testScript"])
  File "<string>", line 69, in <module>
  File "<string>", line 18, in create_machine_named
NameError: name 'default_flags' is not defined

name 'default_flags' is not defined
```

There’s no reason to expose the local variables of the `run_tests` function, anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
