### PR TITLE
rambox-pro: 1.4.1 → 1.5.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/pro.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/pro.nix
@@ -4,14 +4,14 @@ let
   mkRambox = opts: callPackage (import ./rambox.nix opts) { };
 in mkRambox rec {
   pname = "rambox-pro";
-  version = "1.4.1";
+  version = "1.5.0";
 
   desktopName = "Rambox Pro";
 
   src = {
     x86_64-linux = fetchurl {
       url = "https://github.com/ramboxapp/download/releases/download/v${version}/RamboxPro-${version}-linux-x64.AppImage";
-      sha256 = "18383v3g26hd1czvw06gmjn8bdw2w9c7zb04zkfl6szgakrv26x4";
+      sha256 = "1g7lrjm8yxklqpc2mp8gy0g61wfilr15dl80r3sh6pa5b4k5spir";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There is a newer version of the rambox-pro package, I have tested this extensively locally and it appears to be working perfectly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
