### PR TITLE
htmltest: init at 0.14.0

### DIFF
--- a/pkgs/development/tools/htmltest/default.nix
+++ b/pkgs/development/tools/htmltest/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "htmltest";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "wjdp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0z2j54ywim1nl10vidcnbwhywyzanj4qd93ai533808wrm3ghwb6";
+  };
+
+  vendorSha256 = "0zx3ii9crick647kslzwg4d39li6jds938f9j9dp287rhrlzjfbm";
+
+  # tests require network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tool to test generated HTML output";
+    longDescription = ''
+      htmltest runs your HTML output through a series of checks to ensure all your
+      links, images, scripts references work, your alt tags are filled in, etc.
+    '';
+    homepage = "https://github.com/wjdp/htmltest";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8770,6 +8770,8 @@ in
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration Foundation;
   };
 
+  htmltest = callPackage ../development/tools/htmltest { };
+
   rcm = callPackage ../tools/misc/rcm {};
 
   td = callPackage ../tools/misc/td { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
htmltest runs your HTML output through a series of checks to ensure all your
links, images, scripts references work, your alt tags are filled in, etc.

https://github.com/wjdp/htmltest

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
