### PR TITLE
legendary-gl: Remove wchresta from maintainers

### DIFF
--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -29,6 +29,6 @@ buildPythonApplication rec {
     description = "A free and open-source Epic Games Launcher alternative";
     homepage = "https://github.com/derrod/legendary";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ wchresta equirosa ];
+    maintainers = with maintainers; [ equirosa ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I created this derivation due to because it was requested in #88963. I
do not use legendary-gl myself. Now that we have another maintainer,
there is no good reason for me to stay maintainer of this.



###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
