### PR TITLE
carla: fixed crash on launch "No module named 'PyQt5.sip'"

### DIFF
--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
       patchPythonScript "$f"
     done
     patchPythonScript "$out/share/carla/carla_settings.py"
+    patchPythonScript "$out/share/carla/carla_database.py"
 
     for program in $out/bin/*; do
       wrapQtApp "$program" \

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -34,10 +34,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     file liblo alsaLib fluidsynth ffmpeg_3 jack2 libpulseaudio libsndfile
-  ] ++ pythonPath
-    ++ optional withQt qtbase
+  ] ++ optional withQt qtbase
     ++ optional withGtk2 gtk2
     ++ optional withGtk3 gtk3;
+
+  propagatedBuildInputs = pythonPath;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently in master, Carla fails to launch with the error:

```
Traceback (most recent call last):
  File "/nix/store/s2k98gvi5p4srqsrspjyszdk9nh2w8r9-carla-2.2.0/share/carla/carla", line 23, in <module>
    from carla_host import *
  File "/nix/store/s2k98gvi5p4srqsrspjyszdk9nh2w8r9-carla-2.2.0/share/carla/carla_host.py", line 40, in <module>
    from PyQt5.QtCore import (
ModuleNotFoundError: No module named 'PyQt5.sip'
```

This failure was traced back to commit 6347fdf07101e636c4d79bb26f23b064b9d778d3 from #108041, thanks to `git bisect` (thank you for your existence).

After that, it was kind of a shot in the dark, I remembered that Python dependencies needed to be specified under "propagatedBuildInputs" and not "buildInputs". I am not sure why the python wrapping was missing `PyQt5_sip` and other things, but it should be fixed, now.

Also fixed `carla-database` since I noticed it wasn't properly wrapped.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
