### PR TITLE
teleport: 5.1.0 -> 5.1.2

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -4,21 +4,21 @@ let
   webassets = fetchFromGitHub {
     owner = "gravitational";
     repo = "webassets";
-    rev = "eb98cd28e34144c6473b79743066d1c63c6427ab";
+    rev = "2d79788dbcd005bdcfe5b5120007d0faf8f1fc82";
     sha256 = "001a3bx8yyx1hq8y5yiy1jzp122q8gcl369lj0609gaxp6dk5bdw";
   };
 in
 
 buildGoPackage rec {
   pname = "teleport";
-  version = "5.1.0";
+  version = "5.1.2";
 
   # This repo has a private submodule "e" which fetchgit cannot handle without failing.
   src = fetchFromGitHub {
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    sha256 = "0jkr4max6mcn8k5nhlg71byb0yzr9kplpl1q96pdk2gbvkh7q6xb";
+    sha256 = "0h1hn2dpdsmhxac06gn6787z2mnfcwb3wn0c2l7l2qhw6iqpgmvh";
   };
 
   goPackagePath = "github.com/gravitational/teleport";
@@ -42,6 +42,14 @@ buildGoPackage rec {
   '';
 
   dontStrip = true;
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/tsh version | grep ${version} > /dev/null
+    $out/bin/tctl version | grep ${version} > /dev/null
+    $out/bin/teleport version | grep ${version} > /dev/null
+  '';
 
   meta = {
     description = "A SSH CA management suite";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
