### PR TITLE
ocamlPackages.ocaml-migrate-parsetree: use Dune 2

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/1.8.x.nix
@@ -1,8 +1,10 @@
-{ lib, fetchFromGitHub, buildDunePackage, result, ppx_derivers }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, result, ppx_derivers }:
 
 buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
    version = "1.8.0";
+
+   useDune2 = lib.versionAtLeast ocaml.version "4.08";
 
    src = fetchFromGitHub {
      owner = "ocaml-ppx";


### PR DESCRIPTION
###### Motivation for this change

Prepare for OCaml 4.12

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
