### PR TITLE
Fix deprecated ?GPL* licenses, adopt a package.

### DIFF
--- a/pkgs/applications/misc/nrsc5/default.nix
+++ b/pkgs/applications/misc/nrsc5/default.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/theori-io/nrsc5";
     description = "HD-Radio decoder for RTL-SDR";
     platforms = lib.platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ markuskowa ];
   };
 }

--- a/pkgs/applications/radio/multimon-ng/default.nix
+++ b/pkgs/applications/radio/multimon-ng/default.nix
@@ -37,7 +37,8 @@ stdenv.mkDerivation {
       ZVEI3 DZVEI PZVEI EEA EIA CCIR MORSE CW
     '';
     homepage = "https://github.com/EliasOenal/multimon-ng";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
+    maintainers = [ maintainers.markuskowa ];
   };
 }

--- a/pkgs/applications/radio/soapybladerf/default.nix
+++ b/pkgs/applications/radio/soapybladerf/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation {
   meta = with lib; {
     homepage = "https://github.com/pothosware/SoapyBladeRF";
     description = "SoapySDR plugin for BladeRF devices";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     maintainers = with maintainers; [ markuskowa ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/radio/welle-io/default.nix
+++ b/pkgs/applications/radio/welle-io/default.nix
@@ -43,7 +43,7 @@ in mkDerivation {
     description = "A DAB/DAB+ Software Radio";
     homepage = "https://www.welle.io/";
     maintainers = with maintainers; [ ck3d markuskowa ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = with platforms; [ "x86_64-linux" "i686-linux" ] ++ darwin;
   };
 }

--- a/pkgs/applications/science/astronomy/gpredict/default.nix
+++ b/pkgs/applications/science/astronomy/gpredict/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation {
       well. Gpredict uses the SGP4/SDP4 algorithms, which are compatible with the
       NORAD Keplerian elements.
     '';
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
     homepage = "http://gpredict.oz9aec.net/";
     maintainers = [ maintainers.markuskowa maintainers.cmcdragonkai ];

--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -69,7 +69,7 @@ in stdenv.mkDerivation {
     description = "Advanced quantum chemistry software package";
     homepage = "https://gitlab.com/Molcas/OpenMolcas";
     maintainers = [ maintainers.markuskowa ];
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -16,7 +16,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     homepage = "https://github.com/tibirna/qgit";
     description = "Graphical front-end to Git";
     maintainers = with maintainers; [ peterhoeg markuskowa ];

--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Speech codec designed for communications quality speech at low data rates";
     homepage = "http://www.rowetel.com/blog/?page_id=452";
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [ markuskowa ];
   };

--- a/pkgs/os-specific/linux/linuxptp/default.nix
+++ b/pkgs/os-specific/linux/linuxptp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Implementation of the Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux";
     homepage = "http://linuxptp.sourceforge.net/";
     maintainers = [ maintainers.markuskowa ];
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/computing/slurm-spank-x11/default.nix
+++ b/pkgs/servers/computing/slurm-spank-x11/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/hautreux/slurm-spank-x11";
     description = "Plugin for SLURM to allow for interactive X11 sessions";
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ markuskowa ];
   };
 }

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.schedmd.com/";
     description = "Simple Linux Utility for Resource Management";
     platforms = platforms.linux;
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ jagajaga markuskowa ];
   };
 }

--- a/pkgs/tools/misc/snapper/default.nix
+++ b/pkgs/tools/misc/snapper/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tool for Linux filesystem snapshot management";
     homepage = "http://snapper.io";
-    license = licenses.gpl2;
+    license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ tstrobel markuskowa ];
   };


### PR DESCRIPTION
###### Motivation for this change
Fix outdated SPDX license identifiers (gplN -> gplNOnly/gplNPlus) in packages maintained by me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
