### PR TITLE
firewall: support multicast

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -179,9 +179,15 @@ let
       ) cfg.allowedUDPPortRanges
     ) allInterfaces)}
 
-    # Accept IPv4 multicast.  Not a big security risk since
-    # probably nobody is listening anyway.
-    #iptables -A nixos-fw -d 224.0.0.0/4 -j nixos-fw-accept
+    ${optionalString cfg.allowBroadcast ''
+      # Accept broadcast.
+      ip46tables -A nixos-fw -m pkttype --pkt-type broadcast -j nixos-fw-accept
+    ''}
+
+    ${optionalString cfg.allowMulticast ''
+      # Accept multicast.
+      ip46tables -A nixos-fw -m pkttype --pkt-type multicast -j nixos-fw-accept
+    ''}
 
     # Optionally respond to ICMPv4 pings.
     ${optionalString cfg.allowPing ''
@@ -399,6 +405,24 @@ in
             ("pings").  ICMPv6 pings are always allowed because the
             larger address space of IPv6 makes network scanning much
             less effective.
+          '';
+      };
+
+      allowBroadcast = mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          ''
+            Whether to allow broadcast traffic.
+          '';
+      };
+
+      allowMulticast = mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          ''
+            Whether to allow multicast traffic.
           '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Instead of having multicast support commented out, make it configurable (and defaulting to off).

Been using this for *years* - just didn't get around to upstreaming it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
