### PR TITLE
asciidoc: set revdate

### DIFF
--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -147,6 +147,8 @@ stdenv.mkDerivation rec {
   pname = "asciidoc";
   version = "9.0.4";
 
+  # Note: a substitution to improve reproducibility should be updated once 10.0.0 is
+  # released. See the comment in `patchPhase` for more information.
   src = fetchFromGitHub {
     owner = "asciidoc";
     repo = "asciidoc-py3";
@@ -262,6 +264,15 @@ stdenv.mkDerivation rec {
     patchShebangs .
 
     sed -i -e "s,/etc/vim,,g" Makefile.in
+    # Note: this substitution will not work in the planned 10.0.0 release:
+    #
+    # https://github.com/asciidoc/asciidoc-py3/commit/dfffda23381014481cd13e8e9d8f131e1f93f08a
+    #
+    # Update this substitution to:
+    #
+    # --replace "python3 -m asciidoc.a2x" "python3 -m asciidoc.a2x -a revdate=01/01/1980"
+    substituteInPlace Makefile.in \
+      --replace "python3 a2x.py" "python3 a2x.py -a revdate=01/01/1980"
   '';
 
   preInstall = "mkdir -p $out/etc/vim";

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -263,7 +263,6 @@ stdenv.mkDerivation rec {
   '') + ''
     patchShebangs .
 
-    sed -i -e "s,/etc/vim,,g" Makefile.in
     # Note: this substitution will not work in the planned 10.0.0 release:
     #
     # https://github.com/asciidoc/asciidoc-py3/commit/dfffda23381014481cd13e8e9d8f131e1f93f08a


### PR DESCRIPTION
###### Motivation for this change
https://r13y.com/
```

Offset 1, 17 lines modified | Offset 1, 17 lines modified
-- | --
1 | '\"·​t | 1 | '\"·​t
2 | .​\"·​·​·​·​·​Title:​·​a2x | 2 | .​\"·​·​·​·​·​Title:​·​a2x
3 | .​\"·​·​·​·​Author:​·​[see·​the·​"AUTHOR"·​section] | 3 | .​\"·​·​·​·​Author:​·​[see·​the·​"AUTHOR"·​section]
4 | .​\"·​Generator:​·​DocBook·​XSL·​Stylesheets·​vsnapshot·​<http:​/​/​docbook.​sf.​net/​> | 4 | .​\"·​Generator:​·​DocBook·​XSL·​Stylesheets·​vsnapshot·​<http:​/​/​docbook.​sf.​net/​>
5 | .​\"·​·​·​·​·​·​Date:​·​01/​24/​2021 | 5 | .​\"·​·​·​·​·​·​Date:​·​02/​01/​2021
6 | .​\"·​·​·​·​Manual:​·​\·​\& | 6 | .​\"·​·​·​·​Manual:​·​\·​\&
7 | .​\"·​·​·​·​Source:​·​\·​\& | 7 | .​\"·​·​·​·​Source:​·​\·​\&
8 | .​\"·​·​Language:​·​English | 8 | .​\"·​·​Language:​·​English
9 | .​\" | 9 | .​\"
10 | .​TH·​"A2X"·​"1"·​"01/​24/​2021"·​"\·​\&"·​"\·​\&" | 10 | .​TH·​"A2X"·​"1"·​"02/​01/​2021"·​"\·​\&"·​"\·​\&"
11 | .​\"·​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​ | 11 | .​\"·​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​
12 | .​\"·​*·​Define·​some·​portability·​stuff | 12 | .​\"·​*·​Define·​some·​portability·​stuff
13 | .​\"·​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​ | 13 | .​\"·​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​-​
14 | .​\"·​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~ | 14 | .​\"·​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~
15 | .​\"·​http:​/​/​bugs.​debian.​org/​507673 | 15 | .​\"·​http:​/​/​bugs.​debian.​org/​507673
16 | .​\"·​http:​/​/​lists.​gnu.​org/​archive/​html/​groff/​2009-​02/​msg00013.​html | 16 | .​\"·​http:​/​/​lists.​gnu.​org/​archive/​html/​groff/​2009-​02/​msg00013.​html
17 | .​\"·​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~ | 17 | .​\"·​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~~~~~~~~~~~~~~~~~~~~​~~


```

###### Things done
Tried to use SOURCE_DATE_EPOCH, but this did not affect the generation of the man pages' dates. Setting the revdate attribute seems to work, but am unfamiliar with docbook or if there is a more canonical method. 

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
