### PR TITLE
ssh-to-pgp: init at 1.0.0

### DIFF
--- a/pkgs/tools/security/ssh-to-pgp/default.nix
+++ b/pkgs/tools/security/ssh-to-pgp/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, buildGoModule, gnupg }:
+
+buildGoModule rec {
+  pname = "ssh-to-pgp";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "ssh-to-pgp";
+    rev = version;
+    sha256 = "sha256-TDrpnWAez8muysMdmKFBDZfK8CyhGn1VqHB8+zD6jSk=";
+  };
+
+  vendorSha256 = "sha256-ZF/WsmqmGHZIAGTPKJ70UhtmssNhiInEZfzrKxQLw9I=";
+
+  checkInputs = [ gnupg ];
+  checkPhase = ''
+    HOME=$TMPDIR go test .
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Convert ssh private keys to PGP";
+    homepage = "https://github.com/Mic92/ssh-to-pgp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mic92 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7900,6 +7900,8 @@ in
 
   ssh-chat = callPackage ../applications/networking/instant-messengers/ssh-chat { };
 
+  ssh-to-pgp = callPackage ../tools/security/ssh-to-pgp { };
+
   suricata = callPackage ../applications/networking/ids/suricata {
     python = python3;
   };


### PR DESCRIPTION
This is needed for onboarding sops-nix.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
