### PR TITLE
ocamlPackages.kafka: 0.4 → 0.5

### DIFF
--- a/pkgs/development/ocaml-modules/kafka/default.nix
+++ b/pkgs/development/ocaml-modules/kafka/default.nix
@@ -1,18 +1,16 @@
-{ lib, fetchFromGitHub, buildDunePackage, base, cmdliner, ocaml_lwt,
-  rdkafka, zlib }:
+{ lib, fetchurl, buildDunePackage
+, rdkafka, zlib }:
 
 buildDunePackage rec {
   pname = "kafka";
-  version = "0.4";
+  version = "0.5";
 
-  src = fetchFromGitHub {
-    owner = "didier-wenzek";
-    repo = "ocaml-kafka";
-    rev = version;
-    sha256 = "0lb8x0wh7sf8v9mjwhq32azjz54kw49fsjfb7m76z4nhxfkjw5hy";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/didier-wenzek/ocaml-kafka/releases/download/${version}/kafka-${version}.tbz";
+    sha256 = "0m9212yap0a00hd0f61i4y4fna3141p77qj3mm7jl1h4q60jdhvy";
   };
-
-  buildInputs = [ base cmdliner ocaml_lwt zlib ];
 
   propagatedBuildInputs = [ rdkafka zlib ];
 
@@ -20,7 +18,7 @@ buildDunePackage rec {
     homepage = "https://github.com/didier-wenzek/ocaml-kafka";
     description = "OCaml bindings for Kafka";
     license     = licenses.mit;
-    maintainers = [ maintainers.rixed ];
+    maintainers = [ maintainers.vbgl ];
   };
 }
 

--- a/pkgs/development/ocaml-modules/kafka/lwt.nix
+++ b/pkgs/development/ocaml-modules/kafka/lwt.nix
@@ -1,0 +1,19 @@
+{ buildDunePackage
+, kafka
+, lwt
+, cmdliner
+}:
+
+buildDunePackage rec {
+  pname = "kafka_lwt";
+
+  inherit (kafka) version useDune2 src;
+
+  buildInputs = [ cmdliner ];
+
+  propagatedBuildInputs = [ kafka lwt ];
+
+  meta = kafka.meta // {
+    description = "OCaml bindings for Kafka, Lwt bindings";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -506,6 +506,8 @@ let
 
     kafka = callPackage ../development/ocaml-modules/kafka { };
 
+    kafka_lwt = callPackage ../development/ocaml-modules/kafka/lwt.nix { };
+
     ke = callPackage ../development/ocaml-modules/ke { };
 
     lablgl = callPackage ../development/ocaml-modules/lablgl { };


### PR DESCRIPTION
###### Motivation for this change

Fixes & improvements: https://github.com/didier-wenzek/ocaml-kafka/blob/0.5/CHANGES.md#05
Use Dune 2.

cc maintainer @rixed

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).