### PR TITLE
plexamp: 3.3.1 -> 3.4.1

### DIFF
--- a/pkgs/applications/audio/plexamp/default.nix
+++ b/pkgs/applications/audio/plexamp/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "plexamp";
-  version = "3.3.1";
+  version = "3.4.1";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-${version}.AppImage";
     name="${pname}-${version}.AppImage";
-    sha256 = "6/asP8VR+rJ52lKKds46gSw1or9suUEmyR75pjdWHIQ=";
+    sha256 = "Vv+e1q5ThuXDPX8baSU+7/U63p6/dvh0ZvScO1Loj+U=";
   };
 
   appimageContents = appimageTools.extractType2 {


### PR DESCRIPTION
###### Motivation for this change

Update to latest release

https://forums.plex.tv/t/plexamp-release-notes/221280/last

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
