### PR TITLE
scientifica: init at 2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3159,6 +3159,12 @@
     githubId = 92793;
     name = "Friedrich von Never";
   };
+  fortuneteller2k = {
+    email = "lythe1107@gmail.com";
+    github = "fortuneteller2k";
+    githubId = 20619776;
+    name = "fortuneteller2k";
+  };
   fpletz = {
     email = "fpletz@fnordicwalking.de";
     github = "fpletz";

--- a/pkgs/data/fonts/scientifica/default.nix
+++ b/pkgs/data/fonts/scientifica/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchurl }:
+
+let
+  version = "2.1";
+in fetchurl rec {
+  name = "scientifica-${version}";
+
+  url = "https://github.com/NerdyPepper/scientifica/releases/download/v${version}/scientifica-v${version}.tar";
+
+  downloadToTemp = true;
+
+  recursiveHash = true;
+
+  sha256 = "081faa48d6g86pacmgjqa96in72rjldavnwxq6bdq2br33h3qwrz";
+
+  postFetch = ''
+    tar xvf $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    mkdir -p $out/share/fonts/misc
+    cp scientifica/ttf/*.ttf $out/share/fonts/truetype
+    cp scientifica/otb/*.otb $out/share/fonts/misc
+    cp scientifica/bdf/*.bdf $out/share/fonts/misc
+  '';
+
+  meta = with lib; {
+    description = "Tall and condensed bitmap font for geeks";
+    homepage = "https://github.com/NerdyPepper/scientifica";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fortuneteller2k ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20726,6 +20726,8 @@ in
   inter-ui = callPackage ../data/fonts/inter-ui { };
   inter = callPackage ../data/fonts/inter { };
 
+  scientifica = callPackage ../data/fonts/scientifica { };
+
   siji = callPackage ../data/fonts/siji
     { inherit (buildPackages.xorg) mkfontscale fonttosfnt; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
[Scientifica](https://github.com/NerdyPepper/scientifica) is a tall, condensed, bitmap font largely based on creep

###### Motivation for this change

Add scientifica font

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
