### PR TITLE
nixos/xserver: use modern video drivers

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -150,7 +150,6 @@
 <xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy390" ];
 <xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy340" ];
 <xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy304" ];
-<xref linkend="opt-services.xserver.videoDrivers"/> = [ "nvidiaLegacy173" ];
 </programlisting>
    You may need to reboot after enabling this driver to prevent a clash with
    other kernel modules.
@@ -159,21 +158,16 @@
  <simplesect xml:id="sec-x11--graphics-cards-amd">
   <title>Proprietary AMD drivers</title>
   <para>
-   AMD provides a proprietary driver for its graphics cards that has better 3D
-   performance than the X.org drivers. It is not enabled by default because
-   it’s not free software. You can enable it as follows:
+   AMD provides a proprietary driver for its graphics cards that is not
+   enabled by default because it’s not Free Software, is often broken
+   in nixpkgs and as of this writing doesn't offer more features or
+   performance. If you still want to use it anyway, you need to explicitly set:
 <programlisting>
-<xref linkend="opt-services.xserver.videoDrivers"/> = [ "ati_unfree" ];
+<xref linkend="opt-services.xserver.videoDrivers"/> = [ "amdgpu-pro" ];
 </programlisting>
    You will need to reboot after enabling this driver to prevent a clash with
    other kernel modules.
   </para>
-  <note>
-  <para>
-   For recent AMD GPUs you most likely want to keep either the defaults
-   or <literal>"amdgpu"</literal> (both free).
-  </para>
-  </note>
  </simplesect>
  <simplesect xml:id="sec-x11-touchpads">
   <title>Touchpads</title>

--- a/nixos/doc/manual/release-notes/rl-2105.xml
+++ b/nixos/doc/manual/release-notes/rl-2105.xml
@@ -539,6 +539,11 @@ self: super:
      <package>imagemagick6Big</package> if you need the older version.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <xref linkend="opt-services.xserver.videoDrivers" /> no longer uses the deprecated <literal>cirrus</literal> and <literal>vesa</literal> device dependent X drivers by default. It also enables both <literal>amdgpu</literal> and <literal>nouveau</literal> drivers by default now.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -251,11 +251,10 @@ in
 
       videoDrivers = mkOption {
         type = types.listOf types.str;
-        # !!! We'd like "nv" here, but it segfaults the X server.
-        default = [ "radeon" "cirrus" "vesa" "modesetting" ];
+        default = [ "amdgpu" "radeon" "nouveau" "modesetting" "fbdev" ];
         example = [
-          "ati_unfree" "amdgpu" "amdgpu-pro"
-          "nv" "nvidia" "nvidiaLegacy390" "nvidiaLegacy340" "nvidiaLegacy304"
+          "nvidia" "nvidiaLegacy390" "nvidiaLegacy340" "nvidiaLegacy304"
+          "amdgpu-pro"
         ];
         # TODO(@oxij): think how to easily add the rest, like those nvidia things
         relatedPackages = concatLists


### PR DESCRIPTION
This is a rebase of https://github.com/NixOS/nixpkgs/pull/100402

###### Things done

I tested the changes to the manual (in particular it builds).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
