### PR TITLE
rage: skip check if not x86

### DIFF
--- a/pkgs/tools/security/rage/default.nix
+++ b/pkgs/tools/security/rage/default.nix
@@ -21,6 +21,9 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
+  # cargo test has an x86-only dependency
+  doCheck = stdenv.hostPlatform.isx86;
+
   postBuild = ''
     cargo run --example generate-docs
     cargo run --example generate-completions


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This package was failing to build on aarch64 because a [development dependency in the check phase is x86 only](https://gitlab.com/sio4/code/criterion-cycles-per-byte/-/blob/master/src/lib.rs#L34).

###### Things done

Set `doCheck = true` only for x86 systems.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
