### PR TITLE
php.extensions.smbclient: init at 1.0.4

### DIFF
--- a/pkgs/development/php-packages/smbclient/default.nix
+++ b/pkgs/development/php-packages/smbclient/default.nix
@@ -1,0 +1,14 @@
+{ buildPecl, lib, pkgs }:
+buildPecl {
+  pname = "smbclient";
+  version = "1.0.4";
+  sha256 = "07p72m5kbdyp3r1mfxhiayzdvymhc8afwcxa9s86m96sxbmlbbp8";
+
+  # TODO: remove this when upstream merges a fix - https://github.com/eduardok/libsmbclient-php/pull/66
+  LIBSMBCLIENT_INCDIR = "${pkgs.samba.dev}/include/samba-4.0";
+
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [ pkgs.samba ];
+
+  meta.maintainers = lib.teams.php.members;
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -134,6 +134,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     redis = callPackage ../development/php-packages/redis { };
 
+    smbclient = callPackage ../development/php-packages/smbclient { };
+
     sqlsrv = callPackage ../development/php-packages/sqlsrv { };
 
     v8 = buildPecl {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I'm probably going to need this at some point. I also have a sneaking suspicion that `nextcloud` could make use of this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
