### PR TITLE
libsixel: mark as insecure

### DIFF
--- a/pkgs/development/libraries/libsixel/default.nix
+++ b/pkgs/development/libraries/libsixel/default.nix
@@ -22,5 +22,9 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ vrthra ];
     license = licenses.mit;
     platforms = with platforms; unix;
+    knownVulnerabilities = [
+      "CVE-2020-11721" # https://github.com/saitoha/libsixel/issues/134
+      "CVE-2020-19668" # https://github.com/saitoha/libsixel/issues/136
+    ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
closes https://github.com/NixOS/nixpkgs/issues/90869 and closes https://github.com/NixOS/nixpkgs/issues/106204
Upstream has not replied to the issues https://github.com/saitoha/libsixel/issues/134 and https://github.com/saitoha/libsixel/issues/136.

```
8 packages removed:
ffmpeg-sixel-nightly (†2.3.x) green-pdfviewer-nightly (†2014-04-22) libsixel (†1.8.6) SDL_sixel (†1.2-nightly) termplay (†2.0.6) vp (†1.8) xsw (†0.1.2) zgv (†5.9)
```