### PR TITLE
dmd: remove references to dmd-bootstrap

### DIFF
--- a/pkgs/development/compilers/dmd/generic.nix
+++ b/pkgs/development/compilers/dmd/generic.nix
@@ -6,6 +6,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, removeReferencesTo
 , makeWrapper
 , which
 , writeTextFile
@@ -20,7 +21,8 @@
 , installShellFiles
 , git
 , unzip
-, dmd_bin ? "${callPackage ./bootstrap.nix { }}/bin"
+, dmdBootstrap ? callPackage ./bootstrap.nix { }
+, dmd_bin ? "${dmdBootstrap}/bin"
 }:
 
 let
@@ -208,6 +210,12 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  preFixup = ''
+    find $out/bin -type f -exec ${removeReferencesTo}/bin/remove-references-to -t ${dmd_bin}/dmd '{}' +
+  '';
+
+  disallowedReferences = [ dmdBootstrap ];
 
   meta = with lib; {
     description = "Official reference compiler for the D language";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #111475 dmd keeps references to boostrap compiler

###### Things done
Add `preFixup` phase and use `remove-references-to` to remove all references to `dmd-bootstrap`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
