### PR TITLE
python3Packages.spacy: remove myself as a maintainer

### DIFF
--- a/pkgs/development/python-modules/blis/default.nix
+++ b/pkgs/development/python-modules/blis/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/explosion/cython-blis";
     license = licenses.bsd3;
     platforms = platforms.x86_64;
-    maintainers = with maintainers; [ danieldk ];
   };
 }

--- a/pkgs/development/python-modules/catalogue/default.nix
+++ b/pkgs/development/python-modules/catalogue/default.nix
@@ -26,6 +26,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/explosion/catalogue";
     changelog = "https://github.com/explosion/catalogue/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk ];
   };
 }

--- a/pkgs/development/python-modules/mmh3/default.nix
+++ b/pkgs/development/python-modules/mmh3/default.nix
@@ -18,6 +18,5 @@ buildPythonPackage rec {
     description = "Python wrapper for MurmurHash3, a set of fast and robust hash functions";
     homepage = "https://pypi.org/project/mmh3/";
     license = licenses.cc0;
-    maintainers = [ maintainers.danieldk ];
   };
 }

--- a/pkgs/development/python-modules/pkuseg/default.nix
+++ b/pkgs/development/python-modules/pkuseg/default.nix
@@ -31,6 +31,5 @@ buildPythonPackage rec {
     description = "Toolkit for multi-domain Chinese word segmentation";
     homepage = "https://github.com/lancopku/pkuseg-python";
     license = licenses.unfree;
-    maintainers = with maintainers; [ danieldk ];
   };
 }

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -71,6 +71,6 @@ buildPythonPackage rec {
     description = "Industrial-strength Natural Language Processing (NLP) with Python and Cython";
     homepage = "https://github.com/explosion/spaCy";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk sdll ];
+    maintainers = with maintainers; [ sdll ];
   };
 }

--- a/pkgs/development/python-modules/srsly/default.nix
+++ b/pkgs/development/python-modules/srsly/default.nix
@@ -40,6 +40,5 @@ buildPythonPackage rec {
     description = "Modern high-performance serialization utilities for Python";
     homepage = "https://github.com/explosion/srsly";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk ];
   };
 }

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -78,6 +78,6 @@ buildPythonPackage rec {
     description = "Practical Machine Learning for NLP in Python";
     homepage = "https://github.com/explosion/thinc";
     license = licenses.mit;
-    maintainers = with maintainers; [ aborsu danieldk sdll ];
+    maintainers = with maintainers; [ aborsu sdll ];
   };
 }

--- a/pkgs/development/python-modules/wasabi/default.nix
+++ b/pkgs/development/python-modules/wasabi/default.nix
@@ -20,6 +20,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/ines/wasabi";
     changelog = "https://github.com/ines/wasabi/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ danieldk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Remove myself as a maintainer of spaCy and its dependencies.

I don't use spaCy, but sort of became the default maintainer after
fixing the build during a ZHF iteration. It would be better if someone
who actually has an interest in keeping the models in sync, etc. takes
the helm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
