### PR TITLE
klipper: 0.9.1 -> unstable-2021-01-31

### DIFF
--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , python2
+, unstableGitUpdater
 }:
 stdenv.mkDerivation rec {
   name = "klipper";
@@ -38,6 +39,8 @@ stdenv.mkDerivation rec {
     chmod 755 $out/lib/klipper/klippy.py
     runHook postInstall
   '';
+
+  passthru.updateScript = unstableGitUpdater { url = meta.homepage; };
 
   meta = with lib; {
     description = "The Klipper 3D printer firmware";

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation rec {
   name = "klipper";
-  version = "0.9.1";
+  version = "unstable-2021-01-31";
 
   src = fetchFromGitHub {
     owner = "KevinOConnor";
     repo = "klipper";
-    rev = "v${version}";
-    sha256 = "1wgklngsz6xxl25qxi9fkqhbyhwy61iyyk76ycq68b3miayrkgpj";
+    rev = "ef4d9c3abd30ae8a485020fd9ff2fb4529a143b3";
+    sha256 = "puAkSGL0DD0JUWejPdzr7zKIW2UP2soBBtgm2msUKzA=";
   };
 
   sourceRoot = "source/klippy";


### PR DESCRIPTION
###### Motivation for this change
Regular maintenance

###### Things done
```
- klipper: use unstableGitUpdater
- klipper: 0.9.1 -> unstable-2021-01-31
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
