### PR TITLE
hplip: 3.20.5 -> 3.20.11

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig
 , cups, zlib, libjpeg, libusb1, python3Packages, sane-backends
 , dbus, file, ghostscript, usbutils
-, net-snmp, openssl, perl, nettools
+, net-snmp, openssl, perl, nettools, avahi
 , bash, coreutils, utillinux
 # To remove references to gcc-unwrapped
 , removeReferencesTo, qt5
@@ -13,17 +13,17 @@
 
 let
 
-  name = "hplip-${version}";
-  version = "3.20.5";
+  pname = "hplip";
+  version = "3.20.11";
 
   src = fetchurl {
-    url = "mirror://sourceforge/hplip/${name}.tar.gz";
-    sha256 = "004bbd78487b7803cdcf2a96b00de938797227068c4de43ee7ad7d174c4e475a";
+    url = "mirror://sourceforge/hplip/${pname}-${version}.tar.gz";
+    sha256 = "CxZ1s9jnCaEyX+hj9arOO9NxB3mnPq6Gj3su6aVv2xE=";
   };
 
   plugin = fetchurl {
-    url = "https://developers.hp.com/sites/default/files/${name}-plugin.run";
-    sha256 = "ff3dedda3158be64b985efbf636890ddda5b271ae1f1fbd788219e1344a9c2e7";
+    url = "https://developers.hp.com/sites/default/files/${pname}-${version}-plugin.run";
+    sha256 = "r8PoQQFfjdHKySPCFwtDR8Tl6v5Eag9gXpBAp6sCF9Q=";
   };
 
   hplipState = substituteAll {
@@ -50,7 +50,7 @@ assert withPlugin -> builtins.elem hplipArch pluginArches
   || throw "HPLIP plugin not supported on ${stdenv.hostPlatform.system}";
 
 python3Packages.buildPythonApplication {
-  inherit name src;
+  inherit pname version src;
   format = "other";
 
   buildInputs = [
@@ -65,6 +65,7 @@ python3Packages.buildPythonApplication {
     openssl
     perl
     zlib
+    avahi
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I was having issues with `hplip` as described here: https://discourse.nixos.org/t/hp-printer-installation-failure/10603

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
