### PR TITLE
Papermc 1.16.4 -> 1.16.5

### DIFF
--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, bash, jre }:
 let
-  mcVersion = "1.16.4";
-  buildNum = "296";
+  mcVersion = "1.16.5";
+  buildNum = "457";
   jar = fetchurl {
     url = "https://papermc.io/api/v1/paper/${mcVersion}/${buildNum}/download";
-    sha256 = "0885417w7qahk2fwlzvggbwrhvwgpd7xas8lzzb7ar469vyvd9dz";
+    sha256 = "1xkjaj5wgm9rmzk8mz20n9vd674fynvdgqsy96c9bfifa03lsnmc";
   };
 in stdenv.mkDerivation {
   pname = "papermc";

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -31,6 +31,6 @@ in stdenv.mkDerivation {
     homepage    = "https://papermc.io/";
     license     = lib.licenses.gpl3Only;
     platforms   = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ aaronjanse ];
+    maintainers = with lib.maintainers; [ aaronjanse neonfuz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump. New minecraft version and various bugfixes.

###### Things done
- Updated to latest build.
- Tested server with minecraft client
- Added myself as maintainer as I will be using and updating this.

- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
