### PR TITLE
[20.09] pythonPackages.databricks-connect: 7.1.0 -> 7.3.7

### DIFF
--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "databricks-connect";
-  version = "7.1.0";
+  version = "7.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "996a9d0f271f6c7edbd2d85b2efb6ff4e58d15222e80f87ca17fdbf224e17056";
+    sha256 = "c7f508c84edc7f80a131650b892889624e4457c10f44318465dd3f7b8cf5be6d";
   };
 
   sourceRoot = ".";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "databricks-connect";
-  version = "7.3.6";
+  version = "7.3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e3f72ba94c8da6b5aae44ca6133a46206e378609ec0aefadfbdc9a3722afd8d1";
+    sha256 = "35ead50a0550e65a7d6fd78e2c8e54095b53514fba85180768a2dbcdd3f2cf0b";
   };
 
   sourceRoot = ".";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "databricks-connect";
-  version = "7.3.5";
+  version = "7.3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c720298b05648f5de8f17de03f93d60ffb30c2d55ce2750e63c17c341a8de5e4";
+    sha256 = "e3f72ba94c8da6b5aae44ca6133a46206e378609ec0aefadfbdc9a3722afd8d1";
   };
 
   sourceRoot = ".";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "databricks-connect";
-  version = "7.1.10";
+  version = "7.3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bae28fab1e08b709553c8efbeefc5b0ee4f5540a13a04e61fb3d348814823e16";
+    sha256 = "c720298b05648f5de8f17de03f93d60ffb30c2d55ce2750e63c17c341a8de5e4";
   };
 
   sourceRoot = ".";

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -16,8 +16,13 @@ buildPythonPackage rec {
   # requires network access
   doCheck = false;
 
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "py4j==0.10.9" "py4j"
+  '';
+
   preFixup = ''
-      substituteInPlace "$out/bin/find-spark-home" \
+    substituteInPlace "$out/bin/find-spark-home" \
       --replace find_spark_home.py .find_spark_home.py-wrapped
   '';
 

--- a/pkgs/development/python-modules/databricks-connect/default.nix
+++ b/pkgs/development/python-modules/databricks-connect/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "databricks-connect";
-  version = "7.1.1";
+  version = "7.1.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c7f508c84edc7f80a131650b892889624e4457c10f44318465dd3f7b8cf5be6d";
+    sha256 = "bae28fab1e08b709553c8efbeefc5b0ee4f5540a13a04e61fb3d348814823e16";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update databricks-connect from 7.1.0 -> 7.3.7 in nixos-20.09

Changes are mostly fixes https://docs.databricks.com/release-notes/dbconnect/index.html. But version number is following Databricks Runtime. Now 7.3 is the Databricks version with LTS. https://docs.databricks.com/release-notes/dbconnect/index.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
