### PR TITLE
[20.09] pythonPackages.bottle: add patch for CVE-2020-28473

### DIFF
--- a/pkgs/development/python-modules/bottle/default.nix
+++ b/pkgs/development/python-modules/bottle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, setuptools }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, setuptools }:
 
 buildPythonPackage rec {
   pname = "bottle";
@@ -8,6 +8,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0819b74b145a7def225c0e83b16a4d5711fde751cd92bae467a69efce720f69e";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2020-28473.patch";
+      url = "https://github.com/bottlepy/bottle/commit/57a2f22e0c1d2b328c4f54bf75741d74f47f1a6b.patch";
+      sha256 = "0jgvpmsq5zswr077ql5h4kmglqh7z1hf0w5gr8x59am0sgjcz21v";
+    })
+  ];
 
   propagatedBuildInputs = [ setuptools ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2020-28473

Already fixed in master with a bump.

Exact commit identification from https://github.com/bottlepy/bottle/issues/1331

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
