### PR TITLE
lout: add patch for CVE-2019-19917 and CVE-2019-19918

### DIFF
--- a/pkgs/tools/typesetting/lout/CVE-2019-19917-and-CVE-2019-19918.patch
+++ b/pkgs/tools/typesetting/lout/CVE-2019-19917-and-CVE-2019-19918.patch
@@ -1,0 +1,95 @@
+--- a/externs.h
++++ b/externs.h
+@@ -260,6 +260,9 @@ If you're compiling this, you've got the
+ /*                      that can appear correctly on one page.  Can be       */
+ /*                      increased to any small positive integer.             */
+ /*                                                                           */
++/*  MAX_FORMAT          The maximum number of characters for sscanf formats  */
++/*                      for splitting strings with tab-delimited fields.     */
++/*                                                                           */
+ /*****************************************************************************/
+ 
+ #define	MAX_FULL_LENGTH	8388607	/* 2**23 - 1, about 148 metres */
+@@ -275,6 +278,7 @@ If you're compiling this, you've got the
+ #define	MAX_LEX_STACK	20
+ #define	MAX_CHARS	256
+ #define MAX_HCOPIES	3
++#define MAX_FORMAT	100
+ 
+ /*****************************************************************************/
+ /*                                                                           */
+--- a/z02.c
++++ b/z02.c
+@@ -378,7 +378,7 @@ static void srcnext(void)
+   if( blksize != 0 && chpt < limit )
+   { debugcond0(DLA, DD, stack_free <= 1, "srcnext: transferring.");
+     col = buf;
+-    while( chtbl[(*--col = *--limit)] != NEWLINE );
++    while( col > mem_block && chtbl[(*--col = *--limit)] != NEWLINE );
+     frst = col + 1;  limit++;  blksize = 0;
+   }
+ 
+--- a/z33.c
++++ b/z33.c
+@@ -847,6 +847,7 @@ BOOLEAN DbRetrieve(OBJECT db, BOOLEAN ga
+ BOOLEAN DbRetrieveNext(OBJECT db, BOOLEAN *gall, OBJECT *sym, FULL_CHAR *tag,
+   FULL_CHAR *seq, FILE_NUM *dfnum, long *dfpos, int *dlnum, long *cont)
+ { FULL_CHAR line[MAX_BUFF], *cline, fname[MAX_BUFF]; int symnum;
++  char format[MAX_FORMAT];
+   ifdebug(DPP, D, ProfileOn("DbRetrieveNext"));
+   debug2(DBS, DD, "DbRetrieveNext( %s, %ld )", string(db), *cont);
+   assert(reading(db), "DbRetrieveNext: not reading");
+@@ -858,6 +859,8 @@ BOOLEAN DbRetrieveNext(OBJECT db, BOOLEA
+     return FALSE;
+   }
+ 
++  sprintf(format, "%%d&%%%d[^\t]\t%%%d[^\t]\t%%*[^\t]\t%%ld\t%%d\t%%%d[^\n\f]", MAX_BUFF-1, MAX_BUFF-1, MAX_BUFF-1);
++
+   if( in_memory(db) )
+   {
+     /* get next entry from internal database */
+@@ -868,7 +871,7 @@ BOOLEAN DbRetrieveNext(OBJECT db, BOOLEA
+     }
+     cline = (FULL_CHAR *) db_lines(db)[*cont];
+     *gall = (cline[0] == '0' ? 1 : 0);
+-    sscanf((char *)&cline[*gall], "%d&%[^\t]\t%[^\t]\t%*[^\t]\t%ld\t%d\t%[^\n\f]",
++    sscanf((char *)&cline[*gall], format,
+       &symnum, tag, seq, dfpos, dlnum, fname);
+     *cont = *cont + 1;
+   }
+@@ -882,7 +885,7 @@ BOOLEAN DbRetrieveNext(OBJECT db, BOOLEA
+       return FALSE;
+     }
+     *gall = (line[0] == '0' ? 1 : 0);
+-    sscanf((char *)&line[*gall], "%d&%[^\t]\t%[^\t]\t%*[^\t]\t%ld\t%d\t%[^\n\f]",
++    sscanf((char *)&line[*gall], format,
+       &symnum, tag, seq, dfpos, dlnum, fname);
+     *cont = ftell(db_filep(db));
+   }
+--- a/z39.c
++++ b/z39.c
+@@ -79,11 +79,13 @@ int strcollcmp(char *a, char *b)
+ int strcollcmp(char *a, char *b)
+ { char a1[MAX_BUFF], a2[MAX_BUFF], a3[MAX_BUFF];
+   char b1[MAX_BUFF], b2[MAX_BUFF], b3[MAX_BUFF];
++  char format[MAX_FORMAT];
+   int order;
++  sprintf(format, "%%%d[^\t]\t%%%d[^\t]\t%%%d[^\t]", MAX_BUFF-1, MAX_BUFF-1, MAX_BUFF-1);
+   a1[0] = a2[0] = a3[0] = '\0';
+-  sscanf(a, "%[^\t]\t%[^\t]\t%[^\t]", a1, a2, a3);
++  sscanf(a, format, a1, a2, a3);
+   b1[0] = b2[0] = b3[0] = '\0';
+-  sscanf(b, "%[^\t]\t%[^\t]\t%[^\t]", b1, b2, b3);
++  sscanf(b, format, b1, b2, b3);
+   order = strcoll(a1, b1);
+   if( order == 0 )
+   {
+@@ -251,7 +253,7 @@ FULL_CHAR *StringQuotedWord(OBJECT x)
+   *q++ = CH_QUOTE;
+   for( p = string(x);  *p != '\0';  p++ )
+   { 
+-    for( r = (FULL_CHAR *) quoted_string[*p];  *r != '\0';  *q++ = *r++ );
++    for( r = (FULL_CHAR *) quoted_string[*p];  *r != '\0' && q < &buff[MAX_BUFF-2];  *q++ = *r++ );
+   }
+   *q++ = CH_QUOTE;
+   *q++ = '\0';

--- a/pkgs/tools/typesetting/lout/default.nix
+++ b/pkgs/tools/typesetting/lout/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
     sha256 = "1gb8vb1wl7ikn269dd1c7ihqhkyrwk19jwx5kd0rdvbk6g7g25ix";
   };
 
+  patches = [
+    # https://build.opensuse.org/request/show/843612
+    ./CVE-2019-19917-and-CVE-2019-19918.patch
+  ];
+
   buildInputs = [ ghostscript ];
   builder = ./builder.sh;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/90853 and fixes https://github.com/NixOS/nixpkgs/issues/106206

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
